### PR TITLE
Acronym tranche 3: 5 per-record display fixes, verified against register raws

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -824,7 +824,7 @@
 "motorcycle/norton/atlas750":                  "motorcycle/norton/atlas-750"                  # ATLAS750 -> Atlas 750  [nl,nz]
 "motorcycle/norton/commando750":               "motorcycle/norton/commando-750"               # COMMANDO750 -> Commando 750  [fi,nl,nz]
 "motorcycle/norton/commando850":               "motorcycle/norton/commando-850"               # COMMANDO850 -> Commando 850  [nl,nz]
-"motorcycle/norton/commando850mk-iii":         "motorcycle/norton/commando-850mk-iii"         # COMMANDO850MK Iii -> Commando 850MK Iii  [nl,nz]
+"motorcycle/norton/commando850mk-iii": "motorcycle/norton/commando-850-mk-iii" # REPOINTED: used to alias commando-850mk-iii, which this commit retires. THIRD chain of the session, all the same shape — see the note at the foot of this file.
 "motorcycle/norton/commando850mk3":            "motorcycle/norton/commando-850mk3"            # COMMANDO850MK3 -> Commando 850MK3  [nl,nz]
 "motorcycle/norton/commando961cafe-racer":     "motorcycle/norton/commando-961-cafe-racer"    # COMMANDO961CAFE Racer -> Commando 961 Cafe Racer  [fi,nl]
 "motorcycle/norton/dominator-model7":          "motorcycle/norton/dominator-model-7"          # Dominator MODEL7 -> Dominator Model 7  [nl,nz]
@@ -2753,3 +2753,16 @@
 "car/volkswagen/vw-1-11":      "car/volkswagen/vw1-11"
 "bus/man/lions":               "bus/man/lion-s"
 "bus/man/lion":                "bus/man/lion-s"
+"motorcycle/moto-guzzi/850le-mans-iii": "motorcycle/moto-guzzi/850-le-mans-iii" # "850LE Mans III" -> "850 Le Mans III"
+"motorcycle/norton/commando-850mk-iii": "motorcycle/norton/commando-850-mk-iii" # "Commando 850MK III" -> "Commando 850 Mk III"
+
+# ── A NOTE ON CHAINS, after three in one session (S2W 2026-07-26) ───────────
+# Every one had the identical shape: I retire an id X (rename/fold), and
+# something ALREADY aliased to X, so A->X->Y appears the moment X dies.
+#   hayabusa   gsx1300rrqm5hayabusa -> gsx1300-rrqm-5-hayabusa -> hayabusa
+#   combinette combinette428        -> combinette-428          -> 428-combinette
+#   norton     commando850mk-iii    -> commando-850mk-iii      -> commando-850-mk-iii
+# Lint 1f caught all three, which is the system working — but the cheap habit
+# is to grep former_ids for the id you are about to retire BEFORE writing the
+# rename, not after the lint tells you. A retirement is never just about the
+# id you are looking at; it is about everything already pointing there.

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -689,6 +689,7 @@ Harley-Davidson:
   Wideglide:                   Wide Glide               # registered spelling
   Wlc:                         WLC                      # type code — uppercase, closed (display-only, id stable)
   "Vrscawa V-Rod Abs":         VRSCAWA V-Rod        # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); the non-ABS sibling is published from the same countries
+  "Fxrs Super Glide II":                     FXRS Super Glide II      # FXRS is a Harley frame code, attested in caps elsewhere in this catalog (fxrs-sp, fxrs-sport). Not pinned globally in tranche 2 because it appears in only three records — a per-record fix is cheaper than a global token and carries no rename-key blast radius.
 
 Honda:
   Honda: null                             # motorcycle fi|nl AND moped nl|nz — one make-scoped key covers both kinds (renames are kind-blind)
@@ -1679,6 +1680,7 @@ Moto Guzzi:
   "1200 Sport 8V Abs":               1200 Sport 8V              # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
   MGX21:                     MGX-21               # Moto Guzzi MGX-21 Flying Fortress, hyphenated
   Mgx-21:                    MGX-21               # Moto Guzzi MGX-21 Flying Fortress, hyphenated
+  "850LE Mans III":                          850 Le Mans III          # TWO defects in one string and the raw settles both: nl_rdw carries "850 LE MANS III" SPACED, so the glued "850LE" is a pipeline artifact, and the LE is the FRENCH ARTICLE of Le Mans — not an initialism. This record is why LE was excluded from the tranche-2 global pins: indian/"Ftr R Carbon Le" wants LE (Limited Edition) and this one wants Le. Same three letters, opposite treatment, which no global rule can express.
 
 Mtl:
   "Mtl-Eb-023":                EB-023               # embedded make prefix — strip_make_prefix needs [\s,]+ after the prefix, so a hyphenated or fused badge survives (the IVA pilot's diagnosis)
@@ -1728,9 +1730,11 @@ Nissan:
 
 Norton:
   Norton: null                            # motorcycle nl|nz
