### PR TITLE
B-001 (Tranche C): 46 ledgers, 6 fixes, and the model-column acronym class

### DIFF
--- a/data/name_shapes.yml
+++ b/data/name_shapes.yml
@@ -451,3 +451,58 @@ debt:
       the published catalog this lint measures — the pending-publish window,
       same class lint_review already tolerates via alias-target liveness.
       Empties at the next release; if it survives one, something is wrong.
+  # ── B-001 (Tranche C) cross-make findings, S2W 2026-07-26 ───────────────────
+  - id: model-column-acronym-casing
+    owner: s2w
+    category: model_casing
+    count: 511
+    why: >-
+      THE MAKE-COLUMN ACRONYM PROBLEM HAS A MODEL-COLUMN TWIN, and it is bigger.
+      smart_case title-cases any pure-alpha token missing from styling.yml's
+      `acronyms` list, so an unnoticed type code becomes a word: "CL" -> "Cl",
+      "KS Super" -> "Ks Super", "SC-153" -> "Sc-153", "LT-019" -> "Lt-019",
+      "SXL" -> "Sxl". B-001 hit five instances in 46 tiny makes, which is what
+      prompted measuring it globally.
+      MEASURED, not estimated, by scripts/find_published_name_defects.rb against
+      the build at the head of this branch: 1223 records over 305 distinct
+      tokens catalog-wide; 511 records over 201 tokens in the 2W half (mine).
+      The count is a WORKLIST, NOT A DEFECT COUNT — the check nominates any
+      token the catalog itself also spells in caps, and real nameplate words
+      leak through on purpose (MAX, PRO, LE, BOY, BOB, APE are genuine words
+      that also appear capitalised somewhere). Each TOKEN needs one human call;
+      ~305 calls covers the catalog, and a token pinned in `acronyms` fixes
+      every record carrying it at once.
+      THE UNAMBIGUOUS SUBSET, safe to fix without per-make research: Roman
+      numerals. "Iii", "Ii", "Ix" are never correct in any marque's naming —
+      22 records (moto-guzzi/850LE Mans Iii, moto-guzzi/California Iii,
+      norton/Commando 850MK Iii, harley-davidson/Fxrs Super Glide Ii,
+      ktm/Duke Ii, jaguar/Mark Ix …). Start there.
+      WHY NO EXISTING TOOL CATCHES IT: registers uppercase every string, so the
+      raw can never disprove a title-cased published name, and
+      find_duplicate_spellings compares raws to raws. This defect is introduced
+      AFTER normalisation and is only visible in the published catalog.
+      Fixed in this batch where B-001 owned the make (capri/cl, edwards/sc-153,
+      i-goo/lt019, e-solex/es, zundapp-famel/ks-super); the rest is a sweep of
+      its own, deliberately not smuggled into a Tranche C batch.
+  - id: nl-snorfiets-25-suffix
+    owner: s2w
+    category: variant_as_model
+    id_list: [moped/fosti/ft50qt-e-25, moped/znen/zn50qt-e-25, moped/znen/zn50qt-f-25, moped/zhongneng/zn50qt-e-25, moped/znen/zn50qt-e3-25]
+    count: 5
+    why: >-
+      Dutch law splits 50cc two-wheelers into the bromfiets (45 km/h, blue
+      plate) and the snorfiets (25 km/h), and RDW type designations mark the
+      speed-limited version by appending ".25" to the OEM type code. So
+      "FT50QT-E" and "FT50QT-E.25" are ONE nameplate in two speed variants, not
+      two models — SCHEMA.md puts speed variants below the model level.
+      Four of the five have their unsuffixed base ALSO published, so the merge
+      target already exists; znen/zn50qt-e3-25 does not and would need its base
+      to publish first or a rename to the bare code.
+      NOT ACTIONED because folding them means asserting the variant relationship
+      in a layer that does not exist yet — there is no model-level variant
+      store, so the only available "fix" is deleting a published id and losing
+      the distinction. Filed so the variant work has a concrete first case, and
+      so nobody merges them blind in the meantime.
+      Same convention explains the ".S" and "E3" suffixes in the same registers
+      (fosti RETRO / RETRO.S), which are NOT speed classes — do not generalise
+      the dot.

--- a/data/review/bashan.yml
+++ b/data/review/bashan.yml
@@ -1,0 +1,19 @@
+# VERIFICATION LEDGER — Bashan (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/bashan.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: bashan
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:caa0a5c99212be67a33824709c8a76f04e6f3b76244b50f9e1b18867d9519d7e
+records:
+  - id: motorcycle/bashan/atv200s-7
+    verdict: canonical
+    note: >-
+      Chongqing Bashan Motorcycle Co. (affiliate of the China Astronautic Sci-Tec group), a
+      real marque exporting under its own Bashan badge. ATV200S-7 is Bashan's own model
+      designation, not a registry mangling — the sibling BS200S-7 uses the same scheme. A
+      type code that IS the nameplate.
+    evidence: http://www.chinabashan.com/en/index.php

--- a/data/review/batavus.yml
+++ b/data/review/batavus.yml
@@ -1,0 +1,24 @@
+# VERIFICATION LEDGER — Batavus (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/batavus.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: batavus
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:7994f7497a4c9846a484e62b1dc4793b532185f1839c1b69f2af14c0c3a25a4b
+records:
+  - id: moped/batavus/mot-o-mat
+    verdict: canonical
+    note: >-
+      Batavus, Heerenveen — a major Dutch marque. The Mot-o-Mat is a genuine Batavus moped.
+      TWO WARNINGS for whoever touches this make next. (1) The register's BATAVUS make column
+      is a DUMPING GROUND: its raw rows include BERINI M13, GAZELLE GRANT, SOLEX, ITOM,
+      MONDIAL and MOSQUITO — six other marques — plus placeholders "-", "---" and "OOOOO".
+      Only the publication threshold keeps them out of the catalog; anything that lowers the
+      threshold for this make imports six marques' worth of wrong attributions. (2) This
+      nameplate has ~19 raw spellings (MOT-O-MAT, MOT O MAT, MOT O'MAT, Mot o' mat, MOTOMAT,
+      MOT-O-MATIC, MOT'OMAT, BATAVUS MOT-O-MAT, BILONET MOT O MAT…) and is the sharpest
+      illustration in the dataset of the one-id-many-names problem.
+    evidence: https://www.brommer.nl/merk/batavus/

--- a/data/review/batches.yml
+++ b/data/review/batches.yml
@@ -38,8 +38,9 @@ batches:
             saxonette, spyder-wheelz, stint, tante-paula, tianying, tisong, tym,
             veeley, viraggio, vom, wlie, zundapp-famel]
     owner: s2w
-    status: claimed
-    claimed_by: s2w        # claimed 2026-07-26
+    status: awaiting_verification
+    claimed_by: s2w
+    verifier: null      # I-11: S4W verifies; researcher must not sign their own batch
     notes: >-
       TRANCHE C, first real batch. 46 makes / 61 published records, and the set
       is defined by an EVIDENCE PROPERTY rather than by size: every record is

--- a/data/review/benzhou.yml
+++ b/data/review/benzhou.yml
@@ -7,7 +7,7 @@ researcher: s2w-opus5
 verifier: null            # I-11: the researcher does not verify their own batch
 status: awaiting_verification
 reviewed_at: 2026-07-26
-raw_fingerprint: sha256:d2d854e5635d363969daf6c25e512f9bf306c45b7c44277a8d5d10dc337eb7a7
+raw_fingerprint: sha256:09f179425e2569cb09f9365d888614aaffb57dfbc396db8c69feb83189a2cd69
 records:
   - id: moped/benzhou/25-sixties
     verdict: canonical

--- a/data/review/benzhou.yml
+++ b/data/review/benzhou.yml
@@ -1,0 +1,31 @@
+# VERIFICATION LEDGER — Benzhou (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/benzhou.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: benzhou
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:d2d854e5635d363969daf6c25e512f9bf306c45b7c44277a8d5d10dc337eb7a7
+records:
+  - id: moped/benzhou/25-sixties
+    verdict: canonical
+    note: >-
+      Benzhou Vehicle Industry (Taizhou), YY-prefixed type codes. This make is the batch's
+      OEM hub: its raw rows include IVA LUX50, IVA-RA9015, BTC CLASSIC 50, CAPRI 50/125,
+      AIYUMO YOUNG and TIANMA — six other marques' badges filed under the builder. One of
+      those, IVA LUX50, was moved to `iva` in this batch's first PR; the rest sit below
+      threshold. Anything that lowers the threshold here imports the same contamination
+      Batavus has.
+    evidence: https://www.brommer.nl/merk/benzhou/
+  - id: moped/benzhou/50-retro
+    verdict: canonical
+    note: >-
+      Benzhou Vehicle Industry (Taizhou), YY-prefixed type codes. This make is the batch's
+      OEM hub: its raw rows include IVA LUX50, IVA-RA9015, BTC CLASSIC 50, CAPRI 50/125,
+      AIYUMO YOUNG and TIANMA — six other marques' badges filed under the builder. One of
+      those, IVA LUX50, was moved to `iva` in this batch's first PR; the rest sit below
+      threshold. Anything that lowers the threshold here imports the same contamination
+      Batavus has.
+    evidence: https://www.brommer.nl/merk/benzhou/

