### PR TITLE
Swarm-dossier batch: alfa-romeo + citroen collisions — 12 groups → 0

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2603,3 +2603,23 @@
 "motorcycle/velocette/200le": "motorcycle/velocette/le200" # Velocette duplicate fold, see renames.yml
 "moped/kreidler/florett-type-k53-21n-l": "moped/kreidler/florett-k53-21nl" # same Kreidler type K53/21 NL, periods vs none
 "motorcycle/kreidler/rs": "motorcycle/kreidler/florett-rs" # bare RS is the Florett RS
+# ---------------------------------------------------------------------------
+# 2026-07-26 — swarm-dossier collision batch: alfa-romeo (6 groups → 0, half
+# the detector proposals REFUTED by the dossier) + citroen (6 groups → 0).
+# Dossiers: Opus researchers, S4W fetch-verified; sources on every rename key.
+"car/alfa-romeo/1300-gt-junior": "car/alfa-romeo/gt-1300-junior"  # inversion folds; survivor superset fi,lu,nl,nz
+"car/alfa-romeo/1300gt-junior":  "car/alfa-romeo/gt-1300-junior"
+"car/alfa-romeo/159sw":          "car/alfa-romeo/159-sw"
+"car/alfa-romeo/1750gtv":        "car/alfa-romeo/1750-gtv"
+"car/alfa-romeo/gtv-1750":       "car/alfa-romeo/1750-gtv"
+"car/alfa-romeo/gtv1750":        "car/alfa-romeo/1750-gtv"
+"car/alfa-romeo/2000gtv":        "car/alfa-romeo/2000-gtv"
+"car/citroen/cx-22trs":          "car/citroen/cx-22-trs"
+"car/citroen/cx22trs":           "car/citroen/cx-22-trs"
+"car/citroen/bx16trs":           "car/citroen/bx-16-trs"
+"car/citroen/bx19trs":           "car/citroen/bx-19-trs"
+"car/citroen/bx-19gti":          "car/citroen/bx-19-gti"
+"car/citroen/bx19gti":           "car/citroen/bx-19-gti"
+"car/citroen/id-19":             "car/citroen/id19"
+"van/citroen/hy78":              "van/citroen/hy-78"
+"car/alfa-romeo/gtv-6":          "car/alfa-romeo/gtv6"    # the closed-badge fold (gate-demanded; the dossier's group-6 merge pair)

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -5,6 +5,23 @@ Aixam:
   Aixam: null                             # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Alfa Romeo:
+  # ── swarm-dossier batch (2026-07-26; Opus researcher, S4W verified): the
+  # 105/115 coupés put the badge BEFORE the displacement (GT 1300 Junior) but
+  # the displacement BEFORE GTV (1750 GTV); GTV6 is CLOSED (catalog corrobo-
+  # ration: alfetta-gtv6 outranks encyclopedias per NAMING.md §2). Half the
+  # detector proposals were refuted by the dossier. ──
+  1300 GT Junior: GT 1300 Junior   # token-order inversion — the coupé is the GT 1300 Junior; the inverted form appears in no Alfa source (en.wikipedia 105/115 Series Coupés)
+  1300GT Junior: GT 1300 Junior    # same inversion, fused nz_nzta shape; joins the existing GT1300JUNIOR fold (it.wikipedia Giulia Sprint GT)
+  159 Sw: 159 SW                   # estate abbreviation is caps; the 307 Sw precedent shape (renames.yml Peugeot block)
+  159SW: 159 SW                    # fused registry variant (nl_rdw "ALFA ROMEO 159SW")
+  1750 Gtv: 1750 GTV               # GTV = GT Veloce badge, all-caps; casing-only, slug unchanged (en.wikipedia 105/115 Series Coupés)
+  1750GTV: 1750 GTV                # fused registry variant (corpus observed_variants)
+  Gtv 1750: 1750 GTV               # token-order inversion; displacement precedes the badge on 105/115 coupés (it.wikipedia Giulia Sprint GT)
+  GTV1750: 1750 GTV                # same inversion, fused nz_nzta shape
+  2000 Gtv: 2000 GTV               # same badge family, casing-only (en.wikipedia 105/115 Series Coupés)
+  2000GTV: 2000 GTV                # fused registry variant
+  Gtv 6: GTV6                      # the Alfetta V6 coupé badge is CLOSED — catalog corroboration: alfa-romeo/alfetta-gtv6 "Alfetta GTV6" (nl+nz registration evidence outranks encyclopedias, NAMING.md §2); it.wikipedia infobox concurs
+  Gtv-6: GTV6                      # second observed display form (observed_model_names.json) — flap insurance
   GT1300JUNIOR: GT 1300 Junior                # spelling variant of "GT 1300 Junior" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Alvis:
