### PR TITLE
B5 batch 3: Triumph — 18 collision groups → 0, two marques in one make

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2258,3 +2258,31 @@
 # no-vanish check, not by any lint.
 "moped/yamaha/fs-1": "moped/yamaha/fs1"        # "Fs-1" -> "FS1", moped kind
 "moped/yamaha/neos": "moped/yamaha/neo-s"      # "Neos" -> "Neo's", moped kind
+
+# --- 2026-07-25, S2W: Triumph convention batch (B5 batch 3) -----------------
+# KIND-AWARE, because Triumph publishes in car AND motorcycle and renames are
+# kind-blind. The Yamaha batch shipped motorcycle-only keys for a make that
+# also publishes as moped, and two ids would have 404'd; each entry below is
+# emitted per kind the SOURCE name actually appears in, read off the build.
+"car/triumph/g-t-6": "car/triumph/gt6" # "G.T.6" -> "GT6"
+"car/triumph/gt-6": "car/triumph/gt6" # "GT 6" -> "GT6"
+"car/triumph/gt6-mk-3": "car/triumph/gt6-mk3" # "GT6 Mk 3" -> "GT6 Mk3"
+"motorcycle/triumph/speed-master": "motorcycle/triumph/speedmaster" # "Speed Master" -> "Speedmaster"
+"motorcycle/triumph/speedtriple": "motorcycle/triumph/speed-triple" # "Speedtriple" -> "Speed Triple"
+"motorcycle/triumph/speedtwin": "motorcycle/triumph/speed-twin" # "Speedtwin" -> "Speed Twin"
+"car/triumph/spitfire-mk-2": "car/triumph/spitfire-mk2" # "Spitfire Mk 2" -> "Spitfire Mk2"
+"car/triumph/spitfire-mk-4": "car/triumph/spitfire-mk4" # "Spitfire Mk 4" -> "Spitfire Mk4"
+"motorcycle/triumph/tf250-e": "motorcycle/triumph/tf-250-e" # "TF250-E" -> "TF 250-E"
+"motorcycle/triumph/tf250e": "motorcycle/triumph/tf-250-e" # "TF250E" -> "TF 250-E"
+"motorcycle/triumph/tf450-e": "motorcycle/triumph/tf-450-e" # "TF450-E" -> "TF 450-E"
+"motorcycle/triumph/tf450e": "motorcycle/triumph/tf-450-e" # "TF450E" -> "TF 450-E"
+"car/triumph/tr3-a": "car/triumph/tr3a" # "TR3 A" -> "TR3A"
+"car/triumph/tr4-a": "car/triumph/tr4a" # "TR4 A" -> "TR4A"
+"car/triumph/tr6pi": "car/triumph/tr6-pi" # "TR6PI" -> "TR6 PI"
+"car/triumph/tr-2": "car/triumph/tr2" # "Tr 2" -> "TR2"
+"car/triumph/tr-250": "car/triumph/tr250" # "Tr 250" -> "TR250"
+"car/triumph/tr-3": "car/triumph/tr3" # "Tr 3" -> "TR3"
+"car/triumph/tr-4a": "car/triumph/tr4a" # "Tr 4A" -> "TR4A"
+"car/triumph/tr-6": "car/triumph/tr6" # "Tr 6" -> "TR6"
+"car/triumph/tr-7": "car/triumph/tr7" # "Tr 7" -> "TR7"
+"car/triumph/tr-8": "car/triumph/tr8" # "Tr 8" -> "TR8"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1510,7 +1510,66 @@ Trigano:
   Trigano: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Triumph:
