### PR TITLE
Swarm-dossier batches: british + american tail — 31 groups → 0 (53 → 22)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1558,7 +1558,7 @@
 "car/mercedes-benz/170s": "car/mercedes-benz/170-s"
 "car/mercedes-benz/170sb": "car/mercedes-benz/170-sb"
 "car/mercedes-benz/170sd": "car/mercedes-benz/170-sd"
-"car/mercedes-benz/170sv": "car/mercedes-benz/170-sv"
+"car/mercedes-benz/170sv": "car/mercedes-benz/170-s-v" # repointed 2026-07-26: 170-sv itself retired into 170-s-v (W136 designation; american-tail dossier M-1)
 "car/mercedes-benz/170v": "car/mercedes-benz/170-v"
 "car/mercedes-benz/170va": "car/mercedes-benz/170-va"
 "car/mercedes-benz/180b": "car/mercedes-benz/180-b"
@@ -1865,7 +1865,7 @@
 "car/volvo/xc-70": "car/volvo/xc70"
 "car/volvo/xc-90": "car/volvo/xc90"
 "car/wartburg/353w": "car/wartburg/353-w"
-"car/willys/cj-5": "car/willys/cj5"
+# "car/willys/cj-5": "car/willys/cj5" — REMOVED 2026-07-26: direction reversed on jeep.com evidence, cj-5 is live again (stale-alias-reversal precedent, 7th instance)
 "car/willys/mb": "car/willys/m-b"
 "car/willys/mb-jeep": "car/willys/m-b-jeep"
 "moped/bultaco/brinco-c": "moped/bultaco/brinco"
@@ -2086,7 +2086,7 @@
 "van/volkswagen/transporter-doublecab": "van/volkswagen/transporter-double-cab"
 "van/volvo/145": "car/volvo/140"
 "van/volvo/xc-90": "car/volvo/xc90"
-"van/willys/cj-3b": "car/willys/cj3b"
+"van/willys/cj-3b": "car/willys/cj-3b" # repointed 2026-07-26: cj3b retired into cj-3b (direction reversal, american-tail dossier W-1)
 # --- 2026-07-25, S2W: two MAKE merges (see rule 3's named exception above) ----
 # `zero` -> `zero-motorcycles`: UK/NZ/UA register the marque as bare "ZERO",
 # NL/ES/FI/LU as "ZERO MOTORCYCLES". Merged toward the longer form because the
@@ -2661,3 +2661,45 @@
 "car/maserati/ghibli-sq4":          "car/maserati/ghibli-s-q4"
 "car/maserati/granturismo-folgore": "car/maserati/gran-turismo-folgore"
 "car/maserati/quattroporte-sq4":    "car/maserati/quattroporte-s-q4"
+# ---------------------------------------------------------------------------
+# 2026-07-26 — swarm-dossier batch: british small makes (saab/austin/jaguar/
+# daimler/morris/morgan; 14 groups → 0, 16 ids retired, 0 minted).
+"car/austin/a-30": "car/austin/a30"
+"car/austin/healey-3000-mk-111": "car/austin/healey-3000-mkiii"
+"car/austin/healey-3000-mk111": "car/austin/healey-3000-mkiii"
+"car/austin/mini-mk-2": "car/austin/mini-mkii"
+"car/austin/mini-mk2": "car/austin/mini-mkii"
+"car/daimler/250v8": "car/daimler/250-v8"
+"car/daimler/v8-250": "car/daimler/v8250"
+"car/jaguar/38s": "car/jaguar/3-8s"
+"car/jaguar/x-j-s": "car/jaguar/xj-s"
+"car/jaguar/xj-6": "car/jaguar/xj6"
+"car/morgan/plus8": "car/morgan/plus-8"
+"car/morris/mini1000": "car/morris/mini-1000"
+"car/saab/900i-16v": "car/saab/900-i-16v"
+"car/saab/900se": "car/saab/900-se"
+"car/saab/900-t16": "car/saab/900-t-16"
+"car/saab/96v4": "car/saab/96-v4"
+# ---------------------------------------------------------------------------
+# 2026-07-26 — swarm-dossier batch: american tail (chevrolet Option A/jeep/
+# willys/skoda/smart/vinfast/ford/mercedes-benz; 17 groups → 0). CJ direction
+# reversed on jeep.com; the two pre-existing willys chains edited above.
+"van/chevrolet/c10": "van/chevrolet/c-10"
+"car/chevrolet/c10": "car/chevrolet/c-10"
+"car/chevrolet/impala-s-s": "car/chevrolet/impala-ss"
+"van/chevrolet/s10-pick-up": "van/chevrolet/s10-pickup"
+"car/jeep/cj5": "car/jeep/cj-5"
+"car/jeep/cj7": "car/jeep/cj-7"
+"car/willys/cj3b": "car/willys/cj-3b"
+"car/willys/cj5": "car/willys/cj-5"
+"car/skoda/120l": "car/skoda/120-l"
+"car/smart/for-two": "car/smart/fortwo"
+"car/vinfast/vf8": "car/vinfast/vf-8"
+"car/ford/eco-sport": "car/ford/ecosport"
+"car/ford/m-151-a1": "car/ford/m151a1"
+"car/ford/sierra-xr-4i": "car/ford/sierra-xr4i"
+"car/mercedes-benz/170-sv": "car/mercedes-benz/170-s-v"
+"car/mercedes-benz/220-se-b": "car/mercedes-benz/220-seb"
+"car/mercedes-benz/280se-automatic": "car/mercedes-benz/280-se-automatic"
+"car/mercedes-benz/300ce-24": "car/mercedes-benz/300-ce-24"
+"car/mercedes-benz/300te-4-matic": "car/mercedes-benz/300-te-4-matic"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -54,6 +54,18 @@ Audi:
   Q 5: Q5                                     # spelling variant of "Q5" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 Austin:
+  # ── swarm-dossier batch: Mk goes FUSED ROMAN here — Austin registers EMIT
+  # Roman (healey-3000-mkiii, mini-mkii live in-catalog), so the MG Midget
+  # MkIII conditional applies, NOT the Triumph Mk-arabic one. No styling.yml
+  # pin (stylings run before renames and would kill these keys). ──
+  "A-30": A30                # third raw shape (hyphenated) — Austin badged the A30 closed, 1952-56 (en.wikipedia Austin_A30); completes A 30/A-40/A 40
+  "A/30": A30                # fourth raw shape (slash) — same nameplate
+  Healey 3000 Mk 111: Healey 3000 MkIII   # "111" is three ones typed for Roman III — the car is the 3000 Mk III (BJ8, 1964-67; en.wikipedia Austin-Healey_3000)
+  Healey 3000 MK111: Healey 3000 MkIII    # all-caps register variant of the same typo
+  Healey 3000 Mkiii: Healey 3000 MkIII    # same id already — display fix from the caser's "Mkiii"
+  Mini Mk 2: Mini MkII                    # classic Mini Mark II, 1967-70 (en.wikipedia Mini); same Roman conditional as the Healey
+  Mini MK2: Mini MkII                     # fused arabic register variant
+  Mini Mkii: Mini MkII                    # same id already — display fix
   HEALEY3000: Healey 3000                     # spelling variant of "Healey 3000" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Austin: null                                # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   A 30: A30                                   # spelling variant of "A30" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -165,6 +177,15 @@ Chery:
   Icaur 03: iCAUR 03                      # official styling of Chery's off-road EV sub-brand is iCAUR (https://www.icaur.com/); the default caser yields "Icaur"
 
 Chevrolet:
+  # ── swarm-dossier batch (2026-07-26): C-10 direction reversed on GM's own
+  # prose (Option A of the dossier's maintainer call); SS is a badge, not a
+  # word; "Pickup" one-word fix limited to the collision (S-10 family pass
+  # deferred — no live GM page to cite). ──
+  C10: C-10         # fused registry spelling of the same truck; folds van/chevrolet/c10 + moves the car bystander — https://www.gm.com/heritage/collection/chevrolet-trucks/1971-chevrolet-c-10-pickup
+  C/10: C-10        # RDW slash spelling — same source
+  Impala S.s: Impala SS   # RDW punctuates the Super Sport badge; Chevrolet's badge is SS (https://en.wikipedia.org/wiki/Chevrolet_Impala; GM collection titles "1963 Chevy Nova SS")
+  Impala Ss: Impala SS    # caser Title-cases the badge — same sources; slug unchanged (impala-ss survives)
+  S10 Pick Up: S10 Pickup # GM writes the body style one word ("1971 Chevy C-10 Pickup", https://www.gm.com/heritage/collection); same truck as the ca/us "S10 Pickup" record
   Belair: Bel Air                             # spelling variant of "Bel Air" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Bellair: Bell Air                           # spelling variant of "Bell Air" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Camaro Z28: Camaro Z/28                     # spelling variant of "Camaro Z/28" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -175,12 +196,12 @@ Chevrolet:
   Styleline Deluxe: Styleline De Luxe         # spelling variant of "Styleline De Luxe" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Trailblazer: Trail Blazer                   # spelling variant of "Trail Blazer" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "3100 Pickup": "3100 Pick-Up"               # spelling variant of "3100 Pick-Up" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  C10 Custom Deluxe: C 10 Custom Deluxe       # spelling variant of "C 10 Custom Deluxe" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  C10 Pick Up: C 10 Pick Up                   # spelling variant of "C 10 Pick Up" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  C10 Custom Deluxe: C-10 Custom Deluxe     # display-only coherence with the C-10 repoint (same slug either way)
