### PR TITLE
Acronym makes round 2: IFA, AWO, and the three-way KSR fork

### DIFF
--- a/overrides/makes/aliases.yml
+++ b/overrides/makes/aliases.yml
@@ -218,7 +218,7 @@ DENNIS: Alexander Dennis             # UK legacy 'DENNIS' rows = the same builde
 "IVECO MAGIRUS": Iveco   # Iveco Magirus AG is Iveco's German plant/subsidiary; 'Iveco-Magiru
 "KG MOBILITY": KGM   # KG Mobility is the corporate name of the rebranded SsangYong; 'KGM
 "KNAUS TABBERT AG": Knaus Tabbert   # Corporate-entity suffix variant of 'Knaus Tabbert', which exists i
-"KSR MOTO AUSTRIA": Ksr Moto   # KSR Moto is the Austrian KSR Group's brand; 'Ksr Moto Austria' is
+"KSR MOTO AUSTRIA": KSR Moto   # KSR Moto is the Austrian KSR Group's brand; 'Ksr Moto Austria' is
 "KYBURZ SWITZERLAND AG": Kyburz Switzerland   # Identical Swiss electric three-wheeler maker (KYBURZ Switzerland A
 "LADA-VAZ": Lada   # VAZ (Volzhsky Avtomobilny Zavod / AvtoVAZ) is the factory name for
 "LUCID MOTORS": Lucid   # Same marque as 'Lucid' (Lucid Group, Air/Gravity maker); 'Lucid Mo
@@ -339,3 +339,30 @@ DKW: DKW      # Dampf-Kraft-Wagen, founded 1916 by Jørgen Skafte Rasmussen; mer
 LML: LML      # Lohia Machinery Limited, Kanpur — Piaggio technical partner from 1984, equal-equity partner 1990, insolvent 2017. All-caps
 FN: FN        # Fabrique Nationale de Herstal, Belgium — arms from 1889, motorcycles 1901-1967; built one of the first four-cylinder motorcycles. All-caps
 EBR: EBR      # Erik Buell Racing, East Troy, Wisconsin — all-caps on its own site (https://erikbuellracing.jp/contents/about_ebr/index.php)
+
+# --- S2W acronym-make casing, round 2 (2026-07-25) ---------------------------
+# Applying the three the cross-session research pass resolved that my own
+# shortlist had missed or left open (S4W Turn 45). IFA and AWO both carry TWO
+# vowels, which is exactly the blind spot my detector documented: it filters on
+# ≤1 vowel for precision and therefore under-reports initialisms like these.
+# Independent confirmation from a second research pass is how they surfaced —
+# worth noting as evidence for the two-passes-by-different-agents rule.
+IFA: IFA         # Industrieverband Fahrzeugbau, the GDR's vehicle-industry combine; the AWO 425 moved to "the Awtowelo and later IFA facilities in Suhl" (https://en.wikipedia.org/wiki/Simson_(company) as locator; DDR-era usage is uniformly all-caps). Initialism, never "Ifa"
+AWO: AWO         # Awtowelo — the Soviet joint-stock company that took over the Suhl works post-1945; the marque is the AWO 425 (four-stroke, 250cc: the "4" and "25" of the type number), >209,000 built 1949-62, catalogued as "AWO-425 S" by the Technikmuseum Magdeburg (https://st.museum-digital.de/object/1547). Became VEB Simson Suhl — so {AWO, Simson, IFA} is a co-batch cluster
+# KSR: the raw string forks THREE ways and only one spelling was pinned, so the
+# other two fell through to smart_case. "KSR MOTO" happened to title-case to the
+# same string by luck; "KSRMOTO" did not and was heading for its own make id.
+# Display follows the MV Agusta precedent above — an initialism plus a word gets
+# the initialism upper and the word title ("MV Agusta", not "MV AGUSTA"), even
+# though ksr-moto.com styles the lockup "KSR MOTO" (https://www.ksr-moto.com/).
+# KSR Group (Austria) also distributes Brixton, Malaguti, Benelli and Royal
+# Enfield (https://ksr-group.com/news/moto-austria/) — those are SEPARATE
+# marques with their own approvals and must NOT fold into KSR Moto.
+"KSR MOTO": KSR Moto    # 19 raw rows — the commonest spelling, previously unpinned
+KSRMOTO: KSR Moto       # 2 raw rows — would have forked to its own make id "Ksrmoto"
+# DELIBERATELY NOT PINNED, both agreed with the research pass:
+#   Iva — RDW uppercases every make string, so we have an existence proof and
+#     nothing more. Could be the initialism IVA or a marque spelled Iva. Left as
+#     "Iva" and marked unverified rather than guessed; see the moped/iva pilot
+#     batch, which is where this gets settled with the rest of that make.
+#   Evt — distributor-only evidence, no manufacturer source found.

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1062,7 +1062,7 @@
 "motorcycle/voge/300rally":                    "motorcycle/voge/300-rally"                    # 300RALLY -> 300 Rally  [es,fi,gb,nl,ua]
 "motorcycle/yamaha/600radian":                 "motorcycle/yamaha/600-radian"                 # 600RADIAN -> 600 Radian  [nl,nz]
 "motorcycle/yamaha/bt1100bulldog":             "motorcycle/yamaha/bt1100-bulldog"             # BT1100BULLDOG -> BT1100 Bulldog  [fi,nl]
-"motorcycle/yamaha/drag-star1100":             "motorcycle/yamaha/drag-star-1100"             # Drag STAR1100 -> Drag Star 1100  [nl,ua]
+"motorcycle/yamaha/drag-star1100":             "motorcycle/yamaha/dragstar-1100"             # Drag STAR1100 -> Drag Star 1100  [nl,ua] [re-chained]
 "motorcycle/yamaha/fazer8abs":                 "motorcycle/yamaha/fazer-8abs"                 # FAZER8ABS -> Fazer 8ABS  [nl,ua]
 "motorcycle/yamaha/fino125":                   "motorcycle/yamaha/fino-125"                   # FINO125 -> Fino 125  [th]
 "motorcycle/yamaha/fz1fazer":                  "motorcycle/yamaha/fz1-fazer"                  # FZ1FAZER -> FZ1 Fazer  [nl,ua]
