### PR TITLE
mega/mega: marque confirmed (Aixam Mega), model unrecoverable

### DIFF
--- a/data/name_shapes.yml
+++ b/data/name_shapes.yml
@@ -437,9 +437,24 @@ debt:
     id_list: [mega/mega]
     count: 1
     why: >-
-      moped/mega/mega (lu,nl) — either the product-is-the-brand class (G9
-      precedent) or Aixam's Mega utility marque with a blank model column.
-      Filed for S2W marque research (NEGOTIATION Turn 71); do not guess.
+      RESEARCHED 2026-07-26 (S2W, the marque question filed to me in NEGOTIATION
+      Turn 71). It is the SECOND of the two hypotheses: Aixam's Mega marque with
+      an echoed model column, NOT the product-is-the-brand class.
+      THE MAKE IS REAL AND WELL EVIDENCED. Mega is the marque Aixam (Aix-les-
+      Bains, Savoie, founded 1983) has used since 1992, and it still sells under
+      it — in the Netherlands the current Mega product is the e-Scouty, an
+      electric brommobiel launched 2023. https://www.aixam.com/
+      THE MODEL IS NOT RECOVERABLE. Both registers echo the make into the model
+      column and nothing else: lu_snca `MEGA | MEGA` (1 row) and nl_rdw
+      `MEGA | MEGA` (28). Mega has real nameplates (e-Scouty, e-City, Club,
+      Multitruck), so this is not a marque that names its product after itself —
+      the register simply did not record which one. Same wall as `ebretti` and
+      `veeley`: the existence question is ANSWERED, the disposition is blocked.
+      NOTE FOR THE G24 KIND WORK: a brommobiel is an L6e/L7e quadricycle, not a
+      two-wheeler. These 29 rows sit in `moped` because that is where NL/LU
+      registration puts them, and they are the same adjudication as the ua
+      КВАДРОЦИКЛ/ТРИЦИКЛ rows and the es_dgt L6E quadricycle nameplates. If G24
+      ever mints a quadricycle kind, this record moves with them.
 
   - id: fixed-awaiting-publish
     owner: s2w


### PR DESCRIPTION
Resolves the `mega-marque-research` item S4W filed to me in the post-publish sweep (NEGOTIATION Turn 71), which offered two hypotheses and said *do not guess*.

**It is the second one.** Not the product-is-the-brand class — Aixam's Mega marque with an echoed model column.

**The make is real and well evidenced.** Mega is the marque Aixam (Aix-les-Bains, Savoie, founded 1983) has used since 1992, and still sells under: the current Dutch product is the **e-Scouty**, an electric brommobiel launched 2023. https://www.aixam.com/

**The model is not recoverable.** Both registers echo the make and nothing else — `lu_snca MEGA | MEGA` (1 row), `nl_rdw MEGA | MEGA` (28). Mega has real nameplates (e-Scouty, e-City, Club, Multitruck), so this is *not* a marque that names its product after itself; the register simply did not record which one. Same wall as `ebretti` and `veeley` in B-001: **existence answered, disposition blocked.**

## One thing worth more than the verdict

A **brommobiel is an L6e/L7e quadricycle, not a two-wheeler.** These 29 rows sit in `moped` because that is where NL and LU registration puts them — the same adjudication as the `ua_mvs` КВАДРОЦИКЛ (1,096) / ТРИЦИКЛ (139) rows and the `es_dgt` L6E quadricycle nameplates I worked through in B3. Noted in the entry so that if G24 ever mints a quadricycle kind, this record moves with that family instead of being rediscovered as a one-off.

Also in this branch: nothing else. Kept separate from the Roman-numeral tranche (#39) so each has its own review surface.