### PR TITLE
Heal the MC LAREN make split — make-name collisions to zero

### DIFF
--- a/overrides/makes/aliases.yml
+++ b/overrides/makes/aliases.yml
@@ -90,6 +90,7 @@ ASTON MARTIN: Aston Martin
 FERRARI: Ferrari
 LAMBORGHINI: Lamborghini
 MCLAREN: McLaren
+"MC LAREN": McLaren   # lu/nl registry spelling with a space — was minting a SPLIT make (mc-laren, 2 models incl. a 570S duplicate of the real one); the last make-name collision the detector reported
 LOTUS: Lotus
 ALPINE: Alpine
 MORGAN: Morgan

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2489,3 +2489,9 @@
 "motorcycle/gas-gas/es700": "motorcycle/gas-gas/es-700" # "ES700" -> "ES 700"
 "motorcycle/ariel/redhunter": "motorcycle/ariel/red-hunter" # "Redhunter" -> "Red Hunter"
 "car/triumph/spitfire1500": "car/triumph/spitfire-1500" # "SPITFIRE1500" -> "Spitfire 1500"
+
+# --- 2026-07-25, S4W: "MC LAREN" make split healed (the last make-name
+# collision). Cross-make entries legal under rule 3: with the raw spelling
+# aliased, the mc-laren make leaves the build entirely.
+"car/mc-laren/570s":   "car/mclaren/570s"    # evidence unions into the real 570S
+"car/mc-laren/artura": "car/mclaren/artura"  # mints the Artura under the real make (lu,nl unchanged)


### PR DESCRIPTION
One alias line + two rule-3 cross-make aliases. lu/nl write the marque spaced, minting a split make with a duplicate 570S. Verified: split make gone from the build, both records live under the real make with migration aliases, all gates green. `find_duplicate_makes`: **0 groups**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)