### PR TITLE
ES-brand audit: canonicalize Spanish makes across all 6 kinds (192 records, find→verify→critic pass)

### DIFF
--- a/overrides/body_types/body_types.yml
+++ b/overrides/body_types/body_types.yml
@@ -54,6 +54,12 @@ overrides:
   Daihatsu|Materia: mpv
   Nissan|Note: hatchback
   Nissan|Leaf: hatchback
+  # --- ES-brand audit (2026-07-12) ---
+  SEAT|600: sedan                # classic rear-engined 2-door saloon (1957-73); the make-unscoped "600" set entry (meant for the Fiat 600e revival) was poisoning it
+  SEAT|Exeo: sedan               # Audi A4 B7-based saloon (Exeo ST = the wagon secondary); no hatchback Exeo existed
+  EBRO|S700: suv                 # mid-size SUV (Chery Tiggo 7 platform, built ex-Nissan Barcelona) — DGT-only rows were default-typed hatchback
+  EBRO|S800: suv                 # 7-seat SUV (Chery Tiggo 8 platform), same revival family
+  EBRO|S400: suv                 # compact SUV (Chery Tiggo 4 Pro base) — key is the post-rename nameplate (S400 Hev → S400)
 
 keywords:                        # [type, ruby-regex] — checked before the sets
   - [suv, '\b(Aircross|Crossback|Cross)\b']   # *Cross / Aircross / Crossback crossovers

--- a/overrides/makes/aliases.yml
+++ b/overrides/makes/aliases.yml
@@ -252,3 +252,16 @@ DENNIS: Alexander Dennis             # UK legacy 'DENNIS' rows = the same builde
 "MERCEDES IDILIS": Mercedes-Benz   # Idilis (RO) coachbuilt buses on MB chassis (audit medium, verified)
 "MV": MV Agusta                    # register abbreviation; no other MV marque in scope
 "M V AGUSTA": MV Agusta            # spacing variant
+
+# --- ES-brand audit (2026-07-12): make merges + display-casing pins ----------
+# Raw keys inferred from catalog display names (title-case inversion) unless a
+# register was measured directly; the private pipeline should confirm raws.
+GAS-GAS: Gas Gas         # RDW also emits merk=GAS-GAS (measured 2026-07-12, m9d7-ebf2 "Gas-Gas Wild E HP 450" rows); pins to the canonical instead of title-case "Gas-Gas"
+SCUTUM: Silence          # Scutum Logistic S.L. = Silence's legal entity (pre-rebrand brand name, Barcelona) — RDW carries Silence's lineup under merk SCUTUM (https://en.wikipedia.org/wiki/Silence_S04; measured 2026-07-12)
+E-BROH: Ebroh            # brand writes "Ebroh" one word (https://ebroh.eu/); registries hyphenate — RDW merk is literally "E-BROH" (measured 2026-07-12)
+MITT: MITT               # Barcelona marque styles itself all-caps (https://mittmotors.com/) — identity pin like the SEAT/BMW lines
+TRS: TRS                 # TRS Motorcycles (Santpedor; Jordi Tarrés) is all-caps (https://trsmotorcycles.com/); identity pin, deliberately NOT an acronym token — token TRS would restyle Citroën "BX 16 TRS" trim rows
+OSSA: OSSA               # O.S.S.A. initialism (Orpheo Sincronic S.A.), all-caps incl. the 2010-15 revival (https://www.cycleworld.com/2012/05/04/ossa-tr280i-first-ride/); fixes display "Ossa"
+UNVI: UNVI               # Unidad de Vehículos Industriales S.A. (Ourense bus builder) — official all-caps (https://www.unvi.es/); fixes display "Unvi"
+EBRO: EBRO               # revived ES marque (Ebro Factory, Zona Franca BCN) styles itself all-caps like SEAT (https://www.ebroauto.com/)
+CAR-BUS.NET: Car-bus.net # brand's own casing (lowercase bus/net) — Indcar's integration note writes "Car-bus.net" (https://indcar.es/en/indcar-integrates-the-car-body-maker-car-bus-net/); default caser yields "Car-Bus.net"

--- a/overrides/makes/drop.yml
+++ b/overrides/makes/drop.yml
@@ -86,6 +86,11 @@ car:
   # --- junk make strings (audit, high-confidence) ---
   - FACTORY BUILT   # placeholder registration string, not a marque
   - EIGENBOUW       # Dutch "self-build" — kit/amateur builds, not a marque
+  # --- motorhome coachbuilders surfaced by the ES-brand audit (2026-07-12);
+  # matched against the RESOLVED make (BENIMAR/BUNKERVAN precedent) ---
+  - MONCAYO         # Caravanas Moncayo (Villanueva de Gállego, Zaragoza; defunct 2011) — NL RDW rows 100% inrichting=kampeerwagen; ES M1 leakage (https://opendata.rdw.nl/resource/m9d7-ebf2.json?merk=MONCAYO)
+  - PLA             # P.L.A. srl motorhome coachbuilder (IT, Giottiline group) — NL RDW rows 100% kampeerwagen (PLA 390, HS75…); camper-typical multi-stage TANs
+  - ILUSION         # Ilusion Caravaning motorhomes (Pinseque, Zaragoza) — NL RDW rows 100% kampeerwagen (590/690/695; https://ilusioncaravaning.com/)
 
 moped: []           # no drops yet; curation TBD when the kind ships
 

--- a/overrides/makes/search_aliases.yml
+++ b/overrides/makes/search_aliases.yml
@@ -49,3 +49,12 @@
 "三菱": Mitsubishi          # ja kanji
 "현대": Hyundai             # ko hangul
 "기아": Kia                 # ko hangul
+
+# --- ES-brand audit (2026-07-12) ---------------------------------------------
+"Montesa Honda": Montesa    # corporate name since the 1982 Honda agreement (Montesa Honda, S.A. — 88% Honda by 1986); bikes and dealer/registry listings co-badged (https://montesa.com/en/history/)
+"TRRS": TRS                 # the marque badges its bikes and web catalog TRRS (trsmotorcycles.com); UK registry strings say "TRRS ONE"
+"GASGAS": Gas Gas           # official one-word rendering since the Pierer era (gasgas.com); canonical display "Gas Gas" is a repo decision
+"Scutum": Silence           # former brand / legal-entity name (Scutum Logistic S.L.) — how pre-rebrand listings name the marque (https://www.wikidata.org/wiki/Q22059031)
+"MH": Motorhispania              # the marque's own initialism — bikes badged MH (MH Furia, MH RYZ); brand site mhmotorcycles.com titles itself "MH Motorhispania"
+"Motor Hispania": Motorhispania  # documented two-word trade form (wemoto.com "Motor Hispania Furia, RYZ 50") — also guards future ingest of a spaced raw string
+"Stark Future": Stark       # full company name (https://starkfuture.com/) — press and listings use it alongside the short badge

--- a/overrides/models/aliases.yml
+++ b/overrides/models/aliases.yml
@@ -39,3 +39,33 @@ Ford:
   Model T: [Tin Lizzie]                              # historic nickname
 Fiat:
   "500": [Cinquecento]                               # IT spoken form (also a distinct 90s nameplate — alias stays on the icon)