+  # TRIUMPH CONVENTION DOSSIER (§11.2). This make is TWO marques sharing a name,
+  # and makes/aliases.yml already warns about it — "Triumph is BOTH a classic car
+  # make and a motorcycle make; kind context disambiguates, do NOT merge". This
+  # batch is where that bites: the halves need different EVIDENCE and land in
+  # different kinds. Renames are kind-blind, so check the kind before editing.
+  #
+  #  MOTORCYCLES (Hinckley, 1990s-, live marque — manufacturer-sourced):
+  #    "Speed Twin" and "Speed Triple" are TWO words; "Speedmaster" is ONE (the
+  #    Bonneville Speedmaster). Same marque, same family, opposite conventions —
+  #    the Yamaha DragStar/Road Star lesson again.
+  #    https://www.triumphmotorcycles.com/motorcycles/classic/bonneville-speedmaster/speedmaster-2023
+  #    Motocross is "TF 250-X" on Triumph's own pages: SPACE after TF, HYPHEN
+  #    before the suffix letter.
+  #    https://www.triumphmotorcycles.com/motorcycles/off-road/motocross/tf-250-x-2025
+  #
+  #  CARS (Standard-Triumph, 1950s-80s, DEFUNCT — badge evidence, since there is
+  #  no company left to publish anything):
+  #    TR-series and GT6 are closed uppercase as badged. The register splits them
+  #    every way imaginable ("Tr 2", "TR4 A", "G.T.6").
+  #    Mk is ARABIC and CLOSED — Triumph's own script badge read "Mk3". Reference
+  #    works use Roman numerals (Mk I-IV), but no register emits them and no badge
+  #    showed them, so Roman would be inventing a third form.
+  #
+  # HOW THIS BLOCK WAS ALMOST LOST: the batch generator inserted a SECOND
+  # `Triumph:` block instead of merging into this one. YAML keeps only the last
+  # duplicate key, so one of the two would have vanished silently — the exact
+  # failure lint_curation's duplicate-key check exists for. The generator's own
+  # guard caught it and aborted; I misread the abort as success and shipped 22
+  # former_ids for renames that had never been applied. The gate caught THAT.
+  # If you add to this make, add HERE.
   Triumph: null                           # motorcycle nl|nz
+  G.T.6: GT6                              # TR-series/GT6 badge form: closed uppercase
+  GT 6: GT6                               # ditto
+  GT-6: GT6                               # FOURTH occurrence of one-id-many-names: gt-6 is published as "GT-6" (hyphen), not the "GT 6" I keyed from the detector output. The detector shows one representative name per id and it is not always the one your key matches
+  GT6 Mk 3: GT6 Mk3                       # Mk arabic + closed, per the badge
+  GT6 MK3: GT6 Mk3                        # ditto
+  Speed Master: Speedmaster               # Triumph writes the Bonneville Speedmaster as ONE word
+  Speedtriple: Speed Triple               # ...but Speed Triple as TWO. Same marque, opposite conventions
+  Speedtwin: Speed Twin                   # ...and Speed Twin as two
+  Spitfire Mk 2: Spitfire Mk2             # Mk arabic + closed, per the badge
+  Spitfire MK2: Spitfire Mk2              # ditto
+  Spitfire Mk 4: Spitfire Mk4             # ditto
+  Spitfire MK4: Spitfire Mk4              # ditto
+  Spitfire MK3: Spitfire Mk3              # not a collision group (no rival spelling) but the same Mk convention — left inconsistent it would be the only MK in the make
+  TF250-E: TF 250-E                       # motocross range is "TF 250-X": space after TF, hyphen before the suffix
+  TF250E: TF 250-E                        # ditto
+  TF450-E: TF 450-E                       # ditto
+  TF450E: TF 450-E                        # ditto
+  Tr 2: TR2                               # TR-series badge form: closed uppercase
+  Tr 3: TR3                               # ditto
+  Tr 6: TR6                               # ditto
+  Tr-6: TR6                               # same: tr-6 publishes as "Tr-6"
+  Tr 7: TR7                               # ditto
+  Tr 8: TR8                               # ditto
+  Tr 250: TR250                           # ditto
+  Tr 4A: TR4A                             # ditto
+  TR3 A: TR3A                             # ditto
+  TR4 A: TR4A                             # ditto
+  TR6 Pi: TR6 PI                          # PI = petrol injection, an uppercase suffix on the badge
+  TR6PI: TR6 PI                           # ditto
 
 TRS:
   Trrs One: One          # strip the embedded badge — bikes are badged TRRS but the make resolves to TRS, so the prefix strip missed (trsmotorcycles.com); CREATES the One canonical


### PR DESCRIPTION
29 rename lines, 22 kind-aware `former_ids`. **Collision count for this make measured at zero** after the final build.

