### PR TITLE
MG lane-A: shipped stop-split pins reversed — 6 groups → 0

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1686,10 +1686,9 @@
 "car/mercedes-benz/600sl": "car/mercedes-benz/600-sl"
 "car/mercedes-benz/609d": "car/mercedes-benz/609-d"
 "car/mercury/montclair": "car/mercury/mont-clair"
-"car/mg/bgt": "car/mg/b-g-t"
+"car/mg/bgt": "car/mg/b-gt"
 "car/mg/cgt": "car/mg/c-gt"
-"car/mg/mg-b": "car/mg/m-g-b"
-"car/mg/mgb": "car/mg/m-g-b"
+"car/mg/mg-b": "car/mg/mgb"
 "car/mg/mgbgt": "car/mg/mgb-gt"
 "car/mg/rx6": "car/mg/hs"
 "car/mg/s9": "car/mg/mgs9-phev"
@@ -2623,3 +2622,15 @@
 "car/citroen/id-19":             "car/citroen/id19"
 "van/citroen/hy78":              "van/citroen/hy-78"
 "car/alfa-romeo/gtv-6":          "car/alfa-romeo/gtv6"    # the closed-badge fold (gate-demanded; the dossier's group-6 merge pair)
+# 2026-07-26 — MG lane-A (swarm dossier): the shipped stop-split artifacts
+# reversed. car/mg/mgb RESURRECTS as the live id (its old alias deleted —
+# the tvr/c70/austin precedent, 5th instance); artifacts fold in.
+"car/mg/b-g-t":        "car/mg/b-gt"
+"car/mg/bgt-v8":       "car/mg/b-gt-v8"
+"car/mg/bgtv8":        "car/mg/b-gt-v8"
+"car/mg/m-g-a":        "car/mg/mga"
+"car/mg/m-g-b":        "car/mg/mgb"      # the reversal — the artifact id folds into the resurrected closed-token id
+"car/mg/midget-mk-3":  "car/mg/midget-mkiii"
+"car/mg/midget-mk3":   "car/mg/midget-mkiii"
+"car/mg/t-d-roadster": "car/mg/td-roadster"
+"car/mg/tf-1500":      "car/mg/tf1500"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1447,11 +1447,31 @@ MG:
   RX6: HS                                 # NOT a model name: KBA's internal type code for the MG HS/EHS. FZ 6.1 HSN 2180 Handelsname reads 'MG RX6;-HS;-EHS;-EHS PHEV' (https://dewiki.de/Lexikon/MG_HS)
   S6: MGS6 EV                             # official German name is the fused MGS6 EV (https://www.mgmotor.de/model/mgs6); KBA's make string "MG ROEWE" is SAIC's dual-brand label for HSN 2180 and there is no Roewe S6 — no Roewe is sold in Germany at all
   S9: MGS9 PHEV                           # same fused naming family, 7-seat SUV, DE launch 2026-04-18 (https://de.motor1.com/reviews/796581/mgs9-phev-2026-fahrbericht-siebensitzer/)
-  B GT: B G T                                 # spelling variant of "B G T" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Bgt: B G T                                  # spelling variant of "B G T" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  # ── lane-A corrections (swarm dossier 2026-07-26): "B G T"/"M G B" were
+  # STOP-SPLIT ARTIFACTS pinned as canonicals (raws "B.G.T"/"M.G.B"); MG
+  # writes GT fused on the MGB GT and MGB/MGA as closed tokens (en.wikipedia
+  # MG_MGB / MG_MGA; the block itself pinned Cgt: C GT one line up — the
+  # internal contradiction that exposed this). ──
+  "B G T": B GT                              # fold the artifact display back to the sourced form
+  "B.g.t": B GT                              # stop-form raw, uncased tail
+  "B. GT": B GT                              # leading stop survives as a token boundary
+  "B.gt": B GT                               # fused stop form
+  Bgt: B GT                                   # register shorthand for the MGB GT
+  "Bgt V8": B GT V8                          # MGB GT V8 (1973-76, Rover 3.5 V8 — en.wikipedia MGB_GT_V8); Bgt is shorthand, never a badge
+  BGTV8: B GT V8                              # fully fused register form
   Cgt: C GT                                   # spelling variant of "C GT" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  MG B: M G B                                 # spelling variant of "M G B" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Mgb: M G B                                  # spelling variant of "M G B" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  MG B: MGB                                   # MGB is one closed token (en.wikipedia MG_MGB); the old pin propagated the stop-split artifact