@@ -1073,7 +1073,7 @@
 "motorcycle/yamaha/majesty400":                "motorcycle/yamaha/majesty-400"                # MAJESTY400 -> Majesty 400  [fi,nl,ua]
 "motorcycle/yamaha/maxim650":                  "motorcycle/yamaha/maxim-650"                  # MAXIM650 -> Maxim 650  [nl,nz]
 "motorcycle/yamaha/mt-07tracer":               "motorcycle/yamaha/mt-07-tracer"               # Mt-07TRACER -> Mt-07 Tracer  [fi,nl]
-"motorcycle/yamaha/neos100":                   "motorcycle/yamaha/neos-100"                   # NEOS100 -> Neos 100  [nl,nz]
+"motorcycle/yamaha/neos100":                   "motorcycle/yamaha/neo-s-100"                   # NEOS100 -> Neos 100  [nl,nz] [re-chained]
 "motorcycle/yamaha/nmax150":                   "motorcycle/yamaha/nmax-150"                   # NMAX150 -> Nmax 150  [nl,ua]
 "motorcycle/yamaha/serow250":                  "motorcycle/yamaha/serow-250"                  # SEROW250 -> Serow 250  [nl,ua]
 "motorcycle/yamaha/tenere700":                 "motorcycle/yamaha/tenere-700"                 # TENERE700 -> Tenere 700  [nl,nz,th,ua]
@@ -1961,10 +1961,10 @@
 "motorcycle/vespa/sprint": "moped/vespa/sprint"
 "motorcycle/yamaha/mt-09tracer": "motorcycle/yamaha/mt-09-tracer"
 "motorcycle/yamaha/mt09tracer": "motorcycle/yamaha/mt-09-tracer"
-"motorcycle/yamaha/xvs1100drag-star": "motorcycle/yamaha/xvs1100-drag-star"
-"motorcycle/yamaha/xvs1100dragstar": "motorcycle/yamaha/xvs1100-drag-star"
-"motorcycle/yamaha/xvs650drag-star": "motorcycle/yamaha/xvs650-drag-star"
-"motorcycle/yamaha/xvs650dragstar": "motorcycle/yamaha/xvs650-drag-star"
+"motorcycle/yamaha/xvs1100drag-star": "motorcycle/yamaha/xvs1100-dragstar" # RE-CHAINED: pointed at motorcycle/yamaha/xvs1100-drag-star, which this batch relocates
+"motorcycle/yamaha/xvs1100dragstar": "motorcycle/yamaha/xvs1100-dragstar" # RE-CHAINED: pointed at motorcycle/yamaha/xvs1100-drag-star, which this batch relocates
+"motorcycle/yamaha/xvs650drag-star": "motorcycle/yamaha/xvs650-dragstar" # RE-CHAINED: pointed at motorcycle/yamaha/xvs650-drag-star, which this batch relocates
+"motorcycle/yamaha/xvs650dragstar": "motorcycle/yamaha/xvs650-dragstar" # RE-CHAINED: pointed at motorcycle/yamaha/xvs650-drag-star, which this batch relocates
 "truck/chevrolet/pickup": "truck/chevrolet/pick-up"
 "truck/ford/v-8": "truck/ford/v8"
 "truck/hummer/hummer": "truck/hummer/h1"
@@ -2195,3 +2195,66 @@
 "motorcycle/harley-davidson/vrsca-vrod": "motorcycle/harley-davidson/vrsca-v-rod" # "Vrsca Vrod" -> "VRSCA V-Rod"
 "motorcycle/harley-davidson/w-l-c": "motorcycle/harley-davidson/wlc" # "W L C" -> "WLC"
 "motorcycle/harley-davidson/wideglide": "motorcycle/harley-davidson/wide-glide" # "Wideglide" -> "Wide Glide"
