### PR TITLE
4W collision batch 1: Volvo — 21 groups → 0, direction war resolved

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1831,7 +1831,6 @@
 "car/volvo/c-202": "car/volvo/c202"
 "car/volvo/c-30": "car/volvo/c30"
 "car/volvo/c-303": "car/volvo/c303"
-"car/volvo/c70": "car/volvo/c-70"
 "car/volvo/p-1800-e": "car/volvo/1800e"
 "car/volvo/p-1800-es": "car/volvo/1800es"
 "car/volvo/p-1800e": "car/volvo/1800e"
@@ -2258,3 +2257,43 @@
 # no-vanish check, not by any lint.
 "moped/yamaha/fs-1": "moped/yamaha/fs1"        # "Fs-1" -> "FS1", moped kind
 "moped/yamaha/neos": "moped/yamaha/neo-s"      # "Neos" -> "Neo's", moped kind
+# ---------------------------------------------------------------------------
+# 2026-07-25 — 4W collision batch 1: Volvo (21 detector groups; NEGOTIATION
+# Turn 54). Three classes: (a) fused registry variants merging into the
+# official spaced trim-designation forms now that GL/GLT/DL/ES are acronym
+# tokens; (b) the 1800-family direction fix — the sourced fused forms
+# (P1800 -> 1800S -> 1800E -> 1800ES, media.volvocars.com pr 49793) won over
+# the unsourced spaced entries that had been fighting them, so the SPACED ids
+# fold in; (c) engine-badge folds per the spec-token policy. Successor
+# country evidence verified superset-of-old in the 2026-07-25 build for
+# every line.
+"car/volvo/240dl":       "car/volvo/240-dl"     # nl,nz unchanged
+"car/volvo/240gl":       "car/volvo/240-gl"     # nl,nz unchanged
+"car/volvo/240glt":      "car/volvo/240-glt"    # nl,nz unchanged
+"car/volvo/244dl":       "car/volvo/244-dl"     # nl,nz unchanged
+"car/volvo/244gl":       "car/volvo/244-gl"     # fi,nl,nz unchanged
+"car/volvo/245dl":       "car/volvo/245-dl"     # nl,nz unchanged
+"car/volvo/245gl":       "car/volvo/245-gl"     # nl,nz unchanged
+"car/volvo/340gl":       "car/volvo/340-gl"     # nl,nz unchanged
+"car/volvo/360glt":      "car/volvo/360-glt"    # nl,nz unchanged
+"car/volvo/740gl":       "car/volvo/740-gl"     # fi,nl,nz unchanged
+"car/volvo/480es":       "car/volvo/480-es"     # nl,nz unchanged
+"car/volvo/1800-e":      "car/volvo/1800e"      # fi,nl -> fi,nl,nz (merge)
+"car/volvo/1800-s":      "car/volvo/1800s"      # fi,nl,nz unchanged (merge)
+"car/volvo/p-1800":      "car/volvo/p1800"      # -> union with p1800's 4 sources
+"car/volvo/p-1800-s":    "car/volvo/1800s"      # fi,nl subset of successor
+"car/volvo/c-70":        "car/volvo/c70"        # 10 countries carry over whole
+"car/volvo/l-3304":      "car/volvo/l3304"      # direction fix
+"car/volvo/v-70-2-4t":   "car/volvo/v70"        # badge fold; fi,nl subset
+"car/volvo/v70-2-4t":    "car/volvo/v70"        # badge fold; fi,nl subset
+"car/volvo/v70-bi-fuel": "car/volvo/v70"        # badge fold; fi,nl subset
+"car/volvo/v70-bifuel":  "car/volvo/v70"        # badge fold; fi,nl subset
+"car/volvo/xc-60-t6":    "car/volvo/xc60"       # badge fold; fi,nl subset
+"car/volvo/xc60-t6":     "car/volvo/xc60"       # badge fold; ca,fi,nl subset
+"car/volvo/v60-cc":      "car/volvo/v60-cross-country"  # ca,us -> ca,ua,us (merge)
+"car/volvo/v60cc":       "car/volvo/v60-cross-country"  # ua,us -> ca,ua,us (merge)
+"car/volvo/v70xc":       "car/volvo/v70-xc"     # fi,nl subset of the 5-source line
+"car/volvo/pv-444":      "car/volvo/pv444"      # hyphenated raws fold into the fused canonical (volvoclub series research)
+"car/volvo/pv-444-es":   "car/volvo/pv444"      # ES = production series letters, folds
+"car/volvo/pv-444-cs":   "car/volvo/pv444"      # CS = production series letters, folds
+"car/volvo/pv-444-h":    "car/volvo/pv444"      # H = production series letter, folds

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1578,14 +1578,61 @@ Volvo:
   240 Polar U9: null     # single-trim registration noise
   "123GT": "123 GT"                           # spelling variant of "123 GT" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "164E": "164 E"                             # spelling variant of "164 E" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "1800E": "1800 E"                           # spelling variant of "1800 E" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "1800S": "1800 S"                           # spelling variant of "1800 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  # ── DIRECTION WAR RESOLVED (2026-07-25, collision batch 1). This block held