+  Mgb: MGB                                    # register shorthand, same closed token
+  "M G B": MGB                               # fold the shipped artifact display back
+  "M.g.b": MGB                               # stop-form raw
+  "M G A": MGA                               # same artifact class on the MGA (en.wikipedia MG_MGA); the styling pin MGA: MGA carries the casing — do NOT also key Mga (ordering hazard: the pin recases before renames run)
+  "M.g.a": MGA                               # stop-form raw
+  Midget Mk 3: Midget MkIII                   # MG registers EMIT Roman (Midget Mkii/Mkiii live in-catalog), so Roman is not a minted third form here — diverges from the Triumph Mk-arabic precedent DELIBERATELY, per its own conditional
+  Midget Mk3: Midget MkIII                    # arabic register variant folds
+  Midget MK3: Midget MkIII                    # all-caps register variant — the actual produced form (found by the liveness gate)
+  T D Roadster: TD Roadster                   # stop-split of the TD; canonical slugs to the existing td-roadster (casing fix + fi evidence gained)
+  T.d.roadster: TD Roadster                   # fused stop-form — the actual produced display (liveness gate find); the dot survives the caser as a token boundary
+  Tf 1500: TF1500                             # the factory designation is TF1500 fused (T-type source); the generator would have made the EXISTING value a key — the direction-war trap avoided
   Mgbgt: Mgb GT                               # spelling variant of "Mgb GT" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Tf: T F                                     # spelling variant of "T F" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   MG: null                                    # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.

--- a/overrides/styling.yml
+++ b/overrides/styling.yml
@@ -56,6 +56,8 @@ stylings:
   I6: i6                 # Irizar official casing; also the merge target of the Irizar "16" rename
   I8: i8                 # Irizar official casing; BMW i8 shares it
   "480 ES": 480 ES        # Volvo 480 ES — spaced official launch name (1986). Whole-string pin, deliberately NOT an ES acronym token: token ES orphaned Gas Gas "Es: ES 700" (gb/nz evidence lost, spotcheck caught it) and un-folded the entire Lexus ES family (liveness gate fired on 8 aliases) — measured 2026-07-25, GPR-precedent applies
+  MGA: MGA               # MG MGA (1955-62) — one closed token (en.wikipedia MG_MGA); whole-string pin, blast radius 1 (only car/mg/mga displays Mga catalog-wide, dossier-verified)
+  MGB: MGB               # same closed-token rule (en.wikipedia MG_MGB); blast radius 2 (car/mg + car/leyland MGBs, both genuine); does NOT touch the MotoGB make mgb — make casing lives in makes/aliases.yml
 
 # --- S2W two-wheeler pins (2026-07-25) ---
 XXX: XXX               # Talaria XXX — a REAL e-motorbike model, not a placeholder. Raw RDW pairs it explicitly: "TL2500, XXX" (https://talaria.bike/). Without this pin smart_case yields "Xxx", which reads as junk and invited a drop; the whole-string form has no other match catalog-wide.


### PR DESCRIPTION
The swarm dossier's strongest finding applied: the repo's own pinned canonicals `B G T`/`M G B` were stop-split artifacts. Closed-token corrections with styling pins, the mgb id resurrection (5th stale-alias precedent), and the deliberate Roman-numeral divergence per the Triumph rule's own conditional. 4W half: **68 → 62**. Build+gates+suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)