+  C10 Pick Up: C-10 Pick Up                 # display-only coherence with the C-10 repoint (same slug either way); GM titles write "Pickup" one word but that family pass is deferred
   Fleetside Pickup: Fleetside Pick-Up         # spelling variant of "Fleetside Pick-Up" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Pickup: Pick Up                             # spelling variant of "Pick Up" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Chevrolet: null                             # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
-  C 10: C10                                   # spelling variant of "C10" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+  C 10: C-10                                # REPOINT (was → C10). GM's own heritage prose writes the pickup C-10, 15x on one page (https://www.gm.com/heritage/collection/chevrolet-trucks/1971-chevrolet-c-10-pickup); the rest of the family already publishes hyphenated (c-10-cheyenne, c-20, k-10)
   K 1500: K1500                               # spelling variant of "K1500" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 Chrysler:
@@ -243,6 +264,14 @@ Daihatsu:
   Hijet: Hi-Jet                               # spelling variant of "Hi-Jet" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Daimler:
+  # ── swarm-dossier batch: merged in the SETTLED direction under protest —
+  # en.wikipedia Daimler_250 spells the 1967-69 car "V8-250" and never
+  # "250 V8"/"V8 250"; the inversion block is in the dossier (U2). Do not
+  # extend this direction without reading it. ──
+  "250V8": "250 V8"          # fused register shape; V8 stays a closed token per this block's "V 8": V8
+  "V8  250": V8250           # DOUBLE space from raw "V8 - 250" (smart_case lone-hyphen defect); corpus-proven, replay-invisible
+  "V8-250": V8250            # follows the settled "V8 250": V8250 — NOTE the source spells the car V8-250; see dossier U2 before extending
+  "V8/250": V8250            # slash register shape
   Daimler: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   DS 420: DS420                               # spelling variant of "DS420" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Sp 250: SP250                               # spelling variant of "SP250" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -461,6 +490,14 @@ Fiat:
   X 1/9: X1/9                                 # spelling variant of "X1/9" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 Ford:
+  # ── swarm-dossier batch: residuals only — F-Series direction untouched. ──
+  Ecosport: EcoSport      # Ford styles it camel-case, one word (https://en.wikipedia.org/wiki/Ford_EcoSport); the us_fueleconomy raw is literally "EcoSport AWD" — display-only, slug stays ecosport
+  Eco Sport: EcoSport     # es_dgt/RDW split spelling of the same car — same source
+  M 151 A1: M151A1        # US Army designation is one fused token — M151/M151A1/M151A2 (https://en.wikipedia.org/wiki/M151_jeep); the fi/RDW raw "M 151 A1 CABRIOLET" is the same MUTT
+  M-151 A1: M151A1        # hyphenated registry spelling — same source
+  Sierra XR4I: Sierra XR4i    # Ford's injection badge keeps a lowercase i — XR4i (https://en.wikipedia.org/wiki/Ford_Sierra); the curated Citroen GTi / 405 SRi convention
+  Sierra Xr 4I: Sierra XR4i   # spaced registry spelling — same source
+  Sierra Xr-4I: Sierra XR4i   # hyphenated registry spelling (observed published form) — same source
   Mustang Mach: Mustang Mach-E  # the -E stripper (for Corsa-E) eats Mach-E; restore the official name
   "17M": "17 M"                               # spelling variant of "17 M" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "20M": "20 M"                               # spelling variant of "20 M" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -765,6 +802,18 @@ Jaecoo:
   JAECOO8: Jaecoo 8                       # marque fused; official spelling is spaced
 
 Jaguar:
+  # ── swarm-dossier batch: X.J.S stop-split artifacts (the MG "M G B"
+  # class) + the settled fused XJ6 direction completed. "Xj  6" has TWO
+  # literal spaces (smart_case lone-hyphen defect; corpus-proven,
+  # replay-invisible — do not "fix" the spacing). ──
+  "38S": "3.8S"              # de-dotted register shape of the 3.8-litre S-Type (1963-68, 15,065 built; en.wikipedia Jaguar_S-Type_(1963))
+  "X J S": XJ-S              # stop-split artifact of raw "X.J.S"; XJ-S is the launch name 1975-91 (block's jaguarheritage pin; en.wikipedia Jaguar_XJS)
+  "X.j.s": XJ-S              # stop-form raw, uncased tail
+  "Xj S": XJ-S               # same id already — keyed so the display cannot flap off XJ-S
+  "Xj.s": XJ-S               # same id already — fused stop form
+  "XJ.6": XJ6                # stop form of the XJ6 (1968-92; en.wikipedia Jaguar_XJ writes XJ6 closed) — completes the settled "Xj 6": XJ6
+  "Xj  6": XJ6               # DOUBLE space from raw "XJ - 6" (smart_case drops the lone hyphen and leaves two spaces)
+  "Xj-6": XJ6                # hyphenated register shape
   "420G": "420 G"                             # spelling variant of "420 G" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Mki: Mk I                                   # spelling variant of "Mk I" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Xjs He: XJ-S                            # XJ-S is the launch name (1975); the hyphen was dropped from the badge only at the 1991 facelift, and Jaguar heritage still writes XJ-S. Engine/trim suffixes (HE, V12, Auto) and the XJ-SC cabriolet body fold into the nameplate (https://www.jaguarheritage.com/jaguar-world-may-2018-jaguar-convertible-at-30/)
@@ -807,9 +856,19 @@ Jawa:
   Jawa: null                              # motorcycle fi|nl
 
 Jeep:
+  # ── swarm-dossier batch: CJ direction reversed on jeep.com's own history
+  # pages (marque-official hyphenation beats the fused-prefix heuristic —
+  # the settled F-150 shape). ──
+  Cj-5: CJ-5        # case-only: the caser Title-cases CJ — https://www.jeep.com/history/1950s.html
+  CJ5: CJ-5         # fused registry spelling — same source
+  Cj -5: CJ-5       # stray-space registry spelling (observed published form) — same source
+  Cj-7: CJ-7        # case-only — https://www.jeep.com/history/1970s.html
+  CJ7: CJ-7         # fused registry spelling — same source
+  CJ/7: CJ-7        # RDW slash spelling (observed published form) — same source
+  "Cj  7": CJ-7     # double-space published form (smart_case lone-hyphen defect class) — same source
   Jeep: null                                  # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
-  Cj 5: CJ5                                   # spelling variant of "CJ5" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
-  Cj 7: CJ7                                   # spelling variant of "CJ7" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+  Cj 5: CJ-5                                # REPOINT (was → CJ5). Jeep's own brand history hyphenates: CJ-5 x81/x128, zero fused (https://www.jeep.com/history/1950s.html, /1970s.html) — the F-150 resolution shape, marque beats the fused-prefix heuristic
+  Cj 7: CJ-7                                # REPOINT (was → CJ7). "In 1976, the Jeep Brand introduced the CJ-7" — CJ-7 x67, zero fused (https://www.jeep.com/history/1970s.html)
 
 Joint:
   E 33: E33                                   # spelling variant of "E33" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -1157,13 +1216,29 @@ Mazda:
   Bt-50: BT50                                 # spelling variant of "BT50" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 Mercedes-Benz:
+  # ── swarm-dossier batch: oddballs settled TOWARD the block's own archive-
+  # sourced convention; everything genuinely open stayed out (220 SE B/c,
+  # 170 SD, L-trucks, 4MATIC — see the dossier). ──
+  "170 Sv": 170 S-V       # caser Title-cases the suffix; same W136 car as the 170SV repoint — https://en.wikipedia.org/wiki/Mercedes-Benz_W136
+  "220SE B": 220 SEb      # fused-number registry spelling of the same W111 coupe — https://en.wikipedia.org/wiki/Mercedes-Benz_W111
+  "280SE Automatic": 280 SE Automatic     # fused-number spelling of the W108 curated as "280 SE Automatic" (https://mercedes-benz-publicarchive.com/marsClassic/)
+  "280SE-Automatic": 280 SE Automatic     # same, hyphenated — same source
+  "280/SE Automatic": 280 SE Automatic    # RDW slash spelling (observed published form) — same source
+  "300CE-24": 300 CE-24   # fused registry spelling; curated form splits number from letters, hyphenates the valve count — same source
+  "300 Ce 24": 300 CE-24  # unhyphenated valve count, caser Title-case (observed published form) — same source
+  "300TE-4-Matic": 300 TE 4-Matic    # fused registry spelling of the W124 4MATIC estate — same source
+  "300 Te 4 Matic": 300 TE 4-Matic   # caser Title-case, unhyphenated (observed published form) — same source
+  "300 Te-4 Matic": 300 TE 4-Matic   # hyphen after TE — this is what the record publishes today; no existing key matched the produced form — same source
+  "300 Te-4-Matic": 300 TE 4-Matic   # both hyphens — same source
+  "300TE 4 Matic": 300 TE 4-Matic    # fused number, no hyphens — same source
+  "906 Ba 35": 906 BA-35  # produced form of raw "906 BA 35"; the existing "906 BA35"/"906BA35" keys miss it, so the record published against the curated 906 XX-nn convention — display-only fix
   Evito: null            # eVito is the van kind (electric Vito), leaks via RDW car class
   "200": null            # bare engine-code registrations (W123/W124 era), not nameplates
   "110D": "110 D"                             # spelling variant of "110 D" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "123D": "123 D"                             # spelling variant of "123 D" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "124T": "124 T"                             # spelling variant of "124 T" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "170S": "170 S"                             # spelling variant of "170 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "170SV": 170 SV                         # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
