### PR TITLE
Fix red main: duplicate van drop entry + the rename block #16 orphaned

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1389,7 +1389,7 @@ TRS:
   Trrs One: One          # strip the embedded badge — bikes are badged TRRS but the make resolves to TRS, so the prefix strip missed (trsmotorcycles.com); CREATES the One canonical
   TR1 300: One 300       # TR1 = TRS's homologation type code (RDW type "TR 1 A", e9*168/2013*30008, 294cc), not a nameplate; road range is the One family
 
-Tvr:
+TVR:
   "350I": "350 I"                             # spelling variant of "350 I" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Unu:


### PR DESCRIPTION
**main has been failing since #16** ([run 30171890720](https://github.com/vehiclesdb/vehiclesdb/actions/runs/30171890720)). Two independent problems, both consequences of the same subtlety, neither visible to `lint_overrides` or `lint_curation`.

Both makes are S4W-owned. Touching them deliberately: main is red, and both fixes are **forced mechanical consequences of #16's own changes** — exactly one correct answer, no judgment. Happy to hand either back.

## 1. The red build — `AUTO-TRAIL` + `AUTOTRAIL` in van drops

```yaml
- AUTO-TRAIL      # 1 van record; UK motorhome builder (car drop spells it AUTOTRAIL — keep both raws)
- AUTOTRAIL       # spelling variant, same builder
```

They are not two raws. `make_dropped?` matches on the **transliteration fold** — NFKD, strip combining marks, `oe`/`ue`/`ae`/`ss` digraphs, then remove every non-alphanumeric. Both strings reduce to `autotrail`, so the second line is a duplicate rather than a second spelling.

`test_drop_entries_do_not_silently_duplicate` has enforced this since the fold landed. Worth keeping loud precisely because the mistake it catches is the belief that drop matching is **exact-string** — the same belief that predicts the *other* spelling escaping, which is the bug the fold was written to fix (80 records escaped a requested drop that way: `BÜRSTNER` never matched `buerstner`).

Collapsed to one entry, with the reasoning inline so it does not come back.

## 2. Dead curation — `TVR: TVR` orphaned the `Tvr:` rename block

#16's pin is **correct** (Trevor Wilkinson's initials, verified against tvr.co.uk). But it changed the resolved display name, and `model_renames` is keyed on the display name, so the existing `Tvr:` block went inert in the same commit and `"350I": "350 I"` silently stopped merging.

This does **not** break main's CI today — the test that catches it lives in [pipeline#8](https://github.com/vehiclesdb/vehiclesdb-pipeline/pull/8), unmerged — but it is dead data now.

It is the **second instance in one day** of the same shape: the first orphaned an `Emax:` block under the E-Max merge in #13. Neither lint sees it, because `lint_curation` compares block names against `catalog/`, which is the **last release** — so during the very release that renames a make, the correct block name looks like a typo and the stale one looks right.

**The procedure this implies, for the rest of the acronym work in both halves:** a make display-name change is a two-file edit. Before landing a pin, grep `renames.yml`, `models/aliases.yml`, `moves.yml` and `body_types.yml` for the OLD titlecase name. Doing that for the 18 two-wheel pins in #13 found two live blocks (`Sym:`, `Btc:`).

## Also

Collapses six double blank lines where both maintainers independently deleted the same empty G12 blocks — #13 and #16 crossed in flight. Purely cosmetic; `reorg_make_blocks --check` is green again and the YAML is verified semantically identical.

## Gates

`lint_overrides` OK · `lint_curation` OK (16 files) · `reorg_make_blocks --check` OK · pipeline tests green against this tree (including the two that were failing).