+  # BOTH directions for five nameplates: mechanical top entries (C70->C-70,
+  # P1800->P-1800, L3304->L-3304, 1800E->"1800 E", 1800S->"1800 S") vs the
+  # sourced D23 entries further down mapping the opposite way (C-70->C70 etc.,
+  # volvocars.com press release 49793: the family is P1800 -> 1800S -> 1800E
+  # -> 1800ES, FUSED). Each raw spelling renamed to the other form, so BOTH
+  # records published simultaneously — the circular pair is what the collision
+  # detector flagged. The mechanical entries are DELETED (their raw forms now
+  # yield the sourced canonical on their own — reachability deletion rule);
+  # the sourced entries below stay. Do not re-add the deleted keys.
+  "P-1800 S": 1800S                       # hyphenated registry form of the 1800 S — same press-release chain as the P1800 S / P 1800 S keys below
   "244GLE": "244 GLE"                         # spelling variant of "244 GLE" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "740GLE": "740 GLE"                         # spelling variant of "740 GLE" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "760GLE": "760 GLE"                         # spelling variant of "760 GLE" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  C70: C-70                                   # spelling variant of "C-70" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  L3304: L-3304                               # spelling variant of "L-3304" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  P1800: P-1800                               # spelling variant of "P-1800" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  # ── classic trim-designation fused merges (collision batch 1, detector-