+  "170SV": 170 S-V                        # REPOINT (was → 170 SV). Not a two-letter suffix: the W136's 1953-55 de-contented model is the hyphenated 170 S-V (https://en.wikipedia.org/wiki/Mercedes-Benz_W136)
   "170SB": 170 Sb                         # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "180B": "180 B"                             # spelling variant of "180 B" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "180C": "180 C"                             # spelling variant of "180 C" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1244,7 +1319,7 @@ Mercedes-Benz:
   "220 SB": 220 Sb                        # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "220 Se": 220 SE                        # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "220 Se Automatic": 220 SE Automatic    # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
-  "220 Se B": 220 SE B                    # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
+  "220 Se B": 220 SEb                     # REPOINT (was → 220 SE B). W111 series letter is lowercase — "220 b, 220 Sb, 220 SEb" (https://en.wikipedia.org/wiki/Mercedes-Benz_W111); the block held two targets that normalize identically, so the pair could never merge
   "220 Se B/c": "220 SE B/c"              # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "220 Te": 220 TE                        # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "220A": 220 A                           # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
@@ -1520,7 +1595,15 @@ Montesa:
   Cota 4RT260: Cota 4RT 260      # official spacing (current trim "Cota 4RT 260R"; https://montesa.com/en/modelos/cota-4rt-260r/); 259cc
   Cota 4RT301RR: Cota 4RT 301RR  # official model-page name (https://montesa.com/en/modelos/cota-4rt-301rr/); 298cc race replica
 
+Morgan:
+  # swarm-dossier batch: Plus Four (2020-, CX-Generation) is a DIFFERENT CAR
+  # from Plus 4 (1950-2020), same for Plus Six/Plus 6 — never sweep the
+  # spelled-out names into the digits (en.wikipedia Morgan_Plus_Four).
+  # plus-eight left alone (no factory attestation either way; dossier U3).
+  PLUS8: "Plus 8"            # fused register shape; Morgan Plus 8, 1968-2004 + 2012-18 (en.wikipedia Morgan_Plus_8; "Plus Eight" never appears)
+
 Morris:
+  MINI1000: "Mini 1000"      # fused register shape of the Morris Mini 1000 (en.wikipedia Mini); matches morris/mini-850, austin/mini-1000. NOTE morris/mini-mk-2 left dangling (dossier U6)
   Coopers: Cooper S                           # spelling variant of "Cooper S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Moto Guzzi:
@@ -1775,6 +1858,15 @@ Rover:
   Vanden Plas: Van Den Plas                   # spelling variant of "Van Den Plas" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Saab:
+  # ── swarm-dossier batch (2026-07-26): 93/95 vs 9-3/9-5 boundary checked,
+  # untouched — no key here can reach them. ──
+  "900I 16V": "900 I 16V"    # 900i 16-valve, same nameplate; follows this block's own "900I": "900 I" (en.wikipedia Saab_900)
+  "900I-16V": "900 I 16V"    # hyphenated register shape of the same string
+  "900SE": "900 Se"          # fused register shape; Se is the house form catalog-wide (9-3-se, 9-5-se; SE not in styling acronyms)
+  "900/SE": "900 Se"         # slash shape — same id already, keyed so the display cannot flap
+  "900 T16": "900 T 16"      # T16 = Turbo 16-valve; matches the sibling "900 T 16 S" (factory strings "900 Turbo 16"/"T16S" — nameplate fold deferred, see dossier U4)
+  "96V4": "96 V4"            # Saab 96 V4, Ford Taunus V4 engine 1967-76 (en.wikipedia Saab_96); matches sibling "95 V4"
+  "96-V4": "96 V4"           # same id already — keyed so the published display is the sourced spacing
   "9-4X": "9-4 X"                             # spelling variant of "9-4 X" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "94X": "9-4 X"                              # spelling variant of "9-4 X" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "95 Aero": "9-5 Aero"                       # spelling variant of "9-5 Aero" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1878,6 +1970,7 @@ Simson:
   Awo: AWO                                  # AWO = Awtowelo, the Soviet-era trade name under which Simson (Suhl) built the 425; never a word. Variants AWO 425 S (Sport) and 425 T (Touren). https://en.wikipedia.org/wiki/Simson_(company) — NOTE the register also holds "AW0 425" with a DIGIT ZERO for the letter O, which is registry noise and correctly stayed below threshold
 
 Smart:
+  For Two: Fortwo   # smart writes the nameplate as ONE word — "smart fortwo" (https://www.smart.com/en/models/); the es_dgt/RDW "SMART FOR TWO" rows are the same car. Display stays Title-case while the make does (deliberate — CPx/GTi covers internal case, not the initial)
   "1": "#1"                              # smart official model names carry the hash: de.smart.com/de/models renders "smart #1". KBA strips both the marque token and the symbol. NB the block key is the catalog display name "Smart"; the marque is officially lowercase "smart" (de.smart.com) but changing the display name is a makes/aliases.yml identity pin and a separate change.
   "3": "#3"                              # as above
   "5": "#5"                              # as above
@@ -2107,6 +2200,10 @@ Vespa:
   G.s.:                      GS                   # Gran Sport, closed; the register's 'G.s.' is punctuation noise
   Seigiorni:                 Sei Giorni           # Italian for Six Days — two words, as Vespa writes it
 
+Vinfast:
+  VF8: VF 8    # VinFast spaces the range — VF 5/6/7/8/9 (https://en.wikipedia.org/wiki/VinFast_VF_8); sibling car/vinfast/vf-6 already publishes "VF 6"
+  VF-8: VF 8   # hyphenated registry spelling of the same car — same source
+
 Vmoto:
   "N.a.": null   # 169 placeholder rows; make survives on CITI / F01 / CPX / VS1 / CU ECONOMY / CUMINI ECONOMY
 
@@ -2262,10 +2359,16 @@ Wartburg:
   "353W": "353 W"                             # spelling variant of "353 W" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Willys:
+  # ── swarm-dossier batch: same CJ evidence as Jeep — the 1950s page
+  # attributes the CJ-3B to Willys BY NAME; keeping Willys fused would spell
+  # one nameplate two ways across two makes. ──
+  CJ3B: CJ-3B       # fused registry spelling — https://www.jeep.com/history/1950s.html
+  Cj 5: CJ-5        # spaced registry spelling — same source
+  CJ5: CJ-5         # fused registry spelling — same source
   Mb: M B                                     # spelling variant of "M B" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Mb Jeep: M B Jeep                           # spelling variant of "M B Jeep" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Cj 3B: CJ3B                                 # spelling variant of "CJ3B" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
-  Cj-5: CJ5                                   # spelling variant of "CJ5" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+  Cj 3B: CJ-3B                              # REPOINT (was → CJ3B). "Willys dramatically updated its CJ line on January 28, 1953 with the CJ-3B" — x51 hyphenated (https://www.jeep.com/history/1950s.html)
+  Cj-5: CJ-5                                # REPOINT (was → CJ5); Willys built the CJ-5 from 1955, marque form hyphenated — same source as CJ-3B
 
 Yamaha:
   # YAMAHA CONVENTION DOSSIER (§11.2). FOUR rules, and they contradict each
@@ -2402,6 +2505,8 @@ Zundapp Famel:
   Ks Super: KS Super                        # Famel KS Super, the Portuguese-built Zündapp-engined moped. KS is Zündapp's type prefix, never a word: https://zundapp.one/zundapp-models/9/zundapp-mebea-en-exoten/39/famel-ks-super
 
 Škoda:
+  120L: 120 L       # Škoda spaces the trim letters across the range — 105 S / 105 L / 120 L / 120 LS / 120 GLS (https://en.wikipedia.org/wiki/%C5%A0koda_105/120)
+  120-L: 120 L      # hyphenated registry spelling of the same trim — same source
   Enyaq 60: Enyaq        # battery-size registrations
   Enyaq 80: Enyaq                           # battery/power trim number (80 = 82 kWh RWD) — trim, not nameplate (skoda-auto.com/models/enyaq)
   Enyaq 85: Enyaq                           # same trim-number class as Enyaq 80


### PR DESCRIPTION
## What