+
+# --- 2026-07-25, S2W: Yamaha convention batch (B5 batch 2) ------------------
+# See the dossier comment on the Yamaha block in renames.yml for the four
+# rules and their sources. The other 23 renames in this batch are
+# display-only (same slug) and deliberately have NO entry here.
+"motorcycle/yamaha/drag-star": "motorcycle/yamaha/dragstar" # "Drag Star" -> "DragStar"
+"motorcycle/yamaha/drag-star-1100": "motorcycle/yamaha/dragstar-1100" # "Drag Star 1100" -> "DragStar 1100"
+"motorcycle/yamaha/drag-star-classic": "motorcycle/yamaha/dragstar-classic" # "Drag Star Classic" -> "DragStar Classic"
+"motorcycle/yamaha/fz1n": "motorcycle/yamaha/fz1-n" # "FZ1N" -> "FZ1-N"
+"motorcycle/yamaha/fz1s": "motorcycle/yamaha/fz1-s" # "FZ1S" -> "FZ1-S"
+"motorcycle/yamaha/fz1sa": "motorcycle/yamaha/fz1-sa" # "FZ1SA" -> "FZ1-SA"
+"motorcycle/yamaha/fz6s": "motorcycle/yamaha/fz6-s" # "FZ6S" -> "FZ6-S"
+"motorcycle/yamaha/fs-1": "motorcycle/yamaha/fs1" # "Fs-1" -> "FS1"
+"motorcycle/yamaha/fzs-1000": "motorcycle/yamaha/fzs1000" # "Fzs-1000" -> "FZS1000"
+"motorcycle/yamaha/mt01": "motorcycle/yamaha/mt-01" # "MT01" -> "MT-01"
+"motorcycle/yamaha/mt03": "motorcycle/yamaha/mt-03" # "MT03" -> "MT-03"
+"motorcycle/yamaha/mt07": "motorcycle/yamaha/mt-07" # "MT07" -> "MT-07"
+"motorcycle/yamaha/mt09": "motorcycle/yamaha/mt-09" # "MT09" -> "MT-09"
+"motorcycle/yamaha/mt09-tracer": "motorcycle/yamaha/mt-09-tracer" # "MT09 Tracer" -> "MT-09 Tracer"
+"motorcycle/yamaha/mt09a": "motorcycle/yamaha/mt-09a" # "MT09A" -> "MT-09A"
+"motorcycle/yamaha/mt09sp": "motorcycle/yamaha/mt-09sp" # "MT09SP" -> "MT-09SP"
+"motorcycle/yamaha/mt125": "motorcycle/yamaha/mt-125" # "MT125" -> "MT-125"
+"motorcycle/yamaha/neos": "motorcycle/yamaha/neo-s" # "Neos" -> "Neo's"
+"motorcycle/yamaha/neos-100": "motorcycle/yamaha/neo-s-100" # "Neos 100" -> "Neo's 100"
+"motorcycle/yamaha/roadstar": "motorcycle/yamaha/road-star" # "Roadstar" -> "Road Star"
+# ACCEPTED LOSS (ua). The successor does not carry Ukraine, so the strict
+# superset rule (rule 4) would reject this alias. Recording the exception
+# rather than dropping the alias, because a consumer holding t-max500 still
+# deserves to be pointed at tmax-500.
+#
+# VERIFIED: Ukraine's Yamaha TMAX evidence has NOT left the dataset —
+# yamaha/tmax carries ua (gb,nl,nz,ua) and yamaha/xp500-tmax carries ua
+# (fi,nl,ua). What changed is WHICH TMAX record the single Ukrainian row lands
+# on, because the spelling normalisation moved: UA writes "T MAX", "T-MAX",
+# "TMAX", "T MAX 500", "TMAX 500" and "T-MAX 530" as one row each, and those
+# now fold differently than they did.
+#
+# NOT VERIFIED: which specific UA row moved where. ua_mvs is a deduped ~710k
+# vehicle register delivered as a 35 MB zip and every TMAX spelling in it is a
+# single row, so isolating one is disproportionate to a one-country flag on one
+# record. Left as a stated unknown rather than a guess.
+"motorcycle/yamaha/t-max500":
+  to: "motorcycle/yamaha/tmax-500"
+  accepted_loss: [ua]
+"motorcycle/yamaha/t-max": "motorcycle/yamaha/tmax" # "T Max" -> "TMAX"
+"motorcycle/yamaha/tzr-250": "motorcycle/yamaha/tzr250" # "Tzr-250" -> "TZR250"
+"motorcycle/yamaha/v-max1200": "motorcycle/yamaha/vmax-1200" # "V-MAX1200" -> "VMAX 1200"
+"motorcycle/yamaha/v-max": "motorcycle/yamaha/vmax" # "V-Max" -> "VMAX"
+"motorcycle/yamaha/x-max125": "motorcycle/yamaha/xmax-125" # "X-MAX125" -> "XMAX 125"
+"motorcycle/yamaha/x-max300": "motorcycle/yamaha/xmax-300" # "X-MAX300" -> "XMAX 300"
+"motorcycle/yamaha/x-max400": "motorcycle/yamaha/xmax-400" # "X-MAX400" -> "XMAX 400"
+"motorcycle/yamaha/xvs1100-drag-star": "motorcycle/yamaha/xvs1100-dragstar" # "XVS1100 Drag Star" -> "XVS1100 DragStar"
+"motorcycle/yamaha/xvs1100-a": "motorcycle/yamaha/xvs1100a" # "XVS1100/A" -> "XVS1100A"
+"motorcycle/yamaha/xvs650-drag-star": "motorcycle/yamaha/xvs650-dragstar" # "XVS650 Drag Star" -> "XVS650 DragStar"
+"motorcycle/yamaha/xvs650a-drag-star": "motorcycle/yamaha/xvs650a-dragstar" # "XVS650A Drag Star" -> "XVS650A DragStar"
+"motorcycle/yamaha/yl-1": "motorcycle/yamaha/yl1" # "Yl-1" -> "YL1"
+"motorcycle/yamaha/yzfr-1": "motorcycle/yamaha/yzf-r1" # "Yzfr 1" -> "YZF-R1"
+# MOPED-kind counterparts. Yamaha publishes FS1 and Neo's in BOTH kinds, and
+# renames are make-scoped but KIND-BLIND, so the batch above moved the moped ids
+# too — but the generator hardcoded "motorcycle/" into every key. Caught by the
+# no-vanish check, not by any lint.
+"moped/yamaha/fs-1": "moped/yamaha/fs1"        # "Fs-1" -> "FS1", moped kind
+"moped/yamaha/neos": "moped/yamaha/neo-s"      # "Neos" -> "Neo's", moped kind

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2150,3 +2150,48 @@
 "car/jaecoo/jaecoo5-hev": "car/jaecoo/jaecoo-5"   # es ⊂ de,es,gb,nl,th
 "car/omoda/omoda5-hev":   "car/omoda/omoda-5"     # es ⊂ de,es,gb,lu,nl,nz,th
 "car/lynk-co/lynk-co-01": "car/lynk-co/01"        # es,nl ⊂ de,es,fi,nl,ua