+# --- ES-brand audit (2026-07-12) — keys are post-rename nameplates -----------
+SEAT:
+  Leon: [León]                  # ES official spelling — seat.es titles "SEAT León"; international sites drop the accent
+  Cordoba: [Córdoba]            # named after the city; Spanish-market materials carry the accent
+  Malaga: [Málaga, Gredos]      # ES accent (city name); Gredos = Greek market name (Málaga sounded like the swear word malakas)
+  "600": [Seiscientos, Seílla]  # ES spoken forms of the icon that motorized Spain (Fiat 500: Cinquecento precedent)
+Cupra:
+  Leon: [León]                  # ES official spelling — Cupra's Spanish site writes "CUPRA León" (https://www.cupraofficial.es/coches/leon)
+Derbi:
+  Senda 50: [Senda DRD]         # DRD (Derbi Racing Development) sub-badge on 2004+ Senda 50s — how the bikes are commonly listed ("Senda DRD Racing/X-Treme")
+Montesa:
+  Cota 4RT 301RR: [Cota 301RR]  # Montesa's own short form — official model-page copy and launch news say "Cota 301RR" (https://montesa.com/en/modelos/cota-4rt-301rr/)
+Gas Gas:
+  EC: [Enducross]               # EC is short for Enducross — the long form registries and brand history use
+  ES 700: [ES700]               # common unspaced form (registry/listing strings)
+  SM 700: [SM700]               # same
+Sherco:
+  125 SE: [125 SE-R]            # -R (Racing) badge form — official model name 2013-2019 and the dominant registry string
+  250 SE: [250 SE-R]            # same
+  300 SE: [300 SE-R]            # same
+  250 SEF: [250 SEF-R]          # same
+  300 SEF: [300 SEF-R]          # same
+  450 SEF: [450 SEF-R]          # same
+  500 SEF: [500 SEF-R]          # same
+Rieju:
+  Aventura Rally 307: [Rally 307]  # documented short form — press and the ES registry drop the family prefix (https://advhead.com/fr/rieju-307-rally-first-ride-review/)
+Silence:
+  S04: [Nanocar]                # marketed as "S04 Nanocar" (https://www.silence.eco/global/productos/s04-nanocar; Nissan sells the lineup as "Silence S04 Nanocar")
+Santana:
+  PS10: [Aníbal]                # ES market name — the Santana Aníbal / PS-10 utility 4x4 (Linares, 2003-2011; https://autopista.es/noticias-motor/articulo/mot11298.htm)

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -74,3 +74,154 @@ Chrysler:
 
 Tesla:
   "512": null   # data error — Tesla never made a "512" (likely a miscoded Ferrari/other); drop
