### PR TITLE
G23a data half: enrich seed + lint + observed-names detector feed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,10 @@ jobs:
         # Alphabetical order is what lets two maintainers append concurrently
         # without conflicting, and what stops a second `Honda:` block appearing.
         run: ruby scripts/reorg_make_blocks.rb --check
+      - name: Enrichment lint (production runs — G23a)
+        # Id liveness, year sanity, run ordering, per-entry citation,
+        # cross-file duplicate ids. See scripts/lint_enrich.rb header.
+        run: ruby scripts/lint_enrich.rb
       - name: Verify OWNERSHIP.yml matches the catalog
         # Regenerating must be a no-op; a diff here means a release added makes
         # and the ownership map needs regenerating + both maintainers acking.

--- a/overrides/enrich/README.md
+++ b/overrides/enrich/README.md
@@ -1,0 +1,26 @@
+# overrides/enrich/ — open-layer enrichment facts (G23a+)
+
+One file per make, keys are full ids, first fact class: **production runs**.
+Spec: **PRD-QUALITY.md §14.4** (store facts, derive labels). The pipeline
+derives `era` (`discontinued` / `classic` at the 30-year H-Kennzeichen line /
+`vintage` pre-1931 FIVA line) at emit time — never write an era by hand.
+
+```yaml
+"motorcycle/triumph/bonneville":
+  runs:
+    - {year_start: 1959, year_end: 1983, note: Meriden}  # source URL on the line — MANDATORY
+    - {year_start: 2001}                                 # open run = in production, suppresses all tags
+```
+
+Rules (all lint-enforced by `scripts/lint_enrich.rb`, wired into CI):
+- id must be live in the catalog (pending-publish alias targets tolerated);
+- make-aligned files; cross-file duplicate ids fail (the loader last-write-wins silently);
+- `1885 ≤ year_start`; `year_end ≤ current+1`; runs sorted, non-overlapping —
+  **source conflicts go in the `note`, never encoded as overlapping data**;
+- every id entry carries a citation comment (§14.1: enrichment without
+  provenance is how open datasets rot). Sources per §12 hierarchy: heritage
+  archives → marque clubs → period regulator documents. Wikipedia locates,
+  never sources.
+
+Capture rule (§7): review-batch researchers already inside heritage pages
+record runs **when the source in hand states them** — zero marginal cost.

--- a/overrides/enrich/volvo.yml
+++ b/overrides/enrich/volvo.yml
@@ -1,0 +1,20 @@
+# overrides/enrich/volvo.yml — production runs (G23a seed; PRD-QUALITY §14.4).
+# Every entry carries its source on the line. Runs are NAMEPLATE-level;
+# per-generation years wait for `generations`. The seed uses Volvo because its
+# press library is already the repo's evidence precedent (renames.yml cites
+# these exact pages).
+"car/volvo/p1800":
+  runs:
+    - {year_start: 1961, year_end: 1963}  # P1800 proper (Jensen-built), then renamed 1800 S — https://www.media.volvocars.com/global/en-gb/media/pressreleases/49793/volvo-p18001800-1961-19721 (family: P1800 1961→ 1800S → 1800E → 1800ES to 1973)
+"car/volvo/1800s":
+  runs:
+    - {year_start: 1963, year_end: 1969}  # same press release: 1800 S built in Sweden from 1963, replaced by the injected 1800 E in 1969
+"car/volvo/1800e":
+  runs:
+    - {year_start: 1969, year_end: 1972}  # same press release
+"car/volvo/1800es":
+  runs:
+    - {year_start: 1971, year_end: 1973}  # same press release: the ES estate closed the family in 1973
+"car/volvo/240":
+  runs:
+    - {year_start: 1974, year_end: 1993}  # https://www.media.volvocars.com/global/en-gb/media/pressreleases/194064/ (the 240 series, 1974-1993; badge consolidation to plain "240" MY1983 — same page renames.yml already cites)

--- a/scripts/find_duplicate_spellings.rb
+++ b/scripts/find_duplicate_spellings.rb
@@ -72,6 +72,14 @@ require "set"
 ROOT = File.expand_path(ENV["VDB_DATA_REPO"] || "~/GitHub/.vdb-worktrees/s4w-data")
 SIDE = ENV["VDB_SIDE"] || "s4w"
 CATALOG = File.expand_path(ENV["VDB_CATALOG"] || File.join(ROOT, "catalog"))
