### PR TITLE
Velocette: combined duplicate+acronym pass (17 -> 14 records)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2598,3 +2598,6 @@
 "car/renault/r4-gtl":  "car/renault/4-gtl"
 "car/renault/r5-gtl":  "car/renault/5-gtl"
 "car/renault/r5gtl":   "car/renault/5-gtl"
+"motorcycle/velocette/mac350": "motorcycle/velocette/mac" # Velocette duplicate fold, see renames.yml
+"motorcycle/velocette/mss500": "motorcycle/velocette/mss" # Velocette duplicate fold, see renames.yml
+"motorcycle/velocette/200le": "motorcycle/velocette/le200" # Velocette duplicate fold, see renames.yml

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1977,6 +1977,15 @@ Vauxhall:
 Velocette:
   L.e.:                      LE                   # the Velocette LE (Little Engine). DEFUNCT marque — badge evidence
   Le:                        LE                   # the Velocette LE (Little Engine). DEFUNCT marque — badge evidence
+  Gtp: GTP                                  # Velocette GTP, a 1930s two-stroke — a type designation, never a word
+  Kss: KSS                                  # Velocette KSS (K-series, OHC "Super Sports")
+  Kts: KTS                                  # Velocette KTS, the touring sibling of the KSS
+  Mov: MOV                                  # Velocette MOV, the 250 of the M-series
+  Mac: MAC                                  # Velocette MAC, the 350 of the M-series (1933-1960)
+  MAC350: MAC                               # SAME NAMEPLATE — Velocette built exactly one MAC and it was a 350, so the register is restating displacement, not naming a second machine. Folds.
+  Mss: MSS                                  # Velocette MSS, the 500 of the M-series
+  MSS500: MSS                               # SAME NAMEPLATE — one MSS, and it was a 500. Folds for the same reason as MAC350.
+  200LE: LE200                              # same string reversed. Folds into LE200, and DELIBERATELY NOT into bare "LE": the LE came in 149cc (Mk I/II) and 192cc (Mk III), so the 200 distinguishes a real machine. Merging it away would destroy that with no variant layer to catch it.
 
 Vespa:
   Vespa: null                             # motorcycle es|nl AND moped nl|nz


### PR DESCRIPTION
First make under the merged sequencing I flagged in Turn 83: **duplicates and acronym casing as one pass per make**, because the G23 sweep kept surfacing both in the same make and separate tranches meant touching it twice.

## Casing (6)

`Gtp` `Kss` `Kts` `Mac` `Mov` `Mss` → `GTP` `KSS` `KTS` `MAC` `MOV` `MSS`. All Velocette type designations; none is a word.

## Folds (3 ids, all aliased)

| from | to | why |
|---|---|---|
| `MAC350` | `MAC` | Velocette built exactly **one** MAC, and it was a 350 |
| `MSS500` | `MSS` | exactly **one** MSS, and it was a 500 |
| `200LE` | `LE200` | the same string reversed |

## The one I did NOT fold, and the rule behind it

**`LE200` stays out of bare `LE`.** The LE came in two displacements — 149cc (Mk I/II) and 192cc (Mk III) — so that number distinguishes a real machine, and there is no variant layer to catch the distinction if it were dropped. Same reasoning that left the NL snorfiets `.25` records alone in B-001.

So the rule is **not** "drop the displacement". It is: **fold a redundant number, keep a meaningful one.** MAC350 and MSS500 restate the displacement of a single nameplate; LE200 names one of two. Worth stating explicitly because the three look identical from the outside and a future sweep will be tempted to treat them the same way.

## The runs survived the merge

`velocette/mac`, `mss` and `le200` all kept their G23 production runs with **zero re-research**. That is because I deliberately wrote runs for *both* members of each pair in #51, before knowing which id would win — the merge then simply dropped the losing copies. Cheap insurance, and worth repeating in the remaining sweep makes since kreidler and puch have the same pending merges.

## Note for the enrichment relocation

This fold makes three of the entries you are about to relocate redundant — `velocette/mac350`, `velocette/mss500`, `velocette/200le` now alias to ids that already carry identical runs. `lint_enrich` tolerates them (pending-publish alias targets), so nothing breaks, but they can be dropped during the move. **I have not touched `overrides/enrich/` myself** — sweep commits are paused per your directive.