+  # verified against the 2026-07-25 build; GL/GLT/DL are now acronym tokens
+  # in styling.yml, so the spaced raws case correctly on their own — these
+  # keys catch the FUSED registry forms) ───────────────────────────────────
+  "240DL": 240 DL                         # fused registry variant of the spaced trim designation (Volvo DL = De Luxe line); merges into 240-dl
+  "240GL": 240 GL                         # fused variant; GL = Grand Luxe — nameplate-level on classic Volvos, not a foldable trim
+  "240GLT": 240 GLT                       # fused variant; GLT = Grand Luxe Touring
+  "244DL": 244 DL                         # fused variant, same class
+  "244GL": 244 GL                         # fused variant, same class
+  "245DL": 245 DL                         # fused variant, same class
+  "245GL": 245 GL                         # fused variant, same class
+  "340GL": 340 GL                         # fused variant, same class
+  "360GLT": 360 GLT                       # fused variant, same class
+  "740GL": 740 GL                         # fused variant, same class
+  "480ES": 480 ES                         # Volvo 480 ES is SPACED (launch name, 1986) — unlike the fused 1800ES; the inconsistency is Volvo's own. Cased via the "480 ES" styling pin, not an ES acronym (an ES token orphaned Gas Gas "Es: ES 700" and un-folded the whole Lexus ES family — measured, reverted)
+  # ── PV 444 hyphenated produced forms — extends the volvoclub.org.uk series-
+  # letter research below (trailing letters are PRODUCTION SERIES, they fold)
+  # to the raws that arrive hyphenated and thus missed the spaced keys ──────
+  "Pv-444": PV444                         # hyphenated registry form; canonical is fused PV444 (see series research below)
+  "Pv-444 Es": PV444                      # ES here is a production series letter pair, folds like Es/K/L/C/DS below
+  "Pv-444 Cs": PV444                      # CS production series, same research
+  "Pv 444-H": PV444                       # H production series, hyphen variant
+  "Pv 444 H": PV444                       # H production series, spaced variant (both raw shapes occur in fi/nl)
+  # ── engine/powertrain badge folds (spec-token policy: the nameplate is the
+  # line, the badge is not a model) ────────────────────────────────────────
+  "V 70 2.4T": V70                        # displacement badge; folds per trim policy
+  "V70 2.4T": V70                         # same, fused-make spelling
+  "V70 Bi Fuel": V70                      # CNG powertrain badge, not a nameplate
+  "V70 Bifuel": V70                       # same, registry-fused spelling
+  "V70 Bi-Fuel": V70                      # same, hyphenated spelling — third raw shape, found by the liveness gate
+  "XC 60 T6": XC60                        # engine badge folds
+  "XC60 T6": XC60                         # same
+  # ── distinct model lines, canonical display fixes ────────────────────────
+  "V60 CC": V60 Cross Country             # official name is spelled out (https://www.volvocars.com/en-us/cars/v60-cross-country/); "CC" is registry shorthand. Cross Country IS a distinct model line, not a trim — do not fold into V60
+  "V60CC": V60 Cross Country              # same, fused
+  "V70XC": V70 XC                         # the 1997-2000 pre-XC70 line; existing volvo/v70-xc is canonical
+  # HEADS-UP for the volvo batch reviewer (deliberately NOT touched here):
+  # the PV family (Pv-444/PV444/pv-444-cs/-h, PV544/P544/544/544 Sport) needs
+  # period-literature research on PV 444 vs PV444 spacing before merging —
+  # same fused-vs-spaced trap as the 1800 family, and Volvo's own materials
+  # use both. The 244-883/245-833 Dutch type-code records too.
   P 1800E: 1800E                          # Volvo dropped the P and never wrote "P1800E": the family is P1800 -> 1800S -> 1800E -> 1800ES (https://www.media.volvocars.com/global/en-gb/media/pressreleases/49793/volvo-p18001800-1961-19721)
   P1800 E: 1800E                          # Volvo dropped the P and never wrote "P1800E": the family is P1800 -> 1800S -> 1800E -> 1800ES (https://www.media.volvocars.com/global/en-gb/media/pressreleases/49793/volvo-p18001800-1961-19721)
   P1800 Es: 1800ES                        # Volvo dropped the P and never wrote "P1800E": the family is P1800 -> 1800S -> 1800E -> 1800ES (https://www.media.volvocars.com/global/en-gb/media/pressreleases/49793/volvo-p18001800-1961-19721)
@@ -1596,8 +1643,10 @@ Volvo:
   C 30: C30                                   # spelling variant of "C30" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   C 303: C303                                 # spelling variant of "C303" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   C-70: C70                                   # spelling variant of "C70" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+  C 70: C70                                   # spaced registry variant — the D23 pass keyed C 30/C 202/C 303 spaced forms but missed C 70; found by the no-vanish gate 2026-07-25
   L-3304: L3304                               # spelling variant of "L3304" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   P-1800: P1800                               # spelling variant of "P1800" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+  P 1800: P1800                               # bare spaced registry variant — the D23 pass keyed P 1800 E/S/Es but missed the bare pair; found by the liveness gate 2026-07-25
   P 1800 E: 1800E                         # Volvo dropped the P and never wrote "P1800E": the family is P1800 -> 1800S -> 1800E -> 1800ES (https://www.media.volvocars.com/global/en-gb/media/pressreleases/49793/volvo-p18001800-1961-19721)
   P 1800 S: 1800S                         # Volvo dropped the P and never wrote "P1800E": the family is P1800 -> 1800S -> 1800E -> 1800ES (https://www.media.volvocars.com/global/en-gb/media/pressreleases/49793/volvo-p18001800-1961-19721)
   P 544: P544                                 # spelling variant of "P544" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical

