### PR TITLE
Acronym makes round 3: six resolved, 23 filed as debt with the ceiling named

### DIFF
--- a/data/name_shapes.yml
+++ b/data/name_shapes.yml
@@ -231,3 +231,39 @@ debt:
       a JOIN KEY, but the collapsed key is also used as the DISPLAY name, so
       "BANDIT 1200" publishes as BANDIT1200. Remedy is an identity/display split
       restoring the dominant spaced raw form, not override lines.
+  # ── G20/D23: the two-wheel acronym-make tail (S2W, 2026-07-25) ─────────────
+  - id: acronym-make-casing-2w-tail
+    owner: s2w
+    category: make_casing
+    count: 23
+    why: >-
+      Makes whose DISPLAY NAME may be an initialism the pipeline title-cased,
+      and which could not be resolved with evidence. 24 were resolved and
+      pinned across three rounds (KTM, BSA, SYM, MZ, SWM, PGO, CPI, MBK, GPX,
+      CCM, CZ, DKW, LML, FN, EBR, AGM, BTC, ZNEN, IFA, AWO, KSR Moto, JDM,
+      QWIC, RGNT, UM, TYM, KMZ); these are what is left.
+
+      THE SHAPE OF THE PROBLEM, because it is not laziness: every one is a 1-3
+      record make whose only accessible evidence is the register itself, and
+      registers UPPERCASE every make string — so the register can prove the
+      marque exists and can never prove how it styles its own name. That is the
+      same ceiling the IVA pilot documented for discontinued models, in the make
+      column. mgb (2 records, uk_dft "Fantasy" and "R8") is the clearest
+      example: it is NOT MG's B — that was checked and cost a research detour —
+      but no source establishes what it is.
+
+      NOT-ACRONYMS, verified and deliberately left alone so nobody "fixes" them:
+      Puch (Johann Puch, a surname), Mash, Mutt (Mutt Motorcycles), Trek, Next,
+      Kral (Kral Motor, Turkish), Rhon. The detector flags them because they are
+      short and vowel-poor, which is a shape and not a fact.
+
+      GENUINELY OPEN, needing a marque source that may not exist: mgb, gts
+      (Italian-named scooter range — Bravo, Cappucino 50, Palermo, Toscana —
+      consistent with a real marque but unsourced), em (five th_dlt records:
+      Enzo, Legend, Owen, Qarez), smc (SMC Ram, likely the ATV maker), vom, tol,
+      kl, aj, felq, rso, jzr, mtl, dts, djjd, dh, evt.
+
+      ALSO OPEN AND WORTH A LOOK FIRST: moped/tym/vespa-alpha. TYM is an
+      agricultural-machinery maker, so a Vespa-named moped filed under it is
+      probably a registry mis-attribution rather than a casing question. The
+      make is cased; the record identity is not settled.

--- a/overrides/makes/aliases.yml
+++ b/overrides/makes/aliases.yml
@@ -365,3 +365,15 @@ KSRMOTO: KSR Moto       # 2 raw rows — would have forked to its own make id "K
 # DELIBERATELY NOT PINNED, both agreed with the research pass:
 #   Iva — SETTLED by the B4 pilot: pinned IVA above with manufacturer evidence.
 #   Evt — distributor-only evidence, no manufacturer source found.
+
+# --- S2W acronym-make casing, round 3 (2026-07-25) ---------------------------
+# Six more resolved from the 29 remaining candidates. The other 23 are filed as
+# tracked debt in data/name_shapes.yml rather than guessed: they are 1-3 record
+# makes where the only accessible evidence is the register itself, which is the
+# same ceiling the IVA pilot documented.
+JDM: JDM         # Simpa JDM S.A., Avrillé — French sans-permis microcar maker (SIMPA = Société Industrielle de Matières Plastiques Armées, plastics subcontractor for Alpine and Matra before it built cars from 1981). Corroborated by the published models, which are JDM's own range: Abaca, Aloes, Roxsy, Xheos
+QWIC: QWIC       # Dutch e-bike marque, Amsterdam, since 2006 — all-caps on its own sites (https://qwic.nl/ and https://qwic.uk/)
+RGNT: RGNT       # RGNT Motorcycles, Kungsbacka, Sweden — all-caps throughout https://rgnt-motorcycles.com/. Corroborated by the published model "NO.1", which is RGNT's own naming
+UM: UM           # UM Motorcycles / United Motors, Miami, est. 1999 — all-caps on https://www.ummotorcycles.eu/. Corroborated by the published model Renegade, UM's cruiser line
+TYM: TYM         # TYM Corporation, Seoul (Tong Yang Moolsan) — all-caps. NOTE: TYM is an agricultural-machinery maker, so the two moped records under it want checking; moped/tym/vespa-alpha in particular is a Vespa-named row under a tractor marque and smells like a registry mis-attribution. Cased here, identity NOT settled — see the debt entry
+KMZ: KMZ         # Kyiv Motorcycle Plant (Київський мотоциклетний завод), maker of the K-750 and later the Dnepr. Cased only, NOT merged into Dnepr: the Cyrillic "КМЗ" alias above DOES map to Dnepr, but that is for rows the UA register files under the factory name, whereas motorcycle/kmz/k-750 is the K-750 itself — a model that predates the Dnepr badge. Merging it would date the marque wrongly