+  "Commando 850MK III":                      Commando 850 Mk III      # Ungluing "850MK" and casing MK the British way. nl_rdw carries "850 COMMANDO MKIII" and "850 COMMANDO MK3 ROADSTER" — the 850 is always spaced off in the register, and MK is Mark, which British usage writes "Mk III" not "MK III". Word order preserved as published rather than reordered to match the raw: this display comes from another source and reordering would be a second, unevidenced change.
 
 NSU:
   RO80:                      Ro 80                # the NSU Ro 80 (Ro = Rotationskolbenmotor, the Wankel) — two words. DEFUNCT marque
+  "Prima III Kl":                            Prima III KL             # KL confirmed uppercase by the raw: nl_rdw carries "PRIMA 3 KL". (The published "III" against the raw's "3" comes from another source; left alone — this fix is the KL only.)
 
 Oldsmobile:
   SUPER88: Super 88                           # spelling variant of "Super 88" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1925,6 +1929,9 @@ Rover:
   Landrover: Land Rover                       # spelling variant of "Land Rover" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Rangerover: Range Rover                     # spelling variant of "Range Rover" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Vanden Plas: Van Den Plas                   # spelling variant of "Van Den Plas" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+
+Ryuka:
+  "Save-II S Fi":                            Save-II S FI             # FI is fuel injection, an initialism in every marque that uses it. Two tokens fixed in one record.
 
 Saab:
   # ── swarm-dossier batch (2026-07-26): 93/95 vs 9-3/9-5 boundary checked,


### PR DESCRIPTION
**5 per-record display fixes. 2 id moves, both aliased. Gate 0. Zero unintended churn (16829 → 16829, control-diffed).**

Tranche 2 exhausted the tokens that are safe as **global** pins. Everything left is per-record, because every token here is either a real word somewhere or means different things in different marques.

## What the raws settled

I pulled the register raw for each before writing anything, and three of the five changed what I would have written:

| published | raw | fix |
|---|---|---|
| `850LE Mans III` | `850 LE MANS III` (nl_rdw, **spaced**) | `850 Le Mans III` |
| `Commando 850MK III` | `850 COMMANDO MKIII`, `850 COMMANDO MK3 ROADSTER` | `Commando 850 Mk III` |
| `Prima III Kl` | `PRIMA 3 KL` | `Prima III KL` |
| `Fxrs Super Glide II` | FXRS attested in-catalog (`fxrs-sp`, `fxrs-sport`) | `FXRS Super Glide II` |
| `Save-II S Fi` | FI = fuel injection | `Save-II S FI` |

**Moto Guzzi is the one worth reading.** Two defects in one string, and the raw settles both: the glued `850LE` is a *pipeline artifact* (the register spaces it), and the `LE` is the **French article of Le Mans** — not an initialism. This is the exact record that kept `LE` out of the tranche-2 global pins, because `indian/Ftr R Carbon Le` wants LE = Limited Edition. Same three letters, opposite correct answer, no global rule can express it.

**Norton**: word order left as published rather than reordered to match the raw's `850 COMMANDO`. The display comes from a different source; reordering would be a second, unevidenced change riding along on a casing fix.

## Deliberately not done

`suzuki/Lets II` — the marque writes **Let's**. No raw is reachable in my archive (nl_rdw has no LETS row) and slugify turns the apostrophe into `let-s-ii`, which is a **worse** id than the one we have. Cosmetic gain, real id churn, unverifiable source.

## The tranche-2 lesson recurred one tranche later

All five rename keys I wrote were **stale on arrival**. `renames.yml` is keyed on the *produced* display name, and **tranche 1 had already pinned `II`/`III`** — so my keys (`"Prima Iii Kl"`, `"Save-Ii S Fi"`, …) named strings the pipeline no longer produces. Every rename went inert; the build showed the five records completely unchanged.

I predicted this class in the tranche-2 writeup and still walked into it, which is the useful part: **knowing the failure mode is not the same as having a step that catches it.** `test_override_key_reachability.rb` is that step, and it printed the exact target form for each:

```
NSU "Prima Iii Kl" would be produced as ["Prima", "Prima III Kl"]
Ryuka "Save-Ii S Fi" would be produced as ["Save-II S Fi", "Save"]
```

## Third chain of the session, same shape

`commando850mk-iii` already aliased to `commando-850mk-iii`, which this PR retires — instant `A→X→Y`. Lint 1f caught it, as it caught `hayabusa` and `combinette428` earlier today.

Three occurrences, one shape: **I retire an id, and something already pointed there.** I've written the pattern and its cheap prophylactic (grep `former_ids` for the id *before* writing the rename) into a note at the foot of `former_ids.yml` — the lint catches it reliably, but it's catching a habit I should not need it for.

## Verification

Control build with the overrides stashed, then re-applied: `16829 → 16829`, and the **only** diff is the two intended moves. Reachability suite green (5 runs, 0 failures). Curation lint green. Gate **0**.