--- a/data/review/black-n-roll.yml
+++ b/data/review/black-n-roll.yml
@@ -1,0 +1,19 @@
+# VERIFICATION LEDGER — Black N Roll (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/black-n-roll.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: black-n-roll
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:66e56e8bd4036682f640a019bbd280012ea45a822cdf7d765041d01de40980ff
+records:
+  - id: moped/black-n-roll/s4800d
+    verdict: debt
+    note: >-
+      raw rows also include "MOPEX E-SCOOT" and "N/A"; S4800/S4800D look like a supplier type
+      code rather than a marque nameplate. VERDICT IS `debt` BECAUSE the Dutch RDW open
+      register is the only evidence that exists for this make; see the batch header in
+      data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/black-n-roll/

--- a/data/review/brekr.yml
+++ b/data/review/brekr.yml
@@ -1,0 +1,19 @@
+# VERIFICATION LEDGER — Brekr (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/brekr.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: brekr
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:17d044fb79366e113e08d230ba496f38c5761f3892692d4209e3a5665e8869e1
+records:
+  - id: moped/brekr/model-b4000
+    verdict: canonical
+    note: >-
+      Dutch manufacturer in Doetinchem; the Model B is its best-known machine and the B4000
+      the current type. Assembled at IBN Groep, Veghel. Model naming ("Model B", "Model F")
+      is the marque's own convention, so the "Model" token is part of the nameplate and must
+      not be stripped as a filler word.
+    evidence: https://www.brekr.com/

--- a/data/review/capri.yml
+++ b/data/review/capri.yml
@@ -1,0 +1,23 @@
+# VERIFICATION LEDGER — Capri (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/capri.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: capri
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:590bc4e4a919301aed1871ed103d3a40f85b354f12318edff648760d914b94e6
+records:
+  - id: moped/capri/cl
+    verdict: fixed
+    note: >-
+      display "Cl" -> "CL", and the separate id `capri/cl50` ("CL50") merged in behind a
+      former_ids alias — one nameplate that published twice because bare "CL" is a pure-alpha
+      token smart_case title-cases while "CL50" is alphanumeric and survives untouched.
+      Register holds all three spellings (CL x3, CL 50 x2, CL50 x2). The marque itself is
+      mixed-era: 1960s Capri mopeds used Sachs blocks and were imported by Stokvis & Zonen,
+      while modern rows carry Chinese codes (WY50QT-86) and an E-CAPRI badge, so `capri`
+      spans a historic and a current marque of the same name — NOT resolved here, and a
+      reason to be careful before merging anything else into it.
+    evidence: https://www.brommer.nl/merk/capri/cl/

--- a/data/review/djjd.yml
+++ b/data/review/djjd.yml
@@ -1,0 +1,21 @@
+# VERIFICATION LEDGER — Djjd (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/djjd.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: djjd
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:c89def6de933f7a5120600b266aab4538b7e957c3d08803441f0f0c3f1dcad6f
+records:
+  - id: moped/djjd/cashmere
+    verdict: debt
+    note: >-
+      an initialism-shaped make (filed in the acronym-make debt tail) with an Italianate
+      model range — Cashmere, Avantgarde, Elegance, Valetta, Twist — plus a WY50QT-111 OEM
+      code. The range reads like a real badge; nothing establishes the make's own styling.
+      VERDICT IS `debt` BECAUSE the Dutch RDW open register is the only evidence that exists
+      for this make; see the batch header in data/review/batches.yml for why that is a
+      ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/djjd/

