### PR TITLE
B5 batch 5: the collision tail — the two-wheel half reaches 1 group

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1163,7 +1163,7 @@
 "motorcycle/piaggio/vespa-px150e":             "motorcycle/vespa/px150e"                      # moves.yml Piaggio|Vespa PX150E -> Vespa|PX150E  [nl,nz]
 "motorcycle/piaggio/vespa-px200e":             "motorcycle/vespa/px200e"                      # moves.yml Piaggio|Vespa PX200E -> Vespa|PX200E  [nl,nz]
 "motorcycle/piaggio/vespa-sei-giorni":         "motorcycle/vespa/sei-giorni"                  # moves.yml Piaggio|Vespa Sei Giorni -> Vespa|Sei Giorni  [fi,nl]
-"motorcycle/piaggio/vespa-seigiorni":          "motorcycle/vespa/seigiorni"                   # moves.yml Piaggio|Vespa Seigiorni -> Vespa|Seigiorni  [es,lu,nl]
+"motorcycle/piaggio/vespa-seigiorni":          "motorcycle/vespa/sei-giorni"                   # moves.yml Piaggio|Vespa Seigiorni -> Vespa|Seigiorni  [es,lu,nl] [chain collapsed]
 
 # ---------------------------------------------------------------------------
 # RELEASE 2026-07-25 (f) — un-prefixed Vespa twins (see moves.yml).
@@ -1898,8 +1898,8 @@
 "moped/sherco/n-a": "moped/sherco/50"
 "moped/silence/s01ls": "moped/silence/s01"
 "moped/silence/s02ls": "moped/silence/s02"
-"motorcycle/aprilia/etv1000capo-nord": "motorcycle/aprilia/etv1000-capo-nord"
-"motorcycle/aprilia/etv1000caponord": "motorcycle/aprilia/etv1000-capo-nord"
+"motorcycle/aprilia/etv1000capo-nord": "motorcycle/aprilia/etv1000-caponord" # chain collapsed: the intermediate is itself an alias
+"motorcycle/aprilia/etv1000caponord": "motorcycle/aprilia/etv1000-caponord" # chain collapsed: the intermediate is itself an alias
 "motorcycle/derbi/gpr125": "motorcycle/derbi/gpr-125"
 "motorcycle/derbi/gpr50": "motorcycle/derbi/gpr-50"
 "motorcycle/derbi/mulhacen125": "motorcycle/derbi/mulhacen-125"
@@ -2457,4 +2457,38 @@
 # were left alone rather than guessed.
 "car/honda/frv": "car/honda/fr-v" # "Frv" -> "Fr-V"
 "motorcycle/kawasaki/er5": "motorcycle/kawasaki/er-5" # "ER5" -> "Er-5"
-"motorcycle/suzuki/gsx-r": "motorcycle/suzuki/gsxr" # "Gsx-R" -> "Gsxr"
+
+# --- 2026-07-25, S2W: B5 batch 5 — the collision tail ----------------------
+# 22 makes, most with a single group. For the DEFUNCT marques here (Ariel,
+# Velocette, Matchless, NSU, Puch) there is no manufacturer left to consult
+# and the evidence is the model designation as the marque itself badged it —
+# the per-line comments in renames.yml say which lines those are.
+"motorcycle/bsa/a-10": "motorcycle/bsa/a10" # "A-10" -> "A10"
+"motorcycle/bsa/goldstar": "motorcycle/bsa/gold-star" # "Goldstar" -> "Gold Star"
+"motorcycle/bsa/thunder-bolt": "motorcycle/bsa/thunderbolt" # "Thunder Bolt" -> "Thunderbolt"
+"motorcycle/ktm/1290-superduke-gt": "motorcycle/ktm/1290-super-duke-gt" # "1290 Superduke GT" -> "1290 Super Duke GT"
+"motorcycle/ktm/1290-superduke-r": "motorcycle/ktm/1290-super-duke-r" # "1290 Superduke R" -> "1290 Super Duke R"
+"motorcycle/ktm/e-xc": "motorcycle/ktm/exc" # "E-XC" -> "EXC"
+"motorcycle/suzuki/gsxr": "motorcycle/suzuki/gsx-r" # "Gsxr" -> "GSX-R"
+"motorcycle/suzuki/gsxr-600": "motorcycle/suzuki/gsx-r600" # "Gsxr 600" -> "GSX-R600"
+"motorcycle/aprilia/sport-city": "motorcycle/aprilia/sportcity" # "Sport City" -> "Sportcity"
+"motorcycle/aprilia/etv1000-capo-nord": "motorcycle/aprilia/etv1000-caponord" # "ETV1000 Capo Nord" -> "ETV1000 Caponord"
+"motorcycle/indian/741-b": "motorcycle/indian/741b" # "741-B" -> "741B"
+"motorcycle/indian/power-plus": "motorcycle/indian/powerplus" # "Power Plus" -> "PowerPlus"
+"motorcycle/vespa/seigiorni": "motorcycle/vespa/sei-giorni" # "Seigiorni" -> "Sei Giorni"
+"motorcycle/vespa/g-s": "motorcycle/vespa/gs" # "G.s." -> "GS"
+"motorcycle/matchless/g3-ls": "motorcycle/matchless/g3ls" # "G3/LS" -> "G3LS"
+"motorcycle/matchless/g80-s": "motorcycle/matchless/g80s" # "G80/S" -> "G80S"
+"moped/microcar/mgo": "moped/microcar/m-go" # "Mgo" -> "M.Go"
+"moped/i-coco/lt-018": "moped/i-coco/lt018" # "Lt-018" -> "LT018"
+"motorcycle/yamaha/bws": "motorcycle/yamaha/bw-s" # "Bws" -> "BW's"
+"motorcycle/velocette/l-e": "motorcycle/velocette/le" # "L.e." -> "LE"
+"motorcycle/moto-guzzi/mgx21": "motorcycle/moto-guzzi/mgx-21" # "MGX21" -> "MGX-21"
+"car/puch/230ge": "car/puch/230-ge" # "230GE" -> "230 GE"
+"car/nsu/ro80": "car/nsu/ro-80" # "RO80" -> "Ro 80"
+"moped/sym/xpro": "moped/sym/x-pro" # "Xpro" -> "X Pro"
+"moped/senzo/riva-lux": "moped/senzo/rivalux" # "Riva Lux" -> "Rivalux"
+"motorcycle/swm/sixdays": "motorcycle/swm/six-days" # "Sixdays" -> "Six Days"
+"motorcycle/gas-gas/es700": "motorcycle/gas-gas/es-700" # "ES700" -> "ES 700"
+"motorcycle/ariel/redhunter": "motorcycle/ariel/red-hunter" # "Redhunter" -> "Red Hunter"
+"car/triumph/spitfire1500": "car/triumph/spitfire-1500" # "SPITFIRE1500" -> "Spitfire 1500"

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -908,8 +908,8 @@
 "motorcycle/suzuki/gsf600bandit-s":            "motorcycle/suzuki/gsf600-bandit-s"            # GSF600BANDIT S -> GSF600 Bandit S  [nl]
 "motorcycle/suzuki/gsf650bandit":              "motorcycle/suzuki/gsf650-bandit"              # GSF650BANDIT -> GSF650 Bandit  [nl,ua]
 "motorcycle/suzuki/gsx1300rrqm5hayabusa":      "motorcycle/suzuki/gsx1300-rrqm-5-hayabusa"    # GSX1300RRQM5HAYABUSA -> GSX1300 Rrqm 5 Hayabusa  [gb]