Two verified swarm dossiers in one batch (the #57 M-B+Fiat pattern): **british small makes (14 groups) + american tail (17 groups) → 4W collisions 53 → 22.** 31 merges, 35 ids retired, 2 minted (both deliberate: `chevrolet/c-10` Option A, `willys/cj-5` direction-reversal revival), 12 display fixes, 0 countries lost.

## Direction changes, each on marque-primary evidence

- **Jeep/Willys CJ**: jeep.com's own history pages hyphenate (CJ-5 ×128, CJ-7 ×67, CJ-3B ×51, zero fused) — the settled F-150 resolution shape. The two pre-existing Willys `former_ids` chains are edited in the same commit (repoint + replace; stale-alias-reversal precedent, 7th instance).
- **Chevrolet C-10 (Option A of the dossier's maintainer call)**: GM heritage prose writes C-10 15× on one page and the family already publishes hyphenated slugs (`c-10-cheyenne`, `c-20`, `k-10`). K-family stays fused per GM's own K20 page.
- **M-B `170SV` → `170 S-V`** and **`220 Se B` → `220 SEb`**: both repoints move *toward* the block's archive-sourced convention; the 220 pair could never merge while the block held two identically-normalizing targets.
- **Austin Mk → fused Roman** (`Healey 3000 MkIII`, `Mini MkII`): Austin registers EMIT Roman, so the MG conditional applies, not Triumph's.

## Verification (researcher ≠ verifier)

- All 33 availability rows recomputed independently against a control catalog before applying; the only deviations since the dossiers' snapshots are benign drift *gains* (`jaguar/xj-s` +ar).
- Build diff vs the previous batch baseline is **exactly** the intended change set (35 GONE / 2 BORN / 12 NAME / 8 AVAIL), nothing else; gate failure set byte-identical to the origin/main control build (the known 31 upstream-drift failures — see the drift workstream).
- The agents' curl captures (gm.com/jeep.com 403 WebFetch but clean to curl) were re-grepped: claimed occurrence counts reproduce exactly.
- Suite 6/6; the two literal double-space keys (`"Xj  6"`, `"V8  250"` — smart_case lone-hyphen defect) pass the reachability harness via the sibling hatch as the dossier predicted. **Do not rekey them to single spaces.**

## Filed follow-ups (not in this PR)

smart_case lone-hyphen normalizer fix (15 published ids, cross-owner) · Jaguar Mk genuinely-split family (U1: `Mki`/`Mk 1` put one car at two live ids) · Daimler V8-250 inversion (U2, source-correct direction; ready block in the dossier) · `morris/mini-mk-2` dangling (U6) · variant-strip Roman collapse (U7, normalizer) · Chevrolet SS acronym family + S-10 family pass · `audi/ag` corporate-string removal (raw is verbatim "AUDI AG").

<details>
<summary>Dossier 1: british small makes (verbatim)</summary>

# Dossier — British small makes: Saab, Austin, Jaguar, Daimler, Morris, Morgan

Research pass, 2026-07-26. **14 collision groups, 14 merges recommended, 0 skipped as
unresolvable.** Every proposal is availability-superset-clean and mints **zero new ids**
— every surviving slug already exists in the build.

Catalogs read:
* build (fresh, 04:16): `/Users/javi/GitHub/.vdb-worktrees/s4w-pipeline/build/out/catalog/`
* published: `/Users/javi/GitHub/.vdb-worktrees/s4w-data/catalog/`
* corpus forms: `/Users/javi/GitHub/.vdb-worktrees/s4w-pipeline/build/observed_model_names.json`
* existing curation (READ ONLY): `/Users/javi/GitHub/.vdb-worktrees/s4w-data/overrides/models/renames.yml`

---

## 0. Two things the generator got wrong, and one normalizer defect

### 0.1 `find_duplicate_spellings.rb`'s proposed canonicals are wrong in 11 of 14 groups

The script computes a canonical by casing/spacing arithmetic, not by asking whether a
canonical **already exists**. It starred 11 groups as "NEW — mints an id" when in every
case the correct target is already in the catalog. Its proposals `X.J.S`, `XJ 6`,
`900 I-16 V`, `96-V 4`, `250 V 8`, `V 8 250`, `MINI 1000`, `PLUS 8`, `Mini MK 2`,
`Healey 3000 MK 111`, `A-30` are all rejected below with reasons. **Net effect of this
dossier vs. the script's output: 0 new ids instead of 12.**

Three of them actively contradict settled `renames.yml` lines:

| script says | settled line | verdict |
|---|---|---|
| canonical `A-30` (fuse → hyphen) | `A 30: A30`, `A-40: A40`, `A 40: A40` | script is **backwards**; A-series closed is settled |
| canonical `XJ 6` (fuse → spaced) | `Xj 6: XJ6` | script is **backwards** |
| canonical `250 V 8` / `V 8 250` | `V 8: V8` | script is **backwards** (V8 is a closed token) |

### 0.2 `smart_case` drops a lone-hyphen token and leaves a DOUBLE SPACE (systemic)

`Normalizer#smart_case` is `str.split(/\s+/).map { |w| w.split("-").map { case_token }.join("-") }.join(" ")`.
A standalone `-` token splits to `[]`, joins to `""`, and the outer `join(" ")` then emits
**two spaces**. Verified live:

```
classify("JAGUAR",  "XJ - 6")         => ["Jaguar",  "Xj  6"]
classify("DAIMLER", "V8 - 250")       => ["Daimler", "V8  250"]
classify("AUSTIN",  "HEALEY 100 - 6") => ["Austin",  "Healey 100  6"]
classify("SAAB",    "9 - 5 AERO 4D")  => ["Saab",    "9  5 Aero 4D"]
```

Blast radius **15 published ids** catalog-wide (`car` 9, `van` 3, `motorcycle` 2, `moped` 1):
`daimler/v8-250`, `jaguar/xj-6`, `jaguar/xj6-2`, `de-lorean/dmc-12`, `de-soto/s-3`,
`hyundai/atos-prime`, `jeep/cj-7`, `jeep/willys-overland`, `opel/kadett-d`,
`iveco/35s14-multitel`, `peugeot/partner-furgon-m-die`,
`saxas-nutzfahrzeuge-werdau/mkd-43-l-u`, `triumph/tiger-900-bond-edition`,
`triumph/trident-660-triple-tribute`, `tomos/a35-hda`.
Two of them (`jaguar/xj-6`, `daimler/v8-250`) are in scope here and get fixed incidentally.
**The general cure is a one-line normalizer fix** (`.reject(&:empty?)` before the outer join,
or `.gsub(/\s+/, " ")` on the result) — recommended, but out of scope for a data pass.

**Consequence for the reachability harness.** `test_override_key_reachability.rb`
replays a key by feeding the key *itself* back through `classify`. For the two
double-space keys below that is a **false negative** — feeding `"XJ  6"` yields `"Xj 6"`,
because the producing raw is `"XJ - 6"`, not `"XJ  6"`. The corpus proves the form is
produced (it is the catalog `name`). Corpus beats test. Both keys are additionally covered
by the harness's own sibling hatch (`XJ.6`/`Xj-6` and `V8-250`/`V8/250` map to the same
target and replay clean), so **the suite stays green without a `KNOWN_DEAD` entry**.

### 0.3 Reachability replay — all 30 proposed keys

Run with renames suppressed, raw makes from `build/observed_raw_makes.json`, kinds
car/van/truck/bus. **28/30 reproduce themselves exactly; the 2 misses are the §0.2
false negatives.** Every key in this dossier is either replay-clean or corpus-proven.

---

## 1. SAAB — 4 groups, 4 merges

**Hazard cleared first: 93/95 vs 9-3/9-5.** The 1955 Saab 93 (`saab/93`, nl+nz) and the
1998 Saab 9-3 are different cars; likewise `saab/95` (fi,gb,nl,nz — the 1959 estate) vs the
9-5. **No group in this make touches them** and nothing below merges across the boundary.
The existing `"95 Aero": "9-5 Aero"` line is untouched. Also untouched: `saab/95e-v4-van`
(van kind) — the kind-blind key `"96-V4"` does not match it.

### S1 · `saab/900i-16v` → `saab/900-i-16v`

* forms: dying id `"900I 16V"`, `"900I-16V"`; survivor `"900 I 16V"`.
* Settled by the Saab block's own `"900I": "900 I"` — the make already spaces the `900i`
  suffix. Script's `900 I-16 V` rejected (would mint an id and invent a hyphen).
* availability: nl,nz ∪ nl,nz = **nl,nz** ✓ (identical; nothing gained, nothing lost)
* Source: en.wikipedia.org/wiki/Saab_900 spells the injected car `"900i"`; the repo's
  spaced house form is the settled local convention, not a claim about the badge.

```yaml
  "900I 16V": "900 I 16V"    # 900i 16-valve — same nameplate; follows this block's own "900I": "900 I"
  "900I-16V": "900 I 16V"    # hyphenated register shape of the same string
```
`"car/saab/900i-16v": "car/saab/900-i-16v"`

### S2 · `saab/900se` → `saab/900-se`

* forms: dying `"900SE"`; survivor `"900 Se"`, **plus a flapping alternate `"900/SE"`**.
* Canonical `900 Se` follows `"900S": "900 S"` and matches `saab/9-3-se` / `saab/9-5-se` /
  `jaguar/xk-120-se` — `SE` is not in `styling.yml#acronyms`, so `Se` is the house form
  catalog-wide. **Script's `900 SE` rejected**: it would be the only `SE` in the catalog.
* availability: `900se`(nl,nz,us) ∪ `900-se`(ca,fi,nl) = **ca,fi,nl,nz,us** ✓ strict superset
  of both; survivor gains nz + us_fueleconomy (legitimate — the US-market 1994 900 SE).
* The `"900/SE"` key is **flap insurance**: it already slugs to `900-se` but competes for the
  display name. Keying it makes the published `name` deterministic.

```yaml
  "900SE": "900 Se"          # fused register shape of the 900 SE
  "900/SE": "900 Se"         # slash shape — same id already, keyed so the display cannot flap
```
`"car/saab/900se": "car/saab/900-se"`

### S3 · `saab/900-t16` → `saab/900-t-16`

* forms: dying `"900 T16"`; survivor `"900 T 16"` (single form).
* T16 = Turbo 16-valve. Survivor matches its own sibling `saab/900-t-16-s` (`"900 T 16 S"`).
  This is the one group where the script's proposal (`900 T 16`) is **correct** and SAFE.
* availability: es,nl ∪ fi,nl = **es,fi,nl** ✓ strict superset; survivor gains es_dgt.
* Source caveat: en.wikipedia.org/wiki/Saab_900 gives the factory forms as
  `"900 Turbo 16"` / `"Turbo 16 S"`, with `"T16S"` noted as the **UK** designation.
  Neither catalog form is the factory string — see U4.

```yaml
  "900 T16": "900 T 16"      # T16 = Turbo 16-valve; matches the sibling "900 T 16 S"
```
`"car/saab/900-t16": "car/saab/900-t-16"`

### S4 · `saab/96v4` → `saab/96-v4`, **and the survivor's display is corrected to `96 V4`**

* forms: dying `"96V4"`; survivor holds **two** forms, `"96 V4"` and `"96-V4"`, and the
  build currently publishes the hyphenated one.
* `slugify("96 V4") == slugify("96-V4") == "96-v4"`, so keying **both** to `"96 V4"`
  merges the third spelling *and* fixes the display **without minting an id**.
* Source: en.wikipedia.org/wiki/Saab_96 — "The article consistently uses `96 V4` (with a
  space) throughout"; e.g. "Saab 96 V4, with the Ford Taunus V4 engine" (1967-1976).
  Matches the in-catalog siblings `saab/95-v4` (`"95 V4"`) and `saab/sonett-v4`.