+# Corpus-observed display forms per id (build/observed_model_names.json,
+# written by the pipeline pack sweep). Located relative to VDB_CATALOG
+# (…/build/out/catalog -> …/build/); absent = the feature degrades to the
+# old one-representative behavior, silently and safely.
+OBSERVED_NAMES = begin
+  p = File.expand_path(File.join(CATALOG, "..", "..", "observed_model_names.json"))
+  File.exist?(p) ? JSON.parse(File.read(p)) : {}
+end
 KINDS = %w[car van motorcycle moped truck bus]
 own = YAML.safe_load_file(File.join(ROOT, "OWNERSHIP.yml"))
 MINE = Set.new(own[SIDE] || [])
@@ -153,6 +161,16 @@ by_make.each do |_, gs|
     puts format("%s %-11s %-16s %-24s ← %s", flag, g[:kind], g[:make], g[:canonical].inspect,
                 others.map(&:inspect).join(" + "))
     puts format("  %sids: %s", " " * 12, g[:records].map { |r| r["id"] }.join("  "))
+    # ONE-ID-MANY-NAMES (Turns 57/60/77 — 7 wasted rebuild cycles): a record's
+    # display can flap between builds among same-slug spellings, and this
+    # listing used to show only the current one. When the pipeline's corpus
+    # sweep has run (gen_review_pack writes build/observed_model_names.json,
+    # derived from VDB_CATALOG's build dir), show EVERY observed form so keys
+    # get written against all of them the first time.
+    g[:records].each do |r|
+      forms = OBSERVED_NAMES["#{r['_kind']}/#{r['id']}"]
+      puts format("  %sall observed forms of %s: %s", " " * 12, r["id"], forms.map(&:inspect).join(" ")) if forms && forms.size > 1
+    end
   end
 end
 puts

