### PR TITLE
Rekey six slash-bearing rename keys for pipeline#36

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -128,11 +128,11 @@ BMW:
   R Nine T:                    R nineT                # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
   R Nine T Pure:               R nineT Pure           # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
   R Nine T Scrambler:          R nineT Scrambler      # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
-  R Nine T Urban G/s:          R nineT Urban G/S      # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
+  "R Nine T Urban G/S":          R nineT Urban G/S      # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
   R Ninet:                     R nineT                # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
   R Ninet Pure:                R nineT Pure           # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
   R Ninet Scrambler:           R nineT Scrambler      # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
-  R Ninet Urban G/s:           R nineT Urban G/S      # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
+  "R Ninet Urban G/S":           R nineT Urban G/S      # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
   R100G/S:                     R100GS                 # closed/spaced per BMW usage
   R602:                        R60/2                  # airhead designation: the SLASH is part of the type code, not punctuation
   R80GS:                       R80G/S                 # airhead designation: the SLASH is part of the type code, not punctuation
@@ -657,11 +657,11 @@ Harley-Davidson:
   "Fx ST":                       FXST                     # type code — uppercase, closed
   Fx Stc:                      FXSTC                    # type code — uppercase, closed
   Fxst-C:                      FXSTC                    # same as Fxe-F above: a third hyphenated spelling of the same code, invisible in the detector output because it reports one representative name per id
-  Fxd/i Dyna Super Glide:      FXDI Dyna Super Glide    # code closed + registered name spaced
+  "Fxd/I Dyna Super Glide":      FXDI Dyna Super Glide    # code closed + registered name spaced
   Fxdi Dyna Super Glide:       FXDI Dyna Super Glide    # code closed + registered name spaced (display-only, id stable)
   Fxe F:                       FXEF                     # type code — uppercase, closed
   Fxe-F:                       FXEF                     # SAME id, DIFFERENT nameplate string: the raws carry "FXE F" and "FXE-F" and both slug to fxe-f, so whichever the reconciler picks as the display name is the one a rename must match. Keying only the space form left this behind — a rename must cover every spelling the pipeline can PRODUCE, not just the one the catalog happens to show
-  "Fxe/f":                     FXEF                     # the DOMINANT raw spelling and the one that actually held the fxe-f id: "FXE/F 1340" (153 rows) with a SLASH. Harley's code is FXEF (the Fat Bob) and the raws confirm it themselves — "FXE/F 1340 FAT BOB", "FXE/F FAT BOB". Found only by grepping the snapshots for every FXE spelling after two rebuilds still left fxe-f standing; the detector never showed it, because it reports ONE representative name per id and the representative changed between builds
+  "Fxe/F":                     FXEF                     # the DOMINANT raw spelling and the one that actually held the fxe-f id: "FXE/F 1340" (153 rows) with a SLASH. Harley's code is FXEF (the Fat Bob) and the raws confirm it themselves — "FXE/F 1340 FAT BOB", "FXE/F FAT BOB". Found only by grepping the snapshots for every FXE spelling after two rebuilds still left fxe-f standing; the detector never showed it, because it reports ONE representative name per id and the representative changed between builds
   Fxe-1200:                    FXE1200                  # type code — uppercase, closed
   Fxef:                        FXEF                     # type code — uppercase, closed (display-only, id stable)
   Fxr Super Glide:             FXR Super Glide          # code closed + registered name spaced (display-only, id stable)
@@ -1385,7 +1385,7 @@ Mercedes-Benz:
   "220 Se": 220 SE                        # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "220 Se Automatic": 220 SE Automatic    # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "220 Se B": 220 SEb                     # REPOINT (was → 220 SE B). W111 series letter is lowercase — "220 b, 220 Sb, 220 SEb" (https://en.wikipedia.org/wiki/Mercedes-Benz_W111); the block held two targets that normalize identically, so the pair could never merge
