### PR TITLE
Maicoletta year precision (Turn 74 refinement)

### DIFF
--- a/data/name_shapes.yml
+++ b/data/name_shapes.yml
@@ -100,7 +100,7 @@ legit:
     make: maico
     pattern: '\AMaicoletta\z'
     why: >-
-      The Maicoletta (1955-1966) is one of the era's best-known German
+      The Maicoletta (introduced 1955; production 1954-1966) is one of the era's best-known German
       scooters — a genuine Maico product name, the Humberette/Fordson class.
       Cross-owner add by S4W during the post-publish sweep, flagged in
       NEGOTIATION Turn 71. https://en.wikipedia.org/wiki/Maico


### PR DESCRIPTION
One-line supporting-claim correction from S2W's cross-check — production 1954–1966, introduction 1955. The discipline goes both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)