+
+# --- 2026-07-25, S2W: Harley-Davidson convention batch (B5 batch 1) ---------
+# All 35 are the G11 MERGE class: the target id already exists, so evidence
+# unions and nothing can vanish. Resolved against H-D's own model-code page
+# and model pages — see the dossier comment on the Harley-Davidson block in
+# renames.yml for the two rules and why the detector's proposal was wrong on
+# 24 of 34 groups.
+# The other 20 renames in that batch are display-only (same slug) and
+# deliberately have NO entry here: rule 1 forbids aliasing a live id.
+"motorcycle/harley-davidson/dyna-lowrider": "motorcycle/harley-davidson/dyna-low-rider" # "Dyna Lowrider" -> "Dyna Low Rider"
+"motorcycle/harley-davidson/dyna-wideglide": "motorcycle/harley-davidson/dyna-wide-glide" # "Dyna Wideglide" -> "Dyna Wide Glide"
+"motorcycle/harley-davidson/electraglide": "motorcycle/harley-davidson/electra-glide" # "Electraglide" -> "Electra Glide"
+"motorcycle/harley-davidson/f-x-r-s": "motorcycle/harley-davidson/fxrs" # "F X R S" -> "FXRS"
+"motorcycle/harley-davidson/fl-htc": "motorcycle/harley-davidson/flhtc" # "FL Htc" -> "FLHTC"
+"motorcycle/harley-davidson/fatboy": "motorcycle/harley-davidson/fat-boy" # "Fatboy" -> "Fat Boy"
+"motorcycle/harley-davidson/flh-electraglide": "motorcycle/harley-davidson/flh-electra-glide" # "Flh Electraglide" -> "FLH Electra Glide"
+"motorcycle/harley-davidson/flh-1200": "motorcycle/harley-davidson/flh1200" # "Flh-1200" -> "FLH1200"
+"motorcycle/harley-davidson/flhrc-roadking": "motorcycle/harley-davidson/flhrc-road-king" # "Flhrc Roadking" -> "FLHRC Road King"
+"motorcycle/harley-davidson/flhri-roadking": "motorcycle/harley-davidson/flhri-road-king" # "Flhri Roadking" -> "FLHRI Road King"
+"motorcycle/harley-davidson/flhtc-i": "motorcycle/harley-davidson/flhtci" # "Flhtc-I" -> "FLHTCI"
+"motorcycle/harley-davidson/flhtcu-i": "motorcycle/harley-davidson/flhtcui" # "Flhtcu-I" -> "FLHTCUI"
+"motorcycle/harley-davidson/flst-f": "motorcycle/harley-davidson/flstf" # "Flst-F" -> "FLSTF"
+"motorcycle/harley-davidson/flstf-fatboy": "motorcycle/harley-davidson/flstf-fat-boy" # "Flstf Fatboy" -> "FLSTF Fat Boy"
+"motorcycle/harley-davidson/flstn-softail-de-luxe": "motorcycle/harley-davidson/flstn-softail-deluxe" # "Flstn Softail De Luxe" -> "FLSTN Softail Deluxe"
+"motorcycle/harley-davidson/fx-st": "motorcycle/harley-davidson/fxst" # "Fx St" -> "FXST"
+"motorcycle/harley-davidson/fx-stc": "motorcycle/harley-davidson/fxstc" # "Fx Stc" -> "FXSTC"
+"motorcycle/harley-davidson/fxst-c": "motorcycle/harley-davidson/fxstc" # third spelling "Fxst-C" of the same code
+"motorcycle/harley-davidson/fxd-i-dyna-super-glide": "motorcycle/harley-davidson/fxdi-dyna-super-glide" # "Fxd/i Dyna Super Glide" -> "FXDI Dyna Super Glide"
+"motorcycle/harley-davidson/fxe-f": "motorcycle/harley-davidson/fxef" # "Fxe F" -> "FXEF"
+"motorcycle/harley-davidson/fxe-1200": "motorcycle/harley-davidson/fxe1200" # "Fxe-1200" -> "FXE1200"
+"motorcycle/harley-davidson/fxr-superglide": "motorcycle/harley-davidson/fxr-super-glide" # "Fxr Superglide" -> "FXR Super Glide"
+"motorcycle/harley-davidson/fxr-s": "motorcycle/harley-davidson/fxrs" # "Fxr-S" -> "FXRS"
+"motorcycle/harley-davidson/fxrs-lowrider": "motorcycle/harley-davidson/fxrs-low-rider" # "Fxrs Lowrider" -> "FXRS Low Rider"
+"motorcycle/harley-davidson/fxs-lowrider": "motorcycle/harley-davidson/fxs-low-rider" # "Fxs Lowrider" -> "FXS Low Rider"
+"motorcycle/harley-davidson/fxst-s": "motorcycle/harley-davidson/fxsts" # "Fxst-S" -> "FXSTS"
+"motorcycle/harley-davidson/lowrider": "motorcycle/harley-davidson/low-rider" # "Lowrider" -> "Low Rider"
+"motorcycle/harley-davidson/pan-head": "motorcycle/harley-davidson/panhead" # "Pan Head" -> "Panhead"
+"motorcycle/harley-davidson/shovel-head": "motorcycle/harley-davidson/shovelhead" # "Shovel Head" -> "Shovelhead"
+"motorcycle/harley-davidson/softail-fatboy": "motorcycle/harley-davidson/softail-fat-boy" # "Softail Fatboy" -> "Softail Fat Boy"
+"motorcycle/harley-davidson/sport-ster": "motorcycle/harley-davidson/sportster" # "Sport Ster" -> "Sportster"
+"motorcycle/harley-davidson/superglide": "motorcycle/harley-davidson/super-glide" # "Superglide" -> "Super Glide"
+"motorcycle/harley-davidson/vrod": "motorcycle/harley-davidson/v-rod" # "Vrod" -> "V-Rod"
+"motorcycle/harley-davidson/vrsca-vrod": "motorcycle/harley-davidson/vrsca-v-rod" # "Vrsca Vrod" -> "VRSCA V-Rod"
+"motorcycle/harley-davidson/w-l-c": "motorcycle/harley-davidson/wlc" # "W L C" -> "WLC"
+"motorcycle/harley-davidson/wideglide": "motorcycle/harley-davidson/wide-glide" # "Wideglide" -> "Wide Glide"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1671,6 +1671,103 @@ Zero Motorcycles:
   # plural-insensitive prefix match is not obviously safe across 849 makes).
   Motorcycle Xb: Xb    # raw handelsbenaming "ZERO MOTORCYCLE XB" (2 rows); merges into the existing moped/zero-motorcycles/xb
   Motorcycle Xe: Xe    # raw handelsbenaming "ZERO MOTORCYCLE XE" (1 row); merges into the existing motorcycle/zero-motorcycles/xe
