### PR TITLE
Acronym worklist tranche 1: Roman numerals (18 records, 0 id churn)

### DIFF
--- a/data/name_shapes.yml
+++ b/data/name_shapes.yml
@@ -484,6 +484,19 @@ debt:
       Fixed in this batch where B-001 owned the make (capri/cl, edwards/sc-153,
       i-goo/lt019, e-solex/es, zundapp-famel/ks-super); the rest is a sweep of
       its own, deliberately not smuggled into a Tranche C batch.
+      TRANCHE 1 DONE (2026-07-26): Roman numerals II/III pinned as global
+      `acronyms` tokens — 18 records, 17 of them 2W, ZERO id churn (a casing pin
+      cannot change a slug, and that was verified rather than assumed). IX was
+      deliberately NOT pinned: Jaguar Mark IX wants caps but Hyundai ix35 is
+      officially lowercase, so one global token cannot serve both.
+      RESIDUAL DEFECTS still visible in those same 18 records, i.e. the numeral
+      was never the only thing wrong: moto-guzzi/850LE Mans III (should be
+      "850 Le Mans III" — glued displacement AND a French article title-cased
+      as an initialism), norton/Commando 850MK III ("850 Mk III"),
+      harley-davidson/Fxrs Super Glide II (FXRS), nsu/Prima III Kl (KL),
+      ryuka/Save-II S Fi (FI), suzuki/Lets II (Suzuki writes "Let's"). These
+      need per-record renames plus former_ids where the slug moves, and are the
+      next tranche.
   - id: nl-snorfiets-25-suffix
     owner: s2w
     category: variant_as_model

--- a/overrides/styling.yml
+++ b/overrides/styling.yml
@@ -61,6 +61,19 @@ stylings:
 XXX: XXX               # Talaria XXX — a REAL e-motorbike model, not a placeholder. Raw RDW pairs it explicitly: "TL2500, XXX" (https://talaria.bike/). Without this pin smart_case yields "Xxx", which reads as junk and invited a drop; the whole-string form has no other match catalog-wide.
 
 acronyms:
+  # --- Roman numerals (S2W, 2026-07-26, B-001 acronym worklist) ---
+  # Safe as GLOBAL token pins because no marque spells a numeral as a word:
+  # smart_case turns raw "III" into "Iii", which is wrong in every marque that
+  # uses it (Triumph Rocket III, Moto Guzzi California III, Norton Commando Mk
+  # III, KTM Duke II, SYM Fiddle II...). 17 two-wheeler records plus the
+  # four-wheel half — the acronyms list is global, so this necessarily crosses
+  # ownership; flagged to S4W in NEGOTIATION for veto on their half.
+  # DELIBERATELY NOT ADDED: IX. Jaguar Mark IX wants caps but Hyundai ix35 is
+  # officially LOWERCASE, so one global pin cannot serve both — same collision
+  # that made "480 ES" a whole-string pin instead of an ES token. IV/VI/VII/XII
+  # are not attested as defects and are not pinned speculatively.
+  - II                   # Roman numeral: KTM Duke II, SYM Fiddle II, Moto Guzzi California II — smart_case yields "Ii"
+  - III                  # Roman numeral: Triumph Rocket III, Norton Commando Mk III, Moto Guzzi California III — smart_case yields "Iii"
   - GT
   - GTI
   - GTD


### PR DESCRIPTION
First tranche of the `model-column-acronym-casing` worklist measured in B-001 (#35).

## What and why

`smart_case` title-cases any pure-alpha token missing from `styling.yml` `acronyms`, so raw `III` becomes **`Iii`** — wrong in every marque that uses it. Pinning `II` and `III` fixes all of them at once.

| | |
|---|---|
| Display renames | **18** (17 two-wheel, 1 four-wheel) |
| ids gone / added | **0 / 0** |

Zero id churn is the load-bearing claim — a pure casing pin cannot move a slug — and it was **verified by diffing the built catalog before and after**, not assumed.

2W: Triumph Rocket III ×4, Moto Guzzi California II/III + 850LE Mans III, Norton Commando Mk III ×3, KTM Duke II, SYM Fiddle II / Orbit II, Suzuki Lets II, Harley FXRS Super Glide II, NSU Prima III, Ryuka Save-II.

## 🔵 S4W: one record of yours, veto surface

The `acronyms` list is **global across every make and kind**, so this necessarily crosses ownership. Your entire exposure is one record:

```
car  neta/v-ii   "V-Ii"  ->  "V-II"
```

Flagging it the way you flagged Maicoletta to me. Revert the pin or tell me and I will.

## Why `IX` is deliberately absent

`IX` looks like the same free win and is not. **Jaguar Mark IX wants caps; Hyundai ix35 is officially lowercase.** One global token cannot serve both — precisely the collision recorded in `styling.yml` for `"480 ES"`, where an `ES` token orphaned Gas Gas evidence and un-folded the whole Lexus ES family. `IV`/`VI`/`VII`/`XII` are not attested as defects and are not pinned speculatively.

That precedent is also why I am **not** proposing to bulk-pin the remaining ~300 tokens. Most are not globally safe: `LE` is Limited Edition in `indian/Ftr R Carbon Le` and the French article in `moto-guzzi/Le Mans`; `MK` should stay `Mk` in British usage while the numeral beside it is fixed. The rest of the worklist is per-token adjudication biased toward **whole-string `stylings` pins**, not token pins.

## Residual defects, recorded not bundled

The numeral was rarely the only thing wrong in these records, and I have written the leftovers into the debt entry rather than quietly widening this PR:

- `moto-guzzi/850LE Mans III` → should be `850 Le Mans III` (glued displacement **and** a French article title-cased as an initialism)
- `norton/Commando 850MK III` → `Commando 850 Mk III`
- `harley-davidson/Fxrs Super Glide II` → `FXRS`
- `nsu/Prima III Kl` → `KL` · `ryuka/Save-II S Fi` → `FI` · `suzuki/Lets II` → Suzuki writes `Let's`

Those need per-record renames plus `former_ids` where the slug moves — next tranche.