### PR TITLE
Puch: 4 casing fixes — and the raws killed the merges I expected to make

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1623,6 +1623,10 @@ Puch:
   Radical 40KM/H: Radical                     # L1e/L2e speed-class marker folds (NAMING.md §6) [reason re-attached: the union merge lifted this line out of a block whose comment sat above it]
   "230 Ge":                  230 GE               # Puch G 230 GE (the Mercedes G-Wagen twin) — space before the engine code
   "230GE":                   230 GE               # Puch G 230 GE (the Mercedes G-Wagen twin) — space before the engine code
+  Ms: MS                                      # Puch MS type prefix — uppercase in every register row (MS, MS 25, MS 50, MS-25, MS 50 V SKYHUNTER). NOT merged into ms50: the register also holds MS 25, so bare "MS" is not necessarily the 50.
+  Sg: SG                                      # Puch SG type prefix, uppercase in the register. NOT merged into 250sg — Puch built the SG in more than one displacement.
+  Sgs: SGS                                    # Puch SGS type prefix; register carries "SGS 248 CCM". NOT merged into 250sgs: Puch built both a 175 SGS and a 250 SGS, so the bare form is ambiguous.
+  Rla: RLA                                    # Puch RLA type designation, uppercase in the register
 
 Ram:
   RAM1500: "1500"                        # lu_snca fused-marque form; Ram's nameplate is the bare 1500 (ramtrucks.com). Value QUOTED: bare 1500 parses as Integer


### PR DESCRIPTION
Continues the combined dedup+casing per-make pass.

## Fixed (4)

`Ms` `Sg` `Sgs` `Rla` → `MS` `SG` `SGS` `RLA`. All are Puch type prefixes, uppercase in every register row, and each was publishing as a title-cased non-word **alongside correctly-capitalised `MS50`, `250SG`, `250SGS` in the same make** — the GOVECS signature from B-002.

## The useful half: three merges I expected to make, and did not

I went in assuming the bare forms would fold into their numbered siblings. **The register said no:**

- bare `MS` is not necessarily the MS50 — the register also holds `MS 25` and `MS-25`
- Puch built **both a 175 SGS and a 250 SGS**, so bare `SGS` is ambiguous
- same problem for `SG`

So this PR is casing only. Checking the raws before acting is what stopped three plausible merges here, and it is the same discipline that stopped the `K53` prefix fold in #54 — where I had already publicly claimed three ids were duplicates and was wrong.

Two makes in a row where **the merge I expected was the wrong move and only the raw strings showed it.** Worth stating as a rule for the per-make passes: the published names tell you where to *look*; only the register tells you what to *do*.