+Yamaha:
+  # YAMAHA CONVENTION DOSSIER (§11.2). FOUR rules, and they contradict each
+  # other — which is exactly why nothing mechanical can resolve this make and
+  # why the detector's canonical() column is unusable here:
+  #
+  #  1. MT series — HYPHENATED, uppercase, leading zero kept: MT-03, MT-07,
+  #     MT-09, MT-125.
+  #     https://www.yamaha-motor.eu/gb/en/motorcycles/hyper-naked/pdp/mt-07-2025/
+  #  2. MAX series — ALL-CAPS and CLOSED, no hyphen, no space: TMAX, XMAX,
+  #     NMAX. Yamaha's own MAX-series page:
+  #     https://global.yamaha-motor.com/business/mc/lineup/max/
+  #     Displacement is appended with a SPACE ("TMAX 500", "XMAX 300").
+  #     So MT-07 hyphenates and XMAX does not: both are correct.
+  #  3. Type codes — CLOSED uppercase (FZS1000, TZR250, YL1, FS1), EXCEPT when
+  #     the suffix is a VARIANT marker, which Yamaha hyphenates: FZ1-N (naked),
+  #     FZ1-S (Fazer, semi-faired), FZ1-SA (ABS), FZ6-S. First-generation
+  #     Europe was FZS1000 Fazer, closed.
+  #     https://global.yamaha-motor.com/news/2005/0929/fz1.html
+  #  4. Model NAMES follow Yamaha's own spelling, which is NOT uniform.
+  #     "DragStar" is camelCase — Yamaha Communication Plaza, "1999 XVS1100
+  #     DragStar" (https://global.yamaha-motor.com/showroom/cp/collection/xvs1100dragstar/)
+  #     while "Road Star" is TWO words — "1999 XV1600 Road Star"
+  #     (https://global.yamaha-motor.com/showroom/cp/collection/xv1600roadstar/).
+  #     Same company, same era, same product category, opposite conventions.
+  #     "Neo's" carries the apostrophe.
+  #
+  # THE CONVENTION CHANGE, recorded rather than flattened: the 1985 model was
+  # the V-Max and Yamaha RENAMED it VMAX for the 2009 relaunch, so BOTH
+  # spellings are historically correct for their own era. Merged to VMAX (the
+  # marque's current form) because a model record is a NAMEPLATE covering its
+  # generations, and the schema has no year fields yet to carry the split
+  # (G16). If year_start/year_end ever land, this is the first candidate to
+  # split back apart — do not treat the merge as settling the history.
+  #
+  # 23 of the lines below are DISPLAY-ONLY (same slug, e.g. Mt-07 -> MT-07):
+  # they change `name`, not `id`, and correctly carry no former_ids entry.
+  Drag Star:                 DragStar               # DragStar is camelCase in Yamaha's own usage (Communication Plaza)
+  Drag Star 1100:            DragStar 1100          # DragStar is camelCase in Yamaha's own usage (Communication Plaza)
+  Drag Star Classic:         DragStar Classic       # DragStar is camelCase in Yamaha's own usage (Communication Plaza)
+  Dragstar:                  DragStar               # DragStar is camelCase in Yamaha's own usage (Communication Plaza) (display-only)
+  FZ1-Sa:                    FZ1-SA                 # hyphenated VARIANT suffix (N=naked, S=Fazer semi-faired, A=ABS) (display-only)
+  FZ1N:                      FZ1-N                  # hyphenated VARIANT suffix (N=naked, S=Fazer semi-faired, A=ABS)
+  FZ1S:                      FZ1-S                  # hyphenated VARIANT suffix (N=naked, S=Fazer semi-faired, A=ABS)
+  FZ1SA:                     FZ1-SA                 # hyphenated VARIANT suffix (N=naked, S=Fazer semi-faired, A=ABS)
+  FZ6S:                      FZ6-S                  # hyphenated VARIANT suffix (N=naked, S=Fazer semi-faired, A=ABS)
+  Fs-1:                      FS1                    # type code — closed uppercase
+  Fzs-1000:                  FZS1000                # type code — closed uppercase
+  MT01:                      MT-01                  # MT series — hyphenated (yamaha-motor.eu)
+  MT03:                      MT-03                  # MT series — hyphenated (yamaha-motor.eu)
+  MT07:                      MT-07                  # MT series — hyphenated (yamaha-motor.eu)
+  MT09:                      MT-09                  # MT series — hyphenated (yamaha-motor.eu)
+  MT09 Tracer:               MT-09 Tracer           # MT series — hyphenated (yamaha-motor.eu)
+  MT09A:                     MT-09A                 # MT series — hyphenated (yamaha-motor.eu)
+  MT09SP:                    MT-09SP                # MT series — hyphenated (yamaha-motor.eu)
+  MT125:                     MT-125                 # MT series — hyphenated (yamaha-motor.eu)
+  "Mt  09SP":                MT-09SP                # MT series — hyphenated (yamaha-motor.eu) (display-only)
+  Mt-01:                     MT-01                  # MT series — hyphenated (yamaha-motor.eu) (display-only)
+  Mt-03:                     MT-03                  # MT series — hyphenated (yamaha-motor.eu) (display-only)
+  Mt-07:                     MT-07                  # MT series — hyphenated (yamaha-motor.eu) (display-only)
+  Mt-09:                     MT-09                  # MT series — hyphenated (yamaha-motor.eu) (display-only)
+  Mt-09 Tracer:              MT-09 Tracer           # MT series — hyphenated (yamaha-motor.eu) (display-only)
+  Mt-09A:                    MT-09A                 # MT series — hyphenated (yamaha-motor.eu) (display-only)
+  Mt-125:                    MT-125                 # MT series — hyphenated (yamaha-motor.eu) (display-only)
+  Neo S:                     Neo's                  # Yamaha writes it with the apostrophe (display-only)
+  Neos:                      Neo's                  # Yamaha writes it with the apostrophe
+  Neos 100:                  Neo's 100              # Yamaha writes it with the apostrophe
+  Nmax:                      NMAX                   # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page) (display-only)
+  Nmax 150:                  NMAX 150               # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page) (display-only)
+  Nmax Tech Max:             NMAX Tech Max          # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page) (display-only)
+  Roadstar:                  Road Star              # Road Star is TWO words in Yamaha's own usage — opposite to DragStar, same era
+  T MAX500:                  TMAX 500               # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page)
+  Tmax 500:                  TMAX 500               # the ALREADY-CLOSED raw "TMAX 500" title-cases to "Tmax 500", a third spelling of this id; same slug, so display-only, but without it the catalog shows whichever raw the reconciler picked
+  T-MAX530:                  TMAX 530               # "T-MAX 530" collapses to "T-MAX530" (pass 1 closes the letter/digit gap, pass 2 needs 4+ letters to reopen it and "MAX" is 3). Not a collision the detector could see — t-max530 is below threshold and lives in candidates
+  T Max:                     TMAX                   # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page)
+  T-Max:                     TMAX                   # ANOTHER spelling of the same id: t-max is produced by "T Max" AND "T-Max", and which one shows in the catalog depends on which the reconciler picks that build. Keying only one leaves the id standing
+  Tmax:                      TMAX                   # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page) (display-only)
+  Tzr-250:                   TZR250                 # type code — closed uppercase
+  V-MAX1200:                 VMAX 1200              # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page)
+  V-Max:                     VMAX                   # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page)
+  V Max:                     VMAX                   # as above — v-max is produced by "V-Max" AND "V Max"
+  Vmax:                      VMAX                   # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page) (display-only)
+  X-MAX125:                  XMAX 125               # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page)
+  X-MAX300:                  XMAX 300               # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page)
+  X-MAX400:                  XMAX 400               # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page)
+  XP500 Tmax:                XP500 TMAX             # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page) (display-only)
+  XVS1100 Drag Star:         XVS1100 DragStar       # DragStar is camelCase in Yamaha's own usage (Communication Plaza)
+  XVS1100 Dragstar:          XVS1100 DragStar       # DragStar is camelCase in Yamaha's own usage (Communication Plaza) (display-only)
+  XVS1100/A:                 XVS1100A               # type code — closed uppercase
+  XVS1100A Dragstar:         XVS1100A DragStar      # DragStar is camelCase in Yamaha's own usage (Communication Plaza) (display-only)
+  XVS650 Drag Star:          XVS650 DragStar        # DragStar is camelCase in Yamaha's own usage (Communication Plaza)
+  XVS650 Dragstar:           XVS650 DragStar        # DragStar is camelCase in Yamaha's own usage (Communication Plaza) (display-only)
+  XVS650A Drag Star:         XVS650A DragStar       # DragStar is camelCase in Yamaha's own usage (Communication Plaza)
+  Xmax:                      XMAX                   # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page) (display-only)
+  Xmax 300:                  XMAX 300               # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page) (display-only)
+  Yl-1:                      YL1                    # type code — closed uppercase
+  Yzf-R1:                    YZF-R1                 # type code — closed uppercase (display-only)
+  Yzfr 1:                    YZF-R1                 # type code — closed uppercase
 
 Zundapp:
   Zundapp: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -352,6 +352,99 @@ Gilera:
 GMC:
   Pickup: Pick-Up                             # spelling variant of "Pick-Up" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
