### PR TITLE
Resolve 30 two-wheeler casing contradictions (Harley frame codes, Zero, Ryuka)

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -690,6 +690,32 @@ Harley-Davidson:
   Wlc:                         WLC                      # type code — uppercase, closed (display-only, id stable)
   "Vrscawa V-Rod Abs":         VRSCAWA V-Rod        # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); the non-ABS sibling is published from the same countries
   "Fxrs Super Glide II":                     FXRS Super Glide II      # FXRS is a Harley frame code, attested in caps elsewhere in this catalog (fxrs-sp, fxrs-sport). Not pinned globally in tranche 2 because it appears in only three records — a per-record fix is cheaper than a global token and carries no rename-key blast radius.
+  "Fat Boy Flstf":                             "Fat Boy FLSTF"                            # resolves an intra-make casing contradiction: FLSTF attested x2 in-make (harley-davidson/fat-boy-flstf)
+  "Flh":                                       FLH                                        # resolves an intra-make casing contradiction: FLH attested x1 in-make (harley-davidson/flh)
+  "Flh Duo Glide":                             "FLH Duo Glide"                            # resolves an intra-make casing contradiction: FLH attested x1 in-make (harley-davidson/flh-duo-glide)
+  "Flhrc":                                     FLHRC                                      # resolves an intra-make casing contradiction: FLHRC attested x1 in-make (harley-davidson/flhrc)
+  "Flhrc Road King Classic":                   "FLHRC Road King Classic"                  # resolves an intra-make casing contradiction: FLHRC attested x1 in-make (harley-davidson/flhrc-road-king-classic)
+  "Flhri":                                     FLHRI                                      # resolves an intra-make casing contradiction: FLHRI attested x1 in-make (harley-davidson/flhri)
+  "Flhri Road King Efi":                       "FLHRI Road King Efi"                      # resolves an intra-make casing contradiction: FLHRI attested x1 in-make (harley-davidson/flhri-road-king-efi)
+  "Flhtc Electra Glide Classic":               "FLHTC Electra Glide Classic"              # resolves an intra-make casing contradiction: FLHTC attested x1 in-make (harley-davidson/flhtc-electra-glide-classic)
+  "Flhtc Ultra":                               "FLHTC Ultra"                              # resolves an intra-make casing contradiction: FLHTC attested x1 in-make (harley-davidson/flhtc-ultra)
+  "Flstn":                                     FLSTN                                      # resolves an intra-make casing contradiction: FLSTN attested x1 in-make (harley-davidson/flstn)
+  "Flstn Softail":                             "FLSTN Softail"                            # resolves an intra-make casing contradiction: FLSTN attested x1 in-make (harley-davidson/flstn-softail)
+  "Fxdi":                                      FXDI                                       # resolves an intra-make casing contradiction: FXDI attested x1 in-make (harley-davidson/fxdi)
+  "Fxr":                                       FXR                                        # resolves an intra-make casing contradiction: FXR attested x1 in-make (harley-davidson/fxr)
+  "Fxs":                                       FXS                                        # resolves an intra-make casing contradiction: FXS attested x1 in-make (harley-davidson/fxs)
+  "Fxs Blackline":                             "FXS Blackline"                            # resolves an intra-make casing contradiction: FXS attested x1 in-make (harley-davidson/fxs-blackline)
+  "Fxst Custom":                               "FXST Custom"                              # resolves an intra-make casing contradiction: FXST attested x1 in-make (harley-davidson/fxst-custom)
+  "Fxst Softail":                              "FXST Softail"                             # resolves an intra-make casing contradiction: FXST attested x1 in-make (harley-davidson/fxst-softail)
+  "Fxst Softail Standard":                     "FXST Softail Standard"                    # resolves an intra-make casing contradiction: FXST attested x1 in-make (harley-davidson/fxst-softail-standard)
+  "Fxstc 1340":                                "FXSTC 1340"                               # resolves an intra-make casing contradiction: FXSTC attested x1 in-make (harley-davidson/fxstc-1340)
+  "Fxstc Softail":                             "FXSTC Softail"                            # resolves an intra-make casing contradiction: FXSTC attested x1 in-make (harley-davidson/fxstc-softail)
+  "Fxstc Softail Custom":                      "FXSTC Softail Custom"                     # resolves an intra-make casing contradiction: FXSTC attested x1 in-make (harley-davidson/fxstc-softail-custom)
+  "Fxsts Softail Springer":                    "FXSTS Softail Springer"                   # resolves an intra-make casing contradiction: FXSTS attested x1 in-make (harley-davidson/fxsts-softail-springer)
+  "Fxsts Springer Softail":                    "FXSTS Springer Softail"                   # resolves an intra-make casing contradiction: FXSTS attested x1 in-make (harley-davidson/fxsts-springer-softail)
+  "Heritage Softail Nostalgia Flstn":          "Heritage Softail Nostalgia FLSTN"         # resolves an intra-make casing contradiction: FLSTN attested x1 in-make (harley-davidson/heritage-softail-nostalgia-flstn)
+  "Low Rider Fxs":                             "Low Rider FXS"                            # resolves an intra-make casing contradiction: FXS attested x1 in-make (harley-davidson/low-rider-fxs)
+  "Vrsca":                                     VRSCA                                      # resolves an intra-make casing contradiction: VRSCA attested x1 in-make (harley-davidson/vrsca)
 
 Honda:
   Honda: null                             # motorcycle fi|nl AND moped nl|nz — one make-scoped key covers both kinds (renames are kind-blind)
