### PR TITLE
B-002 claimed: the ceiling batch (24 makes / 147 records)

### DIFF
--- a/data/review/batches.yml
+++ b/data/review/batches.yml
@@ -30,6 +30,48 @@
 # status: open | claimed | in_review | done
 
 batches:
+  B-002:
+    makes: [ajp, benda, big-dog, boom, brixton, chatenet, cyclone, e-ride-pro,
+            energica, govecs, hanway, horwin, huatian, kove, livewire, microcar,
+            mutt, rewaco, shansu, silence, simson, super-soco, swm, zhenhua]
+    owner: s2w
+    status: claimed
+    claimed_by: s2w        # claimed 2026-07-26
+    verifier: null
+    notes: >-
+      THE OPPOSITE POLE FROM B-001, and chosen for that reason. B-001 measured
+      the FLOOR — 46 makes where every record was single-source, single-country
+      nl_rdw, §8.3 sources of record mostly did not exist, and 26 of 58 verdicts
+      were necessarily `debt`. That number bounds the programme from below but
+      says nothing about what verification costs when evidence IS available.
+      B-002 measures the CEILING. Selection is again by evidence property, not
+      by size: EVERY published record is multi-source, the make spans >=3
+      countries and >=3 sources, and the make has a live manufacturer presence.
+      24 makes / 147 records — 2.5x B-001's record count on a third fewer makes,
+      which is itself the point: at the ceiling the work is per-RECORD (does the
+      manufacturer spell it that way?) rather than per-MAKE (does this marque
+      exist at all?).
+      TWO NUMBERS FROM TWO POLES BOUND THE WHOLE PROGRAMME. A second
+      floor-batch would only re-measure the floor.
+      DELIBERATELY EXCLUDED, because they are a THIRD evidence class and G23's
+      territory: defunct marques with heritage archives rather than live sites
+      (nsu, cz, bultaco, morbidelli, mbk, montesa). Their sources exist but are
+      enthusiast-maintained, which is a different question about source quality
+      and should be measured separately rather than blended in here.
+      ONE DELIBERATE EXCEPTION TO THAT EXCLUSION: `simson`. It is defunct (VEB
+      Fahrzeug- und Jagdwaffenwerk, Suhl) but exceptionally well archived, so it
+      tests which property is actually load-bearing — "the marque is trading" or
+      "sources of record exist". If simson verifies as cleanly as the live
+      marques, the live/defunct split is the wrong axis and G23 should be scoped
+      by source availability instead.
+      EXPECTED FAILURE MODE, stated in advance so it is a prediction and not a
+      post-hoc excuse: at the ceiling the risk inverts. B-001's danger was
+      asserting a marque that could not be evidenced; B-002's is accepting a
+      manufacturer's CURRENT catalogue as evidence for a DISCONTINUED record and
+      quietly retiring a nameplate the marque simply stopped listing. The B-000
+      IVA pilot hit exactly this and it is why `evidence_class: register-only`
+      exists — a live marque site is a source of record for what it sells today,
+      not for what it sold in 2011.
   B-001:
     makes: [bashan, batavus, benzhou, black-n-roll, brekr, capri, djjd, dts, e-solex,
             ebretti, edwards, elveco, evader, fosti, gazelle, gerray, go-tulip-b-v,


### PR DESCRIPTION
Claim only — no verdicts yet. Research follows once #39/#40 land.

## Why this set

B-001 measured the **floor**: 46 makes, every record single-source single-country `nl_rdw`, §8.3 sources of record mostly absent, **26 of 58 verdicts necessarily `debt`**. That bounds the programme from below and says nothing about what verification costs when evidence *is* available.

B-002 measures the **ceiling**, selected by the inverse evidence property: every published record multi-source, make spanning ≥3 countries and ≥3 sources, live manufacturer presence.

**24 makes / 147 records** — 2.5× B-001's record count on a third fewer makes. That inversion is the point: at the ceiling the work is per-**record** (does the manufacturer spell it that way?) rather than per-**make** (does this marque exist at all?).

`ajp benda big-dog boom brixton chatenet cyclone e-ride-pro energica govecs hanway horwin huatian kove livewire microcar mutt rewaco shansu silence simson super-soco swm zhenhua`

## Deliberate exclusions, and one deliberate inclusion

**Excluded as a third evidence class** (and G23's territory): defunct marques with heritage archives rather than live sites — `nsu`, `cz`, `bultaco`, `morbidelli`, `mbk`, `montesa`. Their sources exist but are enthusiast-maintained, which is a different question about source *quality* and deserves its own measurement rather than being blended in.

**`simson` kept anyway, as the control.** It is defunct (VEB Fahrzeug- und Jagdwaffenwerk, Suhl) but exceptionally well archived. If it verifies as cleanly as the live marques, then "the marque is trading" is the wrong axis and **G23 should be scoped by source availability instead** — which would change how the defunct-marque year sweep is organised.

## Predicted failure mode, recorded before the work

Stating this now so it is a prediction rather than a post-hoc excuse. **At the ceiling the risk inverts.** B-001's danger was asserting a marque that could not be evidenced. B-002's is the opposite: accepting a manufacturer's **current catalogue** as evidence about a **discontinued** record, and quietly retiring a nameplate the marque merely stopped listing.

The B-000 IVA pilot hit exactly this — it is why `evidence_class: register-only` exists. A live marque site is a source of record for what it sells *today*, not for what it sold in 2011. I expect that to be the main source of verifier findings on this batch, and I would rather be measured against a stated prediction.