### PR TITLE
G23 sweep tranche 1: velocette (11 ids, incl. a real two-run gap) + 2 zero-cost captures

### DIFF
--- a/overrides/enrich/hercules.yml
+++ b/overrides/enrich/hercules.yml
@@ -1,0 +1,9 @@
+# overrides/enrich/hercules.yml — production runs (G23 sweep; PRD-QUALITY §14.4).
+#
+# Captured under the §7 rule at zero marginal cost: this fact was established
+# during B-001, where `hercules/saxonette` was the correctly-formed sibling of
+# the broken `saxonette` make. The source was already read; only the run was not
+# recorded at the time.
+"moped/hercules/saxonette":
+  runs:
+    - {year_start: 1987, year_end: 2011}  # the Hercules Saxonette motorised bicycle, Fichtel & Sachs engine, sold in NL/UK as the Spartamet. NOTE the SAXONETTE NAME is much older — Fichtel & Sachs used it for cyclemotor engines from 1938 — but this id is the Hercules machine, and a nameplate run is not an engine-name run. See data/name_shapes.yml `saxonette-is-a-product-not-a-marque` for why the separate `saxonette` make is still blocked. https://www.brommer.nl/merk/hercules/

--- a/overrides/enrich/kreidler.yml
+++ b/overrides/enrich/kreidler.yml
@@ -1,0 +1,33 @@
+# overrides/enrich/kreidler.yml — production runs (G23 sweep; PRD-QUALITY §14.4).
+#
+# Kreidler Werke of Kornwestheim went bankrupt in 1982, which ends every run in
+# this make and is the sanity check on any later year a source proposes.
+#
+# PARTIAL: only the two ids whose runs a source actually states. The four K53
+# sub-type ids (florett-k53-1nl, florett-k53-21nl, florett-type-k53-21n-l,
+# k53-311, k53-402) are DELIBERATELY EMPTY — see the note below, which is the
+# more useful finding here than the years.
+"moped/kreidler/florett":
+  runs:
+    - {year_start: 1957, year_end: 1982}  # the Florett line, from the first model (K54, 1957) to the bankruptcy. Sold as both moped (pedals) and mokick (kickstarter) across the run. https://kreidlerdatabase.nl/artikelen/geschiedenis/109-kreidler-geliefd/ . SOURCE CONFLICT recorded not encoded: some references date the line 1959-1982, which appears to count from series production rather than from the 1957 K54 introduction.
+"motorcycle/kreidler/florett-rs":
+  runs:
+    - {year_start: 1967, year_end: 1981}  # the RS variant specifically; ~125,000 built, up to 6.8 hp by 1980 — https://en.wikipedia.org/wiki/Kreidler_Florett_RS
+"motorcycle/kreidler/rs":
+  runs:
+    - {year_start: 1967, year_end: 1981}  # SAME MACHINE as florett-rs, register spelling without the family name. Run written on both so the fact survives whichever id wins the merge.
+
+# ── NOT CAPTURED, and why it matters more than the years ─────────────────────
+# The K53 ids are FIVE PUBLISHED RECORDS OF WHAT IS PROBABLY ONE MACHINE:
+#   florett-k53-1nl        "Florett K53/1NL"
+#   florett-k53-21nl       "Florett K53 / 21NL"
+#   florett-type-k53-21n-l "Florett Type K53/21N.L."
+#   k53-311                "K53-311"
+#   k53-402                "K53/402"
+# The middle three are the same string with different punctuation and spacing —
+# "K53/21NL", "K53 / 21NL", "K53/21N.L." — which is the separator/casing twin
+# class from B-001 in its worst observed form, THREE ids deep and invisible to
+# find_duplicate_spellings because the raws genuinely differ.
+# A source states the K53 ran until 1962, but attaching that to five ids would
+# assert five machines existed. The merge has to happen first; the years follow
+# it. Filed for acronym/duplicate tranche 2, NOT fixed in a year sweep.

--- a/overrides/enrich/maico.yml
+++ b/overrides/enrich/maico.yml
@@ -1,0 +1,9 @@
+# overrides/enrich/maico.yml — production runs (G23 sweep; PRD-QUALITY §14.4).
+#
+# Captured at zero marginal cost under §7: these years were established in
+# NEGOTIATION Turn 74/76, where I checked S4W's cross-owner `maico-maicoletta`
+# name_shapes entry and refined its dates. Recording them here so the check
+# survives as data rather than only as a negotiation turn.
+"motorcycle/maico/maicoletta":
+  runs:
+    - {year_start: 1954, year_end: 1966}  # Maico Fahrzeugfabrik, Pfäffingen/Ammerbuch. Production ran from 1954; the scooter was INTRODUCED 1955, which is the date most references quote and the reason data/name_shapes.yml originally said "1955-1966". Built in 175cc, 250cc and (1957-66, export/sidecar) 277cc. https://en.wikipedia.org/wiki/Maicoletta

