### PR TITLE
Swarm-dossier batch: ferrari + maserati — 8 groups → 0 (fold-key leak class)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2649,3 +2649,15 @@
 "car/nissan/leaf-30-kwh":    "car/nissan/leaf"
 "car/nissan/leaf-30kwh":     "car/nissan/leaf"
 "car/mitsubishi/galant-vr4": "car/mitsubishi/galant-vr-4"
+# ---------------------------------------------------------------------------
+# 2026-07-26 — swarm-dossier batch: ferrari + maserati (8 groups → 0; the
+# detector leaked its letter/digit fold key into 4 of 8 canonicals).
+# Unions verified per pair against the catalog AND the dossier table.
+"car/ferrari/308gtb":               "car/ferrari/308-gtb"
+"car/ferrari/308gtsi":              "car/ferrari/308-gtsi"
+"car/ferrari/348ts":                "car/ferrari/348-ts"
+"car/ferrari/gtc4-lusso":           "car/ferrari/gtc4lusso"
+"car/ferrari/gtc4-lusso-t":         "car/ferrari/gtc4lusso-t"
+"car/maserati/ghibli-sq4":          "car/maserati/ghibli-s-q4"
+"car/maserati/granturismo-folgore": "car/maserati/gran-turismo-folgore"
+"car/maserati/quattroporte-sq4":    "car/maserati/quattroporte-s-q4"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -421,6 +421,21 @@ Evt:
   "Evt-4000E":                 4000E                # embedded make prefix — strip_make_prefix needs [\s,]+ after the prefix, so a hyphenated or fused badge survives (the IVA pilot's diagnosis)
 
 Ferrari:
+  # ── swarm-dossier batch (2026-07-26): 4 of 8 detector canonicals were the
+  # FOLD KEY leaked into the display string ("GTC 4 Lusso", "Ghibli S Q 4" —
+  # attested nowhere). GTC4 and Q4 are closed tokens. No styling.yml acronym
+  # for TS: blocked by Subaru BRZ tS (officially lowercase t) — the 480-ES
+  # class again; whole batch stays make-scoped here. ──
+  "308 Gtb": "308 GTB"          # GTB = Gran Turismo Berlinetta, caps initialism — https://en.wikipedia.org/wiki/Ferrari_308_GTB/GTS
+  "308GTB": "308 GTB"           # register-fused spelling of the same car; folds ferrari/308gtb in — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
+  "308 Gtsi": "308 GTSi"        # caps initialism + LOWERCASE i for iniezione, as Ferrari badged it (house precedent: Citroen GTi, 405 SRi, styling 2.5i) — https://en.wikipedia.org/wiki/Ferrari_308_GTB/GTS
+  "308GTSI": "308 GTSi"         # register-fused and over-capitalised — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
+  "348 Ts": "348 TS"            # ts = Trasversale Spider (transverse gearbox); marque list + all four registers use caps, slug identical either way — https://en.wikipedia.org/wiki/Ferrari_348
+  "348TS": "348 TS"             # register-fused; folds ferrari/348ts into 348-ts, the id carrying the Argentine evidence — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
+  "GTC4 Lusso": GTC4Lusso       # one closed word per Ferrari (press text: "GTC4Lusso's two rear seats…"; ferrari.com slug /auto/gtc4lusso) — https://en.wikipedia.org/wiki/Ferrari_GTC4Lusso
+  "GTC4LUSSO": GTC4Lusso        # register all-caps; folds gtc4-lusso + gtc4lusso onto one id (biggest evidence consolidation in the batch: 4 regions) — https://it.wikipedia.org/wiki/Ferrari_GTC4Lusso
+  "GTC4 Lusso T": GTC4Lusso T   # the rear-drive V8; T is a separate suffix token, GTC4Lusso stays closed — applied WITH the base car so the family cannot disagree — https://en.wikipedia.org/wiki/Ferrari_GTC4Lusso
+  "GTC4LUSSO T": GTC4Lusso T    # register all-caps of the same — https://it.wikipedia.org/wiki/Ferrari_GTC4Lusso
   "400I": "400 I"                             # spelling variant of "400 I" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "575M Maranello": "575 M Maranello"         # spelling variant of "575 M Maranello" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   F430 Spider: F 430 Spider                   # spelling variant of "F 430 Spider" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1099,6 +1114,11 @@ MAN:
   Man: null                                   # registry rows where the make was written into the model column (truck kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Maserati:
+  # ── swarm-dossier batch: Q4 = Maserati's AWD system, one token; S is the
+  # engine trim. "S Q 4" is the fold key leaking, attested nowhere. ──
+  "Ghibli SQ4": "Ghibli S Q4"                   # register glued the trim tokens; pure merge onto the correctly-spelled id — https://en.wikipedia.org/wiki/Maserati_Ghibli_(M157)
+  "Granturismo Folgore": "Gran Turismo Folgore" # follows the block's committed Granturismo -> Gran Turismo direction; Folgore is the range-wide EV suffix; rescues th/us evidence from the duplicate — https://en.wikipedia.org/wiki/Maserati_GranTurismo
+  "Quattroporte SQ4": "Quattroporte S Q4"       # same S + Q4 split as the Ghibli; M156 spec table lists "Quattroporte S Q4" — https://en.wikipedia.org/wiki/Maserati_Quattroporte
   "3200GT": "3200 GT"                         # spelling variant of "3200 GT" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Biturbo: Bi Turbo                           # spelling variant of "Bi Turbo" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Granturismo: Gran Turismo                   # spelling variant of "Gran Turismo" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence


