### PR TITLE
styling.yml: re-home an inert pin, lint the root shape, add a contradiction detector

### DIFF
--- a/overrides/styling.yml
+++ b/overrides/styling.yml
@@ -58,9 +58,7 @@ stylings:
   "480 ES": 480 ES        # Volvo 480 ES — spaced official launch name (1986). Whole-string pin, deliberately NOT an ES acronym token: token ES orphaned Gas Gas "Es: ES 700" (gb/nz evidence lost, spotcheck caught it) and un-folded the entire Lexus ES family (liveness gate fired on 8 aliases) — measured 2026-07-25, GPR-precedent applies
   MGA: MGA               # MG MGA (1955-62) — one closed token (en.wikipedia MG_MGA); whole-string pin, blast radius 1 (only car/mg/mga displays Mga catalog-wide, dossier-verified)
   MGB: MGB               # same closed-token rule (en.wikipedia MG_MGB); blast radius 2 (car/mg + car/leyland MGBs, both genuine); does NOT touch the MotoGB make mgb — make casing lives in makes/aliases.yml
-
-# --- S2W two-wheeler pins (2026-07-25) ---
-XXX: XXX               # Talaria XXX — a REAL e-motorbike model, not a placeholder. Raw RDW pairs it explicitly: "TL2500, XXX" (https://talaria.bike/). Without this pin smart_case yields "Xxx", which reads as junk and invited a drop; the whole-string form has no other match catalog-wide.
+  XXX: XXX               # Talaria XXX — a REAL e-motorbike model, not a placeholder. Raw RDW pairs it explicitly: "TL2500, XXX" (https://talaria.bike/), n=6. NOTE: this pin is currently BELT-AND-BRACES, not the load-bearing fix — what actually produces "XXX" today is renames.yml `Talaria: TL2500: XXX`, whose value is used verbatim without smart_case. This entry only matters if that rename is ever removed, at which point case_token would yield "Xxx". It sat at column 0 (outside `stylings:`) from 2026-07-25 until 2026-07-26 and was inert the whole time, while its comment claimed credit for the correct output — see lint 1a-bis.
 
 acronyms:
   # --- S2W acronym tranche 2 (2026-07-26): marque TYPE CODES ---

