### PR TITLE
A4 harness: verification ledger + review lint + dispatch board; A6 factory-built; embedded-make pass

### DIFF
--- a/data/name_shapes.yml
+++ b/data/name_shapes.yml
@@ -69,6 +69,56 @@ legit:
     why: >-
       The Humberette (1903-1905, revived 1913) is a real Humber model name.
       https://en.wikipedia.org/wiki/Humberette
+  - id: jensen-healey
+    category: embedded_make
+    make: jensen
+    pattern: '\AJensen-Healey\z'
+    why: >-
+      The Jensen-Healey (1972-1976, ~10,500 built) is a real nameplate — a
+      Jensen Motors / Donald Healey joint venture, sold under exactly that
+      hyphenated name. https://en.wikipedia.org/wiki/Jensen-Healey
+
+  # ── modern marques whose OFFICIAL nameplates embed the make ────────────────
+  # These are not prefix-strip failures: the manufacturer's own naming puts the
+  # marque INSIDE the model name. Patterns are exact-list, never open-ended —
+  # a new "Mazda7" appearing tomorrow should surface as a suspect, not be
+  # silently excused by a wildcard.
+  - id: mazda-fused-official-names
+    category: embedded_make
+    make: mazda
+    pattern: '\AMAZDA[2356]\z'
+    why: >-
+      Since 2002 Mazda's official nameplates ARE the fused form — "Mazda2",
+      "Mazda3", "Mazda5", "Mazda6" (https://www.mazda.com/en/about/profile/library/,
+      and every national Mazda site: https://www.mazdausa.com/vehicles/mazda3-sedan).
+      13 sources corroborate. All-caps display styling is a display-form
+      question, not a shape defect.
+  - id: polestar-numbered-official-names
+    category: embedded_make
+    make: polestar
+    pattern: '\APolestar [2-6]\z'
+    why: >-
+      Polestar's models are officially named "Polestar 2" … "Polestar 5" — the
+      marque word is part of the nameplate (https://www.polestar.com/us/polestar-2/).
+      10-12 sources corroborate each.
+  - id: omoda-numbered-official-names
+    category: embedded_make
+    make: omoda
+    pattern: '\AOmoda (5|7|9|E5)\z'
+    why: >-
+      Chery's Omoda marque names its cars "Omoda 5", "Omoda 9", "Omoda E5" —
+      marque-in-the-name, per the brand's own European sites
+      (https://www.omodajaecoo-auto.de/modelle/omoda-5, https://omodauk.com).
+      The FUSED registry forms (OMODA5, OMODA5 EV/HEV) are folded into these
+      by renames.yml — only the spaced official forms are legitimate.
+  - id: jaecoo-numbered-official-names
+    category: embedded_make
+    make: jaecoo
+    pattern: '\AJaecoo [5-8]\z'
+    why: >-
+      Chery's Jaecoo marque names its cars "Jaecoo 5" … "Jaecoo 8"
+      (https://www.omodajaecoo-auto.de/modelle/jaecoo-7, https://www.jaecoo.co.uk).
+      Same structure as Omoda above; fused registry forms fold via renames.yml.
 
   # ── numeric type designations in the commercial kinds ─────────────────────
   # NAMING.md §7 makes this verdict explicitly KIND-DEPENDENT: in van, truck and
@@ -123,18 +173,22 @@ debt:
   - id: make-as-model-4w
     owner: s4w
     category: make_as_model
-    count: 2
+    count: 5
     why: >-
-      Was 51, now 2. Dropped 49 registry rows where the make was written into the
-      model column ("Audi Audi", "Toyota Toyota"); merged hummer/hummer into H1,
-      because the civilian AM General Hummer really was sold under that name from
-      1992 until the H1 rename in 1999. NOTE corroboration does NOT clear this
-      class — every one of the 51 was multi-source, because registers share the
-      same fallback habit when a model field is blank. What remains is
+      Was 51, then 2, now 5. Dropped 49 registry rows where the make was written
+      into the model column ("Audi Audi", "Toyota Toyota"); merged hummer/hummer
+      into H1, because the civilian AM General Hummer really was sold under that
+      name from 1992 until the H1 rename in 1999. NOTE corroboration does NOT
+      clear this class — every one of the 51 was multi-source, because registers
+      share the same fallback habit when a model field is blank. What remains:
       van/uaz/uaz, whose true identity is one of UAZ's own numeric type
       designations (452 / 469 / 3741 / 2206 — that IS their naming convention)
-      and cannot be recovered from an aggregate row. Tracked rather than guessed:
-      guessing at an unresolvable row is what produced the SEAT incident.
+      and cannot be recovered from an aggregate row; plus bus/geely/geely,
+      bus/yutong/yutong, bus/zhongtong/zhongtong — DELIBERATE additions from
+      dissolving NZTA's "FACTORY BUILT" pseudo-make (moves.yml 2026-07-25),
+      where the marque was ALL the model column carried, so make-as-model is
+      the honest maximum. Tracked rather than guessed: guessing at an
+      unresolvable row is what produced the SEAT incident.
 
   - id: spec-token-4w
     owner: s4w
@@ -148,12 +202,21 @@ debt:
   - id: embedded-make-prefix-4w
     owner: s4w
     category: embedded_make
-    count: 22
+    count: 1
     why: >-
-      Model names repeating their own make ("JAECOO5 EV", "OMODA5",
-      "Volkswagen-Vw"). Note multi-source corroboration does NOT clear this
-      class: every register shares the habit of prefixing the make, so it needs
-      per-record judgment against the manufacturer's own naming.
+      Was 22 declared / 24 measured (es_dgt re-land added two). Resolved
+      2026-07-25 by per-record judgment against the manufacturer's own naming,
+      exactly as this entry prescribed: 15 records were OFFICIAL
+      marque-in-the-name nameplates, moved to legit (mazda/polestar/omoda/
+      jaecoo entries above) with brand-site evidence; 7 were genuine fused or
+      repeated-make artifacts, merged into their corroborated canonical ids
+      via renames.yml + former_ids (AUDIA6→A6, Audi Q5→Q5, FIAT500→500,
+      JAECOO5 HEV→Jaecoo 5, OMODA5 HEV→Omoda 5, Lynk Co 01→01) or nulled with
+      a removals.yml manifest (Volkswagen-Vw — make twice, zero model info);
+      Jensen-Healey was a real nameplate, moved to legit. What remains is
+      van/palfinger/palfinger-p200txe-l-f24p-e6 — a crane-body type code
+      (PALFINGER_P200TXE-L_F24P_E6, fi/nl) that needs the coachbuilder
+      treatment, not a rename.
 
   # ── 2W half (S2W) — seeded from their measurement so the counter exists;
   #    they own the entries and the remedy (NEGOTIATION.md Turn 8 §4/§5) ──────

--- a/data/review/README.md
+++ b/data/review/README.md
@@ -1,0 +1,40 @@
+# data/review/ — the verification ledger
+
+This directory is the receipt behind the claim "manually reviewed,
+model-per-model". Everything here is specified in **PRD-QUALITY.md §5–§7**
+(repo root) — read that first; this file is only the map.
+
+| File | What it is |
+|---|---|
+| `<make>.yml` | One ledger per make: a verdict + evidence for every published record of that make, dual-signed (researcher ≠ verifier). |
+| `batches.yml` | The dispatch board — which makes are batched together, who claimed what, status. Claim before working. |
+| `_coverage.yml` | Generated monotonic baseline (coverage may never drop on main). Written by `lint_review.rb --update`, never by hand. |
+
+Tooling:
+
+- `scripts/lint_review.rb` (this repo) — validates every ledger and computes
+  coverage. Runs in CI. `VDB_CATALOG=…/build/out/catalog` measures against a
+  fresh build; `VDB_PACKS=…/build/packs` enables fingerprint staleness.
+- `pipeline/tools/gen_review_pack.rb` (pipeline repo, private) — generates the
+  review pack for a make: published records with their raw registry rows, the
+  candidate queue, dead override keys, dropped rows, and the
+  `raw_fingerprint` the ledger must store.
+
+Ledger shape (lint-enforced; see PRD §5.2 for field semantics):
+
+```yaml
+make: iva
+researcher: s2w-r1        # who researched — an agent/session id
+verifier: s2w-v1          # who verified — MUST differ from researcher (I-11)
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:…  # from the pack; verdicts go stale when it changes
+records:
+  - id: moped/iva/e-go-s2          # <kind>/<make>/<slug>, must be live
+    verdict: canonical             # canonical|fixed|debt|removed|moved|stale
+    evidence: https://…            # exact URL(s) — a verdict without evidence
+                                   # is an opinion; mandatory
+  - id: moped/iva/ra-9015
+    verdict: removed               # id must be GONE + covered by removals.yml
+    note: duplicate spelling of ra9015   # debt/removed/moved need a note
+    evidence: https://…
+```

--- a/data/review/batches.yml
+++ b/data/review/batches.yml
@@ -1,0 +1,46 @@
+# batches.yml — the REVIEW DISPATCH BOARD (PRD-QUALITY §6).
+#
+# One entry per batch of makes. A batch is CLAIMED by writing `claimed_by`,
+# DONE when every make in it has a ledger file that passes lint_review.rb
+# with dual signatures. Claim before working — two swarms researching the
+# same make burns tokens and produces two conflicting ledgers.
+#
+# RULES (from PRD §6, enforced socially + by lint where possible):
+#   * Batches are MAKE-sets, never kind-sets: the make's owner curates it in
+#     every kind (OWNERSHIP.yml is the owner map).
+#   * Approval-holder clusters must stay in ONE batch (a Vespa verdict written
+#     without the Piaggio context re-creates the split it exists to fix).
+#     Mandatory co-batches are listed in PRD §6.2 — {Piaggio,Vespa,Aprilia,
+#     Moto Guzzi,Derbi,Gilera}, {KTM,Husqvarna,GasGas}, {SEAT,Cupra},
+#     {Hyundai,Genesis}, {Honda,Montesa}, and the rest.
+#   * researcher != verifier within a batch, and the HARNESS AUTHOR never
+#     pilots their own harness (I-11): the pilot batch is run by S2W because
+#     S4W built lint_review + gen_review_pack.
+#
+# WORKFLOW per batch (PRD §7 has the full researcher/verifier prompts):
+#   1. build:  ruby pipeline/run.rb            (fresh build/out + candidates)
+#   2. pack:   ruby pipeline/tools/gen_review_pack.rb <makes…>
+#   3. research: one Opus researcher per make, pack + internet → draft ledger
+#   4. verify:  a DIFFERENT Opus verifier re-derives verdicts from evidence
+#   5. lint:   ruby scripts/lint_review.rb     (data repo; VDB_PACKS=… for
+#              staleness, VDB_CATALOG=… to measure against the fresh build)
+#   6. PR with ledger + any override fixes the review produced; CI green;
+#      merge; coverage baseline update (`lint_review.rb --update`) in the PR.
+#
+# status: open | claimed | in_review | done
+
+batches:
+  B-000:
+    makes: [iva]
+    owner: s2w            # moped-dominant make → S2W per OWNERSHIP.yml
+    status: open
+    claimed_by: null
+    notes: >-
+      PILOT (PRD P1). Deliberately small (16 published moped records, 34
+      candidate rows, 1 dropped row) and deliberately dirty: the pack already
+      shows a three-way duplicate-spelling split published as separate records
+      (iva/iva-ra9015 vs iva/ra-9015 vs iva/ra9015, and the ra9011 family
+      split across published+candidates) plus prefix-strip merges to sanity-
+      check (JET50, LUX50, VENTI 50). Run by S2W because S4W authored the
+      harness (I-11). The pilot's job is to break the harness, not to be
+      efficient — every friction point goes in the negotiation log.

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2120,3 +2120,33 @@
 # from `Emax:` to `E-Max:` — see the note there.
 "moped/emax/110s": "moped/e-max/110s"    # fi,nl unchanged
 "moped/emax/90s": "moped/e-max/90s"      # fi,nl unchanged (merged into a pre-existing id)
+# ---------------------------------------------------------------------------
+# 2026-07-25 — NZ NZTA "FACTORY BUILT" pseudo-make dissolved (bus). The make
+# was a body-provenance flag (fully-imported vs NZ-coachbuilt), never a
+# manufacturer; the real marque sat in the model column. Cross-make entries
+# are legal under rule 3 because factory-built no longer appears in the build
+# at all (its ~600 remaining raw pairs are all sub-threshold candidates).
+# Successors are make-as-model debt rows — see moves.yml for why no nameplate
+# is guessed, and data/name_shapes.yml `make-as-model-4w`.
+# ---------------------------------------------------------------------------
+"bus/factory-built/geely":     "bus/geely/geely"          # nz unchanged
+"bus/factory-built/yutong":    "bus/yutong/yutong"        # nz unchanged
+"bus/factory-built/zhongtong": "bus/zhongtong/zhongtong"  # nz unchanged
+# 2026-07-25 — TVR renames block rekeyed from orphaned display form `Tvr:` to
+# `TVR:` (block-reachability test find, pipeline#8). With the block now LIVE,
+# raw "350 I" folds into the official lowercase-i 350i for the first time, so
+# the old raw-derived id vanishes into the canonical one.
+"car/tvr/350-i": "car/tvr/350i"    # nl unchanged; TVR wedge-era official form
+# 2026-07-25 — embedded-make-prefix artifact merges (debt bucket
+# `embedded-make-prefix-4w`, was 22 declared / 24 measured after the es_dgt
+# re-land added JAECOO5 HEV + OMODA5 HEV). Each old id was a marque-fused or
+# marque-repeated duplicate of an already-published corroborated id; renames
+# now fold them (see the make blocks in renames.yml for per-key evidence).
+# Country evidence of every successor is a superset of the old id's (rule 4),
+# verified against build 2026-07-25.
+"car/audi/audia6":        "car/audi/a6"           # es,nl ⊂ 14-country A6
+"car/audi/audi-q5":       "car/audi/q5"           # es,nl ⊂ 14-country Q5
+"car/fiat/fiat500":       "car/fiat/500"          # es,nl ⊂ 12-country 500
+"car/jaecoo/jaecoo5-hev": "car/jaecoo/jaecoo-5"   # es ⊂ de,es,gb,nl,th
+"car/omoda/omoda5-hev":   "car/omoda/omoda-5"     # es ⊂ de,es,gb,lu,nl,nz,th
+"car/lynk-co/lynk-co-01": "car/lynk-co/01"        # es,nl ⊂ de,es,fi,nl,ua

--- a/overrides/models/moves.yml
+++ b/overrides/models/moves.yml
@@ -161,3 +161,27 @@
 "Piaggio|Primavera 50": "Vespa|Primavera 50"
 "Piaggio|S50": "Vespa|S50"
 "Piaggio|Sprint": "Vespa|Sprint"
+
+# ── NZ NZTA "FACTORY BUILT" pseudo-make (bus imports) ────────────────────────
+# NZTA's fleet data writes make="FACTORY BUILT" for fully-imported (non-NZ-
+# coachbuilt) buses and puts the ACTUAL MARQUE in the model column — it is a
+# body-provenance flag, not a manufacturer. Verified against the published
+# build 2026-07-25: the pseudo-make's only ≥threshold rows are `FACTORY BUILT |
+# GEELY / YUTONG / ZHONGTONG` (bus, nz_nzta single-source), and all three
+# target makes already exist in the bus kind (geely/c13e, yutong/e9…, and
+# zhongtong/lck — the latter also NZ-only). The model column carries no
+# nameplate beyond the marque, so the target is an honest make-as-model row
+# (van/uaz/uaz precedent) — tracked in data/name_shapes.yml debt
+# `make-as-model-4w`, NOT guessed into a specific nameplate (a Yutong bus in
+# NZ could be a ZK6119 or an E9; guessing is the SEAT-incident failure mode).
+#
+# HEADS-UP for whoever tackles the rest: ~600 sub-threshold candidate rows
+# remain under factory-built across ALL kinds (real historical marques in the
+# model column: Douglas, Francis Barnett, Dnepr, Optare, King Long…). Those
+# need per-row moves like these three — the pseudo-make must NEVER be allowed
+# to publish a record under its own name. After these moves the make has zero
+# published records, which is what makes the cross-make former_ids aliases
+# legal (former_ids.yml rule 3: old make gone from the build entirely).
+"Factory Built|Geely": "Geely|Geely"
+"Factory Built|Yutong": "Yutong|Yutong"
+"Factory Built|Zhongtong": "Zhongtong|Zhongtong"

--- a/overrides/models/removals.yml
+++ b/overrides/models/removals.yml
@@ -612,3 +612,4 @@
 
 # ── NOT A MARQUE (S2W, 2026-07-25) ──────────────────────────────────────────
 "motorcycle/eigenbouw/softail": "\"Eigenbouw\" is Dutch for self-built — RDW's placeholder for home-built machines, not a marque. NAMING.md line 33 has listed EIGENBOUW under \"not a marque at all -> drop for that kind\" since before this pass; it had simply never been implemented. No alias target is honest: a self-built frame in a Softail style is NOT a Harley-Davidson, and moving it there would invent a provenance the register never claimed."
+"car/volkswagen/volkswagen-vw": "null rename 2026-07-25: fi/nl model column literally reads VOLKSWAGEN-VW — the make written twice, zero model information. Not aliasable: no honest successor exists (aliasing it to any VW nameplate would fabricate evidence)."

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -676,8 +676,21 @@ Luqi:
 
 # Display name is "Lynk & Co" (catalog car/makes.json) — renames are keyed by
 # make DISPLAY NAME, and a key of "Lynk Co" would be silently inert.
+#
+# HISTORY, worth keeping: car/lynk-co/lynk-co-01 (was es+nl published) lost
+# its ES evidence when the 2026-07 es_dgt re-pin changed the raw spelling to
+# one that folds straight to "01" — the record DEMOTED to candidates rather
+# than merged, stranding the nl/fi residue spellings below (the exact
+# stranded-spelling failure moves.yml's LESSON block describes). A first fix
+# keyed "Lynk Co 01" — the OLD es form that no longer occurs anywhere — and
+# was caught by the reachability test as never-matching. Keys below are the
+# PRODUCED forms verified against build/candidates natives ("LYNK&CO |
+# LYNK &CO 01" and "LYNK&CO | Lynk and Co 01").
 "Lynk & Co":
-  Lynk Co 01: "01"                        # es_dgt/nl_rdw wrote the marque into the model column; the nameplate is just "01" (https://www.lynkco.com/en/01) — merges into the 5-source lynk-co/01 id. "01" QUOTED: bare 01 would parse as Integer 1
+  Lynk &co 01: "01"                       # nl_rdw residue (69 regs): marque fused into the model column; the nameplate is just "01" (https://www.lynkco.com/en/01) — merges into the 5-source lynk-co/01 id. "01" QUOTED: bare 01 would parse as Integer 1
+  Lynk And Co 01: "01"                    # fi_traficom residue (22 regs): same marque-in-model habit, spelled out
+  Lynk Co 01: "01"                        # es_dgt residue (10 regs): the pre-2026-07 ES spelling still trickles in. NB the reachability test once called this key dead — false positive from replaying under the display make instead of the raw "LYNK&CO" (fixed in the test, raw-make variants)
+  "Link & Co 01": "01"                    # es_dgt residue (3 regs): registry misspelling (LINK for LYNK) of the same car
 
 MAN:
   Man: null                                   # registry rows where the make was written into the model column (truck kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -19,6 +19,8 @@ Aston Martin:
 Audi:
   "5000S": "5000 S"                           # spelling variant of "5000 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Audi: null                                  # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
+  AUDIA6: A6                                  # es_dgt/nl_rdw glue artifact ("AUDIA6") — the make fused onto the nameplate; merges into the 14-source A6 id
+  Audi Q5: Q5                                 # make repeated in the model column with a space, which strip_make_prefix misses when the RAW make spelling differs from the model's prefix; merges into the 14-source Q5 id
   A 2: A2                                     # spelling variant of "A2" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   A 3: A3                                     # spelling variant of "A3" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   A 4: A4                                     # spelling variant of "A4" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -265,6 +267,7 @@ Ferrari:
   F 430: F430                                 # spelling variant of "F430" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 Fiat:
+  FIAT500: "500"                              # es_dgt/nl_rdw glue artifact — make fused onto the nameplate; merges into the corroborated 500 id. Value QUOTED: a bare 500 parses as Integer and crashes slugify (lint_curation catches this, but don't rely on it)
   "126P": "126 P"                             # spelling variant of "126 P" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "2300S": "2300 S"                           # spelling variant of "2300 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "500C": "500 C"                             # spelling variant of "500 C" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -393,6 +396,7 @@ Iveco:
 
 Jaecoo:
   "7": Jaecoo 7                           # official European name is "Jaecoo 7" (https://www.omodajaecoo-auto.de/modelle/jaecoo-7); "J7" is the China-market designation. Bare "7" is not self-identifying so the marque word stays (NAMING.md §1).
+  JAECOO5 HEV: Jaecoo 5                   # es_dgt form: marque fused + powertrain badge (HEV); folds into the 5-source Jaecoo 5 id like the OMODA5 EV precedent below
   J7: Jaecoo 7                            # China-market designation of the same car
   JAECOO7: Jaecoo 7                       # registry form with the marque fused; official spelling is spaced
   "7 Luxury": Jaecoo 7                    # trim level folds
@@ -669,6 +673,11 @@ Lincoln:
 
 Luqi:
   Luqi: null                              # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
+
+# Display name is "Lynk & Co" (catalog car/makes.json) — renames are keyed by
+# make DISPLAY NAME, and a key of "Lynk Co" would be silently inert.
+"Lynk & Co":
+  Lynk Co 01: "01"                        # es_dgt/nl_rdw wrote the marque into the model column; the nameplate is just "01" (https://www.lynkco.com/en/01) — merges into the 5-source lynk-co/01 id. "01" QUOTED: bare 01 would parse as Integer 1
 
 MAN:
   Man: null                                   # registry rows where the make was written into the model column (truck kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
@@ -1102,6 +1111,7 @@ Omoda:
   C5: Omoda 5                             # China-market designation of the same car
   OMODA5: Omoda 5                         # registry form with the marque fused
   OMODA5 EV: Omoda 5                      # marque fused + powertrain badge
+  OMODA5 HEV: Omoda 5                     # es_dgt 2026-07 newcomer — same fused-marque habit, hybrid badge this time
   OMODA5 Hev: Omoda 5                     # as above
   C5 EV Long Range Max: Omoda 5           # China name + powertrain/range/trim tokens
   "5 Comfort Auto": Omoda 5               # trim + transmission tokens fold
@@ -1400,8 +1410,16 @@ TRS:
   Trrs One: One          # strip the embedded badge — bikes are badged TRRS but the make resolves to TRS, so the prefix strip missed (trsmotorcycles.com); CREATES the One canonical
   TR1 300: One 300       # TR1 = TRS's homologation type code (RDW type "TR 1 A", e9*168/2013*30008, 294cc), not a nameplate; road range is the One family
 
-Tvr:
-  "350I": "350 I"                             # spelling variant of "350 I" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+TVR:
+  # Block rekeyed Tvr → TVR 2026-07-25: the display-name pin changed the make's
+  # canonical form and orphaned the old block key (found by pipeline#8's
+  # block-reachability test; handed over in NEGOTIATION Turn 49). The old
+  # "350 I" target was also wrong — a mechanical spelling merge that predated
+  # the marque research. TVR's own wedge-era naming is lowercase-i "350i"
+  # (Tasmin 350i, 1983-89; https://www.tvr-car-club.co.uk/ and period press) —
+  # same convention family as BMW's i suffix.
+  "350I": 350i                                # registry casing of the TVR 350i (wedge era); official form is lowercase i
+  "350 I": 350i                               # spaced registry variant of the same car
 
 Unu:
   Unu: Scooter
@@ -1424,6 +1442,7 @@ Vmoto:
 
 Volkswagen:
   Buggy: null            # kit-car/beach-buggy registrations on Beetle base
+  Volkswagen-Vw: null    # fi/nl rows whose model column literally reads "VOLKSWAGEN-VW" — the make twice, zero model information. Unlike make-as-model keeps (van/uaz/uaz), there is no single-model marque hypothesis to preserve; removal manifest: removals.yml
   Kever: null            # Dutch for Beetle — classic-era rows; Beetle nameplate covers it
   Multivan: null         # van kind (T-series passenger)
   Kombi: null            # van kind

--- a/scripts/lint_review.rb
+++ b/scripts/lint_review.rb
@@ -1,0 +1,185 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# lint_review.rb — validates the VERIFICATION LEDGER (data/review/<make>.yml)
+# and computes review coverage. PRD-QUALITY §5 is the spec; this file is the
+# enforcement.
+#
+# The ledger is the receipt behind the claim "manually reviewed model-per-
+# model". A verdict that cannot be trusted mechanically is worse than no
+# verdict — it converts an unreviewed record into a falsely-reviewed one. So
+# this lint is strict where it counts:
+#
+#   * closed verdict vocabulary; unknown verdicts fail
+#   * EVERY verdict carries an evidence citation (a verdict without evidence is
+#     an opinion)
+#   * researcher != verifier, always (I-11: the author never certifies their
+#     own work — in the correction pass, not one of five major wrong
+#     conclusions was caught by its author)
+#   * verdicts must point at reality: `canonical`/`debt` need the id LIVE in
+#     the catalog; `removed`/`moved` need the id GONE and covered by
+#     former_ids/removals — a verdict claiming a fix that does not exist is
+#     the silent-loss class this repo specializes in producing
+#   * staleness: each ledger file records the raw fingerprint it was reviewed
+#     against; when the pack generator reports a different fingerprint, the
+#     make's verdicts are STALE and count as unreviewed until re-verified
+#
+# Coverage = dual-signed, non-stale verdicts / published records, per owner.
+# The number may never decrease on main once nonzero (monotonicity is checked
+# against data/review/_coverage.yml, updated by this script with --update).
+#
+# Usage:
+#   ruby scripts/lint_review.rb              # validate + report coverage
+#   ruby scripts/lint_review.rb --update     # also write _coverage.yml baseline
+#   VDB_CATALOG=…/build/out/catalog …        # measure against a fresh build
+
+require "yaml"
+require "json"
+require "set"
+require "date"
+
+ROOT = File.expand_path("..", __dir__)
+CATALOG_DIR = ENV["VDB_CATALOG"] ? File.expand_path(ENV["VDB_CATALOG"]) : File.join(ROOT, "catalog")
+KINDS = %w[car van motorcycle moped truck bus].freeze
+VERDICTS = %w[canonical fixed debt removed moved stale].freeze
+FAILURES = []
+def fail!(msg) = FAILURES << msg
+
+# ── load reality ─────────────────────────────────────────────────────────────
+live = {}        # kind => Set of "make/slug"
+by_make = Hash.new(0) # make_id => published record count (all kinds)
+KINDS.each do |k|
+  path = File.join(CATALOG_DIR, k, "models.json")
+  next unless File.exist?(path)
+  ids = JSON.parse(File.read(path)).map { |m| m["id"] }
+  live[k] = ids.to_set
+  ids.each { |id| by_make[id.split("/").first] += 1 }
+end
+former = (YAML.safe_load_file(File.join(ROOT, "overrides/models/former_ids.yml")) rescue nil) || {}
+removals = (YAML.safe_load_file(File.join(ROOT, "overrides/models/removals.yml")) rescue nil) || {}
+own = (YAML.safe_load_file(File.join(ROOT, "OWNERSHIP.yml")) rescue nil) || {}
+owner_of = ((own["s4w"] || []).to_h { |m| [m, "s4w"] }).merge((own["s2w"] || []).to_h { |m| [m, "s2w"] })
+
+# ── validate every ledger file ───────────────────────────────────────────────
+reviewed = Hash.new(0) # owner => count of valid, non-stale verdicts
+# Everything in data/review/*.yml is a per-make ledger EXCEPT the dispatch
+# board (batches.yml) and generated files (_-prefixed). Skip by name, don't
+# pattern-guess — a make genuinely named "batches" cannot exist (no registry
+# emits it), so the carve-out is safe.
+ledgers = Dir[File.join(ROOT, "data/review", "*.yml")]
+          .reject { |f| File.basename(f).start_with?("_") || File.basename(f) == "batches.yml" }
+ledgers.sort.each do |abs|
+  rel = abs.sub("#{ROOT}/", "")
+  doc = begin
+    # Date is permitted because `reviewed_at: 2026-07-25` (unquoted) is the
+    # natural way every ledger writes it, and Psych types a bare ISO date as
+    # Date — without the permit the lint CRASHES on well-formed input instead
+    # of linting it (found by the fixture self-test, first run).
+    YAML.safe_load_file(abs, permitted_classes: [Date], aliases: false)
+  rescue Psych::SyntaxError, Psych::DisallowedClass => e
+    fail! "#{rel}: does not parse — #{e.message}"
+    next
+  end
+  make = doc["make"].to_s
+  fail! "#{rel}: `make` missing or mismatched with filename" if make.empty? || "#{make}.yml" != File.basename(abs)
+  %w[researcher verifier reviewed_at raw_fingerprint].each do |k|
+    fail! "#{rel}: `#{k}` missing" if doc[k].to_s.empty?
+  end
+  if doc["researcher"].to_s == doc["verifier"].to_s && !doc["researcher"].to_s.empty?
+    fail! "#{rel}: researcher == verifier (#{doc['researcher'].inspect}) — the author never certifies " \
+          "their own work (I-11). A second, independent agent must sign."
+  end
+
+  # Staleness (PRD §5.3): when pack fingerprints from a FRESH build are on
+  # hand (VDB_PACKS=…/build/packs, written by pipeline/tools/gen_review_pack.rb),
+  # a ledger whose raw_fingerprint no longer matches is STALE — the registry
+  # started emitting different raw spellings after the review. Stale is NOT a
+  # lint failure (nobody did anything wrong); the make's verdicts simply stop
+  # counting toward coverage until re-verified. Without VDB_PACKS this check
+  # is skipped — plain repo runs can't know the current raw surface.
+  stale_make = false
+  if ENV["VDB_PACKS"]
+    fp_path = File.join(File.expand_path(ENV["VDB_PACKS"]), "#{make}.fingerprint")
+    if File.exist?(fp_path) && File.read(fp_path).strip != doc["raw_fingerprint"].to_s.strip
+      stale_make = true
+      puts "STALE: #{rel} — raw fingerprint changed since review; verdicts excluded from coverage until re-verified"
+    end
+  end
+
+  seen_ids = Set.new
+  (doc["records"] || []).each do |r|
+    id = r["id"].to_s
+    verdict = r["verdict"].to_s
+    label = "#{rel} → #{id}"
+    fail! "#{label}: duplicate record entry" unless seen_ids.add?(id)
+    kind, rest = id.split("/", 2)
+    unless KINDS.include?(kind) && rest.to_s.include?("/")
+      fail! "#{label}: id must be <kind>/<make>/<slug>"
+      next
+    end
+    fail! "#{label}: unknown verdict #{verdict.inspect} (allowed: #{VERDICTS.join(', ')})" unless VERDICTS.include?(verdict)
+    fail! "#{label}: verdict without an evidence citation is an opinion — add `evidence:`" if r["evidence"].to_s.strip.empty? && verdict != "stale"
+    if %w[debt removed moved].include?(verdict) && r["note"].to_s.strip.empty?
+      fail! "#{label}: #{verdict} requires a `note:` naming the blocker/mechanism"
+    end
+
+    is_live = live[kind]&.include?(rest)
+    case verdict
+    when "canonical", "fixed", "debt"
+      fail! "#{label}: verdict #{verdict} but the id is NOT live in the catalog being measured — " \
+            "either the record vanished since review (re-review) or the id is mistyped" unless is_live
+    when "removed"
+      fail! "#{label}: verdict removed but the id is STILL LIVE — the removal did not happen" if is_live
+      unless removals.key?(id) || former.key?(id)
+        fail! "#{label}: removed without a removals.yml entry or former_ids alias — a consumer holding " \
+              "this id gets an undocumented 404 (I-5)"
+      end
+    when "moved"
+      fail! "#{label}: verdict moved but the id is STILL LIVE" if is_live
+      fail! "#{label}: moved without a former_ids alias — the migration path is missing" unless former.key?(id)
+    end
+
+    # Only VALID, non-stale verdicts count toward coverage — an unknown
+    # verdict or a stale make must not inflate the number it exists to gate.
+    make_id = rest.split("/").first
+    if VERDICTS.include?(verdict) && verdict != "stale" && !stale_make
+      reviewed[owner_of[make_id] || "?"] += 1
+    end
+  end
+end
+
+# ── coverage + monotonicity ──────────────────────────────────────────────────
+published = Hash.new(0)
+by_make.each { |mk, n| published[owner_of[mk] || "?"] += n }
+coverage = {}
+%w[s4w s2w].each do |o|
+  coverage[o] = published[o].zero? ? 0.0 : (100.0 * reviewed[o] / published[o]).round(2)
+end
+total_pub = published.values.sum
+total_rev = reviewed.values.sum
+coverage["total"] = total_pub.zero? ? 0.0 : (100.0 * total_rev / total_pub).round(2)
+
+baseline_path = File.join(ROOT, "data/review/_coverage.yml")
+baseline = (YAML.safe_load_file(baseline_path) rescue nil) || {}
+coverage.each do |o, pct|
+  prev = baseline[o].to_f
+  if pct < prev
+    fail! "coverage for #{o} DECREASED: #{prev}% → #{pct}% — verdicts may go stale (re-review) " \
+          "but coverage on main may never silently drop (PRD §5.3)"
+  end
+end
+if ARGV.include?("--update") && FAILURES.empty?
+  File.write(baseline_path, "# GENERATED by lint_review.rb --update — the coverage floor (monotonicity baseline).\n" + coverage.to_yaml)
+end
+
+puts format("review coverage: total %s%% (%d/%d) · s4w %s%% (%d/%d) · s2w %s%% (%d/%d) · ledgers %d",
+            coverage["total"], total_rev, total_pub,
+            coverage["s4w"], reviewed["s4w"], published["s4w"],
+            coverage["s2w"], reviewed["s2w"], published["s2w"], ledgers.size)
+
+if FAILURES.any?
+  FAILURES.each { |f| puts "LINT FAIL: #{f}" }
+  exit 1
+else
+  puts "review lint: OK"
+end


### PR DESCRIPTION
Part of the P1 review-harness milestone (PRD-QUALITY.md §5–§7; NEGOTIATION.md Turn 51 work claim). Companion pipeline PR: vehiclesdb-pipeline#s4w/a4-pack-tool (pack generator + reachability-test fix).

## What this delivers

### 1. A4 — the verification-ledger harness (P1)
- **`scripts/lint_review.rb`** — enforcement for `data/review/<make>.yml` ledgers: closed verdict vocabulary (`canonical/fixed/debt/removed/moved/stale`), mandatory evidence per verdict, `researcher != verifier` (I-11), and verdict-vs-reality cross-checks against the catalog being measured (canonical/fixed/debt ⇒ id LIVE; removed ⇒ id GONE + removals/former_ids coverage; moved ⇒ former_ids alias). Coverage per owner with a **monotonic baseline** (`data/review/_coverage.yml`, advanced only via `--update` on a green run). `VDB_CATALOG` measures a fresh build; `VDB_PACKS` enables **fingerprint staleness** (a stale make's verdicts stop counting toward coverage — no failure, they just stop counting).
- **Fixture-tested, all nine violation classes fire.** Two bugs found and fixed during self-test: (a) unquoted `reviewed_at: 2026-07-25` crashed the lint (Psych types bare ISO dates as `Date`; now permitted + `DisallowedClass` rescued into a lint failure); (b) invalid verdicts counted toward coverage (now only valid, non-stale verdicts count).
- **`data/review/batches.yml`** — the dispatch board. Pilot **B-000 = `iva`** pre-registered for **S2W** per I-11 (the harness author never pilots their own harness). The pilot pack already surfaces real work: the `RA9015`/`RA9011` duplicate-spelling splits published as separate records.
- **`data/review/README.md`** — directory map + ledger shape example.

### 2. A6 — factory-built dissolution
NZTA writes `make="FACTORY BUILT"` for fully-imported buses (body-provenance flag, not a manufacturer) with the real marque in the model column. Its only three published records move via `moves.yml` to honest make-as-model rows (`bus/geely/geely`, `bus/yutong/yutong`, `bus/zhongtong/zhongtong` — `van/uaz/uaz` precedent; NOT guessed into nameplates, that's the SEAT-incident failure mode). With the pseudo-make gone from the build entirely, the cross-make `former_ids` aliases are legal under rule 3. **Heads-up recorded in moves.yml**: ~600 sub-threshold candidate rows remain under factory-built across all kinds (Douglas, Optare, King Long…) — the pseudo-make must never publish under its own name.

### 3. TVR rekey (pipeline#8 handoff, Turn 49)
Orphaned `Tvr:` block → display form `TVR:`, canonical corrected to the official wedge-era lowercase-i **350i**. The newly-live fold vanished `car/tvr/350-i` — caught by the no-vanish gate on the first build (working exactly as designed), aliased.

### 4. embedded-make-prefix-4w debt: 22 declared / 24 measured → 1
Resolved per-record against manufacturers' own naming: **15 official marque-in-the-name nameplates → `legit`** with brand-site evidence (`MAZDA[2356]`, `Polestar [2-6]`, `Omoda 5/7/9/E5`, `Jaecoo [5-8]`, `Jensen-Healey`; patterns exact-list so a new "Mazda7" still surfaces as a suspect); **7 artifacts → merged/nulled** (`AUDIA6→A6`, `Audi Q5→Q5`, `FIAT500→500`, `JAECOO5 HEV→Jaecoo 5`, `OMODA5 HEV→Omoda 5`, `Lynk Co 01→01`, `Volkswagen-Vw→null` + removals manifest). Every vanish carries a former_ids alias (successor country evidence verified superset). Remaining count: **1** (the palfinger crane-body code).

### 5. Lynk & Co — a full stranded-spelling case study
`lynk-co/lynk-co-01` (was es+nl published) DEMOTED to candidates when the es_dgt re-pin changed its raw spelling — precisely the stranded-spelling failure moves.yml's LESSON block warns about. All four residue spellings keyed **to the corpus-verified produced forms** (`Lynk &co 01` nl/69, `Lynk And Co 01` fi/22, `Lynk Co 01` es/10, `Link & Co 01` es/3) → merged into `lynk-co/01`. The reachability test false-positived on two of these keys (display-vs-raw make replay); fixed in the pipeline PR, **flagged for S2W cross-review**.

## Verification
- Full offline build: **exit 0, ALL GATES GREEN** (gate 7 validated every vanish in this PR; it caught the TVR fold within one build cycle).
- All 5 pipeline test files green (80 runs, 309 assertions).
- `lint_curation.rb` OK; `lint_review.rb` OK (0 ledgers yet); `lint_dataset.rb` vs fresh build: `embedded-make-prefix-4w 1` (= declared), **no GREW**; 89 unexplained remain = S2W's G9 backlog (88) + ownerless `vanster/vanster` (G19, regens at publish) — expected, and the enforcement pressure is the design.

## For the next agent (context you cannot infer)
- Ledger workflow, batch rules, and researcher/verifier prompts: **PRD-QUALITY.md §5–§7**. Pack generation: pipeline `pipeline/tools/gen_review_pack.rb` (run a build first; packs are regenerable, never committed).
- The **fingerprint contract**: ledger stores the pack's `raw_fingerprint`; when a register's raw spellings change, `lint_review.rb` (with `VDB_PACKS`) marks the make stale automatically.
- `batches.yml` B-000 (iva) is S2W's to claim — do not research it from the S4W side (I-11).
- Remaining 4W backlog lives in PRD-QUALITY.md's gap register: G3 quadricycles, G4 FZ 11.1, G5 volvo/60, G6 be_fps, G7 atego/unimog, G21 legal-entity duplicate makes, ~146 4W collision residue, supervised publish §16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)