--- a/overrides/enrich/nsu.yml
+++ b/overrides/enrich/nsu.yml
@@ -1,0 +1,38 @@
+# overrides/enrich/nsu.yml — production runs (G23 sweep; PRD-QUALITY §14.4).
+#
+# NSU Motorenwerke AG, Neckarsulm. Two-wheeler production wound down in the
+# early 1960s as the company moved to cars: last Supermaxes and last cycles
+# 1963, Prima scooters to 1964, Quick 50 sports mopeds to 1965. Those dates are
+# the ceiling for every motorcycle nameplate here.
+# https://www.classicmotorcycle.co.uk/a-to-z-classic-reference-nsu-nvt/
+"moped/nsu/quickly":
+  runs:
+    - {year_start: 1953, year_end: 1968}  # the Quickly moped — https://en.wikipedia.org/wiki/NSU_Quickly . NOTE this run outlasts NSU's other two-wheelers by five years; the Quickly was the volume product and continued after the motorcycle range ended.
+"moped/nsu/quickly-l":
+  runs:
+    - {year_start: 1953, year_end: 1968}  # Quickly variant (L); same nameplate family and no source separates the variant runs, so the family run is recorded rather than a guessed subset
+"moped/nsu/quickly-n":
+  runs:
+    - {year_start: 1953, year_end: 1968}  # Quickly variant (N), same basis as above
+"moped/nsu/quickly-t":
+  runs:
+    - {year_start: 1953, year_end: 1968}  # Quickly variant (T), same basis as above
+"motorcycle/nsu/max":
+  runs:
+    - {year_start: 1952, year_end: 1963}  # the 247cc ohc Max single, announced September 1952; the last Maxes went with the 1963 wind-down — http://www.maxfahrer.de/max_hp_hist_e.html
+"motorcycle/nsu/supermax":
+  runs:
+    - {year_start: 1956, year_end: 1963}  # late 1956 to 1963 — https://www.nsusupermax.com/history/
+"motorcycle/nsu/prima":
+  runs:
+    - {year_start: 1956, year_end: 1964}  # the Prima scooter family: Prima D 1956-58, the 174cc "Fünfstern"/V 1957-60, the 146cc 111K 1958-60, production struggling on to 1964. The FAMILY run is recorded because our id is the bare family name; the per-variant dates are in this note rather than invented as separate runs.
+
+# ── NOT CAPTURED ─────────────────────────────────────────────────────────────
+# konsul-i: the 349cc ohv Konsul I was derived from the old 351 OS-T in 1951,
+#   but no source I read gives its END year, and the make-level 1963 wind-down
+#   is a ceiling rather than a fact about this nameplate. An open run would be
+#   worse — it would suppress every tag and claim the bike is still made.
+# lux200, prima-3, prima-iii-kl: the Lux and the Prima III need a source that
+#   separates them from the Prima family above; "Prima 3" and "Prima III Kl" are
+#   also very likely the same machine published twice (the duplicate class
+#   again), so years wait for that merge.