* availability: `96v4`(nl,nz) ∪ `96-v4`(fi,nl) = **fi,nl,nz** ✓ strict superset.
* Script's `96-V 4` rejected (invents a space inside `V4`, contradicts `95 V4`).

```yaml
  "96V4": "96 V4"            # Saab 96 V4, Ford Taunus V4 engine 1967-76 (en.wikipedia Saab_96); matches sibling "95 V4"
  "96-V4": "96 V4"           # same id already — keyed so the published display is the sourced spacing
```
`"car/saab/96v4": "car/saab/96-v4"`

---

## 2. AUSTIN — 3 groups, 3 merges (2 of them 3-way)

**Marque note.** Austin-Healey is a separate marque (en.wikipedia.org/wiki/Austin-Healey_3000:
"consistently written as Austin-Healey (hyphenated) throughout, presented as a distinct
marque from Austin"). The repo has **already settled** this as an in-`austin` nameplate
family — `HEALEY3000: Healey 3000` is curated and `"car/austin/healey3000": "car/austin/healey-3000"`
is in `former_ids.yml`. **Nothing below changes marque identity**; all merges stay inside
`car/austin/`. Relocating the family to an `austin-healey` make is a `moves.yml` question
and is explicitly out of scope.

**Kind-blindness cleared:** `van/austin` holds `a30`, `a35`, `a40`, `mini-1000-pick-up`,
`mini-van`, `seven`, `6cwt`; `truck/austin` holds `fg`. None of the keys below collide, and
`"A-30": A30` would, if it ever fired on a van row, land on the correct existing `van/austin/a30`.

### A1 · `austin/a-30` → `austin/a30` — **direction is settled; the script is backwards**

* forms: dying `"A-30"`, `"A/30"`; survivor `"A30"`.
* The A-series closed form is settled curation: `A 30: A30`, `A 35: A35`, `A-40: A40`,
  `A 40: A40`, `A 50: A50`, with `"car/austin/a-35": "car/austin/a35"` and
  `"car/austin/a-50": "car/austin/a50"` already in `former_ids.yml`. This group is the same
  shape, third and fourth raw shapes.
* Source: en.wikipedia.org/wiki/Austin_A30 — lead reads "The **Austin A30** is a small
  family car produced by Austin from May 1952 to September 1956"; siblings A35, A40 are
  likewise closed.
* availability: `a-30`(nl,nz) ∪ `a30`(fi,gb,nl,nz) = **fi,gb,nl,nz** ✓ — the survivor is
  already a superset, so this merge loses literally nothing.

```yaml
  "A-30": A30                # third raw shape (hyphenated) — Austin badged the A30 closed (en.wikipedia Austin_A30); completes A 30/A-40/A 40
  "A/30": A30                # fourth raw shape (slash) — same nameplate
```
`"car/austin/a-30": "car/austin/a30"`

### A2 · `austin/healey-3000-mk-111` + `austin/healey-3000-mk111` → `austin/healey-3000-mkiii`

**This is a 3-way merge, and the surviving id is one the script never saw.**

* `"Mk 111"` / `"MK111"` are **three ones typed for three Roman I's**. There is no
  Austin-Healey "3000 Mark 111"; the car is the **3000 Mk III** (BJ8, 1964-67, 17,712 built)
  — en.wikipedia.org/wiki/Austin-Healey_3000, which uses "Mark III" in headings and "Mk III"
  in captions/body text.
* **Do the registers emit Roman for this make?** YES, and that is the whole decision.
  In-catalog Austin already holds `austin/healey-3000-mkiii` (`"Healey 3000 Mkiii"`, nl+nz),
  `austin/healey-3000-mk-i` (`"Healey 3000 Mk I"`), `austin/mini-mkii` (`"Mini Mkii"`).
  Roman is therefore **not a minted third form** — the MG conditional applies, not the
  Triumph one:
  * Triumph went Mk-arabic *because* "no register emits them and no badge showed them, so
    Roman would be inventing a third form" (`renames.yml` Triumph block).
  * MG went `Midget MkIII` *because* "MG registers EMIT Roman (Midget Mkii/Mkiii live
    in-catalog), so Roman is not a minted third form here — diverges from the Triumph
    Mk-arabic precedent DELIBERATELY, per its own conditional".
  * Austin satisfies the MG condition exactly. **Canonical: `Healey 3000 MkIII`**, fused
    Roman as MG did.
* **Why fused, not spaced.** `slugify("Healey 3000 MkIII") == "healey-3000-mkiii"` = the
  **existing** id. Spaced `"Healey 3000 Mk III"` would slug to `healey-3000-mk-iii` and mint
  a new id. Fused is also what MG chose, for the same reason.
* availability: (nl,nz) ∪ (nl,nz) ∪ (nl,nz) = **nl,nz** ✓ identical, nothing lost.
* The third key is a **display fix on the surviving id** (same slug), so the published
  `name` becomes `Healey 3000 MkIII` instead of the caser's `Healey 3000 Mkiii`.
* **Do NOT add a `styling.yml` whole-string pin for this** — stylings run *before* renames,
  which would change the produced form and silently kill these keys (the ordering hazard
  the MG block records at `"M G A"`).

```yaml
  Healey 3000 Mk 111: Healey 3000 MkIII   # "111" is three ones typed for Roman III — the car is the 3000 Mk III (BJ8, 1964-67; en.wikipedia Austin-Healey_3000)
  Healey 3000 MK111: Healey 3000 MkIII    # all-caps register variant of the same typo
  Healey 3000 Mkiii: Healey 3000 MkIII    # same id already — Austin registers EMIT Roman (Mkiii/Mk I live in-catalog), so Roman is not a minted form (MG Midget MkIII conditional, NOT the Triumph Mk-arabic one)
```
```
"car/austin/healey-3000-mk-111": "car/austin/healey-3000-mkiii"
"car/austin/healey-3000-mk111":  "car/austin/healey-3000-mkiii"
```

### A3 · `austin/mini-mk-2` + `austin/mini-mk2` → `austin/mini-mkii`

* Same conditional, same make, same shape. en.wikipedia.org/wiki/Mini gives
  "Mark II: 1967-1970" in headings and "Mk II" in body text; `austin/mini-mkii`
  (`"Mini Mkii"`) is already live with nl+nz.
* `slugify("Mini MkII") == "mini-mkii"` = existing id. Script's `"Mini MK 2"` rejected
  (mints an id, and picks arabic against the make's own Roman evidence).
* availability: (nl,nz) ∪ (nl,nz) ∪ (nl,nz) = **nl,nz** ✓.

```yaml
  Mini Mk 2: Mini MkII                    # classic Mini Mark II, 1967-70 (en.wikipedia Mini); same MG-conditional Roman call as Healey 3000 MkIII above
  Mini MK2: Mini MkII                     # fused arabic register variant
  Mini Mkii: Mini MkII                    # same id already — keyed so the display is MkII, not the caser's "Mkii"
```
```
"car/austin/mini-mk-2": "car/austin/mini-mkii"
"car/austin/mini-mk2":  "car/austin/mini-mkii"
```

---

## 3. JAGUAR — 3 groups, 3 merges

### Mk-form hazard: checked, and **none of the three groups is a Mk group** — see U1

The task's conditional required checking what the registers emit before choosing.
**Answer: Jaguar registers emit BOTH, abundantly.** Roman: `jaguar/mk-i`, `jaguar/mkii`,
`jaguar/mk-ix`, `jaguar/mk-x`, `jaguar/mark-i`, `jaguar/mark-ix`, `jaguar/mark-x`,
`jaguar/340-mkii`. Arabic: `jaguar/mk1`, `mk2`, `mk4`, `mk5`, `mk7`, `mk9`, `mk10`, `mk11`,
`mark-1`, `mark-2`, `mark-7`, `mark-8`, `mark-10`, `mark-11`.

And **Jaguar itself was split**, which neither Triumph nor MG was:
* en.wikipedia.org/wiki/Jaguar_Mark_2 — "The **Jaguar Mark 2** is a mid-sized luxury sports
  saloon built from late 1959 to 1967"; **arabic** throughout; "The previous Jaguar 2.4
  Litre and 3.4 Litre models made between 1955 and 1959 are identified as **Mark 1** Jaguars."
* en.wikipedia.org/wiki/Jaguar_Mark_IX — "The **Jaguar Mark IX** is a four-door luxury saloon
  car announced 8 October 1958"; the big saloons are **Mark VII / VIII / IX / X**, Roman.

So Jaguar needs a **split rule**, not a single convention, and the existing block is
half-right and half-wrong. That is a real finding but it is **not a collision group and
reversing settled lines is out of scope** — recorded as U1, nothing proposed.

**XK/XJ spacing hazard: checked.** The block's fused convention (`Xk 120: XK120`,
`Xj 6: XJ6`, `Xj 12: XJ12`) is confirmed by en.wikipedia.org/wiki/Jaguar_XJ — "The article
consistently uses **XJ6** and **XJ12** without hyphens or spaces". Group J3 follows it.

### J1 · `jaguar/38s` → `jaguar/3-8s`

