### PR TITLE
A7: pilot findings — awaiting_verification state, slug hint, register-only evidence class

### DIFF
--- a/PRD-QUALITY.md
+++ b/PRD-QUALITY.md
@@ -429,6 +429,36 @@ detector flags requires the evidence to address the flag specifically ("looks
 like D9 but is Rieju's official model name, per rieju.com/…"). Verdicts are per
 **id**; a make is done when every published id under it has a non-stale verdict.
 
+**Two-phase state (amended after the B4 pilot, Turn 55 finding 1 — BLOCKING).**
+A researched-but-unverified ledger is a legitimate intermediate: the researcher
+ships with `status: awaiting_verification` + `verifier: null`. The lint
+tolerates exactly this pair (a signed verifier with awaiting status fails, and
+vice versa), and the make's verdicts are EXCLUDED from the coverage numerator
+until a verifier signs. Anything else would force single sessions to sign both
+fields — the letter of I-11 with none of its substance, which is how a
+verification ledger's central claim becomes unfalsifiable.
+
+**Evidence classes (amended after the B4 pilot, Turn 55 finding 3).** For
+long-tail makes the register IS the totality of available evidence — RA9015-
+class models have no manufacturer page, no press release, no archive, and
+Tranche C is ~400 makes of this. Forcing a URL there pushes researchers toward
+laundering retailer listings into "evidence", which is strictly worse than an
+honest ceiling statement. Sanctioned substitute:
+
+```yaml
+  - id: moped/iva/ra9015
+    verdict: fixed
+    evidence_class: register-only   # asserts: the pack's registry rows are the
+                                    # totality of evidence, corroborated across
+                                    # the raw spellings listed there
+```
+
+`register-only` verdicts count toward coverage (they are verified against the
+ceiling of what exists) but are tallied on their OWN coverage line so the split
+stays visible — the number stays honest instead of the verdicts getting
+optimistic. The class list is closed (the lint rejects others); propose new
+classes here first, with the failure mode they prevent.
+
 ### 5.3 Coverage metric and CI wiring
 
 `scripts/lint_review.rb` (to build, Phase 1):
@@ -681,7 +711,12 @@ HARD RULES YOU MUST NOT VIOLATE:
 - Wikipedia/wikis/other vehicle databases: use only to LOCATE primary sources.
   Never import their content or lists (they are ShareAlike; this dataset is
   CC-BY). Manufacturer sites, press releases, heritage archives, regulator
-  documents are your sources of record.
+  documents are your sources of record. When NONE of those exist for a model —
+  discontinued OEM-code long-tail, the RA9015 class — do NOT launder a retailer
+  listing into an "evidence" URL and do NOT park two-thirds of a make in debt
+  to look compliant: write `evidence_class: register-only` (§5.2), which
+  asserts the pack's registry rows are the totality of evidence. Honest ceiling
+  beats optimistic verdict, always.
 - Corroboration proves a record is REAL, not that its name is canonical — and
   proves nothing for make-as-model / embedded-make records.
 - Trims, editions, body styles and engine variants FOLD into the nameplate;

--- a/scripts/lint_review.rb
+++ b/scripts/lint_review.rb
@@ -59,6 +59,17 @@ KINDS.each do |k|
   ids.each { |id| by_make[id.split("/").first] += 1 }
 end
 former = (YAML.safe_load_file(File.join(ROOT, "overrides/models/former_ids.yml")) rescue nil) || {}
+# former_ids has TWO authored shapes (flat string / nested {to:, accepted_loss:})
+# — normalize at the boundary exactly like the pipeline gate does (pipeline#10
+# fixed the same crash there; same lesson, same shape).
+former = former.transform_values { |v| v.is_a?(Hash) ? v["to"] : v }.compact
+# Alias TARGETS are ids guaranteed live in the NEXT build (the pipeline
+# liveness gate enforces it) but possibly absent from the PUBLISHED catalog
+# this lint measures between releases. A `fixed` verdict on a merge target
+# is exactly that state — the fix is merged, the publish is pending (§16).
+# Found by the B4 pilot verification: venti-50/ra9011/e-go-s4-new failed
+# the live check against the repo catalog while being fully correct.
+pending_publish = former.values.to_set
 removals = (YAML.safe_load_file(File.join(ROOT, "overrides/models/removals.yml")) rescue nil) || {}
 own = (YAML.safe_load_file(File.join(ROOT, "OWNERSHIP.yml")) rescue nil) || {}
 owner_of = ((own["s4w"] || []).to_h { |m| [m, "s4w"] }).merge((own["s2w"] || []).to_h { |m| [m, "s2w"] })
@@ -167,7 +178,7 @@ ledgers.sort.each do |abs|
       fail! "#{label}: #{verdict} requires a `note:` naming the blocker/mechanism"
     end
 
-    is_live = live[kind]&.include?(rest)
+    is_live = live[kind]&.include?(rest) || pending_publish.include?(id)
     case verdict
     when "canonical", "fixed", "debt"
       fail! "#{label}: verdict #{verdict} but the id is NOT live in the catalog being measured — " \

--- a/scripts/lint_review.rb
+++ b/scripts/lint_review.rb
@@ -12,10 +12,13 @@
 #
 #   * closed verdict vocabulary; unknown verdicts fail
 #   * EVERY verdict carries an evidence citation (a verdict without evidence is
-#     an opinion)
+#     an opinion) — OR `evidence_class: register-only` when the register is the
+#     totality of available evidence (B4 pilot finding 3; tallied separately)
 #   * researcher != verifier, always (I-11: the author never certifies their
 #     own work — in the correction pass, not one of five major wrong
-#     conclusions was caught by its author)
+#     conclusions was caught by its author). The two-phase intermediate is
+#     `status: awaiting_verification` + `verifier: null` — tolerated, excluded
+#     from coverage (B4 pilot finding 1)
 #   * verdicts must point at reality: `canonical`/`debt` need the id LIVE in
 #     the catalog; `removed`/`moved` need the id GONE and covered by
 #     former_ids/removals — a verdict claiming a fix that does not exist is
@@ -61,7 +64,9 @@ own = (YAML.safe_load_file(File.join(ROOT, "OWNERSHIP.yml")) rescue nil) || {}
 owner_of = ((own["s4w"] || []).to_h { |m| [m, "s4w"] }).merge((own["s2w"] || []).to_h { |m| [m, "s2w"] })
 
 # ── validate every ledger file ───────────────────────────────────────────────
-reviewed = Hash.new(0) # owner => count of valid, non-stale verdicts
+reviewed = Hash.new(0) # owner => count of valid, non-stale, VERIFIED verdicts
+reg_only = Hash.new(0) # owner => subset of `reviewed` whose evidence is register-only
+awaiting_count = 0     # ledgers parked in awaiting_verification (visible, not counted)
 # Everything in data/review/*.yml is a per-make ledger EXCEPT the dispatch
 # board (batches.yml) and generated files (_-prefixed). Skip by name, don't
 # pattern-guess — a make genuinely named "batches" cannot exist (no registry
@@ -81,9 +86,31 @@ ledgers.sort.each do |abs|
     next
   end
   make = doc["make"].to_s
-  fail! "#{rel}: `make` missing or mismatched with filename" if make.empty? || "#{make}.yml" != File.basename(abs)
-  %w[researcher verifier reviewed_at raw_fingerprint].each do |k|
+  if make.empty? || "#{make}.yml" != File.basename(abs)
+    # Say WHICH form is wanted: "make" means the DISPLAY name everywhere else
+    # in overrides/ (renames blocks are display-keyed), so a researcher writes
+    # "IVA" here on reflex — the B4 pilot did exactly that (Turn 55 finding 2).
+    fail! "#{rel}: `make` missing or mismatched with filename — expected the SLUG " \
+          "(#{File.basename(abs, '.yml').inspect}), not the display name"
+  end
+
+  # Two-phase workflow (B4 pilot finding 1, the blocking one): a researched-
+  # but-unverified ledger is a legitimate intermediate state — the researcher
+  # MUST be able to ship without signing the verifier field themselves, or
+  # I-11 becomes a fiction (single sessions would sign both). The contract:
+  #   status: awaiting_verification  +  verifier: null   → tolerated by lint,
+  #   but the make's verdicts are EXCLUDED from the coverage numerator (they
+  #   are not verified, so they must not count — same treatment as stale).
+  # Any other status with a missing verifier still fails.
+  awaiting = doc["status"].to_s == "awaiting_verification"
+  awaiting_count += 1 if awaiting
+  required = awaiting ? %w[researcher reviewed_at raw_fingerprint] : %w[researcher verifier reviewed_at raw_fingerprint]
+  required.each do |k|
     fail! "#{rel}: `#{k}` missing" if doc[k].to_s.empty?
+  end
+  if awaiting && !doc["verifier"].to_s.empty?
+    fail! "#{rel}: status awaiting_verification but `verifier` is signed — pick one: a signed " \
+          "ledger is past awaiting, an awaiting ledger must leave verifier null"
   end
   if doc["researcher"].to_s == doc["verifier"].to_s && !doc["researcher"].to_s.empty?
     fail! "#{rel}: researcher == verifier (#{doc['researcher'].inspect}) — the author never certifies " \
@@ -118,7 +145,24 @@ ledgers.sort.each do |abs|
       next
     end
     fail! "#{label}: unknown verdict #{verdict.inspect} (allowed: #{VERDICTS.join(', ')})" unless VERDICTS.include?(verdict)
-    fail! "#{label}: verdict without an evidence citation is an opinion — add `evidence:`" if r["evidence"].to_s.strip.empty? && verdict != "stale"
+    # Evidence classes (B4 pilot finding 3): for long-tail makes the register
+    # IS the only evidence there is — RA9015-class models have no manufacturer
+    # page, no press release, no archive. Forcing a URL there pushes the
+    # researcher toward laundering a retailer listing into an "evidence" link,
+    # which is worse than an honest statement of the ceiling. So
+    #   evidence_class: register-only
+    # is a sanctioned substitute for `evidence:` — it asserts "the registry
+    # rows in the pack are the totality of available evidence, corroborated
+    # across the raw spellings listed there". It gets its own coverage line
+    # below so the honesty is visible, not buried.
+    register_only = r["evidence_class"].to_s == "register-only"
+    if r["evidence_class"] && !register_only
+      fail! "#{label}: unknown evidence_class #{r['evidence_class'].inspect} (allowed: register-only)"
+    end
+    if r["evidence"].to_s.strip.empty? && !register_only && verdict != "stale"
+      fail! "#{label}: verdict without an evidence citation is an opinion — add `evidence:` " \
+            "(or `evidence_class: register-only` when the register is the totality of evidence)"
+    end
     if %w[debt removed moved].include?(verdict) && r["note"].to_s.strip.empty?
       fail! "#{label}: #{verdict} requires a `note:` naming the blocker/mechanism"
     end
@@ -139,11 +183,15 @@ ledgers.sort.each do |abs|
       fail! "#{label}: moved without a former_ids alias — the migration path is missing" unless former.key?(id)
     end
 
-    # Only VALID, non-stale verdicts count toward coverage — an unknown
-    # verdict or a stale make must not inflate the number it exists to gate.
+    # Only VALID, non-stale, VERIFIED verdicts count toward coverage — an
+    # unknown verdict, a stale make, or an awaiting_verification ledger must
+    # not inflate the number this lint exists to gate. Register-only evidence
+    # counts (the verdict is verified against the ceiling of what exists) but
+    # is tallied separately so the split stays visible.
     make_id = rest.split("/").first
-    if VERDICTS.include?(verdict) && verdict != "stale" && !stale_make
+    if VERDICTS.include?(verdict) && verdict != "stale" && !stale_make && !awaiting
       reviewed[owner_of[make_id] || "?"] += 1
+      reg_only[owner_of[make_id] || "?"] += 1 if register_only
     end
   end
 end
@@ -172,10 +220,12 @@ if ARGV.include?("--update") && FAILURES.empty?
   File.write(baseline_path, "# GENERATED by lint_review.rb --update — the coverage floor (monotonicity baseline).\n" + coverage.to_yaml)
 end
 
-puts format("review coverage: total %s%% (%d/%d) · s4w %s%% (%d/%d) · s2w %s%% (%d/%d) · ledgers %d",
+puts format("review coverage: total %s%% (%d/%d) · s4w %s%% (%d/%d) · s2w %s%% (%d/%d) · " \
+            "register-only %d · awaiting %d · ledgers %d",
             coverage["total"], total_rev, total_pub,
             coverage["s4w"], reviewed["s4w"], published["s4w"],
-            coverage["s2w"], reviewed["s2w"], published["s2w"], ledgers.size)
+            coverage["s2w"], reviewed["s2w"], published["s2w"],
+            reg_only.values.sum, awaiting_count, ledgers.size)
 
 if FAILURES.any?
   FAILURES.each { |f| puts "LINT FAIL: #{f}" }


### PR DESCRIPTION
Implements all three lint/spec findings from S2W's B4 pilot (NEGOTIATION.md Turn 55), unblocking #21:

1. **BLOCKING — two-phase state**: `status: awaiting_verification` + `verifier: null` tolerated; verdicts excluded from coverage numerator until signed; both contradiction states fail (awaiting+signed, missing-verifier-without-awaiting). PRD §5.2 amended.
2. **Slug hint**: the make-mismatch message names the expected form — everywhere else in overrides/ "make" means the display name, so `make: IVA` is the predictable reflex.
3. **`evidence_class: register-only`**: sanctioned, counts toward coverage, tallied on its own coverage line (`register-only N · awaiting N` added to output). Closed class list. §8.3 researcher prompt now forbids both failure modes the old rule incentivized (evidence-laundering; strategic debt).

Fixture-tested all paths. Companion pipeline change already merged (vehiclesdb-pipeline#12): corpus-observed raw-make map closing the reachability test's residual gap per Turn 54's cross-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)