### PR TITLE
Swarm-dossier batch: toyota/nissan/mitsubishi — 9 groups → 0 (62 → 53)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2634,3 +2634,18 @@
 "car/mg/midget-mk3":   "car/mg/midget-mkiii"
 "car/mg/t-d-roadster": "car/mg/td-roadster"
 "car/mg/tf-1500":      "car/mg/tf1500"
+# ---------------------------------------------------------------------------
+# 2026-07-26 — swarm-dossier batch: toyota/nissan/mitsubishi (9 groups → 0;
+# the detector canonical refuted in 8 of 9 — it fought settled curation).
+# Union merges verified per pair in the dossier availability table.
+"car/toyota/landcruiser-v8": "car/toyota/land-cruiser-v8"
+"van/toyota/landcruiser-v8": "van/toyota/land-cruiser-v8"
+"car/toyota/mr-2":           "car/toyota/mr2"
+"car/toyota/rav-4":          "car/toyota/rav4"
+"van/toyota/hi-ace":         "van/toyota/hiace"
+"van/toyota/hi-lux":         "van/toyota/hilux"
+"car/nissan/180-sx":         "car/nissan/180sx"
+"car/nissan/200-sx":         "car/nissan/200sx"
+"car/nissan/leaf-30-kwh":    "car/nissan/leaf"
+"car/nissan/leaf-30kwh":     "car/nissan/leaf"
+"car/mitsubishi/galant-vr4": "car/mitsubishi/galant-vr-4"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1482,6 +1482,12 @@ Microcar:
   Mgo:                       M.Go                 # Microcar writes M.GO with the period; title form M.Go
 
 Mitsubishi:
+  # ── swarm-dossier batch: VR-4 is a hyphenated suffix badge (Viscous
+  # Realtime 4WD — en.wikipedia Galant VR-4), the Celica GT-4 class, NOT the
+  # fusing letter-prefix class (L200/L300). ──
+  Galant Vr-4: Galant VR-4          # casing-only, slug unchanged
+  Galant VR4: Galant VR-4           # the hyphen is part of the badge in both carrying generations (E30/E39A, E50-E80)
+  "Galant VR.4": Galant VR-4        # third observed display form — flap insurance
   "3000GT": "3000 GT"                         # spelling variant of "3000 GT" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Mitsubishi: null                            # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   L 300: L300                                 # spelling variant of "L300" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -1524,6 +1530,15 @@ Nio:
   ES8: EL8                                # NIO renamed ES6→EL6 and ES8→EL8 for Europe; the German lineup is ET5 / ET5 Touring / EL6 / EL8 (https://www.chinaelektro.de/nio/). The catalog already carries EL6, so this keeps the family consistent.
 
 Nissan:
+  # ── swarm-dossier batch: Silvia-derived export badges FUSE (en.wikipedia
+  # 180SX/Silvia; corpus corroboration 6 registers vs 2); battery-capacity
+  # suffixes dissolve per the in-block Leaf 40KWH precedent. LANE-A FLAGGED,
+  # NOT touched: the shipped "350Z"/"370Z" spaced pins are the detector
+  # space-inserter output and contradict Nissan — own pass needed. ──
+  "180 Sx": "180SX"                 # fused across the family (en.wikipedia Nissan_180SX: "Japan: 180SX, Europe: 200SX"); catalog corroboration my_jpj+nl+nz on the fused id (NAMING.md §2)
+  "200 Sx": "200SX"                 # fused across S110/S12/S14/S15 (en.wikipedia Nissan_Silvia); six registers on the fused id vs two spaced
+  Leaf 30 Kwh: Leaf                 # battery pack is a per-trim option, never a nameplate (en.wikipedia Leaf first gen); the in-block Leaf 40KWH: Leaf precedent
+  Leaf 30KWH: Leaf                  # same fold, fused registry shape
   Leaf 40KWH: Leaf       # battery-size registrations
   Leaf 62KWH: Leaf                          # battery-capacity suffix (62 kWh pack), not a nameplate — cf. the Ebro "S400 HEV" powertrain-badge fold
   QASHQAI+2: Qashqai     # 7-seat variant
