### PR TITLE
Dodge collision batch: 10 groups → 0, dossier-over-detector twice

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2561,3 +2561,17 @@
 "moped/capri/cl50": "moped/capri/cl" # "CL50" and "Cl" were one nameplate under two ids
 "moped/i-goo/lt-019": "moped/i-goo/lt019" # closed to match the i-coco LT018 sibling
 "motorcycle/livewire/s2del-mar": "motorcycle/livewire/s2-del-mar" # "S2DEL Mar" -> "S2 Del Mar"
+# ---------------------------------------------------------------------------
+# 2026-07-26 — Dodge collision batch (10 groups → 0). Canonicals per the
+# marque dossier in the Dodge renames block (R/T-T/A slashed, LX SRT8 closed,
+# Viper SRT-10 hyphenated, Ram a word). Kinds verified against the build.
+"car/dodge/challenger-rt":    "car/dodge/challenger-r-t"
+"car/dodge/challenger-srt-8": "car/dodge/challenger-srt8"
+"car/dodge/challenger-ta":    "car/dodge/challenger-t-a"
+"car/dodge/charger-rt":       "car/dodge/charger-r-t"
+"car/dodge/charger-srt-8":    "car/dodge/charger-srt8"
+"car/dodge/coronet-rt":       "car/dodge/coronet-r-t"
+"car/dodge/magnum-rt":        "car/dodge/magnum-r-t"
+"car/dodge/magnum-srt-8":     "car/dodge/magnum-srt8"
+"car/dodge/viper-srt10":      "car/dodge/viper-srt-10"
+"van/dodge/ram1500":          "van/dodge/ram-1500"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -259,6 +259,39 @@ Derbi:
   Mulhacen 659: Mulhacén 659  # official accented name; 659cc Yamaha-engined single (2006-2013)
 
 Dodge:
+  # ── collision batch: Dodge performance suffixes (2026-07-26). The marque
+  # convention dossier, per Dodge press materials + dodge.com heritage:
+  # R/T and T/A carry the SLASH (Road/Track; Trans Am — 1970 and the 2017
+  # revival both badge "T/A"); the LX-era SRT cars are CLOSED "SRT8"
+  # (press kits: "2006 Dodge Charger SRT8"); the Viper alone hyphenates
+  # ("Dodge Viper SRT-10" throughout 2003-2010 materials); the pre-2010
+  # pickup is "Ram 1500" — a word, not an acronym. Two of the four rules
+  # contradict the detector's mechanical proposal, which is why the batch
+  # is authored and not applied. Keys cover every variant + every
+  # corpus-observed display form (observed_model_names.json).
+  Challenger R/t: Challenger R/T            # slash per Dodge (Road/Track; dodge.com heritage + every press kit)
+  Challenger Rt: Challenger R/T             # fused registry variant of the slashed badge
+  Challenger Srt-8: Challenger SRT8         # LX-era SRT cars are CLOSED per Dodge press kits ("2008 Dodge Challenger SRT8")
+  Challenger Srt 8: Challenger SRT8         # spaced observed form, same closed badge
+  Challenger T/a: Challenger T/A            # slash per the 1970 Trans Am homologation car and the 2017 revival, both badged T/A
+  Challenger Ta: Challenger T/A             # fused registry variant
+  Charger R/t: Charger R/T                  # slash per Dodge (Road/Track)
+  Charger Rt: Charger R/T                   # fused registry variant
+  Charger Srt-8: Charger SRT8               # LX-era closed badge ("2006 Dodge Charger SRT8" press kit)
+  Charger Srt 8: Charger SRT8               # spaced observed form
+  CHARGER.SRT8: Charger SRT8                # dotted registry artifact (observed_model_names.json)
+  Coronet R/t: Coronet R/T                  # slash per Dodge (1967-70 Coronet R/T)
+  Coronet Rt: Coronet R/T                   # fused registry variant
+  Magnum R/t: Magnum R/T                    # slash per Dodge
+  Magnum Rt: Magnum R/T                     # fused registry variant
+  Magnum Srt-8: Magnum SRT8                 # LX-era closed badge
+  Magnum Srt 8: Magnum SRT8                 # spaced observed form
+  Magnum Srt  8: Magnum SRT8                # double-space observed form (registry keystroke noise)
+  Viper Srt-10: Viper SRT-10                # the Viper alone HYPHENATES: "Dodge Viper SRT-10" throughout 2003-2010 Dodge materials
+  Viper Srt 10: Viper SRT-10                # spaced observed form
+  Viper SRT10: Viper SRT-10                 # fused registry variant
+  RAM1500: Ram 1500                         # Ram is a WORD on the pre-2010 Dodge pickup, not an acronym ("Dodge Ram 1500")
+  Ram-1500: Ram 1500                        # hyphenated observed form
   Ramcharger: Ram Charger                     # spelling variant of "Ram Charger" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Dodge: null                                 # registry rows where the make was written into the model column (truck kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   A 100: A100                                 # spelling variant of "A100" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical


### PR DESCRIPTION
All ten groups fall to one convention dossier — and the detector's mechanical canonical was wrong on two of its four rules (SRT8 closed, Ram-a-word), right on two (R/T-T/A slashes, Viper SRT-10). First batch to use the observed-forms feed: every corpus display shape keyed in one pass. 4W half: **106 → 96 groups**. Build+gates+suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)