-"motorcycle/suzuki/gsxr600":                   "motorcycle/suzuki/gsxr-600"                   # GSXR600 -> Gsxr 600  [lu,nl]
-"motorcycle/suzuki/gsxr750":                   "motorcycle/suzuki/gsxr-750"                   # GSXR750 -> Gsxr 750  [nl,ua]
+"motorcycle/suzuki/gsxr600":                   "motorcycle/suzuki/gsx-r600"                   # GSXR600 -> Gsxr 600  [lu,nl] [re-chained: target moved]
+"motorcycle/suzuki/gsxr750":                   "motorcycle/suzuki/gsx-r750"                   # GSXR750 -> Gsxr 750  [nl,ua] [re-chained: target moved]
 "motorcycle/suzuki/intruder1400":              "motorcycle/suzuki/intruder-1400"              # INTRUDER1400 -> Intruder 1400  [fi,nl,nz,ua]
 "motorcycle/suzuki/intruder1500lc":            "motorcycle/suzuki/intruder-1500lc"            # INTRUDER1500LC -> Intruder 1500LC  [fi,nl]
 "motorcycle/suzuki/intruder750":               "motorcycle/suzuki/intruder-750"               # INTRUDER750 -> Intruder 750  [fi,ua]
@@ -1907,9 +1907,9 @@
 "motorcycle/derbi/senda": "motorcycle/derbi/senda-125"
 "motorcycle/derbi/senda-sm125": "motorcycle/derbi/senda-125"
 "motorcycle/derbi/senda-sm125-4t": "motorcycle/derbi/senda-125"
-"motorcycle/ducati/750super-sport": "motorcycle/ducati/750-super-sport"
-"motorcycle/ducati/900super-sport": "motorcycle/ducati/900-super-sport"
-"motorcycle/ducati/900supersport": "motorcycle/ducati/900-super-sport"
+"motorcycle/ducati/750super-sport": "motorcycle/ducati/750-supersport" # RE-CHAINED: motorcycle/ducati/750-super-sport was relocated by this batch
+"motorcycle/ducati/900super-sport": "motorcycle/ducati/900-supersport" # RE-CHAINED: motorcycle/ducati/900-super-sport was relocated by this batch
+"motorcycle/ducati/900supersport": "motorcycle/ducati/900-supersport" # RE-CHAINED: motorcycle/ducati/900-super-sport was relocated by this batch
 "motorcycle/gas-gas/cg": "motorcycle/gas-gas/ec"
 "motorcycle/gas-gas/cg-ec300": "motorcycle/gas-gas/ec-300"
 "motorcycle/gas-gas/ec250": "motorcycle/gas-gas/ec-250"
@@ -2375,3 +2375,86 @@
 # lu_snca 3-month accumulation surfaced two fused-marque spellings (pipeline#13):
 "car/jaecoo/jaecoo5": "car/jaecoo/jaecoo-5"   # JAECOO5 → Jaecoo 5, the OMODA5 precedent
 "van/ram/ram1500":    "van/ram/1500"          # RAM1500 → 1500