-  "220 Se B/c": "220 SE B/c"              # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
+  "220 Se B/C": "220 SE B/c"              # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "220 Te": 220 TE                        # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "220A": 220 A                           # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "220SE": 220 SE                         # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
@@ -1759,7 +1759,7 @@ Omoda:
 
 Opel:
   Karl / Viva: Karl      # RDW dual-market label
-  Karl/viva: Karl                           # Opel Karl and its Vauxhall-badged twin Viva registered as one string; Karl is the Opel nameplate
+  "Karl/Viva": Karl                           # Opel Karl and its Vauxhall-badged twin Viva registered as one string; Karl is the Opel nameplate
   Karl Rocks / Viva Rocks: Karl             # same twin-string case for the raised "Rocks" trim — trim folds into the nameplate
   Karl Rocks: Karl       # Rocks is a trim
   Crossland X: Crossland # X dropped in 2020 facelift; one nameplate


### PR DESCRIPTION
**Six rename keys, rekeyed. Mechanical fallout from pipeline#36 — no curation judgement in it.**

> ⚠️ **Coupled with [pipeline#36](https://github.com/vehiclesdb/vehiclesdb-pipeline/pull/36) — must merge back-to-back.** This PR alone turns the gate red, and so does that one alone. Details at the bottom.

## Why

pipeline#36 makes `smart_case` treat `/` as a token separator. `renames.yml` is keyed on the **produced display name**, so every key containing a slash-joined alphabetic token now describes a string the pipeline no longer emits, and the fold goes inert.

```
R Nine T Urban G/s        ->  "R Nine T Urban G/S"
R Ninet Urban G/s         ->  "R Ninet Urban G/S"
"220 Se B/c"              ->  "220 Se B/C"
"Fxe/f"                   ->  "Fxe/F"
Fxd/i Dyna Super Glide    ->  "Fxd/I Dyna Super Glide"
Karl/viva                 ->  "Karl/Viva"
```

Values and comments untouched — only the keys move. Three of these are on the 4W half (`220 Se B/c` Mercedes, `Karl/viva` Opel); flagging that explicitly, but they are consequences of a tokenizer change rather than decisions about those marques, so I have not treated them as a half-boundary crossing. @S4W say if you'd rather own them.

The eight slash keys that **don't** change are the digit-bearing ones — `"A/30"`, `"300C/SRT-8"`, `"V8/250"`, `"TUCSON/IX35"`, `"280/SE Automatic"`, `"BUXI45KM/H"`, `"900/SE"`, `"Vw 1/11"` — because pipeline#36's guard only splits digit-free tokens. That guard is what keeps this PR to six lines instead of fourteen.

## How they were found, and the part worth keeping

`test_override_key_reachability.rb` found **three**: the two BMW keys and the Mercedes one.

**It missed the other three.** `Fxe/f`, `Fxd/i Dyna Super Glide` and `Karl/viva` showed up only as four resurrected ids in the control build, three of them `ALIVE yet aliased`. The reason is a real limit of the test rather than a bug in it: it asks *"does feeding this key back through `classify()` reproduce it?"*, and these keys **are** reachable — but the records they target have longer raws (`FXE/F 1340`) that collapse to a different produced name. Reachability is necessary, not sufficient.

> The control build is the only complete check for this class. The test is a fast pre-filter, not a substitute.

Worth noting the `Fxe/f` comment already said something similar for a different reason ("the detector never showed it, because it reports ONE representative name per id"). That key has now evaded two different detectors.

## Verification

With pipeline#36 applied: gate **0**, reachability suite green (5 runs, 0 failures), curation lint green, **16829 ids unchanged**. 51 display names improve; none loses an all-caps segment.

## Merge order

Data CI checks out `vehiclesdb-pipeline` at **`main`, no ref**, so there's no pin to stage this behind and the two PRs are one logical change in two repos. Either order leaves a window where the gate would be red — old keys under the new pipeline, or new keys under the old one.

The window is safe because the gate runs in `monthly-build.yml` (scheduled), not on PRs — `lint.yml` does no pipeline checkout, which is why this PR's own CI is green in isolation and shouldn't be read as proof it's independent.

**Recommend: pipeline#36 first, then this immediately.**