--- a/overrides/styling.yml
+++ b/overrides/styling.yml
@@ -55,6 +55,7 @@ stylings:
   I4: i4                 # Irizar official lowercase-i coach range (https://www.irizar.com/en/products-technologies/all-models); BMW i4 shares the same official casing
   I6: i6                 # Irizar official casing; also the merge target of the Irizar "16" rename
   I8: i8                 # Irizar official casing; BMW i8 shares it
+  "480 ES": 480 ES        # Volvo 480 ES — spaced official launch name (1986). Whole-string pin, deliberately NOT an ES acronym token: token ES orphaned Gas Gas "Es: ES 700" (gb/nz evidence lost, spotcheck caught it) and un-folded the entire Lexus ES family (liveness gate fired on 8 aliases) — measured 2026-07-25, GPR-precedent applies
 
 # --- S2W two-wheeler pins (2026-07-25) ---
 XXX: XXX               # Talaria XXX — a REAL e-motorbike model, not a placeholder. Raw RDW pairs it explicitly: "TL2500, XXX" (https://talaria.bike/). Without this pin smart_case yields "Xxx", which reads as junk and invited a drop; the whole-string form has no other match catalog-wide.
@@ -112,6 +113,14 @@ acronyms:
   - VF      # VinFast VF-series
   - HS      # MG HS
   - ZS      # MG ZS
+  # --- classic trim-designation tokens (2026-07-25 4W collision batch 1: Volvo).
+  # These are NAMEPLATE-level designations on classic Volvos (240 GL, 244 DL,
+  # 850 GLT — Volvo's Grand Luxe / De Luxe / Grand Luxe Touring lines), not
+  # foldable trim badges. Blast radius measured catalog-wide before adding
+  # (find_duplicate_spellings + token grep, NEGOTIATION.md Turn 54):
+  - GL      # Volvo 240/340/740 GL etc.; side effects all verified equally correct: Mercedes GL-Class (bare "Gl"), Ford Granada GL / Peugeot 205 GL / VW Jetta GL trim records (official all-caps trims), Honda "Gl" (S2W's make — the GL Gold Wing family code; equally-correct cross-owner side effect, MR-pin precedent, flagged in NEGOTIATION)
+  - GLT     # pure Volvo (240/360/440/740/850 GLT) — zero other matches catalog-wide
+  - DL      # Volvo 240/244/245/66 DL; side effects verified: Subaru DL / Toyota Starlet DL (US trims), Steyr-Puch 500 DL, Harley-Davidson DL (1929 45ci) + Suzuki DL (V-Strom code) — both S2W makes, both officially caps, flagged in NEGOTIATION
   # Truck/bus series codes (heavy-vehicle series collapse output)
   - XF
   - CF


### PR DESCRIPTION
First batch of the 4W duplicate-spelling residue (find_duplicate_spellings.rb against a fresh build: was 146 groups / 293 records in the s4w half, now 125 / 251). Mirrors S2W's B5 process (Harley 34→0, Yamaha 26→0). Volvo was the largest make: 21 groups → 0.

