### PR TITLE
PRD-QUALITY §20 stretch addendum + DEBT.md consolidated ledger

### DIFF
--- a/DEBT.md
+++ b/DEBT.md
@@ -1,0 +1,48 @@
+# DEBT — the consolidated open-work ledger (4W half)
+
+*Created 2026-07-26 at the end of the owner-AFK stretch. One line per item,
+with owner, source-of-record, and what resolves it. Items here are FILED, not
+forgotten — each was deliberately deferred with a reason. When you take one,
+delete its line in the same PR. S2W's half keeps its own ledger in
+`data/name_shapes.yml` (`debt:` entries) and their NEGOTIATION turns.*
+
+## Curation passes (renames/folds, per-family)
+
+| item | source of record | what resolves it |
+|---|---|---|
+| Chevrolet `Lt`/`Ltz` family (9 records, uniformly wrong) | #78 dossier §6.4 | marque styling check (chevrolet.com trim pages) + one family pass; the `Hhr Lt` line was deliberately half-done to avoid a new contradiction |
+| Chevrolet `Trail Blazer` vs `TrailBlazer` direction | #78 dossier §6.5 | GM styles it TrailBlazer; repointing the settled spaced lines is a direction change — needs its own reviewed pass |
+| Chevrolet SS acronym family + S-10 family | #63 dossier (american tail) | the S-10 pass needs a live GM citation (brochure archive is gone); SS records now fixed per-record, the styling-pin question stays closed (blast radius) |
+| Ferrari `Gta` residue (post-#36) | #78 dossier §6.1 | one key (`456 GT/Gta`) once the GTA badge is sourced |
+| Nissan `Sr` (4 records, uniformly wrong) | #78 dossier §6.2 | marque check; interacts with the aprilia/yamaha SR fixes (#79) — per-record, no pin |
+| Volvo `Se` residue (4 records) | #78 dossier §6.3 | the SE pin (below) or four per-record lines |
+| **`SE` styling pin** — the one pin worth doing | #78 dossier §7 | 63 records / 22 makes, all officially caps; costs 18 rekeys, all enumerated in the dossier; S4W-owned; ship as its own PR with every rekey in the same commit (the #71 lesson) |
+| Jaguar Mk split family (`Mki`/`Mk 1` = one car at two live ids; `Mk 5/7/10` contradict source) | #63 dossier U1 | per-model split rule (Mark 1/2 arabic, VII–X Roman), needs its own pass |
+| Daimler V8-250 inversion (source spells the car V8-250; five ids for one car) | #63 dossier U2, ready inversion block in-dossier | maintainer decision to reverse the settled line; inversion block is paste-ready |
+| Morris `mini-mk-2` dangling (Austin and Morris now spell the same car differently) | #63 dossier U6 | would mint `morris/mini-mkii`; take it with the next Morris touch |
+| Austin-Healey Mk family (~10 records: `3000-mk1`, `3000-mk`, `sprite-mk*`, `healy-mk3` typo) | #72 dossier §6 | one dedicated family pass; the `AUSTIN HEALEY` aliases fix (#72) already protects es rows |
+| Mazda RX7-stem family (~8 raws: `RX7 GT-X`, `RX7 TURBO`…) | #63 dossier (mazda §13 adjacent) | one family pass in the settled RX-7 direction |
+| Chrysler `300C: "300 C"` (settled line contradicts source; nl_rdw `300C` ×968) | #72 dossier §7 | 9-country repoint — needs its own reviewed pass |
+| Datsun spaced Z-cars (`240Z: 240 Z` etc., generated boilerplate vs fused source) | #72 dossier §8 | re-source the five lines; `280ZX` (fixed) sits beside `280 Z` until then |
+| Kia `ceed-1` / `ed-ceed` noise ids; `BX 1` truncated-displacement id | #78 dossier §1/§8 | raw-row evidence passes |
+| FAW/Hongqi make attribution (`E-HS9` is a Hongqi) | #72 dossier §9 | `moves.yml` decision (`FAW\|E-HS9 → Hongqi\|E-HS9`), plus the hongqi-ehs7 sibling |
+| VW alias-merge cluster (`beatle`/`bug`/`toureg`/`tranporter`…) | pipeline #30 PR body | wants MERGING not enriching; one dossier pass |
+| Nissan 350Z/370Z lane-A (shipped keys are detector space-inserting artifacts) | #61 dossier | its own reviewed pass — do not drive-by reverse |
+| ~40 unverified uniformly-wrong candidates (vespa GTS/GTV, ural CT, verge TS, triumph SD, yamaha CJ/NS/DA…) | #79 PR body | per-marque styling checks; the two-halves evidence rule is binding (cross-make attestation AND marque styling) |
+
+## Structural / pipeline
+
+| item | source of record | what resolves it |
+|---|---|---|
+| U7 variant-strip Roman collapse (spaced Roman numerals stripped pre-rename → unresolvable truncated ids: `austin/healey-3000-mk`, `jaguar/mk` 5-country…) | #63 dossier U7 | normalizer change with its own blast-radius measurement |
+| `VARIANT_SUFFIXES` `.*` tails destroy model info (`VW KOMBI 1500` ≠ `VW VARIANT 1600`) | #78 dossier §3 | normalizer design question, not curation |
+| Post-release fold-key cleanup habit | #70 precedent (double-space keys), pipeline #31/#33 | at each release: prune rename keys and enrich twins whose producing raws/ids died — the insurance lint (#34) now catches the enrich half at PR time |
+| Kind-boundary proposal (van/411 is a car; t2–t6/lt/vanagon in car kind) | `PROPOSAL-kind-boundary.md` + pipeline #30 PR body | owner review of the proposal |
+
+## Enrichment (the big lever)
+
+| item | source of record | what resolves it |
+|---|---|---|
+| **G26c Wikidata bulk import** — the next major enrichment program | PRD-QUALITY §14, PRD-PAID §2 | CC0 bulk source; staging + graduation through lint_enrich; conflicts lose to curation. Unbuilt. |
+| G26d fueleconomy.gov per-year-per-trim specs | PRD-PAID §2 | spec'd, unbuilt; feeds catalog-plus |
+| Coverage: 4W enrich sweep beyond the ~30 makes done | pipeline enrich/ (39 files, 506 ids) | continue the swarm pattern (research → verify → land) per marque |

--- a/PRD-QUALITY.md
+++ b/PRD-QUALITY.md
@@ -1274,3 +1274,79 @@ cross-referenced in the pass log. New defect classes REQUIRE a taxonomy entry +
 detector before scaled fixing (I-15). The one thing that may never be amended
 away is I-5/I-6: the id contract survives every future re-organization, because
 it is the thing consumers — and the business — stand on.
+
+---
+
+## 20. STRETCH ADDENDUM 2026-07-26 — what changed while this document slept
+
+*Everything below is LANDED and verified, not planned. Each item names its PR;
+the PR bodies carry the full dossiers and evidence. Sections above are amended
+in place only where they stated something now false; this section is the delta
+narrative so a future agent can reconcile the two.*
+
+### 20.1 Publication semantics changed: HYSTERESIS (pipeline #32)
+
+§15's gates assumed the publish partition was memoryless (2 sources OR
+count ≥ threshold). That flapped: ids at a threshold edge vanished on normal
+upstream churn (measured: epure at 298/300 after a DfT quarterly; classic cars
+whose last NZ example deregistered), and the no-vanish gate fired on noise —
+which meant it was being skimmed. Now: an id in the PUBLISHED catalog stays
+published while (single-source-published) any source shows ≥ threshold/3, or
+(multi-source-published) ANY residual vehicle — corroboration did the
+anti-garbage work at entry. Excluded from the grace, because curation already
+decided they die: `overrides/models/demotions.yml` entries (corrections that
+strip fabricated evidence — the file is OPTIONAL, loader defaults empty) and
+former_ids ALIAS SOURCES (a residual raw once resurrected mg/m-g-b into its
+own alias). Result: 31 gate failures → 11 true disappearances, all
+dispositioned; fresh builds on any cache state are gate-clean.
+
+### 20.2 The disposition PAIR rule (learned on #67, now binding)
+
+A retirement is only complete as a PAIR: the former_ids ALIAS (where consumers
+go) + the rename/move FOLD (which makes the source id dead in EVERY cache
+state). An alias alone races the cache: CI's pre-drift snapshot still evidences
+the id → "alias names a live id". A fold alone loses consumers. Ship both in
+one commit, and check kind-blindness (the Caddymaxi car-leak needed a
+drop_patterns guard because the cross-kind prune has a ≥100 floor).
+
+### 20.3 The collision program is COMPLETE; the detector suite replaced it
+
+§2's "146 collision groups" is history: 146 → 0 across seven batches
+(#57/#58/#61/#62/#63/#66/#72), every group source-decided — the detector's
+canonical column was wrong in 45/55 then 15/15 and is officially a
+hint-about-pairings, never an answer. Quality work now flows from detectors,
+each with its limits stated in its own header:
+- `find_duplicate_spellings.rb` — collision groups (at zero, reruns catch new upstream forms)
+- `find_casing_contradictions.rb` (#74) — one make, one token, two spellings; MAJORITY IS NOT AUTHORITY (VITO×4 lost to Vito×1; Mga×4 lost to MGA×1); structurally blind to uniformly-wrong makes (#79 closed the known instances under the two-halves rule: cross-make attestation AND marque styling)
+- `find_corporate_strings.rb` (#59) — company names as nameplates (3 cases, 3 different dispositions: move/debt/removal)
+- `find_published_name_defects.rb` — catalog-wide candidates needing adjudication (the citroën ë- pairs are a RECORDED false positive: `data/review/citroen-e-prefix-verdict.md`)
+
+### 20.4 Casing-pipeline changes stale rename keys — the control build is the only complete check
+
+`renames.yml` is keyed on the casing pipeline's OUTPUT. Any styling pin or
+normalizer change (smart_case slash fix, pipeline #36) stales every key
+describing the old output — including keys written by another session after
+your branch was cut (the ZX/`280 Zx` cross-half catch). The reachability test
+is necessary but NOT sufficient (it misses keys whose records have longer raws
+that collapse differently — the Fxe/f case beat two detectors). Binding
+habits: never guess post-change produced forms (hold work back for a real
+build); a pin PR enumerates and rekeys every affected key in the same commit;
+judge by control build, not by test suite alone.
+
+### 20.5 Release protocol notes (§16 amendments in practice)
+
+v2026.07.4 and v2026.07.5 both shipped through §16 with 0 orphans. Learned:
+local RC diffs and the CI publish differ by cache-state (~37 records at .5) —
+the publish run's own gates are the authority; the §16 artifact is kept beside
+NEGOTIATION.md per release. At each release, prune rename keys and enrich
+twins whose producing raws/ids died (the #70/#33 cleanups; the enrich half is
+now caught at PR time by pipeline #34's three-state insurance lint). The
+private `plus-<VERSION>` release ships in the same cycle (first: plus-2026.07.5,
+469 enriched records — DATA-CONTRACT flow now LIVE).
+
+### 20.6 The open-work ledger moved to DEBT.md
+
+Scattered U-items, dossier §UNCERTAINs and PR-body follow-ups are consolidated
+in `DEBT.md` (one line each, owner + source-of-record + resolution). Take an
+item → delete its line in the same PR. §17's phase table should be read
+through it.


### PR DESCRIPTION
Records the 2026-07-26 stretch in the spec so future agents don't re-derive it: hysteresis publication semantics (pipeline #32) with its two exclusions, the fold+alias disposition pair rule (#67), collision program complete (146→0) and the detector suite that replaced it (each with stated limits), the casing-pipeline-stales-keys law + control-build-is-the-only-complete-check, release-protocol learnings (cache-state variance, per-release cleanup, plus-feed now live), and DEBT.md — the consolidated open-work ledger (one line per item, owner, source of record, resolution; delete the line when you take the item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)