* forms: dying `"38S"`; survivor `"3.8S"`. `"38S"` is a de-dotted `"3.8S"` — nl/nz registers
  strip the decimal point (`jaguar/s-type-3-8s` `"S Type 3.8S"` is the same string with the
  marque attached, and it kept its dot).
* Source: en.wikipedia.org/wiki/Jaguar_S-Type_(1963) — the 3.8-litre S-Type was introduced
  September 1963, discontinued mid-1968, 15,065 built; the article uses **both** `"3.8 S-Type"`
  in prose and `"3.8S"` in tables, and explicitly notes it "does not identify official
  factory badge specifications".
* **Canonical `3.8S`, i.e. the existing id.** Script's `"3.8 S"` rejected: with no factory
  badge evidence to prefer it, it would mint `jaguar/3-8-s` for a cosmetic change.
* availability: nl,nz ∪ nl,nz = **nl,nz** ✓.
* Larger question (whether both should fold into `jaguar/s-type`, 9 countries) is a
  nameplate call, not a spelling call — see U9.

```yaml
  "38S": "3.8S"              # de-dotted register shape of the 3.8-litre S-Type (1963-68, 15,065 built; en.wikipedia Jaguar_S-Type_(1963))
```
`"car/jaguar/38s": "car/jaguar/3-8s"`

### J2 · `jaguar/x-j-s` → `jaguar/xj-s` — the cleanest merge in the dossier

* forms: dying `"X J S"`, `"X.j.s"`; survivor `"XJ-S"`, plus two flapping alternates
  `"Xj S"` and `"Xj.s"`.
* These are **stop-split artifacts** — exactly the class the MG lane-A pass found and fixed
  (`"M G B"` / `"B G T"` were "STOP-SPLIT ARTIFACTS pinned as canonicals"). Raw `X.J.S`
  survives the caser as three tokens.
* Direction is **already settled and sourced** in the Jaguar block: 14 lines map `Xjs`,
  `Xj-S`, `Xjsc`, `Xjs He`, … → `XJ-S`, citing jaguarheritage.com; 11 `former_ids` entries
  point at `car/jaguar/xj-s`. Confirmed independently: en.wikipedia.org/wiki/Jaguar_XJS —
  "The **Jaguar XJ-S** (later called **XJS**) …"; "Ford dropped the model name's hyphen,
  marketing it as the XJS" at the **1991** facelift. Variants XJ-S HE, XJ-SC, and the
  separate **XJR-S** (already correctly split off by `Xjrs: XJR-S`).
* Script's `"X.J.S"` rejected outright — it would pin the artifact as the canonical, the
  precise mistake the MG pass had to undo.
* availability: `x-j-s`(nl,nz) ∪ `xj-s`(ca,fi,gb,lu,nl,nz,us) = **7 countries** ✓ strict
  superset; the survivor is already a superset, so nothing is lost.
* `"Xj S"` / `"Xj.s"` are **flap insurance**: same slug already, keyed so the display cannot
  drift off `XJ-S`. (Note the block's existing `Xj-S: XJ-S` key is a dead letter — the
  pipeline produces `"Xj-S"`… actually it does, replay confirms `XJ-S` → `Xj-S`, so that
  key is the live one and the display `XJ-S` comes from its **value**. Leave it alone.)

```yaml
  "X J S": XJ-S              # stop-split artifact of raw "X.J.S" — same MG "M G B" class; XJ-S is the launch name (1975-91) per the block's jaguarheritage pin and en.wikipedia Jaguar_XJS
  "X.j.s": XJ-S              # stop-form raw, uncased tail
  "Xj S": XJ-S               # same id already — keyed so the display cannot flap off XJ-S
  "Xj.s": XJ-S               # same id already — fused stop form
```
`"car/jaguar/x-j-s": "car/jaguar/xj-s"`

### J3 · `jaguar/xj-6` → `jaguar/xj6` — **direction is settled; the script is backwards**

* forms: dying `"XJ.6"`, `"Xj  6"` (the §0.2 double space), `"Xj-6"`; survivor `"XJ6"`.
* Settled by `Xj 6: XJ6` (which is why single-spaced rows already land on `jaguar/xj6` and
  no `"Xj 6"` form remains on the dying id). Sourced: en.wikipedia.org/wiki/Jaguar_XJ uses
  `XJ6`/`XJ12` closed, Series 1-3 1968-1992. `former_ids.yml` already carries
  `"car/jaguar/xj-12": "car/jaguar/xj12"` and `"car/jaguar/xj-8": "car/jaguar/xj8"`.
* Script's `"XJ 6"` rejected: backwards against settled curation *and* against the source.
* availability: `xj-6`(nl,nz) ∪ `xj6`(ca,fi,nl,nz,ua,us) = **6 countries** ✓ strict superset.
* `"Xj  6"` carries **two literal ASCII spaces** (`od -c` verified, not U+00A0). Keep the
  quotes. See §0.2 for why the replay harness reports it as a miss and why that is a false
  negative.

```yaml
  "XJ.6": XJ6                # stop form of the XJ6 (Series 1-3, 1968-92; en.wikipedia Jaguar_XJ writes XJ6 closed) — completes the settled "Xj 6": XJ6
  "Xj  6": XJ6               # DOUBLE space, produced from raw "XJ - 6": smart_case drops a lone-hyphen token and leaves two spaces. Corpus-proven, replay-invisible — do not "fix" the spacing
  "Xj-6": XJ6                # hyphenated register shape
```
`"car/jaguar/xj-6": "car/jaguar/xj6"`

---

## 4. DAIMLER — 2 groups, 2 merges (and one sourced tension, flagged not fixed)

**Sovereign / Double-Six hazard: checked, clear.** `daimler/double-six` already absorbs both
`"Double Six"` and `"Double-Six"` into one id (fi,gb,lu,nl,nz) — no collision.
`daimler/sovereign` vs `jaguar/sovereign` is a cross-make question, not a spelling one, and
is out of scope. Neither is in a collision group.

**Kind-blindness cleared:** `bus/daimler/fleetline`, `van/daimler/sprinter` — no key collides.

### The car, first, because both groups are the same car

en.wikipedia.org/wiki/Daimler_250 (canonical title; `Daimler_V8-250` redirects to it):

> "The **Daimler 2.5 V8/V8-250** is a four-door saloon which was produced by The Daimler
> Company Limited in the United Kingdom from 1962 to 1969."
> "Produced from October 1967 to 1969, **the V8-250** was a minor facelift and renaming of
> the 2.5 V8 saloon…"

So the two attested names are **`2.5 V8`** (1962-67) and **`V8-250`** (1967-69).
**The word order `250 V8` never appears in the source.** Four ids currently split this one
car — `daimler/250-v8`, `daimler/250v8`, `daimler/v8-250`, `daimler/v8250` — plus a bare
`daimler/250`.

### D1 · `daimler/250v8` → `daimler/250-v8`

* forms: dying `"250V8"`; survivor `"250 V8"` (single form).
* Direction-safe and settled-consistent: the block's `V 8: V8` keeps `V8` a closed token, so
  the only question is the space between `250` and `V8`, and the spaced survivor already
  exists. Script's `"250 V 8"` rejected — it splits `V8`, contradicting the block's own line.
* availability: nl,nz ∪ nl,nz = **nl,nz** ✓.

```yaml
  "250V8": "250 V8"          # fused register shape; V8 stays a closed token per this block's "V 8": V8
```
`"car/daimler/250v8": "car/daimler/250-v8"`

### D2 · `daimler/v8-250` → `daimler/v8250` — **merging in the settled direction, under protest**

* forms: dying `"V8  250"` (the §0.2 double space), `"V8-250"`, `"V8/250"`; survivor `"V8250"`.
* The settled line is `V8 250: V8250`, which is why no single-spaced `"V8 250"` form survives
  on the dying id — the rename already fired and moved those rows. Following it keeps this
  pass direction-war-free.
* **Tension, stated plainly:** the settled line carries only the generated boilerplate
  ("a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën
  C1, Chevrolet C10)"). That rationale does not fit — `V8` here is an **engine layout**, not
  an A3/C1-style letter-prefix nameplate — and the source spells the car **`V8-250`**, which
  slugs to `v8-250`, the id this merge is about to retire. See U2.
* availability: nl,nz ∪ nl,nz = **nl,nz** ✓ (identical either way, so the direction choice
  costs no evidence and is purely a naming call).
* `"V8  250"` carries **two literal ASCII spaces**. Same §0.2 note as `"Xj  6"`.

```yaml
  "V8  250": V8250           # DOUBLE space, produced from raw "V8 - 250" (smart_case lone-hyphen defect); corpus-proven, replay-invisible
  "V8-250": V8250            # follows the settled "V8 250": V8250. NOTE: en.wikipedia Daimler_250 spells the 1967-69 car "V8-250" — see U2 before extending this direction
  "V8/250": V8250            # slash register shape
```
`"car/daimler/v8-250": "car/daimler/v8250"`

> If the maintainer decides U2 instead, the whole family unifies on **`V8-250`** with **no
> new id** (`slugify("V8-250") == "v8-250"`, live today), and this block inverts to
> `"V8250": V8-250` + `"V8 250": V8-250` + `"V8  250": V8-250` + `"V8/250": V8-250`, with
> `"car/daimler/v8250": "car/daimler/v8-250"`. **Do not apply both.**

---

## 5. MORRIS — 1 group, 1 merge

### M1 · `morris/mini1000` → `morris/mini-1000`