+
+# =============================================================================
+# ES-brand audit (2026-07-12, multi-agent find→verify pass). NOTE these blocks
+# are make-scoped but kind-blind — kind hazards are tripwired in spotchecks.yml.
+# =============================================================================
+
+SEAT:
+  # Cupra split (brand standalone since 2018; pre-2018 Cupra = SEAT trim):
+  Cupra: null              # brand-as-model row ("SEAT CUPRA", nl/nz) — Cupra is a make, never a SEAT nameplate; unresolvable to one model (https://en.wikipedia.org/wiki/Cupra_(marque))
+  Cupra Leon: null         # post-2018 Cupra Leon misparented under SEAT — TANs e9*2007/46*3167*06/10/12/17 identical to cupra/leon's; no cross-make move exists, cupra/leon covers all its countries
+  Cupra Ateca: null        # post-2018 Cupra Ateca under SEAT — TAN e9*2007/46*6394*40 shared with cupra/ateca (same approval family); cupra/ateca covers it
+  Formentor: null          # Formentor is Cupra-exclusive (first Cupra-only model, 2020) — TANs e9*2007/46*4008*03/07 shared with cupra/formentor (https://en.wikipedia.org/wiki/Cupra_Formentor)
+  Leon Cupra: Leon         # pre-2018 Cupra = SEAT performance trim (nameplate-first word order); folds per policy
+  Ibiza Cupra: Ibiza       # pre-2018 Cupra trim of the Ibiza; folds per policy
+  # Body/trim/generation variants of existing nameplates:
+  Leon Sc: Leon            # SC = 3-door "Sports Coupé" body of the Leon III — TANs e9*2007/46*0094*05/25 sit inside seat/leon's own approval family
+  Leon Sportourer: Leon    # ST/Sportstourer estate body — TANs e9*2007/46*0094*37/38, same family; seat.es sells "León Sportstourer"
+  Leon X-Perience: Leon    # AWD crossover trim of the Leon ST — TAN e9*2007/46*0094*12, same family
+  Leon 1: Leon             # registry generation marker (Leon Mk1) — TAN e9*98/14*0026*20 = the 0026 family seat/leon already carries
+  Altea Freetrack: Altea   # crossover trim of the Altea XL — TAN e9*2001/116*0050*33 is a revision of seat/altea's approval
+  Altea 4 Freetrack: Altea # 4WD Freetrack spelling — its TAN e9*2001/116*0050*18 is literally also present on seat/altea
+  127 Sport: "127"         # sport sub-badge folds; rename intentionally CREATES the missing 127 nameplate (Cee D precedent; SEAT 127 1972-82, 1.24M units). NB: no factory SEAT "127 Sport" trim documented — string is likely Fiat 127 Sport badge-bleed (https://en.wikipedia.org/wiki/SEAT_127)
+  Terra: null              # Marbella-based panel van (1987-96) leaking into cars via camper/kombi car-class rows — van-kind nameplate (Evito precedent). CAUTION kind-blind: if the van build ever ingests raw SEAT TERRA rows, this null suppresses them too (van/seat currently holds only Inca)
+  # de_kba_fz10 numeric type-codes, not nameplates (Tesla "512" precedent);
+  # single-source de-only block 468–474, seat/468 even held DE rank 33:
+  "468": null              # KBA type-code
+  "469": null              # KBA type-code
+  "470": null              # KBA type-code
+  "471": null              # KBA type-code
+  "472": null              # KBA type-code
+  "473": null              # KBA type-code
+  "474": null              # KBA type-code
+
+Cupra:
+  Tavascan V1 EV: Tavascan          # V1 = UK entry trim (V1/V2/VZ1/VZ2 lineup) + EV fuel marker in the uk_dft string; adds gb to the nameplate
+  Terramar Amrica Cp Ed: Terramar   # truncated uk_dft string for the "Terramar America's Cup Edition" launch edition; editions fold
+
+Derbi:
+  # moped Senda 50 — one nameplate: every 50cc trim/edition/registry-code row
+  # folds here. TAN families each prove one approved type: e9*2002/24*0001
+  # (R/Sm/X-Trem), e9*2002/24*0053 (R50AF=SM50AF identical), e1*168/2013*00126
+  # (2016+ X-Treme/Racing gen). Rename CREATES the Senda 50 canonical.
+  Senda R: Senda 50               # 50cc enduro trim (TAN base e9*2002/24*0001)
+  Senda Sm: Senda 50              # supermoto trim, same type (e9*2002/24*0001*03)
+  Senda R X-Trem: Senda 50        # trim (TAN e9*2002/24*0001*01)
+  Senda R50AF: Senda 50           # registry variant string; TAN e9*2002/24*0053*00 IDENTICAL to SM50AF
+  Senda SM50AF: Senda 50          # registry variant string; same TAN e9*2002/24*0053*00
+  Senda RACING50SM: Senda 50      # 2016+ gen trim (TAN e1*168/2013*00126*00)
+  Senda X-Treme Limited: Senda 50 # special edition, same type
+  Senda X-TREME50R: Senda 50      # trim, same type
+  Senda X-TREME50SM: Senda 50     # trim, same type
+  Black Devil: Senda 50           # special edition of the Senda 50 — TAN e9*2002/24*0001*01 IDENTICAL to Senda R X-Trem; sold as "Senda SM/R 50 Black Devil"
+  Sm X-Trem: Senda 50             # RDW handelsbenaming with the family name dropped — TAN e9*2002/24*0001*00/*01 (CC0 RDW API, 2026-07-12)
+  Sdr: Senda 50                   # RDW type-code "SDR" for the 1997-2005 Senda 50 gen: TAN base e9*92/61*0027, L1e 45 km/h, Senda R/SM geometry (CC0 RDW API 2026-07-12)
+  Ab: Senda 50                    # RDW junk type-string "AB": every row TAN e11*2002/24*1050*00 = the 2010+ Piaggio-built Senda DRD 50; same TAN also registered as "SENDA DRD X-TREME SM"
+  # motorcycle Senda 125 (displacement granularity keeps 50 vs 125 apart):
+  Senda SM125: Senda 125     # supermoto trim of the 125 (TAN base e9*92/61*0130 shared across the family)
+  Senda SM125 4T: Senda 125  # "4T" = engine descriptor (all Senda 125s are 4T), not a nameplate (TAN e9*92/61*0130*05/*09)
+  Senda: Senda 125           # motorcycle-kind bare Senda: FI rows are the 125 (TAN e9*92/61*0130*01); UK rows land here too (VEH0120 merges mopeds into Motorcycles by design — kind_maps/uk_dft.yml)
+  # GPR sport family (Racing/Nude are the two catalog versions of one type):
+  Gpr NUDE50: GPR 50   # naked variant — TAN e9*2002/24*0011*06 IDENTICAL to GPR50RACING (https://es.wikipedia.org/wiki/Derbi_(motocicletas))
+  GPR50RACING: GPR 50  # faired variant, same type (TAN e9*2002/24*0011*06)
+  GPR50: GPR 50        # official spaced form; UK motorcycle-class rows (UK merges mopeds into Motorcycles, kind_maps/uk_dft.yml)
+  GPR125: GPR 125      # official spaced form (GPR 125 Racing/Nude, 2005-2015) — same respace as GPR50; motorcycle-kind only (https://en.wikipedia.org/wiki/Derbi_GPR125)
+  # Display/casing renames + family folds:
+  MULHACEN125: Mulhacén 125  # official accented name (after the Mulhacén peak), scrambler 2007-2013 (https://www.autoevolution.com/moto/derbi/mulhacen/)
+  MULHACEN659: Mulhacén 659  # official accented name; 659cc Yamaha-engined single (2006-2013)
+  BOULEVARD50: Boulevard 50  # display spacing; Derbi-badged scooter line (TAN e9*2002/24*0329*01, no cross-make twin in catalog)
+  Variant Start: Variant     # Start (1984) is a version of the Variant family (América/Start/Sport/Box) — folds to the nameplate (https://blog.terranea.es/variant-ciclomotor-volador-derbi/)
+  DFW50: null                # DFW 50 is a 50cc QUAD (ATV) — no quad kind exists (POLARIS precedent in makes/drop.yml: "revisit if quads become a kind"); https://www.autoevolution.com/moto/derbi-dfw-50-2005.html
+
+Bultaco:
+  Brinco C: Brinco  # C/S/R are same-2kW equipment trims of the one Brinco e-moped platform (2015 revival); rename CREATES the Brinco nameplate (https://newatlas.com/bultaco-brinco-street-bikes/43202/)
+
+Montesa:
+  COTA315R: Cota 315R           # digit-frozen registry token; official spacing of the 1997-2004 two-stroke Cota (https://www.retrotrials.com/montesa--montesa-honda-motorcycles.html)
+  COTA4RT: Cota 4RT             # official naming (https://montesa.com/en/montesa-range/); 249cc 2005-13 — stays separate from 260/301RR per displacement granularity
+  COTA4RT260: Cota 4RT 260      # official spacing (current trim "Cota 4RT 260R"; https://montesa.com/en/modelos/cota-4rt-260r/); 259cc
+  COTA4RT301RR: Cota 4RT 301RR  # official model-page name (https://montesa.com/en/modelos/cota-4rt-301rr/); 298cc race replica
+
+Gas Gas:
+  Enducross: EC          # same nameplate: EC is short for Enducross — shared TAN e9*92/61*0062*09 with gas-gas/ec (https://en.wikipedia.org/wiki/Gas_Gas)
+  Cg: EC                 # CG = GasGas Motos' type code for the EC 2-stroke enduro family — RDW CG rows are 125-299cc on the EC approvals e9*2002/24*0506 and e9*168/2013*30006 (measured 2026-07-12)
+  Cg-EC300: EC 300       # registry compound "type code + commercial name"; 299cc on e9*168/2013*30006 = the EC 300 (targets the respaced canonical directly — rename chaining is not assumed)
+  # EC-number family respace to the official forms (gasgas.com model pages) —
+  # same canonical style as ES 700/SM 700 above:
+  EC250: EC 250          # official spacing (2T enduro)
+  EC250F: EC 250F        # official "EC 250F" (4T)
+  EC300: EC 300          # official spacing; also the Cg-EC300 merge destination
+  EC350F: EC 350F        # official
+  EC450F: EC 450F        # official
+  EC500F: EC 500F        # official (MY2024+)
+  Tg: TXT                # TG = type code of the TXT trials family — RDW TG rows are 248/294cc trials engines; the record's TAN e9*168/2013*30004*04 is the TXT Racing 300 approval
+  Es: ES 700             # Gas Gas has only ever made one ES — the ES 700 dual-sport (2022+, 693cc, e1*168/2013*00298); bare gb/nz "ES" strings are that bike (https://www.gasgas.com/en-us/models/travel/es-700-2024.html)
+  Gasgas ES700: ES 700   # strip the embedded brand (raw "GASGAS ES700", unspaced, missed the make-prefix strip) + official spacing (gasgas.com)
+  Gasgas SM700: SM 700   # same fix for the supermoto sibling (https://www.gasgas.com/en-us/models/supermoto/sm-700-2024.html)
+  Trial: null            # generic category string, not a nameplate — RDW "TRIAL" rows span 49-294cc across eras; unresolvable to TXT/TX/Contact
+  Enduro: null           # generic category string — RDW "ENDURO" rows are the FSE/FSR 400-515 four-strokes (444-503cc, e9*92/61*0081); displacement split unrecoverable
+
+Sherco:
+  # -R (Racing) trim folds; nameplate = displacement + line (sherco.com):
+  125SE-R: 125 SE        # Racing trim of the 125 SE 2T enduro
+  250SE-R: 250 SE        # same
+  300SE-R: 300 SE        # same
+  250SEF-R: 250 SEF      # SEF = the 4T enduro line; Racing trim folds
+  300SEF-R: 300 SEF      # same
+  450SEF-R: 450 SEF      # same
+  500SEF-R: 500 SEF      # same
+  300SE-F: 300 SE        # NOT the SEF 4T: TAN e13*168/2013*00113*07 + RDW 293cc prove the 2-stroke SE — trailing F is the FACTORY trim
+  250 2ST: 250 SE        # "2ST" = registry shorthand for 2-stroke; Sherco's only 250 2T enduro is the SE (RDW 249cc, e13*2002/24*0620)
+  300 2ST: 300 SE        # same — RDW 293cc = SE 300 2T
+  125 4T EUR5: 125 4T    # strip the Euro-5 emissions token; "125 4T" is Sherco's family name for the 124cc four-strokes (sherco.com)
+  Sherco: null           # make-as-model placeholder (RDW "SHERCO SHERCO" at 294cc trials AND 249cc enduro — unresolvable mixture)
+  "N.a": "50"            # RDW registers Sherco's 50cc mopeds as handelsbenaming "N/A" (~806 rows, all 50cc, e13*168/2013*00339); rename to the honest displacement family instead of dropping ES's top-3 moped
+  "50SM": 50 SM          # supermoto 50 line per Sherco's "<cc> <line>" schema (sherco.com "50 SM-R FACTORY"); respace like 125SE-R → 125 SE; the "50" umbrella stays for the unresolvable N/A rows
+
+TRS:
+  Trrs One: One          # strip the embedded badge — bikes are badged TRRS but the make resolves to TRS, so the prefix strip missed (trsmotorcycles.com); CREATES the One canonical
+  TR1 300: One 300       # TR1 = TRS's homologation type code (RDW type "TR 1 A", e9*168/2013*30008, 294cc), not a nameplate; road range is the One family
+
+Rieju:
+  "N.a.": null                   # registry "not available" placeholder (es_dgt + nl_rdw rows), not a nameplate; rieju keeps es via e-Tango (es_dgt)
+  AVENTURA500: Aventura 500      # official spacing (471cc A2 twin trail; https://www.diariomotor.com/motos/rieju-aventura-500/)
+  NKD125: NKD 125                # official "NKD 125" naked, NKD stays caps (https://rieju.com/us/naked/130/524/nkd-125)
+  RALLY307: Aventura Rally 307   # official product name incl. family prefix (https://rieju.com/us/off-road/121/522/aventura-rally-307); registry drops "AVENTURA" and the space
+  XPLORA557: Xplora 557          # official "Xplora 557" 554cc A2 twin (https://www.motorbikemag.es/rieju-xplora-557-xplora-707-2025-prueba-opiniones/)
+  XPLORA707: Xplora 707          # sibling 693cc twin (https://rieju.com/en/news/new-rieju-xplora-707/257/294); consecutive TANs e9*168/2013*16461/16462 prove two approved models, not dupes
+
+Silence:
+  S02LS: S02             # "S02 LS" = the L1e speed variant; kind=moped already encodes the class — RDW writes both strings for the same scooter (681 S02LS vs 104 S02 bromfiets rows; Silence's manual says "S02 LS")
+  S01LS: S01             # L1e (45 km/h, 4 kW) version of the S01 — same nameplate, kind captures the class; intentionally CREATES the moped-kind S01 beside the L3e motorcycle record
+
+MITT:
+  300GT Max: GT-MAX 300  # registry writes "300GT MAX" (RDW measured 2026-07-12); official model name is GT-MAX 300 (https://mittmotors.com/vehiculo/mitt-gt-max-125-330)
+
+EBRO:
+  S400 Hev: S400         # HEV is the powertrain badge, not the nameplate — official lineup is s400/s700/s800 (sold as "s400 HEV"; sibling records are already powertrain-bare); folds like Leaf 40KWH (https://www.ebroauto.com/)
+  S400 HEV: S400         # same fold — key form that applies once HEV joins styling.yml acronyms (the caser runs before renames; cf. the "Town&country LX" key, LX being an acronym)
+
+Irizar:
+  "16": i6               # digit-1 typo of I6 — RDW merk IRIZAR carries "16 14.07.37 EFFICIENT" beside "I6 14.07.37 EFFICIENT"; Irizar's range has no "16" (https://www.irizar.com/en/products-technologies/all-models); target is the post-styling lowercase i6
+
+Scania:
+  Irizar: null           # chassis+bodybuilder registration strings ("SCANIA IRIZAR I4/NEW CENTURY", RDW), not a Scania nameplate — in bus kind the bodybuilder IS the make (Plaxton/Caetano precedent; irizar/i4-i6-i8 exist). NOTE: drops ua evidence (Century/PB-era bodies not yet catalogued under irizar)
+
+UNVI:
+  Microbus: null         # approval type-designation fallback, not a nameplate — EU approval e9*2007/46*6019*02 type field reads "MICROBUS_2"; UNVI's real range is Compa/Urbis/Vega/Sil/Vendal (https://unvibus.com/product/) — Tesla "512" precedent
+
+Iveco:
+  Sunrise: null          # Ferqui Sunrise minicoach body on Iveco Daily chassis, registered under the chassis make; canonical is ferqui/sunrise (https://ferqui.com/en/sunrisef2/). NOTE: loses nl evidence (ferqui/sunrise currently es,fi)
+  Wing: null             # Indcar Wing minibus body on Iveco Daily 70C, same pattern; canonical is indcar/wing (https://en.wikipedia.org/wiki/Indcar). NOTE: loses ua evidence (indcar/wing currently es,fi,gb,nl)

