### PR TITLE
Release prep: retire the three double-space rename keys (unreachable since pipeline #31)

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -270,7 +270,6 @@ Daimler:
   # "250 V8"/"V8 250"; the inversion block is in the dossier (U2). Do not
   # extend this direction without reading it. ──
   "250V8": "250 V8"          # fused register shape; V8 stays a closed token per this block's "V 8": V8
-  "V8  250": V8250           # DOUBLE space from raw "V8 - 250" (smart_case lone-hyphen defect); corpus-proven, replay-invisible
   "V8-250": V8250            # follows the settled "V8 250": V8250 — NOTE the source spells the car V8-250; see dossier U2 before extending
   "V8/250": V8250            # slash register shape
   Daimler: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
@@ -825,7 +824,6 @@ Jaguar:
   "Xj S": XJ-S               # same id already — keyed so the display cannot flap off XJ-S
   "Xj.s": XJ-S               # same id already — fused stop form
   "XJ.6": XJ6                # stop form of the XJ6 (1968-92; en.wikipedia Jaguar_XJ writes XJ6 closed) — completes the settled "Xj 6": XJ6
-  "Xj  6": XJ6               # DOUBLE space from raw "XJ - 6" (smart_case drops the lone hyphen and leaves two spaces)
   "Xj-6": XJ6                # hyphenated register shape
   "420G": "420 G"                             # spelling variant of "420 G" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Mki: Mk I                                   # spelling variant of "Mk I" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -878,7 +876,6 @@ Jeep:
   Cj-7: CJ-7        # case-only — https://www.jeep.com/history/1970s.html
   CJ7: CJ-7         # fused registry spelling — same source
   CJ/7: CJ-7        # RDW slash spelling (observed published form) — same source
-  "Cj  7": CJ-7     # double-space published form (smart_case lone-hyphen defect class) — same source
   Jeep: null                                  # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   Cj 5: CJ-5                                # REPOINT (was → CJ5). Jeep's own brand history hyphenates: CJ-5 x81/x128, zero fused (https://www.jeep.com/history/1950s.html, /1970s.html) — the F-150 resolution shape, marque beats the fused-prefix heuristic
   Cj 7: CJ-7                                # REPOINT (was → CJ7). "In 1976, the Jeep Brand introduced the CJ-7" — CJ-7 x67, zero fused (https://www.jeep.com/history/1970s.html)


### PR DESCRIPTION
The smart_case lone-hyphen fix means no raw produces the double-space forms anymore; their raws land on the settled single-space keys with identical targets. Removing them now prevents the post-release lint failure the #31 commit message scheduled (key-validity is measured against the published catalog, which stops carrying the double-space names at the next release). No id, display, or evidence change in any cache state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)