+Harley-Davidson:
+  # H-D CONVENTION DOSSIER (§11.2). Two rules, both from Harley's own pages,
+  # and rows routinely need both at once ("FLSTF Fat Boy"):
+  #
+  #  1. MODEL CODES are continuous UPPERCASE alphanumeric — no spaces, no
+  #     hyphens: FXST, FLHTCU, FXRS, FLSTF, FLHXS, RA1250, RH1250S.
+  #     https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html
+  #     Prefix = engine family (F = Big Twin, XL = Sportster), then the model
+  #     family (FL, FXD), then variant suffixes (C = Custom/Classic, I = fuel
+  #     injection, R = Roadster/Road King/Racing). Registries split these codes
+  #     on arbitrary boundaries ("FL Htc", "F X R S", "Fx Stc"), which is what
+  #     produced most of the collisions below.
+  #  2. MODEL NAMES are SPACED, in H-D's registered forms: Fat Boy®,
+  #     Low Rider®, Wide Glide®, Super Glide®, Electra Glide®, Road King®,
+  #     Softail® Deluxe, Sportster®, Street Bob®. Same page + the model pages.
+  #
+  # ENGINE-ERA NICKNAMES (Panhead, Shovelhead, Knucklehead) are ONE word. They
+  # are heritage/enthusiast terms rather than registered model names, and the
+  # closed form is universal usage — so they go the OPPOSITE way from the
+  # registered names above. That split is exactly why no mechanical rule works
+  # here; see the note below.
+  #
+  # WHY THESE ARE HAND-RESOLVED. find_duplicate_spellings.rb's `canonical()`
+  # picks the variant with the MOST tokens, which for an alphanumeric type code
+  # selects the registry-mangled spelling. Measured on this make it was right on
+  # 10 of 34 groups; it proposed "F X R S" for FXRS, "FL Htc" for FLHTC,
+  # "W L C" for WLC and "Sport Ster" for Sportster. Treat its canonical column
+  # as a candidate, never as evidence.
+  #
+  # 20 of these lines are DISPLAY-ONLY (both spellings already slug the same,
+  # e.g. Fxstc -> FXSTC), so they change `name` and not `id` and correctly have
+  # no former_ids entry — rule 1 there forbids aliasing an id that still lives.
+  # The other 35 are real id changes and every one MERGES into an id that
+  # already exists, so nothing can vanish.
+  Dyna Lowrider:               Dyna Low Rider           # registered spelling
+  Dyna Wideglide:              Dyna Wide Glide          # registered spelling
+  Electraglide:                Electra Glide            # registered spelling
+  F X R S:                     FXRS                     # type code — uppercase, closed
+  FL Htc:                      FLHTC                    # type code — uppercase, closed
+  Fatboy:                      Fat Boy                  # registered spelling
+  Flh Electra-Glide:           FLH Electra Glide        # code closed + registered name spaced (display-only, id stable)
+  Flh Electraglide:            FLH Electra Glide        # code closed + registered name spaced
+  Flh-1200:                    FLH1200                  # type code — uppercase, closed
+  Flhrc Road King:             FLHRC Road King          # code closed + registered name spaced (display-only, id stable)
+  Flhrc Roadking:              FLHRC Road King          # code closed + registered name spaced
+  Flhri Road King:             FLHRI Road King          # code closed + registered name spaced (display-only, id stable)
+  Flhri Roadking:              FLHRI Road King          # code closed + registered name spaced
+  Flhtc:                       FLHTC                    # type code — uppercase, closed (display-only, id stable)
+  Flhtc-I:                     FLHTCI                   # type code — uppercase, closed
+  Flhtci:                      FLHTCI                   # type code — uppercase, closed (display-only, id stable)
+  Flhtcu-I:                    FLHTCUI                  # type code — uppercase, closed
+  Flhtcui:                     FLHTCUI                  # type code — uppercase, closed (display-only, id stable)
+  Flst-F:                      FLSTF                    # type code — uppercase, closed
+  Flstf:                       FLSTF                    # type code — uppercase, closed (display-only, id stable)
+  Flstf Fat Boy:               FLSTF Fat Boy            # code closed + registered name spaced (display-only, id stable)
+  Flstf Fatboy:                FLSTF Fat Boy            # code closed + registered name spaced
+  Flstn Softail De Luxe:       FLSTN Softail Deluxe     # code closed + registered name spaced
+  Flstn Softail Deluxe:        FLSTN Softail Deluxe     # code closed + registered name spaced (display-only, id stable)
+  Fx St:                       FXST                     # type code — uppercase, closed
+  Fx Stc:                      FXSTC                    # type code — uppercase, closed
+  Fxst-C:                      FXSTC                    # same as Fxe-F above: a third hyphenated spelling of the same code, invisible in the detector output because it reports one representative name per id
+  Fxd/i Dyna Super Glide:      FXDI Dyna Super Glide    # code closed + registered name spaced
+  Fxdi Dyna Super Glide:       FXDI Dyna Super Glide    # code closed + registered name spaced (display-only, id stable)
+  Fxe F:                       FXEF                     # type code — uppercase, closed
+  Fxe-F:                       FXEF                     # SAME id, DIFFERENT nameplate string: the raws carry "FXE F" and "FXE-F" and both slug to fxe-f, so whichever the reconciler picks as the display name is the one a rename must match. Keying only the space form left this behind — a rename must cover every spelling the pipeline can PRODUCE, not just the one the catalog happens to show
+  "Fxe/f":                     FXEF                     # the DOMINANT raw spelling and the one that actually held the fxe-f id: "FXE/F 1340" (153 rows) with a SLASH. Harley's code is FXEF (the Fat Bob) and the raws confirm it themselves — "FXE/F 1340 FAT BOB", "FXE/F FAT BOB". Found only by grepping the snapshots for every FXE spelling after two rebuilds still left fxe-f standing; the detector never showed it, because it reports ONE representative name per id and the representative changed between builds
+  Fxe-1200:                    FXE1200                  # type code — uppercase, closed
+  Fxef:                        FXEF                     # type code — uppercase, closed (display-only, id stable)
+  Fxr Super Glide:             FXR Super Glide          # code closed + registered name spaced (display-only, id stable)
+  Fxr Superglide:              FXR Super Glide          # code closed + registered name spaced
+  Fxr-S:                       FXRS                     # type code — uppercase, closed
+  Fxrs:                        FXRS                     # type code — uppercase, closed (display-only, id stable)
+  Fxrs Low Rider:              FXRS Low Rider           # code closed + registered name spaced (display-only, id stable)
+  Fxrs Lowrider:               FXRS Low Rider           # code closed + registered name spaced
+  Fxs Low Rider:               FXS Low Rider            # code closed + registered name spaced (display-only, id stable)
+  Fxs Lowrider:                FXS Low Rider            # code closed + registered name spaced
+  Fxst:                        FXST                     # type code — uppercase, closed (display-only, id stable)
+  Fxst-S:                      FXSTS                    # type code — uppercase, closed
+  Fxstc:                       FXSTC                    # type code — uppercase, closed (display-only, id stable)
+  Fxsts:                       FXSTS                    # type code — uppercase, closed (display-only, id stable)
+  Lowrider:                    Low Rider                # registered spelling
+  Pan Head:                    Panhead                  # engine-era nickname, one word in universal usage
+  Shovel Head:                 Shovelhead               # engine-era nickname, one word in universal usage
+  Softail Fatboy:              Softail Fat Boy          # registered spelling
+  Sport Ster:                  Sportster                # registered spelling
+  Superglide:                  Super Glide              # registered spelling
+  Vrod:                        V-Rod                    # registered spelling
+  Vrsca V-Rod:                 VRSCA V-Rod              # code closed + registered name spaced (display-only, id stable)
+  Vrsca Vrod:                  VRSCA V-Rod              # code closed + registered name spaced
+  W L C:                       WLC                      # type code — uppercase, closed
+  Wideglide:                   Wide Glide               # registered spelling
+  Wlc:                         WLC                      # type code — uppercase, closed (display-only, id stable)
+
 Honda:
   Honda: null                             # motorcycle fi|nl AND moped nl|nz — one make-scoped key covers both kinds (renames are kind-blind)
 

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1654,23 +1654,6 @@ Willys:
   Cj 3B: CJ3B                                 # spelling variant of "CJ3B" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Cj-5: CJ5                                   # spelling variant of "CJ5" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