### PR DESCRIPTION
## What

Applies the italian swarm dossier (Ferrari + Maserati): **8 collision groups → 0**. 13 rename lines + 8 `former_ids` transitions. Stacked on #61 (jp3) — merge that first.

**Headline: 4 of 8 detector canonicals were the fold key leaked into the display string** (`GTC 4 Lusso`, `Ghibli S Q 4` — attested nowhere; `GTC4` and `Q4` are closed tokens). A 5th (`308 GTSI`) had the wrong final case — the *iniezione* `i` is lowercase, per the curated GTi/405 SRi precedent.

## Verification (researcher ≠ verifier)

- All 8 availability unions recomputed independently against the catalog before applying — all clean, and re-confirmed in the build diff (exactly 8 GONE + 5 NAME fixes + 5 availability unions, nothing else).
- **GTC4Lusso closed spelling**: the dossier's own flagged weak link (no manufacturer-side confirmation) was closed during verification — Ferrari's reproduced press text writes "GTC4Lusso's two rear seats…" (closed word) and ferrari.com's own URL slug is `/auto/gtc4lusso`. The only spaced renderings anywhere are aggregator house style.
- FE-4/FE-5 applied together (base car + T variant can never disagree on the spelling).
- Gate failure set byte-identical to the origin/main control build (the known 31 upstream-drift failures; zero Ferrari/Maserati ids among them — see #61 for the drift workstream).
- **Acronym blast-radius drill** (per protocol): `TS` as a styling token is BLOCKED by Subaru BRZ `tS` (officially lowercase t) — the 480-ES class. Whole batch is make-scoped renames.

## Deliberately separate / filed

- §4 sibling alignment (`296/328/488/599 Gtb` caps family, `3500GT`, `308GTS`, Gran Turismo family completion) — **separate PR by the dossier's own design**, so the 8 merges aren't blocked by style arguments.
- UNCERTAINs preserved in the dossier: Spider/Spyder Cambiocorsa, bare `425`/`3500`, GranCabrio/GranSport house inconsistency, the `849 Testarossa` whole-string-rename hazard, slash-artifact variant lists.

<details>
<summary>Full research dossier (verbatim, for future agents)</summary>

# Marque-convention dossier — Ferrari & Maserati collision groups

Research only. Nothing applied. A maintainer verifies and applies.
Prepared 2026-07-26 against `s4w-data` @ catalog build of 2026-07-26 01:01 and
`s4w-pipeline` @ 2026-07-26.

---

## 0. Headline finding, in one line

**Four of the eight auto-proposed canonicals are wrong, and they are wrong in the
same way: the collision tool's *fold key* leaked into the *display string*.**

The grouper segments letters from digits to decide that `GTC4 Lusso` and
`GTC4LUSSO` are the same car — that segmentation is *correct as a fold key* and
*never valid as a name*. Rendered back out it produces `GTC 4 Lusso`,
`GTC 4 Lusso T`, `Ghibli S Q 4`, `Quattroporte S Q 4` — none of which any
manufacturer, register or reference has ever written. `GTC4` and `Q4` are
closed tokens: `GTC4` is half of a one-word nameplate, `Q4` is the name of
Maserati's all-wheel-drive system.

The remaining four proposals (`308 GTB`, `308 GTSI`, `348 TS`,
`Gran Turismo Folgore`) are directionally right; one of them (`308 GTSI`) still
has the wrong final character case.

---

## 1. Mechanism recap (why the keys below take the exact form they do)

Verified in source, not assumed:

- `pipeline/lib/normalizer.rb:153-186` — order is **`smart_case` → renames.yml
  lookup → moves → slugify**. So a rename **key must be the already-smart_cased
  string**, i.e. *exactly the `name` a record currently shows in the catalog*.
  A key in any other form is silently inert (`overrides.rb:79` says so
  explicitly).
- `pipeline/lib/support.rb:117-120` — `slugify` = downcase → NFKD → strip
  combining marks → `[^a-z0-9]+` → `-`. **No camelCase splitting.** Therefore
  `"GTC4Lusso"` → `gtc4lusso`, `"GTC4 Lusso"` → `gtc4-lusso`,
  `"GTC 4 Lusso"` → `gtc-4-lusso` (a bogus new id).
- `smart_case` freezes any token containing a digit and title-cases pure-alpha
  tokens unless they are in `styling.yml → acronyms`. That is the whole reason
  the catalog reads `308 Gtb`, `348 Ts`, `512 Bb`, `Mondial Qv` — and why
  `Q4`, `GTC4`, `SQ4`, `MC20`, `SF90` already survive untouched.
- `scripts/lint_curation.rb:285-297` — **any value that is also a key in its own
  block is a hard lint failure** (no rename chains). Every proposal below was
  checked against the existing Ferrari and Maserati values; none collides.
- `scripts/lint_curation.rb:350` — valid key set is *catalog display names ∪
  makes/aliases.yml values*. Every key below is a live catalog `name` today.
- Retiring an id requires a migration alias in
  `overrides/models/former_ids.yml`, or validate gate 7 (no-vanish) fires
  (`pipeline/tests/test_id_contract_gate.rb`). Those are auto-proposed by
  `scripts/propose_former_ids.rb` — do not hand-write them.

### Existing curation treated as immutable (no direction wars)

| Block | Keys already taken | **Values — never key these** |
|---|---|---|
| Ferrari | `400I`, `575M Maranello`, `F430 Spider`, `Testarossa`, `F 355`, `F 430` | `400 I`, `575 M Maranello`, `F 430 Spider`, `Testa Rossa`, `F355`, `F430` |
| Maserati | `3200GT`, `Biturbo`, `Granturismo` | `3200 GT`, `Bi Turbo`, `Gran Turismo` |

Nothing below keys any of those values. Two of them (`Testa Rossa`,
`Bi Turbo`) are, for the record, *contrary* to the marques' own orthography
(Ferrari **Testarossa**, Maserati **Biturbo**) — noted, **not reopened**.

---

## 2. Convention dossier, per family

### 2.1 Ferrari — displacement + suffix initialism (`308 GTB`, `348 TS`, `512 TR`)

Ferrari's classic naming is `<number> <initialism>`, where the number is
displacement-derived and the trailing letters are a **caps initialism**:

- **GTB** = *Gran Turismo Berlinetta*, **GTS** = *Gran Turismo Spider*.
- **tb / ts** on the 348 = *Trasversale Berlinetta / Trasversale Spider*; the
  `t` marks the transverse gearbox
  (<https://en.wikipedia.org/wiki/Ferrari_348>).
- A trailing **lowercase `i`** means *iniezione* (fuel injection): the 1980–82
  cars are badged **`308 GTBi` / `308 GTSi`**, not `GTBI/GTSI`
  (<https://en.wikipedia.org/wiki/Ferrari_308_GTB/GTS>).
- Digits and letters are **separated by a space**; the fused registry forms
  (`308GTB`, `348TS`, `308GTSI`) are register glue, not badges.

**Casing conflict, resolved:** the Ferrari 348 model article uses lowercase
`348 tb` / `348 ts` (Ferrari's own brochure style); the marque-wide list article
uses `348 TB` / `348 TS`. All four contributing registers (ar, fi, nl, nz) write
uppercase. **Slug is identical either way (`348-ts`), so the choice is purely
cosmetic and carries zero id risk.** Recommended: uppercase, consistent with the
block's existing `400 I` and `575 M Maranello`.

**No such conflict on the injected `i`:** the lowercase `i` is unanimous across
both Wikipedia pages, and the house already honours official lowercase suffixes
elsewhere — `styling.yml` carries `"2.5I": 2.5i`, `"3.0I": 3.0i`,
`"4.5I": 4.5i` (Sherco), `I4: i4`, `E-TRON: e-tron`, `BZ4X: bZ4X`.

**Do not over-merge — these are genuinely different cars:**
`308 GTB` ≠ `308 GTBi` ≠ `308 GT4` (the last is the Bertone Dino 2+2, not a
Pininfarina two-seater). `348 TS` ≠ `348 GTS` (the 1993 revision genuinely
renamed the variants). `512 TR` ≠ `Testarossa` ≠ `F512M`. All are already
separate records and all must stay separate.

### 2.2 Ferrari — `GTC4Lusso`: one closed word

Ferrari's 2016 FF successor is **`GTC4Lusso`**, written as a single word with
internal capital L; the rear-drive V8 is **`GTC4Lusso T`**. Corroborated three
ways: <https://en.wikipedia.org/wiki/Ferrari_GTC4Lusso>,
<https://it.wikipedia.org/wiki/Ferrari_GTC4Lusso>, and the successor sentence in
<https://en.wikipedia.org/wiki/Ferrari_FF>. `ferrari.com` is a JS shell and
returned no text to WebFetch; `caranddriver.com` is blocked — manufacturer-side
confirmation was **not** obtained, so this rests on three reference sources, all
in agreement, plus the marque-wide list article.

`GTC 4 Lusso` (spaces around the 4) is attested **nowhere**.

### 2.3 Maserati — `Q4` is a system name, one token

`Q4` is Maserati's all-wheel-drive system; the trim reads
`<model> S Q4` — `S` is the engine trim, `Q4` the drivetrain. Attested in three
separate articles: `Ghibli S Q4`
(<https://en.wikipedia.org/wiki/Maserati_Ghibli_(M157)>: *"the same as that in
the Quattroporte VI (Q4)"*), `Quattroporte S Q4` (M156 spec table,
<https://en.wikipedia.org/wiki/Maserati_Quattroporte>), and `Q4` used bare on
the Levante Trofeo (<https://en.wikipedia.org/wiki/Maserati_Levante>).

`Q 4` is attested nowhere. `SQ4` is register glue.

Catalog check: `Q4` already renders correctly in three records
(`audi/q4`, `maserati/ghibli-s-q4`, `maserati/quattroporte-s-q4`) because
`smart_case` freezes digit-bearing tokens — **no styling change is needed or
wanted**, only the two folds below.

### 2.4 Maserati — the `Gran*` family (house style ≠ marque style)

Maserati's official orthography is closed camelCase: **`GranTurismo`**,
**`GranCabrio`**, **`GranSport`**, **`GranLusso`**
(<https://en.wikipedia.org/wiki/Maserati_GranTurismo>,
<https://en.wikipedia.org/wiki/Maserati>). `Folgore` ("lightning") is the EV
suffix across the range: *"All Maserati EVs will wear the Folgore name."*

The block already committed to `Granturismo: Gran Turismo` — the **spaced**
form. That is a deliberate, immutable house choice and this dossier follows it.
Consequence worth stating plainly: the house is currently **internally
inconsistent**, spacing `Gran Turismo` while leaving `Grancabrio` and
`Gransport` fused. That is a maintainer decision, flagged in §5, not proposed.

---

## 3. Per-group proposals

Format per group: canonical → paste-ready renames.yml lines → id transitions →
availability superset (verified against
`s4w-data/catalog/car/models.json`; every merge is a strict union, **no country
or source is lost in any of the eight**).

---

### FE-1 — canonical **`308 GTB`**  ✅ auto-proposal was correct

```yaml
Ferrari:
  "308 Gtb": "308 GTB"    # GTB = Gran Turismo Berlinetta, a caps initialism; smart_case has no GTB acronym token so the bare word title-cases to "Gtb" — https://en.wikipedia.org/wiki/Ferrari_308_GTB/GTS
  "308GTB":  "308 GTB"    # same car, register-fused spelling; folds ferrari/308gtb into the spaced id — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
```

| old id | surviving id |
|---|---|
| `car/ferrari/308-gtb` | `car/ferrari/308-gtb` *(unchanged; name only)* |
| `car/ferrari/308gtb` | `car/ferrari/308-gtb` |

Availability: `fi,nl,nz` ∪ `fi,nl,nz` = **`fi,nl,nz`** (regions `eu,oc`;
sources `fi_traficom,nl_rdw,nz_nzta`). Superset holds; nothing lost.
Retires 1 id → needs one `former_ids.yml` alias.

---

### FE-2 — canonical **`308 GTSi`**  ⚠️ auto-proposal `308 GTSI` has the wrong final case

```yaml
Ferrari:
  "308 Gtsi": "308 GTSi"  # the injected 308: caps initialism plus LOWERCASE i for iniezione, exactly as Ferrari badged it — https://en.wikipedia.org/wiki/Ferrari_308_GTB/GTS
  "308GTSI":  "308 GTSi"  # same car, register-fused and over-capitalised; folds ferrari/308gtsi into the spaced id — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
```

| old id | surviving id |
|---|---|
| `car/ferrari/308-gtsi` | `car/ferrari/308-gtsi` *(unchanged; name only)* |
| `car/ferrari/308gtsi` | `car/ferrari/308-gtsi` |

Availability: `fi,nl,nz` ∪ `nl,nz` = **`fi,nl,nz`** (regions `eu,oc`).
Superset holds. Slug is `308-gtsi` for both `GTSI` and `GTSi`, so the case fix
is free.
If the reviewer prefers house-uniform caps over the marque badge, substitute
`"308 GTSI"` in both values — the ids are unaffected. I recommend against it;
see §2.1 for the lowercase-`i` precedent already in `styling.yml`.

---

### FE-3 — canonical **`348 TS`**  ✅ auto-proposal was correct

```yaml
Ferrari:
  "348 Ts": "348 TS"      # ts = Trasversale Spider (transverse gearbox); Ferrari's brochures used lowercase "348 ts" but the marque list and all four contributing registers use caps, and the slug is 348-ts either way — https://en.wikipedia.org/wiki/Ferrari_348
  "348TS":  "348 TS"      # same car, register-fused; folds ferrari/348ts into ferrari/348-ts, the only member carrying the Argentine evidence — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
```

| old id | surviving id |
|---|---|
| `car/ferrari/348-ts` | `car/ferrari/348-ts` *(unchanged; name only)* |
| `car/ferrari/348ts` | `car/ferrari/348-ts` |

Availability: `ar,fi,nl,nz` ∪ `fi,nl,nz` = **`ar,fi,nl,nz`** (regions
`eu,oc,sa`; sources add `ar_dnrpa`). Superset holds — **note the `ar`/`sa`
evidence lives only on the surviving id, so the merge direction is also the
evidence-preserving one.**

---

### FE-4 — canonical **`GTC4Lusso`**  ❌ auto-proposal `GTC 4 Lusso` is wrong

```yaml
Ferrari:
  "GTC4 Lusso": GTC4Lusso   # Ferrari's nameplate is one closed word — not "GTC4 Lusso", and emphatically not the fold-key rendering "GTC 4 Lusso", which is attested nowhere — https://en.wikipedia.org/wiki/Ferrari_GTC4Lusso
  "GTC4LUSSO":  GTC4Lusso   # the same car in a register's all-caps spelling; folds ferrari/gtc4-lusso and ferrari/gtc4lusso onto one id — https://it.wikipedia.org/wiki/Ferrari_GTC4Lusso
```

| old id | surviving id |
|---|---|
| `car/ferrari/gtc4-lusso` | `car/ferrari/gtc4lusso` |
| `car/ferrari/gtc4lusso` | `car/ferrari/gtc4lusso` *(unchanged)* |

Availability: `es,fi,lu,nl,nz` ∪ `my,nl,us` = **`es,fi,lu,my,nl,nz,us`**
(regions `as,eu,na,oc`; 7 sources). Superset holds — this merge is the single
biggest evidence consolidation in the batch, going from two 2-region records to
one 4-region record.

**Read this before applying:** the surviving id flips to the *fused* slug, and
the id being retired (`gtc4-lusso`) is currently the better-covered one.
No evidence is lost — the merged record carries the union — but the published id
string changes, so `scripts/propose_former_ids.rb` must run before the gate.
Note also that the id-churn cost is **identical either way**: canonicalising to
`GTC4 Lusso` instead would retire exactly one id too (`gtc4lusso`). Marque
accuracy is therefore free here, which is why I recommend `GTC4Lusso` without
hedging.
*Id-conservative alternative, if the reviewer wants `gtc4-lusso` to survive:*
`"GTC4LUSSO": "GTC4 Lusso"` as a one-liner. Still fixes the `GTC 4 Lusso`
defect; still not the marque's spelling.

---

### FE-5 — canonical **`GTC4Lusso T`**  ❌ auto-proposal `GTC 4 Lusso T` is wrong

```yaml
Ferrari:
  "GTC4 Lusso T": GTC4Lusso T   # the rear-drive V8 GTC4Lusso; the T is a separate suffix token but "GTC4Lusso" stays closed — https://en.wikipedia.org/wiki/Ferrari_GTC4Lusso
  "GTC4LUSSO T":  GTC4Lusso T   # same car, register all-caps; folds ferrari/gtc4-lusso-t and ferrari/gtc4lusso-t onto one id — https://it.wikipedia.org/wiki/Ferrari_GTC4Lusso
```

| old id | surviving id |
|---|---|
| `car/ferrari/gtc4-lusso-t` | `car/ferrari/gtc4lusso-t` |
| `car/ferrari/gtc4lusso-t` | `car/ferrari/gtc4lusso-t` *(unchanged)* |

Availability: `fi,lu,nl,nz` ∪ `nl,us` = **`fi,lu,nl,nz,us`** (regions
`eu,na,oc`). Superset holds. Same id-flip caveat as FE-4 — apply the two
together or not at all, so the base car and its T variant never disagree about
how `GTC4Lusso` is spelled.

---

### MA-1 — canonical **`Ghibli S Q4`**  ❌ auto-proposal `Ghibli S Q 4` is wrong

Only **one** line is needed: `Ghibli S Q4` is already correct in the catalog.

```yaml
Maserati:
  "Ghibli SQ4": "Ghibli S Q4"   # S is the engine trim, Q4 is Maserati's AWD system — two tokens, never "S Q 4"; the register glued them — https://en.wikipedia.org/wiki/Maserati_Ghibli_(M157)
```

| old id | surviving id |
|---|---|
| `car/maserati/ghibli-sq4` | `car/maserati/ghibli-s-q4` |
| `car/maserati/ghibli-s-q4` | `car/maserati/ghibli-s-q4` *(unchanged, name unchanged)* |

Availability: `ca,es,fi,lu,nl,ua` ∪ `ca,es,nl,us` = **`ca,es,fi,lu,nl,ua,us`**
(regions `eu,na`; 7 sources). Superset holds.
This is the cleanest group in the batch: a pure merge onto an existing,
correctly-spelled id — no new string, no id flip, one alias.

---

### MA-2 — canonical **`Gran Turismo Folgore`**  ✅ auto-proposal was correct (house style)

```yaml
Maserati:
  "Granturismo Folgore": "Gran Turismo Folgore"   # follows this block's established Granturismo -> Gran Turismo direction; Folgore is Maserati's EV suffix across the range — https://en.wikipedia.org/wiki/Maserati_GranTurismo
```

| old id | surviving id |
|---|---|
| `car/maserati/granturismo-folgore` | `car/maserati/gran-turismo-folgore` |
| `car/maserati/gran-turismo-folgore` | `car/maserati/gran-turismo-folgore` *(unchanged)* |

Availability: `lu,nl` ∪ `fi,nl,th,us` = **`fi,lu,nl,th,us`** (regions
`as,eu,na`; 5 sources). Superset holds; the retiring id is the *better-covered*
one, so this merge is what rescues the `th`/`us`/`as` evidence from a
duplicate — worth doing on those grounds alone.

Marque note, for the record only: Maserati writes **`GranTurismo Folgore`**.
The house spells it `Gran Turismo`, that value is already committed, and this
dossier does not reopen it. **But applying MA-2 alone leaves the family split
five ways** (`Granturismo Modena/S/S Automatic/Sport/Trofeo` keep the fused
spelling) — see §4.

---

### MA-3 — canonical **`Quattroporte S Q4`**  ❌ auto-proposal `Quattroporte S Q 4` is wrong

Only **one** line is needed.

```yaml
Maserati:
  "Quattroporte SQ4": "Quattroporte S Q4"   # same S + Q4 split as the Ghibli; the M156 specification table lists the AWD car as "Quattroporte S Q4" — https://en.wikipedia.org/wiki/Maserati_Quattroporte
```

| old id | surviving id |
|---|---|
| `car/maserati/quattroporte-sq4` | `car/maserati/quattroporte-s-q4` |
| `car/maserati/quattroporte-s-q4` | `car/maserati/quattroporte-s-q4` *(unchanged)* |

Availability: `ca,es,fi,lu,nl` ∪ `ca,us` = **`ca,es,fi,lu,nl,us`** (regions
`eu,na`). Superset holds. Pure merge, no new string, no id flip.

---

## 4. Optional sibling alignment (flap insurance) — separate review, separate PR

These are **not** collision groups. They are records that share a defect with a
group above; applying the groups without them leaves a half-fixed family, which
is how a marque ends up flapping between spellings across releases. Each is
independently sourced. **Recommend a separate PR** so the eight merges above are
not blocked by argument about these.

### 4a. Ferrari — display-only, zero id change (safest tier)

Slug is unchanged for every line here; only the published `name` changes.

```yaml
Ferrari:
  "296 Gtb":         "296 GTB"          # GTB caps initialism, same as the 308 — https://en.wikipedia.org/wiki/Ferrari_296
  "328 Gtb":         "328 GTB"          # ditto — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
  "488 Gtb":         "488 GTB"          # ditto — https://en.wikipedia.org/wiki/Ferrari_488
  "599 Gtb":         "599 GTB"          # ditto — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
  "599 Gtb Fiorano": "599 GTB Fiorano"  # ditto, full nameplate — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
  "308 Gtbi":        "308 GTBi"         # the GTB half of the injected pair; leaving it as "Gtbi" while FE-2 fixes "Gtsi" splits the family — https://en.wikipedia.org/wiki/Ferrari_308_GTB/GTS
  "348 Tb":          "348 TB"           # the TB half of the 348 pair; FE-3 fixes TS, this keeps the coupe and targa spelled alike — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
```

Blast radius measured catalog-wide: token `Gtb` appears on exactly 6 records,
all Ferrari, all officially uppercase; token `Tb` on 2 (`ferrari/348-tb`,
`mg/tb` — MG TB Midget, also officially caps).

### 4b. Ferrari — mints a new id (needs `former_ids.yml`)

```yaml
Ferrari:
  "308GTS": "308 GTS"   # the GTS half of the 308 pair, register-fused with no spaced sibling to merge into; leaving it fused while FE-1 spaces the GTB is the exact half-fix this section exists to prevent — https://en.wikipedia.org/wiki/Ferrari_308_GTB/GTS
```

`car/ferrari/308gts` (`nl,nz`) → `car/ferrari/308-gts`. No merge, no evidence
change — a rename plus one migration alias.

### 4c. Maserati — completes the `Gran Turismo` family started by MA-2

Same direction as the committed `Granturismo: Gran Turismo`, so no direction
war. All five mint new ids and need aliases.

```yaml
Maserati:
  "Granturismo Modena":      "Gran Turismo Modena"       # MA-2 sibling; block already spells the bare nameplate "Gran Turismo" — https://en.wikipedia.org/wiki/Maserati_GranTurismo
  "Granturismo Trofeo":      "Gran Turismo Trofeo"       # ditto — https://en.wikipedia.org/wiki/Maserati_GranTurismo
  "Granturismo S":           "Gran Turismo S"            # ditto (M145 generation) — https://en.wikipedia.org/wiki/Maserati_GranTurismo
  "Granturismo S Automatic": "Gran Turismo S Automatic"  # ditto — https://en.wikipedia.org/wiki/Maserati_GranTurismo
  "Granturismo Sport":       "Gran Turismo Sport"        # ditto — https://en.wikipedia.org/wiki/Maserati_GranTurismo
```

### 4d. Maserati — the `3200GT` precedent, unfinished

```yaml
Maserati:
  "3500GT": "3500 GT"   # exact mirror of the committed "3200GT": "3200 GT" line; Maserati 3500 GT (1957-64) is a spaced nameplate — https://en.wikipedia.org/wiki/Maserati_3500_GT
```

`car/maserati/3500gt` (`nl,nz`) → `car/maserati/3500-gt`. **Does not** merge
with the separate bare `maserati/3500` record — that one is a different
question, see §5.

---

## 5. UNCERTAIN — deliberately NOT proposed

Listed plainly so nobody has to rediscover them; each needs evidence I could not
get, or a maintainer's judgement call rather than a source.

1. **`maserati/425` vs `maserati/biturbo-425`.** Very likely the same car (the
   Biturbo 425 saloon), but "425" alone could equally be a register
   abbreviation. A merge would need raw-row evidence, not a reference page.
   Skipped.
2. **`maserati/3500` (bare) vs `maserati/3500gt`.** Same suspicion, same
   missing evidence. §4d renames the second without touching the first.
3. **`maserati/spider-cambiocorsa` vs `maserati/spyder-cambiocorsa`, and
   `maserati/spider-gt` vs `maserati/spyder-gt`.** Maserati used *Spyder* for
   the 4200-series convertible; whether the "Spider" rows are typos or a
   distinct market spelling is not decidable from the sources I could reach.
   Also `maserati/cambio-corsa` (bare) — Maserati's gearbox is **Cambiocorsa**,
   one word, so the spaced bare record is probably a fragment, but "probably" is
   not a merge. Skipped, all four.
4. **`maserati/430`.** Genuinely a Maserati (Biturbo-family saloon), not a
   misfiled Ferrari F430. Different make, so no id collision — flagged only so a
   future pass does not "fix" it. **Do not touch.**
5. **Maserati `Grancabrio` / `Gransport` vs `Gran Turismo`.** The house spaces
   one and fuses the other two; the marque closes all three
   (`GranCabrio`, `GranSport`, `GranTurismo`). Picking a single rule is a
   maintainer decision about house style, not a sourcing question. Not proposed.
6. **Ferrari `Testa Rossa` and Maserati `Bi Turbo`.** Both contrary to the
   marques' own spelling (`Testarossa`, `Biturbo`); both are committed values.
   Not reopened. **Related hazard:** `ferrari/849-testarossa` (the 2025 car) is
   safe *only* because renames match whole strings. If anyone ever migrates
   `Testarossa: Testa Rossa` to a `styling.yml` token or substring lever, it
   becomes `849 Testa Rossa`, which is wrong. Leave it as a rename.
7. **Ferrari slash artifacts** — `ferrari/456-gt-gta` ("456 Gt/gta"),
   `ferrari/250-gt-e` ("250 Gt/e"), `ferrari/f355-355-f1` ("F355/355 F1"),
   `ferrari/f355-berlinetta-gts` ("F355 Berlinetta/gts"). These are
   register-concatenated *variant lists*, not nameplates, and each needs a
   split-or-drop decision rather than a rename. Out of scope; noted for the
   backlog.
8. **`ferrari/dino-208gt4` ("Dino 208GT4") vs `ferrari/dino-308-gt4`
   ("Dino 308 GT4").** Inconsistent spacing within the Dino family; the marque
   list writes `Dino 208 GT4` / `Dino 308 GT4`. Not a collision today, but a
   future fold run will propose `Dino 208 GT 4` — the same fold-key leak as
   FE-4. Worth pre-empting; not proposed here because the Dino make-vs-model
   question (`ferrari/dino` bare, `ferrari/dino-gt`) should be settled first.

---

## 6. Levers considered and rejected — the acronym blast-radius drill

Adding tokens to `overrides/styling.yml → acronyms` would fix casing in bulk and
is tempting for `GTB`/`GTS`/`TB`/`TS`. **Measured before recommending**, per the
480-ES/`IX` precedents already recorded in that file:

| candidate token | catalog records hit | verdict |
|---|---|---|
| `GTB` | 6 — all Ferrari, all officially caps | *would* be safe, **but** see below |
| `TB` | 2 — `ferrari/348-tb`, `mg/tb` (MG TB Midget, caps) | would be safe |
| `GTS` | 8 — Holden, McLaren, NIU, SYM, Vespa ×3, Yamaha; no Ferrari | would be safe, fixes nothing here |
| **`TS`** | 9 — incl. **`subaru/brz-ts`** | ❌ **BLOCKED** |

**`TS` is the counterexample.** Subaru's STI-tuned BRZ is officially **`tS`**,
lowercase t — *"tS standing for 'tuned by STI'"*
(<https://en.wikipedia.org/wiki/Subaru_BRZ>). One global token cannot serve both
`348 TS` and `BRZ tS`; this is precisely the collision that forced `480 ES` to
be a whole-string pin and kept `IX` off the list. So **no acronym token for
`TS`**.

And because `TS` must be per-make, `GTB`/`TB` should be too — a family split
across two different levers is harder to reason about than one that is
consistently per-make. **Recommendation: use `renames.yml` for all of it.** It
is make-scoped (zero cross-marque blast radius), it is the lever the Ferrari and
Maserati blocks already use, and it is the only one that can also *merge*
records.

One trap if anyone disagrees and adds the tokens anyway: `smart_case` runs
**before** the rename lookup, so adding `GTB` to `acronyms` instantly turns the
key `"308 Gtb"` into dead text. The two levers are mutually exclusive per token.
`pipeline/tests/test_override_key_reachability.rb` and
`scripts/lint_curation.rb:350` will catch it — but only after the fact.

---

## 7. Application checklist

1. Apply §3 (8 groups, 12 rename lines) into the existing `Ferrari:` and
   `Maserati:` blocks. Keep the blocks alphabetical; quote every digit-leading
   key and value (the `FIAT500` note on `renames.yml:432` explains why a bare
   numeric value crashes `slugify`).
2. `ruby scripts/lint_curation.rb` — expect clean; the no-chain rule
   (`:285`) and key-reachability rule (`:350`) were both pre-checked against
   every line above.
3. `ruby scripts/propose_former_ids.rb` — **8 ids retire** across the batch
   (`308gtb`, `308gtsi`, `348ts`, `gtc4-lusso`, `gtc4-lusso-t`, `ghibli-sq4`,
   `granturismo-folgore`, `quattroporte-sq4`). Without aliases, validate gate 7
   (no-vanish) fires.
4. Rebuild, then diff `catalog/car/models.json` and confirm the eight
   availability unions in §3 land exactly as tabulated. Any country missing from
   a merged record means the merge went the wrong way — stop and re-read.
5. §4 and beyond: separate PR.

---

## 8. Sources

Fetched and read for this dossier (all 2026-07-26):

- <https://en.wikipedia.org/wiki/Ferrari_GTC4Lusso> — `GTC4Lusso`, `GTC4Lusso T`
- <https://it.wikipedia.org/wiki/Ferrari_GTC4Lusso> — independent confirmation of the closed spelling
- <https://en.wikipedia.org/wiki/Ferrari_FF> — successor sentence, third confirmation
- <https://en.wikipedia.org/wiki/Ferrari_308_GTB/GTS> — `308 GTB/GTS`, `308 GTBi/GTSi` (lowercase i), `quattrovalvole`
- <https://en.wikipedia.org/wiki/Ferrari_348> — `348 tb`/`348 ts` lowercase brochure style; *Trasversale Berlinetta/Spider*; transverse-gearbox rationale
- <https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars> — marque-wide list: `308 GTB`, `308 GTS`, `308 GTBi`, `308 GTSi`, `308 GT4`, `348 TB`, `348 TS`, `348 GTB`, `348 GTS`, `348 Spider`, `GTC4Lusso`, `GTC4Lusso T`, `F355`, `512 TR`, `Testarossa`, `Dino 246 GT`
- <https://en.wikipedia.org/wiki/Ferrari_F355> — `F355` fused; `355 F1` variant
- <https://en.wikipedia.org/wiki/Maserati_Ghibli_(M157)> — `Ghibli S Q4`, Q4 = AWD shared with Quattroporte VI
- <https://en.wikipedia.org/wiki/Maserati_Quattroporte> — M156 spec table: `Quattroporte S Q4`
- <https://en.wikipedia.org/wiki/Maserati_Levante> — `Q4` used bare, third Q4 confirmation
- <https://en.wikipedia.org/wiki/Maserati_GranTurismo> — `GranTurismo`, `GranTurismo Folgore`, `GranCabrio`
- <https://en.wikipedia.org/wiki/Maserati_Grecale> — `Folgore` as range-wide EV designation
- <https://en.wikipedia.org/wiki/Maserati> — `Folgore` = "lightning"; `3200 GT`, `Biturbo`, `Bora`, `Merak`, `Khamsin` word-forms
- <https://en.wikipedia.org/wiki/Subaru_BRZ> — `tS` lowercase; the counterexample that blocks a global `TS` acronym token

**Not reachable** (asserted nothing on their basis): `ferrari.com/en-EN/history`
and `ferrari.com/en-EN/auto/gtc4lusso` returned empty bodies (JS-rendered);
`maserati.com/international/en/models/ghibli` returned HTTP 403;
`caranddriver.com` is blocked by the fetch tool. WebSearch was unavailable, so
no search-based corroboration was possible. Every claim above therefore rests on
reference sources rather than manufacturer sites — the `GTC4Lusso` closed
spelling in particular has three independent confirmations but **no
manufacturer-side one**, which is the weakest link in this dossier and the thing
a verifier should check first.

**Corpus note:** `s4w-pipeline/build/observed_model_names.json` was consulted but
is near-empty for this batch — it only records ids that carry *more than one raw
spelling*, and none of the eight groups here is such a case (each group is two
*separate ids*, one spelling each). It yielded 9 Ferrari rows (`250-gt-swb`,
`275-gtb`, `360-modena-spider`, `365-gt-2-2`, `365-gt4-2-2`, `365-gt4-bb`,
`365-gt4`, `365-gtb-4`, `512-bb`) and 2 Maserati (`quattro-porte`,
`spyder-gt-cambiocorsa`), none overlapping the collision groups. Several of those
rows also do not exist in the `s4w-data` catalog snapshot, so the two artifacts
are from different pipeline runs — the catalog was used as the authoritative
corpus throughout.

Repo files read (not modified): `s4w-data/overrides/models/renames.yml`,
`s4w-data/overrides/styling.yml`, `s4w-data/overrides/models/gate_acks.yml`,
`s4w-data/catalog/car/models.json`, `s4w-pipeline/pipeline/lib/normalizer.rb`,
`s4w-pipeline/pipeline/lib/overrides.rb`, `s4w-pipeline/pipeline/lib/support.rb`,
`s4w-pipeline/pipeline/lib/emit.rb`,
`s4w-pipeline/pipeline/tests/test_id_contract_gate.rb`,
`s4w-data/scripts/lint_curation.rb`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