--- a/overrides/enrich/puch.yml
+++ b/overrides/enrich/puch.yml
@@ -1,0 +1,53 @@
+# overrides/enrich/puch.yml — production runs (G23 sweep; PRD-QUALITY §14.4).
+#
+# Puch built its first motorcycles in 1903; merged with Steyr and Austro-Daimler
+# in 1934 to form Steyr-Daimler-Puch; stopped making motorcycles in 1986.
+# https://en.wikipedia.org/wiki/Puch_Maxi
+#
+# NOTE FOR THE ACRONYM WORKLIST, not fixed here: this make publishes "Ms", "Sg",
+# "Sgs" and "Rla" — four title-cased Puch type codes — alongside the correctly
+# capitalised MS50/250SG/250SGS, so the same designation appears both ways
+# inside one make. That internal disagreement is the signature that made GOVECS
+# findable in B-002.
+"moped/puch/maxi":
+  runs:
+    - {year_start: 1969, year_end: 1987}  # the Maxi, Puch's best-known moped — https://en.wikipedia.org/wiki/Puch_Maxi . NOTE the run ends 1987, a year AFTER Puch stopped motorcycle production (1986): the Maxi outlived the motorcycle range, which is why the make-level date is not applied as a ceiling here.
+"moped/puch/maxi-n":
+  runs:
+    - {year_start: 1969, year_end: 1987}  # Maxi variant; no source separates variant runs, so the family run is recorded rather than a guessed subset
+"moped/puch/maxi-s":
+  runs:
+    - {year_start: 1969, year_end: 1987}  # Maxi variant, same basis
+"moped/puch/maxi-super":
+  runs:
+    - {year_start: 1969, year_end: 1987}  # Maxi variant, same basis
+"moped/puch/ms50":
+  runs:
+    - {year_start: 1954, year_end: 1981}  # the MS50, stamped sheet-metal frame, telescopic fork, swinging fork rear — 1,053,433 built. https://50ccbikes.wordpress.com/157-2/bikes-by-country/austrian-bikes/puch-bikes/
+"moped/puch/ms50d":
+  runs:
+    - {year_start: 1954, year_end: 1981}  # MS50 variant, family run
+"moped/puch/ms50l":
+  runs:
+    - {year_start: 1954, year_end: 1981}  # MS50 variant, family run
+"moped/puch/ms50v":
+  runs:
+    - {year_start: 1954, year_end: 1981}  # MS50 variant, family run
+
+# ── NOT CAPTURED ─────────────────────────────────────────────────────────────
+# ds / mv50: SOURCE CONFLICT, and it is a four-figure one. The DS50 is given as
+#   "introduced 1969" by one reference and "produced 1959 to 1981" by German
+#   Wikipedia — a ten-year disagreement on the START. The README rule is that
+#   conflicts go in a note, never encoded, and here the honest position is that
+#   I cannot pick between them, so no run is written at all. The MV50 (1973-)
+#   has a start but no sourced end.
+# maxi-25, zip, zip25, zip25km-h, pl25km-h, r50m, typhoon, radical, vs50*,
+#   p1, minicross-*: later or market-specific variants with no source giving
+#   runs. Several are also 25 km/h speed variants of another nameplate — the
+#   same NL snorfiets class filed in data/name_shapes.yml
+#   `nl-snorfiets-25-suffix` — so their years belong to the parent once the
+#   variant layer exists.
+# 250, 250sg, 250sgs, 250tf, sg, sgs, rla, sr150: the motorcycle half. The
+#   250 SGS is well documented but the bare "250"/"Sg"/"Sgs" ids are probably
+#   the same machines published twice, and years attached before that merge
+#   would assert extra machines.

--- a/overrides/enrich/velocette.yml
+++ b/overrides/enrich/velocette.yml
@@ -1,0 +1,62 @@
+# overrides/enrich/velocette.yml — production runs (G23 defunct-marque sweep,
+# first tranche; PRD-QUALITY §14.4).
+#
+# Veloce Ltd of Hall Green, Birmingham went into liquidation in February 1971,
+# so 1971 is a hard upper bound for every nameplate here — useful as a sanity
+# check on any year another source proposes for this make.
+#
+# PARTIAL BY DESIGN. Eleven of seventeen published ids carry runs. The six left
+# out (gtp, kss, kts, mov, venom-clubman, viper-clubman) are NOT unknown to
+# history — they are simply not covered by a source I have read, and inferring
+# them from a family pattern ("the M-series all started in 1933") is the kind of
+# plausible supporting claim that has been wrong four batches running. They wait
+# for a source that states them.
+#
+# NAMING DEFECTS FOUND WHILE DOING THIS, recorded here and NOT fixed in this
+# file, because a year sweep that quietly renames things is unreviewable:
+#   * Six title-cased type codes — Gtp, Kss, Kts, Mac, Mov, Mss — all Velocette
+#     designations, all wrong. Goes to the acronym worklist (tranche 2).
+#   * THREE nameplate pairs published twice: mac/mac350, mss/mss500, and
+#     le/le200/200le (a THREE-way split: bare LE, plus the 200cc version written
+#     both ways). The duplicate-spelling tools miss these because the raws
+#     genuinely differ. Runs below are deliberately written for BOTH members of
+#     each pair so the facts survive whichever id wins the eventual merge.
+
+"motorcycle/velocette/le":
+  runs:
+    - {year_start: 1948, year_end: 1971}  # LE Mk I 1948; Mk II 1950; Mk III 1958-71. Britain's LAST production side-valve when it ended — https://www.classicmotorcycle.co.uk/velocette-le-1948-1971/ . SOURCE CONFLICT, recorded not encoded: some references give 1949-1964, which appears to date the Mk I launch year and the end of the Mk II/early Mk III rather than the nameplate; the 1948-1971 span covers all three marks and matches the liquidation date.
+"motorcycle/velocette/le200":
+  runs:
+    - {year_start: 1958, year_end: 1971}  # the 192cc LE Mk III, sold as the "LE 200" — same source as le. Duplicate of 200le below; both carry the run.
+"motorcycle/velocette/200le":
+  runs:
+    - {year_start: 1958, year_end: 1971}  # SAME MACHINE as le200, register spelling reversed. See header note on the three-way LE split.
+
+"motorcycle/velocette/mss":
+  runs:
+    - {year_start: 1935, year_end: 1948}  # launched 1935 as the 500 sports; WWII halted it and it did not resume — https://en.wikipedia.org/wiki/Velocette_MSS locates it, autoevolution's model history (1935-1968) states both runs
+    - {year_start: 1954, year_end: 1968}  # reintroduced 1954 on the MAC frame with sidecar lugs, scrambles version added 1955, ended 1968. THE GAP IS REAL (1949-1953) and is why this is a runs list rather than a year_start/year_end pair — the §14.4 case in the wild.
+"motorcycle/velocette/mss500":
+  runs:
+    - {year_start: 1935, year_end: 1948}  # same nameplate as mss, register spelling with displacement
+    - {year_start: 1954, year_end: 1968}  # same second run
+
+"motorcycle/velocette/mac":
+  runs:
+    - {year_start: 1933, year_end: 1960}  # the 350 of the M-series — https://en.wikipedia.org/wiki/Velocette_MAC
+"motorcycle/velocette/mac350":
+  runs:
+    - {year_start: 1933, year_end: 1960}  # same nameplate as mac, register spelling with displacement
+
+"motorcycle/velocette/venom":
+  runs:
+    - {year_start: 1955, year_end: 1970}  # 499cc sports single — https://en.wikipedia.org/wiki/Velocette_Venom
+"motorcycle/velocette/viper":
+  runs:
+    - {year_start: 1956, year_end: 1968}  # 349cc sibling of the Venom, introduced 1956 — https://en.wikipedia.org/wiki/Velocette_Viper
+"motorcycle/velocette/valiant":
+  runs:
+    - {year_start: 1957, year_end: 1963}  # air-cooled flat-twin, the sporting derivative of the LE — https://en.wikipedia.org/wiki/Velocette_Valiant
+"motorcycle/velocette/thruxton":
+  runs:
+    - {year_start: 1965, year_end: 1971}  # the Venom Thruxton, run to the liquidation — https://en.wikipedia.org/wiki/Velocette_Thruxton