-Zero Motorcycles:
-  # Residue of a SINGULAR/PLURAL mismatch between the two columns, not a naming
-  # choice. RDW writes merk="ZERO MOTORCYCLES" (plural) but handelsbenaming
-  # "ZERO MOTORCYCLE XB"/"XE" (singular). strip_make_prefix tries the exact raw
-  # make first (no match — plural ≠ singular), then falls back to the raw make's
-  # FIRST TOKEN, which strips only "ZERO " and leaves "MOTORCYCLE" sitting in
-  # the nameplate. Verified against the current normalizer: the plural form
-  # "ZERO MOTORCYCLES XE" strips correctly to "Xe", so this is specific to the
-  # 3 singular rows (measured 2026-07-25, m9d7-ebf2).
-  #
-  # Fixed with override lines rather than a prefix-normalizing rule on purpose:
-  # NAMING.md "Rule-first" sets the bar at ~20 instances and this is 3. A
-  # singular/plural-tolerant strip is also the kind of loosening that would
-  # start eating real nameplates (a "Motorcycle"-prefixed model is rare but a
-  # plural-insensitive prefix match is not obviously safe across 849 makes).
-  Motorcycle Xb: Xb    # raw handelsbenaming "ZERO MOTORCYCLE XB" (2 rows); merges into the existing moped/zero-motorcycles/xb
-  Motorcycle Xe: Xe    # raw handelsbenaming "ZERO MOTORCYCLE XE" (1 row); merges into the existing motorcycle/zero-motorcycles/xe
 Yamaha:
   # YAMAHA CONVENTION DOSSIER (§11.2). FOUR rules, and they contradict each
   # other — which is exactly why nothing mechanical can resolve this make and
@@ -1768,6 +1751,24 @@ Yamaha:
   Yl-1:                      YL1                    # type code — closed uppercase
   Yzf-R1:                    YZF-R1                 # type code — closed uppercase (display-only)
   Yzfr 1:                    YZF-R1                 # type code — closed uppercase
+
+Zero Motorcycles:
+  # Residue of a SINGULAR/PLURAL mismatch between the two columns, not a naming
+  # choice. RDW writes merk="ZERO MOTORCYCLES" (plural) but handelsbenaming
+  # "ZERO MOTORCYCLE XB"/"XE" (singular). strip_make_prefix tries the exact raw
+  # make first (no match — plural ≠ singular), then falls back to the raw make's
+  # FIRST TOKEN, which strips only "ZERO " and leaves "MOTORCYCLE" sitting in
+  # the nameplate. Verified against the current normalizer: the plural form
+  # "ZERO MOTORCYCLES XE" strips correctly to "Xe", so this is specific to the
+  # 3 singular rows (measured 2026-07-25, m9d7-ebf2).
+  #
+  # Fixed with override lines rather than a prefix-normalizing rule on purpose:
+  # NAMING.md "Rule-first" sets the bar at ~20 instances and this is 3. A
+  # singular/plural-tolerant strip is also the kind of loosening that would
+  # start eating real nameplates (a "Motorcycle"-prefixed model is rare but a
+  # plural-insensitive prefix match is not obviously safe across 849 makes).
+  Motorcycle Xb: Xb    # raw handelsbenaming "ZERO MOTORCYCLE XB" (2 rows); merges into the existing moped/zero-motorcycles/xb
+  Motorcycle Xe: Xe    # raw handelsbenaming "ZERO MOTORCYCLE XE" (1 row); merges into the existing motorcycle/zero-motorcycles/xe
 
 Zundapp:
   Zundapp: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)