--- a/scripts/lint_enrich.rb
+++ b/scripts/lint_enrich.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# lint_enrich.rb — validates overrides/enrich/<make>.yml (production runs,
+# G23a; PRD-QUALITY §14.4). The pipeline's loader guards shape hard enough to
+# never emit garbage; THIS is the curation-quality gate:
+#
+#   * every id key must be LIVE in the catalog (or be a former_ids alias
+#     TARGET — the pending-publish window, same tolerance as lint_review)
+#   * id keys are full kind/make/slug and the file is make-aligned (a volvo
+#     fact in bmw.yml is a merge accident waiting to be missed)
+#   * year sanity: 1885 <= year_start (Benz Patent-Motorwagen — nothing we
+#     catalog predates it) ; year_end <= current year + 1 (next-model-year
+#     announcements are real; anything later is a typo)
+#   * runs sorted, non-overlapping (overlapping runs mean two sources
+#     disagree — record the conflict in the note, do not encode it as data)
+#   * EVERY id entry carries a same-line `#` citation on at least one of its
+#     lines (the standing provenance rule; enrichment without provenance is
+#     how open datasets rot — §14.1)
+#
+# Usage: ruby scripts/lint_enrich.rb    [VDB_CATALOG=… for a fresh build]
+
+require "yaml"
+require "json"
+require "set"
+
+ROOT = File.expand_path("..", __dir__)
+CATALOG_DIR = ENV["VDB_CATALOG"] ? File.expand_path(ENV["VDB_CATALOG"]) : File.join(ROOT, "catalog")
+KINDS = %w[car van motorcycle moped truck bus].freeze
+MAX_YEAR = Time.now.year + 1
+FAILURES = []
+def fail!(m) = FAILURES << m
+
+live = {}
+KINDS.each do |k|
+  p = File.join(CATALOG_DIR, k, "models.json")
+  live[k] = File.exist?(p) ? JSON.parse(File.read(p)).map { |m| m["id"] }.to_set : Set.new
+end
+former = (YAML.safe_load_file(File.join(ROOT, "overrides/models/former_ids.yml")) || {})
+         .transform_values { |v| v.is_a?(Hash) ? v["to"] : v }.compact
+pending = former.values.to_set
+
+files = Dir[File.join(ROOT, "overrides/enrich", "*.yml")].sort
+entries = 0
+seen_ids = {} # id => first file (the pipeline loader last-write-wins across files)
+files.each do |abs|
+  rel = abs.sub("#{ROOT}/", "")
+  make_of_file = File.basename(abs, ".yml")
+  raw_lines = File.readlines(abs)
+  doc = begin
+    YAML.safe_load_file(abs, permitted_classes: [], aliases: false) || {}
+  rescue Psych::SyntaxError => e
+    fail! "#{rel}: does not parse — #{e.message}"
+    next
+  end
+  doc.each do |id, entry|
+    entries += 1
+    if (first = seen_ids[id.to_s])
+      fail! "#{rel}: #{id} already defined in #{first} — the loader keeps only ONE silently"
+    else
+      seen_ids[id.to_s] = rel
+    end
+    kind, make, slug = id.to_s.split("/", 3)
+    unless KINDS.include?(kind) && make && slug
+      fail! "#{rel}: #{id.inspect} is not kind/make/slug"
+      next
+    end
+    fail! "#{rel}: #{id} belongs in overrides/enrich/#{make}.yml (make-aligned files)" unless make == make_of_file
+    unless live[kind].include?("#{make}/#{slug}") || pending.include?(id.to_s)
+      fail! "#{rel}: #{id} is not live in the catalog being measured (and is not a pending-publish alias target)"
+    end
+    runs = entry.is_a?(Hash) ? entry["runs"] : nil
+    unless runs.is_a?(Array) && runs.any?
+      fail! "#{rel}: #{id}: expected {runs: [...]}"
+      next
+    end
+    prev_end = nil
+    runs.each do |r|
+      ys, ye = r["year_start"], r["year_end"]
+      fail! "#{rel}: #{id}: year_start #{ys.inspect} not an Integer" unless ys.is_a?(Integer)
+      next unless ys.is_a?(Integer)
+      fail! "#{rel}: #{id}: year_start #{ys} predates the Benz Patent-Motorwagen (1885) — typo?" if ys < 1885
+      fail! "#{rel}: #{id}: year_end #{ye} beyond #{MAX_YEAR} — typo?" if ye.is_a?(Integer) && ye > MAX_YEAR
+      fail! "#{rel}: #{id}: run #{ys}..#{ye} ends before it starts" if ye.is_a?(Integer) && ye < ys
+      fail! "#{rel}: #{id}: runs out of order or overlapping (#{prev_end} then #{ys}) — sort them; if sources genuinely disagree, record the conflict in the note" if prev_end && ys <= prev_end
+      prev_end = ye || MAX_YEAR
+    end
+    # Citation: at least one line of this entry's block carries a `#` comment.
+    id_line = raw_lines.index { |l| l.start_with?("\"#{id}\":", "#{id}:") }
+    if id_line
+      block = raw_lines[id_line..].take_while.with_index { |l, i| i.zero? || l =~ /\A\s/ }
+      fail! "#{rel}: #{id}: no citation — every enrichment fact carries its source on the line (§14.1)" unless block.any? { |l| l.include?("#") }
+    end
+  end
+end
+
+puts "enrich lint: #{files.size} files, #{entries} ids"
+if FAILURES.any?
+  FAILURES.each { |f| puts "LINT FAIL: #{f}" }
+  puts "#{FAILURES.size} failure(s)."
+  exit 1
+else
+  puts "enrich lint: OK"
+end


### PR DESCRIPTION
Companion to vehiclesdb-pipeline#17 (merged first, lockstep rule). Three pieces:

1. **`overrides/enrich/`** opens with a 5-id Volvo seed sourced from the press-library pages this repo already cites as evidence (P1800 family + 240), plus the §14.4 rules README. In the shipped build these derive `era: classic` end to end (catalog fields + two appended CSV columns).
2. **`scripts/lint_enrich.rb`** (CI-wired): id liveness with pending-publish tolerance, make-alignment, cross-file duplicate detection (the loader last-write-wins silently), the 1885-Benz/current+1 year rails, run ordering with conflicts-in-notes, per-entry citations. All violation classes fixture-tested.
3. **Detector observed-names consumption**: collision groups now print every corpus-observed display form per id (3,112 multi-form ids measured) — the one-id-many-names class that cost 7 rebuild cycles is closed end to end.

This unblocks the defunct-marque classics sweep (S2W's 416-record worklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)