@@ -1932,6 +1958,7 @@ Rover:
 
 Ryuka:
   "Save-II S Fi":                            Save-II S FI             # FI is fuel injection, an initialism in every marque that uses it. Two tokens fixed in one record.
+  "Classic Fi":                                "Classic FI"                               # resolves an intra-make casing contradiction: FI attested x1 in-make (ryuka/classic-fi)
 
 Saab:
   # ── swarm-dossier batch (2026-07-26): 93/95 vs 9-3/9-5 boundary checked,
@@ -2572,6 +2599,9 @@ Zero Motorcycles:
   # plural-insensitive prefix match is not obviously safe across 849 makes).
   Motorcycle Xb: Xb    # raw handelsbenaming "ZERO MOTORCYCLE XB" (2 rows); merges into the existing moped/zero-motorcycles/xb
   Motorcycle Xe: Xe    # raw handelsbenaming "ZERO MOTORCYCLE XE" (1 row); merges into the existing motorcycle/zero-motorcycles/xe
+  "Sr":                                        SR                                         # resolves an intra-make casing contradiction: SR attested x1 in-make (zero-motorcycles/sr)
+  "Sr ZF13.0":                                 "SR ZF13.0"                                # resolves an intra-make casing contradiction: SR attested x1 in-make (zero-motorcycles/sr-zf13-0)
+  "Sr ZF15.6":                                 "SR ZF15.6"                                # resolves an intra-make casing contradiction: SR attested x1 in-make (zero-motorcycles/sr-zf15-6)
 
 Zhenhua:
   Ztr: ZTR                                  # ZTR is Zhenhua's own roadster-trike line, not a word: https://www.zhenhuagm.com/


### PR DESCRIPTION
**30 per-record renames. Two-wheeler casing contradictions: 16 → 2, 57 records → 15. Zero id churn, gate 0.**

Resolves the motorcycle half of the class `scripts/find_casing_contradictions.rb` found (data#74). The remaining 2/15 are the slash-bearing Zero records, which belong to pipeline#36 — see *What's deliberately left*.

## The evidence rule, and what it does and doesn't claim

A token is upcased here **only if the same make already publishes it in caps somewhere else**. `harley-davidson` ships both `FXS Low Rider` and `Fxs Blackline`; one of those is wrong regardless of what FXS stands for.

Worth being precise about what that evidence is: most attestations are `x1`, and that single caps record is usually itself the product of an *earlier* per-record rename in this same file (`Flh Electra-Glide: FLH Electra Glide`, `Flstf Fat Boy: FLSTF Fat Boy`, …).

> So this is a **consistency sweep against decisions already made and sourced**, not 30 fresh determinations that these strings are initialisms. The originals carry the sourcing; these carry the consistency.

That is also why I did not treat a weak `x1` count as weak evidence — the count measures how much of the make has been curated so far, not how confident the call is.

## Why per-record and not a global pin

13 of the 16 tokens are Harley frame codes, and a pin would be one line each. Three reasons it's the wrong tool here:

1. **`renames.yml` already carries ~26 hand-written keys for exactly these codes**, every one written against the *title-cased* produced form. A pin changes that form, so it doesn't add to that layer — it **invalidates all 26 at once**.
2. **Tranche 2 already tried this.** `FXST` and `FXSTC` were in its first cut and were backed out: they resurrected `harley/fxst-c`, a previously folded id, by staling the `Fxst-C:` key.
3. **Upcasing a token never moves a slug** (slugify lowercases), so the per-record route has zero id churn and needs no `former_ids`. The pin route needs churn-checking on all 26.

Accepted cost: a *new* Harley record still arrives title-cased. The detector will find it.

## What's deliberately left

**All slash-bearing names are excluded** — `Dsr/x`, `Sr/f`, `Sr/s ZF14.4` and the rest. pipeline#36 makes `smart_case` split on `/` and fixes them wholesale. Writing per-record keys for them here would half-fix them (the single-letter half after the slash isn't a 2–5 char token this generator touches) **and go stale the moment #36 lands** — which is the exact trap this tranche exists to clean up.

**Known follow-up, after #36:** `DSR` is pinned, so #36 gives `DSR/X` outright. `SR` is not, so `Sr/f` becomes `Sr/F` and Zero still contradicts itself on `SR`. That needs either an `SR` pin (which would also fix `aprilia/Sr GT`, but stales every rename key containing `Sr` — not something to stack on top of an unmerged #36) or five per-record keys. **I'm not guessing the post-#36 produced forms; I'll do it against a build once #36 is in.**

## Generated, not hand-typed

The 30 came from a generator that reads the published catalog, computes in-make attestation, skips anything already keyed (a duplicate key silently discards one side), and preserves original separators. Every line carries its evidence and the record id it came from.

## Verification

Control build against `origin/main` with the overrides reverted, then applied: **16829 → 16829, zero id churn**, 30 names change and nothing else. Gate **0**. Reachability suite green (5 runs, 0 failures). Curation lint green.

Detector re-run on the two-wheeler half: `16 contradictions / 57 records` → `2 / 15`, and the 15 are precisely the slash records above.