--- a/scripts/find_casing_contradictions.rb
+++ b/scripts/find_casing_contradictions.rb
@@ -1,0 +1,116 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# find_casing_contradictions.rb — find tokens that ONE MAKE spells two different
+# ways in the published catalog ("FLH Electra Glide" alongside "Flh Duo Glide").
+#
+# WHY THIS DETECTOR IS DIFFERENT FROM THE OTHER TWO
+#
+# scripts/find_published_name_defects.rb asks "is this token spelled in caps
+# somewhere in the catalog?" — a catalog-wide question that needs a judgement
+# call about whether the token is an initialism at all. Its check-1 output is a
+# list of *candidates*, and most of the work is deciding which are real words
+# (Fat BOY, Super CUB, Piaggio APE would all be wrong).
+#
+# This one asks a narrower question with no judgement in it: **does one make
+# spell the same token both ways?** If Harley publishes both `FXS Low Rider`
+# and `Fxs Blackline`, one of them is wrong no matter what FXS stands for. No
+# dictionary, no word list, no external source, no opinion about acronyms — the
+# dataset contradicts itself and that is the whole finding.
+#
+# Scoped PER MAKE deliberately. Type codes are marque-scoped facts: Honda's CBR
+# says nothing about whether Kawasaki should capitalise the same three letters,
+# and a catalog-wide comparison manufactures collisions across marques that have
+# no relationship. (This is the same reasoning that kept `LE` out of the global
+# acronym pins — moto-guzzi wants the French article, indian wants Limited
+# Edition. Cross-make evidence is not evidence.)
+#
+# IT FINDS THE DISAGREEMENT. IT DOES NOT RESOLVE IT.
+#
+# The majority spelling is NOT automatically right, and the counts are printed
+# so you can see that for yourself rather than trusting a heuristic:
+#
+#   mercedes-benz VITO   VITOx4 / Vitox1   <- the SINGLE record is correct.
+#                                             "Vito" is a Mercedes nameplate
+#                                             word, not an initialism; the four
+#                                             all-caps ones are the defect.
+#   mg            MGA    MGAx1 / Mgax4     <- the opposite: MGA is right and
+#                                             the four Title-cased ones are the
+#                                             defect. Same shape, inverse answer.
+#
+# Two records, opposite resolutions, identical detector output. Anything that
+# auto-applied "majority wins" would get one of them wrong every time. Read the
+# marque, then decide.
+#
+# HOW TO FIX ONE
+#   * whole token wrong across a make, and the token is never a word anywhere
+#     -> a pin in overrides/styling.yml `acronyms:` (global; read the warning
+#        in that file about rename keys before you do this)
+#   * one or two records, or the token IS a word in some other marque
+#     -> per-record keys in overrides/models/renames.yml
+#     -> and if the slug moves, an overrides/models/former_ids.yml alias, or
+#        the id-contract gate will fail the build
+#
+# Usage:
+#   ruby scripts/find_casing_contradictions.rb                # published catalog
+#   VDB_CATALOG=../s2w-pipeline/build/out/catalog ruby scripts/find_casing_contradictions.rb
+#   ruby scripts/find_casing_contradictions.rb motorcycle moped   # limit to kinds
+
+require "json"
+
+ROOT = File.expand_path("..", __dir__)
+CATALOG = ENV["VDB_CATALOG"] ? File.expand_path(ENV["VDB_CATALOG"]) : File.join(ROOT, "catalog")
+ALL_KINDS = %w[car van motorcycle moped truck bus].freeze
+kinds = ARGV.empty? ? ALL_KINDS : (ARGV & ALL_KINDS)
+abort "no valid kinds in #{ARGV.inspect} (want any of #{ALL_KINDS.join(" ")})" if kinds.empty?
+
+records = kinds.flat_map do |k|
+  path = File.join(CATALOG, k, "models.json")
+  File.exist?(path) ? JSON.parse(File.read(path)).map { |m| m.merge("kind" => k) } : []
+end
+abort "no models found under #{CATALOG} — build first, or set VDB_CATALOG" if records.empty?
+
+# Split on whitespace and slashes only. NOT on hyphens: "ZX-6R" is one token to
+# a reader, and splitting it would compare "ZX" against every hyphenated variant
+# and drown the signal. Tokens of 2..5 alpha chars only — single letters are
+# almost always a real word or a series letter, and 6+ is a word far more often
+# than an initialism.
+forms = Hash.new { |h, k| h[k] = Hash.new { |a, b| a[b] = [] } }
+records.each do |m|
+  m["name"].to_s.split(%r{[\s/]+}).each do |tok|
+    next unless tok =~ /\A[A-Za-z]{2,5}\z/
+    forms[[m["make_id"], tok.upcase]][tok] << m
+  end
+end
+
+# A contradiction needs an all-caps spelling AND a not-all-caps spelling. Two
+# mixed spellings that are both non-caps ("McLaren"/"Mclaren") are a different
+# and rarer defect; left out so this stays a single-signal detector.
+conflicts = forms.select do |_key, spellings|
+  spellings.size > 1 &&
+    spellings.keys.any? { |s| s == s.upcase } &&
+    spellings.keys.any? { |s| s != s.upcase }
+end
+
+touched = conflicts.values.flat_map { |s| s.values.flatten }.uniq
+puts "== tokens one make spells two ways =="
+puts "#{conflicts.size} make+token contradictions across #{touched.size} records"
+puts "by kind: " + touched.group_by { |m| m["kind"] }.map { |k, v| "#{k} #{v.size}" }.sort.join("  ")
+puts
+puts "MAJORITY IS NOT AUTHORITY — mercedes VITOx4/Vitox1 resolves to the single"
+puts "record; mg MGAx1/Mgax4 resolves to the single record the other way."
+puts
+
+conflicts
+  .sort_by { |(make, tok), s| [make, -s.values.flatten.size, tok] }
+  .each do |(make, tok), spellings|
+    tally = spellings.map { |s, ms| "#{s} x#{ms.size}" }.join("  /  ")
+    puts "#{make}  [#{tok}]  #{tally}"
+    spellings.each do |spelling, ms|
+      ms.sort_by { |m| m["id"] }.first(4).each { |m| puts "    #{spelling.ljust(6)} #{m["kind"]}/#{m["id"]}  #{m["name"].inspect}" }
+      puts "    #{" " * 6} … and #{ms.size - 4} more" if ms.size > 4
+    end
+    puts
+  end
+
+puts "#{conflicts.size} contradictions, #{touched.size} records."

--- a/scripts/lint_curation.rb
+++ b/scripts/lint_curation.rb
@@ -123,9 +123,27 @@ end
 #
 # Same shape as the duplicate-key and flow-style classes: silently valid, wrong.
 # Cheap to guard because these files have exactly one legal root key.