+
+# --- 2026-07-25, S2W: B5 batch 4 — Honda/BMW/Suzuki/Kawasaki/Ducati --------
+# Kind-aware (these makes publish across car, motorcycle and moped) and
+# de-duplicated against what is already here: several of these ids already
+# carry aliases from the 912-entry backfill.
+"car/honda/c-rv": "car/honda/cr-v" # "C-Rv" -> "CR-V"
+"car/honda/crv": "car/honda/cr-v" # "Crv" -> "CR-V"
+"car/honda/crx": "car/honda/cr-x" # "Crx" -> "CR-X"
+"car/honda/crz": "car/honda/cr-z" # "Crz" -> "CR-Z"
+"car/honda/zrv": "car/honda/zr-v" # "Zrv" -> "ZR-V"
+"car/honda/n-360": "car/honda/n360" # "N 360" -> "N360"
+"car/honda/s-2000": "car/honda/s2000" # "S 2000" -> "S2000"
+"motorcycle/honda/cb-x": "motorcycle/honda/cbx" # "Cb-X" -> "CBX"
+"motorcycle/honda/fire-blade": "motorcycle/honda/fireblade" # "Fire Blade" -> "Fireblade"
+"motorcycle/honda/goldwing": "motorcycle/honda/gold-wing" # "Goldwing" -> "Gold Wing"
+"motorcycle/honda/gl1200-goldwing": "motorcycle/honda/gl1200-gold-wing" # "GL1200 Goldwing" -> "GL1200 Gold Wing"
+"motorcycle/honda/goldwing-gl1500": "motorcycle/honda/gold-wing-gl1500" # "Goldwing GL1500" -> "Gold Wing GL1500"
+"motorcycle/honda/goldwing-gl1800": "motorcycle/honda/gold-wing-gl1800" # "Goldwing GL1800" -> "Gold Wing GL1800"
+"moped/honda/gyrox": "moped/honda/gyro-x" # "Gyrox" -> "Gyro X"
+"moped/honda/ac0-1": "moped/honda/ac01" # "AC0 1" -> "AC01"
+"moped/honda/ns1": "moped/honda/ns-1" # "NS1" -> "NS-1"
+"moped/honda/z50ak2": "moped/honda/z50a-k2" # "Z50AK2" -> "Z50A K2"
+"car/bmw/i-3": "car/bmw/i3" # "I 3" -> "i3"
+"car/bmw/z-3": "car/bmw/z3" # "Z 3" -> "Z3"
+"car/bmw/1-er-reihe": "car/bmw/1er-reihe" # "1 Er Reihe" -> "1er Reihe"
+"car/bmw/1erreihe": "car/bmw/1er-reihe" # "1ERREIHE" -> "1er Reihe"
+"car/bmw/serie3": "car/bmw/serie-3" # "SERIE3" -> "Serie 3"
+"car/bmw/activehybrid-7-l": "car/bmw/activehybrid-7l" # "Activehybrid 7 L" -> "ActiveHybrid 7L"
+"car/bmw/30cs": "car/bmw/3-0cs" # "30CS" -> "3.0CS"
+"motorcycle/bmw/r-nine-t": "motorcycle/bmw/r-ninet" # "R Nine T" -> "R nineT"
+"motorcycle/bmw/r-nine-t-pure": "motorcycle/bmw/r-ninet-pure" # "R Nine T Pure" -> "R nineT Pure"
+"motorcycle/bmw/r-nine-t-scrambler": "motorcycle/bmw/r-ninet-scrambler" # "R Nine T Scrambler" -> "R nineT Scrambler"
+"motorcycle/bmw/r-nine-t-urban-g-s": "motorcycle/bmw/r-ninet-urban-g-s" # "R Nine T Urban G/s" -> "R nineT Urban G/S"
+"motorcycle/bmw/r100g-s": "motorcycle/bmw/r100gs" # "R100G/S" -> "R100GS"
+"motorcycle/bmw/r602": "motorcycle/bmw/r60-2" # "R602" -> "R60/2"
+"motorcycle/bmw/r80gs": "motorcycle/bmw/r80g-s" # "R80GS" -> "R80G/S"
+"motorcycle/bmw/r90s": "motorcycle/bmw/r90-s" # "R90S" -> "R90/S"
+"car/suzuki/x90": "car/suzuki/x-90" # "X90" -> "X-90"
+"car/suzuki/xl-7": "car/suzuki/xl7" # "XL-7" -> "XL7"
+"car/suzuki/sj-410": "car/suzuki/sj410" # "Sj 410" -> "SJ410"
+"car/suzuki/sj-413": "car/suzuki/sj413" # "Sj 413" -> "SJ413"
+"car/suzuki/sj413jx": "car/suzuki/sj413-jx" # "SJ413JX" -> "SJ413 JX"
+"car/suzuki/sx-4": "car/suzuki/sx4" # "Sx 4" -> "SX4"
+"motorcycle/suzuki/drz400": "motorcycle/suzuki/dr-z400" # "DRZ400" -> "DR-Z400"
+"motorcycle/suzuki/gsf-1200s": "motorcycle/suzuki/gsf1200s" # "Gsf-1200S" -> "GSF1200S"
+"motorcycle/suzuki/gsx-750f": "motorcycle/suzuki/gsx750f" # "Gsx-750F" -> "GSX750F"
+"motorcycle/suzuki/gsx-750r": "motorcycle/suzuki/gsx-r750" # "Gsx-750R" -> "GSX-R750"
+"motorcycle/suzuki/gsxr-750": "motorcycle/suzuki/gsx-r750" # "Gsxr 750" -> "GSX-R750"
+"motorcycle/suzuki/rmz450": "motorcycle/suzuki/rm-z450" # "RMZ450" -> "RM-Z450"
+"motorcycle/kawasaki/er650a": "motorcycle/kawasaki/er-650a" # "ER650A" -> "ER-650A"
+"motorcycle/kawasaki/er6n": "motorcycle/kawasaki/er-6n" # "ER6N" -> "ER-6n"
+"motorcycle/kawasaki/ninja-zx10r": "motorcycle/kawasaki/ninja-zx-10r" # "Ninja ZX10R" -> "Ninja ZX-10R"
+"motorcycle/kawasaki/vn15": "motorcycle/kawasaki/vn-15" # "VN15" -> "VN-15"
+"motorcycle/kawasaki/zh2": "motorcycle/kawasaki/z-h2" # "ZH2" -> "Z H2"
+"motorcycle/kawasaki/zx10r": "motorcycle/kawasaki/zx-10r" # "ZX10R" -> "ZX-10R"
+"motorcycle/kawasaki/zx6r": "motorcycle/kawasaki/zx-6r" # "ZX6R" -> "ZX-6R"
+"motorcycle/kawasaki/zx9r": "motorcycle/kawasaki/zx-9r" # "ZX9R" -> "ZX-9R"
+"motorcycle/kawasaki/zx9r-ninja": "motorcycle/kawasaki/zx-9r-ninja" # "ZX9R Ninja" -> "ZX-9R Ninja"
+"motorcycle/kawasaki/zzr1100": "motorcycle/kawasaki/zz-r1100" # "ZZR1100" -> "ZZ-R1100"
+"motorcycle/kawasaki/zzr600": "motorcycle/kawasaki/zz-r600" # "ZZR600" -> "ZZ-R600"
+"motorcycle/ducati/750-super-sport": "motorcycle/ducati/750-supersport" # "750 Super Sport" -> "750 SuperSport"
+"motorcycle/ducati/900-super-sport": "motorcycle/ducati/900-supersport" # "900 Super Sport" -> "900 SuperSport"
+"motorcycle/ducati/super-sport": "motorcycle/ducati/supersport" # "Super Sport" -> "SuperSport"
+"motorcycle/ducati/desert-x": "motorcycle/ducati/desertx" # "Desert X" -> "DesertX"
+"motorcycle/ducati/desert-x-rally": "motorcycle/ducati/desertx-rally" # "Desert X Rally" -> "DesertX Rally"
+"motorcycle/ducati/x-diavel": "motorcycle/ducati/xdiavel" # "X Diavel" -> "XDiavel"
+"motorcycle/ducati/panigale-v4s": "motorcycle/ducati/panigale-v4-s" # "Panigale V4S" -> "Panigale V4 S"
+# Old-catalog spellings of the Ducati SuperSport family. These ids are in the
+# LAST RELEASE under names the earlier passes produced ("750SUPER Sport",
+# "900SUPERSPORT") and the gate compares against that release, not against the
+# previous build — so they need aliases even though no build of mine ever
+# published them under those exact names.
+
+# --- 2026-07-25, S2W: release-baseline sweep for B5 batch 4 -----------------
+# Ids present in the LAST RELEASE that this branch's renames relocate. The
+# batch generator missed them because it keys on the FRESH BUILD, where the
+# old names no longer exist — but the gate (correctly) compares against the
+# release, which is what consumers actually hold. Each is a de-hyphenation
+# with exactly ONE live successor under the same kind+make; ambiguous ones
+# were left alone rather than guessed.
+"car/honda/frv": "car/honda/fr-v" # "Frv" -> "Fr-V"
+"motorcycle/kawasaki/er5": "motorcycle/kawasaki/er-5" # "ER5" -> "Er-5"
+"motorcycle/suzuki/gsx-r": "motorcycle/suzuki/gsxr" # "Gsx-R" -> "Gsxr"