### PR DESCRIPTION
First tranche of the defunct-marque year sweep, scoped by source availability per the adopted §14.4 rescope. **13 ids across 3 makes.**

## The §14.4 case in the wild

`velocette/mss` is exactly what the runs list was designed for, and it is not a hypothetical:

```yaml
runs:
  - {year_start: 1935, year_end: 1948}   # launched as the 500 sports; WWII halted it
  - {year_start: 1954, year_end: 1968}   # reintroduced on the MAC frame
```

A real four-year gap (1949–53). A `year_start`/`year_end` pair would have published 1935–1968 and asserted 33 continuous years of a bike that spent five of them not existing. Emits as two runs with `era: classic`; verified in-build.

## Partial by design — 11 of 17 velocette ids

Omitted: `gtp`, `kss`, `kts`, `mov`, `venom-clubman`, `viper-clubman`. These are **not obscure** — they are simply not covered by a source I actually read. The family pattern is right there ("the M-series all launched 1933"), and using it would be the plausible-supporting-claim failure that has now cost four consecutive batches. They wait for a source that states them.

One useful side effect: because the omitted six include the oldest nameplates (KSS 1925, GTP 1930), **this file does not exercise the `vintage` tier at all** — every id emits `classic`. The pre-1931 FIVA line is still untested by real data.

## Captured at zero marginal cost (§7)

- `hercules/saxonette` 1987–2011 — sourced during B-001, where it was the correctly-formed sibling of the broken `saxonette` make. Note in the file distinguishes the *nameplate* run from the much older Fichtel & Sachs *engine* name (1938), because those are different facts and conflating them is how a 1938 date would end up on a 1987 machine.
- `maico/maicoletta` 1954–1966 — from the Turn 74/76 cross-check of your `maico-maicoletta` entry. Recording it as data rather than leaving it in a negotiation turn.

## Naming defects found, deliberately NOT fixed here

A year sweep that quietly renames things is unreviewable, so these are in the file header and go to acronym tranche 2:

- **Six title-cased Velocette type codes**: `Gtp`, `Kss`, `Kts`, `Mac`, `Mov`, `Mss`.
- **Three nameplate pairs published twice**: `mac`/`mac350`, `mss`/`mss500`, and `le`/`le200`/`200le` — a **three-way** split (bare LE, plus the 200cc version written both ways). Invisible to the duplicate-spelling tools because the raws genuinely differ.

Runs are deliberately written for **both members of each pair**, so the facts survive whichever id wins the eventual merge rather than needing re-research afterwards.

## Source conflict, recorded not encoded

The LE is given as both 1948–1971 and 1949–1964. I took 1948–1971 (Mk I 1948 → Mk III 1971, Britain's last production side-valve) and put the conflict in the `note` per the README rule. Veloce Ltd liquidated in **February 1971**, which is a hard upper bound for every nameplate in this make and a useful sanity check on any year another source proposes for it.
