### PR TITLE
Kreidler: 2 verified merges + the K53 type-number question filed (corrects my Turn 83 claim)

### DIFF
--- a/data/name_shapes.yml
+++ b/data/name_shapes.yml
@@ -534,3 +534,36 @@ debt:
       Same convention explains the ".S" and "E3" suffixes in the same registers
       (fosti RETRO / RETRO.S), which are NOT speed classes — do not generalise
       the dot.
+  - id: kreidler-k53-type-numbers
+    owner: s2w
+    category: code_string
+    id_list: [kreidler/florett-k53-1nl, kreidler/florett-k53-21nl, kreidler/k53-311, kreidler/k53-402]
+    count: 4
+    why: >-
+      A CORRECTION FIRST, because I asserted the opposite in NEGOTIATION Turn 83
+      and in the #51 PR comment. I claimed three published ids were one string
+      punctuated three ways. THEY ARE NOT. `K53/1NL` and `K53/21NL` are
+      DIFFERENT Kreidler type numbers — K53/1 and K53/21 — and only the two
+      K53/21 forms were duplicates. That merge is done; the rest are distinct
+      types and folding them would have destroyed real records. I got this
+      wrong by reading the published names instead of the register.
+      WHAT THE REGISTER ACTUALLY HOLDS: about 100 distinct raw spellings under
+      this make for a handful of type numbers — K53, K53/1, K53/2, K53/3,
+      K53/21, K53/31, K53/40x, K53/M and so on, each appearing with and without
+      slashes, spaces, hyphens, periods, an NL market suffix, a FLORETT prefix,
+      and in one case a digit-zero for the letter O. `K53/402` alone appears as
+      K53/402, K53402, K53-402, K53 402, K53 / 402, K53/ 402, K53 /402,
+      K53/402NL, K53/402 NL and K531402.
+      THE REAL QUESTION IS NOT SPELLING, IT IS LEVEL. K53/21 is a TYPE-APPROVAL
+      NUMBER, not a nameplate. The nameplate is Florett — that is what Kreidler
+      sold and what a buyer would name. So the honest disposition is probably to
+      fold every K53/* id into `kreidler/florett` and keep the type numbers as
+      variants, exactly as the IVA RA9015 case in B-000 concluded.
+      NOT DONE, because there is no variant layer to hold them and a fold would
+      DESTROY the type distinction rather than relocate it — the same wall that
+      stopped the NL snorfiets `.25` records and the Velocette LE200. Kreidler
+      is the sharpest case yet: 4 published ids, ~100 raw spellings, one
+      nameplate underneath. Resolve when variants land (G26 / §14.1).
+      DO NOT bulk-fold on the K53 prefix in the meantime. The prefix is shared
+      by genuinely different types, which is the mistake this entry opens by
+      admitting.

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2601,3 +2601,5 @@
 "motorcycle/velocette/mac350": "motorcycle/velocette/mac" # Velocette duplicate fold, see renames.yml
 "motorcycle/velocette/mss500": "motorcycle/velocette/mss" # Velocette duplicate fold, see renames.yml
 "motorcycle/velocette/200le": "motorcycle/velocette/le200" # Velocette duplicate fold, see renames.yml
+"moped/kreidler/florett-type-k53-21n-l": "moped/kreidler/florett-k53-21nl" # same Kreidler type K53/21 NL, periods vs none
+"motorcycle/kreidler/rs": "motorcycle/kreidler/florett-rs" # bare RS is the Florett RS

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -835,6 +835,10 @@ Kia:
   EV 6: EV6                                   # spelling variant of "EV6" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   EV 9: EV9                                   # spelling variant of "EV9" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
+Kreidler:
+  RS: Florett RS                               # bare "RS" is the Florett RS — the register writes it as RS, KREIDLER RS, FLORETT RS and KREIDLER FLORETT RS for the same machine (~125,000 built 1967-81). Folding it here matches what I already asserted in the G23 runs, where both ids carry identical years.
+  Florett Type K53/21N.L.: Florett K53 / 21NL   # SAME TYPE as "Florett K53 / 21NL" — both are Kreidler type K53/21, Dutch-market spec, written with and without the periods. Register holds K53/21NL, K53/21 NL, K53/21-NL, K53/21nl and FLORETT TYPE K53/21 N.L. for it.
+
 KTM:
   "KTM690 Enduro R":           690 Enduro R         # embedded make prefix — strip_make_prefix needs [\s,]+ after the prefix, so a hyphenated or fused badge survives (the IVA pilot's diagnosis)
   "1290 Superduke GT":       1290 Super Duke GT   # KTM writes it with spaces: 1290 Super Duke R/GT/RR (ktm.com)


### PR DESCRIPTION
## 🔴 First: this corrects a claim I made in Turn 83 and in the #51 comment

I said three published Kreidler ids were **one string punctuated three ways**. **They are not.**

`K53/1NL` and `K53/21NL` are **different type numbers** — K53/1 and K53/21. Only the two K53/21 forms were duplicates. I reached the wrong conclusion by reading the *published names* instead of the register, and folding on the shared `K53` prefix would have destroyed real records.

Corrected in the debt entry, which now opens with the admission so the next person meets it before the recommendation.

## Merged (2, both verified against raws)

- `Florett Type K53/21N.L.` → `Florett K53 / 21NL` — same type K53/21 NL, periods vs none. Register also holds `K53/21NL`, `K53/21 NL`, `K53/21-NL`, `K53/21nl`.
- bare `RS` → `Florett RS` — register writes `RS`, `KREIDLER RS`, `FLORETT RS`, `KREIDLER FLORETT RS` for one machine (~125,000 built 1967–81). Consistent with the G23 runs, where I already gave both ids identical years.

## Filed as debt: the question is level, not spelling

The register holds **~100 distinct raw spellings** under this make for a handful of type numbers. `K53/402` alone appears as `K53/402`, `K53402`, `K53-402`, `K53 402`, `K53 / 402`, `K53/ 402`, `K53 /402`, `K53/402NL`, `K53/402 NL` and `K531402`.

But spelling is the shallow problem. **`K53/21` is a type-approval number; the nameplate is Florett.** That is what Kreidler sold and what a buyer would name. So the honest disposition is folding every `K53/*` id into `kreidler/florett` and keeping the type numbers as variants — the same conclusion B-000 reached for IVA `RA9015`.

**Not done**, because there is no variant layer to hold them and a fold would *destroy* the type distinction rather than relocate it. Same wall as the NL snorfiets `.25` records and Velocette `LE200`. Kreidler is the sharpest instance yet: **4 published ids, ~100 raw spellings, one nameplate underneath.**

The entry says explicitly: **do not bulk-fold on the K53 prefix** — that is exactly the mistake it opens by admitting.