+#
+# styling.yml added 2026-07-26 after this check earned its keep a second time,
+# on a file it did not yet cover. `XXX: XXX` (the Talaria XXX pin) had been
+# sitting at column 0 since 2026-07-25 — a sibling of `stylings:` rather than an
+# entry in it — so the loader, which reads only `styling["stylings"]` and
+# `styling["acronyms"]`, never saw it. It was inert for a day.
+#
+# What made it nastier than the batches.yml case: THE OUTPUT WAS STILL CORRECT.
+# A renames.yml entry (`Talaria: TL2500: XXX`) produces "XXX" verbatim, so the
+# published name looked right and the dead pin's comment claimed credit for it.
+# Nothing was broken — a trap was armed. Delete that rename believing the
+# styling pin has your back and the name silently becomes "Xxx".
+#
+# The general lesson, and the reason this check is worth extending rather than
+# fixing one file: an override that is inert is not detectable by looking at the
+# OUTPUT. It is only detectable by looking at the SHAPE. Any file whose loader
+# reads a fixed set of root keys should be in this table.
 {
   "data/review/batches.yml" => %w[batches],
   "data/name_shapes.yml"    => %w[legit debt],
+  "overrides/styling.yml"   => %w[stylings acronyms],
 }.each do |rel, allowed|
   path = File.join(ROOT, rel)
   next unless File.exist?(path)


### PR DESCRIPTION
**An override that had been inert for a day while its comment claimed credit for the correct output. Plus the lint that would have caught it, and a new detector for a class neither of us has swept.**

## The find

`overrides/styling.yml` had `XXX: XXX` (the Talaria XXX pin) at **column 0** — a sibling of `stylings:`, not an entry in it. The loader reads only `styling["stylings"]` and `styling["acronyms"]`, so it never saw the pin. Dead since 2026-07-25.

**What makes this worse than the batches.yml case: the published output was correct the whole time.** `renames.yml` has `Talaria: TL2500: XXX`, and rename values are emitted verbatim without `smart_case`. So `moped/talaria/xxx` published as `"XXX"`, exactly as intended, while the pin that was supposed to be responsible did nothing — and its comment said *"Without this pin smart_case yields Xxx"*.

Nothing was broken. **A trap was armed.** Delete that rename believing the styling pin has your back, and the name silently becomes `Xxx`.

> An override that is inert is not detectable by looking at the **output**. Only by looking at the **shape**.

That is the argument for the lint rather than the one-line fix.

## Fixes

1. **Re-homed the pin** inside `stylings:`, where it was always meant to be — now genuinely belt-and-braces. Comment corrected to say which mechanism is actually load-bearing today, and to record that it was inert for a day.
2. **Extended lint 1a-bis** to `overrides/styling.yml` (`stylings`, `acronyms`). Third file class, same check. Negative-controlled: re-breaking the indentation fires the check, restoring clears it.

## New detector: `scripts/find_casing_contradictions.rb`

Different question from the two detectors we already have, and a narrower one with no judgement in it: **does one make spell the same token two ways?**

```
harley-davidson  [FXS]   Fxs x3  /  FXS x1
    Fxs    .../fxs-blackline       "Fxs Blackline"
    FXS    .../fxs-low-rider       "FXS Low Rider"
```

If Harley publishes both, one is wrong *no matter what FXS stands for*. No dictionary, no word list, no external source. `find_published_name_defects.rb` asks a catalog-wide question and hands you candidates you then have to adjudicate; this one hands you contradictions.

Scoped **per make** deliberately — type codes are marque-scoped facts, and cross-make comparison manufactures collisions between marques with no relationship. (Same reasoning that kept `LE` out of the global pins.)

**It finds the disagreement; it does not resolve it, and majority is not authority:**

| | |
|---|---|
| `mercedes-benz VITO x4 / Vito x1` | the **single** record is right — Vito is a nameplate word |
| `mg MGA x1 / Mga x4` | the **single** record is right — the other way |

Identical detector output, inverse resolutions. Anything auto-applying "majority wins" gets one of them wrong every time. The counts are printed so you can see that rather than trust a heuristic.

## What it found, and the split

**41 contradictions, 213 records** — `car 130, van 20, motorcycle 57, truck 5, bus 1`.

**Motorcycle 57 are mine** — almost entirely Harley frame codes (`FLSTN FXS FXST FXSTC FLH FLHRC FLHRI FLHTC FLSTF FXSTS FXDI FXR VRSCA`), plus Zero's `SR`/`DSR` and `ryuka/FI`. Next tranche on my board; `FXST`/`FXSTC` need care, they were in the tranche-2 first cut and resurrected `harley/fxst-c`.

**@S4W: the other 156 are yours** and include the two examples above. `mercedes-benz CDI x21/Cdi x1`, `chevrolet SS x11/SS x1`, `citroen BX x9/BX x3`, `volvo GLE`/`GL`/`GLT`, `alfa-romeo GTV`, `peugeot SW`/`GR`. Run `ruby scripts/find_casing_contradictions.rb car van truck bus`.

Also handing over from `find_published_name_defects.rb` check 2, all yours and all likely **false positives worth a documented verdict**: `citroen C3`/`ë-C3`, `C4`/`ë-C4`, `Jumper`/`Ë-Jumper`. The `ë-` prefix is Citroën's electric line — genuinely distinct models, not duplicate ids.

## Verification

Build green, gate **0**, `16829` ids unchanged, `talaria/xxx` still publishes `"XXX"`. Curation lint green, negative-controlled.
