### PR TITLE
Fix 19 uniformly-wrong casings the contradiction detector cannot see

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -30,6 +30,17 @@ Alvis:
 Aprilia:
   ETV1000 Capo Nord:         ETV1000 Caponord     # Caponord is ONE word; ETV1000 is the type code
   Sport City:                Sportcity            # Aprilia writes Sportcity as ONE word
+  "Sr":                                  "SR"                                   # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half (aprilia/sr)
+  "Sr Ac":                               "SR AC"                                # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half | air-cooled, paired with LC (liquid-cooled) on the SR 50 — Aprilia's own variant suffixes (aprilia/sr-ac)
+  "Sr GT":                               "SR GT"                                # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half (aprilia/sr-gt)
+  "Sr GT125":                            "SR GT125"                             # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half (aprilia/sr-gt125)
+  "Sr GT200":                            "SR GT200"                             # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half (aprilia/sr-gt200)
+  "Sr GT400":                            "SR GT400"                             # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half (aprilia/sr-gt400)
+  "Sr LC":                               "SR LC"                                # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half (aprilia/sr-lc)
+  "Sr Max":                              "SR Max"                               # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half (aprilia/sr-max)
+  "Sr Motard":                           "SR Motard"                            # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half (aprilia/sr-motard)
+  "Sr Motard 125":                       "SR Motard 125"                        # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half (aprilia/sr-motard-125)
+  "Sr-Motard 50":                        "SR-Motard 50"                         # uniformly-wrong casing (invisible to the contradiction detector): Aprilia styles the scooter family SR — SR GT 125, SR 50 R (aprilia.com). 12 records, the largest uniformly-wrong group on the two-wheeler half (aprilia/sr-motard-50)
 
 Ariel:
   Redhunter:                 Red Hunter           # Ariel Red Hunter — two words. DEFUNCT marque — badge evidence
@@ -145,6 +156,7 @@ BMW:
   R90 / S: R90S                           # third raw shape (spaced slash) — the one-id-many-names flap set includes slash spacing too
   SERIE3:                      Serie 3                # German-register nameplate; NOT the English 1 Series — left as the register wrote it
   Z 3:                         Z3                     # closed/spaced per BMW usage
+  "Ce":                                  "CE"                                   # uniformly-wrong casing (invisible to the contradiction detector): BMW CE 04 and CE 02, the electric scooters (bmw-motorrad.com) (bmw/ce)
 
 Bricklin:
   Sv-1: SV1                                   # spelling variant of "SV1" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -716,6 +728,8 @@ Harley-Davidson:
   "Heritage Softail Nostalgia Flstn":          "Heritage Softail Nostalgia FLSTN"         # resolves an intra-make casing contradiction: FLSTN attested x1 in-make (harley-davidson/heritage-softail-nostalgia-flstn)
   "Low Rider Fxs":                             "Low Rider FXS"                            # resolves an intra-make casing contradiction: FXS attested x1 in-make (harley-davidson/low-rider-fxs)
   "Vrsca":                                     VRSCA                                      # resolves an intra-make casing contradiction: VRSCA attested x1 in-make (harley-davidson/vrsca)
+  "Fxrs-Sp":                             "FXRS-Sp"                              # uniformly-wrong casing (invisible to the contradiction detector): Harley frame code, already caps on FXRS Super Glide II and attested x3 in-make (harley-davidson/fxrs-sp)
+  "Fxrs-Sport":                          "FXRS-Sport"                           # uniformly-wrong casing (invisible to the contradiction detector): Harley frame code, already caps on FXRS Super Glide II and attested x3 in-make (harley-davidson/fxrs-sport)
 
 Honda:
   Honda: null                             # motorcycle fi|nl AND moped nl|nz — one make-scoped key covers both kinds (renames are kind-blind)
@@ -757,6 +771,10 @@ Humber:
 
 Hummer:
   Hummer: H1                                  # the civilian AM General Hummer was sold as just "Hummer" from 1992 and renamed H1 in 1999 when the H2 was announced — same vehicle, so it merges into the H1 nameplate rather than being dropped (https://en.wikipedia.org/wiki/Hummer_H1)
+
+Husqvarna:
+  "Te":                                  "TE"                                   # uniformly-wrong casing (invisible to the contradiction detector): Husqvarna's enduro line is TE — TE 300, TE 150 (husqvarna-motorcycles.com) (husqvarna/te)
+  "Te E610":                             "TE E610"                              # uniformly-wrong casing (invisible to the contradiction detector): Husqvarna's enduro line is TE — TE 300, TE 150 (husqvarna-motorcycles.com) (husqvarna/te-e610)
 
 Hyundai:
   # ── singleton-tail dossier: the LM-generation (2009-15) Tucson was sold as
@@ -2581,6 +2599,8 @@ Yamaha:
   "Aerox Abs":                       Aerox                      # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
   "Bw's":                    BW's                 # Yamaha's BW's keeps the apostrophe — confirmed via MBK's platform history, the MBK Booster being the BW's twin
   Bws:                       BW's                 # Yamaha's BW's keeps the apostrophe — confirmed via MBK's platform history, the MBK Booster being the BW's twin
