### PR TITLE
Italian §4 sibling alignment: Ferrari caps family + Gran Turismo completion

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2703,3 +2703,13 @@
 "car/mercedes-benz/280se-automatic": "car/mercedes-benz/280-se-automatic"
 "car/mercedes-benz/300ce-24": "car/mercedes-benz/300-ce-24"
 "car/mercedes-benz/300te-4-matic": "car/mercedes-benz/300-te-4-matic"
+# ---------------------------------------------------------------------------
+# 2026-07-26 — italian dossier §4 sibling alignment (#62 follow-up): seven
+# re-slugs to sourced spellings, no merges (each target is a fresh id).
+"car/ferrari/308gts":                  "car/ferrari/308-gts"
+"car/maserati/granturismo-modena":      "car/maserati/gran-turismo-modena"
+"car/maserati/granturismo-trofeo":      "car/maserati/gran-turismo-trofeo"
+"car/maserati/granturismo-s":           "car/maserati/gran-turismo-s"
+"car/maserati/granturismo-s-automatic": "car/maserati/gran-turismo-s-automatic"
+"car/maserati/granturismo-sport":       "car/maserati/gran-turismo-sport"
+"car/maserati/3500gt":                  "car/maserati/3500-gt"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -450,6 +450,18 @@ Evt:
   "Evt-4000E":                 4000E                # embedded make prefix — strip_make_prefix needs [\s,]+ after the prefix, so a hyphenated or fused badge survives (the IVA pilot's diagnosis)
 
 Ferrari:
+  # ── italian dossier §4a/4b (sibling alignment; #62 follow-up): the caps
+  # family the collision batch fixed for 308/348, completed for the rest —
+  # display-only except 308GTS (one mint + alias). Blast radius measured:
+  # token Gtb = 6 records, all Ferrari, all officially caps. ──
+  "296 Gtb": "296 GTB"          # GTB caps initialism, same as the 308 — https://en.wikipedia.org/wiki/Ferrari_296
+  "328 Gtb": "328 GTB"          # ditto — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
+  "488 Gtb": "488 GTB"          # ditto — https://en.wikipedia.org/wiki/Ferrari_488
+  "599 Gtb": "599 GTB"          # ditto — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
+  "599 Gtb Fiorano": "599 GTB Fiorano"  # ditto, full nameplate — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
+  "308 Gtbi": "308 GTBi"        # the GTB half of the injected pair; #62 fixed Gtsi, this keeps the family spelled alike — https://en.wikipedia.org/wiki/Ferrari_308_GTB/GTS
+  "348 Tb": "348 TB"            # the TB half of the 348 pair; #62 fixed TS — https://en.wikipedia.org/wiki/List_of_Ferrari_road_cars
+  "308GTS": "308 GTS"           # register-fused with no spaced sibling; mints ferrari/308-gts + alias — leaving it fused while the GTB is spaced is the half-fix §4 exists to prevent — https://en.wikipedia.org/wiki/Ferrari_308_GTB/GTS
   # ── swarm-dossier batch (2026-07-26): 4 of 8 detector canonicals were the
   # FOLD KEY leaked into the display string ("GTC 4 Lusso", "Ghibli S Q 4" —
   # attested nowhere). GTC4 and Q4 are closed tokens. No styling.yml acronym
@@ -1173,6 +1185,16 @@ MAN:
   Man: null                                   # registry rows where the make was written into the model column (truck kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Maserati:
+  # ── italian dossier §4c/4d: completes the Gran Turismo family the MA-2
+  # merge started (same committed Granturismo -> Gran Turismo direction; a
+  # half-fixed family flaps between spellings across releases) + the 3200GT
+  # precedent mirror. Six mints, six aliases. ──
+  "Granturismo Modena": "Gran Turismo Modena"           # MA-2 sibling — https://en.wikipedia.org/wiki/Maserati_GranTurismo
+  "Granturismo Trofeo": "Gran Turismo Trofeo"           # ditto — https://en.wikipedia.org/wiki/Maserati_GranTurismo
+  "Granturismo S": "Gran Turismo S"                     # ditto (M145 generation) — https://en.wikipedia.org/wiki/Maserati_GranTurismo
+  "Granturismo S Automatic": "Gran Turismo S Automatic" # ditto — https://en.wikipedia.org/wiki/Maserati_GranTurismo
+  "Granturismo Sport": "Gran Turismo Sport"             # ditto — https://en.wikipedia.org/wiki/Maserati_GranTurismo
+  "3500GT": "3500 GT"           # exact mirror of the committed "3200GT": "3200 GT"; the 3500 GT (1957-64) is a spaced nameplate; does NOT touch the separate bare maserati/3500 (dossier §5.2) — https://en.wikipedia.org/wiki/Maserati_3500_GT
   # ── swarm-dossier batch: Q4 = Maserati's AWD system, one token; S is the
   # engine trim. "S Q 4" is the fold key leaking, attested nowhere. ──
   "Ghibli SQ4": "Ghibli S Q4"                   # register glued the trim tokens; pure merge onto the correctly-spelled id — https://en.wikipedia.org/wiki/Maserati_Ghibli_(M157)


### PR DESCRIPTION
Follow-up the #62 dossier designed as a separate PR: 7 display-only caps fixes (`296/328/488/599 Gtb` → GTB, `308 Gtbi`, `348 Tb` — token blast radius measured, all-Ferrari, all officially caps) + 7 re-slugs with aliases (`308GTS` → `308 GTS`; the five `Granturismo *` siblings complete the family MA-2 started, same committed direction; `3500GT` mirrors the committed `3200GT` line). No merges — every target is a fresh id; every line sourced. Untouched by design: bare `maserati/3500` (needs raw-row evidence), `Grancabrio`/`Gransport` (house-style call, recorded in the #62 dossier §5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)