--- a/overrides/styling.yml
+++ b/overrides/styling.yml
@@ -38,6 +38,23 @@ stylings:
   CX-5: CX-5
   CX-60: CX-60
   CX-80: CX-80
+  # --- ES-brand audit (2026-07-12): whole-string pins (deliberately NOT
+  # acronym tokens — token forms would restyle other records' fold keys) ---
+  GPR: GPR               # Derbi GPR (Gran Premio Replica) — bare "GPR" must not title-case to "Gpr" (motorcycle derbi/gpr; only Derbi carries the token). NOT an acronym: token GPR would restyle "Gpr NUDE50" and orphan its renames.yml key
+  EC: EC                 # Gas Gas EC (Enducross) family — official all-caps (gasgas.com); whole-string, only gas-gas/ec matches
+  TXT: TXT               # Gas Gas TXT trials — official all-caps; whole-string, only gas-gas/txt matches
+  TX: TX                 # Gas Gas TX (1998 trials) — also correct for LEVC TX and Van Hool TX, the only other whole-string matches
+  SM: SM                 # Gas Gas SM supermoto family — also correct for Citroën SM (official) and Aprilia/Sisu SM codes, the only other matches
+  "2.5I": 2.5i           # Sherco's injected 4T enduro era uses lowercase i (2.5i Enduro, 2008-2011)
+  "3.0I": 3.0i           # same series (RDW 290/304cc)
+  "4.5I": 4.5i           # same series (449cc)
+  MR: MR                 # Rieju MR enduro family (MR 250/300, 2021+) keeps caps (rieju.com); side effect: re-cases Toyota's whole-string "Mr" (MR2 truncation), equally correct
+  E-TANGO: e-Tango       # Rieju's official lowercase e- prefix (https://rieju.com/us/electric/112/527/etango) — e-tron precedent
+  EXE II: EXE II         # Nerva EXE II — maker/press all-caps (https://www.motociclismo.es/pruebas/nerva-exe-ii-segunda-version-scooter-electrico-espanol_310667_102.html); numbered two-wheeler generations stay separate records (ktm/duke-ii precedent)
+  EXE: EXE               # Nerva's all-caps model name — future gen-1 "EXE" rows must not title-case to "Exe"; no whole-string collisions catalog-wide
+  I4: i4                 # Irizar official lowercase-i coach range (https://www.irizar.com/en/products-technologies/all-models); BMW i4 shares the same official casing
+  I6: i6                 # Irizar official casing; also the merge target of the Irizar "16" rename
+  I8: i8                 # Irizar official casing; BMW i8 shares it
 
 acronyms:
   - GT
