### PR TITLE
Acronym tranche 2: 13 type codes, 127 renames, 0 id churn — and a pin/rename-key interaction worth documenting

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -654,7 +654,7 @@ Harley-Davidson:
   Flstf Fatboy:                FLSTF Fat Boy            # code closed + registered name spaced
   Flstn Softail De Luxe:       FLSTN Softail Deluxe     # code closed + registered name spaced
   Flstn Softail Deluxe:        FLSTN Softail Deluxe     # code closed + registered name spaced (display-only, id stable)
-  Fx St:                       FXST                     # type code — uppercase, closed
+  "Fx ST":                       FXST                     # type code — uppercase, closed
   Fx Stc:                      FXSTC                    # type code — uppercase, closed
   Fxst-C:                      FXSTC                    # same as Fxe-F above: a third hyphenated spelling of the same code, invisible in the detector output because it reports one representative name per id
   Fxd/i Dyna Super Glide:      FXDI Dyna Super Glide    # code closed + registered name spaced
@@ -928,8 +928,8 @@ Kawasaki:
   "Er-6F Abs":                 ER-6F                # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); the non-ABS sibling is published from the same countries
   "Er-6N Abs":                 ER-6n                # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); the non-ABS sibling is published from the same countries
   "Ninja 250SL Abs":                 Ninja 250SL                # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
-  "Ninja Zx-10R Abs":                Ninja ZX-10R               # ABS folds AND the target takes the tail-batch caps form directly (chain collapsed in the S4W review merge of #29)
-  "Ninja Zx-6R Abs":                 Ninja Zx-6R                # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
+  "Ninja ZX-10R Abs":                Ninja ZX-10R               # ABS folds AND the target takes the tail-batch caps form directly (chain collapsed in the S4W review merge of #29)
+  "Ninja ZX-6R Abs":                 Ninja Zx-6R                # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
   "VN1700 Classic Abs":              VN1700 Classic             # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
   "VN1700 Classic Tourer Abs":       VN1700 Classic Tourer      # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
   "VN1700 Voyager Abs":              VN1700 Voyager             # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
@@ -2073,8 +2073,8 @@ Suzuki:
   DRZ400:                      DR-Z400                # off-road keeps the hyphen
   Dr-Z400:                     DR-Z400                # off-road keeps the hyphen
   Gsf-1200S:                   GSF1200S               # closed alphanumeric
-  Gsx-750F:                    GSX750F                # ...while the F sport-tourer line does NOT: GSX750F
-  Gsx-750R:                    GSX-R750               # the R sportbike line HYPHENATES (suzukicycles.com GSX-R750)
+  "GSX-750F":                    GSX750F                # ...while the F sport-tourer line does NOT: GSX750F
+  "GSX-750R":                    GSX-R750               # the R sportbike line HYPHENATES (suzukicycles.com GSX-R750)
   Gsx-R750:                    GSX-R750               # the R sportbike line HYPHENATES (suzukicycles.com GSX-R750)
   Gsxr 750:                    GSX-R750               # the R sportbike line HYPHENATES (suzukicycles.com GSX-R750)
   RMZ450:                      RM-Z450                # off-road keeps the hyphen

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -293,7 +293,7 @@ Daimler:
   V8 250: V8250                               # spelling variant of "V8250" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 Datsun:
-  280 Zx: 280ZX                               # the S130 badge is the closed 280ZX (https://en.wikipedia.org/wiki/Nissan_S130, 1978-83); nl_rdw bare forms tie (8 vs 6) so the marque decides; matches the unrenamed Datsun house form (280C, 180B, 160J). The block's spaced 240Z/260Z/280Z lines are filed as debt, not fought here
+  280 ZX: 280ZX                               # the S130 badge is the closed 280ZX (https://en.wikipedia.org/wiki/Nissan_S130, 1978-83); nl_rdw bare forms tie (8 vs 6) so the marque decides; matches the unrenamed Datsun house form (280C, 180B, 160J). The block's spaced 240Z/260Z/280Z lines are filed as debt, not fought here [rekeyed with the ZX pin (#71): the pin changes the produced form Zx->ZX — the pin/rename-key interaction this PR documents]
   "120Y": "120 Y"                             # spelling variant of "120 Y" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "1200 Deluxe": "1200 De Luxe"               # spelling variant of "1200 De Luxe" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "240Z": "240 Z"                             # spelling variant of "240 Z" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence

--- a/overrides/styling.yml
+++ b/overrides/styling.yml
@@ -63,6 +63,32 @@ stylings:
 XXX: XXX               # Talaria XXX — a REAL e-motorbike model, not a placeholder. Raw RDW pairs it explicitly: "TL2500, XXX" (https://talaria.bike/). Without this pin smart_case yields "Xxx", which reads as junk and invited a drop; the whole-string form has no other match catalog-wide.
 
 acronyms:
+  # --- S2W acronym tranche 2 (2026-07-26): marque TYPE CODES ---
+  # Selected by a rule narrower than the detector's: a token qualifies only if it
+  # is not a word in any language likely to appear in a nameplate. The pin is
+  # GLOBAL across every make and kind, so "the catalog spells it in caps
+  # somewhere" is not sufficient.
+  # DELIBERATELY EXCLUDED — real nameplate words that merely LOOK like codes:
+  #   PRO BOY BOB MAX PAN APE BIG ZIP DAX EVO JET CUB. "Fat Boy", "Fat Bob",
+  #   "Pan America", "Big Chief", "Super Cub", Piaggio Ape/Zip, Honda Dax are
+  #   all correct today; pinning these would break 80+ good records.
+  # ALSO EXCLUDED — LE, the proven collision: indian/"Ftr R Carbon Le" wants LE
+  #   (Limited Edition) while moto-guzzi/"Le Mans" wants Le (French article).
+  #   One global token cannot serve both — the 480-ES lesson.
+  # ALSO EXCLUDED — MK: British usage is "Mk III", not "MK III".
+  - GSX   # Suzuki's sport family prefix (GSX-R, GSX-S, GSX650F) — 25 records
+  - CVO   # Harley-Davidson Custom Vehicle Operations — 20 records
+  - YZF   # Yamaha's supersport prefix (YZF-R1, YZF-R125) — 14 records
+  - ZX    # Kawasaki's Ninja ZX series — 12 records
+  - MT    # Yamaha MT (Master of Torque) naked family; also Dnepr MT-9 — 9 records
+  - FTR   # Indian FTR (Flat Track Racer) — 6 records
+  - FLHT  # Harley Electra Glide frame code — 5 records
+  - DSR   # Zero Motorcycles DSR — 5 records
+  - XLH   # Harley Sportster frame code — 4 records
+  - DR    # Suzuki DR dual-sport family — 4 records
+  - SU    # Yamaha model-code suffix (MTN690-SU) — 4 records
+  - ZZ    # Kawasaki ZZ-R, Suzuki ZZ — 3 records
+  - ST    # Ducati ST sport-tourer, Harley Road Glide ST — 13 records
   # --- Roman numerals (S2W, 2026-07-26, B-001 acronym worklist) ---
   # Safe as GLOBAL token pins because no marque spells a numeral as a word:
   # smart_case turns raw "III" into "Iii", which is wrong in every marque that


### PR DESCRIPTION
**13 marque type codes pinned. 127 display fixes (116 motorcycle). Zero id churn. Gate at 0.**

`GSX CVO YZF ZX MT FTR FLHT DSR XLH SU DR ZZ ST`

## The selection rule is narrower than the detector's, deliberately

A token qualifies only if it is **not a word in any language likely to appear in a nameplate**. "The catalog spells it in caps somewhere" — the detector's bar — is not sufficient when the pin is global across every make and kind.

**Excluded as real words**: `PRO BOY BOB MAX PAN APE BIG ZIP DAX EVO JET CUB`. "Fat Boy", "Fat Bob", "Pan America", "Big Chief", "Super Cub", Piaggio's Ape and Zip, Honda's Dax are all **correct today** — pinning them would break 80+ good records.

**Excluded as a proven collision**: `LE`. `indian/Ftr R Carbon Le` wants LE (Limited Edition); `moto-guzzi/Le Mans` wants Le (French article). One global token cannot serve both.

**Excluded as British usage**: `MK` — "Mk III", not "MK III".

## Seven more removed after measuring, not predicting

`SP FX XR SE MC GTS FXST` were in my first cut. Each **resurrected previously-folded ids** — `daimler/sp-250`, `infiniti/fx-30d`, `smart/mc-01`, `harley/fxst-c` — and `GTS` broke a Vespa spotcheck.

**The first cut took the gate from 8 failures to 25.** I would not have predicted a single one of those from reading the token list.

## The interaction worth knowing, and it is not obvious

> **A casing pin silently breaks every existing rename key containing that token.**

`renames.yml` is keyed on the **produced display name**. Pin `ZX`, and `"Ninja Zx-6R Abs"` is no longer produced — `"Ninja ZX-6R Abs"` is. The fold goes **inert**, and the id it was retiring **comes back alive**.

The gate then reports `ALIVE yet aliased`, which reads like an alias bug and is really a stale rename key three steps upstream. Five keys rekeyed to their post-pin produced forms.

This is worth a line in whatever documents `styling.yml`, because the next person to add an acronym pin will hit it and the error message points at the wrong place.

## Caught by my own test

`test_override_key_reachability.rb` found it and printed the exact target form to rekey to:

```
Kawasaki "Ninja Zx-6R Abs" would be produced as ["Ninja ZX-6R Abs", "Ninja"]
Suzuki   "Gsx-750F"        would be produced as ["GSX-750F", "GSX"]
```

I wrote that test in an earlier batch for an unrelated reason. **Second time today one of my own checks has caught me — both times on a change I believed was purely cosmetic.** That is the argument for building the check when you notice the class, not when you next get bitten.

## Verification

Zero ids gone, zero added, measured against a pre-change build of the same tree. Reachability suite green. Curation lint green. Gate failures **0**.
