### PR TITLE
Reunite 17 Vespa nameplates my own moves had split

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1146,3 +1146,10 @@
 "motorcycle/piaggio/vespa-px200e":             "motorcycle/vespa/px200e"                      # moves.yml Piaggio|Vespa PX200E -> Vespa|PX200E  [nl,nz]
 "motorcycle/piaggio/vespa-sei-giorni":         "motorcycle/vespa/sei-giorni"                  # moves.yml Piaggio|Vespa Sei Giorni -> Vespa|Sei Giorni  [fi,nl]
 "motorcycle/piaggio/vespa-seigiorni":          "motorcycle/vespa/seigiorni"                   # moves.yml Piaggio|Vespa Seigiorni -> Vespa|Seigiorni  [es,lu,nl]
+
+# ---------------------------------------------------------------------------
+# RELEASE 2026-07-25 (f) — un-prefixed Vespa twins (see moves.yml).
+# Registers disagree on whether the badge appears: fi writes "VESPA ET4 150",
+# nl writes "ET4 150". Moving only the prefixed form split each nameplate into
+# two single-source candidates below the publication threshold.
+# ---------------------------------------------------------------------------

--- a/overrides/models/moves.yml
+++ b/overrides/models/moves.yml
@@ -121,3 +121,43 @@
 "Piaggio|Vespa Sprint 125ABS":     "Vespa|Sprint 125ABS"
 "SEAT|Cupra Leon": "Cupra|Leon"
 "SEAT|Cupra Ateca": "Cupra|Ateca"
+
+# ── S2W follow-up: the UN-PREFIXED twins of the 46 moves above ──────────────
+# Found by reading build/candidates/, which I should have done before landing
+# the first batch. Registers disagree on whether the badge appears at all:
+#
+#   fi_traficom  merk=Piaggio  handelsbenaming="VESPA ET4 150"   ← moved
+#   nl_rdw       merk=PIAGGIO  handelsbenaming="ET4 150"          ← did NOT move
+#
+# Moving only the prefixed spelling SPLIT each nameplate into two
+# single-source candidates, and neither then cleared the >=2-source
+# publication threshold — so records that used to publish vanished into the
+# candidate queue. 21 nameplates were affected; these 17 reunite them.
+#
+# SAFETY: every plate here is a genuine VESPA nameplate with no Piaggio-branded
+# namesake (Vespa Primavera/Sprint/PK/ET4/LX/GTS/GTV/PX/150 Super). Candidates
+# matching a real Piaggio line (Beverly, Liberty, Zip, Fly, Ciao, Runner,
+# Velofax, Typhoon, Ape …) were excluded by a filter, and bare "50" was
+# excluded BY HAND: Piaggio has its own 50cc lines, so 3 NL registrations are
+# not worth a mis-attribution.
+#
+# LESSON, recorded because it generalises: after any cross-make move, read the
+# candidate queue. A move that relocates one spelling of a nameplate can strand
+# the other below the threshold, and the build stays GREEN while it happens.
+"Piaggio|150 Super": "Vespa|150 Super"
+"Piaggio|50N": "Vespa|50N"
+"Piaggio|50R": "Vespa|50R"
+"Piaggio|C16": "Vespa|C16"
+"Piaggio|ET4 125": "Vespa|ET4 125"
+"Piaggio|ET4 150": "Vespa|ET4 150"
+"Piaggio|GTS250": "Vespa|GTS250"
+"Piaggio|GTV125": "Vespa|GTV125"
+"Piaggio|LX125": "Vespa|LX125"
+"Piaggio|PK50XL": "Vespa|PK50XL"
+"Piaggio|PX150": "Vespa|PX150"
+"Piaggio|Primavera": "Vespa|Primavera"
+"Piaggio|Primavera 125": "Vespa|Primavera 125"
+"Piaggio|Primavera 125ABS": "Vespa|Primavera 125ABS"
+"Piaggio|Primavera 50": "Vespa|Primavera 50"
+"Piaggio|S50": "Vespa|S50"
+"Piaggio|Sprint": "Vespa|Sprint"

--- a/spotchecks.yml
+++ b/spotchecks.yml
@@ -535,3 +535,11 @@ checks:
   - id: piaggio/vespa
     kind: motorcycle
     reason: "DELIBERATELY still under piaggio: the bare brand-as-model row is unresolvable to one Vespa model, exactly like PR #1's `SEAT: Cupra: null`. Kept so the decision stays visible; it is NOT an oversight in the 46-move block."
+  - id: vespa/et4-150
+    kind: motorcycle
+    availability_includes: [fi, nl]
+    reason: "REGRESSION GUARD: moving only the badge-prefixed spelling (fi 'VESPA ET4 150') split this nameplate from its un-prefixed twin (nl 'ET4 150'), leaving two single-source candidates below the >=2-source threshold — the record vanished while the build stayed GREEN. Both spellings must land here."
+  - id: vespa/pk50xl
+    kind: motorcycle
+    availability_includes: [gb, nl]
+    reason: "same split: gb wrote 'PIAGGIO PK50 XL' (25 regs) and nl 'PK50XL' (27) — reuniting them is what gets this published at all"


### PR DESCRIPTION
A defect in **my own work from an hour ago**, found by reading `build/candidates/` — which I should have done before landing the first 46 moves.

## What happened

Registers disagree on whether the badge appears in the model column at all:

```
fi_traficom  merk=Piaggio  handelsbenaming="VESPA ET4 150"   ← my move matched
nl_rdw       merk=PIAGGIO  handelsbenaming="ET4 150"          ← it did not
```

Moving only the badge-prefixed spelling **split each nameplate into two single-source candidates**, and neither then cleared the ≥2-source publication threshold. Records that previously published silently vanished into the candidate queue — **and the build stayed green throughout**, because nothing asserts that a move must not orphan its own twin.

## Recovered, evidence unioned

| id | now | note |
|---|---|---|
| `vespa/et4-150` | motorcycle[fi\|nl] | had vanished entirely |
| `vespa/pk50xl` | motorcycle[gb\|nl] moped[nl\|nz] | gb 25 regs + nl 27 |
| `vespa/150-super` | motorcycle[gb\|nl\|nz] | gb 50 regs |
| `vespa/lx125` | motorcycle[es\|fi\|nl\|ua] | gained ua |
| `vespa/primavera` | moped[es\|fi\|lu\|nl\|nz] | nz 11 regs |

## Safety

Every plate is a genuine Vespa nameplate with no Piaggio-branded namesake (Primavera, Sprint, PK, ET4, LX, GTS, GTV, PX, 150 Super). Candidates matching a real Piaggio line (Beverly, Liberty, Zip, Fly, Ciao, Runner, Velofax, Typhoon, Ape) were excluded by filter. Bare `"50"` was excluded **by hand** — Piaggio has its own 50cc lines, so 3 Dutch registrations aren't worth a mis-attribution.

No new `former_ids` are needed, and that's correct rather than an omission: the un-prefixed ids were *candidates*, never published, so rule 1 of the generator (only alias an id that actually shipped) excludes them.

+2 regression tripwires (126 rows). **ALL GATES GREEN.**

**Lesson worth generalising:** after any cross-make move, read the candidate queue. A move that relocates one spelling of a nameplate can strand the other below the threshold, and every gate stays green while it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQDfCFGiqdN5VL1Wz6fpmG