@@ -1914,6 +1929,16 @@ Tol:
   "TOL1500":                   "1500"                 # embedded make prefix — strip_make_prefix needs [\s,]+ after the prefix, so a hyphenated or fused badge survives (the IVA pilot's diagnosis)
 
 Toyota:
+  # ── swarm-dossier batch (2026-07-26): the detector canonical was wrong in
+  # 8 of 9 groups here — it fought SETTLED in-repo decisions (Mr 2: MR2,
+  # Hi Ace: Hiace, Landcruiser: Land Cruiser). Fused acronym badges are the
+  # Toyota/Nissan convention; sources per line. ──
+  Landcruiser V8: Land Cruiser V8   # two words per Toyota (toyota.nl land-cruiser); V8 stays — NL/BE sold Prado and V8 as SIDE-BY-SIDE nameplates (nl.wikipedia Land Cruiser), not a collapsible engine spec
+  Mr-2: MR2                         # fused all-caps (en.wikipedia Toyota_MR2); joins the existing Mr 2: MR2 — the hyphen is an nl_rdw/nz_nzta habit; the only truly hyphenated family member is the JDM MR-S, already curated
+  Rav 4: RAV4                       # no space in the official name (toyota.nl rav4; en.wikipedia: Recreational Activity Vehicle, 4WD); fused acronyms settled for this make
+  Rav-4: RAV4                       # second observed display form (observed_model_names.json) — flap insurance
+  Hi-Ace: Hiace                     # one word per Toyota (en.wikipedia HiAce finds no Toyota use of Hi-Ace); joins the existing "Hi Ace": Hiace; the hyphen is an RDW/Traficom habit across the derivative family
+  Hi-Lux: Hilux                     # Toyota UK live page "All-New Hilux"; the fi/nl rows share the registry habit, not era-accurate 1968 badges; joins "Hi Lux": Hilux
   Prius Plus: Prius      # Prius+ (7-seat) folded per nameplate-granularity policy
   Prius Plug-In: Prius                      # plug-in variant (Prius Plug-in Hybrid / Prime) folds into the nameplate per the trim policy
   BZ4: bZ4X                               # KBA truncation (it strips the marque token and trailing suffixes); official name is bZ4X, lowercase b (https://www.toyota.de/neuwagen/bz4x). Present as "BZ4" since at least the 2023 FZ10 workbook, i.e. never a real nameplate. The bZ rename is North-America-only.


### PR DESCRIPTION
## What

Applies the jp3 swarm dossier (Toyota/Nissan/Mitsubishi): **9 collision groups → 0** (4W collisions 62 → 53). 13 rename keys + 11 `former_ids` transitions.

**The detector's canonical was wrong in 8 of 9 groups** — it fought settled in-repo curation (`Mr 2: MR2`, `Hi Ace: Hiace`, `Landcruiser: Land Cruiser` all pre-existed; the detector re-proposed the split/fused forms it was built to kill). Every decision below is source-backed per line in `renames.yml`.

## Verification (researcher ≠ verifier)