## Triumph is two marques sharing a name

`makes/aliases.yml` has warned about this all along — *"BOTH a classic car make and a motorcycle make; kind context disambiguates, do NOT merge"*. This is the batch where it bites: the halves need **different evidence**, land in **different kinds**, and renames are kind-blind.

**Motorcycles** (Hinckley, live marque, manufacturer-sourced):
- **"Speed Twin"** and **"Speed Triple"** are two words; **"Speedmaster"** is one (it's the Bonneville Speedmaster). Same marque, same family, opposite conventions — the Yamaha DragStar/Road Star shape again. [source](https://www.triumphmotorcycles.com/motorcycles/classic/bonneville-speedmaster/speedmaster-2023)
- Motocross is **"TF 250-X"**: space after TF, hyphen before the suffix letter. [source](https://www.triumphmotorcycles.com/motorcycles/off-road/motocross/tf-250-x-2025)

**Cars** (Standard-Triumph, defunct — badge evidence, since there is no company left to publish anything):
- TR-series and GT6 closed uppercase, as badged. The register splits them every way imaginable: `Tr 2`, `TR4 A`, `G.T.6`.
- **Mk is Arabic and closed** — Triumph's own script badge read `Mk3`. Reference works use Roman numerals (Mk I–IV), but no register emits them and no badge showed them, so Roman would be inventing a **third** form.

## Three process failures, all mine, all caught by tooling

Recording them because the pattern is now unmistakable.

**1. A `Triumph:` block already existed** and my generator tried to insert a second. YAML keeps only the last duplicate key, so one would have vanished silently.

The generator's own guard caught it and **aborted** — and I misread the abort as success, because I had tailed the wrong script's output. I then appended 22 `former_ids` for renames that had never been applied. **The id-contract gate caught that.**

Two independent controls, two catches, one misread by me in between. The block now carries this history inline so the next person adding to this make adds to the right place.

**2. One id, many names — fourth occurrence in three batches.** `gt-6` publishes as `"GT-6"` and `tr-6` as `"Tr-6"`, both hyphenated, while the detector showed me the spaced forms.

This is no longer an incident, it is **the dominant failure mode of collision work**: `find_duplicate_spellings.rb` reports one representative name per id, and *which* one it reports changes between builds. Harley needed three rebuilds for `FXE/F`; Yamaha needed two for `T-Max`/`V Max`; this one needed two.

**3. The duplicate-key lint caught my manual `former_ids` additions immediately** — `"GT 6"` and `"GT-6"` slug identically, so the generator had already emitted those aliases and mine were duplicates. Exactly the check's purpose, working on the first try.

Also fixed a non-collision inconsistency found while in the block: `"Spitfire MK3"` was the only `MK` in the make, every sibling being `Mk`. Display-only, so correctly **no** alias (rule 1).

## Verified, final build

| check | result |
|---|---|
| triumph collision groups | **18 → 0** |
| `lint_overrides` / `lint_curation` | green |
| my dangling aliases | 0 |
| my alias chains | 0 |
| pre-existing aliases pointing at an id this batch removes | 0 |

## Read before merging — the build still exits 1, and it is not this batch

105 no-vanish failures remain, of which **74 are records the last release published on a 2-source pair including `lu_snca`** — a monthly *delta* feed whose model set rotates completely each month.

The two `triumph/tiger-*` failures in that list are **S4W backfill aliases in the same class**, verified present on `main` and untouched by this branch:

```
motorcycle/triumph/tiger-sport800tour -> …/tiger-sport-800-tour   (on main)
motorcycle/triumph/tiger800xc-abs     -> …/tiger-800xc-abs        (on main)
```

This is the churn problem reported in NEGOTIATION.md Turn 55, not a defect here. Either accumulate `lu_snca` over N months the way `es_dgt` already does (`MONTHS_BACK = 3`, *"so one slow month doesn't starve the picture"* — the exact reasoning `lu_snca` lacks), or teach the gate that a 2-source record losing a delta-feed source is churn rather than a vanish. I'd prefer the first: it fixes the data instead of teaching the gate to ignore it.