@@ -176,6 +193,23 @@ Chrysler:
   Chrysler: null                              # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Citroën:
+  # ── swarm-dossier batch (2026-07-26): BX/CX trims spaced-caps per Citroën
+  # own versions gallery; the PSA injection badge keeps lowercase i (GTi —
+  # the 405 SRi precedent); HY 78 spaced (78 = the 78mm-bore engine type);
+  # ID19 fused per the existing curated direction. ──
+  CX 22 Trs: CX 22 TRS   # trim code is an acronym — Citroën versions gallery "CX 22 TRS" (https://www.citroenorigins.com/en/cars/cx)
+  CX 22TRS: CX 22 TRS    # registry glue; official form spaces both (https://en.wikipedia.org/wiki/Citro%C3%ABn_CX)
+  CX22TRS: CX 22 TRS     # fully glued form; fr.wikipedia CX range spaced, zero fused hits (https://fr.wikipedia.org/wiki/Citro%C3%ABn_CX)
+  Bx 16 Trs: BX 16 TRS   # BX initialism + TRS trim — versions gallery "BX 16 TRS" (https://www.citroenorigins.com/en/cars/bx)
+  BX16TRS: BX 16 TRS     # glued registry form; fr.wikipedia BX table "BX 16 TRS" ×8 (https://fr.wikipedia.org/wiki/Citro%C3%ABn_BX)
+  Bx 19 Trs: BX 19 TRS   # same family; gallery "BX 19 TRS Break" (https://www.citroenorigins.com/en/cars/bx)
+  BX19TRS: BX 19 TRS     # glued registry form (same sources)
+  Bx 19GTI: BX 19 GTi    # number spaced off the trim; gallery reads "BX 19 GTi"/"BX 19 GTi 16S" (https://www.citroenorigins.com/en/cars/bx)
+  BX19GTI: BX 19 GTi     # glued form; en.wikipedia lowercase-i "GTi" ×18 vs ×3 (https://en.wikipedia.org/wiki/Citro%C3%ABn_BX) — the 405 SRi PSA precedent
+  Id-19: ID19            # the hyphen has ZERO attestation in any fetched source; target matches the existing curated ID19 direction (renames.yml Citroën block)
+  Hy 78: HY 78           # HY initialism; 78 = the 78mm-bore engine type, spaced by Citroën and 1964 period press (https://en.wikipedia.org/wiki/Citro%C3%ABn_H_Van)
+  Hy-78: HY 78           # hyphen is a registry artefact; en+fr wikipedia both space it (https://fr.wikipedia.org/wiki/Citro%C3%ABn_Type_H)
+  HY78: HY 78            # glued form; 78 is an engine type on the HY nameplate, not part of the badge (https://www.citroenorigins.com/en/cars/type-h)
   C4 Space: C4           # C4 Spacetourer → keyword rule handles body; name folds to C4? NO —
                          # kept from MVP; revisit: Spacetourer is arguably its own MPV nameplate
   2CV6: null             # trim of 2CV; classic tail


### PR DESCRIPTION
First swarm-researched collision batch: two Opus dossiers, session-verified (spot re-fetches), half the detector proposals refuted with sources, zero unnecessary id mints. 4W half: **80 → 68 groups**. Filed-not-applied follow-ups documented in the commit (Citroën D-series contradiction; MG existing-pin corrections). Build+gates+suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)