- All 11 merge pairs' availability unions recomputed independently against the catalog before applying.
- **Control-build proof**: a build at pristine `origin/main` and the jp3 build were diffed catalog-to-catalog. The jp3 delta is EXACTLY: 10 retiring ids GONE (each with an alias below), 1 BORN (`van/toyota/land-cruiser-v8`, the dossier's pure re-slug), 1 NAME fix (`Galant Vr-4` → `Galant VR-4`), 3 strict availability gains (`180sx`+fi, `200sx`+ua, `rav4`+de). Nothing else moves.
- Curation lint, reorg --check, and the full pipeline suite are green.

## Known context: pre-existing drift failures (NOT this PR)

Fresh full builds currently show **31 gate failures on pristine origin/main** — upstream rotation (ar_dnrpa rolled to its 202606 monthly CSV, ua_mvs registry zip changed, uk_dft published a new quarterly file, nl_rdw/nz_nzta live updates). Zero of the failing ids are in this PR's makes; the failure sets with and without this branch are byte-identical. Tracked as the drift-adoption workstream (snapshot accumulation per the lu_snca precedent; whatever still vanishes gets `removals.yml` manifest entries at release prep). One dossier-time fact moved underneath us meanwhile: `rav-4` carried `ar` evidence at the dossier's 01:01 snapshot; the 202606 rotation dropped it, so the union lands without `ar` — accumulation will restore it onto the surviving `rav4` id via the `Rav-4` key.

## Filed, deliberately not touched

- **Nissan 350Z/370Z lane-A**: the *shipped* keys `"350Z": "350 Z"` / `"370Z": "370 Z"` are detector space-inserting artifacts and contradict Nissan — needs its own reviewed pass, not a drive-by reversal.
- **Land Cruiser V8 granularity**: whether the V8 nameplate folds into Land Cruiser is a granularity-lane decision (NL/BE sold them as side-by-side nameplates — kept separate here).

<details>
<summary>Full research dossier (verbatim, for future agents)</summary>

# Marque-convention dossier — Toyota / Nissan / Mitsubishi (JP3)

Research only. Nothing in the repo was edited. 9 collision groups total
(toyota 5, nissan 3, mitsubishi 1). **8 proposed, 1 deferred as UNCERTAIN.**

Headline: **the detector's proposed canonical is wrong in 8 of 9 groups.** Its
canonicaliser inserts a space between a digit run and a letter run
(`RAV4`→`RAV 4`, `180SX`→`180 SX`, `MR2`→`MR-2`, `Land Cruiser V8`→`Land
Cruiser V 8`, `Leaf 30KWH`→`Leaf 30 KWH`) and prefers the hyphenated member of a
pair (`Hiace`→`Hi-Ace`). Only **Mitsubishi `Galant VR-4`** survives review
unchanged. Two of the "NEW id" classifications are also wrong: `RAV4` and
`Land Cruiser V8` already exist as produced display forms, so those are SAFE
pure merges, not id mints.

---

## 1. CONVENTION DOSSIER

### TOYOTA

**Family: acronym nameplates (RAV4, MR2, GT86, GR86, bZ4X)** — *fused, no space,
acronym in caps.* Toyota writes `RAV4` with no space in first-party European
marketing (page title "Toyota RAV4 (2026) – Plug-in hybride SUV | Toyota.nl";
every heading on the page); en.wikipedia gives the expansion "Recreational
Activity Vehicle with 4-wheel drive". `MR2` likewise fused (en.wikipedia Toyota
MR2, used throughout; the only hyphenated member of the family is the *third*
generation's Japanese name `MR-S`, which the repo already carries correctly as
`Mrs: Mr-S`). This family is **already settled in-repo**: `Gr 86: GR86`,
`GT 86: GT86`, `Mr 2: MR2` — the "short letter prefix glued to digits IS the
nameplate" rule. Nothing here is new; the detector is fighting existing curation.

**Family: "Hi-" compound commercial names (Hiace, Hilux, Lite Ace, Fun Cargo)** —
*one word, no hyphen, no internal capital.* Toyota UK's live page is titled
"All-New Hilux | Diesel or Electric Pick-Up | Toyota UK" with heading "All-new
Hilux". en.wikipedia records the styling as `HiLux`, "historically as `Hi-Lux`",
and for the van `HiAce` — **and explicitly no evidence Toyota ever officially
used `Hi-Ace`**. The repo already resolved this family to the flat one-word form
(`"Hi Ace": Hiace`, `"Hi Lux": Hilux`, `Liteace: Lite Ace`, `Funcargo: Fun
Cargo`) citing toyota-europe.com. The hyphen in the catalog is a **registry
habit, not a badge**: RDW/Traficom emit `Hi-Ace`/`Hi Lux` across a whole family
of derivative strings — `Hi-Ace Comm. Lang Diesel`, `Hi-Ace RH11L-JRW3`,
`Hi-Lux P.U.2.4D`, `Hi-Lux Pick Up`, `Hi Lux Shasta Kampeerauto` — while the
*same registries* also emit `Hiace 2.4D Lang Dubb Cab`. A 1968-72-era `Hi-Lux`
reading is refuted by that spread: the hyphen tracks the register, not the year.
*Note for the maintainer:* the camelCase question (`Hiace`/`HiAce`,
`Hilux`/`HiLux`) is live per en.wikipedia but is **lane-A** — the repo's
canonical is flat and I do not touch it here.

