### PR TITLE
A3 hygiene: empty blocks, kind-scoped drops, fresh-build lint, verified 4W acronym pins

### DIFF
--- a/overrides/makes/aliases.yml
+++ b/overrides/makes/aliases.yml
@@ -108,7 +108,7 @@ XIAOMI: Xiaomi
 DONGFENG: Dongfeng
 MAXUS: Maxus
 AIWAYS: Aiways
-SERES: Seres
+SERES: SERES# their own English site writes SERES throughout (https://en.seres.cn/) — corrected 2026-07-25
 HONGQI: Hongqi
 GAC: GAC
 AION: Aion                           # GAC's EV brand appears standalone in TH DLT (e.g. "AION UT") — kept as its own make
@@ -181,7 +181,7 @@ DENNIS: Alexander Dennis             # UK legacy 'DENNIS' rows = the same builde
 "БОГДАН": Bogdan         # 622 — Ukrainian bus maker (A091/A092 city buses)
 "БАЗ": BAZ               # 376 — Boryspil bus plant (Bogdan group chassis)
 "МАЗ": MAZ               # 847 — Minsk Automobile Plant (buses reach the bus kind; freight is skipped)
-"КАМАЗ": KamAZ           # 1,355 — Kama trucks (mostly freight-skipped; buses exist)
+"КАМАЗ": KAMAZ           # the manufacturer's own English site writes KAMAZ, never "KamAZ" (https://kamaz.ru/en/) — corrected 2026-07-25 from an unverified pin
 "КРАЗ": KrAZ             # 415 — Kremenchuk trucks
 "ЗИЛ": ZIL               # 1,370 — Moscow plant (freight-skipped; the rare limousines are cars)
 "ЛУАЗ": LuAZ             # LuAZ 969 amphibious 4x4s — iconic UA marque, low volume but CIS-only
@@ -269,3 +269,24 @@ CAR-BUS.NET: Car-bus.net # brand's own casing (lowercase bus/net) — Indcar's i
 # --- S2W (2026-07-25) -------------------------------------------------------
 "JAWA-CZ": Jawa   # Jawa (Prague, 1929) and ČZ (Strakonice, 1919) were nationalised into ONE enterprise in 1949 and exported badged "JAWA-ČZ" through the 50s-60s, so this is a real joint-era badge rather than a typo. Merged rather than kept because the DUPLICATE-SPELLING test holds: jawa-cz's only model (356) ALSO exists under jawa (fi|nl vs fi|nl|nz) — an approval-holder artefact would show the parent carrying DIFFERENT models (cf. Piaggio carrying Vespa's). Evidence unions on jawa/356
 "JAWA CZ": Jawa   # spacing variant, same reasoning
+
+# ── acronym-make identity pins, four-wheel half (D23 / G20; research pass
+# 2026-07-25, every casing verified against the marque or an archival source —
+# NEVER add these as styling acronym tokens, they would re-case model strings
+# catalog-wide; an alias pin is scoped to the make name) ──────────────────────
+TVR: TVR                 # initialism (Trevor Wilkinson); "© TVR Electric Vehicles" (https://www.tvr.co.uk/)
+LDV: LDV                 # Leyland DAF Vans initialism; SAIC's official site (https://www.ldvautomotive.com.au/)
+DFSK: DFSK               # Dongfeng Sokon initialism (https://www.dfsk.com/)
+AMC: AMC                 # American Motors Corporation (https://www.amcrc.com/ — heritage source, marque defunct)
+JCB: JCB                 # J.C. Bamford initialism (https://www.jcb.com/en-gb/about)
+FAW: FAW                 # First Automobile Works (https://www.cnfaw.com/)
+JAC: JAC                 # JAC Group, all-caps (http://www.jac.com.cn/ — NOT jacmotors.com, an unrelated Spanish exhaust company)
+LEVC: LEVC               # London Electric Vehicle Company (https://www.levc.com/)
+FSO: FSO                 # Fabryka Samochodów Osobowych (company's own archived site, web.archive.org/web/20050208041112/http://www.fso-sa.pl/)
+CRRC: CRRC               # CRRC Corporation, all-caps throughout (https://www.crrcgc.cc/en/)
+# DELIBERATE NON-PINS, verified the other way (the expand-the-initials
+# heuristic gives the WRONG answer for these — do not "fix" them):
+#   Togg — a true initialism the company styles "Togg" (https://www.togg.com.tr/en)
+#   Iso  — title case in every authoritative usage (RM Sotheby's lot titles, Zagato's IsoRivolta revival); zero all-caps usage found
+"M.A.N.": MAN               # punctuated raw of the MAN truck marque (G18/G21 fold pass: truck/m-a-n sat beside truck/man); Maschinenfabrik Augsburg-Nürnberg
+"M A N": MAN                # spaced raw variant, same marque