+  "Sr":                                  "SR"                                   # uniformly-wrong casing (invisible to the contradiction detector): Yamaha SR400 / SR500, caps in every Yamaha catalogue (yamaha/sr)
+  "Xj":                                  "XJ"                                   # uniformly-wrong casing (invisible to the contradiction detector): Yamaha XJ6, XJR1300 — the XJ line is always caps (yamaha/xj)
 
 Zero Motorcycles:
   # Residue of a SINGULAR/PLURAL mismatch between the two columns, not a naming

--- a/scripts/find_casing_contradictions.rb
+++ b/scripts/find_casing_contradictions.rb
@@ -42,6 +42,25 @@
 # auto-applied "majority wins" would get one of them wrong every time. Read the
 # marque, then decide.
 #
+# WHAT THIS DETECTOR STRUCTURALLY CANNOT SEE
+#
+# It finds makes that disagree with THEMSELVES. A make that gets a token wrong
+# on EVERY record has no disagreement to find and is invisible here — and that
+# is not a rare corner. `aprilia` published "Sr", "Sr GT", "Sr Max", "Sr Motard"
+# and eight more: twelve records, uniformly wrong, perfectly self-consistent,
+# and this script reported zero contradictions for the make.
+#
+# Uniform wrongness needs a different evidence pair, and BOTH halves are
+# required (see the 2026-07-26 uniform-casing tranche):
+#   1. the token is attested in caps somewhere ELSE in the catalog — another
+#      make spells it that way, so it is a plausible initialism; AND
+#   2. the marque itself styles it in caps, checked by hand and cited.
+# Cross-make attestation alone is NOT sufficient — that is precisely the
+# reasoning that would have pinned LE and broken "Le Mans".
+#
+# So: run this to clean up disagreement, then go looking separately for the
+# makes that are quietly consistent. Zero contradictions is not zero defects.
+#
 # HOW TO FIX ONE
 #   * whole token wrong across a make, and the token is never a word anywhere
 #     -> a pin in overrides/styling.yml `acronyms:` (global; read the warning


### PR DESCRIPTION
**19 records fixed in the class the contradiction detector structurally cannot see. Zero id churn, gate 0.**

## The blind spot

`find_casing_contradictions.rb` (data#74) finds makes that disagree with **themselves**. A make that gets a token wrong on **every** record has no disagreement to find.

That isn't a rare corner. `aprilia` published `Sr`, `Sr GT`, `Sr Max`, `Sr Motard`, `Sr LC` and seven more — **twelve records, uniformly wrong, perfectly self-consistent**, and the detector reported *zero* contradictions for the make. It's the largest single naming defect left on the two-wheeler half and the strongest detector we have was blind to it by construction.

> Zero contradictions is not zero defects.

I've written that limitation into the detector's header so the next person reading a clean run knows what a clean run means.

## The evidence rule, and why it needs two halves

Uniform wrongness can't be self-evidenced, so it needs external support — and **cross-make attestation alone is not enough**:

1. the token is attested in caps somewhere else in the catalog (another make spells it that way, so it's a plausible initialism), **and**
2. **the marque itself styles it in caps**, checked by hand and cited per marque.

Dropping (2) is exactly the reasoning that would have pinned `LE` and broken `Le Mans`. Every entry carries its citation inline:

| make | token | why |
|---|---|---|
| aprilia | `SR` | SR GT 125, SR 50 R — aprilia.com |
| aprilia | `AC` | air-cooled, paired with `LC` on the SR 50 |
| harley-davidson | `FXRS` | frame code, already caps on `FXRS Super Glide II` |
| husqvarna | `TE` | TE 300, TE 150 — husqvarna-motorcycles.com |
| yamaha | `SR` / `XJ` | SR400/SR500, XJ6/XJR1300 |
| bmw | `CE` | CE 04, CE 02 electric scooters — bmw-motorrad.com |

Marques I could **not** verify are left alone — `vespa GTS/GTV`, `ural CT`, `verge TS`, `triumph SD`, `yamaha CJ/NS/DA` and 40-odd more. They're real candidates, not rejections.

## Per-record, not pins

Same reason as data#76: a global pin stales every rename **and `moves.yml`** key containing the token. `vespa/gts` matters here specifically — it's guarded by a spotcheck tied to a Piaggio→Vespa move, and `GTS` is one of the seven tokens tranche 2 had to back out. Upcasing inside a rename **value** cannot move a slug, so this route has zero id churn and cannot disturb that move.

## A silent no-op I nearly shipped

The generator aborted mid-apply on `no block for Husqvarna` (that make had no `renames.yml` block yet). `File.write` runs after the loop, so **nothing was written** — but I'd piped the generator through `tail -1`, and **a shell pipeline exits with the status of the last command**, so `tail` returned 0, the `&&` chain carried on, and lint passed green on an unmodified file.

I caught it only because the control build showed 18 renames producing 5 unrelated name changes. Same shape as the ENAMETOOLONG incident earlier in this session: **an error scrolled past because of how I piped output**. The generator now creates a missing block alphabetically instead of aborting, and I checked exit codes explicitly on the re-run.

## Verification

Control build: **16829 → 16829, zero id churn**. 19 records change (18 keys — `aprilia/sr` exists under both `motorcycle` and `moped`, and renames are kind-blind, so one key serves both). Gate **0**. Reachability green. Curation lint green.