**Family: Land Cruiser** — *two words; the V8 suffix is a market nameplate, not a
spec.* Toyota Netherlands titles its page "Toyota Land Cruiser (2026) –
Iconische 4x4 | Toyota.nl" (two words; only URLs/asset filenames fuse it). The
repo already has `Landcruiser: Land Cruiser`. Crucially, nl.wikipedia records
that the J200 was a *separate marketed nameplate* in exactly the two countries
that produced these records: "In Nederland en België werden sinds 2001 enkel de
luxueuze SUV's **Land Cruiser Prado** en **Land Cruiser V8** verkocht." So `V8`
distinguishes the J200 from the J150 Prado sold beside it — it is not the
collapsible engine spec that NAMING.md §6 has in mind. `Land Cruiser V8` stays a
nameplate.
*Hazard checked and cleared:* the series-code ids (`land-cruiser-fj40`,
`landcruiser-hj-60`, `land-cruiser-hj`, `hzj-78`, `hzj-79`, `landcruiser-bj40-
hardtop`) are **not** in any collision group and are untouched by this dossier.
en.wikipedia also notes "sometimes spelt as LandCruiser" (Toyota Australia's
styling) — noted, not proposed; that too is lane-A against `Landcruiser: Land
Cruiser`.

### NISSAN

**Family: Silvia-derived export badges (180SX / 200SX / 240SX)** — *fused.*
en.wikipedia Nissan 180SX: fused in every market — "Japan: 180SX, Europe: 200SX,
North America: 240SX" — and notes the name derives from the 1.8 L CA18DET, i.e.
displacement and body letters are one token by construction. en.wikipedia Nissan
Silvia gives "Datsun 200SX" (S110), "badged as a 'Nissan 200SX'" (S12), and the
S14/S15 export names, all fused, across every generation.
**Catalog corroboration agrees and is decisive** (NAMING.md §2 — registration
evidence outranks encyclopedias, per the Alfa `GTV6` precedent): the fused form
is the majority registry spelling, produced *independently* by six registers.
`nissan/200sx` = ca,fi,lu,nl,nz,us (ca_nrcan, fi_traficom, lu_snca, nl_rdw,
nz_nzta, us_fueleconomy); `nissan/180sx` = my,nl,nz (my_jpj, nl_rdw, nz_nzta).
The spaced `200 Sx`/`180 Sx` comes only from fi_traficom + nl_rdw.
In-repo Nissan precedent also fuses letter+digit badges: `Z 33: Z33`,
`D 22: D22`, `Np 300: NP300`, `Nv 200: NV200`, `Nv 400: NV400`.

