### PR TITLE
Peugeot collision batch: 9 groups → 0

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2575,3 +2575,14 @@
 "car/dodge/magnum-srt-8":     "car/dodge/magnum-srt8"
 "car/dodge/viper-srt10":      "car/dodge/viper-srt-10"
 "van/dodge/ram1500":          "van/dodge/ram-1500"
+# 2026-07-26 — Peugeot collision batch (9 groups → 0; dossier in the Peugeot
+# renames block: uppercase trim codes, lowercase injection i, closed V6):
+"car/peugeot/205gr":     "car/peugeot/205-gr"
+"car/peugeot/305sr":     "car/peugeot/305-sr"
+"car/peugeot/307sw":     "car/peugeot/307-sw"
+"car/peugeot/405-mi-16": "car/peugeot/405-mi16"    # the closed Mi16 badge wins
+"car/peugeot/405sri":    "car/peugeot/405-sri"
+"car/peugeot/504gl":     "car/peugeot/504-gl"
+"car/peugeot/504ti":     "car/peugeot/504-ti"
+"car/peugeot/505gr":     "car/peugeot/505-gr"
+"car/peugeot/505v6":     "car/peugeot/505-v6"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1526,6 +1526,26 @@ Panther:
   Panther: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Peugeot:
+  # ── collision batch (2026-07-26): 9 groups, one dossier — trim codes
+  # uppercase-spaced; injection-era badges keep Peugeot's lowercase i;
+  # engine badges closed. Two detector proposals overridden (Mi16, V6). ──
+  205 Gr: 205 GR                            # trim codes badge UPPERCASE (GR = Grand Routier; period brochures)
+  205GR: 205 GR                             # fused registry variant
+  305 Sr: 305 SR                            # same uppercase trim-code convention
+  305SR: 305 SR                             # fused registry variant
+  307 Sw: 307 SW                            # SW is the official estate designation ("307 SW", peugeot.com archive)
+  307SW: 307 SW                             # fused registry variant
+  405 Mi 16: 405 Mi16                       # the badge is CLOSED with the lowercase injection i: "Mi16" — the 16v flagship; detector proposed "MI 16", wrong on both counts
+  405 Mi-16: 405 Mi16                       # hyphenated observed form (observed_model_names.json)
+  405 MI16: 405 Mi16                        # all-caps registry variant of the same badge
+  405 Sri: 405 SRi                          # Peugeot injection badges keep the lowercase i (SRi, GRi — as on the 205 GTi)
+  405SRI: 405 SRi                           # fused registry variant
+  504GL: 504 GL                             # fused variant; the spaced form cases correctly via the GL acronym token
+  504 Ti: 504 TI                            # period 504 trim badge is uppercase TI (brochures; the injected 504)
+  504TI: 504 TI                             # fused registry variant
+  505 Gr: 505 GR                            # uppercase trim code, as 205/305
+  505GR: 505 GR                             # fused registry variant
+  505V6: 505 V6                             # V6 is an engine badge, CLOSED — the spaced "V 6" the detector proposed appears nowhere
   "206CC": "206 CC"                           # spelling variant of "206 CC" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "307CC": "307 CC"                           # spelling variant of "307 CC" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Peugeot: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.


### PR DESCRIPTION
Uppercase trim codes, lowercase injection i (405 SRi / Mi16 closed), closed engine badges — detector overridden twice on marque evidence. 4W half: **96 → 87**. Build+gates+suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)