### PR TITLE
Zundapp Combinette: five ids to three, justified by the raws

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -194,7 +194,7 @@
 "moped/znen/bella50":                          "moped/znen/bella-50"                          # BELLA50 -> Bella 50  [fi,nl,nz]
 "moped/zundapp/428combinette":                 "moped/zundapp/428-combinette"                 # 428COMBINETTE -> 428 Combinette  [fi,nl]
 "moped/zundapp/combinette423":                 "moped/zundapp/combinette-423"                 # COMBINETTE423 -> Combinette 423  [nl,nz]
-"moped/zundapp/combinette428":                 "moped/zundapp/combinette-428"                 # COMBINETTE428 -> Combinette 428  [fi,nl]
+"moped/zundapp/combinette428": "moped/zundapp/428-combinette" # REPOINTED: used to alias combinette-428, which this commit retires into 428-combinette. Chained aliases are dangling migrations the moment the middle id dies — the no-chain rule, and my own lint 1f caught it.
 "motorcycle/ajp/spr510enduro":                 "motorcycle/ajp/spr510-enduro"                 # SPR510ENDURO -> SPR510 Enduro  [fi,nl]
 "motorcycle/ajs/model20":                      "motorcycle/ajs/model-20"                      # MODEL20 -> Model 20  [nl,nz]
 "motorcycle/ajs/model31":                      "motorcycle/ajs/model-31"                      # MODEL31 -> Model 31  [nl,nz]
@@ -2729,3 +2729,5 @@
 "van/peugeot/boxer-35-professional": "van/peugeot/boxer"    # trim string of the Boxer (35 = GVW series, Professional = trim); nameplate id carries 6 sources
 "bus/irisbus/daily":              "bus/iveco/daily"         # cross-make, same vehicle: Irisbus was Iveco's bus marque and the Daily minibus IS the Iveco Daily; iveco/daily carries 5 sources
 "car/gmc/hummer-ev-suv-3x":       "car/gmc/hummer-ev"       # trim fold (3X = trim of the Hummer EV SUV), the leaf-30-kwh precedent; hummer-ev live with 2 sources
+"moped/zundapp/423": "moped/zundapp/combinette-423" # one type, four raw transcriptions — see renames.yml
+"moped/zundapp/combinette-428": "moped/zundapp/428-combinette" # one type, three raw transcriptions — see renames.yml

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -2531,6 +2531,8 @@ Zhenhua:
 Zundapp:
   Zundapp: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
   Werke: null                                 # NOT A VEHICLE. Raw is "ZUENDAPP | ZUNDAPP WERKE" — the manufacturer's own legal name (Zuendapp-Werke GmbH) sitting in the model column; strip_make_prefix removed "ZUNDAPP" and published the residue "Werke" as a nameplate. DROPPED rather than renamed: there is no machine here to name. Gate entry in overrides/models/removals.yml; the class this produced is scripts/find_corporate_strings.rb.
+  "423": Combinette 423                       # SAME MACHINE as Combinette 423 — nl_rdw carries "423", "423 Combinette", "COMBINETTE 423" and "COMBINETTE 423 S" for one type. Folded to the marque's own form (zundapp.one publishes it as "Combinette 423 S").
+  Combinette 428: 428 Combinette              # SAME MACHINE as 428 Combinette — nl_rdw carries "428", "428 COMBINETTE" and "COMBINETTE 428" for one type. Folded the other way round from the 423 pair ON PURPOSE: zundapp.one publishes THIS one as "428 Combinette". The two pairs disagree because the marque does; do not "fix" the inconsistency.
 
 Zundapp Famel:
   Ks Super: KS Super                        # Famel KS Super, the Portuguese-built Zündapp-engined moped. KS is Zündapp's type prefix, never a word: https://zundapp.one/zundapp-models/9/zundapp-mebea-en-exoten/39/famel-ks-super


### PR DESCRIPTION
The swarm researcher flagged this cluster and explicitly declined to act, saying *"confirm against the register's raw strings first, because the 420-438 range contains many near-adjacent distinct types."* It was right to, and the raws confirm the merge.

## What `nl_rdw` actually carries under make ZUNDAPP

```
type 423:  "423" · "423 Combinette" · "423 COMBINETTE" ·
           "COMBINETTE 423" · "COMBINETTE 423 S"
type 428:  "428" · "428 COMBINETTE" · "COMBINETTE 428"  (+ sub-codes)
bare:      "COMBINETTE" x3, plus SUPER/SPORT COMBINETTE variants
```

Each type appears **with and without the family word, and in both word orders**. That is transcription variance of one string — the *opposite* of the Kreidler K53 case, where a shared prefix concealed genuinely different type numbers. The distinction was confirmed by checking, not assumed by analogy, which is the only reason I trust it after K53.

| fold | |
|---|---|
| `423` → `Combinette 423` | |
| `Combinette 428` → `428 Combinette` | |
| `combinette` | left alone — the **parent** nameplate, with its own raw (3 rows) plus Super/Sport variants |

## The two pairs fold in opposite word orders on purpose

zundapp.one publishes the 423 as **"Combinette 423 S"** and the 428 as **"428 Combinette"**. The marque disagrees with itself; the data follows the marque. Recorded in-file so nobody later "fixes" the inconsistency into uniformity.

## My own chain lint caught a regression

A pre-existing alias `combinette428 → combinette-428` became a chain the instant this commit retired that target. Lint 1f caught it; repointed to `428-combinette` in the same commit.

That is the **same no-chain shape as the hayabusa fix an hour earlier**, and the second time today that check has paid for itself — both times on a retirement I was introducing, which is exactly when a chain forms and exactly when you are not looking for one.

Build at the environmental baseline of 8.