### PR TITLE
Casing contradictions, 4W half: 19 groups → 0 (finish the half-fixed families)

### DIFF
--- a/data/review/citroen-e-prefix-verdict.md
+++ b/data/review/citroen-e-prefix-verdict.md
@@ -1,0 +1,13 @@
+# Verdict: citroën ë- prefix pairs are NOT duplicates (recorded 2026-07-26)
+
+`find_published_name_defects.rb` check 2 flags `citroen/c3` vs `citroen/e-c3`,
+`c4` vs `e-c4`, and `jumper` vs `e-jumper` as near-duplicate names. **All three
+are false positives and must not be folded.** The `ë-` prefix is Citroën's
+battery-electric line (ë-C3, ë-C4, ë-Jumper — https://www.citroen.com), sold
+ALONGSIDE the ICE cars as distinct products with their own registrations,
+pricing and (eventually) production runs. The same shape as VW ID.3-vs-Golf,
+not the same shape as a spelling variant.
+
+Raised by S2W (NEGOTIATION Turn 112), verdict recorded by S4W (Turn 115) so
+the next sweep does not re-open it. If a future source shows registries using
+the two spellings for ONE product line, reopen with that evidence.

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2766,3 +2766,12 @@
 # is to grep former_ids for the id you are about to retire BEFORE writing the
 # rename, not after the lint tells you. A retirement is never just about the
 # id you are looking at; it is about everything already pointing there.
+# ---------------------------------------------------------------------------
+# 2026-07-26 — casing-contradiction batch (4W half of the #74 detector → 0):
+# the five slug-moving folds; all clean merges (no evidence lost, verified
+# per pair in the dossier §5.4).
+"car/alfa-romeo/romeo-gtv":         "car/alfa-romeo/gtv"
+"van/mercedes-benz/639-vito-109":   "van/mercedes-benz/vito"
+"van/mercedes-benz/639-vito-111":   "van/mercedes-benz/vito"
+"van/mercedes-benz/639-vito-115":   "van/mercedes-benz/vito"
+"van/mercedes-benz/639-vito-120":   "van/mercedes-benz/vito"

--- a/overrides/models/removals.yml
+++ b/overrides/models/removals.yml
@@ -641,3 +641,6 @@
 "car/karmann-mobil/dexter-560-trend": "make dropped (Karmann-Mobil motorhome brand — see davis-540 entry and makes/drop.yml)"
 "car/karmann-mobil/dexter-570": "make dropped (Karmann-Mobil motorhome brand — see davis-540 entry and makes/drop.yml)"
 "car/karmann-mobil/dexter-580": "make dropped (Karmann-Mobil motorhome brand — see davis-540 entry and makes/drop.yml)"
+# ---------------------------------------------------------------------------
+# 2026-07-26 — casing-contradiction batch.
+"car/mercedes-benz/cdi": "not a nameplate: every raw is a bare engine badge — 'CDI 2.2', 'CDI 316', 'CDI2.2' (es_dgt, nl_rdw). No model designation survives in the string, and the two raw shapes would fold to different cars (a 2.2-litre displacement vs the 316 CDI), so no single alias target is honest. Same class as the block's bare-engine-code '200' drop."

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -5,6 +5,14 @@ Aixam:
   Aixam: null                             # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Alfa Romeo:
+  # ── casing-contradiction batch (2026-07-26): finish the GTV family the
+  # 1750/2000 GTV caps fixes started — the detector reads the seam of
+  # half-fixed families. ──
+  Alfetta Gtv: Alfetta GTV          # GTV = Gran Turismo Veloce, all-caps — https://en.wikipedia.org/wiki/Alfa_Romeo_Alfetta
+  Alfetta Gtv 2000: Alfetta GTV 2000 # same badge; display-only (slug unchanged)
+  Gtv: GTV                          # bare nameplate; register raws all-caps ("GTV COUPE 2.0 T.SPARK 16V", nl_rdw)
+  Gtv 2000: GTV 2000                # same family, display-only
+  Romeo Gtv: GTV                    # FOLD, not a casing fix: raw is verbatim "ALFA ROMEO GTV" and strip_make_prefix eats only "ALFA " — same car as alfa-romeo/gtv; slug moves, alias in former_ids
   # ── swarm-dossier batch (2026-07-26; Opus researcher, S4W verified): the
   # 105/115 coupés put the badge BEFORE the displacement (GT 1300 Junior) but
   # the displacement BEFORE GTV (1750 GTV); GTV6 is CLOSED (catalog corrobo-
@@ -189,6 +197,24 @@ Chery:
   Icaur 03: iCAUR 03                      # official styling of Chery's off-road EV sub-brand is iCAUR (https://www.icaur.com/); the default caser yields "Icaur"
 
 Chevrolet:
+  # ── casing-contradiction batch: the SS badge family finished (Impala SS
+  # was fixed in #63, ten siblings weren't). Hhr Lt keeps Lt lowercase ON
+  # PURPOSE — 8 sibling chevrolet Lt records; capitalising one mints a new
+  # contradiction (dossier §4.4). ──
+  Camaro Ss: Camaro SS              # SS = Super Sport badge — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport ; raw "CAMARO SS COUPE"
+  Chevelle Malibu Ss: Chevelle Malibu SS # mixed-case raw writes it caps: "Chevelle Malibu SS Convertible" (ca_nrcan)
+  Chevelle Ss: Chevelle SS          # same badge — same source
+  Cobalt Ss: Cobalt SS              # mixed-case raw "Cobalt SS Coupe" (ca_nrcan)
+  El Camino Ss: El Camino SS        # van kind; same badge ("El Camino SS 1968-1987")
+  Hhr: HHR                          # FLAP insurance — HHR = Heritage High Roof initialism; hits car+van, both intended — https://en.wikipedia.org/wiki/Chevrolet_HHR
+  Hhr LS: HHR LS                    # FLAP — LS already caps; only the nameplate token moves
+  Hhr Lt: HHR Lt                    # FLAP — Lt deliberately LEFT lowercase (8 sibling Lt records; §6.4 owns that family)
+  Hhr Ss: HHR SS                    # both tokens initialisms — "HHR SS" verbatim in the Super Sport article
+  Impala Ss Sport: Impala SS Sport  # raw "Impala SS Sport Coupe"; matches the curated Impala SS
+  Monte Carlo Ss: Monte Carlo SS    # mixed-case raw "Chevrolet Monte Carlo SS" (ca_nrcan)
+  Nova Ss: Nova SS                  # same badge — Super Sport article
+  Ss: SS                            # the 2014-17 sedan IS named SS — https://en.wikipedia.org/wiki/Chevrolet_SS
+  Trailblazer Ss: Trailblazer SS    # SS only; the TrailBlazer-vs-Trail Blazer direction question is filed (dossier §6.5), deliberately not settled here
   # ── swarm-dossier batch (2026-07-26): C-10 direction reversed on GM's own
   # prose (Option A of the dossier's maintainer call); SS is a badge, not a
   # word; "Pickup" one-word fix limited to the collision (S-10 family pass
@@ -229,6 +255,19 @@ Chrysler:
   Chrysler: null                              # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Citroën:
+  # ── casing-contradiction batch: the BX family finished (BX 16/19 TRS were
+  # fixed earlier, nine siblings weren't). ──
+  Bx: BX                            # model code all-caps — https://en.wikipedia.org/wiki/Citro%C3%ABn_BX ; raws "CITROEN BX", "BX GTI"
+  Bx 1: BX 1                        # casing only; the "1" is a truncated 1,4/1,6 (raws "BX 1,4 TGE") — filed as debt
+  Bx 14: BX 14                      # https://www.citroenorigins.com/en/cars/bx
+  Bx 16: BX 16                      # raws "BX 16 RS", "BX 16 GTI"
+  Bx 16 TGS: BX 16 TGS              # raw "BX 16 TGS ESTATE"
+  Bx 19: BX 19                      # raws "BX 19 GTI", "CITROEN BX 19"
+  Bx 19 GT: BX 19 GT                # GT already caps; only the model code moves
+  Bx 19 Trd: BX 19 TRD              # raw "CITROEN BX 19 TRD"; TRD caps in the BX range table — same article
+  Bx Tzd Turbo: BX TZD Turbo        # "BX 17 TZD Diesel Turbo 1.8" verbatim, same article
+  CX 25 Trd: CX 25 TRD              # FLAP insurance — same trim code, matches the block's CX 22 TRS
+  Hy: HY                            # H-Van type code — raws "CITROEN HY", "HY-E"; matches Hy 78: HY 78; hits car+van, both intended
   # ── swarm-dossier batch (2026-07-26): BX/CX trims spaced-caps per Citroën
   # own versions gallery; the PSA injection badge keeps lowercase i (GTi —
   # the 405 SRi precedent); HY 78 spaced (78 = the 78mm-bore engine type);
@@ -468,6 +507,7 @@ FAW:
   EHS9: E-HS9                                 # Hongqi E-HS9 is hyphenated (https://en.wikipedia.org/wiki/Hongqi_E-HS9); nl_rdw E-HS9 n=133 vs EHS9 n=14. Hongqi-vs-FAW make attribution filed as a moves.yml question, not handled here
 
 Ferrari:
+  "F355 Berlinetta/Gts": F355 Berlinetta/GTS  # POST-#36 KEY (pre-#36 …/gts form would be inert). Mixed-case raw decides both halves: "Ferrari F355 Berlinetta/GTS" (ca_nrcan) — https://en.wikipedia.org/wiki/Ferrari_F355
   # ── italian dossier §4a/4b (sibling alignment; #62 follow-up): the caps
   # family the collision batch fixed for 308/348, completed for the rest —
   # display-only except 308GTS (one mint + alias). Blast radius measured:
@@ -1045,6 +1085,7 @@ Leike:
   Leike: null                             # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Lexus:
+  Rc F: RC F                        # mixed-case raw writes it caps: "Lexus RC F" (ca_nrcan); "RC F" spaced — https://en.wikipedia.org/wiki/Lexus_RC
   IS 250C: IS                             # engine/powertrain variant of the IS line — Lexus writes "IS 450h" style and the NAMEPLATE is the line (lexus.co.uk/car-models); folds per the trim policy
   IS 350C: IS                             # engine/powertrain variant of the IS line — Lexus writes "IS 450h" style and the NAMEPLATE is the line (lexus.co.uk/car-models); folds per the trim policy
   Isf: IS F                                   # spelling variant of "IS F" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1307,6 +1348,12 @@ Mazda:
   Bt-50: BT50                                 # spelling variant of "BT50" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 Mercedes-Benz:
+  # ── casing-contradiction batch: SEC/TD casing finished; Cdi dropped (not
+  # a nameplate); the four 639 Vito lines above REPOINTED to folds. ──
+  Cdi: null                         # NOT A NAMEPLATE: every raw is a bare engine badge ("CDI 2.2", "CDI 316", "CDI2.2" — es_dgt/nl_rdw); the two raw shapes want different cars so no single fold is honest. Same class as this block's "200": null. Manifest: removals.yml
+  Sec: SEC                          # C126 coupe badge all-caps (380/500/560 SEC) — https://en.wikipedia.org/wiki/Mercedes-Benz_C126 ; matches six existing "nnn Sec: nnn SEC" lines. Whether the bare row should FOLD instead is filed (dossier U1)
+  300 T Td: 300 T TD                # TD all-caps per the block's six existing "nnn TD" records (W123 turbodiesel estate)
+  902-6 Ka: 902-6 KA                # KA all-caps per the curated 906 KA-nn / 902 KA convention; sibling raws "902 KA", "902.KA"
   # ── swarm-dossier batch: oddballs settled TOWARD the block's own archive-
   # sourced convention; everything genuinely open stayed out (220 SE B/c,
   # 170 SD, L-trucks, 4MATIC — see the dossier). ──
@@ -1487,7 +1534,7 @@ Mercedes-Benz:
   "300SE": 300 SE                         # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "300SEL": 300 SEL                       # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "300SL 24V": 300 SL 24V                 # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
-  "300T Td": 300 T Td                     # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
+  "300T Td": 300 T TD                     # REPOINT with the TD casing fix: its target is the string being re-cased, so leaving it folds onto a name that no longer exists (casing-contradiction dossier)
   "300TD": 300 TD                         # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "300TDT": 300 TDT                       # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "300TE": 300 TE                         # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
@@ -1559,10 +1606,10 @@ Mercedes-Benz:
   "313CDI": 313 CDI                       # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "318CDI": 318 CDI                       # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "516CDI": 516 CDI                       # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
-  "639 Vito 109": 639 VITO 109            # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
-  "639 Vito 111": 639 VITO 111            # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
-  "639 Vito 115": 639 VITO 115            # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
-  "639 Vito 120": 639 VITO 120            # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
+  "639 Vito 109": Vito                    # REPOINT (was -> "639 VITO 109"): the line AUTHORED the caps defect — VITO is a nameplate word not an initialism, the W639 chassis code is never part of the name (https://en.wikipedia.org/wiki/Mercedes-Benz_Vito), and van/mercedes-benz/vito already absorbs the identical raw "VITO 109 CDI". Fold, not a re-case; clean merge (fi,lu,nl all within the target)
+  "639 Vito 111": Vito                    # REPOINT (was -> "639 VITO 111"): the line AUTHORED the caps defect — VITO is a nameplate word not an initialism, the W639 chassis code is never part of the name (https://en.wikipedia.org/wiki/Mercedes-Benz_Vito), and van/mercedes-benz/vito already absorbs the identical raw "VITO 111 CDI". Fold, not a re-case; clean merge (es,nl all within the target)
+  "639 Vito 115": Vito                    # REPOINT (was -> "639 VITO 115"): the line AUTHORED the caps defect — VITO is a nameplate word not an initialism, the W639 chassis code is never part of the name (https://en.wikipedia.org/wiki/Mercedes-Benz_Vito), and van/mercedes-benz/vito already absorbs the identical raw "VITO 115 CDI". Fold, not a re-case; clean merge (nl all within the target)
+  "639 Vito 120": Vito                    # REPOINT (was -> "639 VITO 120"): the line AUTHORED the caps defect — VITO is a nameplate word not an initialism, the W639 chassis code is never part of the name (https://en.wikipedia.org/wiki/Mercedes-Benz_Vito), and van/mercedes-benz/vito already absorbs the identical raw "VITO 120 CDI". Fold, not a re-case; clean merge (nl all within the target)
   "902 Ka": 902 KA                        # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "906 BA35": 906 BA-35                   # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
   "906 Ka 30": 906 KA-30                  # Mercedes writes classic car designations as "<number> <UPPERCASE letters>" with a lowercase series letter (220 SEb) and a hyphenated valve-count suffix (300 CE-24) — verified against https://mercedes-benz-publicarchive.com/marsClassic/ (Mercedes' own heritage archive)
@@ -1633,6 +1680,26 @@ Mercury:
   Montclair: Mont Clair                       # spelling variant of "Mont Clair" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 MG:
+  # ── casing-contradiction batch: MGA/MGB closed tokens finished; the TD
+  # fix forces the TF family in the same commit (flap insurance) or a new
+  # contradiction ships. ──
+  Mga 1500 Roadster: MGA 1500 Roadster # MGA one closed all-caps token — https://en.wikipedia.org/wiki/MG_MGA ; raws "MG MGA", "MGA CABRIOLET 1500"
+  Mga 1600 Mk: MGA 1600 Mk          # raw "MGA 1600 MK II"; Mk stays British title-case (MK deliberately unpinned)
+  Mga Roadster: MGA Roadster        # same closed token
+  Mga Twin Cam: MGA Twin Cam        # raw "MGA TWIN-CAM COUPE"
+  Mga-1600: MGA 1600                # FLAP — hyphen-joined so the detector cannot see it; raw "MGA-1600 COUPE/2390"; slug mga-1600 unchanged
+  Mgb B: MGB B                      # raws "MGB B SPORTS", "MGB B TOURER" — https://en.wikipedia.org/wiki/MG_MGB
+  Mgb GT: MGB GT                    # raws "MG MGB GT", "MGB GT COUPE"
+  Mgb GT V8: MGB GT V8              # same family — same article
+  Mgb Roadster: MGB Roadster        # same closed token
+  Mgb-1800: MGB 1800                # FLAP — hyphen-joined, detector-invisible; raw "MGB-1800 COUPE GT"; slug mgb-1800 unchanged
+  Midget Td: Midget TD              # T-types all-caps; the TD IS a Midget ("TD Midget") — https://en.wikipedia.org/wiki/MG_T-type
+  Midget Tf: Midget TF              # FLAP — same family, same source ("TF Midget")
+  Td: TD                            # raws "MG TD", "TD SPORTS", "TD II" — all-caps in every one
+  "Td/Tf": TD/TF                    # POST-#36 KEY (pre-#36 Td/tf would be inert). Raw "MG TD/TF" — both halves caps
+  Tf 1250: TF 1250                  # FLAP — https://en.wikipedia.org/wiki/MG_T-type
+  Tf Midget: TF Midget              # FLAP, same source
+  Tf Roadster: TF Roadster          # FLAP, same source
   "M.g. B": MGB                     # tenth one-id-many-names instance: residual stop-form raw "M.G. B." (nl_rdw, 1 row) survived the lane-A pass and resurrected the retired m-g-b id under publication hysteresis — found by the alias-source exclusion (pipeline #32). Same MGB target as the whole family.
   RX6: HS                                 # NOT a model name: KBA's internal type code for the MG HS/EHS. FZ 6.1 HSN 2180 Handelsname reads 'MG RX6;-HS;-EHS;-EHS PHEV' (https://dewiki.de/Lexikon/MG_HS)
   S6: MGS6 EV                             # official German name is the fused MGS6 EV (https://www.mgmotor.de/model/mgs6); KBA's make string "MG ROEWE" is SAIC's dual-brand label for HSN 2180 and there is no Roewe S6 — no Roewe is sold in Germany at all
@@ -1662,7 +1729,7 @@ MG:
   T D Roadster: TD Roadster                   # stop-split of the TD; canonical slugs to the existing td-roadster (casing fix + fi evidence gained)
   T.d.roadster: TD Roadster                   # fused stop-form — the actual produced display (liveness gate find); the dot survives the caser as a token boundary
   Tf 1500: TF1500                             # the factory designation is TF1500 fused (T-type source); the generator would have made the EXISTING value a key — the direction-war trap avoided
-  Mgbgt: Mgb GT                               # spelling variant of "Mgb GT" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  Mgbgt: MGB GT                               # REPOINT with the MGB casing fix: its target is the string being re-cased (casing-contradiction dossier)
   Tf: T F                                     # spelling variant of "T F" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   MG: null                                    # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   Tf-1500: TF1500                             # spelling variant of "TF1500" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -1804,6 +1871,17 @@ Panther:
   Panther: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Peugeot:
+  # ── casing-contradiction batch: the trim-code ladder finished (205 GR /
+  # 305 SR / 307 SW were fixed earlier, nine siblings weren't). ──
+  104 Sr: 104 SR                    # trim codes all-caps ("SR, SRD, SR Injection") — https://en.wikipedia.org/wiki/Peugeot_309 ; matches 305 Sr: 305 SR
+  207 Sw: 207 SW                    # SW = estate suffix; raw "207 SW GTI"
+  308 Sw: 308 SW                    # matches the block's 307 Sw: 307 SW
+  308 Sw Style: 308 SW Style        # raws "308 SW STYLE BLUEHDI 1", "308 SW STYLE HYBRID 14"
+  309 Gr: 309 GR                    # "XR, GR: 1580cc XU5" verbatim — Peugeot 309 article
+  309 Sr: 309 SR                    # "SR, SRD, SR Injection" verbatim, same article
+  405 Gr: 405 GR                    # same house trim ladder; matches 205 GR / 505 GR
+  505 Gr Family: 505 GR Family      # same; "Family" is the Familiale estate body word, stays title-case
+  508 Sw: 508 SW                    # same estate suffix
   "Boxer 35 Professional": Boxer    # drift-adoption fold: GVW-series trim string of the Boxer
   # ── collision batch (2026-07-26): 9 groups, one dossier — trim codes
   # uppercase-spaced; injection-era badges keep Peugeot's lowercase i;
@@ -1904,6 +1982,8 @@ Ram:
   Ram: null                                   # registry rows where the make was written into the model column (truck kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Renault:
+  R 16 Tl: R 16 TL                  # version ladder L/TL/TS/TX all-caps — https://en.wikipedia.org/wiki/Renault_16 ; matches 12 Tl: 12 TL
+  R4 Tl: R4 TL                      # same ladder on the R4; R-prefix is the catalog's Renault house form
   # ── collision batch (2026-07-26): trim codes uppercase-spaced; the 4CV is
   # CLOSED (it IS the name, a different car from the R4); the R prefix is
   # shorthand and folds into the numeric designation. ──
@@ -2189,6 +2269,8 @@ Trigano:
   Trigano: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Triumph:
+  2500 Pi: 2500 PI                  # PI = petrol injection — "the 2.5 PI (petrol injection)" https://en.wikipedia.org/wiki/Triumph_2000 ; raw "TRIUMPH 2500 PI"
+  TR5 Pi: TR5 PI                    # same badge; observed all-caps "TR5/PI"; matches TR6 Pi: TR6 PI
   Tiger 800XC Abs: Tiger 800XC           # ABS is EQUIPMENT and folds into the nameplate (the batch-4 ABS class; this one surfaced only when the published catalog updated). Cross-owner add by S4W post-publish, flagged in NEGOTIATION Turn 71
   # TRIUMPH CONVENTION DOSSIER (§11.2). This make is TWO marques sharing a name,
   # and makes/aliases.yml already warns about it — "Triumph is BOTH a classic car


### PR DESCRIPTION
## What

The 4W half of the casing-contradiction class (data #74's detector): **19 surviving groups → 0** (simulated to zero before shipping, three flap-cascade iterations recorded in the dossier). 72 rename lines across 10 blocks, 6 REPOINTs, 5 clean-merge aliases, 1 removal, the citroën ë- false-positive verdict recorded in `data/review/`, **zero styling pins** (all 13 candidates blast-radius drilled and rejected).

## The load-bearing verdicts (majority-is-not-authority applied)

- **Mercedes VITO** — a direction war, not a casing bug: the four `639 Vito nnn` lines *authored* the all-caps defect, the chassis code is never part of the name, and `van/mercedes-benz/vito` already absorbs the identical raws. Repointed to folds; all four merges verified evidence-clean.
- **Mercedes Cdi** — the majority is right about the token and wrong about the record: bare engine badge, no nameplate survives, two raw shapes wanting different cars → removal with manifest (the `"200": null` class).
- **mg TD** — the ×1 minority wins, and the fix forces the TF family in the same commit or a new contradiction ships (flap insurance applied).

## Verification (researcher ≠ verifier, with a twist)

The researcher **corrected my own mid-flight instruction** — pipeline #36's slash split alone doesn't fix a segment that is neither pinned nor a real word; measured per record, 6 of 8 slash groups were upstream-fixed and two survived (`F355 Berlinetta/Gts`, `Td/Tf`), keyed in their **post-#36 produced forms** and replay-verified. All 72 keys replayed byte-exact at post-#36 pipeline main; direction-war audit 6 hits / 6 repoints / 0 supplements; kind-blindness sweep (HHR and HY hit car+van, both intended); suite 7/7; lint + reorg green.

<details>
<summary>Full research dossier (verbatim)</summary>

# Dossier — make+token casing contradictions, CAR / VAN / TRUCK / BUS half

Researcher pass, 2026-07-26. **Nothing was written to any git repo.** Both worktrees were
re-fetched and detached at `origin/main` mid-run (see §0.2); all reads are from those trees.

| | |
|---|---|
| Detector | `scripts/find_casing_contradictions.rb` (data repo, commit `cb92f6a` / `#74`) |
| Data repo read | `/private/tmp/…/scratchpad/control-data` @ **`b3c6f87`** (origin/main; advanced twice mid-run — see §0.2 and §9, every audit re-run at the final head) |
| Pipeline read | `/Users/javi/GitHub/.vdb-worktrees/s4w-pipeline-schema` @ `75664be` (origin/main, **includes #36**) |
| Raw corpus | `/Users/javi/GitHub/.vdb-worktrees/s4w-pipeline/build/observed_variants.json`, `…/observed_model_names.json` |
| Scope | car + van + truck + bus. Motorcycle/moped groups (harley-davidson ×14, zero-motorcycles ×2) deliberately untouched — other session owns them. |

---

## §0 Headline

The detector's 41 groups split **25 four-wheel / 16 two-wheel**. Of the 25 four-wheel groups,
**6 are resolved by pipeline #36** (slash tokenizer) and need no curation; **19 survive** and
need `renames.yml`.

**Every one of the 19 is a half-fixed family**, not a fresh finding. In each case an earlier
pass fixed one or two records of a family and left the rest — `Impala SS` beside `Camaro Ss`,
`BX 16 TRS` beside `Bx 16`, `1750 GTV` beside `Alfetta Gtv`. The detector is reading the seam
of previous batches. That is why the fix is uniformly "finish the family", and why the
flap-insurance rule (§4) matters more here than the verdicts do.

**Result of the proposed batch, simulated against the post-#36 catalog: the 4W half of this
detector goes to ZERO** (§5.1). 72 rename lines, 5 id transitions, 1 removal, **no new
`styling.yml` pins** (all pin candidates drilled and rejected — §7).

### §0.1 Per-token verdict table

Source class key: **RAW** = register raw corpus (strongest, NAMING.md §2); **MARQUE** =
manufacturer page; **ENC** = Wikipedia article title/infobox/body; **BLOCK** = this repo's own
already-curated convention in the same make block.

| # | make | token | winner | why (source class) | records fixed |
|---|---|---|---|---|---|
| 1 | alfa-romeo | GTV | **GTV** | RAW `"ALFA ROMEO GTV"`, `"GTV COUPE …"`, `"1750 GTV COUPE"` + ENC + BLOCK | 5 |
| 2 | chevrolet | SS | **SS** | RAW mixed-case rows write it caps (`"Chevelle Malibu SS Convertible"`, `"Cobalt SS Coupe"`, `"Chevrolet Monte Carlo SS"`) + ENC + BLOCK | 11 |
| 3 | citroen | BX | **BX** | RAW `"BX GTI"`, `"BX 16 RS"`, `"CITROEN BX 19 TRD"` + ENC + MARQUE + BLOCK | 9 |
| 4 | citroen | HY | **HY** | RAW `"CITROEN HY"`, `"HY-E"` + BLOCK (`Hy 78: HY 78`) | 2 |
| 5 | ferrari | GTS | **GTS** | RAW `"Ferrari F355 Berlinetta/GTS"` (mixed-case raw, GTS caps) + ENC | 1 |
| 6 | lexus | RC | **RC** | RAW `"Lexus RC F"` (mixed-case raw) + ENC | 1 |
| 7 | mercedes-benz | CDI | **CDI** — but the odd record is **not a nameplate** | RAW `"CDI 2.2"`, `"CDI 316"`, `"CDI2.2"` = engine badge only; BLOCK precedent `"200": null` | 1 (drop) |
| 8 | mercedes-benz | SEC | **SEC** | ENC (C126: `380 SEC`, `500 SEC`, `560 SEC`) + BLOCK (6 existing `nnn Sec: nnn SEC`) | 1 |
| 9 | mercedes-benz | TD | **TD** | BLOCK (6 existing `nnn TD`) + ENC (W123 300TD) | 1 |
| 10 | mercedes-benz | VITO | **Vito** — *and the four caps records should not exist* | ENC: chassis code is *never* part of the name; RAW: `vito` already absorbs `"VITO 109 CDI"`…`"VITO 120 CDI"` | 4 (fold) |
| 11 | mercedes-benz | KA | **KA** | BLOCK (curated `906 KA-nn` / `906 BA-nn` convention) + RAW `"902 KA"`, `"902.KA"` | 1 |
| 12 | mg | MGA | **MGA** | RAW `"MGA 1600 MK II"`, `"MGA TWIN-CAM COUPE"`, `"MG MGA"` + existing whole-string pin | 4 (+1) |
| 13 | mg | MGB | **MGB** | RAW `"MGB B TOURER"`, `"MG MGB GT"`, `"MGB-1800 COUPE GT"` + existing whole-string pin | 4 (+1) |
| 14 | mg | TD | **TD** | RAW `"MG TD"`, `"TD SPORTS"`, `"TD II"`, `"MG TD/TF"` + ENC (`TD Midget`) | 3 (+4 TF) |
| 15 | peugeot | GR | **GR** | ENC (309 trim table: `XR, GR`) + BLOCK (`205 Gr: 205 GR`) | 3 |
| 16 | peugeot | SR | **SR** | ENC (309 trim table: `SR, SRD, SR Injection`) + BLOCK (`305 Sr: 305 SR`) | 2 |
| 17 | peugeot | SW | **SW** | RAW `"207 SW GTI"`, `"308 SW STYLE BLUEHDI 1"` + BLOCK | 4 |
| 18 | renault | TL | **TL** | ENC (R16 versions: L / TL / TS / TX) + BLOCK (`12 Tl: 12 TL`) | 2 |
| 19 | triumph | PI | **PI** | RAW `"TRIUMPH 2500 PI"`, `"TR5/PI"` + ENC (`2.5 PI (petrol injection)`) | 2 |

**Majority-is-not-authority scoreboard.** 16 of 19 happen to resolve toward the majority; the
three that do not are the load-bearing ones:

* **#10 mercedes VITO** — the detector's own worked example. `Vito ×1` beats `VITO ×4`. But the
  right fix is stronger than re-casing: the four caps rows are *the same vans* as `van/…/vito`,
  and the all-caps spelling was **deliberately authored** by four existing rename lines
  (`639 Vito 109: 639 VITO 109`). This is a **direction war → REPOINT**, not a supplement.
* **#7 mercedes CDI** — `CDI ×21` is right about the token and wrong about the record. The
  single `Cdi` row is not a badly-cased nameplate, it is not a nameplate.
* **#14 mg TD** — `Td ×3 / TD ×1`: the minority wins, and finishing it forces the sibling **TF**
  family in the same commit or a brand-new contradiction is created (§4.3).

### §0.2 Mid-run rebase — what moved and what it cost

The maintainer's mid-research update landed while §1–§3 were drafted. Actions taken:

1. `s4w-pipeline-schema` was at `5ad75a2` (pre-merge #36 branch tip) → re-fetched, detached at
   `origin/main` = `75664be` = **#36 merged**.
2. `control-data` was at `9789fa4` "Rekey six slash-bearing rename keys for pipeline#36" — a
   branch tip that was **not then an ancestor of origin/main** → re-fetched, detached at
   `origin/main` = `14282d5`.
3. `origin/main` then advanced again during the write-up, to **`b3c6f87`**, picking up
   `b1c4175` (data#75, the six slash rekeys — now merged) and `b3c6f87` (the two-wheeler
   batch, 30 groups). **Every audit in §5 was re-run at `b3c6f87`**: 72/72 keys still
   reachable, the 6 REPOINTs unchanged, the 5 id transitions unchanged, and the batch
   simulation still lands on 0 four-wheel groups. Neither new commit touches a key in §5
   (they touch BMW/Harley/Ryuka/Zero, plus `Opel "Karl/Viva"` and
   `Mercedes-Benz "220 Se B/C"` — no overlap).
4. Every produced form and every proposed key was re-derived against #36. No conclusion from
   the pre-#36 draft was carried over unverified.

**Correction to the brief's classification instruction.** The update said slash-caused groups
are "fixed at the tokenizer". That is true for 6 of my 8 slash-touching groups but **not** for
all of them, because #36 only splits the token — each resulting segment still has to be a
pinned acronym or a real word to come out right. Measured, not assumed:

| record | pre-#36 | post-#36 | group verdict |
|---|---|---|---|
| `car/opel/manta-gt-e` | `Manta Gt/e` | **`Manta GT/E`** ✅ | opel GT resolved |
| `car/ferrari/250-gt-e` | `250 Gt/e` | **`250 GT/E`** ✅ | ferrari GT resolved |
| `car/ferrari/456-gt-gta` | `456 Gt/gta` | `456 GT/Gta` ⚠️ | GT resolved, `Gta` residue (§6.1) |
| `car/nissan/sentra-sl-sr` | `Sentra Sl/sr` | `Sentra SL/Sr` ⚠️ | nissan SL resolved, `Sr` residue (§6.2) |
| `car/volvo/850-gle-se-gl` | `850 Gle/se/gl` | `850 GLE/Se/GL` ⚠️ | GL+GLE resolved, `Se` residue (§6.3) |
| `car/volvo/850-glt-se` | `850 Glt/se` | `850 GLT/Se` ⚠️ | GLT resolved, `Se` residue (§6.3) |
| `car/ferrari/f355-berlinetta-gts` | `F355 Berlinetta/gts` | `F355 Berlinetta/Gts` ❌ | **ferrari GTS SURVIVES** — still contradicts `308 GTS` |
| `car/mg/td-tf` | `Td/tf` | `Td/Tf` ❌ | **mg TD SURVIVES** |

So: 6 groups fixed upstream (§3), 2 slash records still need keys — and **their keys must be
written in the post-#36 produced form** (`F355 Berlinetta/Gts`, `Td/Tf`), not the published
pre-#36 string. Both were replay-verified reachable (§5.2).

---

## §1 Method and what was actually verified

1. **Detector re-run** at `14282d5`: byte-identical to the supplied `contradictions-full.txt`
   (`diff` clean). Truncation (`… and N more`) was defeated with a local full dump.
2. **Post-#36 produced form** for every published name: `smart_case(name.upcase)` through
   `origin/main` normalizer, holding rename *values* verbatim (rename output bypasses the
   caser). 185 published names change under #36, 60 of them 4W.
3. **Detector re-run on the simulated post-#36 catalog** → the authoritative surviving list
   (19 groups). This is the list §5 fixes, not the pre-#36 list of 25.
4. **Staleness check.** The published catalog is *not* in lockstep with `overrides/` — pins
   from acronym tranches 2/3 landed after the last build, so some published names are already
   fixed in the overrides and will change at the next build with no curation
   (`citroen/gsx "Gsx"→GSX`, `citroen/zx "Zx"→ZX`, `renault/mt "Mt"→MT`, `daf/ftr "Ftr"→FTR`,
   `datsun/280-zx "280 Zx"→280ZX`). **Every record in §5 was individually re-classified against
   live overrides and none of them is in that category** — all 19 groups are real work.
5. **Key reachability**: all 72 proposed keys replayed through `VDB::Normalizer#classify` with
   renames *and* moves suppressed (the `test_override_key_reachability.rb` seam), per make
   display name, across every kind. **72/72 reachable** (§5.2).
6. **Direction-war audit**: every proposed key checked against its block for (a) already being
   a key, (b) already being a *value*. 6 hits, all handled as REPOINTs (§5.3).
7. **Slug audit**: `Support.slugify` on every key and value. 66 display-only, 5 slug moves,
   1 removal (§5.4).
8. **Kind-blindness sweep**: every key matched against all six kinds' catalogs. 2 keys hit
   two kinds each — both intended (§5.5).
9. **Flap-insurance simulation**: the whole batch applied in memory and the detector re-run →
   surfaced 3 records I had missed and 1 cascade I had to *avoid* (§4).
10. **Blast-radius + #71 rekey drill** for all 13 plausible `styling.yml` pins (§7).

### §1.1 Known limits of the replay seam

Feeding a published name back through `classify` re-runs `collapse_variant` / `family_nameplate`,
which strip trims. So for records whose published name came from a rename value, the replay
returns something else — e.g. `308 GTS → "308"`, `111 CDI → "111"`, `RC → "Rc"`,
`BX 19 GTi → "Bx 19"`. **These are replay artifacts, not pending changes.** They were
identified and excluded by hand; they never affect a *key* (keys are pre-rename forms by
construction and all 72 round-trip).

---

## §2 Groups NOT in this dossier

16 two-wheeler groups (harley-davidson `FLSTN FXS FXST FXSTC FLH FLHRC FLHRI FLHTC FLSTF FXRS
FXSTS FXDI FXR VRSCA`; zero-motorcycles `SR DSR`) — other session owns them. One cross-owner
note for them, free of charge: **#36 does not finish zero-motorcycles.** `DSR` is pinned so
`Dsr/x → DSR/X` resolves, but `SR` is not pinned, so `Sr/f`/`Sr/s` become `Sr/F`/`Sr/S` and the
`SR ×1 / Sr ×8` group survives. Worth telling them before they close it as fixed-upstream.

---

## §3 Fixed upstream by pipeline #36 — verify in the next build, no curation needed

These six groups need **no `renames.yml` line, no pin, no alias**. Every one was measured, not
assumed (§0.2 table). Slugs are unchanged in all cases — `slugify` collapses non-alphanumeric
runs, so `Gt/e` and `GT/E` both slug to `gt-e`.

| group | record | post-#36 name | note |
|---|---|---|---|
| ferrari `GT` | `car/ferrari/250-gt-e` | `250 GT/E` | matches ENC + RAW `"250 GT/E COUPE 2+2"` exactly |
| opel `GT` | `car/opel/manta-gt-e` | `Manta GT/E` | matches ENC (`GT/E` ×3) + RAW `"MANTA-A GT/E"` |
| nissan `SL` | `car/nissan/sentra-sl-sr` | `Sentra SL/Sr` | SL half resolved; see §6.2 |
| volvo `GL` | `car/volvo/850-gle-se-gl` | `850 GLE/Se/GL` | GL half resolved; see §6.3 |
| volvo `GLE` | `car/volvo/850-gle-se-gl` | `850 GLE/Se/GL` | same record; GLE half resolved |
| volvo `GLT` | `car/volvo/850-glt-se` | `850 GLT/Se` | GLT half resolved; see §6.3 |

**Verification step for the next build** (put this in the PR that follows the next reconcile):
after building, `VDB_CATALOG=… ruby scripts/find_casing_contradictions.rb` must no longer list
`ferrari [GT]`, `nissan [SL]`, `opel [GT]`, `volvo [GL]`, `volvo [GLE]`, `volvo [GLT]`.
If any of them is still there, #36 did not land in the build that produced the catalog.

---

## §4 Flap insurance — lines that are NOT in the detector output but are mandatory

The detector reports *contradictions*. Fixing a contradiction can manufacture a new one, and
a uniformly-wrong family is invisible to it entirely. The batch was simulated and re-detected
to find these; three would have shipped as regressions.

### §4.1 chevrolet HHR — fixing `Hhr Ss` alone creates an HHR contradiction
`Hhr Ss → HHR SS` leaves `car/chevrolet/hhr "Hhr"`, `van/chevrolet/hhr "Hhr"`,
`car/chevrolet/hhr-ls "Hhr LS"`, `car/chevrolet/hhr-lt "Hhr Lt"` → new `HHR ×1 / Hhr ×4`.
Source: HHR is an initialism for *Heritage High Roof* (en.wikipedia Chevrolet_HHR), and the
Super Sport article writes `HHR SS`. Four extra lines required.

### §4.2 citroen TRD — fixing `Bx 19 Trd` alone creates a TRD contradiction
`Bx 19 Trd → BX 19 TRD` leaves `car/citroen/cx-25-trd "CX 25 Trd"` → new `TRD ×1 / Trd ×1`.
One extra line, and the block already curates the sibling trim the same way (`CX 22 Trs: CX 22 TRS`).

### §4.3 mg TF — fixing `Td/Tf` alone creates a TF contradiction
`Td/Tf → TD/TF` leaves `Midget Tf`, `Tf 1250`, `Tf Midget`, `Tf Roadster` → new `TF ×1 / Tf ×4`.
Source: en.wikipedia MG_T-type spells all five T-types caps (`TA TB TC TD TF`) and heads the
sections "TD Midget" / "TF Midget". Four extra lines required.

### §4.4 A cascade deliberately NOT triggered — chevrolet LT
`car/chevrolet/hhr-lt` is `"Hhr Lt"`. The tempting fix is `HHR LT`. **Do not.** Chevrolet has
8 more `Lt` records (`camaro-lt`, `cruze-lt`, `equinox-lt`, `sonic-lt`, `silverado-1500-lt`,
`silverado-lt-trail-boss`, `trail-blazer-ltz`, `truck/chevrolet/lt`) and *zero* all-caps ones —
capitalising one creates `LT ×1 / Lt ×8`. The proposed line is therefore `Hhr Lt: HHR Lt`:
fix the token under discussion, leave `Lt` for the LS/LT/LTZ family pass (§6.4).
This is the flap-insurance principle applied in the negative direction, and it is the reason
`Hhr Lt`'s value looks half-done on purpose.

### §4.5 Detector-invisible family members swept in
`car/mg/mga-1600 "Mga-1600"` and `car/mg/mgb-1800 "Mgb-1800"` carry the token **hyphen-joined**,
and the detector splits on whitespace and `/` only — so `MGA-1600` is one token and never
compared with `MGA`. They are the same defect and the same family; leaving them behind is the
exact half-fix the alfa GTV precedent warns about. RAW backs both:
`"MGA 1600 SPORTS"`, `"MGA-1600 COUPE/2390"`, `"MGB-1800 COUPE GT"`.

---

## §5 The batch — paste-ready `overrides/models/renames.yml`

72 lines across 10 make blocks. Two-space indent, `Key: Value`, same-line `#` reason with
source. **Keys are byte-exact post-`smart_case` produced strings, all 72 replay-verified.**
Insert each group into its existing make block (all 10 blocks already exist; do **not** create
new headings — `@o.model_renames` is keyed on the resolved *display* name and a duplicated
heading silently loses one copy).

Lines marked `# REPOINT` **replace** an existing line — do not add them alongside.

```yaml
Alfa Romeo:
  Alfetta Gtv: Alfetta GTV          # GTV = Gran Turismo Veloce, all-caps; finishes the family the 1750/2000 GTV lines started — https://en.wikipedia.org/wiki/Alfa_Romeo_Alfetta
  Alfetta Gtv 2000: Alfetta GTV 2000 # same badge, same source; display-only (slug alfetta-gtv-2000 unchanged)
  Gtv: GTV                          # bare nameplate; register raws are all-caps ("GTV COUPE 2.0 T.SPARK 16V-916/254", nl_rdw)
  Gtv 2000: GTV 2000                # same family, display-only
  Romeo Gtv: GTV                    # FOLD, not a casing fix: raw is verbatim "ALFA ROMEO GTV" and strip_make_prefix eats only "ALFA " — the identical raw also lands on alfa-romeo/gtv. Slug moves; see §5.4

Chevrolet:
  Camaro Ss: Camaro SS              # SS = Super Sport badge, all-caps — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport ; raw "CAMARO SS COUPE"
  Chevelle Malibu Ss: Chevelle Malibu SS # mixed-case raw writes it caps: "Chevelle Malibu SS Convertible" (ca_nrcan)
  Chevelle Ss: Chevelle SS          # same badge — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport
  Cobalt Ss: Cobalt SS              # mixed-case raw "Cobalt SS Coupe" (ca_nrcan)
  El Camino Ss: El Camino SS        # van kind; same badge ("El Camino SS 1968-1987", Super Sport article)
  Hhr: HHR                          # FLAP §4.1 — HHR is an initialism (Heritage High Roof); hits car+van, both intended — https://en.wikipedia.org/wiki/Chevrolet_HHR
  Hhr LS: HHR LS                    # FLAP §4.1 — LS already caps here; only the nameplate token moves
  Hhr Lt: HHR Lt                    # FLAP §4.1 — Lt deliberately LEFT lowercase: 8 sibling chevrolet Lt records, capitalising one creates a new contradiction (§4.4)
  Hhr Ss: HHR SS                    # both tokens are initialisms — "HHR SS" verbatim in https://en.wikipedia.org/wiki/Chevrolet_Super_Sport
  Impala Ss Sport: Impala SS Sport  # raw "Impala SS Sport Coupe"; matches the already-curated Impala SS line above
  Monte Carlo Ss: Monte Carlo SS    # mixed-case raw "Chevrolet Monte Carlo SS" (ca_nrcan)
  Nova Ss: Nova SS                  # same badge — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport
  Ss: SS                            # the 2014-17 sedan IS named SS — https://en.wikipedia.org/wiki/Chevrolet_SS
  Trailblazer Ss: Trailblazer SS    # SS only. Chevrolet writes the nameplate "TrailBlazer" but this block currently curates "Trail Blazer"; that direction question is §6.5, deliberately not settled here

Citroën:
  Bx: BX                            # BX is the model code, all-caps — https://en.wikipedia.org/wiki/Citro%C3%ABn_BX ; raws "CITROEN BX", "BX GTI"
  Bx 1: BX 1                        # same; NB the "1" is a truncated "1,4"/"1,6" (raws "BX 1,4 TGE", "BX 1,6 TRS") — filed as debt in §8, casing only here
  Bx 14: BX 14                      # https://www.citroenorigins.com/en/cars/bx
  Bx 16: BX 16                      # raws "BX 16 RS", "BX 16 GTI"
  Bx 16 TGS: BX 16 TGS              # raw "BX 16 TGS ESTATE"; TGS is already caps via the global pin
  Bx 19: BX 19                      # raws "BX 19 GTI", "CITROEN BX 19"
  Bx 19 GT: BX 19 GT                # GT already caps; only the model code moves
  Bx 19 Trd: BX 19 TRD              # raw "CITROEN BX 19 TRD"; TRD spelled caps in the BX range table — https://en.wikipedia.org/wiki/Citro%C3%ABn_BX
  Bx Tzd Turbo: BX TZD Turbo        # "BX 17 TZD Diesel Turbo 1.8" verbatim, same article — TZD all-caps, no periods
  CX 25 Trd: CX 25 TRD              # FLAP §4.2 — same trim code, same marque; matches the block's own CX 22 Trs: CX 22 TRS
  Hy: HY                            # H-Van type code — raws "CITROEN HY", "HY-E"; matches the block's own Hy 78: HY 78. Hits car+van, both intended

Ferrari:
  "F355 Berlinetta/Gts": F355 Berlinetta/GTS  # POST-#36 KEY. Raw is mixed-case and decides both halves: "Ferrari F355 Berlinetta/GTS" (ca_nrcan) — Berlinetta title-case, GTS caps; concurs with https://en.wikipedia.org/wiki/Ferrari_F355

Lexus:
  Rc F: RC F                        # mixed-case raw writes it caps: "Lexus RC F" (ca_nrcan); "RC F" with a space — https://en.wikipedia.org/wiki/Lexus_RC

Mercedes-Benz:
  Cdi: null                         # NOT A NAMEPLATE. Every raw is a bare engine badge: "CDI 2.2", "CDI 316", "CDI2.2" (es_dgt/nl_rdw) — no model survives in the string, and the two raw shapes want different targets so no single fold is honest. Same class as this block's "200": null. Needs a removals.yml entry — §5.4
  Sec: SEC                          # casing only. SEC is all-caps on the C126 coupé (380/500/560 SEC) — https://en.wikipedia.org/wiki/Mercedes-Benz_C126 ; matches the block's six existing "nnn Sec: nnn SEC" lines. Whether this bare row should instead FOLD is §8-U1
  300 T Td: 300 T TD                # TD all-caps per the block's six existing "nnn TD" records and the W123 turbodiesel estate designation
  300T Td: 300 T TD                 # REPOINT (was → "300 T Td"): its target is the string being re-cased, so leaving it makes the fold land on a name that no longer exists
  902-6 Ka: 902-6 KA                # KA all-caps per this block's curated 906 KA-nn / 906 BA-nn convention; register raw for the sibling is caps too ("902 KA", "902.KA")
  639 Vito 109: Vito                # REPOINT (was → "639 VITO 109"). Three faults in one line: VITO is a nameplate word not an initialism, the W639 chassis code is never part of the name (https://en.wikipedia.org/wiki/Mercedes-Benz_Vito), and van/…/vito already absorbs the identical raw "VITO 109 CDI". Fold, don't re-case
  639 Vito 111: Vito                # REPOINT, same three faults; vito already absorbs "VITO 111 CDI"
  639 Vito 115: Vito                # REPOINT, same; vito already absorbs "VITO 115 CDI"
  639 Vito 120: Vito                # REPOINT, same; vito already absorbs "VITO 120 CDI"

MG:
  Mga 1500 Roadster: MGA 1500 Roadster # MGA is one closed all-caps token — https://en.wikipedia.org/wiki/MG_MGA ; raws "MG MGA", "MGA CABRIOLET 1500"
  Mga 1600 Mk: MGA 1600 Mk          # raw "MGA 1600 MK II"; Mk stays British-style title-case (styling.yml deliberately excludes MK)
  Mga Roadster: MGA Roadster        # same closed token — https://en.wikipedia.org/wiki/MG_MGA
  Mga Twin Cam: MGA Twin Cam        # raw "MGA TWIN-CAM COUPE"
  Mga-1600: MGA 1600                # FLAP §4.5 — hyphen-joined, so the detector cannot see it; raws "MGA 1600 SPORTS", "MGA-1600 COUPE/2390". Slug mga-1600 unchanged
  Mgb B: MGB B                      # raws "MGB B SPORTS", "MGB B TOURER" — https://en.wikipedia.org/wiki/MG_MGB
  Mgb GT: MGB GT                    # raws "MG MGB GT", "MGB GT COUPE"
  Mgbgt: MGB GT                     # REPOINT (was → "Mgb GT"): its target is the string being re-cased
  Mgb GT V8: MGB GT V8              # same family — https://en.wikipedia.org/wiki/MG_MGB
  Mgb Roadster: MGB Roadster        # same closed token
  Mgb-1800: MGB 1800                # FLAP §4.5 — hyphen-joined, detector-invisible; raw "MGB-1800 COUPE GT". Slug mgb-1800 unchanged
  Midget Td: Midget TD              # the T-types are all-caps and the TD IS a Midget — section heading "TD Midget" — https://en.wikipedia.org/wiki/MG_T-type
  Midget Tf: Midget TF              # FLAP §4.3 — same family, same source ("TF Midget")
  Td: TD                            # raws "MG TD", "TD SPORTS", "TD II", "TD CABRIOLET" — all-caps in every one
  "Td/Tf": TD/TF                    # POST-#36 KEY. Raw is "MG TD/TF" — both halves caps
  Tf 1250: TF 1250                  # FLAP §4.3 — https://en.wikipedia.org/wiki/MG_T-type
  Tf Midget: TF Midget              # FLAP §4.3, same source
  Tf Roadster: TF Roadster          # FLAP §4.3, same source

Peugeot:
  104 Sr: 104 SR                    # Peugeot trim codes are all-caps ("SR, SRD, SR Injection") — https://en.wikipedia.org/wiki/Peugeot_309 ; matches the block's 305 Sr: 305 SR
  207 Sw: 207 SW                    # SW = Peugeot's estate suffix; raw "207 SW GTI"
  308 Sw: 308 SW                    # matches the block's 307 Sw: 307 SW (and the Alfa 159 SW line that cites it)
  308 Sw Style: 308 SW Style        # raws "308 SW STYLE BLUEHDI 1", "308 SW STYLE HYBRID 14"
  309 Gr: 309 GR                    # "XR, GR: 1580cc XU5…" verbatim — https://en.wikipedia.org/wiki/Peugeot_309
  309 Sr: 309 SR                    # "SR, SRD, SR Injection: 1580 cc XU5…" verbatim, same article
  405 Gr: 405 GR                    # same house trim ladder; matches the block's 205 GR / 505 GR
  505 Gr Family: 505 GR Family      # same; "Family" is the Familiale estate body word and stays title-case
  508 Sw: 508 SW                    # same estate suffix

Renault:
  R 16 Tl: R 16 TL                  # Renault's version ladder is L / TL / TS / TX, all-caps — https://en.wikipedia.org/wiki/Renault_16 ; matches the block's 12 Tl: 12 TL
  R4 Tl: R4 TL                      # same ladder on the R4; the "R" prefix is the catalog's own Renault house form (car/renault/r4 "R4")

Triumph:
  2500 Pi: 2500 PI                  # PI = petrol injection, all-caps — "the 2.5 PI (petrol injection) Mk 1" https://en.wikipedia.org/wiki/Triumph_2000 ; raw "TRIUMPH 2500 PI"
  TR5 Pi: TR5 PI                    # same badge; observed display forms include the all-caps "TR5/PI"; matches the block's TR6 Pi: TR6 PI
```

### §5.1 Effect — simulated

Applying all 72 lines to the post-#36 catalog and re-running the detector:

```
AFTER PROPOSED BATCH: 15 total, 0 4W
```

**The 4W half of this detector reaches zero.** The 15 remaining groups are all two-wheeler and
all already answered by `b3c6f87` (the other session's batch) — they still appear here only
because the simulation runs against the *published* catalog, which predates that commit. They
will clear at the next build, not by anything in §5.

Iterations it took to get there — recorded because each one is a regression that would
otherwise have shipped:

| run | 4W left | what it caught |
|---|---|---|
| 1 | 2 | `chevrolet [HHR]` (missed `hhr-ls`, `hhr-lt`); `mercedes [VITO]` (sim artifact, §5.3) |
| 2 | 2 | key was `Hhr Ls` but the record publishes `Hhr LS`; and `HHR LT` created `chevrolet [LT] LT×1/Lt×7` |
| 3 | **0** | `Hhr LS` byte-exact + `Hhr Lt: HHR Lt` (§4.4) |

### §5.2 Reachability — all 72 keys

Replayed through `VDB::Normalizer#classify` at pipeline `75664be` with renames **and** moves
suppressed, per make display name, across all six kinds. Every key reproduces itself.
Spot samples:

| key | produced forms | verdict |
|---|---|---|
| `Bx Tzd Turbo` | `["Bx Tzd Turbo"]` | OK |
| `"F355 Berlinetta/Gts"` | `["F355 Berlinetta/Gts"]` | OK — post-#36 form, the pre-#36 `…/gts` would now be **inert** |
| `"Td/Tf"` | `["Td/Tf"]` | OK — same, pre-#36 `Td/tf` would be inert |
| `Mga-1600` | `["Mga-1600"]` | OK |
| `902-6 Ka` | `["902-6 Ka"]` | OK |
| `639 Vito 109` | `["639 Vito 109", "639"]` | OK (car-path form first; `"639"` is the truck/bus series-collapse path) |
| `Hhr LS` | `["Hhr LS"]` | OK |

The whole file also parses clean as YAML with every value a `String` (or `nil` for `Cdi`) — no
scalar traps from the digit-leading or slash-bearing keys. The two slash keys are quoted, per
the `"300C/SRT-8"` precedent already in the file.

### §5.3 Direction wars — 6 REPOINTs, 0 supplements

Every proposed key was checked for already being a *value* elsewhere in its block. Six hits;
all are repoints of the existing line, never a second line alongside it:

| block | existing line | becomes | why |
|---|---|---|---|
| Mercedes-Benz | `300T Td: 300 T Td` | `300T Td: 300 T TD` | target is the string being re-cased |
| Mercedes-Benz | `639 Vito 109: 639 VITO 109` | `639 Vito 109: Vito` | the line **authored the defect**; fold instead |
| Mercedes-Benz | `639 Vito 111: 639 VITO 111` | `639 Vito 111: Vito` | same |
| Mercedes-Benz | `639 Vito 115: 639 VITO 115` | `639 Vito 115: Vito` | same |
| Mercedes-Benz | `639 Vito 120: 639 VITO 120` | `639 Vito 120: Vito` | same |
| MG | `Mgbgt: Mgb GT` | `Mgbgt: MGB GT` | target is the string being re-cased |

The four VITO lines are the interesting ones: they are not stale, they are *actively wrong*.
Deleting them would also fix the casing (the bare caser yields `639 Vito 109`), but would leave
four duplicate ids for vans that `van/mercedes-benz/vito` already carries. The repoint is the
better fix. Note the §5.1 simulation could not model this — a rename value bypasses the caser,
so the sim saw `639 VITO 109` as immovable; verified by hand against the rename table instead.

### §5.4 Id transitions

66 of 72 lines are display-only (slug identical before and after — confirmed with
`Support.slugify` on every key and value). Five records move and one disappears. **Each of the
five needs its `former_ids.yml` alias in the same commit as its fold — never an alias without
its fold, never a fold without its alias.**

| # | old id | new id | availability lost | `former_ids.yml` line |
|---|---|---|---|---|
| 1 | `car/alfa-romeo/romeo-gtv` | `car/alfa-romeo/gtv` | **none** — `nl,nz` ⊂ target's `ar,fi,gb,lu,nl,nz,ua,us` | `"car/alfa-romeo/romeo-gtv": "car/alfa-romeo/gtv"` |
| 2 | `van/mercedes-benz/639-vito-109` | `van/mercedes-benz/vito` | **none** — `fi,lu,nl` ⊂ `de,es,fi,gb,lu,nl,th` | `"van/mercedes-benz/639-vito-109": "van/mercedes-benz/vito"` |
| 3 | `van/mercedes-benz/639-vito-111` | `van/mercedes-benz/vito` | **none** — `es,nl` ⊂ same | `"van/mercedes-benz/639-vito-111": "van/mercedes-benz/vito"` |
| 4 | `van/mercedes-benz/639-vito-115` | `van/mercedes-benz/vito` | **none** — `nl` ⊂ same | `"van/mercedes-benz/639-vito-115": "van/mercedes-benz/vito"` |
| 5 | `van/mercedes-benz/639-vito-120` | `van/mercedes-benz/vito` | **none** — `nl` ⊂ same | `"van/mercedes-benz/639-vito-120": "van/mercedes-benz/vito"` |

All five are **clean merges**: no country/source pair on any source record is absent from its
target, so no evidence is consolidated away.

**One removal**, which takes a `removals.yml` entry instead (no honest alias target exists —
the raws point at two different cars):

```yaml
"car/mercedes-benz/cdi": "not a nameplate: every raw is a bare engine badge — \"CDI 2.2\", \"CDI 316\", \"CDI2.2\" (es_dgt, nl_rdw). No model designation survives in the string, and the two raw shapes would fold to different cars (a 2.2-litre displacement vs the 316 CDI), so no single alias target is honest. Same class as the block's bare-engine-code \"200\" drop."
```

Without either an alias or this entry, gate 7 (`gate_id_contract`, no-vanish) fails the build
with *"no former_ids alias and no removals.yml entry — a consumer holding this id 404s at the
next publish"*.

### §5.5 Kind-blindness

Renames are make-scoped but **kind-blind** — one line hits every kind. Every key was matched
against all six catalogs. Two keys resolve to more than one record, both deliberately:

| key | records hit | intended? |
|---|---|---|
| `Chevrolet: Hhr` | `car/chevrolet/hhr`, `van/chevrolet/hhr` | **yes** — same nameplate, both wrong |
| `Citroën: Hy` | `car/citroen/hy`, `van/citroen/hy` | **yes** — same H-Van, both wrong (the car-kind row is an H-Van registered as a car) |

Cross-kind bystanders checked and clear: `El Camino Ss` exists only in `van`; `300 T Td` only
in `car`; the four `639 Vito nnn` only in `van`; every MG key only in `car` (the make's only
non-car record is `van/mg/extender`).

---

## §6 Adjacent findings — sourced, out of contradiction scope, ready when someone wants them

These are **not** in §5. None of them is a contradiction today, so the detector is blind to
them; all are the same defect class and all now have a source. Listed so the next pass does not
have to re-derive them.

### §6.1 ferrari `Gta` — post-#36 residue
`car/ferrari/456-gt-gta` becomes `456 GT/Gta`. GTA is the automatic 456 and is all-caps
(https://en.wikipedia.org/wiki/Ferrari_456: *"456 GT: 1,548"*, *"456 GTA: 403"*); raw is
`"Ferrari 456 GT/GTA"`. One line: `"456 GT/Gta": 456 GT/GTA` (key is the post-#36 form; slug
`456-gt-gta` unchanged). A *fold* to `456 GT` is also defensible under the trim policy (GTA is
a transmission variant; `456-gt-gta` availability `ca,us` ⊂ `456-gt`'s `ca,nl,nz,us`) — that is
a policy call, not a casing one.

### §6.2 nissan `Sr` — 4 records, uniformly wrong
`Altima Sr`, `Altima Sr/Platinum`, `Sentra SL/Sr`, `Sentra Sr`. Nissan's North American trim
ladder is `S / SV / SR / SL`, all-caps (https://en.wikipedia.org/wiki/Nissan_Sentra). Uniformly
wrong ⇒ invisible to this detector. Note `SL` *is* a global pin, which is exactly why
`Sentra SL/Sr` now looks lopsided.

### §6.3 volvo `Se` — 4 records, and the pin that would fix them
`240 Se`, `940 Se`, `850 GLE/Se/GL`, `850 GLT/Se`. Volvo SE is all-caps
(https://en.wikipedia.org/wiki/Volvo_850: *"1995 Volvo 850 SE 2.5 sedan"*) and the raw agrees:
`"850 GLT SE SEDAN"`. See §7.2 — `SE` is the single highest-value pin candidate in the catalog
and is **already flagged as S4W-owned** in the reachability test's `KNOWN_DEAD`
(`["Mercedes-Benz", "280 SE"] => "rekey to '280 Se' (or add SE to acronyms)"`).

### §6.4 chevrolet `Lt` / `Ltz` — 9 records, uniformly wrong
`camaro-lt`, `cruze-lt`, `equinox-lt`, `sonic-lt`, `hhr-lt`, `silverado-1500-lt`,
`silverado-lt-trail-boss`, `truck/chevrolet/lt`, plus `trail-blazer-ltz`. Chevrolet's ladder is
`LS / LT / LTZ`, all-caps — and `LS` already publishes caps catalog-wide because `LS` is a
global pin for Lexus. A textbook uniformly-wrong family: the detector cannot see it precisely
*because* it is uniformly wrong. §4.4 explains why this batch must not poke it.

### §6.5 chevrolet `Trail Blazer` vs `TrailBlazer` — a live direction question
The block currently curates `Trailblazer: Trail Blazer`, but Chevrolet writes it **one
camelCased word**: `"TrailBlazer SS"` verbatim in
https://en.wikipedia.org/wiki/Chevrolet_Super_Sport, and the raws carry both
(`"CHEVROLET TRAIL BLAZER"`, `"CHEVROLET TRAILBLAZER 4X4"`, `"TRAILBLAZER 4WD 4-DOOR"`).
Settling it toward the marque means repointing `Trailblazer: TrailBlazer`, which **moves a
slug** (`car/chevrolet/trail-blazer` → `car/chevrolet/trailblazer`, availability
`ca,fi,nl,th,ua,us`, no existing occupant) and so needs the fold+alias pair, plus
`Trailblazer Ss: TrailBlazer SS` in the same commit. Deliberately **not** bundled: it is a
spelling decision with an id transition, not a casing fix, and §5 must stay display-only where
it can.

### §6.6 mercedes `D-Ka` — 8 records the hyphen hides
`car/…/310-d-ka "310 D-Ka"`, `van/…/208-d-ka`, `van/…/310d-ka`, `truck/…/609d-ka`,
`truck/…/711d-ka`, `truck/…/312d-ka-903462-kasten`, `truck/…/312d-ka-903463-kasten`,
`bus/…/412d-ka-904463-kasten`. Same body code as the `906 KA-nn` family this block already
curates in caps, but hyphen-joined so the detector never compares the tokens. Four kinds — a
good candidate for its own kind-spanning pass. Note I could not source what `KA` expands to
(§10 dead ends), so the §5 comment cites the block's own convention plus the caps raw, and
claims nothing more.

### §6.7 mg `MGC` / `MGF` / `Ta` / `Tb` / `Tc`
`Mgc`, `Mgc GT`, `Mgf`, `Mgf 1.8I`, `Ta`, `Tb`, `Tc`. Identical class to MGA/MGB and TD/TF,
uniformly wrong so detector-invisible. `Mgtf` and `T F` are **not** on this list — see §8-U4.

### §6.8 alfa `Giulia Ss`
`car/alfa-romeo/giulia-ss "Giulia Ss"` — Giulia SS = Sprint Speciale, all-caps. Single record,
no contradiction. Same badge family as `maserati/merak-ss "Merak Ss"`, `jaguar/ss "Ss"`
(raw `"SS TOURER"` — SS Cars Ltd) and `norton/ss` (two-wheeler, other owner).

---

## §7 `styling.yml` pin candidates — all 13 drilled, all rejected

Per the standing directive, the default is make-scoped renames; a global pin needs the
acronym blast-radius drill *and* the #71 rekey audit ("a pin silently breaks every rename key
containing that token, including keys other sessions wrote after your branch was cut").
Both were run for every token in §0.1 plus the adjacent ones. **Recommendation: add no pins in
this batch.** The full measurements, so nobody has to redo them:

| token | catalog records | makes touched | rename keys ORPHANED by the pin | verdict |
|---|---|---|---|---|
| `SS` | 17 | chevrolet 12, alfa-romeo, jaguar, maserati, norton, e-ride-pro | 3 — `Chevrolet "Impala Ss"`, `E Ride Pro "Ss"`, `Jaguar "Ss 100"` | tempting (all 17 are officially caps) but crosses into motorcycle/moped ownership; 11 make-scoped lines cost less than a cross-owner pin |
| `BX` | 12 | citroen only | 3 — `Citroën "Bx 16 Trs"`, `"Bx 19 Trs"`, `"Bx 19GTI"` | 1 pin + 3 rekeys vs 9 clean lines; single-make token gains nothing from being global |
| `MGA` | 6 | mg only | **0** | closest call in the set — see §7.1 |
| `MGB` | 7 | mg 6 + leyland 1 (already caps) | 1 — `MG "Mgb"` (+ value `Mgbgt: Mgb GT` needs restating) | see §7.1 |
| `GTV` | 8 | alfa-romeo 7 + **vespa 1** | 5 — `Alfa Romeo "1750 Gtv"`, `"Gtv 1750"`, `"2000 Gtv"`, `"Gtv 6"`, `"Gtv-6"` | 5 rekeys, and the 8th record is a motorcycle (Vespa GTV, also caps) — cross-owner |
| `CDI` | 22 | mercedes-benz only | **0** | pointless: 21 of 22 are already caps and the 22nd is being dropped |
| `SEC` | 7 | mercedes-benz only | 6 — every `nnn Sec: nnn SEC` line | 6 rekeys to fix 1 record |
| `TD` | 13 | mercedes-benz 7, mg 4, ford, van-hool | 0 | two makes want it for different reasons (turbodiesel vs T-type); make-scoped keeps the reasons legible |
| `KA` | 25 | mercedes-benz 23 + **ford 2** | 14 | **hard reject** — Ford Ka is a word-shaped nameplate (`car/ford/ka "Ka"`, `car/ford/street-ka`). One global token cannot serve both. Same collision class as `LE` and `480 ES` |
| `PI` | 4 | triumph 3 + morgan 1 | 1 — `Triumph "TR6 Pi"` | 4 records is not pin territory; morgan's `Plus 8 Pi` is unsourced (§8-U5) |
| `RC` | 3 | lexus 2 + **ktm 1** | 3 — `Lexus "Rc 200T"`, `"Rc 300"`, `"Rc 350"` | a genuine gap (LC/LS/GS/IS/LX/NX/RX/UX/RZ/ES/EX are all pinned, RC is not) but 3 orphans to fix 1 record, and the third record is a motorcycle |
| `HY` | 3 | citroen only | 2 — `Citroën "Hy 78"`, `"Hy-78"` | 2 rekeys to fix 2 records |
| `SW` / `SR` / `GR` / `TL` | 10 / 33 / 13 / 11 | multi-make | — | all have live cross-make ambiguity or cross-owner records; not evaluated further |

### §7.1 The two that nearly made it: MGA / MGB

`MGA: MGA` and `MGB: MGB` already exist in `styling.yml` — as **whole-string `stylings:`**, which
only fire when the *entire* nameplate uppercases to the key. That is why `car/mg/mga` publishes
`MGA` while `Mga Roadster` does not, and why the pin's own comment ("blast radius 1 … only
car/mg/mga displays Mga catalog-wide") reads as wrong today: it was measured for whole-string
matching, and the token form has 6 and 7 records respectively.

Promoting them to `acronyms:` tokens would fix 5 + 5 records with 2 lines instead of 10. Against:

* `MGB` orphans the key `MG "Mgb"` (post-pin the caser yields `MGB`, so the key can never match)
  and leaves the value in `Mgbgt: Mgb GT` self-inconsistent — both fixable, but it is exactly
  the #71 shape.
* Two lines in `styling.yml` are two lines *every other session* inherits, and the failure mode
  is silent. Ten make-scoped lines in the MG block are inert for everyone else.
* The MG block needs 8 more lines for the TD/TF halves regardless, so the pin saves 10 of 18
  lines, not 18 of 18.

If a maintainer prefers the pin anyway, the complete required change set is: add `- MGA` and
`- MGB` to `acronyms:`, **remove** the now-redundant `MGA:`/`MGB:` whole-string entries, rekey
`MG "Mgb"` → `MG "MGB"`, restate `Mgbgt: MGB GT`, and drop the 10 MGA/MGB lines from §5.
`car/leyland/mgb "MGB"` is the only non-MG record and is already correct.

### §7.2 The pin actually worth doing — `SE`, in its own PR

Not in scope here, but it is the largest single win available and it is already assigned to
S4W: 63 records across 22 makes (mercedes-benz 17, dodge 5, saab 5, volkswagen 5, volvo 5,
ford 3, lotus 3, pontiac 3, toyota 3, sherco 3, +13 singles), and **every one of them is
officially all-caps** — SE is a trim code in every marque that uses it, with no word collision
anywhere in the catalog. Cost: **18 orphaned rename keys**, all in the Mercedes-Benz block
(`220 Se`, `220 Se Automatic`, `220 Se B`, `220 Se B/C`, `250 Se`, `260 Se`, `280 Se`,
`280 Se 3`, `280 Se Automatic`, `300 Se`, `350 Se`, `380 Se`, `400 Se`, `420 Se`, `450 Se`,
`500 Se`, `500 Se Automatic`, `600 Se`), each needing rekey to its caps form, plus two Saab
*values* (`900SE: 900 Se`, `900/SE: 900 Se`) to restate. That is a coherent single-PR unit and
it would retire §6.2's cousin, §6.3 entirely, and the `KNOWN_DEAD` entry.

---

## §8 UNCERTAIN — filed, not guessed

**U1 — `car/mercedes-benz/sec`: cased, or folded?**
§5 proposes `Sec: SEC` (casing only, zero risk, resolves the contradiction). But the record's
*only* recorded raw variant is `"SEC 560 CABRIOLET/2850"` — a token-inverted 560 SEC. If that is
the whole picture, the honest fix is `Sec: 560 SEC`, folding into `car/mercedes-benz/560-sec`
(a clean merge: source `fi,nl` ⊂ target `es,fi,nl,nz,ua,us`; needs
`"car/mercedes-benz/sec": "car/mercedes-benz/560-sec"`). I did not take it because the record
also carries fi evidence that no variant string accounts for, and because a bare `SEC` could
equally be a truncation of any of the six SEC models.
**Resolves it:** a per-source raw dump for the fi_traficom rows on this id. If they are also
`SEC 560 …`, fold; if they are bare `SEC`, keep §5's casing fix, or drop it as a body-code row
under the `"200": null` precedent.

**U2 — `car/mercedes-benz/300-t-td`: `300 T TD` is not a Mercedes designation.**
The W123 estate is the `300 T`; the turbodiesel estate is the `300 TD`. `300 T TD` looks like a
register concatenation of both, and `car/mercedes-benz/300-td` already exists
(`fi,nl,nz,ua,us`). §5 fixes only the casing. **Resolves it:** the raw strings behind
`300-t-td` — `observed_variants.json` has no entry for this id, so a fresh
`gen_review_pack.rb` run or a direct nl_rdw/ua_mvs query is needed.

**U3 — `car/citroen/bx-1` is a truncated decimal.**
Raws are `"BX 1,4 TGE"` and `"BX 1,6 TRS"` — comma decimals cut at the comma. `BX 1` is not a
car. §5 fixes the casing only; the truncation is a *parser* defect, not a casing one, and
belongs with whatever handles comma-decimal registry strings.

**U4 — mg `Mgtf` and `T F` are a generation collision, not a casing bug.**
There are two MG TFs: the 1953 T-type and the 2002 roadster. `car/mg/mgtf "Mgtf"` is the 2002
car; `car/mg/t-f "T F"` is unattributable. Capitalising either to `TF` risks asserting they are
the same car as the `Tf …` records §5 touches. Deliberately excluded from §4.3's TF sweep.
**Resolves it:** raws for `mgtf` and `t-f` (neither has an `observed_variants` entry).

**U5 — `car/morgan/plus-8-pi "Plus 8 Pi"`.**
Surfaced by the `PI` blast radius, not by the detector (single record, no contradiction). If
Morgan badged the injected Plus 8 the British `PI` way it should be caps, but I could not fetch
a Morgan source and there is no raw. Not touched.

**U6 — `car/renault/r-16-tl`: the `R` prefix.**
Wikipedia titles the car *Renault 16* and the catalog has `car/renault/16 "16"`. `R 16 TL` may
want to be `16 TL`, which would be a slug move into a non-existent id. Left alone: the catalog's
own Renault house form already carries the prefix (`car/renault/r4 "R4"`, raw `"RENAULT R4"`),
so the prefix is house-normal here and removing it is a separate decision.

**U7 — `Mga 1600 Mk` is truncated.**
Raw is `"MGA 1600 MK II"`. §5 keeps the published truncation and fixes casing only; restoring
the `II` is a different (and slug-moving) change.

---

## §9 Coordination — do not collide with in-flight work

* **data#75 has MERGED** (`b1c4175`). It rekeyed six slash-bearing keys for #36
  (`"R Nine T Urban G/S"`, `"R Ninet Urban G/S"`, `"220 Se B/C"`, `"Fxe/F"`,
  `"Fxd/I Dyna Super Glide"`, `"Karl/Viva"`). **None is in §5**, but two sit in blocks §5 also
  edits (`Mercedes-Benz`, `Opel`) — rebase, do not cherry-pick.
* **`b3c6f87` (two-wheeler batch, 30 groups) has also merged.** It adds ~28 harley-davidson /
  zero-motorcycles / ryuka lines. No collision with §5; §5 touches none of those makes.
* `test_override_key_reachability.rb` at pipeline `75664be` + data `b3c6f87` is **GREEN
  (0 failures)**. That is the baseline §5 must preserve: after applying §5 it must still be
  green. Any new finding means a §5 key is wrong — most likely one of the two post-#36 slash
  keys (`"F355 Berlinetta/Gts"`, `"Td/Tf"`), which are the only §5 keys whose correct form
  depends on #36 being in the pipeline you run against.
* The `SE` pin (§7.2) is already named as S4W's in the test's `KNOWN_DEAD`. If someone takes it
  before §5 lands, §5 is unaffected (no §5 key contains a bare `Se` token).

---

## §10 Sources

**Register raw corpus** (strongest class, NAMING.md §2) —
`/Users/javi/GitHub/.vdb-worktrees/s4w-pipeline/build/observed_variants.json` and
`observed_model_names.json`. Decisive for: alfa GTV (`"ALFA ROMEO GTV"`, and `romeo-gtv`'s raw
is byte-identical to one of `gtv`'s — the fold's whole justification); chevrolet SS (mixed-case
raws write it caps); citroen BX and HY; ferrari `"Ferrari F355 Berlinetta/GTS"` and
`"250 GT/E COUPE 2+2"` and `"Ferrari 456 GT/GTA"`; lexus `"Lexus RC F"`; mercedes CDI
(`"CDI 2.2"`, `"CDI 316"`) and Vito (`vito` already absorbs `"VITO 109/111/115/120 CDI"`); every
MG family (`"MG TD"`, `"MG TD/TF"`, `"MGA 1600 MK II"`, `"MGB B TOURER"`, `"MGB-1800 COUPE GT"`);
opel `"MANTA-A GT/E"`; peugeot `"207 SW GTI"`, `"308 SW STYLE BLUEHDI 1"`, `"505 GR ESTATE"`;
triumph `"TRIUMPH 2500 PI"` and display form `"TR5/PI"`; volvo `"850 GLT SE SEDAN"`.

**Encyclopedic** (all fetched this run, all quoted in §5 comments):
`en.wikipedia.org/wiki/Alfa_Romeo_Alfetta` · `.../Chevrolet_SS` · `.../Chevrolet_Super_Sport`
(gave the exact `TrailBlazer` and `HHR` spellings) · `.../Chevrolet_HHR` · `.../Citroën_BX`
(gave `BX 17 TZD Diesel Turbo`) · `.../Ferrari_250_GTE` · `.../Ferrari_456` · `.../Ferrari_F355`
· `.../Lexus_RC` · `.../Mercedes-Benz_C126` · `.../Mercedes-Benz_Vito` (chassis code is never
part of the name) · `.../Mercedes-Benz_Sprinter` · `.../MG_T-type` · `.../Nissan_Sentra` ·
`.../Opel_Manta` · `.../Peugeot_309` (the trim table that settles GR **and** SR) ·
`.../Renault_16` · `.../Triumph_2000` (`"the 2.5 PI (petrol injection) Mk 1"`) ·
`.../Triumph_TR5` · `.../Volvo_850`.

**In-repo curated convention** (`BLOCK` class): the existing `Alfa Romeo`, `Chevrolet`,
`Citroën`, `Mercedes-Benz`, `MG`, `Peugeot`, `Renault`, `Triumph` blocks in
`overrides/models/renames.yml`; `overrides/styling.yml`; `NAMING.md`.

**Dead ends** —
* `en.wikipedia.org/wiki/Triumph_2000/2500` → HTTP 404. Recovered via `.../Triumph_2000`.
* `en.wikipedia.org/wiki/Triumph_TR5` does not badge the car `TR5 PI` in body text (only an
  image filename `Triumph_TR5PI_(1968).jpg`). The PI verdict therefore rests on
  `.../Triumph_2000` + the raw `"TRIUMPH 2500 PI"`, not on the TR5 article.
* `en.wikipedia.org/wiki/Mercedes-Benz_Sprinter` does **not** document the German body-style
  codes (`KA`, `KO`, `BA`). What `KA` expands to is **unsourced**; the §5 comment cites only the
  block's own convention and the caps raw. WebSearch is unavailable, so no further attempt.
* `en.wikipedia.org/wiki/Volvo_850` confirms GLT/GLE/SE but never quotes a bare `GL` trim; the
  GL verdict rests on the 11 existing all-caps `nnn GL` records and the existing `GL` pin.
* No raw variants exist for `car/mercedes-benz/300-t-td`, `car/mg/mgtf`, `car/mg/t-f`,
  `car/morgan/plus-8-pi`, or any peugeot GR/SR record — hence U2, U4, U5, and the reliance on
  the Peugeot 309 trim table for GR/SR.

---

## §11 Application checklist

1. **Branch from `b3c6f87` or later.** Confirm `"220 Se B/C"` and `"Karl/Viva"` (data#75) are
   already in the file before editing the `Mercedes-Benz` and `Opel` blocks — if they are not,
   you are on a stale base and §5's key audit does not apply.
2. Paste §5 into `overrides/models/renames.yml`, **into the ten existing make blocks** — no new
   headings. Keep each block's internal ordering convention.
3. Apply the **6 REPOINTs** as edits to the existing lines (`Mercedes-Benz "300T Td"`,
   `"639 Vito 109/111/115/120"`, `MG "Mgbgt"`). Do not leave the old values behind.
4. Add the **5 `former_ids.yml` aliases** from §5.4 — in the same commit as their folds.
5. Add the **1 `removals.yml` entry** for `car/mercedes-benz/cdi`.
6. Re-run reachability:
   `cd ~/GitHub/.vdb-worktrees/s4w-pipeline-schema && VDB_DATA_REPO=<data repo> ruby pipeline/tests/test_override_key_reachability.rb`
   → must stay **green (0 failures)**, which is the baseline as of `b3c6f87` (§9). Run it
   against a pipeline that **has #36** — against an older pipeline the two slash keys will
   (correctly) report as unreachable.
7. Build, then re-run the detector:
   `VDB_CATALOG=<built catalog> ruby scripts/find_casing_contradictions.rb`
   → **0 car/van/truck/bus groups**; the six §3 groups must be gone without any curation.
8. Gate check: the build must pass `gate_id_contract` with no unexplained vanished ids —
   5 aliased + 1 in `removals.yml` + 0 unexplained.
9. Spot-check the six merged/dropped records in the built catalog: `alfa-romeo/gtv` keeps its
   8 countries, `mercedes-benz/vito` keeps its 7, and neither gained a country it did not have
   (a clean merge adds no availability — if it does, something else folded in too).
10. Do **not** add any `styling.yml` pin as part of this. §7 is analysis for a separate PR.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