@@ -121,3 +138,9 @@ acronyms:
   - AJP
   - AJS
   - BMC
+  # --- ES-brand audit (2026-07-12): model-token acronyms ---
+  - MRT     # Rieju MRT 50/125 family — official all-caps (https://rieju.com); token only in Rieju records today
+  - MRX     # Rieju MRX enduro line (2001+) — official all-caps (https://rieju.com/en/history)
+  - RR      # Rieju RR 50 (1993+) — all-caps industry-wide; re-cases Beta RR, MV Agusta RR, KTM RR, Aprilia RR, MAN RR, Yamaha Jog-RR, Zontes ZT703-RR rows (full 12-record sweep 2026-07-12), all officially RR
+  - HEV     # hybrid powertrain badge (Ebro S400 HEV; Dacia/Hyundai/Mitsubishi/Jaecoo/Omoda "Hev" rows) — sibling of PHEV/EV
+  - VARG    # Stark VARG — maker's all-caps model name (https://starkfuture.com/products/stark-varg); token form covers VARG EX/SM variants

--- a/spotchecks.yml
+++ b/spotchecks.yml
@@ -135,3 +135,263 @@ checks:
     kind: motorcycle
     exists: false
     reason: "ES+GB both hold miscategorized 'Audi A3' motorcycles — multi-source agreement must not corroborate cross-kind garbage"
