### PR TITLE
Matchless: fold 2 manglings with determined targets, file 2 without

### DIFF
--- a/data/name_shapes.yml
+++ b/data/name_shapes.yml
@@ -567,3 +567,34 @@ debt:
       DO NOT bulk-fold on the K53 prefix in the meantime. The prefix is shared
       by genuinely different types, which is the mistake this entry opens by
       admitting.
+  - id: matchless-undetermined-manglings
+    owner: s2w
+    category: code_string
+    id_list: [matchless/g3l5, matchless/g12l]
+    count: 2
+    why: >-
+      TWO OF FOUR FLAGGED MANGLINGS RESOLVED, THESE TWO DELIBERATELY NOT. A swarm
+      researcher flagged g3l5, g805, gs80 and g12l as matching no source and
+      correctly declined to act on any of them. The raws then settled two:
+      nl_rdw carries G80S (x2) alongside G805 (x1) and GS80 (x1), which are
+      one-character corruptions of a well-attested code in a make whose every
+      designation is G-prefixed. Those two are folded.
+      THESE TWO ARE NOT, and the distinction is the point — "matches no source"
+      tells you a string is probably corrupt; it does not tell you what it is
+      corrupt OF, and a fold needs a target.
+      g12l: "G12L" IS a genuine raw (1 row, beside G12 and G12 CSR), but no
+      source records a Matchless G12L. Candidate targets are G12DL (De Luxe,
+      with the D dropped) or a corruption of G12CS/G12CSR. Two plausible
+      targets and no way to choose is not a merge, it is a guess with a
+      citation attached.
+      g3l5: almost certainly G3LS via the same S->5 corruption now DEMONSTRATED
+      in this make by the G805 case. But g3l5 does not appear in nl_rdw — it
+      comes from nz_nzta, which is not in the local archive — so this would be
+      inferring a specific record from a sibling pattern. That is the
+      family-pattern move I warned ten swarm agents against; declining it here
+      costs one fold and keeps the rule honest.
+      RESOLVABLE by reading the nz_nzta raw for g3l5, and by any source that
+      names a Matchless G12L or dates a G12DL. NOTE the OCR context: the
+      cybermotorcycle tables this marque is documented from demonstrably
+      contain this class of damage ("GBLS" for G3LS, "G8OCS" for G80CS,
+      "G180" for G80), so corrupt strings here are expected, not surprising.

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2713,3 +2713,5 @@
 "car/maserati/granturismo-s-automatic": "car/maserati/gran-turismo-s-automatic"
 "car/maserati/granturismo-sport":       "car/maserati/gran-turismo-sport"
 "car/maserati/3500gt":                  "car/maserati/3500-gt"
+"motorcycle/matchless/g805": "motorcycle/matchless/g80s" # register corruption S->5, target determined from the raws
+"motorcycle/matchless/gs80": "motorcycle/matchless/g80s" # register corruption GS<->G8, target determined from the raws

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1208,6 +1208,8 @@ Maserati:
 Matchless:
   G3/LS:                     G3LS                 # Matchless type code, closed (G3L Lightweight + S spring frame). DEFUNCT marque — badge evidence, no manufacturer left to ask
   G80/S:                     G80S                 # ditto (G80 + S spring frame). Defunct marque
+  G805: G80S                                  # register corruption, S read as 5. nl_rdw carries G80S (x2, plus fi_traficom and lu_snca) and G805 (x1) under the same make; Matchless model codes are all G-prefixed (G3, G9, G11, G12, G80) and "G805" fits no scheme. Folded because the TARGET IS DETERMINED, unlike its two siblings — see data/name_shapes.yml `matchless-undetermined-manglings`.
+  GS80: G80S                                  # register corruption, G and S transposed. Same evidence as G805 above: one raw row against G80S's multiple, and "GS80" is not a Matchless designation pattern.
 
 Maxus:
   Edeliver 9: E-Deliver 9                     # spelling variant of "E-Deliver 9" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence


### PR DESCRIPTION
A swarm researcher flagged four ids as matching no source (`g3l5`, `g805`, `gs80`, `g12l`) and correctly declined to act on any of them. The raws then settled exactly two.

## Folded — target determined

`nl_rdw` carries, under make MATCHLESS:

```
G80S  x2   <- the real designation (also in fi_traficom and lu_snca)
G805  x1   <- S read as 5
GS80  x1   <- G and S transposed
```

One-character corruptions of a well-attested code, each appearing **once** against the correct form's multiple rows, in a make whose every model code is G-prefixed (G3, G9, G11, G12, G80). Neither `G805` nor `GS80` fits that scheme.

## Filed as debt — target NOT determined, and the distinction is the whole point

**"Matches no source" tells you a string is probably corrupt. It does not tell you what it is corrupt OF, and a fold needs a target.**

- **`g12l`** — `G12L` *is* a genuine raw (1 row, beside `G12` and `G12 CSR`), but no source records a Matchless G12L. Candidates are `G12DL` (De Luxe, D dropped) or a corruption of `G12CS`/`G12CSR`. Two plausible targets and no way to choose is a guess with a citation attached.
- **`g3l5`** — almost certainly `G3LS` via the same S→5 corruption that `G805` **just demonstrated occurs in this make**. But `g3l5` is not in `nl_rdw`; it comes from `nz_nzta`, which is not in my local archive. So folding it means inferring a specific record from a sibling pattern — the family-pattern move I warned ten swarm agents against, in its most tempting form. Declining costs one fold and keeps the rule honest.

Both are resolvable: read the `nz_nzta` raw for `g3l5`, and find any source naming a Matchless G12L or dating a G12DL.

Worth noting the OCR context recorded in the debt entry: the cybermotorcycle tables this marque is documented from demonstrably contain this class of damage (`GBLS` for G3LS, `G8OCS` for G80CS, `G180` for G80). Corrupt strings here are expected, not surprising.

Build at the environmental baseline of 31 failures, unchanged.