--- a/overrides/models/moves.yml
+++ b/overrides/models/moves.yml
@@ -116,7 +116,7 @@
 "Piaggio|Vespa Primavera 125ABS":  "Vespa|Primavera 125ABS"
 "Piaggio|Vespa Primavera 150ABS":  "Vespa|Primavera 150ABS"
 "Piaggio|Vespa Sei Giorni":        "Vespa|Sei Giorni"
-"Piaggio|Vespa Seigiorni":         "Vespa|Seigiorni"
+"Piaggio|Vespa Seigiorni":         "Vespa|Sei Giorni"   # TARGET IS THE CANONICAL, not the raw form: renames run BEFORE moves, so a move target is NOT re-normalized against the destination make. Keying `Vespa: Seigiorni -> Sei Giorni` in renames.yml does nothing for rows arriving under merk=PIAGGIO, because at rename time the make is still Piaggio. Left as "Vespa|Seigiorni" this move published a second Sei Giorni record forever
 "Piaggio|Vespa Sprint 125":        "Vespa|Sprint 125"
 "Piaggio|Vespa Sprint 125ABS":     "Vespa|Sprint 125ABS"
 "SEAT|Cupra Leon": "Cupra|Leon"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -10,6 +10,13 @@ Alfa Romeo:
 Alvis:
   Tc 21: TC21                                 # spelling variant of "TC21" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
+Aprilia:
+  ETV1000 Capo Nord:         ETV1000 Caponord     # Caponord is ONE word; ETV1000 is the type code
+  Sport City:                Sportcity            # Aprilia writes Sportcity as ONE word
+
+Ariel:
+  Redhunter:                 Red Hunter           # Ariel Red Hunter — two words. DEFUNCT marque — badge evidence
+
 Askoll:
   "N.a.": null   # ALL 179 NL registrations are literal N/A (164 "N/A" + 8 "N.A" + 7 "N.A."), zero real names. NB this ERASES the askoll make from moped: its only record was the placeholder. Askoll's real lineup is eS1/eS2/eS3 (https://www.askoll.com/eva/) — it returns the moment any source emits one. Recorded as candidate-queue debt, not a silent loss.
 
@@ -90,6 +97,11 @@ BMW:
 
 Bricklin:
   Sv-1: SV1                                   # spelling variant of "SV1" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+
+BSA:
+  A-10:                      A10                  # BSA type codes are closed (A10 Golden Flash, A65)
+  Goldstar:                  Gold Star            # TWO words on BSA's own site (bsacompany.co.uk/bsa-goldstar) — and Thunderbolt is ONE, same catalogue
+  Thunder Bolt:              Thunderbolt          # ...ONE word (A65 Thunderbolt). Opposite convention to Gold Star, same marque
 
 BTC:
   Btc: null                               # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
@@ -386,6 +398,7 @@ Gas Gas:
   EC450F: EC 450F        # official
   EC500F: EC 500F        # official (MY2024+)
   Cg-EC300: EC 300       # registry compound "type code + commercial name"; 299cc on e9*168/2013*30006 = the EC 300 (targets the respaced canonical directly — rename chaining is not assumed)
+  ES700:                     ES 700               # Gas Gas ES 700 — space before the displacement. THIS KEY is why the ES acronym token was rejected: adding it would have orphaned this line (S4W Turn 56)
 
 Geely:
   Starray: Starray EM-i                   # KBA truncation; the model sold in Germany is the Starray EM-i PHEV (https://www.geely.com/en/news/2026/geely-e5-starray-em-i-debut-five-european-countries)
@@ -532,11 +545,17 @@ Hyundai:
   Scoupe: S-Coupe                             # spelling variant of "S-Coupe" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Santafe: Santa FE                           # spelling variant of "Santa FE" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
+I-Coco:
+  Lt-018:                    LT018                # closed type code
+
 Imperial:
   Lebaron: Le Baron                           # spelling variant of "Le Baron" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Indian:
   Indian: null                            # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
+  "741-B":                   741B                 # the WWII Indian 741B — closed type code
+  Power Plus:                PowerPlus            # Indian styles it PowerPlus, camelCase (indianmotorcycle.com/powerplus)
+  Powerplus:                 PowerPlus            # Indian styles it PowerPlus, camelCase (indianmotorcycle.com/powerplus)
 
 Infiniti:
   Fx 30D: FX30D                               # spelling variant of "FX30D" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -699,6 +718,8 @@ Kawasaki:
   Zx-9R Ninja:                 ZX-9R Ninja            # ZX/ZZ-R/ER designations hyphenate before the trailing letter
   Zz R1100:                    ZZ-R1100               # ZX/ZZ-R/ER designations hyphenate before the trailing letter
   Zz-R600:                     ZZ-R600                # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  ER5:                       ER-5                 # Kawasaki ER designations hyphenate, as in batch 4
+  Er-5:                      ER-5                 # Kawasaki ER designations hyphenate, as in batch 4
 
 Kia:
   Cee D: Ceed            # RDW writes "CEE D" / "CEE'D"; official spelling since 2018 is Ceed
@@ -719,6 +740,12 @@ Kia:
   EV 3: EV3                                   # spelling variant of "EV3" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   EV 6: EV6                                   # spelling variant of "EV6" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   EV 9: EV9                                   # spelling variant of "EV9" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+
+KTM:
+  "1290 Superduke GT":       1290 Super Duke GT   # KTM writes it with spaces: 1290 Super Duke R/GT/RR (ktm.com)
+  "1290 Superduke R":        1290 Super Duke R    # ditto
+  E-XC:                      EXC                  # KTM's enduro line, closed. NOTE the fold already merges 'E-XC' here and Freeride E-XC is a DIFFERENT electric model — if that ever publishes separately this needs revisiting, not extending
+  Exc:                       EXC                  # KTM's enduro line, closed. NOTE the fold already merges 'E-XC' here and Freeride E-XC is a DIFFERENT electric model — if that ever publishes separately this needs revisiting, not extending
 
 Lada:
   "1200S": "1200 S"                           # spelling variant of "1200 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -934,6 +961,10 @@ Maserati:
   "3200GT": "3200 GT"                         # spelling variant of "3200 GT" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Biturbo: Bi Turbo                           # spelling variant of "Bi Turbo" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Granturismo: Gran Turismo                   # spelling variant of "Gran Turismo" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+