+
+  # === ES-brand cleanup tripwires (2026-07-12 multi-agent audit) ==============
+  # --- SEAT/Cupra split --------------------------------------------------------
+  - id: seat/formentor
+    exists: false
+    reason: "Formentor is Cupra-exclusive (first Cupra-only model, 2020); SEAT-parented rows were brand-transition registry noise (renames null)"
+  - id: seat/cupra
+    exists: false
+    reason: "Brand-as-model row ('SEAT CUPRA') must stay dead — Cupra is a make (see make: cupra row), never a SEAT nameplate"
+  - id: seat/cupra-leon
+    exists: false
+    reason: "Post-2018 Cupra models must not resurface under SEAT (their TANs e9*2007/46*3167* live on cupra/leon)"
+  - id: seat/cupra-ateca
+    exists: false
+    reason: "Post-2018 Cupra Ateca must not resurface under SEAT (TAN family e9*2007/46*6394* lives on cupra/ateca)"
+  - id: seat/ibiza-cupra
+    exists: false
+    reason: "Pre-2018 Cupra is a SEAT trim — folds into Ibiza (renames.yml)"
+  - id: seat/leon-cupra
+    exists: false
+    reason: "Pre-2018 Cupra is a SEAT trim — folds into Leon (renames.yml)"
+  - id: cupra/formentor
+    availability_includes: [es, fi, nl]
+    reason: "Cupra-side canonical keeps the countries the dropped SEAT-parented rows carried"
+  - id: seat/468
+    exists: false
+    reason: "KBA FZ10 numeric type-codes are not nameplates (Tesla 512 precedent); seat/468 held DE rank 33 and polluted popularity"
+  - id: seat/127
+    availability_includes: [es]
+    reason: "'127 Sport' -> '127' fold intentionally creates the classic supermini nameplate with its ES evidence"
+  - id: cupra/tavascan
+    availability_includes: [gb]
+    reason: "'Tavascan V1 EV' (UK trim string) folds in — gb evidence must land on the nameplate"
+  - id: cupra/terramar
+    availability_includes: [gb]
+    reason: "'Terramar Amrica Cp Ed' (UK edition string) folds in — gb evidence must land on the nameplate"
+  # --- Derbi (incl. kind-blind rename tripwires) -------------------------------
+  - id: derbi/senda-50
+    kind: moped
+    skip_if_kind_absent: true
+    availability_includes: [fi, nl]
+    reason: "Senda 50 canonical: 13 trim/edition/registry-code records fold here (TAN bases e9*2002/24*0001, e9*2002/24*0053, e1*168/2013*00126; RDW type-codes SDR/AB)"
+  - id: derbi/senda-sm
+    kind: moped
+    skip_if_kind_absent: true
+    exists: false
+    reason: "'Senda Sm' must stay folded into Senda 50 — a silent rename-key miss would resurrect it"
+  - id: derbi/senda-125
+    kind: motorcycle
+    skip_if_kind_absent: true
+    availability_includes: [fi, nl]
+    reason: "Senda 125 canonical (TAN family e9*92/61*0130: Senda + SM125 + SM125 4T)"
+  - id: derbi/senda-125
+    kind: moped
+    skip_if_kind_absent: true
+    exists: false
+    reason: "kind-blind rename tripwire: 'Senda' -> 'Senda 125' must never materialize in moped kind (moped Sendas are 50s)"
+  - id: derbi/senda-50
+    kind: motorcycle
+    skip_if_kind_absent: true
+    exists: false
+    reason: "kind-blind rename tripwire: moped Senda trim folds must not leak into motorcycle kind"
+  - id: derbi/gpr-50
+    kind: moped
+    skip_if_kind_absent: true
+    availability_includes: [fi, nl]
+    reason: "GPR Nude 50 + GPR 50 Racing are one approved type (identical TAN e9*2002/24*0011*06) -> GPR 50"
+  - id: derbi/dfw50
+    kind: moped
+    skip_if_kind_absent: true
+    exists: false
+    reason: "DFW 50 is a quad (ATV) — dropped pending a quad kind (POLARIS precedent); delete this row if quads become a kind"
+  # --- classic trials ----------------------------------------------------------
+  - id: bultaco/brinco
+    kind: moped
+    skip_if_kind_absent: true
+    availability_includes: [fi, nl]
+    reason: "Brinco C (equipment trim) folds into the created Brinco nameplate; the 2 kW e-revival lives in kind=moped"
+  - id: bultaco/brinco-c
+    kind: moped
+    skip_if_kind_absent: true
+    exists: false
+    reason: "trim suffix must stay folded (renames.yml Bultaco)"
+  - id: montesa/cota-4rt
+    kind: motorcycle
+    skip_if_kind_absent: true
+    availability_includes: [gb, nl]
+    reason: "COTA4RT -> Cota 4RT respace; displacement granularity keeps Cota 4RT / 4RT 260 / 4RT 301RR separate"
+  - id: montesa/cota4rt
+    kind: motorcycle
+    skip_if_kind_absent: true
+    exists: false
+    reason: "unspaced digit-frozen registry token must not resurface (renames.yml Montesa)"
+  # --- modern trials/enduro ----------------------------------------------------
+  - id: gas-gas/ec
+    kind: motorcycle
+    skip_if_kind_absent: true
+    availability_includes: [fi, gb, nl]
+    reason: "EC family holds: Enducross + RDW type-code CG rows fold into EC (shared TAN e9*92/61*0062)"
+  - id: gas-gas/es-700
+    kind: motorcycle
+    skip_if_kind_absent: true
+    availability_includes: [fi, gb, nl, nz]
+    reason: "ES 700 unifies bare gb/nz 'ES' rows with brand-prefixed fi/nl 'GASGAS ES 700' rows"
+  - id: gas-gas/txt
+    kind: motorcycle
+    skip_if_kind_absent: true
+    availability_includes: [gb, nl]
+    reason: "TXT stays a nameplate (top UK Gas Gas string) and gains nl from the TG type-code fold"
+  - id: gas-gas/trial
+    kind: motorcycle
+    skip_if_kind_absent: true
+    exists: false
+    reason: "Generic category strings (TRIAL/ENDURO) must not survive as Gas Gas nameplates"
+  - id: sherco/300-se
+    kind: motorcycle
+    skip_if_kind_absent: true
+    availability_includes: [es, fi, nl]
+    reason: "Racing/Factory trim folds + '300 2ST' merge; '300 SE-F' is the 2T Factory (293cc), not the SEF 4T"
+  - id: sherco/sherco
+    kind: motorcycle
+    skip_if_kind_absent: true
+    exists: false
+    reason: "Make-as-model placeholder must not survive"
+  - id: sherco/n-a
+    kind: moped
+    skip_if_kind_absent: true
+    exists: false
+    reason: "RDW 'N/A' placeholder resolved to the 50 family; must not reappear"
+  - id: sherco/50
+    kind: moped
+    skip_if_kind_absent: true
+    availability_includes: [es, nl]
+    reason: "Sherco 50 moped family: placeholder rename preserves ES top-3 moped evidence (~800 NL rows, all 50cc)"
+  - id: trs/one-300
+    kind: motorcycle
+    skip_if_kind_absent: true
+    availability_includes: [es, nl]
+    reason: "Type-code 'TR1 300' resolves to One 300 (RDW type 'TR 1 A' = TRS trials range)"
+  # --- Rieju / Motorhispania ---------------------------------------------------
+  - id: rieju/nkd-125
+    kind: motorcycle
+    skip_if_kind_absent: true
+    availability_includes: [es]
+    reason: "ES two-wheeler spine + respace rule: DGT 'NKD125' publishes as the official 'NKD 125'"
+  - id: rieju/n-a
+    kind: moped
+    skip_if_kind_absent: true
+    exists: false
+    reason: "Registry 'N.a.' placeholder must never publish as a Rieju nameplate (renames.yml null)"
+  - make: motorhispania
+    kind: moped
+    skip_if_kind_absent: true
+    reason: "Defunct Seville marque stays cataloged (Furia Max); 'MH'/'Motor Hispania' search aliases resolve here, not to a new make"
+  # --- ES e-mobility -----------------------------------------------------------
+  - make: scutum
+    kind: moped
+    skip_if_kind_absent: true
+    exists: false
+    reason: "Scutum Logistic is Silence's legal entity — raw SCUTUM merges into make silence (makes/aliases.yml)"
+  - id: silence/s04
+    kind: moped
+    skip_if_kind_absent: true
+    availability_includes: [es, nl]
+    reason: "S04 Nanocar keeps both countries after absorbing SCUTUM-badged rows"
+  - id: silence/s01
+    kind: moped
+    skip_if_kind_absent: true
+    availability_includes: [es, nl]
+    reason: "S01LS (L1e) folds to S01 within kind=moped; the L3e S01 lives in kind=motorcycle"
+  - id: silence/s02
+    kind: moped
+    skip_if_kind_absent: true
+    availability_includes: [es, fi, nl]
+    reason: "S02LS merge must carry the Finnish evidence into the S02 nameplate"
+  - make: e-broh
+    kind: motorcycle
+    skip_if_kind_absent: true
+    exists: false
+    reason: "Raw E-BROH resolves to make ebroh via aliases.yml — the hyphenated make must not survive"
+  - make: e-broh
+    kind: moped
+    skip_if_kind_absent: true
+    exists: false
+    reason: "same as the motorcycle row — both kinds carry one E-Broh model each today"
+  - id: ebroh/bravo-gle
+    kind: motorcycle
+    skip_if_kind_absent: true
+    availability_includes: [es, nl]
+    reason: "Bravo GLE keeps its evidence across the E-BROH -> Ebroh rename"
+  - id: mitt/gt-max-300
+    kind: motorcycle
+    skip_if_kind_absent: true
+    reason: "Registry '300GT MAX' renamed to the official GT-MAX 300 (renames.yml + MITT casing pin)"
+  # --- ES cars misc ------------------------------------------------------------
+  - make: moncayo
+    kind: car
+    exists: false
+    reason: "Caravan/camper builder (RDW inrichting=kampeerwagen) must not appear as a car make (drop.yml)"
+  - make: pla
+    kind: car
+    exists: false
+    reason: "P.L.A. motorhome coachbuilder (all RDW rows kampeerwagen) must not appear as a car make (drop.yml)"
+  - make: ilusion
+    kind: car
+    exists: false
+    reason: "Ilusion Caravaning motorhomes must not appear as a car make (drop.yml)"
+  - id: ebro/s400
+    availability_includes: [es]
+    reason: "Ebro revival (2024, ex-Nissan Barcelona) lives in kind=car — never drop EBRO from cars for its historic truck era; S400 HEV powertrain suffix folds into S400"
+  - id: santana/ps10
+    kind: van
+    skip_if_kind_absent: true
+    availability_includes: [gb, nl]
+    reason: "Santana PS-10 (Aníbal) utility 4x4 stays kind=van (RDW Bedrijfsauto rows)"
+  # --- ES bus industry (bodybuilder-as-make invariants) ------------------------
+  - make: irizar
+    kind: bus
+    skip_if_kind_absent: true
+    reason: "Spanish bodybuilder-as-make invariant: Irizar exists as a bus make (i6/i8), never as a model under chassis makes"
+  - id: scania/irizar
+    kind: bus
+    skip_if_kind_absent: true
+    exists: false
+    reason: "Bodybuilder is a MAKE in bus kind (Plaxton/Caetano precedent): SCANIA+IRIZAR chassis/body strings must not form a Scania nameplate"
+  - id: irizar/16
+    kind: bus
+    skip_if_kind_absent: true
+    exists: false
+    reason: "Registry digit-typo 'IRIZAR 16' merges into irizar/i6 (renames); Irizar has no model 16"
+  - id: irizar/i6
+    kind: bus
+    skip_if_kind_absent: true
+    availability_includes: [es, nl]
+    reason: "Irizar flagship survives the 16->i6 merge and the scania/irizar drop with ES+NL evidence intact (ES rank 2, measured 2026-07)"
+  - id: unvi/microbus
+    kind: bus
+    skip_if_kind_absent: true
+    exists: false
+    reason: "Approval type-code 'MICROBUS_2' fallback string is not a nameplate (renames drop); UNVI's range is Compa/Urbis/Vega"
+  - id: iveco/sunrise
+    kind: bus
+    skip_if_kind_absent: true
+    exists: false
+    reason: "Coachbuilder-bodied minibuses live under the coachbuilder make (ferqui/sunrise)"
+  - id: ferqui/sunrise
+    kind: bus
+    skip_if_kind_absent: true
+    availability_includes: [es]
+    reason: "Ferqui Sunrise canonical survives the chassis-make drop"
+  - id: iveco/wing
+    kind: bus
+    skip_if_kind_absent: true
+    exists: false
+    reason: "Indcar Wing body on Iveco Daily chassis — lives under indcar/wing (renames drop; documented ua evidence loss)"
+  - id: indcar/wing
+    kind: bus
+    skip_if_kind_absent: true
+    availability_includes: [es]
+    reason: "Indcar Wing canonical survives the chassis-make drop"


