### PR TITLE
Upstream-drift adoption, 4W half — 7 true disappearances dispositioned (11 → 4 gate failures)

### DIFF
--- a/overrides/models/drop_patterns.yml
+++ b/overrides/models/drop_patterns.yml
@@ -14,6 +14,7 @@ car:
   - '\bTRANSPORTER\b' # VW T-series van
   - '\bCRAFTER\b'     # VW van
   - '\bCADDY\b'       # VW van — RDW even has "CADDY MODIFIED PARTITION WALL" (25,250 rows measured)
+  - '\bCADDYMAXI\b'   # fused UK-DfT genmodel of the same van; without this the kind-blind Caddymaxi->Caddy fold mints car/volkswagen/caddy in pre-drift cache states (the cross-kind prune has a >=100 guard these few rows sit under) — caught by the pinned Caddy spotcheck on #67
   - '\bBERLINGO\b'    # Citroën van (passenger Berlingo handled under van kind)
   - '\bKANGOO\b'      # Renault van
   - '\bPARTNER\b'     # Peugeot van

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2717,3 +2717,15 @@
 "motorcycle/matchless/gs80": "motorcycle/matchless/g80s" # register corruption GS<->G8, target determined from the raws
 "motorcycle/suzuki/gsx650": "motorcycle/suzuki/gsx650f" # threshold-edge disappearance (S4W Turn 105). The uk_dft genmodel "GSX650" was the FAMILY BUCKET; aliased to the BASE variant. NB three 650 GSX ids are live — gsx650f, gsx650fa (ABS), gsx650fu (restricted) — so this points at the base of three, not at a sole survivor.
 "motorcycle/suzuki/gsx1300-rrqm-5-hayabusa": "motorcycle/suzuki/hayabusa" # threshold-edge disappearance. "GSX1300 Rrqm 5 Hayabusa" is a mangled genmodel of the Hayabusa; suzuki/hayabusa verified live.
+# ---------------------------------------------------------------------------
+# 2026-07-26 — upstream-drift adoption, 4W half (the 7 TRUE disappearances
+# left after publication hysteresis, pipeline #32; three-build evidence).
+# Each target verified LIVE. The 2W (motorcycle) dispositions are S2W's,
+# handed over in NEGOTIATION Turn 105.
+"car/hyundai/inster-01-ev":       "car/hyundai/inster"      # DfT re-bucketed the trim-flavored genmodel; the nameplate id carries 7 sources
+"car/hyundai/kona-advance-hev-s": "car/hyundai/kona"        # same re-bucket class; kona carries 11 sources
+"car/volkswagen/caddymaxi":       "van/volkswagen/caddy"    # DfT genmodel now files these rows under CADDY; cross-kind like van/willys precedent — the car-kind caddymaxi was registry kind-noise of the same van
+"van/volkswagen/caddymaxi":       "van/volkswagen/caddy"    # same re-bucket, native kind
+"van/peugeot/boxer-35-professional": "van/peugeot/boxer"    # trim string of the Boxer (35 = GVW series, Professional = trim); nameplate id carries 6 sources
+"bus/irisbus/daily":              "bus/iveco/daily"         # cross-make, same vehicle: Irisbus was Iveco's bus marque and the Daily minibus IS the Iveco Daily; iveco/daily carries 5 sources
+"car/gmc/hummer-ev-suv-3x":       "car/gmc/hummer-ev"       # trim fold (3X = trim of the Hummer EV SUV), the leaf-30-kwh precedent; hummer-ev live with 2 sources

--- a/overrides/models/moves.yml
+++ b/overrides/models/moves.yml
@@ -205,3 +205,10 @@
 # is not itself a rename key under IVA. (That lint is the one this pass added
 # after the Vespa Seigiorni case.)
 "Benzhou|Iva LUX50":               "IVA|LUX50"
+
+# ── Irisbus Daily → Iveco Daily (drift adoption, 2026-07-26) ─────────────────
+# Irisbus was Iveco's bus marque; the Daily minibus IS the Iveco Daily. The
+# registers that file it under IRISBUS are recording the marque-of-sale, not a
+# different vehicle. Paired with the former_ids alias in the same change so the
+# retired id is dead in every cache state.
+"Irisbus|Daily": "Iveco|Daily"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -570,6 +570,7 @@ Gilera:
   Runner 45KM/H: Runner      # L1e class marker folds (NAMING.md §6); the Runner nameplate covers it
 
 GMC:
+  "Hummer EV SUV 3X": Hummer EV     # drift-adoption fold: 3X is a trim of the Hummer EV SUV (leaf-30-kwh precedent)
   Pickup: Pick-Up                             # spelling variant of "Pick-Up" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Govecs:
@@ -713,6 +714,8 @@ Hummer:
   Hummer: H1                                  # the civilian AM General Hummer was sold as just "Hummer" from 1992 and renamed H1 in 1999 when the H2 was announced — same vehicle, so it merges into the H1 nameplate rather than being dropped (https://en.wikipedia.org/wiki/Hummer_H1)
 
 Hyundai:
+  "Inster 01 EV": Inster            # drift-adoption fold: DfT re-bucketed this trim-flavored genmodel; folds any remaining rows into the nameplate so the retired id is dead in EVERY cache state (CI pre-drift vs local post-drift — the #67 liveness lesson)
+  "Kona Advance HEV S": Kona        # same fold, same reason
   Atos-Prime: Atos                          # facelift trim name (Atos Prime, 1999-2003) — same nameplate; registries emit both
   H1: H-1                                     # spelling variant of "H-1" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Scoupe: S-Coupe                             # spelling variant of "S-Coupe" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1732,6 +1735,7 @@ Panther:
   Panther: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Peugeot:
+  "Boxer 35 Professional": Boxer    # drift-adoption fold: GVW-series trim string of the Boxer
   # ── collision batch (2026-07-26): 9 groups, one dossier — trim codes
   # uppercase-spaced; injection-era badges keep Peugeot's lowercase i;
   # engine badges closed. Two detector proposals overridden (Mi16, V6). ──
@@ -2237,6 +2241,7 @@ Vmoto:
   "N.a.": null   # 169 placeholder rows; make survives on CITI / F01 / CPX / VS1 / CU ECONOMY / CUMINI ECONOMY
 
 Volkswagen:
+  Caddymaxi: Caddy                  # drift-adoption fold: DfT files these rows under CADDY now; kind-blind — the car-kind residual is minority-kind and cross-kind dominance prunes it
   Buggy: null            # kit-car/beach-buggy registrations on Beetle base
   Volkswagen-Vw: null    # fi/nl rows whose model column literally reads "VOLKSWAGEN-VW" — the make twice, zero model information. Unlike make-as-model keeps (van/uaz/uaz), there is no single-model marque hypothesis to preserve; removal manifest: removals.yml
   Kever: null            # Dutch for Beetle — classic-era rows; Beetle nameplate covers it

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1564,6 +1564,7 @@ Mercury:
   Montclair: Mont Clair                       # spelling variant of "Mont Clair" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 MG:
+  "M.g. B": MGB                     # tenth one-id-many-names instance: residual stop-form raw "M.G. B." (nl_rdw, 1 row) survived the lane-A pass and resurrected the retired m-g-b id under publication hysteresis — found by the alias-source exclusion (pipeline #32). Same MGB target as the whole family.
   RX6: HS                                 # NOT a model name: KBA's internal type code for the MG HS/EHS. FZ 6.1 HSN 2180 Handelsname reads 'MG RX6;-HS;-EHS;-EHS PHEV' (https://dewiki.de/Lexikon/MG_HS)
   S6: MGS6 EV                             # official German name is the fused MGS6 EV (https://www.mgmotor.de/model/mgs6); KBA's make string "MG ROEWE" is SAIC's dual-brand label for HSN 2180 and there is no Roewe S6 — no Roewe is sold in Germany at all
   S9: MGS9 PHEV                           # same fused naming family, 7-seat SUV, DE launch 2026-04-18 (https://de.motor1.com/reviews/796581/mgs9-phev-2026-fahrbericht-siebensitzer/)


### PR DESCRIPTION
Companion to pipeline #32 (publication hysteresis). Of the 11 true disappearances hysteresis left standing, these are the seven 4W ones — each alias target verified live, each disposition reasoned per line in `former_ids.yml` (DfT genmodel re-buckets, trim folds, one cross-kind and one cross-make alias with precedents cited). Plus the `"M.g. B": MGB` key for the residual stop-form raw that briefly resurrected `m-g-b` (the tenth one-id-many-names instance, found by hysteresis's alias-source exclusion).

Verification build: **11 → 4 gate failures**, remainder all 2W (handed to S2W in NEGOTIATION Turn 105 with disposition reads: gsx650→gsx650f, gsxs = family fragment likely removal, hayabusa alias chain repoint). `m-g-b` confirmed dead; `mgb` carries the evidence. Lints + reorg green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)