+Matchless:
+  G3/LS:                     G3LS                 # Matchless type code, closed (G3L Lightweight + S spring frame). DEFUNCT marque — badge evidence, no manufacturer left to ask
+  G80/S:                     G80S                 # ditto (G80 + S spring frame). Defunct marque
 
 Maxus:
   Edeliver 9: E-Deliver 9                     # spelling variant of "E-Deliver 9" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1285,6 +1316,10 @@ MG:
   MG: null                                    # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   Tf-1500: TF1500                             # spelling variant of "TF1500" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
+Microcar:
+  M.go:                      M.Go                 # Microcar writes M.GO with the period; title form M.Go
+  Mgo:                       M.Go                 # Microcar writes M.GO with the period; title form M.Go
+
 Mitsubishi:
   "3000GT": "3000 GT"                         # spelling variant of "3000 GT" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Mitsubishi: null                            # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
@@ -1303,6 +1338,8 @@ Morris:
 
 Moto Guzzi:
   Moto-Guzzi: null                        # motorcycle es|nl — hyphenated by the caser from raw "MOTO-GUZZI"
+  MGX21:                     MGX-21               # Moto Guzzi MGX-21 Flying Fortress, hyphenated
+  Mgx-21:                    MGX-21               # Moto Guzzi MGX-21 Flying Fortress, hyphenated
 
 Nash:
   Nash: null                                  # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
@@ -1335,6 +1372,9 @@ Nissan:
 
 Norton:
   Norton: null                            # motorcycle nl|nz
+
+NSU:
+  RO80:                      Ro 80                # the NSU Ro 80 (Ro = Rotationskolbenmotor, the Wankel) — two words. DEFUNCT marque
 
 Oldsmobile:
   SUPER88: Super 88                           # spelling variant of "Super 88" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1443,6 +1483,8 @@ Porsche:
 Puch:
   P1 40KM/H: P1                               # L1e/L2e speed-class marker folds (NAMING.md §6); exposed by the two-wheeler spacing fix [reason re-attached: the union merge lifted this line out of a block whose comment sat above it]
   Radical 40KM/H: Radical                     # L1e/L2e speed-class marker folds (NAMING.md §6) [reason re-attached: the union merge lifted this line out of a block whose comment sat above it]
+  "230 Ge":                  230 GE               # Puch G 230 GE (the Mercedes G-Wagen twin) — space before the engine code
+  "230GE":                   230 GE               # Puch G 230 GE (the Mercedes G-Wagen twin) — space before the engine code
 
 Ram:
   RAM1500: "1500"                        # lu_snca fused-marque form; Ram's nameplate is the bare 1500 (ramtrucks.com). Value QUOTED: bare 1500 parses as Integer
@@ -1552,6 +1594,9 @@ SEAT:
 Segway:
   "N.a": null    # 6,725 placeholder registrations (3,601 "N/A" + 2,563 "N.A." + 561 "N.A") sitting beside REAL models E110S (2,673), E110SE (2,272), E150S (994) — dropping the placeholder keeps every genuine Segway-Ninebot record
 
+Senzo:
+  Riva Lux:                  Rivalux              # one word, as the marque badges it
+
 Sherco:
   # -R (Racing) trim folds; nameplate = displacement + line (sherco.com):
   125SE-R: 125 SE        # Racing trim of the 125 SE 2T enduro
@@ -1614,9 +1659,18 @@ Suzuki:
   Sx 4:                        SX4                    # closed alphanumeric
   X90:                         X-90                   # closed alphanumeric
   XL-7:                        XL7                    # closed alphanumeric
+  Gsx-R:                     GSX-R                # the R sportbike line hyphenates (suzukicycles.com), as in batch 4
+  Gsx-R600:                  GSX-R600             # ditto
+  Gsxr:                      GSX-R                # the R sportbike line hyphenates (suzukicycles.com), as in batch 4
+  Gsxr 600:                  GSX-R600             # ditto
+  Sx-4:                      SX4                  # closed alphanumeric, as in batch 4
+
+SWM:
+  Sixdays:                   Six Days             # SWM Six Days — two words (the ISDE reference)
 
 SYM:
   "N.a.": null   # small placeholder block against SYM's 56 real names (FIDDLE alone is 36,746 registrations)
+  Xpro:                      X Pro                # SYM writes X Pro with a space
 
 Talaria:
   TL3000: Sting   # type code for the Sting: raws "TL3000, STING" (53) and "TL3000 STING" (14) pair them explicitly, and bare "STING" (42) + "STING PRO" (54) are the same line (https://talaria.bike/)
@@ -1717,6 +1771,7 @@ Triumph:
   TR4 A: TR4A                             # ditto
   TR6 Pi: TR6 PI                          # PI = petrol injection, an uppercase suffix on the badge
   TR6PI: TR6 PI                           # ditto
+  SPITFIRE1500:              Spitfire 1500        # the final Spitfire generation; space before the displacement, matching its Mk siblings
 
 TRS:
   Trrs One: One          # strip the embedded badge — bikes are badged TRRS but the make resolves to TRS, so the prefix strip missed (trsmotorcycles.com); CREATES the One canonical
@@ -1745,8 +1800,14 @@ Valiant:
 Vauxhall:
   Vx 220: VX220                               # spelling variant of "VX220" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
+Velocette:
+  L.e.:                      LE                   # the Velocette LE (Little Engine). DEFUNCT marque — badge evidence
+  Le:                        LE                   # the Velocette LE (Little Engine). DEFUNCT marque — badge evidence
+
 Vespa:
   Vespa: null                             # motorcycle es|nl AND moped nl|nz
+  G.s.:                      GS                   # Gran Sport, closed; the register's 'G.s.' is punctuation noise
+  Seigiorni:                 Sei Giorni           # Italian for Six Days — two words, as Vespa writes it
 
 Vmoto:
   "N.a.": null   # 169 placeholder rows; make survives on CITI / F01 / CPX / VS1 / CU ECONOMY / CUMINI ECONOMY
@@ -2005,6 +2066,8 @@ Yamaha:
   Yl-1:                      YL1                    # type code — closed uppercase
   Yzf-R1:                    YZF-R1                 # type code — closed uppercase (display-only)
   Yzfr 1:                    YZF-R1                 # type code — closed uppercase