### PR DESCRIPTION
Full canonicalization pass over every Spanish-origin make in the catalog — all 6 kinds, 192 model records audited record-by-record (coverage 192/192), plus two horizontal cross-make sweeps. Every fix flows through the curated input layer (`overrides/` + `spotchecks.yml`); `catalog/` and `dist/` are untouched, per AGENTS.md. **497 added lines, zero deletions of existing curation. `ruby scripts/lint_overrides.rb` green.**

---

## 1. Scope

**Vertical slices** (make × kind): SEAT + Cupra (car, van), Ebro (car), Santana (van), Derbi / Bultaco / Montesa / OSSA / Gas Gas / TRS / Sherco / Rieju / Silence / Velca / Nerva / Torrot / Stark / Ebroh / MITT (motorcycle), Derbi / Bultaco / Rieju / Sherco / Silence / Scutum / Motorhispania / Scoobic / Ebroh (moped), Irizar / Ayats / Beulas / Ferqui / Indcar / UNVI / Car-bus.net (bus), plus Spanish motorhome coachbuilders leaked into the car kind (Moncayo, PLA, Ilusion).

**Horizontal sweeps**: (a) ES model names hiding under wrong makes across the entire catalog (found `scania/irizar`, `iveco/sunrise`, `iveco/wing`); (b) make-level near-dupes + casing audit (found the SCUTUM/Silence and E-BROH/Ebroh unmerged rebrands, five casing pins).

Out-of-scope finds were **recorded but deliberately not fixed** to keep this PR reviewable — see §8.

## 2. Methodology (how these lines were produced and checked)

1. **Find** — 10 auditor agents, one per make-group/sweep, each with the full model records (availability, popularity, `xrefs.tan`), the repo's altitude rules, and web access for brand facts.
2. **Adversarial verify** — every finding re-derived by an independent skeptic agent instructed to refute: fact-check against primary sources, recompute data-loss from the catalog, validate YAML shape against each file's contract, and grep blast radius for every regex/styling token. Outcome over 194 findings: **178 confirmed, 15 revised** (comment corrections, mechanism swaps, one blast-radius catch), **1 refuted** (a proposed Velca fold — Tramontana and Tramontana S are genuinely separate models).
3. **Apply** — single writer, only confirmed/revised findings at high/medium confidence.
4. **Two independent critics on the final diff**:
   - *Completeness*: re-walked all 192 records against the diff — caught 3 missed respaces (`GPR125`, the Gas Gas `EC250…EC500F` family, Sherco `50SM`), all applied.
   - *Coherence*: simulated the changeset against all 18,133 catalog records — every rename key checked against every styling/acronym (old and new) for post-casing mismatches; **all 86 spotcheck rows pass in simulation, 0 failures**.

Every override line carries a same-line `#` comment with the why and a source URL or in-data proof, per house rules.

## 3. Evidence standards used

- **TAN overlap** (`xrefs.tan`): two records sharing an EU type-approval number are the same approved vehicle — the primary duplicate proof (e.g. `seat/cupra-leon` and `cupra/leon` share `e9*2007/46*3167*06/10/12/17`).
- **Availability subset**: a duplicate's countries must be covered by its canonical before a null-drop is called lossless; recomputed independently by verifiers. The three exceptions are documented (§6).
- **Registry-level measurement**: RDW open data (CC0) queried live for type-code claims (SDR/AB/CG/TG/TR1, "N/A" placeholder volumes, kampeerwagen classification of motorhome makes).
- **Primary brand sources** for naming/casing (montesa.com, gasgas.com, rieju.com, sherco.com, trsmotorcycles.com, mittmotors.com, silence.eco, starkfuture.com, irizar.com, unvi.es, ebroauto.com…).

## 4. Changes by category