* forms: dying `"MINI1000"`; survivor `"Mini 1000"` (single form).
* Source: en.wikipedia.org/wiki/Mini lists the Morris variants verbatim as
  "Morris Mini 1000", "Morris Mini Traveller", "Morris Mini Cooper S". Matches the in-catalog
  siblings `morris/mini-850`, `morris/mini-clubman`, `morris/mini-cooper`, and
  `austin/mini-1000`.
* Script's `"MINI 1000"` rejected — shouting caps, inconsistent with every Mini id in the
  catalog and with the block's own `Coopers: Cooper S`.
* availability: `mini1000`(fi,nl,nz) ∪ `mini-1000`(fi,nl,nz) = **fi,nl,nz** ✓ identical.
* Kind-blindness: `van/morris` holds `mini` and `6cwt`; no collision.

```yaml
  MINI1000: "Mini 1000"      # fused register shape of the Morris Mini 1000 (en.wikipedia Mini); matches morris/mini-850, austin/mini-1000
```
`"car/morris/mini1000": "car/morris/mini-1000"`

---

## 6. MORGAN — 1 group, 1 merge, and a DO-NOT-MERGE that matters more

### G1 · `morgan/plus8` → `morgan/plus-8`

* forms: dying `"PLUS8"`; survivor `"Plus 8"` (single form).
* Source: en.wikipedia.org/wiki/Morgan_Plus_8 — "The **Morgan Plus 8** is a sports car built
  by British car maker Morgan from 1968 to 2004 and again in revised form between 2012 and
  2018." The string "Plus Eight" **does not appear anywhere in the article**.
* Script's `"PLUS 8"` rejected — caps, and inconsistent with `morgan/plus-4` / `morgan/plus-6`.
* availability: `plus8`(lu,nl) ∪ `plus-8`(es,fi,gb,nl,nz) = **es,fi,gb,lu,nl,nz** ✓ strict
  superset; the survivor **gains lu_snca**, which is the concrete win in this group.
* Kind-blindness: `motorcycle/morgan/sports` — no collision.

```yaml
  PLUS8: "Plus 8"            # fused register shape; Morgan Plus 8, 1968-2004 and 2012-18 (en.wikipedia Morgan_Plus_8)
```
`"car/morgan/plus8": "car/morgan/plus-8"`

### DO NOT MERGE — Morgan's spelled-out names are a *different generation*, not a spelling

The catalog holds `plus-4`+`plus-four`, `plus-6`+`plus-six`, `plus-8`+`plus-eight`. Only the
first member of each pair is in a collision group, and the pairs must **stay split**:

> en.wikipedia.org/wiki/Morgan_Plus_Four: "The **Morgan Plus Four** is a roadster produced by
> the British car manufacturer Morgan **from 2020**." … "The Plus Four **replaces** the
> Morgan +4, which was produced intermittently between 1950 and 2020." … "The Plus Four is
> the second model, after the **Plus Six**, to be developed on Morgan's new bonded aluminium
> 'CX-Generation' platform."

So `Plus Four` (2020-, CX-Generation) ≠ `Plus 4` (1950-2020), and `Plus Six` ≠ `Plus 6`. Both
pairs are currently **correct** in the catalog and any future "spelled-out vs digit" sweep
must skip this make. `morgan/plus-eight` (nz,us) is the ambiguous one — no factory "Plus
Eight" is attested, but given the Four/Six precedent it is **not safe to fold on analogy**.
See U3.

---

## 7. Paste-ready — all keys, grouped by existing block

Insert into the matching block in `overrides/models/renames.yml`. **Merge into the existing
block — never add a second block with the same heading** (YAML keeps only the last duplicate
key; the Triumph block records exactly that near-miss).

```yaml
Saab:
  "900I 16V": "900 I 16V"
  "900I-16V": "900 I 16V"
  "900SE": "900 Se"
  "900/SE": "900 Se"
  "900 T16": "900 T 16"
  "96V4": "96 V4"
  "96-V4": "96 V4"

Austin:
  "A-30": A30
  "A/30": A30
  Healey 3000 Mk 111: Healey 3000 MkIII
  Healey 3000 MK111: Healey 3000 MkIII
  Healey 3000 Mkiii: Healey 3000 MkIII
  Mini Mk 2: Mini MkII
  Mini MK2: Mini MkII
  Mini Mkii: Mini MkII

Jaguar:
  "38S": "3.8S"
  "X J S": XJ-S
  "X.j.s": XJ-S
  "Xj S": XJ-S
  "Xj.s": XJ-S
  "XJ.6": XJ6
  "Xj  6": XJ6
  "Xj-6": XJ6

Daimler:
  "250V8": "250 V8"
  "V8  250": V8250
  "V8-250": V8250
  "V8/250": V8250

Morris:
  MINI1000: "Mini 1000"

Morgan:
  PLUS8: "Plus 8"
```

Verified: this YAML parses under `YAML.safe_load_file` with every key byte-exact —
`"Xj  6"` = 5 bytes, `"V8  250"` = 7 bytes (both double spaces preserved).

### `former_ids.yml` — old id → surviving id

Append-only; all same-kind, same-make. **Every left-hand id ceases to exist in the build
after the rename**, so hard rule 1 ("an old id may appear here ONLY if it no longer exists")
is satisfied for all 14.

```yaml
"car/austin/a-30": "car/austin/a30"
"car/austin/healey-3000-mk-111": "car/austin/healey-3000-mkiii"
"car/austin/healey-3000-mk111": "car/austin/healey-3000-mkiii"
"car/austin/mini-mk-2": "car/austin/mini-mkii"
"car/austin/mini-mk2": "car/austin/mini-mkii"
"car/daimler/250v8": "car/daimler/250-v8"
"car/daimler/v8-250": "car/daimler/v8250"
"car/jaguar/38s": "car/jaguar/3-8s"
"car/jaguar/x-j-s": "car/jaguar/xj-s"
"car/jaguar/xj-6": "car/jaguar/xj6"
"car/morgan/plus8": "car/morgan/plus-8"
"car/morris/mini1000": "car/morris/mini-1000"
"car/saab/900i-16v": "car/saab/900-i-16v"
"car/saab/900se": "car/saab/900-se"
"car/saab/900-t16": "car/saab/900-t-16"
"car/saab/96v4": "car/saab/96-v4"
```

(16 lines for 14 groups — A2 and A3 each retire two ids into one survivor.)

**No `former_ids` line for the display-only keys** (`"900/SE"`, `"96-V4"`, `"Xj S"`,
`"Xj.s"`, `Healey 3000 Mkiii`, `Mini Mkii`): those slugs are unchanged and the ids survive.

### Availability superset audit — all 14, no evidence lost anywhere

| # | merge | dying | surviving | union | verdict |
|---|---|---|---|---|---|
| S1 | 900i-16v → 900-i-16v | nl,nz | nl,nz | nl,nz | ✓ identical |
| S2 | 900se → 900-se | nl,nz,us | ca,fi,nl | ca,fi,nl,nz,us | ✓ +nz,+us |
| S3 | 900-t16 → 900-t-16 | es,nl | fi,nl | es,fi,nl | ✓ +es |
| S4 | 96v4 → 96-v4 | nl,nz | fi,nl | fi,nl,nz | ✓ +nz |
| A1 | a-30 → a30 | nl,nz | fi,gb,nl,nz | fi,gb,nl,nz | ✓ survivor already ⊇ |
| A2 | mk-111, mk111 → mkiii | nl,nz ×2 | nl,nz | nl,nz | ✓ identical |
| A3 | mini-mk-2, mini-mk2 → mini-mkii | nl,nz ×2 | nl,nz | nl,nz | ✓ identical |
| J1 | 38s → 3-8s | nl,nz | nl,nz | nl,nz | ✓ identical |
| J2 | x-j-s → xj-s | nl,nz | ca,fi,gb,lu,nl,nz,us | 7 | ✓ survivor already ⊇ |
| J3 | xj-6 → xj6 | nl,nz | ca,fi,nl,nz,ua,us | 6 | ✓ survivor already ⊇ |
| D1 | 250v8 → 250-v8 | nl,nz | nl,nz | nl,nz | ✓ identical |
| D2 | v8-250 → v8250 | nl,nz | nl,nz | nl,nz | ✓ identical |
| M1 | mini1000 → mini-1000 | fi,nl,nz | fi,nl,nz | fi,nl,nz | ✓ identical |
| G1 | plus8 → plus-8 | lu,nl | es,fi,gb,nl,nz | es,fi,gb,lu,nl,nz | ✓ +lu |

Every survivor keeps **≥2 sources**, so none drops below the publication threshold.
Net: **16 ids retired, 0 minted, 0 countries lost.** Four survivors gain coverage:
`saab/900-se` +nz +us, `saab/900-t-16` +es, `saab/96-v4` +nz, `morgan/plus-8` +lu.
The other ten merges are evidence-neutral — they buy one id and one display where there
were two or three.

---

## 8. UNCERTAIN / deliberately skipped

Nothing here is proposed. Each is either a direction war against settled curation, a
nameplate-identity call rather than a spelling call, or an id-minting change.

**U1 — Jaguar Mk/Mark is a genuinely SPLIT family and the block is half wrong.**
Sourced above: Mark **1**/Mark **2** are arabic (en.wikipedia Jaguar_Mark_2), Mark **VII/
VIII/IX/X** are Roman (en.wikipedia Jaguar_Mark_IX). Therefore `Mk 1: MK1` and `Mk 2: MK2`
are **correct**, but `Mk 5: MK5`, `Mk 7: MK7`, `Mk 10: MK10` are **wrong against source**
(Mark V, Mark VII, Mark X). Worse, `Mki: Mk I` and `Mk 1: MK1` point the *same car* at *two
live ids* — `jaguar/mk-i` (fi,nl,nz) and `jaguar/mk1` (nl,nz) both exist, as do
`jaguar/mkii` (fi,nl,nz) and `jaguar/mk2` (fi,nl,nz). Same for `jaguar/mark-*` vs
`jaguar/mk-*`. Skipped: reversing settled lines, and the correct fix needs a per-model split
rule, not a convention.