--- a/data/review/dts.yml
+++ b/data/review/dts.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — DTS (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/dts.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: dts
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:03df9f90cc11db5b5415084d95b5a0a2dee5bac0fa471db507342f69891dd48f
+records:
+  - id: moped/dts/milano
+    verdict: debt
+    note: >-
+      Italian city-name range (Milano/Monza/Verona/Savano, with E- prefixed electric twins).
+      Make is in the acronym-make debt tail; the display "DTS" is unverified. VERDICT IS
+      `debt` BECAUSE the Dutch RDW open register is the only evidence that exists for this
+      make; see the batch header in data/review/batches.yml for why that is a ceiling and not
+      laziness.
+    evidence: https://www.brommer.nl/merk/dts/

--- a/data/review/e-solex.yml
+++ b/data/review/e-solex.yml
@@ -1,0 +1,19 @@
+# VERIFICATION LEDGER — E-Solex (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/e-solex.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: e-solex
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:eff64ade3a6460806c9f0da0d243e6ece17f0d3bb1bd8b7e9182076703e5ed1e
+records:
+  - id: moped/e-solex/es
+    verdict: fixed
+    note: >-
+      display "Es" -> "ES" (casing only). The raw is "ES" in every row and "Es" is not a
+      word. What ES abbreviates is NOT established: Solex's own machines were numbered
+      (S2200, S3300, S3800) and the 2005-on electric revival was marketed as "e-Solex", so
+      "ES" fits neither scheme cleanly. Casing fixed; identity left open.
+    evidence: https://solex.nl/

--- a/data/review/ebretti.yml
+++ b/data/review/ebretti.yml
@@ -1,0 +1,22 @@
+# VERIFICATION LEDGER — Ebretti (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/ebretti.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: ebretti
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:9534eb5b344eb49252006482b1638d8fce2fa928f43fc05f7cee80d0ec6def7f
+records:
+  - id: moped/ebretti/ebretti
+    verdict: debt
+    note: >-
+      MAKE-AS-MODEL, and unusually the marque is well evidenced while the record is not.
+      Ebretti is a genuine Dutch e-scooter manufacturer trading since 2008 with a published
+      lineup of 318 / 418 / 518, and the register holds EBRETTI 318 and PIONEER rows
+      alongside the bare "EBRETTI" ones. But the published record's raw string is literally
+      "EBRETTI" with no model, so there is nothing to move it TO — the same wall as
+      `saxonette`. Resolvable by type-approval number; not by guessing which of 318/418/518
+      the bare rows are.
+    evidence: http://www.ebretti.com/nl/modellen

--- a/data/review/edwards.yml
+++ b/data/review/edwards.yml
@@ -1,0 +1,18 @@
+# VERIFICATION LEDGER — Edwards (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/edwards.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: edwards
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:ccf8ec81ea6f0105d3fbae4df304aa9c233102220252c6dd1c400dd1859ed94d
+records:
+  - id: moped/edwards/sc-153
+    verdict: fixed
+    note: >-
+      display "Sc-153" -> "SC-153". SC is a type-code prefix, evidenced inside the register
+      by the siblings SC-151 and SC-154 under the same make; the make also carries a ZN50QT-E
+      row, placing it in the ZNEN importer cluster.
+    evidence: https://www.brommer.nl/merk/edwards/

--- a/data/review/elveco.yml
+++ b/data/review/elveco.yml
@@ -1,0 +1,19 @@
+# VERIFICATION LEDGER — Elveco (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/elveco.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: elveco
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:87c83d5de06c523e954c3e01e1e459ceec2a2ba5463204a091ffca87d4905772
+records:
+  - id: moped/elveco/pro
+    verdict: debt
+    note: >-
+      single model row ("PRO") and nothing else in the register — "Pro" is a trim word doing
+      duty as a nameplate. VERDICT IS `debt` BECAUSE the Dutch RDW open register is the only
+      evidence that exists for this make; see the batch header in data/review/batches.yml for
+      why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/elveco/

--- a/data/review/evader.yml
+++ b/data/review/evader.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — Evader (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/evader.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: evader
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:c1aebd3b22754b50d97151d381647a5d99041e3d45f379f10698f685541487ed
+records:
+  - id: moped/evader/ev100-metro
+    verdict: debt
+    note: >-
+      EV100 GT / Metro / S form a coherent family, so EV100 is the platform and Metro the
+      variant; whether the marque writes it "EV100 Metro" or "EV100METRO" (the register does
+      the latter) is not established. VERDICT IS `debt` BECAUSE the Dutch RDW open register
+      is the only evidence that exists for this make; see the batch header in
+      data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/evader/

--- a/data/review/fosti.yml
+++ b/data/review/fosti.yml
@@ -1,0 +1,25 @@
+# VERIFICATION LEDGER — Fosti (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/fosti.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: fosti
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:a1d5cfd940cd85a0a8dbd146e20e8ef68c16dec88306383b095ccdea18e19340
+records:
+  - id: moped/fosti/ft50qt-e
+    verdict: canonical
+    note: >-
+      Fosti is part of the Zhongneng (ZNEN) group of Taizhou — the same group that owns
+      Motowin and Fuxianda — which is why FT-prefixed and ZN-prefixed type codes appear
+      across the same importer network. FT50QT-E is Fosti's own type designation.
+    evidence: https://www.znen.com/
+  - id: moped/fosti/ft50qt-e-25
+    verdict: canonical
+    note: >-
+      Fosti is part of the Zhongneng (ZNEN) group of Taizhou — the same group that owns
+      Motowin and Fuxianda — which is why FT-prefixed and ZN-prefixed type codes appear
+      across the same importer network. FT50QT-E is Fosti's own type designation.
+    evidence: https://www.znen.com/

--- a/data/review/gazelle.yml
+++ b/data/review/gazelle.yml
@@ -1,0 +1,27 @@
+# VERIFICATION LEDGER — Gazelle (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/gazelle.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: gazelle
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:da883b804bf9dba7fd9d81afd1eb4955e27d8a04ac821734605257435dfb5509
+records:
+  - id: moped/gazelle/cityzen-s10sp
+    verdict: canonical
+    note: >-
+      Koninklijke Gazelle, Dieren — a Dutch marque since 1892. CityZen is its
+      e-bike/speed-pedelec line; the S10 speed pedelec registers as a moped.
+    evidence: https://www.gazelle.nl/
+  - id: moped/gazelle/cityzen-speed-powertube
+    verdict: canonical
+    note: >-
+      same CityZen speed-pedelec line, Bosch PowerTube battery variant named in the register.
+    evidence: https://www.gazelle.nl/
+  - id: moped/gazelle/ultimate-speed
+    verdict: canonical
+    note: >-
+      Gazelle Ultimate series, speed-pedelec version.
+    evidence: https://www.gazelle.nl/

--- a/data/review/gerray.yml
+++ b/data/review/gerray.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — Gerray (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/gerray.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: gerray
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:b054eddc1ab1aa05c0f6ff995364cb66530dd8bb872bf9f4c1733395f4f7c1f7
+records:
+  - id: moped/gerray/star
+    verdict: debt
+    note: >-
+      space-themed range (Star, Sun, Luna, Moon Luna, Galaxy, E-Galaxy, E-Space, Ray, Xi) —
+      internally consistent enough to be a real badge, with no marque source found. VERDICT
+      IS `debt` BECAUSE the Dutch RDW open register is the only evidence that exists for this
+      make; see the batch header in data/review/batches.yml for why that is a ceiling and not
+      laziness.
+    evidence: https://www.brommer.nl/merk/gerray/

--- a/data/review/hercules.yml
+++ b/data/review/hercules.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — Hercules (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/hercules.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: hercules
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:cd577718c3363a43d569fe3edae1aa9bb18846f7175ef4fac6b48fdae00ac37c
+records:
+  - id: moped/hercules/saxonette
+    verdict: canonical
+    note: >-
+      correctly formed and must NOT be touched when the sibling `saxonette` make is dealt
+      with: this is the Hercules Saxonette, the motorised bicycle Hercules sold 1987-2011
+      with the Fichtel & Sachs engine. Marque in the make column, product in the model
+      column. Register corroborates internally — Hercules rows include "221 MF SAXONETTE
+      AUTOMATIC", tying the Saxonette to Hercules type numbers.
+    evidence: https://www.brommer.nl/merk/hercules/

--- a/data/review/i-coco.yml
+++ b/data/review/i-coco.yml
@@ -1,0 +1,18 @@
+# VERIFICATION LEDGER — I-Coco (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/i-coco.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: i-coco
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:d99354088e7879f6521e96d0894f724e46d5e634f91d9baf4e48b00983325922
+records:
+  - id: moped/i-coco/lt018
+    verdict: canonical
+    note: >-
+      LT-018/LT018 were merged to the closed form by an earlier pass; verified still merged
+      in this build. Sibling of `i-goo` (LT-019) — consecutive type codes from one OEM, the
+      CityCoco fat-tyre platform.
+    evidence: https://www.brommer.nl/merk/i-coco/

--- a/data/review/i-goo.yml
+++ b/data/review/i-goo.yml
@@ -1,0 +1,21 @@
+# VERIFICATION LEDGER — I-Goo (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/i-goo.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: i-goo
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:ee8e054163844556fc563cf2b829afc9a04303bc260eb3b1cf1dddbb7284a8c9
+records:
+  - id: moped/i-goo/lt019
+    verdict: fixed
+    note: >-
+      display "Lt-019" -> "LT019", merging the open and closed spellings behind a former_ids
+      alias. Closed form chosen to match the `i-coco` LT018 block already in renames.yml —
+      i-coco/LT-018 and i-goo/LT-019 are consecutive type codes from one OEM (the CityCoco
+      platform; i-goo's raws literally include "CITYCOCO"). NEITHER form is
+      manufacturer-attested. Sibling consistency is the only argument available and it is
+      stated as such rather than dressed up as evidence.
+    evidence: https://www.brommer.nl/merk/i-goo/

--- a/data/review/jiajue.yml
+++ b/data/review/jiajue.yml
@@ -1,0 +1,18 @@
+# VERIFICATION LEDGER — Jiajue (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/jiajue.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: jiajue
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:3cabc69ae828b3966a40a4f01387d058b30c5eaffcc219ad1fae34093c42ebc9
+records:
+  - id: moped/jiajue/jj50qt-21
+    verdict: canonical
+    note: >-
+      Jiajue (Zhejiang) builds the JJ50QT-* series; the register holds JJ50QT-3 through -22
+      under this make, so the type-code family is internally consistent and correctly
+      attributed.
+    evidence: https://www.jiajue.com/

--- a/data/review/kickbike.yml
+++ b/data/review/kickbike.yml
@@ -1,0 +1,19 @@
+# VERIFICATION LEDGER — Kickbike (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/kickbike.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: kickbike
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:1b40a886280e15f2709ee09423863b038fa56b4a9d2946b806306fcf0e2ddecf
+records:
+  - id: moped/kickbike/fat-max
+    verdict: canonical
+    note: >-
+      Kickbike Worldwide Ltd, Helsinki. Fat MAX is the marque's own model name for the
+      fat-tyre off-road kick scooter. Marque writes MAX in caps; the register's "FAT MAX" and
+      the published "Fat Max" differ only in that, and no source establishes the caps as
+      load-bearing, so the id is unaffected either way.
+    evidence: https://kickbike.com/en/kickbike/standars/kickbike/fat-max.html

--- a/data/review/klever.yml
+++ b/data/review/klever.yml
@@ -1,0 +1,19 @@
+# VERIFICATION LEDGER — Klever (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/klever.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: klever
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:a7b8b9cfe40f20ef2db9c31d1717594fc8311b40683b611cf82823f33fe1b5da
+records:
+  - id: moped/klever/x-speed
+    verdict: canonical
+    note: >-
+      Klever Mobility's X-series speed pedelec. The marque publishes it as "X Speed 45", the
+      45 denoting the 45 km/h class; the register drops the class number and the published
+      name follows the register. Sibling X Pinion 45 / N Rogue 45 / Y Muse 45 rows are
+      present below threshold, which corroborates the series naming.
+    evidence: https://klever-mobility.com/en/speedpedelec/x-speed-45/

--- a/data/review/lintex.yml
+++ b/data/review/lintex.yml
@@ -1,0 +1,25 @@
+# VERIFICATION LEDGER — Lintex (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/lintex.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: lintex
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:db02df9782ed2187c90e861d5dc9812c9022ee332de57b16cd6089e0640828fb
+records:
+  - id: moped/lintex/ht50qt-29a
+    verdict: canonical
+    note: >-
+      HT-prefixed type codes. NOTE the cross-make check found `HT50QT-29A` published under
+      BOTH lintex and killerbee — one OEM product wearing two importer badges. Neither is
+      wrong as a marque; the shared type code is the evidence that they are the same machine.
+    evidence: https://www.brommer.nl/merk/lintex/
+  - id: moped/lintex/ht50qt-39
+    verdict: canonical
+    note: >-
+      HT-prefixed type codes. NOTE the cross-make check found `HT50QT-29A` published under
+      BOTH lintex and killerbee — one OEM product wearing two importer badges. Neither is
+      wrong as a marque; the shared type code is the evidence that they are the same machine.
+    evidence: https://www.brommer.nl/merk/lintex/

--- a/data/review/luuko.yml
+++ b/data/review/luuko.yml
@@ -1,0 +1,18 @@
+# VERIFICATION LEDGER — Luuko (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/luuko.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: luuko
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:f694cd8219479941b1152f87b334933bf4be9d9430dcb2bf4178a0763cff3985
+records:
+  - id: moped/luuko/retro-50
+    verdict: canonical
+    note: >-
+      Retro 50 is Luuko's principal model — 63.6% of all Luuko registrations in NL (520
+      machines). The marque itself is defunct; the model attribution is nonetheless
+      unambiguous.
+    evidence: https://www.brommer.nl/merk/luuko/retro-50/

--- a/data/review/modena.yml
+++ b/data/review/modena.yml
@@ -1,0 +1,19 @@
+# VERIFICATION LEDGER — Modena (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/modena.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: modena
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:7b53d351c4f2cc72c03447b18418b1bb9b687f17222941275041dac79a44e3fb
+records:
+  - id: moped/modena/dls2
+    verdict: debt
+    note: >-
+      raws mix an OEM code (BD50QT-14), a shared ZNEN code (ZN50QT-E) and named models
+      (Speedy, DLS2). DLS2 is a type designation, not a nameplate. VERDICT IS `debt` BECAUSE
+      the Dutch RDW open register is the only evidence that exists for this make; see the
+      batch header in data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/modena/

--- a/data/review/momo.yml
+++ b/data/review/momo.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — Momo (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/momo.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: momo
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:4d040bcdf1f9c3735d74dea823e6673cc05350879013b8ab5a1fa281aa6561d0
+records:
+  - id: moped/momo/morino-50
+    verdict: canonical
+    note: >-
+      MOMO Scooters Nederland is the marque/importer and the Morino is its retro model line
+      (Standard/Special/Plus/Exclusive, plus the electric E-Morino). NOTE the register also
+      holds "MARINO 50" — a one-letter misspelling of the same nameplate, below threshold so
+      it does not publish; if it ever crosses, it merges here rather than becoming a second
+      model.
+    evidence: https://www.momoscooters.nl/

--- a/data/review/monasso.yml
+++ b/data/review/monasso.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — Monasso (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/monasso.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: monasso
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:1af989617c7e1b2e940d8d27d912e6b071c7afd4628e9c1f7be47309455b1e38
+records:
+  - id: moped/monasso/grace
+    verdict: debt
+    note: >-
+      models Grace, Zeroporte and S5-W. NOTE `wlie` in this same batch publishes "Maple" and
+      holds raw rows for GRACE and E-GRACE — so Monasso's Grace and WLIE's Grace are likely
+      one OEM product under two badges, unproven either way. VERDICT IS `debt` BECAUSE the
+      Dutch RDW open register is the only evidence that exists for this make; see the batch
+      header in data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/monasso/

--- a/data/review/motormania.yml
+++ b/data/review/motormania.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — Motormania (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/motormania.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: motormania
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:94295c3ba6cd6dedb42d48f7242c644d9208c05ce21fdb11b8761a60505d538d
+records:
+  - id: moped/motormania/zn50qt-e
+    verdict: canonical
+    note: >-
+      ZN = ZNEN (Zhongneng, Taizhou). `ZN50QT-E` publishes under FOUR makes — agm,
+      motormania, zhongneng and znen — which is the clearest instance in the dataset of the
+      approval-holder trap PRD-QUALITY warns about for Tranche C: one OEM product, four
+      importer badges, four ids. The make is a real importer badge, so the record is
+      canonical; the DUPLICATION across makes is the finding, recorded in the batch notes.
+    evidence: https://www.znen.com/

--- a/data/review/nimoto.yml
+++ b/data/review/nimoto.yml
@@ -1,0 +1,29 @@
+# VERIFICATION LEDGER — Nimoto (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/nimoto.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: nimoto
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:a9af4f5939c575d1627a7c50b500288f59c36b17061f6062646fc5b430a4dd41
+records:
+  - id: moped/nimoto/ceo50
+    verdict: debt
+    note: >-
+      Dutch-marketed range (CEO, City, Classy, Easy, Trendy) with WY150T-67 and ZPM1000DT-3
+      OEM codes behind it. "CEO" survives as caps because it is already in the acronyms list;
+      "City" and the rest are ordinary words. VERDICT IS `debt` BECAUSE the Dutch RDW open
+      register is the only evidence that exists for this make; see the batch header in
+      data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/nimoto/
+  - id: moped/nimoto/city
+    verdict: debt
+    note: >-
+      Dutch-marketed range (CEO, City, Classy, Easy, Trendy) with WY150T-67 and ZPM1000DT-3
+      OEM codes behind it. "CEO" survives as caps because it is already in the acronyms list;
+      "City" and the rest are ordinary words. VERDICT IS `debt` BECAUSE the Dutch RDW open
+      register is the only evidence that exists for this make; see the batch header in
+      data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/nimoto/

--- a/data/review/nipponia.yml
+++ b/data/review/nipponia.yml
@@ -1,0 +1,22 @@
+# VERIFICATION LEDGER — Nipponia (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/nipponia.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: nipponia
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:e1d0be7e016d9a6f4812e4b64104b013ddfe219654d5302173a888975577e5ed
+records:
+  - id: moped/nipponia/e-rex
+    verdict: canonical
+    note: >-
+      Nipponia is a Dutch-marketed electric-scooter marque (Japanese-sounding name, Chinese
+      manufacture) with its own NL catalogue; the e-Rex is current lineup.
+    evidence: https://nipponia.nl/en/electric/
+  - id: moped/nipponia/volty
+    verdict: canonical
+    note: >-
+      Nipponia Volty, current lineup on the marque's own site.
+    evidence: https://nipponia.nl/en/electric/

--- a/data/review/qwic.yml
+++ b/data/review/qwic.yml
@@ -1,0 +1,30 @@
+# VERIFICATION LEDGER — QWIC (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/qwic.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: qwic
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:9174bc04886cf9bf7a6ddb93ec72d860f80c3e4c37a2559b649ca74ad09f6c04
+records:
+  - id: moped/qwic/emoto-lite
+    verdict: canonical
+    note: >-
+      Dutch e-bike marque, Amsterdam, trading since 2006; the eMTB/Emoto range is current
+      catalogue. Make casing was pinned in acronym round 2 from the marque's own all-caps
+      usage.
+    evidence: https://qwic.nl/
+  - id: moped/qwic/performance-mid-motor-speed
+    verdict: canonical
+    note: >-
+      the Performance series speed-pedelec (45 km/h), which is why it registers as a moped in
+      NL rather than as a bicycle.
+    evidence: https://qwic.nl/
+  - id: moped/qwic/performance-rd11-speed
+    verdict: canonical
+    note: >-
+      Performance RD11, the belt-drive speed pedelec. Register also holds RD10 and a bare
+      "RD11" below threshold — same series.
+    evidence: https://qwic.nl/

--- a/data/review/rover-bikes.yml
+++ b/data/review/rover-bikes.yml
@@ -1,0 +1,19 @@
+# VERIFICATION LEDGER — Rover Bikes (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/rover-bikes.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: rover-bikes
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:2e719bd8b8d9e0f3d25899fe0f773a26bf8b4c27db932ff4788033cda070ea53
+records:
+  - id: moped/rover-bikes/classic
+    verdict: canonical
+    note: >-
+      Rover Bikes, Valkenburg (Limburg) — an RDW-recognised assembler that badges its own
+      retro scooters, so "Rover" IS the marque here even though the machines are
+      Chinese-built (its register rows also carry ZN50QT-*, BT49QT-* and LB50QT-* OEM codes).
+      Rover Classic / Rover Fun / Rover Speedy are its own range.
+    evidence: https://rover-bikes.nl/

--- a/data/review/rso.yml
+++ b/data/review/rso.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — RSO (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/rso.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: rso
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:83f3a9e2d80e4ce102aa07324f6aa86c8c6fd2dd5b9ff5c59489e9987476ed33
+records:
+  - id: moped/rso/sense
+    verdict: debt
+    note: >-
+      Sense / E-Sense / Arrow / Discover / Speedy range plus a TY150T-14E code (the Tianying
+      prefix, another badge link inside this batch). Make is in the acronym-make debt tail.
+      VERDICT IS `debt` BECAUSE the Dutch RDW open register is the only evidence that exists
+      for this make; see the batch header in data/review/batches.yml for why that is a
+      ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/rso/

--- a/data/review/saxonette.yml
+++ b/data/review/saxonette.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — Saxonette (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/saxonette.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: saxonette
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:e32b5a89f2aa3aad725c7aa0b22621fe00f736b5bac2743843d9e73eb39538ec
+records:
+  - id: moped/saxonette/529
+    verdict: debt
+    note: >-
+      see data/name_shapes.yml `saxonette-is-a-product-not-a-marque`: Saxonette is a Fichtel
+      & Sachs product name, never a marque, but the model column holds "529" (a type number)
+      so there is nothing to move it to. Hercules is the likely builder — and
+      `hercules/saxonette` in this same batch is the correctly-formed sibling that must not
+      be disturbed.
+    evidence: https://www.brommer.nl/merk/hercules/

--- a/data/review/selana.yml
+++ b/data/review/selana.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — SELANA (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/selana.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: selana
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:db5b36836ab58f52ef815325d4b72367c1b9d1917f6305b263dd8a819a7fc560
+records:
+  - id: moped/selana/alpha
+    verdict: fixed
+    note: >-
+      moved out of make `go-tulip-b-v`, which was the REGISTRANT not the marque: RDW filed
+      these 576 rows under SELANA's legal entity, whose KVK number is published in the
+      marque's own footer ("Go Tulip B.V. KVK: 75554631"). Badge stripped from the model
+      column in the same pass, so the id is selana/alpha rather than selana/selana-alpha.
+      All-caps SELANA is manufacturer styling used in running prose, not register shouting.
+    evidence: https://selana.nl/en

--- a/data/review/spyder-wheelz.yml
+++ b/data/review/spyder-wheelz.yml
@@ -1,0 +1,24 @@
+# VERIFICATION LEDGER — Spyder Wheelz (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/spyder-wheelz.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: spyder-wheelz
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:5769702f7324c7c022e7108517fe3cef6745324d255e7b2a4048cc5da78d10de
+records:
+  - id: moped/spyder-wheelz/rent-group-nederland-bv
+    verdict: debt
+    note: >-
+      NOT A NAMEPLATE — the model column holds a rental operator's corporate name. Raw is
+      `SPYDER WHEELZ | SPYDER RENT GROUP NEDERLAND BV` across 6,435 rows: Spyder Wheelz is a
+      real Dutch two-wheeler marque, and Spyder Rent Group is its rental arm (~200 locations,
+      14 in NL), so these are fleet registrations filed under the operator rather than under
+      a model. Corroborated independently by voertuig-zoeker.nl, which lists the identical
+      make/model pair (6,356 machines). WHY strip_make_prefix DID NOT SAVE US: it requires
+      the FULL make name followed by [\s,]+, and the string begins "SPYDER RENT", not "SPYDER
+      WHEELZ" — so the shared first token buys nothing. No model can be recovered from the
+      register; a marque source naming the fleet model would be needed.
+    evidence: https://www.voertuig-zoeker.nl/bromfiets/spyder-wheelz/spyder-rent-group-nederland-bv/-/

--- a/data/review/stint.yml
+++ b/data/review/stint.yml
@@ -1,0 +1,22 @@
+# VERIFICATION LEDGER — Stint (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/stint.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: stint
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:8e2f0163982a9fb0d7763904c7a26612a58552de0e3f9a56e6a82a78e6efac26
+records:
+  - id: moped/stint/bus
+    verdict: canonical
+    note: >-
+      Stint Urban Mobility, Oss. "Bus" IS the nameplate, not a body-type word: the marque
+      built Bus, Cargo and Pickup variants and the register holds all three (STINT CARGO /
+      STINT PICKUP sit below threshold). CONTEXT a future editor will want: the Stint was
+      banned from Dutch roads after the fatal Oss level-crossing accident of 20 Sept 2018,
+      and a modified version returned at the end of 2020 as the "BSO-bus". If year data is
+      ever attached to this record it needs the §14.4 runs-list treatment, not a single
+      year_end.
+    evidence: https://nl.wikipedia.org/wiki/Stint

--- a/data/review/tante-paula.yml
+++ b/data/review/tante-paula.yml
@@ -1,0 +1,23 @@
+# VERIFICATION LEDGER — Tante Paula (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/tante-paula.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: tante-paula
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:cd1442983b4c0e10fd014037fd34b4724fae17405366aca4154b4c1b66597d7c
+records:
+  - id: moped/tante-paula/es07
+    verdict: debt
+    note: >-
+      the MAKE is solid — "Tante Paula"® is a protected mark of a Hamburg maker that has sold
+      electric scooters since 2001 under model names Ferdinand 1/2/3, Leonie and Maximilian
+      2. The MODEL is the open question: ES07 is a Typ designation, and a period sales
+      listing pairs it with the Ferdinand III ("ELEKTROROLLER TANTE PAULA Ferdinand III Typ
+      ES07"). One listing is not a mapping — the marque's own site (tante-paula.de) did not
+      resolve at time of review (DNS failure), so the ES07 -> Ferdinand III equivalence could
+      not be established from a source of record. Exactly the IVA RA9015 shape: a type code
+      where a nameplate exists, and the nameplate needs the manufacturer to confirm it.
+    evidence: https://picclick.de/Elektroroller-Tante-Paula-Ferdinand-III-Typ-ES07-Farbe-162796905965.html

--- a/data/review/tianying.yml
+++ b/data/review/tianying.yml
@@ -1,0 +1,18 @@
+# VERIFICATION LEDGER — Tianying (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/tianying.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: tianying
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:40818a23c3c3cf79cecd63cf3eb2420da38b714c6b1051d3ef403b204024403f
+records:
+  - id: moped/tianying/ty50qt-k
+    verdict: canonical
+    note: >-
+      TY-prefixed type codes, consistent across TY50QT-C/-5D/-K and TY125T/TY250T rows. NOTE
+      `TY50QT-K` also publishes under `riya` — the same badge-engineering relationship as
+      lintex/killerbee.
+    evidence: https://www.brommer.nl/merk/tianying/

--- a/data/review/tisong.yml
+++ b/data/review/tisong.yml
@@ -1,0 +1,18 @@
+# VERIFICATION LEDGER — Tisong (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/tisong.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: tisong
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:50a6f8d3e6dd1ecb4959919dae33bd095bdd564ada852d6e6e3fbd1c8ab3d104
+records:
+  - id: moped/tisong/swift
+    verdict: debt
+    note: >-
+      three model rows (C50, Pacer, Swift) and no marque source. VERDICT IS `debt` BECAUSE
+      the Dutch RDW open register is the only evidence that exists for this make; see the
+      batch header in data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/tisong/

--- a/data/review/tym.yml
+++ b/data/review/tym.yml
@@ -1,0 +1,28 @@
+# VERIFICATION LEDGER — TYM (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/tym.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: tym
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:b1a5f3793e8bd4fadc4dd912da92daae693b2d1c26f0038602209367d4ed092b
+records:
+  - id: moped/tym/sxl
+    verdict: debt
+    note: >-
+      see data/name_shapes.yml `tym-identity-unresolved` — my own acronym round-3 pin cited
+      TYM Corporation of Seoul, an agricultural-machinery maker, which is implausible for two
+      Dutch moped rows. A likelier candidate (Tym', a French e-scooter brand) would make the
+      display "Tym'", so the pin may be wrong rather than merely under-evidenced. Also note
+      "Sxl" is itself a title-cased type code awaiting the same sweep as `capri/cl`; left
+      alone deliberately while the make identity is open.
+    evidence: https://www.brommer.nl/merk/tym/
+  - id: moped/tym/vespa-alpha
+    verdict: debt
+    note: >-
+      a Vespa-named row under an unresolved make. Same batch turns up `selana/alpha` and
+      jiajue raw rows literally spelling "VESPA ALPHA", so "Alpha" here is likely another
+      marque's model wearing a Vespa-styling description rather than anything of TYM's.
+    evidence: https://www.brommer.nl/merk/tym/

--- a/data/review/veeley.yml
+++ b/data/review/veeley.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — Veeley (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/veeley.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: veeley
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:c997292179615655bb1c3d7af71f0539ea8336cbc903d46934eadbfd8bf1f899
+records:
+  - id: moped/veeley/veeley
+    verdict: debt
+    note: >-
+      MAKE-AS-MODEL with a single raw string ("VEELEY") and no other model rows in the
+      register at all — unlike `ebretti`, there is not even a sibling nameplate to hint at
+      what the machine is. One of the G9 make-as-model rows flagged as needing marque
+      research; research finds the badge exists in NL sales listings but no manufacturer
+      source.
+    evidence: https://www.brommer.nl/merk/veeley/

--- a/data/review/viraggio.yml
+++ b/data/review/viraggio.yml
@@ -1,0 +1,19 @@
+# VERIFICATION LEDGER — Viraggio (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/viraggio.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: viraggio
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:0c158ef01316945fe781cda93e2434244252c0884dd716d3cccfa44a16fd45f0
+records:
+  - id: moped/viraggio/sensa
+    verdict: debt
+    note: >-
+      Sensa / Sensa E5 / Sensa EL, plus ZN50QT-E and ZN50QT-E3 — another ZNEN-badged
+      importer, same cluster as motormania and wlie. VERDICT IS `debt` BECAUSE the Dutch RDW
+      open register is the only evidence that exists for this make; see the batch header in
+      data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/viraggio/

--- a/data/review/vom.yml
+++ b/data/review/vom.yml
@@ -1,0 +1,41 @@
+# VERIFICATION LEDGER — VOM (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/vom.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: vom
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:e90abe3ee337efab2ce3ef36fe289c57091e60212c5ed03d087fb35a43a123d9
+records:
+  - id: moped/vom/bella-milano
+    verdict: debt
+    note: >-
+      a "Bella" family (Classic/Exclusive/Milano/Retro) plus Rome and Venice. NOTE
+      `motormania` holds BELLA/BELLA50 raws and `rover-bikes` holds BELLA EXCLUSIVE — the
+      Bella range crosses at least three makes in this batch, which is the badge-engineering
+      signature again. Make is in the acronym-make debt tail. VERDICT IS `debt` BECAUSE the
+      Dutch RDW open register is the only evidence that exists for this make; see the batch
+      header in data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/vom/
+  - id: moped/vom/bella-retro
+    verdict: debt
+    note: >-
+      a "Bella" family (Classic/Exclusive/Milano/Retro) plus Rome and Venice. NOTE
+      `motormania` holds BELLA/BELLA50 raws and `rover-bikes` holds BELLA EXCLUSIVE — the
+      Bella range crosses at least three makes in this batch, which is the badge-engineering
+      signature again. Make is in the acronym-make debt tail. VERDICT IS `debt` BECAUSE the
+      Dutch RDW open register is the only evidence that exists for this make; see the batch
+      header in data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/vom/
+  - id: moped/vom/venice
+    verdict: debt
+    note: >-
+      a "Bella" family (Classic/Exclusive/Milano/Retro) plus Rome and Venice. NOTE
+      `motormania` holds BELLA/BELLA50 raws and `rover-bikes` holds BELLA EXCLUSIVE — the
+      Bella range crosses at least three makes in this batch, which is the badge-engineering
+      signature again. Make is in the acronym-make debt tail. VERDICT IS `debt` BECAUSE the
+      Dutch RDW open register is the only evidence that exists for this make; see the batch
+      header in data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/vom/

--- a/data/review/wlie.yml
+++ b/data/review/wlie.yml
@@ -1,0 +1,20 @@
+# VERIFICATION LEDGER — Wlie (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/wlie.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: wlie
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:2a60c95a92808523b4100033585f537ba27c6e0a6a82801e3e7df6691efa3471
+records:
+  - id: moped/wlie/maple
+    verdict: debt
+    note: >-
+      the widest OEM footprint in the batch: raws include E-CAPRI, GRACE/E-GRACE and four
+      ZNEN codes — i.e. WLIE appears to build for Capri and Monasso, both separate published
+      makes here. Maple/Maple 50 is its own badge. VERDICT IS `debt` BECAUSE the Dutch RDW
+      open register is the only evidence that exists for this make; see the batch header in
+      data/review/batches.yml for why that is a ceiling and not laziness.
+    evidence: https://www.brommer.nl/merk/wlie/

--- a/data/review/zundapp-famel.yml
+++ b/data/review/zundapp-famel.yml
@@ -1,0 +1,22 @@
+# VERIFICATION LEDGER — Zundapp Famel (batch B-001, Tranche C)
+#
+# Reviewed against build/packs/zundapp-famel.md. Verdicts per PRD-QUALITY §5.2.
+# Batch context, selection rule and the evidence ceiling: data/review/batches.yml B-001.
+make: zundapp-famel
+researcher: s2w-opus5
+verifier: null            # I-11: the researcher does not verify their own batch
+status: awaiting_verification
+reviewed_at: 2026-07-26
+raw_fingerprint: sha256:f5e46821f77c3c2865d3d703c2180b230538b691fb6da70e318705b3cb960ca5
+records:
+  - id: moped/zundapp-famel/ks-super
+    verdict: fixed
+    note: >-
+      display "Ks Super" -> "KS Super"; KS is Zündapp's type prefix and never a word. Famel
+      (Águeda, Portugal) built mopeds 1960-1994 under a 1962 engine-licence agreement with
+      Zündapp GmbH and the KS Super used the 5-speed type-284 block. NOTE the make name is
+      left as the compound "Zundapp Famel": the marque is arguably Famel alone, but the Dutch
+      register, brommer.nl and the collector literature all treat "Zündapp Famel" as one
+      marque (NL nickname: "Portuguese Zündapps"), and splitting it on one published record
+      is not warranted. Recorded rather than actioned.
+    evidence: https://zundapp.one/zundapp-models/9/zundapp-mebea-en-exoten/39/famel-ks-super

--- a/overrides/makes/aliases.yml
+++ b/overrides/makes/aliases.yml
@@ -379,3 +379,16 @@ UM: UM           # UM Motorcycles / United Motors, Miami, est. 1999 — all-caps
 TYM: TYM         # TYM Corporation, Seoul (Tong Yang Moolsan) — all-caps. NOTE: TYM is an agricultural-machinery maker, so the two moped records under it want checking; moped/tym/vespa-alpha in particular is a Vespa-named row under a tractor marque and smells like a registry mis-attribution. Cased here, identity NOT settled — see the debt entry
 KMZ: KMZ         # Kyiv Motorcycle Plant (Київський мотоциклетний завод), maker of the K-750 and later the Dnepr. Cased only, NOT merged into Dnepr: the Cyrillic "КМЗ" alias above DOES map to Dnepr, but that is for rows the UA register files under the factory name, whereas motorcycle/kmz/k-750 is the K-750 itself — a model that predates the Dnepr badge. Merging it would date the marque wrongly
 MGB: MGB         # MotoGB's own brand — MotoGB is the UK's largest independent motorcycle distributor and launched MGB to keep learner-legal bikes affordable (https://mgbmoto.co.uk/). Resolves the case flagged as the clearest open one in acronym round 3: the published records ARE its range, the Fantasy (50/125cc) and the R8 (50/125cc). Emphatically NOT MG's B — that reading cost a research detour earlier in this pass
+
+# ── B-001 (Tranche C), S2W 2026-07-26 ────────────────────────────────────────
+# NAMING.md line 24, "the make is the marque, not the registrant", in its purest
+# form: the RDW make column holds a Dutch legal entity and the model column holds
+# "SELANA ALPHA" — marque AND nameplate. Go Tulip B.V. is SELANA's own company,
+# not a distributor: the KVK number is published in the footer of the marque's
+# own site ("Go Tulip B.V. KVK: 75554631 BTW: NL860322099B01", https://selana.nl/en).
+# All-caps SELANA is manufacturer styling, not register shouting — the site uses
+# it that way in running prose, incl. third-party press ("ANWB introduceert
+# E-stepverzekering met SELANA"). The paired model rename is in models/renames.yml.
+# The Alpha is the first e-step to hold an RDW type approval (1 July 2025), which
+# is why a six-year-old company appears in the register only now.
+GO TULIP B.V.: SELANA

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2557,3 +2557,6 @@
 # Post-publish sweep (2026-07-26): the last ABS-fold straggler, visible only
 # once the published catalog updated (nl,nz ⊂ fi,nl,nz,ua after union):
 "motorcycle/triumph/tiger-800xc-abs": "motorcycle/triumph/tiger-800xc"
+"moped/go-tulip-b-v/selana-alpha": "moped/selana/alpha" # registrant make -> marque make; badge stripped from the model
+"moped/capri/cl50": "moped/capri/cl" # "CL50" and "Cl" were one nameplate under two ids
+"moped/i-goo/lt-019": "moped/i-goo/lt019" # closed to match the i-coco LT018 sibling

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -141,6 +141,8 @@ Can-Am:
 
 Capri:
   Capri: null                             # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
+  Cl: CL                                    # raw "CL"; "Cl" is a title-cased initialism, not a nameplate
+  CL50: CL                                  # same moped as the "CL"/"CL 50" rows — one nameplate published under two ids because "CL50" keeps its caps (alphanumeric token) while bare "CL" gets title-cased. brommer.nl files them together: https://www.brommer.nl/merk/capri/cl/
 
 Chery:
   Icaur 03: iCAUR 03                      # official styling of Chery's off-road EV sub-brand is iCAUR (https://www.icaur.com/); the default caser yields "Icaur"
@@ -331,9 +333,15 @@ E-Max:
   Emax-110S: 110S            # embedded make: strip_make_prefix misses it because the raw badge is hyphenated to the model ("EMAX-110S"), and the hyphen also defeats its `[\s,]+` separator requirement; E-Max sells the 110S/90S (make+model reads "E-Max 110S")
   Emax-90S: 90S                               # embedded make: strip_make_prefix misses it because the raw badge is hyphenated to the model ("EMAX-90S"); E-Max sells the 110S/90S [reason re-attached: the union merge lifted this line out of a block whose comment sat above it]
 
+E-Solex:
+  Es: ES                                    # raw is "ES" in every row; "Es" is smart_case title-casing a two-letter type code into a non-word. Which words ES abbreviates is NOT established — e-Solex's own range was numbered (S2200, S3300) — so this fixes the casing only.
+
 EBRO:
   S400 Hev: S400         # HEV is the powertrain badge, not the nameplate — official lineup is s400/s700/s800 (sold as "s400 HEV"; sibling records are already powertrain-bare); folds like Leaf 40KWH (https://www.ebroauto.com/)
   S400 HEV: S400         # same fold — key form that applies once HEV joins styling.yml acronyms (the caser runs before renames; cf. the "Town&country LX" key, LX being an acronym)
+
+Edwards:
+  Sc-153: SC-153                            # raw "SC-153"; SC is a type-code prefix (siblings SC-151, SC-154 in the same register), not a word
 
 Elmoto:
   Elmoto: HR-2   # Elmoto built exactly ONE model, the HR-2 (Berlin, 2011-2016 e-motorbike). Raw NL has "ELMOTO" n=13 + "HR-2" n=1, so the bare-brand rows ARE the HR-2 — this keeps the marque AND names it honestly instead of publishing "Elmoto Elmoto"
@@ -571,6 +579,9 @@ Hyundai:
 
 I-Coco:
   Lt-018:                    LT018                # closed type code
+
+I-Goo:
+  Lt-019: LT019                             # closed, to match the I-Coco LT018 block above: i-coco/LT-018 and i-goo/LT-019 are consecutive type codes from one OEM and the register writes both open and closed. Neither form is manufacturer-attested; sibling consistency is the only argument available, and it is the reason stated.
 
 Imperial:
   Lebaron: Le Baron                           # spelling variant of "Le Baron" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -2158,6 +2169,9 @@ Zero Motorcycles:
 
 Zundapp:
   Zundapp: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
+
+Zundapp Famel:
+  Ks Super: KS Super                        # Famel KS Super, the Portuguese-built Zündapp-engined moped. KS is Zündapp's type prefix, never a word: https://zundapp.one/zundapp-models/9/zundapp-mebea-en-exoten/39/famel-ks-super
 
 Škoda:
   Enyaq 60: Enyaq        # battery-size registrations

--- a/scripts/find_published_name_defects.rb
+++ b/scripts/find_published_name_defects.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+#
+# find_published_name_defects.rb — two defect classes that live in the PUBLISHED
+# model name, and which the existing duplicate-finders cannot see.
+#
+# WHY THIS EXISTS, i.e. what the other tools miss. find_duplicate_spellings.rb
+# compares RAW register strings and asks "do these raws mean one nameplate?".
+# That is the right question for registry noise, but it is blind to defects the
+# PIPELINE introduces after normalisation. Two of those turned up in batch B-001
+# and neither is register noise:
+#
+#   1. ACRONYM CASING IN THE MODEL COLUMN. smart_case (pipeline/lib/normalizer)
+#      title-cases any pure-alpha token that is not in overrides/styling.yml's
+#      `acronyms` list. That list is curated, so a type code nobody has noticed
+#      yet becomes a word: "CL" -> "Cl", "KS Super" -> "Ks Super", "SC-153" ->
+#      "Sc-153", "RA9015" -> "Ra-9015". Registers uppercase EVERYTHING, so the
+#      raw cannot settle it and a raw-vs-raw diff sees nothing wrong.
+#
+#   2. THE SEPARATOR/CASING TWIN. The same nameplate published twice under two
+#      ids — "GTV 6" and "GTV6", "Lt-018" and "LT018", "Gold Star" and
+#      "Goldstar". These are invisible to a raw comparison because the raws
+#      genuinely differ, and they are NOT caught by an exact-name dedupe because
+#      the published names differ too. Note the interaction with defect 1: the
+#      spaced form gets title-cased ("Gtv 6") while the glued form keeps its caps
+#      ("GTV6"), because "GTV6" is alphanumeric and smart_case leaves it alone.
+#      So one nameplate ends up differing in BOTH separator and casing, which is
+#      why it reads as two different models to every other check.
+#
+# THIS SCRIPT NOMINATES; IT DOES NOT DECIDE. Both checks are deliberately
+# evidence-based rather than heuristic, but neither is a verdict:
+#
+#   * Check 1 calls a token suspect only when the catalog ITSELF spells the same
+#     letters in caps elsewhere. No vowel-counting, no curated word list — if
+#     "GTV6" exists then "Gtv" is wrong, and if nothing ever spells "VAN" then
+#     "Van" is left alone. Common words still leak through (MAX, PRO, LE, BOY,
+#     BOB are real nameplate words that also appear capitalised somewhere), so
+#     the output is a worklist of TOKENS to adjudicate, not records to rewrite.
+#
+#   * Check 2 groups by name-with-separators-removed. It found a genuine false
+#     positive worth remembering: KTM "E-XC" vs "Exc" are DIFFERENT machines —
+#     the Freeride E-XC is electric, the EXC is the enduro line. Merging on
+#     string shape alone would have destroyed a real model.
+#
+# Usage:  ruby scripts/find_published_name_defects.rb [--kinds motorcycle,moped]
+#         VDB_CATALOG=/path/to/catalog  (default: ../vehiclesdb-pipeline/build/out/catalog)
+#
+# Parameterised the same way as find_duplicate_spellings.rb so either session can
+# run it over its own half without editing the file.
+require "json"
+
+CATALOG = ENV["VDB_CATALOG"] ||
+          File.expand_path("../vehiclesdb-pipeline/build/out/catalog", __dir__ + "/..")
+ALL_KINDS = %w[car van motorcycle moped truck bus].freeze
+kinds = ARGV.find { |a| a.start_with?("--kinds=") }&.split("=", 2)&.last&.split(",") || ALL_KINDS
+kinds -= ["--kinds"]
+
+records = []
+kinds.each do |k|
+  path = File.join(CATALOG, k, "models.json")
+  unless File.exist?(path)
+    warn "skip #{k}: no #{path} (run the pipeline first)"
+    next
+  end
+  JSON.parse(File.read(path)).each { |m| records << m.merge("_kind" => k) }
+end
+abort "no records — check VDB_CATALOG=#{CATALOG}" if records.empty?
+puts "scanned #{records.size} published records across #{kinds.join(',')}\n\n"
+
+# ── check 1 ───────────────────────────────────────────────────────────────────
+# Evidence base: every 2-4 letter ALL-CAPS run appearing anywhere in a published
+# name, whether standalone ("GTV 6") or glued to digits ("GTV6"). Scanning for
+# runs rather than tokens is what makes the glued forms count as evidence.
+caps = Hash.new(0)
+records.each { |r| r["name"].to_s.scan(/[A-Z]{2,4}/) { |m| caps[m] += 1 } }
+
+suspects = Hash.new { |h, k| h[k] = [] }
+records.each do |r|
+  r["name"].to_s.split(%r{[\s\-/]}).each do |tok|
+    next unless tok =~ /\A[A-Z][a-z]{1,3}\z/
+    up = tok.upcase
+    next unless caps[up] >= 2
+    suspects[up] << r
+  end
+end
+total = suspects.values.sum(&:size)
+puts "== 1. title-cased tokens the catalog itself spells in CAPS elsewhere"
+puts "   #{suspects.size} distinct tokens over #{total} records — adjudicate PER TOKEN, then"
+puts "   pin the real ones in overrides/styling.yml `acronyms` (fixes them everywhere at once)\n\n"
+suspects.sort_by { |_, g| -g.size }.each do |up, g|
+  ex = g.first(3).map { |r| "#{r['make_id']}/#{r['name']}" }.join(", ")
+  puts format("  %-6s %4d records (caps attested x%-3d)  %s", up, g.size, caps[up], ex)
+end
+
+# ── check 2 ───────────────────────────────────────────────────────────────────
+puts "\n== 2. published names identical once separators are removed"
+puts "   same make + same kind = almost certainly one nameplate under two ids.\n"
+puts "   VERIFY EACH: E-XC vs EXC are different KTMs. Fix via renames.yml (fold the"
+puts "   loser into the winner) PLUS a former_ids alias, or the no-vanish gate fails.\n\n"
+groups = records.group_by { |r| [r["make_id"], r["_kind"], r["name"].downcase.gsub(/[^a-z0-9]/, "")] }
+                .select { |_, g| g.size > 1 }
+groups.sort_by { |(mk, k, _), _| [k, mk] }.each do |(mk, k, _), g|
+  flag = g.map { |r| r["name"].gsub(/[^A-Za-z0-9]/, "") }.uniq.size > 1 ? " [casing differs too]" : ""
+  puts format("  %-11s %-16s %s%s", k, mk, g.map { |r| "#{r['name'].inspect} (#{r['id']})" }.join("  ==  "), flag)
+end
+puts "\n  #{groups.size} groups, #{groups.values.sum(&:size)} records"


### PR DESCRIPTION
**DO NOT MERGE until the freeze lifts** (Turn 70). Ready and green; parked deliberately.

## What this is

B-001, the first real Tranche C batch: 46 makes / 58 published records, selected for an **evidence property** rather than a size — every record is moped, single-source (`nl_rdw`), single-country (`nl`). That makes it the sharpest available test of the register-only evidence class the B-000 pilot exposed.

**Result: 26 canonical · 6 fixed · 26 debt.** The debt fraction is the finding, not a shortfall. For a make whose entire footprint is 1–3 rows of one national register, PRD-QUALITY §8.3's "sources of record" frequently do not exist, and B-000 established that a retailer listing dressed up as a source is worse than an honest `debt`.

## The six dispositions

| id | was | now | why |
|---|---|---|---|
| `moped/selana/alpha` | `go-tulip-b-v/selana-alpha` | moved + badge stripped | registrant in the make column |
| `moped/capri/cl` | `Cl` + separate `cl50` | `CL`, merged | one nameplate, two ids |
| `moped/i-goo/lt019` | `Lt-019` | `LT019` | sibling consistency with `i-coco/lt018` |
| `moped/e-solex/es` | `Es` | `ES` | casing only; identity left open |
| `moped/edwards/sc-153` | `Sc-153` | `SC-153` | SC-151/SC-154 siblings in-register |
| `moped/zundapp-famel/ks-super` | `Ks Super` | `KS Super` | KS is Zündapp's type prefix |

**SELANA is the headline.** RDW filed 576 rows under `GO TULIP B.V. | SELANA ALPHA` — NAMING.md line 24 ("the make is the marque, not the registrant") in its purest form. Go Tulip B.V. is not a distributor: the marque's own site publishes its KVK number in the footer (`Go Tulip B.V. KVK: 75554631`). All-caps SELANA is manufacturer styling used in running prose, not register shouting. The Alpha holds the first RDW type approval for an e-step (1 July 2025), which is why a six-year-old company shows up in the register only now.

## Two cross-make findings, both measured

**1. `model-column-acronym-casing` — the make-column acronym problem has a model-column twin, and it is bigger.** `smart_case` title-cases any pure-alpha token missing from `styling.yml`'s `acronyms` list, so an unnoticed type code becomes a word: `CL`→`Cl`, `KS Super`→`Ks Super`, `SXL`→`Sxl`. Five instances turned up in 46 tiny makes, so I measured it globally with a new tool:

- **1,223 records over 305 distinct tokens** catalog-wide; **511 / 201** in the 2W half (mine), **712 / ~104** in the 4W half (S4W's).
- **That number is a worklist, not a defect count.** The check nominates any token the catalog itself also spells in caps; real nameplate words leak through on purpose (`MAX`, `PRO`, `LE`, `BOY`, `BOB`, `APE`). Each *token* needs one human call, and a token pinned in `acronyms` fixes every record carrying it at once.
- **Start with Roman numerals** — `Iii`, `Ii`, `Ix` are never correct in any marque's naming. 22 records, no research needed.

**2. `nl-snorfiets-25-suffix`.** Dutch law splits 50cc two-wheelers into bromfiets (45 km/h) and snorfiets (25 km/h); RDW marks the limited version by appending `.25` to the type code. `FT50QT-E` and `FT50QT-E.25` are one nameplate in two speed variants. **Not actioned** — there is no model-level variant layer, so the only available "fix" is deleting an id and losing the distinction. Filed with the 5 concrete cases so the variant work has a first customer. Do not generalise the dot: `RETRO.S` and `E3` are not speed classes.

## New tool: `scripts/find_published_name_defects.rb`

Catches what `find_duplicate_spellings.rb` structurally cannot. That tool compares **raw** register strings; these two defects are introduced *after* normalisation and are only visible in the published catalog. Registers uppercase everything, so a raw can never disprove a title-cased published name.

Check 1 is deliberately **self-evidencing** rather than heuristic: a token is suspect only if the catalog itself spells the same letters in caps elsewhere. `GTV6` proves `Gtv` wrong; nothing ever spells `VAN`, so `Van` is left alone. No curated word list, no vowel-counting.

It nominates, it does not decide — and it found a false positive worth remembering: **KTM `E-XC` vs `Exc` are different machines** (Freeride E-XC is electric, EXC is the enduro line). Merging on string shape alone would have destroyed a real model.

## Things a future agent will otherwise learn the hard way

- **`batavus` is a registry dumping ground.** Its raw rows include `BERINI M13`, `GAZELLE GRANT`, `SOLEX`, `ITOM`, `MONDIAL`, `MOSQUITO` — six other marques — plus `-`, `---`, `OOOOO`. Only the publication threshold keeps them out. Anything that lowers it for this make imports six marques of wrong attributions. It also has ~19 raw spellings of one nameplate (`MOT-O-MAT`, `MOT O'MAT`, `MOTOMAT`, `MOT-O-MATIC`…), the sharpest one-id-many-names case in the dataset.
- **`benzhou` is the batch's OEM hub** and links straight back to B-000: its raws carry `IVA LUX50`, `IVA-RA9015`, `BTC CLASSIC 50`, `CAPRI 50/125`, `AIYUMO YOUNG`, `TIANMA` — six marques' badges filed under the builder.
- **`ZN50QT-E` publishes under four makes** (`agm`, `motormania`, `zhongneng`, `znen`). One ZNEN product, four importer badges, four ids — the approval-holder trap PRD-QUALITY warns about for Tranche C, found at scale exactly where the batch was designed to look. `HT50QT-29A` (lintex/killerbee) and `TY50QT-K` (riya/tianying) are the same shape.
- **`hercules/saxonette` is correct and must not be touched** when the sibling `saxonette` make is dealt with. Marque in the make column, product in the model column — the properly-formed twin of the broken one.
- **`stint/bus`: "Bus" is the nameplate**, not a body-type word (Stint built Bus, Cargo and Pickup). If years are ever attached, it needs §14.4 runs-list treatment: the vehicle was banned after the 2018 Oss accident and returned in 2020 as the "BSO-bus".
- **`spyder-wheelz`**: `strip_make_prefix` could not help — it needs the *full* make name followed by `[\s,]+`, and the string begins `SPYDER RENT`, not `SPYDER WHEELZ`. A shared first token buys nothing.

## Verification notes for S4W

- **`verifier: null` on all 46**, per I-11. Please verify — and note B-000's pattern: your pass found three factual errors in my *supporting claims* while every verdict held. That is where confident errors hide.
- **Correction to your Turn 70 expectation: B-000's `iva` fingerprint did NOT change.** It is still `sha256:e512e024…`. `gen_review_pack.rb` attributes raw rows by **raw make string**, so a cross-make move is invisible to it — `iva.md` contains zero `BENZHOU` rows even though the Benzhou→IVA move landed. **A cross-make move changes what a make publishes without staling that make's ledger.** Worth deciding whether that is a gap; it under-detects exactly the class of change Tranche C batches produce. B-000 is therefore *not* stale and needs no re-verification on those grounds.
- **Fingerprints are pre-publish** and were computed against my local source snapshot. My local build shows 32 pre-existing gate failures that CI does not (moving-window sources: `ar_dnrpa` 1-month, `lu_snca` 3-month, `nz_nzta` MVR_Mar26 — `archive/` is gitignored, so snapshots drift between machines). **None are mine**: the FAIL set is byte-identical before and after my changes, modulo timestamp. If a fingerprint mismatches post-publish, `lint_review` marks the make STALE — which fails safe, toward re-review rather than false confidence. Happy to re-stamp after the lift.
- `moped/iva/ra-9015` publishes as **"Ra-9015"** — my own B-000 make carries an instance of the defect class this batch found. Not fixed here (out of batch scope), flagged for the sweep.

## Verification done here

- `lint_curation` OK (65 files) · `lint_review` OK (46 awaiting, 47 ledgers)
- Build delta is exactly the intent: 3 ids retired (all aliased), 2 new, 4 recased, 1259→1258 moped records
- `bashan/atv200s-7` is a quad and lives in `motorcycle` — ledger ids are resolved from the catalog, not assumed from the batch's dominant kind