### 4.1 SEAT / Cupra split (`models/renames.yml`, 21 SEAT + 2 Cupra entries)
- **Misparented post-2018 Cupras dropped from SEAT**: `Cupra Leon`, `Cupra Ateca`, `Formentor`, and brand-as-model `Cupra`. No cross-make move exists in the override vocabulary, so these are nulls + tripwires; the `cupra/*` canonicals carry every country the dropped rows had (TAN-proven same vehicles).
- **Pre-2018 Cupra trims folded**: `Leon Cupra` → Leon, `Ibiza Cupra` → Ibiza (trim era = nameplate-first word order).
- **Body/trim/generation variants folded**: `Leon Sc`/`Sportourer`/`X-Perience`/`Leon 1`, `Altea (4) Freetrack` — each proven by TANs inside the nameplate's own approval family.
- **KBA numeric type-codes dropped**: `468`–`474` (consecutive, single-source `de_kba_fz10`; `seat/468` held DE rank 33 and polluted popularity). Tesla `"512"` precedent.
- **`127 Sport` → `127`**: intentionally creates the missing classic nameplate (Cee'd precedent). Comment documents that no factory "SEAT 127 Sport" trim is attested — the fold is correct either way.
- **`Terra` → null**: van nameplate leaking into cars via camper/kombi rows (Evito precedent), with an explicit kind-blind caution in the comment.
- **Cupra UK strings folded**: `Tavascan V1 EV` → Tavascan, `Terramar Amrica Cp Ed` → Terramar (each adds `gb` to its nameplate — tripwired).

### 4.2 Two-wheelers (Derbi 25, Gas Gas 16, Sherco 14, Montesa 4, Rieju 6, Bultaco 1, TRS 2, Silence 2, MITT 1 entries)
Altitude rules applied throughout: **trims/editions fold; displacement stays separate** (Senda 50 ≠ Senda 125; Cota 4RT ≠ 4RT 260 ≠ 4RT 301RR).
- **Derbi Senda 50**: 13 trim/edition/registry-code records collapse into one created nameplate — three TAN families prove three approved types across the pile, including RDW type-codes `SDR` and `AB` resolved via live registry queries.
- **Gas Gas**: type-codes `Cg`/`Tg`/bare `Es` resolved to EC/TXT/ES 700; embedded-brand strings (`Gasgas ES700/SM700`) stripped; generic `Trial`/`Enduro` category strings dropped (unresolvable displacement mixtures); EC-number family respaced to official forms (`EC 250`, `EC 250F`, …) with the `Cg-EC300` merge retargeted to the respaced canonical.
- **Sherco**: seven `-R` Racing-trim folds; `300SE-F` disambiguated as the 2T Factory trim (293cc, TAN-proven), not the SEF 4T; `2ST` registry shorthand merged; make-as-model `Sherco` dropped; **~806 RDW "N/A" placeholder rows renamed to the honest `50` family instead of dropped** — they are ES's #3 moped and deletion would have destroyed real evidence; `50SM` respaced to the line convention.
- **Montesa**: digit-frozen `COTA*` tokens respaced to official forms.
- **Rieju**: registry-unspaced names respaced (`NKD 125`, `Aventura 500`, `Aventura Rally 307`, `Xplora 557/707` — consecutive TANs prove 557/707 are distinct models); `N.a.` placeholder dropped.
- **Bultaco**: `Brinco C` equipment trim folds, creating the Brinco nameplate.
- **TRS**: badge string `Trrs One` → One; homologation type-code `TR1 300` → One 300.
- **Silence**: `S01LS`/`S02LS` L1e speed variants fold into S01/S02 — kind already encodes the class.

### 4.3 Make merges and casing pins (`makes/aliases.yml`, 9 lines)
- `SCUTUM` → Silence (Scutum Logistic S.L. is Silence's legal entity; RDW still registers the lineup under SCUTUM).
- `E-BROH` → Ebroh (registry hyphenation of the one-word marque).
- `GAS-GAS` → Gas Gas (RDW raw variant; display canonical unchanged — repo decision).
- Identity pins for official casing: `MITT`, `TRS`, `OSSA`, `UNVI`, `EBRO`, `Car-bus.net`. These use the `makes/aliases.yml` identity mechanism (SEAT/BMW/INEOS precedent) rather than acronym tokens — deliberately, because token-level `TRS` would restyle Citroën `BX 16 TRS` trim rows (verified).

### 4.4 Kind hygiene (`makes/drop.yml`, 3 car-kind drops)
Moncayo, PLA, Ilusion — motorhome coachbuilders registered as M1 "cars" (100% of RDW rows are `inrichting=kampeerwagen`; BENIMAR/BUNKERVAN precedent). PLA turned out to be Italian (Giottiline group), found via the ES sweep but a car-kind pollutant regardless.

### 4.5 Bus bodybuilder convention (`models/renames.yml`: Irizar, Scania, UNVI, Iveco blocks)
In the bus kind the bodybuilder is the make (Plaxton/Caetano precedent): `scania/irizar`, `iveco/sunrise` (→ Ferqui), `iveco/wing` (→ Indcar) dropped as chassis+body registration strings; `irizar/16` digit-typo merged into i6; `unvi/microbus` approval-type-designation fallback dropped.

### 4.6 Styling (`styling.yml`: 15 whole-string pins, 5 acronym tokens)
Whole-string pins (`GPR`, `EC`, `TXT`, `TX`, `SM`, `2.5I/3.0I/4.5I`, `MR`, `E-TANGO`, `EXE`, `EXE II`, `I4/I6/I8`) chosen over acronym tokens wherever a token would re-case another record's rename key or trim string — each line's comment documents its verified blast radius. Acronym tokens only where the full catalog sweep confirmed every affected record wants caps: `MRT`, `MRX`, `RR` (all 12 affected records verified), `HEV`, `VARG`.

### 4.7 Published aliases (`models/aliases.yml` 14 models, `makes/search_aliases.yml` 7 lines)
Documented real-world names only: accented Spanish official forms (León, Córdoba, Málaga, Mulhacén — plus the Greek market name **Gredos**, because Málaga sounded like a Greek expletive), `600` spoken forms (Seiscientos, Seílla), Senda DRD, Cota 301RR short form, Sherco `-R` badge forms, S04 Nanocar, Santana PS-10's market name **Aníbal**; make-level: Montesa Honda, TRRS, GASGAS, Scutum, MH / Motor Hispania, Stark Future.

### 4.8 Body types (`body_types/body_types.yml`, 5 rows)
`SEAT|600: sedan` (was poisoned to suv by the make-unscoped "600" entry meant for Fiat's 600e revival — confirmed in-data), `SEAT|Exeo: sedan`, `EBRO|S400/S700/S800: suv` (2024 revival SUVs on Chery platforms, built in the ex-Nissan Barcelona plant; DGT-only rows default-typed hatchback).

### 4.9 Spotcheck tripwires (`spotchecks.yml`, 56 rows)
One row per invariant this PR establishes, in four flavors:
- **absence** rows for every dropped/folded id (a silent rename-key miss would resurrect them — renames fail silently by design, so these are the only guard);
- **presence + availability** rows proving each merge landed with its evidence union (e.g. `gas-gas/es-700` must show `fi,gb,nl,nz` = bare `ES` rows ∪ `GASGAS ES700` rows);
- **kind-blind tripwires** (e.g. `derbi/senda-125` must never materialize in the moped kind — renames are make-scoped but kind-blind);
- **convention invariants** (Irizar exists as a bus make, never as a chassis-make model).

## 5. Pipeline-order mechanics these lines encode (reviewer notes)

Three traps discovered and designed around during verification:
1. **The caser runs before renames**, so rename keys must match *post-cased* names. Adding `HEV` to acronyms would silently break a key `S400 Hev` — the Ebro block therefore keys **both** forms (`S400 Hev` + `S400 HEV`); inert keys are tolerated (existing `Karl / Viva` vs `Karl/viva` precedent).
2. **Acronym tokens re-case every record**, which can orphan rename keys: token `GPR` would restyle `Gpr NUDE50` → `GPR NUDE50` and un-fold it. Hence whole-string `stylings` pins for bare names.
3. **Renames are kind-blind.** Where a key could someday match in another kind (`Senda`, `Terra`), the comment says so and a spotcheck tripwires it.

## 6. Documented evidence losses (the only three)

| Dropped row | Countries lost | Why accepted |
|---|---|---|
| `scania/irizar` | `ua` | Century/PB-era Irizar bodies not yet catalogued under the irizar make; chassis-make string must not survive |
| `iveco/wing` | `ua` | `indcar/wing` canonical currently `es,fi,gb,nl` |
| `iveco/sunrise` | `nl` | `ferqui/sunrise` canonical currently `es,fi` |

Every other null/fold was verified lossless (canonical carries a superset, or the merge unions the evidence).

## 7. Deliberate keeps (audited, judged correct as-is)

`velca/tramontana` + `tramontana-s` (verifier refuted the fold — genuinely separate models), `nerva/exe-ii` (numbered two-wheeler generations stay separate: ktm/duke-ii, sym/fiddle-ii precedents; casing fixed via styling instead), Sherco's gb-only numeric records `250/300/450/500` (UK class strings, displacement-honest umbrellas), `velca/one` title-case (matches the repo's TRS "One" choice), `santana/ps10` unhyphenated (mixed usage in sources; Aníbal alias added), Gas Gas display name "Gas Gas" (repo decision, not re-litigated).

## 8. For the private pipeline / follow-up queue (not in this PR)

- **Raw-string confirmation**: new `makes/aliases.yml` keys are inferred from catalog display names except where RDW was measured — please confirm against real ingest raws.
- **Vocabulary gap**: there is no cross-make model move; the null+tripwire pattern works but loses row-level popularity for the dropped side. If transition-era misparents keep appearing (more brands will split), a `move:` mechanism may pay for itself.
- **Out-of-scope dupes found during the sweeps** (each one-line-verified, none touched): `zero` vs `zero-motorcycles`, `e-max` vs `emax`, `alpina` vs `bmw-alpina`, `mcc` vs Smart, `ktm` displayed "Ktm", `sea` (Italian motorhome group) in car kind, `renault-alpine` vs `alpine`, `vdl-bova` vs `bova`, `iveco-bus` vs `iveco`, corporate-string makes (`moto-s-p-a`, `go-tulip-b-v`, `mylane-b-v`), `N.a` placeholder models under askoll/jonway/segway/sym/vmoto (the askoll one is its only moped model — a kind-wide drop pattern would erase the make, which is why this PR fixed only its own two makes via make-scoped renames).
- **Pre-existing oddities** (not from this PR, found by the coherence check): the Mercedes-Benz `280 SE` rename key matches no post-cased form under old or new rules; the Citroën `2CV` published alias attaches to no current record (only `Az 2CV`/`Azu 2CV` exist); `gas-gas/ec300` carries a malformed TAN `e1*168/2013*00242-00` (dash instead of `*00`).

---

**Verification chain**: 10 finder agents → 10 adversarial verifiers (194 findings: 178 confirmed / 15 revised / 1 refuted) → single-writer apply → completeness critic (192/192 records re-walked, 3 gaps found and fixed) → coherence critic (full changeset simulation over 18,133 records; all 86 spotcheck rows pass). Lint green at every step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
