### PR TITLE
Finish the Zero SR residual: two-wheeler casing contradictions now 0

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -2602,6 +2602,11 @@ Zero Motorcycles:
   "Sr":                                        SR                                         # resolves an intra-make casing contradiction: SR attested x1 in-make (zero-motorcycles/sr)
   "Sr ZF13.0":                                 "SR ZF13.0"                                # resolves an intra-make casing contradiction: SR attested x1 in-make (zero-motorcycles/sr-zf13-0)
   "Sr ZF15.6":                                 "SR ZF15.6"                                # resolves an intra-make casing contradiction: SR attested x1 in-make (zero-motorcycles/sr-zf15-6)
+  "Sr/F":                                      "SR/F"                                     # post-#36 residual: the slash split fixed the right half, SR still title-cased. Zero styles it SR/F, SR/S (zeromotorcycles.com); SR attested x4 in-make
+  "Sr/F ZF14.4 Premium":                       "SR/F ZF14.4 Premium"                      # post-#36 residual: the slash split fixed the right half, SR still title-cased. Zero styles it SR/F, SR/S (zeromotorcycles.com); SR attested x4 in-make
+  "Sr/S":                                      "SR/S"                                     # post-#36 residual: the slash split fixed the right half, SR still title-cased. Zero styles it SR/F, SR/S (zeromotorcycles.com); SR attested x4 in-make
+  "Sr/S ZF14.4":                               "SR/S ZF14.4"                              # post-#36 residual: the slash split fixed the right half, SR still title-cased. Zero styles it SR/F, SR/S (zeromotorcycles.com); SR attested x4 in-make
+  "Sr/S ZF14.4 Premium":                       "SR/S ZF14.4 Premium"                      # post-#36 residual: the slash split fixed the right half, SR still title-cased. Zero styles it SR/F, SR/S (zeromotorcycles.com); SR attested x4 in-make
 
 Zhenhua:
   Ztr: ZTR                                  # ZTR is Zhenhua's own roadster-trike line, not a word: https://www.zhenhuagm.com/


### PR DESCRIPTION
**The follow-up #76 promised, now done against a real post-#36 build instead of a guess. Two-wheeler casing contradictions: 0.**

#76 landed while I was control-building this, so it's a separate PR rather than a second commit on that branch.

## What #36 left behind, and why

`DSR` is a pinned acronym, so pipeline#36's slash split produced `DSR/X` outright. **`SR` is not pinned**, so the same split fixed only the right-hand side and left `Sr/F`, `Sr/S`, `Sr/S ZF14.4`, `Sr/F ZF14.4 Premium`, `Sr/S ZF14.4 Premium`.

That's the predicted residual, and predicting it is not the same as knowing the produced form — which is why #76 said I'd resolve it against a build. The five keys here are the forms the pipeline actually emits post-#36.

## Per-record, not an `SR` pin

A pin would be one line and would also fix `aprilia/Sr GT`. Two reasons against, for now:

- It stales **every** rename key containing `Sr`, and stacking that on a normalizer change that landed minutes earlier is how the tranche-2 mess happened.
- Aprilia's `SR` deserves its own look — `Sr GT`, `Sr Max`, `Sr Motard` are a live family, not a folded remnant, and they're worth checking against Aprilia's own styling rather than swept along.

Zero styles the whole code in caps — `SR/F`, `SR/S`, `DSR/X` (zeromotorcycles.com) — and this make already publishes `SR` in caps on four other records, so the in-make contradiction rule applies cleanly.

## Verification

Control build vs merged `main`: **16829 → 16829, zero id churn**, 5 names change. Gate **0**. Reachability green. Curation lint green.

`find_casing_contradictions.rb motorcycle moped` → **`0 contradictions across 0 records`**, from `16 / 57` when the detector was written this morning.

The 4W half (`car 130, van 20, truck 5, bus 1`) is still open and is @S4W's.