### PR DESCRIPTION
Closes the D23/G20 two-wheel half. **24 makes resolved and pinned across three rounds**; these six are the last with evidence, and the remaining 23 are tracked rather than guessed.

## Resolved

Each corroborated by its **own published models**, not by the name alone — which is the check that caught the `mgb` trap earlier:

| pin | evidence |
|---|---|
| **JDM** | Simpa JDM S.A., Avrillé — French sans-permis microcars (SIMPA = *Société Industrielle de Matières Plastiques Armées*, an Alpine/Matra plastics subcontractor before it built cars from 1981). The published records **are** its range: Abaca, Aloes, Roxsy, Xheos. |
| **QWIC** | Dutch e-bike marque, Amsterdam, 2006 — all-caps on [qwic.nl](https://qwic.nl/) and [qwic.uk](https://qwic.uk/). |
| **RGNT** | [RGNT Motorcycles](https://rgnt-motorcycles.com/), Kungsbacka, Sweden. Published model `NO.1` is RGNT's own naming. |
| **UM** | [UM Motorcycles / United Motors](https://www.ummotorcycles.eu/), Miami, est. 1999. Published model `Renegade` is UM's cruiser line. |
| **TYM** | TYM Corporation, Seoul (Tong Yang Moolsan). |
| **KMZ** | Kyiv Motorcycle Plant, maker of the K-750 and later the Dnepr. |

## Two deliberate non-merges, recorded inline so they are not "fixed" later

**KMZ is cased only, not merged into Dnepr** — even though the Cyrillic `"КМЗ"` alias *in this same file* does map to Dnepr. That alias is for rows the UA register files under the factory name; `motorcycle/kmz/k-750` is the **K-750 itself**, a model that predates the Dnepr badge. Merging would date the marque wrongly.

**TYM is cased but its records are not settled.** TYM is an agricultural-machinery maker, and `moped/tym/vespa-alpha` is a Vespa-named row filed under a tractor marque. That smells like a registry mis-attribution, which is a different question from casing. Flagged in the debt entry rather than silently folded in.

## The 23 remaining — the ceiling, stated plainly

Every one is a **1–3 record make whose only accessible evidence is the register** — and **registers uppercase every make string**, so the register can prove the marque exists and can *never* prove how it styles its own name.

That is the same ceiling the IVA pilot documented for discontinued models, one column over. Guessing here would be exactly the "wrong confident answer" the PRD names.

Recorded inside the debt entry so nobody re-does the work:

- **Not-acronyms, verified:** Puch (a surname), Mash, Mutt, Trek, Next, Kral, Rhon. The detector flags them because they are short and vowel-poor — **a shape, not a fact**.
- **`mgb` is the clearest open case** — 2 `uk_dft` records, "Fantasy" and "R8". It is **not** MG's B; that was checked and cost a research detour. Nothing establishes what it is.
- Genuinely open with a plausible marque behind them: `gts` (Italian-named scooter range — Bravo, Cappucino 50, Palermo, Toscana), `em` (five `th_dlt` records), `smc` (SMC Ram, likely the ATV maker).

## No `former_ids`

All six slugs are unchanged (`jdm`, `qwic`, `rgnt`, `um`, `tym`, `kmz`), so this changes `name` only and is non-breaking under SCHEMA.md. **Pre-flight orphan grep** run across `renames.yml`, `models/aliases.yml`, `moves.yml`, `body_types.yml` — all clean. (That procedure came out of the `Tvr:` finding and has caught something on two of the five runs since.)

## Gates

`lint_overrides` OK · `lint_curation` OK · pipeline suite 82 runs / 285 assertions · build verified, all six display names correct in the output.