### PR TITLE
Renault collision batch: 7 groups → 0 (incl. the four-id R4 GTL family)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2587,3 +2587,14 @@
 "car/peugeot/504ti":     "car/peugeot/504-ti"
 "car/peugeot/505gr":     "car/peugeot/505-gr"
 "car/peugeot/505v6":     "car/peugeot/505-v6"
+# 2026-07-26 — Renault collision batch (7 groups → 0; dossier in the Renault
+# renames block — incl. the four-id R4 GTL family folding to one):
+"car/renault/12tl":    "car/renault/12-tl"
+"car/renault/16ts":    "car/renault/16-ts"
+"car/renault/4-cv":    "car/renault/4cv"      # the CLOSED 4CV name wins
+"car/renault/4gtl":    "car/renault/4-gtl"
+"car/renault/5gtl":    "car/renault/5-gtl"
+"car/renault/r-4-gtl": "car/renault/4-gtl"    # R-prefix shorthand folds
+"car/renault/r4-gtl":  "car/renault/4-gtl"
+"car/renault/r5-gtl":  "car/renault/5-gtl"
+"car/renault/r5gtl":   "car/renault/5-gtl"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1621,6 +1621,25 @@ Ram:
   Ram: null                                   # registry rows where the make was written into the model column (truck kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Renault:
+  # ── collision batch (2026-07-26): trim codes uppercase-spaced; the 4CV is
+  # CLOSED (it IS the name, a different car from the R4); the R prefix is
+  # shorthand and folds into the numeric designation. ──
+  12 Tl: 12 TL                              # trim codes badge uppercase-spaced (Renault 12 TL, period brochures; renaultclassic heritage)
+  12TL: 12 TL                               # fused registry variant
+  16 Ts: 16 TS                              # same trim-code convention (Renault 16 TS)
+  16TS: 16 TS                               # fused registry variant
+  4 Cv: 4CV                                 # the 1947-1961 4CV is officially CLOSED — it IS the model name, not a 4 + CV trim (renault.com heritage); a DIFFERENT car from the R4. Detector proposed "4 CV", wrong
+  4-CV: 4CV                                 # hyphenated registry variant of the same closed name
+  4 Gtl: 4 GTL                              # trim code on the Renault 4; uppercase-spaced
+  4GTL: 4 GTL                               # fused registry variant
+  5 Gtl: 5 GTL                              # trim code on the Renault 5
+  5GTL: 5 GTL                               # fused registry variant
+  R4 Gtl: 4 GTL                             # the R prefix is shorthand — the model designation is the NUMBER (Renault 4 GTL); folds the duplicate id family
+  R 4 Gtl: 4 GTL                            # spaced R-prefix variant, same fold
+  R4/GTL: 4 GTL                             # slashed observed form (observed_model_names.json)
+  R5 Gtl: 5 GTL                             # same R-prefix fold for the 5
+  R5GTL: 5 GTL                              # fused R-prefix variant
+  R 5 GTL: 5 GTL                            # spaced R-prefix variant (flap insurance)
   Megane Scenic: Scenic  # first-gen Scenic was badged Megane Scenic
   Grand Scenic: Scenic   # LWB variant
   Velsatis: Vel Satis                         # spelling variant of "Vel Satis" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence


### PR DESCRIPTION
Uppercase-spaced trims, the CLOSED 4CV (a different car from the R4 — detector overridden), and the R-prefix shorthand fold that collapses four ids of one Renault 4 GTL. 4W half: **87 → 80**. Build+gates+suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)