### PR TITLE
Drop motorcycle/zundapp/werke — a company name published as a nameplate

### DIFF
--- a/overrides/models/removals.yml
+++ b/overrides/models/removals.yml
@@ -615,3 +615,9 @@
 "car/volkswagen/volkswagen-vw": "null rename 2026-07-25: fi/nl model column literally reads VOLKSWAGEN-VW — the make written twice, zero model information. Not aliasable: no honest successor exists (aliasing it to any VW nameplate would fabricate evidence)."
 "truck/ford/v-8": "cross-kind prune 2026-07-25: the 1930s Ford V-8 rows are car-dominant and the truck-kind duplicate was displaced by the dominance rule; the evidence lives on car/ford/v-8. The old truck→truck alias (v-8→v8) dangled once V-8 became canonical and was deleted with the direction-war resolution."
 "moped/segway/n-a": "placeholder drop 2026-07-26 (G9): the register's N/A row published as a Segway model; the drop-pattern fix removes it and there is no successor to alias — no honest target exists for a placeholder."
+
+# ── CORPORATE NAME IN THE MODEL COLUMN (S2W, G23 sweep 2026-07-26) ──────────
+# Found by a swarm researcher, verified against the raws by this session, and
+# generalised into scripts/find_corporate_strings.rb — the same shape as
+# B-001's spyder-wheelz (operator name) and go-tulip-b-v (registrant name).
+"motorcycle/zundapp/werke": "not a vehicle: the raw register row is 'ZUENDAPP | ZUNDAPP WERKE', i.e. the manufacturer's own legal name (Zuendapp-Werke GmbH) recorded where a model belongs. strip_make_prefix removed the make and published the residue as a nameplate. No alias target is honest because no machine was ever named this; its presence implies at least one upstream record had an empty or malformed model field."

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -2351,6 +2351,7 @@ Zhenhua:
 
 Zundapp:
   Zundapp: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
+  Werke: null                                 # NOT A VEHICLE. Raw is "ZUENDAPP | ZUNDAPP WERKE" — the manufacturer's own legal name (Zuendapp-Werke GmbH) sitting in the model column; strip_make_prefix removed "ZUNDAPP" and published the residue "Werke" as a nameplate. DROPPED rather than renamed: there is no machine here to name. Gate entry in overrides/models/removals.yml; the class this produced is scripts/find_corporate_strings.rb.
 
 Zundapp Famel:
   Ks Super: KS Super                        # Famel KS Super, the Portuguese-built Zündapp-engined moped. KS is Zündapp's type prefix, never a word: https://zundapp.one/zundapp-models/9/zundapp-mebea-en-exoten/39/famel-ks-super


### PR DESCRIPTION
The raw register row is **`ZUENDAPP | ZUNDAPP WERKE`** — the manufacturer's own legal name (Zündapp-Werke GmbH) recorded where a model belongs. `strip_make_prefix` removed the make and published the residue **"Werke"** as a nameplate.

**Dropped rather than renamed or aliased**, because there is no machine here to name and no alias target would be honest. `removals.yml` carries the reviewed reason; the no-vanish gate is satisfied and the build stays at baseline (31 pre-existing local failures, unchanged).

## Why this one is worth a PR of its own

It is the **third instance of a class**, each needing a different disposition, and only the raw string said which:

| case | raw shape | disposition |
|---|---|---|
| `go-tulip-b-v` (B-001) | registrant's legal entity in the **make** column, marque in the model column | cross-make **move** → SELANA |
| `spyder-wheelz` (B-001) | rental operator's name in the **model** column | **debt** — no nameplate recoverable |
| `zundapp/werke` (here) | maker's own legal name in the **model** column | **removal** — not a vehicle |

That is what prompted the detector in data#59. Found by a swarm researcher, **verified against the raws by this session before acting** — the published name said where to look, the register said what to do.

One thing worth remembering: its existence implies at least one upstream record had an empty or malformed model field. If the class recurs, that is where to look.