+  "Bw's":                    BW's                 # Yamaha's BW's keeps the apostrophe — confirmed via MBK's platform history, the MBK Booster being the BW's twin
+  Bws:                       BW's                 # Yamaha's BW's keeps the apostrophe — confirmed via MBK's platform history, the MBK Booster being the BW's twin
 
 Zero Motorcycles:
   # Residue of a SINGULAR/PLURAL mismatch between the two columns, not a naming

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -58,6 +58,35 @@ Bertone:
 
 BMW:
   Bmw: null                               # motorcycle nl|nz
+  # MOTORCYCLES: "R nineT" — lowercase "nine", uppercase T. BMW's own press
+  # releases and model pages write it that way
+  # (https://www.bmwmotorcycles.com/en/models/heritage/r12-ninet.html).
+  # Airhead type codes keep their SLASH: R 80 G/S, R 90/S, R 60/2 — the slash
+  # is part of the designation, not punctuation noise. R100GS (1987) genuinely
+  # has no slash where R80G/S (1980) does.
+  # CARS: "i3" keeps its lowercase i (BMW i sub-brand). German-register rows
+  # carry "1er Reihe" / "Serie 3" — those are the German for "1 Series" and
+  # stay as the register wrote them; they are NOT the English nameplate.
+  "1 Er Reihe":                1er Reihe              # German-register nameplate; NOT the English 1 Series — left as the register wrote it
+  "1ERREIHE":                  1er Reihe              # German-register nameplate; NOT the English 1 Series — left as the register wrote it
+  "30CS":                      3.0CS                  # closed/spaced per BMW usage
+  Activehybrid 7 L:            ActiveHybrid 7L        # closed/spaced per BMW usage
+  Activehybrid 7L:             ActiveHybrid 7L        # closed/spaced per BMW usage
+  I 3:                         i3                     # BMW i sub-brand keeps the lowercase i
+  R Nine T:                    R nineT                # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
+  R Nine T Pure:               R nineT Pure           # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
+  R Nine T Scrambler:          R nineT Scrambler      # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
+  R Nine T Urban G/s:          R nineT Urban G/S      # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
+  R Ninet:                     R nineT                # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
+  R Ninet Pure:                R nineT Pure           # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
+  R Ninet Scrambler:           R nineT Scrambler      # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
+  R Ninet Urban G/s:           R nineT Urban G/S      # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
+  R100G/S:                     R100GS                 # closed/spaced per BMW usage
+  R602:                        R60/2                  # airhead designation: the SLASH is part of the type code, not punctuation
+  R80GS:                       R80G/S                 # airhead designation: the SLASH is part of the type code, not punctuation
+  R90S:                        R90/S                  # airhead designation: the SLASH is part of the type code, not punctuation
+  SERIE3:                      Serie 3                # German-register nameplate; NOT the English 1 Series — left as the register wrote it
+  Z 3:                         Z3                     # closed/spaced per BMW usage
 
 Bricklin:
   Sv-1: SV1                                   # spelling variant of "SV1" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -246,6 +275,31 @@ Ducati:
 # RULE, the hard way: an entry in makes/aliases.yml that changes a display name
 # is a two-file edit. Grep renames.yml AND aliases.yml for the old display name
 # in the same commit.
+  # Ducati CLOSES UP what most marques space out, and this is the exact
+  # inverse of Harley-Davidson in the same repo: "SuperSport", "DesertX" and
+  # "XDiavel" are ONE word each on ducati.com, camelCased
+  # (https://www.ducati.com/us/en/bikes/xdiavel/xdiavel-v4). Displacement
+  # prefixes stay separate: "750 SuperSport". Panigale trim letters are
+  # separate: "Panigale V4 S".
+  "750 Super Sport":           750 SuperSport         # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  "750 Supersport":            750 SuperSport         # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  "900 Super Sport":           900 SuperSport         # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  "900 Supersport":            900 SuperSport         # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  600 Super Sport:             600 SuperSport         # same rule, the 600 was in the catalog under the spaced form
+  Supersport 950:              SuperSport 950         # the 950 family title-cased to "Supersport"; same camelCase rule
+  Supersport 950S:             SuperSport 950 S       # ...and trim letters stay separate, as with Panigale V4 S
+  Supersport S:                SuperSport S           # ditto
+  Desert X:                    DesertX                # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  Desert X Rally:              DesertX Rally          # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  Desertx:                     DesertX                # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  Desertx Rally:               DesertX Rally          # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  Panigale V4/-S:              Panigale V4 S          # trim letters stay separate: Panigale V4 S
+  Panigale V4S:                Panigale V4 S          # trim letters stay separate: Panigale V4 S
+  Super Sport:                 SuperSport             # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  Supersport:                  SuperSport             # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  X Diavel:                    XDiavel                # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+  Xdiavel:                     XDiavel                # Ducati CLOSES UP what Harley spaces out — one camelCased word on ducati.com
+
 E-Max:
   Emax-110S: 110S            # embedded make: strip_make_prefix misses it because the raw badge is hyphenated to the model ("EMAX-110S"), and the hyphen also defeats its `[\s,]+` separator requirement; E-Max sells the 110S/90S (make+model reads "E-Max 110S")
   Emax-90S: 90S                               # embedded make: strip_make_prefix misses it because the raw badge is hyphenated to the model ("EMAX-90S"); E-Max sells the 110S/90S [reason re-attached: the union merge lifted this line out of a block whose comment sat above it]
@@ -438,6 +492,33 @@ Harley-Davidson:
 
 Honda:
   Honda: null                             # motorcycle fi|nl AND moped nl|nz — one make-scoped key covers both kinds (renames are kind-blind)