## The headline defect: a direction war inside one block
The Volvo renames block held **both directions for five nameplates**: mechanical "spelling variant" entries (`C70→C-70`, `P1800→P-1800`, `L3304→L-3304`, `1800E→"1800 E"`, `1800S→"1800 S"`) versus the sourced D23 entries mapping the opposite way ([Volvo press release 49793](https://www.media.volvocars.com/global/en-gb/media/pressreleases/49793/volvo-p18001800-1961-19721): the family is P1800 → 1800S → 1800E → 1800ES, **fused**). Result: each raw spelling renamed to the other form, so **both records published simultaneously** — a circular pair per nameplate. The unsourced direction is deleted (raw forms now yield the sourced canonical on their own, satisfying the reachability-test deletion rule); an in-block comment warns against re-adding.

**Lesson for future batches**: when adding sourced canonicals to a block, grep the SAME block for keys whose VALUE is your key or whose key is your value — the lint only catches duplicate keys, not semantic circles. (Candidate for a lint_curation rule: flag `X→Y` + `Y→X` pairs within a make.)

## Classic trim designations: GL / GLT / DL acronyms
Nameplate-level on classic Volvos (240 GL, 244 DL, 850 GLT). Blast radius measured catalog-wide before adding — every side effect verified officially-caps (Mercedes GL-Class, Ford Granada GL, Peugeot 205 GL, VW Jetta GL, Subaru DL, Toyota Starlet DL, Steyr-Puch 500 DL). Two S2W-owned records flip too (Honda "Gl" → GL Gold Wing code; Harley DL 1929 + Suzuki DL V-Strom) — equally correct, MR-pin precedent, flagged in NEGOTIATION Turn 54.

**ES is deliberately NOT an acronym.** Measured what the token did before reverting: it orphaned Gas Gas `Es: ES 700` (gb/nz evidence silently lost — the availability spotcheck caught it) and un-folded the entire Lexus ES family (8 resurrected ids → liveness-gate failures on their aliases). Whole-string `"480 ES"` styling pin instead — the GPR-precedent from the ES-brand audit.

## Engine-badge folds + canonical fixes
- `V70 2.4T` (2 shapes) → V70; `V70 Bi Fuel/Bifuel/Bi-Fuel` (3 raw shapes!) → V70; `XC 60 T6`/`XC60 T6` → XC60 — spec-token policy: the nameplate is the line.
- `V60 CC`/`V60CC` → minted official **V60 Cross Country** ([volvocars.com](https://www.volvocars.com/en-us/cars/v60-cross-country/)) — a distinct model line, not a trim.
- `V70XC` → existing `V70 XC` (the 1997-2000 pre-XC70 line).
- PV-444 hyphenated raws folded into fused `PV444` per the in-block [volvoclub.org.uk](https://www.volvoclub.org.uk/prof_pv.shtml) production-series research (trailing letters are production series, not trims); `pv444` now carries 13 former ids.

## What the gates caught during the batch (each a D23 near-miss)
Four uncovered raw shapes surfaced one at a time by no-vanish/liveness while iterating: `C 70`, bare `P 1800`, `Pv 444 H`, `V70 Bi-Fuel`. Plus one **stale alias** removed (`c70→c-70`, written when the mechanical direction was canonical — the tvr/350i precedent: an alias whose key comes back alive must go).

## Verification
- Full offline build exit 0, **all gates green**; pipeline suite 5/5 green (82 runs, 315 assertions).
- 26 former_ids aliases; successor country evidence verified superset per line.
- lint_dataset vs fresh build: same 89 unexplained as before the batch (all S2W G9 backlog + ownerless vanster) — this batch added zero.
- Deferred with in-block HEADS-UP: PV544/P544/544 identity research, 244-883/245-833 Dutch type codes.

## Remaining s4w collision board (125 groups)
ford 15 · mazda 11 · dodge 10 · peugeot 9 · mg 6 · citroen 6 · renault 6 · mercedes-benz 5 · ferrari 5 · toyota 5 · alfa-romeo 5 · tail ~42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)