> **LANE-A FLAG (not proposed here).** The Nissan block currently canonicalises
> the *other* digit+letter family the opposite way: `"350Z": "350 Z"` and
> `"370Z": "370 Z"`. Nissan writes these fused — en.wikipedia Nissan 350Z opens
> "The **Nissan 350Z** (known as Nissan Fairlady Z (Z33) in Japan)". Both
> existing lines carry the *auto-generated* collision comment ("spelling variant
> of … different spacing/casing"), i.e. they are this same detector's
> space-inserting output that got merged, not a researched decision. I am
> **not** reversing them (that is a lane-A item and needs its own pass), and I
> am deliberately **not** following them for 180SX/200SX: different family,
> separate sourcing, and the corpus points the other way. The Nissan block will
> be internally inconsistent until 350Z/370Z is revisited. Stating that plainly
> rather than propagating the error.

**Family: Leaf battery-capacity suffixes** — *fold into the nameplate.*
This is not a spelling question; NAMING.md §6 decides it by name: "if they
differ by a number that is a **battery size or power figure**, fold (`Leaf
40KWH` → `Leaf` is the car-kind precedent)". The Nissan block already carries
`Leaf 40KWH: Leaf` and `Leaf 62KWH: Leaf`. `30 kWh` is the same class of token:
en.wikipedia (first-generation Leaf) — "The SL and SV trims are equipped with a
30 kWh battery, while the S trim originally retained the smaller 24 kWh
battery"; "during the 2016 model year, Nissan transitioned the base Leaf S model
from a 24 kWh to a 30 kWh battery" — a pack option spread across trims, never a
model designation. The main en.wikipedia Nissan Leaf article names no "Leaf
30 kWh" nameplate at all. So the whole group folds to `Leaf`, and the detector's
`Leaf 30 KWH` canonical would mint a nameplate that does not exist.

### MITSUBISHI

**Family: VR-4 performance badge** — *hyphenated.* en.wikipedia Mitsubishi
Galant VR-4 opens "The **Mitsubishi Galant VR-4 (Viscous Realtime 4WD)** was the
range-topping version of Mitsubishi Motors' Galant model" — VR-4 is an
initialism-plus-driveline-count, hyphenated, carried by the E39A (sixth
generation, 1987-1992). en.wikipedia Mitsubishi Galant uses "VR-4" consistently
across the sixth (E30) and seventh (E50/60/70/80) generations and shows no
unhyphenated `VR4`.
*Does the make's fused-badge rule apply?* No. Mitsubishi's in-repo fusion
entries (`L 300: L300`, `L 200: L200`) are **letter-prefix + digits** commercial
codes. `VR-4` is a *suffix* badge on a named nameplate, structurally the same as
the repo's `Celica GT-4`, `C-HR`, `GT-R`, `MGX-21` — the hyphenated class. The
one Mitsubishi group is the single case where the detector's proposal is
already correct.

---

## 2. PER GROUP — paste-ready

Keys are the **produced display forms** from the groups file, plus flap
insurance restricted to forms actually observed in
`build/observed_model_names.json` (the Alfa `Gtv-6` convention). Every key was
checked against the make's existing block: **no proposed key is an existing key,
and no proposed value is an existing key** — the direction-war lint is clean.
No existing entry is reversed by anything in section 2.

### Toyota — block additions

```yaml
  Landcruiser V8: Land Cruiser V8   # Toyota writes Land Cruiser as two words (page title "Toyota Land Cruiser (2026) … | Toyota.nl", https://www.toyota.nl/modellen/land-cruiser); joins the existing `Landcruiser: Land Cruiser` fold. V8 stays: NL/BE sold "Land Cruiser Prado" and "Land Cruiser V8" as two nameplates side by side (https://nl.wikipedia.org/wiki/Toyota_Land_Cruiser), so it is not a collapsible engine spec
  Mr-2: MR2                         # MR2 is fused and all-caps (https://en.wikipedia.org/wiki/Toyota_MR2); same target as the existing `Mr 2: MR2` line — the hyphen is an nl_rdw/nz_nzta habit, and the only genuinely hyphenated family member is the JDM MR-S, already curated as `Mrs: Mr-S`
  Rav 4: RAV4                       # official spelling has no space — "Toyota RAV4 (2026)…" on Toyota's own NL site (https://www.toyota.nl/modellen/rav4), and https://en.wikipedia.org/wiki/Toyota_RAV4 ("Recreational Activity Vehicle with 4-wheel drive"); fused acronyms are settled for this make (GT86/GR86/MR2)
  Rav-4: RAV4                       # second observed display form of toyota/rav-4 (observed_model_names.json) — flap insurance
  Hi-Ace: Hiace                     # Toyota writes the model as one word; https://en.wikipedia.org/wiki/Toyota_HiAce finds no evidence Toyota ever used "Hi-Ace". Same target as the existing `"Hi Ace": Hiace`; the hyphen is an RDW/Traficom habit visible across the whole derivative family ("Hi-Ace Comm. Lang Diesel", "Hi-Ace RH11L-JRW3") while the same registers also emit "Hiace 2.4D Lang Dubb Cab"
  Hi-Lux: Hilux                     # Toyota UK's live page is "All-New Hilux | … | Toyota UK" (https://www.toyota.co.uk/new-cars/hilux). "Hi-Lux" is the historic 1968-era styling (https://en.wikipedia.org/wiki/Toyota_Hilux), but these are fi/nl registry rows sharing the "Hi-Lux P.U.2.4D" / "Hi Lux Shasta Kampeerauto" habit, not era-accurate badges. Same target as the existing `"Hi Lux": Hilux`
```

id merges:

| old id | surviving id | availability |
|---|---|---|
| `car/toyota/landcruiser-v8` (fi,nl) | `car/toyota/land-cruiser-v8` (fi,nl) | equal — no gain, no loss ✓ |
| `van/toyota/landcruiser-v8` (fi,nl) | `van/toyota/land-cruiser-v8` (fi,nl) | **new id in the van kind** (no `van/toyota/land-cruiser-v8` today); same country set, pure re-slug ✓ |
| `car/toyota/mr-2` (nl,nz) | `car/toyota/mr2` (es,fi,gb,lu,my,nl,nz,ua,us) | strict superset ✓ |
| `car/toyota/rav-4` (ar,de,es,fi,lu,nl,ua) | `car/toyota/rav4` (ca,es,fi,gb,ie,lu,my,nl,nz,ua,us) | **NOT a superset** — survivor lacks `ar`,`de`. Merge is a union, so post-merge `rav4` = ar,ca,de,es,fi,gb,ie,lu,my,nl,nz,ua,us and gains region `sa`. No loss, but the survivor grows — worth an eyeball on the regions field ✓ |
| `van/toyota/hi-ace` (fi,nl) | `van/toyota/hiace` (es,fi,gb,lu,nl,th) | strict superset ✓ |
| `van/toyota/hi-lux` (fi,nl) | `van/toyota/hilux` (es,fi,gb,lu,nl) | strict superset ✓ |

Detector classification corrections: `Land Cruiser V8` and `RAV4` are **SAFE**
(the canonical already exists as a produced form), not NEW. Only `MR2` was
already classed correctly-ish, and its canonical was wrong.

### Nissan — block additions

```yaml
  "180 Sx": "180SX"                 # Nissan fuses the Silvia-derived export badges — "Japan: 180SX, Europe: 200SX, North America: 240SX" (https://en.wikipedia.org/wiki/Nissan_180SX); the name is built from the 1.8 L CA18DET so digits and body letters are one token. Catalog corroboration (NAMING.md §2): the fused id carries my_jpj+nl_rdw+nz_nzta, the spaced one only fi_traficom+nl_rdw
  "200 Sx": "200SX"                 # same family, fused across every generation — "Datsun 200SX" (S110), "badged as a 'Nissan 200SX'" (S12), S14/S15 export names (https://en.wikipedia.org/wiki/Nissan_Silvia). Corroborated by six independent registers on the fused id (ca,fi,lu,nl,nz,us) against two on the spaced one
  Leaf 30 Kwh: Leaf                 # battery-capacity suffix, not a nameplate — NAMING.md §6 names `Leaf 40KWH` → `Leaf` as the car-kind precedent, and the 30 kWh pack was a per-trim option ("The SL and SV trims are equipped with a 30 kWh battery, while the S trim originally retained the smaller 24 kWh battery", https://en.wikipedia.org/wiki/Nissan_Leaf_(first_generation))
  Leaf 30KWH: Leaf                  # same fold, fused registry shape — joins the existing `Leaf 40KWH: Leaf` / `Leaf 62KWH: Leaf` lines
```

id merges:

| old id | surviving id | availability |
|---|---|---|
| `car/nissan/180-sx` (fi,nl) | `car/nissan/180sx` (my,nl,nz) | **NOT a superset** — survivor lacks `fi`. Union post-merge = fi,my,nl,nz; no loss, survivor gains `fi` ✓ |
| `car/nissan/200-sx` (fi,nl,nz,ua) | `car/nissan/200sx` (ca,fi,lu,nl,nz,us) | **NOT a superset** — survivor lacks `ua`. Union = ca,fi,lu,nl,nz,ua,us; no loss ✓ |
| `car/nissan/leaf-30-kwh` (es,fi) | `car/nissan/leaf` (ca,de,es,fi,gb,ie,lu,my,nl,nz,th,ua,us) | strict superset ✓ |
| `car/nissan/leaf-30kwh` (fi,lu,nl) | `car/nissan/leaf` (as above) | strict superset ✓ |

The Leaf group **dissolves entirely** — it is a fold into an existing nameplate,
not a two-way merge, so no `Leaf 30 …` id survives in any form.

### Mitsubishi — block additions

```yaml
  Galant Vr-4: Galant VR-4          # VR-4 = "Viscous Realtime 4WD", hyphenated and all-caps (https://en.wikipedia.org/wiki/Mitsubishi_Galant_VR-4); casing-only fix, the slug is unchanged
  Galant VR4: Galant VR-4           # the hyphen is part of the badge across both generations that carried it, E30/E39A and E50-E80 (https://en.wikipedia.org/wiki/Mitsubishi_Galant) — this is a suffix badge like Celica GT-4 / GT-R, not the letter-prefix+digits class that fuses (L200/L300)
  "Galant VR.4": Galant VR-4        # third observed display form of mitsubishi/galant-vr-4 (observed_model_names.json) — flap insurance
```

id merges:

| old id | surviving id | availability |
|---|---|---|
| `car/mitsubishi/galant-vr4` (fi,nl) | `car/mitsubishi/galant-vr-4` (fi,nl) | equal — no gain, no loss ✓ |

The surviving slug `galant-vr-4` already exists; only its `name` changes
`"Galant Vr-4"` → `"Galant VR-4"`. Despite the detector's NEW label this mints
no id.

---

## 3. UNCERTAIN — skipped

**Toyota, group `Land Cruiser V8` — the *scope* question, not the spelling.**
The spelling call (`Landcruiser V8` → `Land Cruiser V8`) is confident and is
proposed above. What I am **not** confident about is whether `Land Cruiser V8`
should exist as a nameplate at all, or fold into `Land Cruiser` the way
`Leaf 40KWH` folds into `Leaf`. Both readings are defensible:
- *Keep* (what I propose): nl.wikipedia has NL/BE selling "Land Cruiser Prado"
  and "Land Cruiser V8" as two distinct model lines from 2001, and the two
  records here are exactly fi + nl. Two cars, two nameplates.
- *Fold*: NAMING.md §6 says the car kind collapses engine size as a spec, and a
  cylinder count is squarely a spec. `car/toyota/land-cruiser` already covers fi
  and nl, so the fold would lose no availability.

That is a granularity-policy decision above a spelling dossier's pay grade and
it interacts with the untouched series-code ids. **Apply the spelling merge;
route the fold question to the granularity lane separately.** I did not fetch a
Toyota-first-party European price list confirming "Land Cruiser V8" as a
catalogue name — the 75-years lineage page 404s and global.toyota 403s — so the
nameplate claim rests on nl.wikipedia alone.

Nothing else is uncertain: the other eight groups each have a first-party or
encyclopedic source plus in-repo precedent pointing the same way.

**Explicitly out of scope but flagged for lane A** (do not fold into this
change): `"350Z": "350 Z"` / `"370Z": "370 Z"` should almost certainly be
reversed to fused; `Hiace`/`Hilux` vs Toyota's `HiAce`/`HiLux` styling;
`Landcruiser: Land Cruiser` vs Toyota Australia's `LandCruiser`.

---

## 4. SOURCES FETCHED

- https://en.wikipedia.org/wiki/Toyota_MR2 — official spelling `MR2` fused; JDM third gen is `MR-S`; French markets dropped the 2.
- https://en.wikipedia.org/wiki/Toyota_RAV4 — `RAV4`, no space; "Recreational Activity Vehicle with 4-wheel drive".
- https://www.toyota.nl/modellen/rav4 — Toyota first-party NL: title "Toyota RAV4 (2026) – Plug-in hybride SUV | Toyota.nl"; `RAV4` in every heading.
- https://en.wikipedia.org/wiki/Toyota_HiAce — styled `HiAce`; **no evidence Toyota ever used `Hi-Ace`**.
- https://en.wikipedia.org/wiki/Toyota_Hilux — "stylised as HiLux and historically as Hi-Lux".
- https://www.toyota.co.uk/new-cars/hilux — Toyota first-party UK: "All-New Hilux | Diesel or Electric Pick-Up | Toyota UK"; `Hilux` throughout.
- https://www.toyota.nl/modellen/land-cruiser — Toyota first-party NL: "Toyota Land Cruiser (2026) – Iconische 4x4 | Toyota.nl"; two words in marketing, fused only in URLs/filenames.
- https://nl.wikipedia.org/wiki/Toyota_Land_Cruiser — "In Nederland en België werden sinds 2001 enkel de luxueuze SUV's Land Cruiser Prado en Land Cruiser V8 verkocht"; V8 dropped from West-Europe after 2010.
- https://en.wikipedia.org/wiki/Toyota_Land_Cruiser_(J200) — no European marketing name found; did **not** corroborate "Land Cruiser V8" (negative result, recorded).
- https://en.wikipedia.org/wiki/Toyota_Land_Cruiser — notes "sometimes spelt as LandCruiser"; no J200 V8 marketing string (negative result).
- https://en.wikipedia.org/wiki/Nissan_180SX — `180SX` fused; "Japan: 180SX, Europe: 200SX, North America: 240SX"; name from the 1.8 L CA18DET.
- https://en.wikipedia.org/wiki/Nissan_Silvia — `200SX`/`240SX`/`180SX` fused across S10, S110, S12, S14, S15.
- https://en.wikipedia.org/wiki/Nissan_350Z — opens "The Nissan 350Z (known as Nissan Fairlady Z (Z33) in Japan)"; fused. Basis for the lane-A flag only.
- https://en.wikipedia.org/wiki/Nissan_Leaf — no "Leaf 30 kWh" nameplate; capacities are pack options/trims, `e+`/`Plus` is the only badge.
- https://en.wikipedia.org/wiki/Nissan_Leaf_(first_generation) — "The SL and SV trims are equipped with a 30 kWh battery, while the S trim originally retained the smaller 24 kWh battery"; 30 kWh is an option, not a name.
- https://en.wikipedia.org/wiki/Mitsubishi_Galant_VR-4 — "The Mitsubishi Galant VR-4 (Viscous Realtime 4WD)…"; hyphenated; E39A.
- https://en.wikipedia.org/wiki/Mitsubishi_Galant — `VR-4` consistently, sixth (E30) and seventh (E50/60/70/80) generations; no `VR4`.
- FAILED (recorded so nobody re-tries): https://www.toyota-global.com/company/history_of_toyota/75years/vehicle_lineage/land_cruiser/ → 404; https://global.toyota/en/company/trajectory-of-toyota/decisions/ → 403; https://www.toyota.com.au/hiace → 403; https://www.toyota.co.za/model/hiace → 404; https://en.wikipedia.org/wiki/Nissan_Leaf_(ZE0) → 404; https://www.toyota.co.uk/new-cars/rav4 → socket hang up.

**Repo evidence consulted (read-only):**
`/Users/javi/GitHub/.vdb-worktrees/s4w-data/overrides/models/renames.yml`
(Toyota block L1916-1935, Nissan L1526-1541, Mitsubishi L1484-1488);
`/Users/javi/GitHub/.vdb-worktrees/s4w-data/NAMING.md` §2 (corroboration) and §6
(granularity — the `Leaf 40KWH` → `Leaf` rule is quoted there by name);
`/Users/javi/GitHub/.vdb-worktrees/s4w-pipeline/build/observed_model_names.json`;
`/Users/javi/GitHub/.vdb-worktrees/s4w-data/catalog/{car,van,bus,truck}/models.json`
(availability sets; identical to the pipeline's `build/out/catalog`, verified).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