+  # CARS use hyphenated letter pairs — CR-V, CR-X, CR-Z, ZR-V — but closed
+  # alphanumerics: N360, S2000.
+  # MOTORCYCLES: "Gold Wing" is TWO words on Honda's own model pages
+  # (https://powersports.honda.com/motorcycle/touring/gold-wing) while
+  # "Fireblade" is ONE (CBR1000RR-R Fireblade SP). Same marque, same brochure.
+  AC0 1:                       AC01                   # closed alphanumeric type code
+  C-Rv:                        CR-V                   # Honda car letter-pairs hyphenate: CR-V, CR-Z, ZR-V
+  Cb-X:                        CBX                    # closed alphanumeric type code
+  Cbx:                         CBX                    # closed alphanumeric type code
+  Cr-V:                        CR-V                   # Honda car letter-pairs hyphenate: CR-V, CR-Z, ZR-V
+  Cr-X:                        CR-X                   # Honda car letter-pairs hyphenate: CR-V, CR-Z, ZR-V
+  Cr-Z:                        CR-Z                   # Honda car letter-pairs hyphenate: CR-V, CR-Z, ZR-V
+  Crv:                         CR-V                   # Honda car letter-pairs hyphenate: CR-V, CR-Z, ZR-V
+  Crx:                         CR-X                   # Honda car letter-pairs hyphenate: CR-V, CR-Z, ZR-V
+  Crz:                         CR-Z                   # Honda car letter-pairs hyphenate: CR-V, CR-Z, ZR-V
+  Fire Blade:                  Fireblade              # ...but Fireblade as ONE, same brochure
+  GL1200 Goldwing:             GL1200 Gold Wing       # Honda writes Gold Wing as TWO words (powersports.honda.com)
+  Goldwing:                    Gold Wing              # Honda writes Gold Wing as TWO words (powersports.honda.com)
+  Goldwing GL1500:             Gold Wing GL1500       # Honda writes Gold Wing as TWO words (powersports.honda.com)
+  Goldwing GL1800:             Gold Wing GL1800       # Honda writes Gold Wing as TWO words (powersports.honda.com)
+  Gyrox:                       Gyro X                 # closed alphanumeric type code
+  N 360:                       N360                   # closed alphanumeric type code
+  NS1:                         NS-1                   # closed alphanumeric type code
+  Ns-1:                        NS-1                   # closed alphanumeric type code
+  S 2000:                      S2000                  # closed alphanumeric type code
+  Z50AK2:                      Z50A K2                # closed alphanumeric type code
+  Zrv:                         ZR-V                   # Honda car letter-pairs hyphenate: CR-V, CR-Z, ZR-V
 
 Humber:
   Humber: null                                # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
@@ -593,6 +674,31 @@ Jonway:
 
 Kawasaki:
   Kawasaki: null                          # motorcycle gb|nl
+  # ZX/ZZ-R/ER designations HYPHENATE before the trailing letter: ZX-6R,
+  # ZX-9R, ZX-10R, ZZ-R600, ZZ-R1100, ER-6n, VN-15. Note ER-6n takes a
+  # LOWERCASE n ("n" for naked) — the one lowercase suffix in the range.
+  # "Z H2" keeps its space (the supercharged Z, distinct from Ninja H2).
+  ER650A:                      ER-650A                # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  ER6N:                        ER-6n                  # lowercase n for naked — the one lowercase suffix in the range
+  Er-650A:                     ER-650A                # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  Er-6N:                       ER-6n                  # lowercase n for naked — the one lowercase suffix in the range
+  Ninja ZX10R:                 Ninja ZX-10R           # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  Ninja Zx-10R:                Ninja ZX-10R           # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  VN15:                        VN-15                  # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  Vn-15:                       VN-15                  # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  ZH2:                         Z H2                   # the supercharged Z keeps its space (distinct from Ninja H2)
+  ZX10R:                       ZX-10R                 # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  ZX6R:                        ZX-6R                  # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  ZX9R:                        ZX-9R                  # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  ZX9R Ninja:                  ZX-9R Ninja            # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  ZZR1100:                     ZZ-R1100               # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  ZZR600:                      ZZ-R600                # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  Zx-10R:                      ZX-10R                 # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  Zx-6R:                       ZX-6R                  # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  Zx-9R:                       ZX-9R                  # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  Zx-9R Ninja:                 ZX-9R Ninja            # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  Zz R1100:                    ZZ-R1100               # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  Zz-R600:                     ZZ-R600                # ZX/ZZ-R/ER designations hyphenate before the trailing letter
 
 Kia:
   Cee D: Ceed            # RDW writes "CEE D" / "CEE'D"; official spelling since 2018 is Ceed
@@ -1489,6 +1595,25 @@ Sunbeam:
 Suzuki:
   Wagon-R: Wagon R                          # hyphenation variant of Suzuki Wagon R (global-suzuki.com) — spacing, not a different model
   Suzuki: null                              # registry row where the make was written into the model column (motorcycle+moped) — not a nameplate; restored from a flow-style entry
+  # The R sportbike line hyphenates — GSX-R750 (suzukicycles.com) — while the
+  # F sport-tourer line does NOT: GSX750F. Off-road keeps the hyphen: DR-Z400,
+  # RM-Z450. CARS are closed alphanumerics (SJ410, SJ413, SX4) except X-90.
+  DRZ400:                      DR-Z400                # off-road keeps the hyphen
+  Dr-Z400:                     DR-Z400                # off-road keeps the hyphen
+  Gsf-1200S:                   GSF1200S               # closed alphanumeric
+  Gsx-750F:                    GSX750F                # ...while the F sport-tourer line does NOT: GSX750F
+  Gsx-750R:                    GSX-R750               # the R sportbike line HYPHENATES (suzukicycles.com GSX-R750)
+  Gsx-R750:                    GSX-R750               # the R sportbike line HYPHENATES (suzukicycles.com GSX-R750)
+  Gsxr 750:                    GSX-R750               # the R sportbike line HYPHENATES (suzukicycles.com GSX-R750)
+  RMZ450:                      RM-Z450                # off-road keeps the hyphen
+  Rm-Z450:                     RM-Z450                # off-road keeps the hyphen
+  SJ413 Jx:                    SJ413 JX               # closed alphanumeric
+  SJ413JX:                     SJ413 JX               # closed alphanumeric
+  Sj 410:                      SJ410                  # closed alphanumeric
+  Sj 413:                      SJ413                  # closed alphanumeric
+  Sx 4:                        SX4                    # closed alphanumeric
+  X90:                         X-90                   # closed alphanumeric
+  XL-7:                        XL7                    # closed alphanumeric
 
 SYM:
   "N.a.": null   # small placeholder block against SYM's 56 real names (FIDDLE alone is 36,746 registrations)

--- a/scripts/lint_curation.rb
+++ b/scripts/lint_curation.rb
@@ -176,6 +176,68 @@ if File.exist?(moves_path)
           "moves.yml routes it to #{moves[from].inspect}. A null rename BEATS a move, so the move is " \
           "dead and the record vanishes instead of moving. Retire the null, or delete the move."
   end