--- a/overrides/makes/drop.yml
+++ b/overrides/makes/drop.yml
@@ -118,6 +118,20 @@ moped: []           # no drops yet; curation TBD when the kind ships
 motorcycle:
   - POLARIS         # ATV/side-by-side maker leaking into moto registries; revisit if quads become a kind
 
-van: []
-truck: []
+van:
+  # motorhome coachbuilders leaking into the van kind — same class as the car
+  # drops above; measured 2026-07-25 on a fresh build (G18: 11 records across 6
+  # makes were escaping the car-only scoping)
+  - HYMER           # 1 van record; motorhome builder (already dropped from car)
+  - AUTO-TRAIL      # 1 van record; UK motorhome builder (car drop spells it AUTOTRAIL — keep both raws)
+  - AUTOTRAIL       # spelling variant, same builder
+  - CHAUSSON        # 1 van record; motorhome builder (already dropped from car)
+truck:
+  # motorhome coachbuilders leaking into the truck kind (G18) — these are
+  # liner motorhomes on truck chassis registered N2/N3; the builders are not
+  # truck manufacturers
+  - NIESMANN+BISCHOFF   # 2 truck records
+  - NIESMANN BISCHOFF   # spelling variant
+  - HYMER               # 2 truck records
+  - MOBILVETTA          # 1 truck record
 bus: []

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -60,7 +60,6 @@ BMW:
 Bricklin:
   Sv-1: SV1                                   # spelling variant of "SV1" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
-Bsa:
 
 Btc:
   Btc: null                               # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
@@ -356,7 +355,6 @@ Hyundai:
   Santafe: Santa FE                           # spelling variant of "Santa FE" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   H-1: H1                                     # spelling variant of "H1" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
-I-Coco:
 
 Imperial:
   Lebaron: Le Baron                           # spelling variant of "Le Baron" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -377,7 +375,6 @@ Isuzu:
   Isuzu: null                                 # registry rows where the make was written into the model column (van kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   NLR85EXXXB: N-Series                    # NLR85 is a CHASSIS code, not a nameplate — Isuzu's light truck line is the N-Series (sold as Elf in Japan). The trailing EXXXB is a body/spec suffix. https://www.isuzu.co.jp/world/product/elf/
 
-Iva:
 
 Iveco:
   Sunrise: null          # Ferqui Sunrise minicoach body on Iveco Daily chassis, registered under the chassis make; canonical is ferqui/sunrise (https://ferqui.com/en/sunrisef2/). NOTE: loses nl evidence (ferqui/sunrise currently es,fi)
@@ -673,7 +670,6 @@ Maserati:
   Biturbo: Bi Turbo                           # spelling variant of "Bi Turbo" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Granturismo: Gran Turismo                   # spelling variant of "Gran Turismo" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
-Matchless:
 
 Maxus:
   Edeliver 9: E-Deliver 9                     # spelling variant of "E-Deliver 9" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1091,7 +1087,6 @@ Nissan:
 Norton:
   Norton: null                            # motorcycle nl|nz
 
-NSU:
 
 Oldsmobile:
   SUPER88: Super 88                           # spelling variant of "Super 88" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1528,7 +1523,6 @@ Willys:
   Cj 3B: CJ3B                                 # spelling variant of "CJ3B" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Cj-5: CJ5                                   # spelling variant of "CJ5" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