**U2 — Daimler: the whole V8/250 family should probably be `V8-250`.** Source is
unambiguous ("Daimler 2.5 V8" 1962-67 → "V8-250" 1967-69; "250 V8" unattested), the target
slug `v8-250` already exists, and the settled line it contradicts carries only generated
boilerplate whose stated rationale (letter-prefix nameplate, Audi A3 class) does not describe
an engine-layout token. Five ids for one car today: `250`, `250-v8`, `250v8`, `v8-250`,
`v8250`. Skipped: direction war. Inversion block supplied in §4 if the maintainer takes it.

**U3 — Morgan `plus-eight` (nz,us).** No factory "Plus Eight" is attested and the Plus 8
article never uses it, so it is *probably* a register spelling of Plus 8 — but Morgan's
spelled-out names genuinely denote a different generation (Plus Four 2020- ≠ Plus 4), so
folding on analogy is unsafe. Skipped: needs a raw-row check of the nz/us evidence
(us_fueleconomy year fields would settle it in one query).

**U4 — Saab `900 T 16` is not the factory string.** Factory is "900 Turbo 16" / "Turbo 16 S",
with "T16S" the UK designation (en.wikipedia Saab_900). Neither catalog form matches, and
`saab/900-turbo` (ca,fi,nl,nz) is arguably the real home for both. Skipped: nameplate fold,
not a spelling merge.

**U5 — Austin `a-90` is the last un-fused A-series id.** `austin/a-90` (`"A-90"`, nl,nz) has
no fused sibling — `austin/a10`, `a105`, `a110`, `a7`, `a30`, `a35`, `a40`, `a50`, `a55`,
`a60`, `a95`, `a99` are all closed, and `austin/a90-atlantic` exists. `A-90: A90` would be
consistent with the settled A-series rule but would **mint** `austin/a90`. Skipped: not a
collision group, and id-minting.

**U6 — Morris has its own dangling `Mini Mk 2`.** `morris/mini-mk-2` (nl,nz) has no fused or
Roman sibling in `morris`, so applying the A3 decision there would **mint**
`morris/mini-mkii`. Skipped: not a collision group. Flagged because leaving it means Austin
and Morris now spell the same car differently.

**U7 — the roman-numeral variant strip destroys generation data before renames can see it.**
`VARIANT_SUFFIXES` includes `/ (II|III|IV|VI{0,3})\b.*/`, so raw `"… MK III"` collapses to
`"… Mk"` **before** `smart_case` and before the rename lookup. That is where these came from:
`austin/healey-3000-mk` (es,nl,nz — 3 countries), `austin/mini-mk`, `austin/healey-mk`,
`austin/sprite-mk`, `austin/healey-sprite-mark`, `austin/mark`, `jaguar/mk` (es,fi,gb,nl,nz —
5 countries), `jaguar/mark`, `jaguar/340-mk`, `morris/1100-mk`, `morris/mini-1000-mk`,
`morris/minor-series`, `mg/midget-mk`, `daimler/century` vs `daimler/century-mk2`. These are
**unresolvable per-row** from the overrides layer — the numeral is gone before any curated
line runs. Note the asymmetry that made A2/A3 possible: only the **spaced** Roman is stripped
(the regex needs a leading space), so fused `MKII`/`MKIII` survives. Skipped: a normalizer
change, not a data change.

**U8 — the `smart_case` lone-hyphen double-space defect (§0.2), 15 ids catalog-wide.**
Two are fixed incidentally here; the other 13 span de-lorean, de-soto, hyundai, jeep ×2,
opel, iveco, peugeot, saxas, triumph ×2, tomos, jaguar/xj6-2. Skipped: normalizer fix,
cross-owner (two are S2W motorcycles, one an S2W moped).

**U9 — `jaguar/3-8s` + `jaguar/38s` may belong inside `jaguar/s-type`.** "3.8 S" *is* the
S-Type; `jaguar/s-type` carries 9 countries and `jaguar/s-type-3-8s` already exists. Skipped:
nameplate fold, and it would move evidence across a much larger record.

**U10 — Saab 93/95 vs 9-3/9-5: verified NOT triggered.** Recorded so the next pass does not
re-derive it. `saab/93` (nl,nz) is the 1955-60 two-stroke; `saab/95` (fi,gb,nl,nz) is the
1959 estate; both must stay separate from every `9-3*`/`9-5*` id. No key in §7 can reach
them. Also out of scope: `saab/saab-9-3` / `saab/saab-9-5` (make-prefix rows visible in the
corpus but not published), and `saab/sonet` / `saab/sonnett` / `saab/sonett` (a misspelling
family, not a spacing collision).

---

## 9. Application notes for the maintainer

1. **Merge into existing blocks.** Five of six makes already have a `renames.yml` block —
   `Austin:` L56, `Daimler:` L245, `Jaguar:` L752, `Morris:` L1503, `Saab:` L1757 (line
   numbers as of the 04:14 file; re-grep before editing). **Morgan has no block — create
   one**, alphabetically between `Montesa:` (L1499) and `Morris:` (L1503).
2. **Do not add `styling.yml` pins for MkII/MkIII.** Stylings run *before* renames; a pin
   would change the produced form and silently kill the A2/A3 keys. The MG block records
   this trap at `"M G A"`.
3. **Expect two reachability-harness reports** if the harness is run key-by-key without the
   sibling hatch: `Jaguar "Xj  6"` and `Daimler "V8  250"`. Both are §0.2 false negatives and
   both have live siblings mapping to the same target, so `test_rename_keys_are_reachable`
   passes as written. Do **not** add `KNOWN_DEAD` entries and do **not** rekey them to single
   spaces — that would make them genuinely dead.
4. **Verify after the build** that all 16 `former_ids` left-hand ids are gone (hard rule 1)
   and that `austin/healey-3000-mkiii` / `austin/mini-mkii` publish as `MkIII` / `MkII`.

---

## 10. Sources

* en.wikipedia.org/wiki/Austin-Healey_3000 — Mark I/II/III + BJ8, 1964-67; "Austin-Healey"
  hyphenated, distinct marque
* en.wikipedia.org/wiki/Austin_A30 — "The Austin A30 is a small family car produced by Austin
  from May 1952 to September 1956"; A35/A40 likewise closed
* en.wikipedia.org/wiki/Mini — "Mark II: 1967-1970"; "Morris Mini 1000", "Morris Mini Cooper S",
  "Austin Seven"
* en.wikipedia.org/wiki/Jaguar_S-Type_(1963) — 3.8 S-Type Sept 1963-mid 1968, 15,065 built;
  both "3.8 S-Type" and "3.8S" in use; no factory badge spec given
* en.wikipedia.org/wiki/Jaguar_XJS — "The Jaguar XJ-S (later called XJS)…"; hyphen dropped at
  the 1991 Ford facelift; XJ-S HE, XJ-SC, XJR-S
* en.wikipedia.org/wiki/Jaguar_XJ — XJ6 / XJ12 written closed, Series 1-3 1968-1992
* en.wikipedia.org/wiki/Jaguar_Mark_2 — "The Jaguar Mark 2 … late 1959 to 1967"; arabic;
  1955-59 cars "identified as Mark 1 Jaguars"
* en.wikipedia.org/wiki/Jaguar_Mark_IX — "The Jaguar Mark IX … announced 8 October 1958";
  Mark VII/VIII/IX/X Roman
* en.wikipedia.org/wiki/Daimler_250 (`Daimler_V8-250` redirects here) — "The Daimler 2.5
  V8/V8-250 … from 1962 to 1969"; "Produced from October 1967 to 1969, the V8-250 was a minor
  facelift and renaming of the 2.5 V8 saloon"
* en.wikipedia.org/wiki/Saab_96 — "96 V4" spaced throughout; Ford Taunus V4, 1967-1976
* en.wikipedia.org/wiki/Saab_900 — "900i", "900 Turbo 16", "900 Turbo 16 S", "T16S" (UK),
  "900 Aero", "900 SPG", "900 CD", "900c"
* en.wikipedia.org/wiki/Morgan_Plus_8 — "The Morgan Plus 8 is a sports car built by British
  car maker Morgan from 1968 to 2004 and again in revised form between 2012 and 2018";
  "Plus Eight" never used
* en.wikipedia.org/wiki/Morgan_Plus_Four — "The Morgan Plus Four is a roadster produced …
  from 2020"; "replaces the Morgan +4, which was produced intermittently between 1950 and
  2020"; CX-Generation platform, after the Plus Six
* jaguarheritage.com/jaguar-world-may-2018-jaguar-convertible-at-30/ — cited by the existing
  Jaguar XJ-S curation (not re-fetched; the Wikipedia XJS article corroborates it
  independently)
* Repo precedent, `overrides/models/renames.yml`: MG block (`Midget Mk 3: Midget MkIII` and
  its "MG registers EMIT Roman" conditional; the `"M G B"`/`"B G T"` stop-split reversal) and
  Triumph block ("Mk is ARABIC and CLOSED … no register emits them … Roman would be inventing
  a third form")
* Repo mechanics: `pipeline/lib/normalizer.rb` (`smart_case`, `VARIANT_SUFFIXES`, rename
  ordering), `pipeline/tests/test_override_key_reachability.rb` (replay semantics, sibling
  hatch, "when the test and the corpus disagree, the corpus wins")

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