--- a/spotchecks.yml
+++ b/spotchecks.yml
@@ -563,3 +563,26 @@ checks:
     kind: moped
     availability_includes: [fi, nl]
     reason: "RDW carries BOTH merk spellings (EMAX and E-MAX) for one marque in the same file. Guards the merge AND the rekeyed `E-Max:` renames block: a make display-name change silently orphans rename blocks filed under the old name, which would resurrect `e-max/emax-90s` beside this record."
+  # --- Harley-Davidson convention tripwires (S2W B5 batch 1, 2026-07-25) ------
+  # The two H-D rules pull in OPPOSITE directions, so a single regression can only
+  # be caught by asserting both: codes close up, registered names space out.
+  - id: harley-davidson/fxrs
+    kind: motorcycle
+    availability_includes: [nl]
+    reason: "CODE rule: H-D model codes are continuous uppercase (harley-davidson.com model-codes page). Three registry spellings fold here — 'Fxr-S', 'Fxrs' and a published 'F X R S'. If f-x-r-s or fxr-s reappears, a registry re-split the code and the renames went inert."
+  - id: harley-davidson/flhtc
+    kind: motorcycle
+    availability_includes: [nl]
+    reason: "same CODE rule, and the nastiest split of the set: 'FL Htc' was published as its own id. Guards against the detector's proposal being applied by mistake — canonical() suggested 'FL Htc' as the canonical form."
+  - id: harley-davidson/fat-boy
+    kind: motorcycle
+    availability_includes: [nl]
+    reason: "NAME rule, opposite direction to the codes above: H-D registers 'Fat Boy®' as two words, so fatboy folds into fat-boy. If both ids exist again the batch regressed."
+  - id: harley-davidson/panhead
+    kind: motorcycle
+    availability_includes: [nl]
+    reason: "the EXCEPTION that proves no mechanical rule works here: engine-era nicknames (Panhead, Shovelhead, Knucklehead) are ONE word while registered model names are spaced. A rule that got Fat Boy right and this wrong would look correct in aggregate."
+  - id: harley-davidson/sportster
+    kind: motorcycle
+    availability_includes: [nl]
+    reason: "guards the worst false positive available: two registries genuinely publish 'SPORT STER', and find_duplicate_spellings.rb proposed 'Sport Ster' as canonical because it has more tokens. Sportster® is one word."


### PR DESCRIPTION
Applies the three that the cross-session research pass (NEGOTIATION.md Turn 45) resolved and my own pass had missed or left open.

## IFA and AWO — the blind spot, confirmed empirically

My shortlist filters on *single Titlecase token, ≤4 chars, **≤1 vowel***. High precision, and I documented that it **under-reports two-vowel initialisms**. `IFA` and `AWO` both have two vowels. They were never going to appear on my list no matter how carefully I read it.

They surfaced because a **second, independent research pass** ran on the same makes. That is the strongest evidence in this pass so far for the two-passes-by-different-agents rule — not "the first pass was careless" but "the first pass had a *structural* blind spot that only a differently-shaped search could see."

- **IFA** — Industrieverband Fahrzeugbau, the GDR vehicle-industry combine.
- **AWO** — Awtowelo, the Soviet joint-stock company that took over the Suhl works post-1945. The marque is the AWO 425 (four-stroke, 250cc — the "4" and "25" of the type number), >209,000 built 1949–62, catalogued as "AWO-425 S" by the [Technikmuseum Magdeburg](https://st.museum-digital.de/object/1547). Became VEB Simson Suhl, so **`{AWO, Simson, IFA}` is a co-batch cluster** for §6.2.

## KSR — a bigger fix than a casing pin

Turn 45 reported the target corrected to "KSR Moto". The file still read `Ksr Moto`, and more importantly **only one of three raw spellings was pinned at all**:

| raw string | rows | before |
|---|---|---|
| `KSR MOTO AUSTRIA` | 13 | pinned → `Ksr Moto` (casing now fixed) |
| `KSR MOTO` | 19 | **unpinned** — the commonest spelling, survived only because `smart_case` happened to title-case it to the same string |
| `KSRMOTO` | 2 | **unpinned**, and would have forked to its own make id `ksrmoto` the moment it cleared the threshold |

All three now resolve to one make, verified by calling `Normalizer#classify` on each raw rather than by reading the file.

Display follows the **`MV Agusta` precedent already in this file** — an initialism plus a word takes initialism-upper + word-title — so `KSR Moto` rather than `KSR MOTO`, even though [ksr-moto.com](https://www.ksr-moto.com/) styles the lockup all-caps.

**The over-merge trap, recorded inline:** KSR Group also distributes **Brixton, Malaguti, Benelli and Royal Enfield** ([source](https://ksr-group.com/news/moto-austria/)). Those are separate marques with their own type approvals and must **not** fold into KSR Moto. Verified `BRIXTON` still resolves to its own make.

## Deliberately NOT pinned

Agreeing with the research pass on both:

- **`Iva`** — RDW uppercases every make string, so this is an existence proof and nothing more. Could be the initialism IVA or a marque spelled Iva. Left as `Iva` and **marked unverified rather than guessed** — it gets settled in the `moped/iva` pilot batch along with the rest of that make.
- **`Evt`** — distributor-only evidence, no manufacturer source found.

## No `former_ids`

All three slugs unchanged (`ifa`, `awo`, `ksr-moto`). The `KSRMOTO` rows were below threshold and unpublished, so they **join** `ksr-moto` and strengthen it rather than moving an id.

## Process

Ran the **pre-flight orphan grep** first — the procedure that came out of #17's `Tvr:` finding: `renames.yml`, `models/aliases.yml`, `moves.yml`, `body_types.yml`, all clean of blocks under the old titlecase names. That check is now cheap and it has caught something two out of three times it has been run.

Also agreeing with S4W's correction of the `KAMAZ` pin — kamaz.ru/en writes KAMAZ.

## Gates

`lint_overrides` OK · `lint_curation` OK (16 files) · `classify()` verified per raw string · no id churn.