-Yamaha:
 
 Zundapp:
   Zundapp: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)

--- a/scripts/gen_ownership.rb
+++ b/scripts/gen_ownership.rb
@@ -11,6 +11,10 @@
 # boundary — see NEGOTIATION.md Turn 1/2).
 #
 # Run after any release that adds makes:  ruby scripts/gen_ownership.rb
+# (G19: every build can mint makes belonging to nobody — 17 orphans measured
+#  2026-07-25. Regenerating assigns them by the same dominant-kind rule; a
+#  NEW TIE aborts with instructions rather than guessing, because a silent
+#  tie-flip is how two sessions end up editing one make block.)
 # Review the diff — a make changing owner mid-cleanup needs both sides to ack.
 
 require "json"

--- a/scripts/lint_curation.rb
+++ b/scripts/lint_curation.rb
@@ -92,6 +92,19 @@ curation_files.each do |abs|
   end
 end
 
+# ── 1a2. no EMPTY make blocks ────────────────────────────────────────────────
+#
+# A make block with no entries (`Yamaha:` followed by nothing) parses as nil.
+# Harmless to the pipeline (nil block = no renames) but it crashes naive
+# iteration (`.values.map(&:size)`) — which it did, twice, in maintainer
+# tooling — and it reads as work someone forgot to finish. Six of them were
+# left behind by an ownership-boundary revert; delete the header when you
+# delete the last entry.
+%w[overrides/models/renames.yml overrides/models/aliases.yml].each do |rel|
+  doc = YAML.safe_load_file(File.join(ROOT, rel), permitted_classes: [], aliases: false) || {}
+  doc.each { |mk, v| fail! "#{rel}: make block #{mk.inspect} is EMPTY (parses as nil) — delete the header or add entries" if v.nil? }
+end
+
 # ── 1b. block style only: no inline flow mappings ────────────────────────────
 #
 # `Honda: { Honda: null }   # comment` is valid YAML and parses identically to a

--- a/scripts/lint_dataset.rb
+++ b/scripts/lint_dataset.rb
@@ -37,6 +37,12 @@ require "yaml"
 require "set"
 
 ROOT   = File.expand_path("..", __dir__)
+# G13: the lint's baseline and its subject must be the SAME build. catalog/
+# in the repo is the last RELEASE, which lags merged overrides by up to a
+# month — so "re-measure after the build" was a wait. VDB_CATALOG points the
+# audit at a fresh build/out (e.g. VDB_CATALOG=~/…/pipeline/build/out/catalog)
+# and turns it into a flag.
+CATALOG_DIR = ENV["VDB_CATALOG"] ? File.expand_path(ENV["VDB_CATALOG"]) : File.join(ROOT, "catalog")
 KINDS  = %w[car van motorcycle moped truck bus].freeze
 REPORT = ARGV.include?("--report")
 OWNER  = ARGV.find { |a| a.start_with?("--owner=") }&.split("=", 2)&.last
@@ -78,8 +84,8 @@ DETECTORS = {
 models = []
 makes  = {}
 KINDS.each do |kind|
-  mk_path = File.join(ROOT, "catalog", kind, "makes.json")
-  md_path = File.join(ROOT, "catalog", kind, "models.json")
+  mk_path = File.join(CATALOG_DIR, kind, "makes.json")
+  md_path = File.join(CATALOG_DIR, kind, "models.json")
   next unless File.exist?(md_path)
   JSON.parse(File.read(mk_path)).each { |m| makes[[kind, m["id"]]] = m["name"] }
   JSON.parse(File.read(md_path)).each { |m| models << m.merge("_kind" => kind) }


### PR DESCRIPTION
Four gap-register items in one hygiene pass: G12 (+lint), G18 (11 leaking records + the m-a-n/man fold), G13 (`VDB_CATALOG`), and the 4W half of G20 — every acronym-make casing verified per marque against manufacturer/archival sources by an Opus research pass, including two corrections to existing pins (KAMAZ, SERES) and two documented non-pins where the heuristic is wrong (Togg, Iso).

🤖 Generated with [Claude Code](https://claude.com/claude-code)