+
+  # ── 1e. a move TARGET must already be canonical ────────────────────────────
+  #
+  # RENAMES RUN BEFORE MOVES, so a move's target nameplate is NOT re-normalized
+  # against the destination make. If moves.yml routes to "Vespa|Seigiorni" while
+  # renames.yml has `Vespa: Seigiorni -> Sei Giorni`, the rename never fires for
+  # those rows — at rename time the make is still the SOURCE make (Piaggio), so
+  # the Vespa block is never consulted — and the move publishes a second,
+  # non-canonical record beside the canonical one, forever.
+  #
+  # Found the hard way: it was the last surviving duplicate-spelling group in
+  # the two-wheel half after 163 others had been resolved, and it survived a
+  # full batch precisely because the rename LOOKED correct in isolation
+  # (classify("VESPA","SEIGIORNI") returns "Sei Giorni" — it is only rows
+  # arriving as PIAGGIO that miss).
+  moves.each do |from, to|
+    next unless to.is_a?(String)
+    t_make, t_model = to.split("|", 2).map { |s| s&.strip }
+    next unless t_make && t_model
+    next unless renames[t_make]&.key?(t_model)
+    canon = renames[t_make][t_model]
+    next if canon.nil? # a null target is check 1d's problem, not this one
+    fail! "overrides/models/moves.yml: #{from.inspect} targets #{to.inspect}, but #{t_make.inspect} " \
+          "renames #{t_model.inspect} -> #{canon.inspect}. Renames run BEFORE moves, so the move target " \
+          "is NOT re-normalized and this publishes a non-canonical record beside the canonical one. " \
+          "Write the canonical form directly in the move target."
+  end
+end
+
+# ── 1f. former_ids must not chain or cycle ───────────────────────────────────
+#
+# An alias whose TARGET is itself an alias key sends a consumer to an id that is
+# also dead — one redirect short of useful at best, and an infinite loop at
+# worst. Two shapes, both seen for real:
+#
+#   CHAIN  a -> b -> c, because a later batch relocated b after a was written.
+#          Three of these existed at once after the tail batch moved Vespa's
+#          "Seigiorni" and Aprilia's "Capo Nord".
+#   CYCLE  a -> b AND b -> a. This is the DIRECTION WAR that S4W found in
+#          renames.yml (NEGOTIATION Turn 56), in the alias file instead: an
+#          auto-generated de-hyphenation alias (gsx-r -> gsxr) met a later batch
+#          that reversed the canonical (Gsxr -> GSX-R), and the pair published
+#          two live records pointing at each other. Keys are unique so the
+#          duplicate-key check cannot see it, and both halves look right alone.
+fi_path = File.join(ROOT, "overrides/models/former_ids.yml")
+if File.exist?(fi_path)
+  fi = YAML.safe_load_file(fi_path, permitted_classes: [], aliases: false) || {}
+  target = ->(v) { v.is_a?(Hash) ? v["to"] : v }
+  fi.each do |old_id, v|
+    tgt = target.call(v)
+    next unless fi.key?(tgt)
+    if target.call(fi[tgt]) == old_id
+      fail! "overrides/models/former_ids.yml: DIRECTION WAR — #{old_id.inspect} -> #{tgt.inspect} and " \
+            "#{tgt.inspect} -> #{old_id.inspect}. Each alias names the other's key, so both ids are " \
+            "'former' and a consumer holding either is sent to a dead id. Pick one canonical and delete " \
+            "the reverse."
+    else
+      fail! "overrides/models/former_ids.yml: CHAIN — #{old_id.inspect} -> #{tgt.inspect}, but " \
+            "#{tgt.inspect} is itself an alias for #{target.call(fi[tgt]).inspect}. Point the first one " \
+            "straight at the final target: a consumer following one redirect lands on another dead id."
+    end
+  end
 end
 
 # ── DIRECTION WAR: a rename whose TARGET is also a KEY in the same block ─────


### PR DESCRIPTION
41 rename lines, 30 `former_ids`, 22 makes — most with a single group. **With this the 2W duplicate-spelling residue is 165 → 1**, and the survivor is the IVA RA9015 triplet, already fixed on the pilot branch ([#21](https://github.com/vehiclesdb/vehiclesdb/pull/21)).

## The tail is a different job

No per-marque dossier to write, and for the **defunct** ones — Ariel, Velocette, Matchless, NSU, Puch — there is no manufacturer left to consult. Where the marque is alive the source is its own site; where it is not, the evidence is the designation as the marque badged it. The per-line comment says which of the two applies, so nobody later mistakes badge evidence for a manufacturer citation.

**BSA is the tail in miniature:** `Gold Star` is two words and `Thunderbolt` is one — same marque, same catalogue. Ninth marque in a row where the two halves of one brochure disagree with each other.

## Two new defect classes, both found by chasing the last surviving groups

### 1. A move target is not re-normalized

**Renames run before moves**, so a move's target nameplate never passes through the *destination* make's renames.

```yaml
moves.yml:    "Piaggio|Vespa Seigiorni" -> "Vespa|Seigiorni"
renames.yml:  Vespa: { Seigiorni: Sei Giorni }     # correct, and never fires for these rows
```

The move published a second Sei Giorni record beside the canonical one, forever. And the rename *is* correct — for rows arriving as `merk=VESPA`. Only rows arriving as `merk=PIAGGIO` miss, because at rename time the make is still Piaggio and the Vespa block is never consulted.

`classify("VESPA","SEIGIORNI")` returns the right answer in isolation, which is exactly why a whole batch went straight past it. **This was the last surviving duplicate group in the half, after 163 others had been resolved.**

Fixed by writing the canonical directly in the move target. Swept: **0** other move targets have it. Now linted.

### 2. An alias direction war

Your renames.yml finding (Turn 56), in `former_ids`:

```
motorcycle/suzuki/gsx-r -> motorcycle/suzuki/gsxr
motorcycle/suzuki/gsxr  -> motorcycle/suzuki/gsx-r
```

My own release-baseline sweep emitted the first when `gsxr` was live; this batch then renamed `Gsxr → GSX-R`, reversing it. The pair published two live records pointing at each other. **Keys are unique, so the duplicate-key check cannot see it, and each half looks right alone.**

The same lint also catches **chains** (`a → b → c` where `b` is itself an alias): three existed after this batch relocated Vespa's `Seigiorni` and Aprilia's `Capo Nord`. Collapsed; 0 remain.

Both lint branches negative-controlled.

## Verified, final build

| check | result |
|---|---|
| 2W collision groups | **165 → 1** (survivor fixed on #21) |
| `lint_overrides` / `lint_curation` | green |
| pipeline suite | 82 runs / 285 assertions |
| gate failures | 36, of which **exactly one was mine** (the direction war above, now fixed) |

The remaining 35 are the release-baseline / threshold class already reported in NEGOTIATION.md Turn 59 — and [pipeline#14](https://github.com/vehiclesdb/vehiclesdb-pipeline/pull/14) removes 74 of that family on its own.

## Merge order

This stacks cleanly on nothing, but it touches `renames.yml`, `former_ids.yml` and `lint_curation.rb`, so it will conflict with #23 and #25 if those land first. Suggest **#23 → #25 → this**, or tell me and I'll rebase in whatever order suits.