### PR TITLE
PRD-FIVE-NINES: the p99.999+ program (both datasets)

### DIFF
--- a/DEBT.md
+++ b/DEBT.md
@@ -1,5 +1,8 @@
 # DEBT — the consolidated open-work ledger (4W half)
 
+> The p99.999 program (PRD-FIVE-NINES.md) re-prioritizes this ledger after
+> each audit round; enrichment/coverage items below feed its workstreams.
+
 *Created 2026-07-26 at the end of the owner-AFK stretch. One line per item,
 with owner, source-of-record, and what resolves it. Items here are FILED, not
 forgotten — each was deliberately deferred with a reason. When you take one,

--- a/PRD-FIVE-NINES.md
+++ b/PRD-FIVE-NINES.md
@@ -1,0 +1,419 @@
+# PRD-FIVE-NINES — the p99.999+ quality program
+
+*Version 1.0, 2026-07-26. Written at the owner's direction as the complete,
+self-contained technical plan for pushing BOTH datasets — the public catalog
+(this repo) and the private catalog-plus (pipeline repo → vehiclesdb-web) —
+to p99.999+ quality. Companions: PRD-QUALITY.md (the quality machine this
+program extends; its §20 records the 2026-07-26 stretch this plan builds on),
+PRD-DEPTH-ENRICHMENT.md (pipeline — enrichment sourcing), PRD-PAID.md (web —
+what quality is FOR commercially), DEBT.md (the finite open-work ledger).
+Amend by PR to this file. Assume the reader has nothing but the repos.*
+
+---
+
+## 0. The one idea this whole program rests on
+
+Every quality mechanism built so far checks the catalog **against itself**
+(collision detection, casing contradictions, direction wars, gates). That
+well is empty: every self-consistency class is at zero (PRD-QUALITY §20.3).
+The remaining defect classes — same car under two ids, uniformly-wrong
+names, phantom granularity, missing models — are invisible to
+self-comparison **by construction** ("zero contradictions is not zero
+defects"). The next order of magnitude comes from three sources only:
+
+1. **External anchoring** — checking identity against entities, not strings
+   (Workstream B: Wikidata QIDs).
+2. **Measurement** — a defect rate with error bars, not a feeling
+   (Workstream A: the audit instrument).
+3. **Prevention** — defects stopped at ingest, not swept after publication
+   (Workstream C: convention enforcement + quarantine).
+
+Certification (D) and the private layer (E) sit on top of those three.
+
+## 1. What "p99.999" MEANS here — definitions and the honest math
+
+### 1.1 The quality unit
+
+A **claim** is one assertable fact on a published record. The identity claims
+per record: (a) the id is canonical (no other id denotes the same vehicle),
+(b) the display name is marque-true, (c) make attribution is correct, (d)
+kind is correct, (e) each availability entry reflects real register evidence.
+A **record is defective** iff any identity claim fails. Enrichment claims
+(runs, era, links, variants — private layer) are counted separately (§6).
+
+### 1.2 The target is USAGE-WEIGHTED
+
+Uniform p99.999 over 16,825 records means proving ≤0.17 expected defective
+records — statistically undemonstrable (§1.3) and economically wrong (it
+gold-plates one-row 1950s tail records nobody queries). The target is:
+
+> **P(defective | a record a consumer actually touches) ≤ 1e-5**,
+> weighted by resolution traffic.
+
+Until the resolver is live (PRD-PAID P-1), the traffic proxy is registration
+mass (sum of per-country counts), which concentrates in the head deciles the
+same way queries will. When `/v1/resolve` ships, its query log replaces the
+proxy (§5.3) — the weights become measured, not modeled.
+
+### 1.3 Why you cannot sample your way to five nines — and the construction that gets there
+
+The rule of three: demonstrating defect rate ≤ r at 95% confidence with zero
+observed defects needs n ≈ 3/r clean samples. For r = 1e-5 that is
+**300,000 verified records** — 18× the catalog. Sampling alone cannot do it.
+The achievable construction is a **weighted sum of three different kinds of
+guarantee**:
+
+```
+weighted_defect_rate ≤ Σ_i  w_i · r_i        over three strata:
+
+STRATUM 1 — the certified head (deciles 1–3: 2,644 records, ~15.7% of
+  records, ≥90% of registration mass, ≥95%+ of expected resolver traffic):
+  EXHAUSTIVELY verified, record by record, under the ledger protocol.
+  r_head is not a sample estimate — it is a deterministic audit result,
+  held at ~0 by the regression gates (Workstream C). Residual risk =
+  regression between certifications, bounded by gate coverage + the
+  recertification triggers (§5.2).
+
+STRATUM 2 — detector-enumerable classes, ALL deciles: every defect class
+  with a detector (collisions, contradictions, corporate strings, name
+  defects, gates 1–7, hysteresis exclusions) is checked over the WHOLE
+  catalog at every build. For these classes r = 0 is deterministic at
+  build time, not statistical.
+
+STRATUM 3 — the residual tail (deciles 4–10, non-enumerable classes):
+  sampled. n = 3,000 clean stratified samples ⇒ r_tail ≤ 1e-3 at 95%
+  (rule of three). With tail traffic weight w_tail ≤ 1%:
+  contribution ≤ 0.01 × 1e-3 = 1e-5.
+```
+
+Head certified + enumerable classes at deterministic zero + tail bounded and
+down-weighted ⇒ **usage-weighted p99.999 is an achievable, falsifiable,
+maintainable claim.** Anyone auditing us can recompute it. That arithmetic —
+published, with the audit data — is itself a product feature (§6.5).
+
+### 1.4 What we will NOT claim
+
+Not uniform per-record five nines; not correctness of upstream registers
+(availability claims assert *what the register said*, verified against the
+register); not completeness (a missing model is a coverage gap tracked in
+§13's candidate program, not a defect in a published record — the two
+metrics are reported separately and never blended).
+
+## 2. Workstream A — the audit instrument (MEASURE FIRST)
+
+*Everything else in this program is prioritized by what A finds. Build it
+first; run it quarterly forever.*
+
+### 2.1 Design
+
+- **Population**: all published records at a pinned release tag.
+- **Stratification**: kind × decile-band (1–3 / 4–6 / 7–10) × make-size
+  band (≥100 records / 10–99 / <10). 54 strata; allocate by Neyman-ish
+  compromise: minimum 8 per non-empty stratum, remainder proportional to
+  registration mass. **Baseline round: n = 400 per ownership half** (S4W:
+  car/van/truck/bus; S2W: motorcycle/moped).
+- **Sampling**: seeded PRNG (seed = release tag string) so the sample is
+  reproducible and cannot be cherry-picked. `scripts/audit_sample.rb`
+  (to build — §9 gate A1) emits the sample manifest.
+- **Per-record protocol**: exactly PRD-QUALITY §7 (the per-record checklist)
+  PLUS the entity check once Workstream B covers the make (id ↔ QID
+  agreement). Every record audited by a researcher agent, verdicts verified
+  by an INDEPENDENT verifier agent (I-11: researcher ≠ verifier), results in
+  a ledger file under `data/review/audit-<tag>/` with the standard schema.
+- **Verdicts per claim**: `correct | defective(class) | unverifiable(reason)`.
+  Unverifiable is counted AGAINST the clean rate for bounding purposes
+  (conservative) and feeds the source-gap queue.
+
+### 2.2 Outputs (per round)
+
+1. `data/review/audit-<tag>/RESULTS.md`: defect rate per class per stratum
+   with 95% Clopper-Pearson intervals; the usage-weighted aggregate (§1.3).
+2. New defect classes found → PRD-QUALITY §4 taxonomy entries + detector
+   spec BEFORE scaled fixing (invariant I-15 already requires this).
+3. Reprioritized DEBT.md.
+4. `QUALITY.md` at repo root (§8): the public dashboard, updated per round.
+
+### 2.3 Acceptance
+
+- A1: sampler script merged, seeded, stratification unit-tested.
+- A2: baseline round complete both halves; results published; every found
+  defect either fixed (with its class detector) or filed in DEBT.md.
+- A3: quarterly cadence entered into the release protocol (§16 of
+  PRD-QUALITY): a release in a quarter with no audit round is blocked.
+
+## 3. Workstream B — entity anchoring (the identity backbone)
+
+*The centerpiece. Converts string-identity (lintable only) into
+entity-identity (verifiable). Absorbs and supersedes G26c.*
+
+### 3.1 The map
+
+New overrides family, public (QIDs are CC0; identity is the OPEN layer per
+PRODUCT-SHAPE — publishing the map adds open value and hardens the moat,
+since the resolver corpus behind it stays ours):
+
+```yaml
+# overrides/identity/<make>.yml       (make-aligned, same lint regime)
+car/alfa-romeo/gtv:
+  wikidata: Q286789            # one QID = one model entity
+  status: verified             # verified | proposed | no-entity | ambiguous
+  note: optional, same-line citations per curation rules
+car/alfa-romeo/gtv-2000:
+  wikidata: Q286789            # SHARED QID = the ids are one entity → §3.4
+  status: proposed
+```
+
+`status` semantics: `verified` = human/agent-confirmed via I-11;
+`proposed` = matcher output awaiting verification; `no-entity` = checked,
+Wikidata has no entity (NOT a defect — tail models are underdocumented;
+this is the B-002 axis again); `ambiguous` = candidates recorded in note.
+
+### 3.2 The per-marque pipeline (tooling to build — §9 gates B1–B3)
+
+1. **Inventory pull** (`pipeline/tools/wikidata_inventory.rb`): SPARQL per
+   marque QID — entities with P31/P279* ⊆ {automobile model, motorcycle
+   model, …} and P176 (manufacturer) in the marque's corporate tree; pull
+   labels, aliases (all languages), P571/P2669 (inception/discontinued),
+   P155/P156 (predecessor/successor). Cache + archive per the fetch layer;
+   licensing: CC0, statement pinned once in data/licenses.
+2. **Matcher** (`pipeline/tools/align_identity.rb`): ladder per catalog id —
+   exact label (post-normalization both sides) → alias → year-constrained
+   token match (runs data, where enriched) → UNMATCHED. Emits
+   `identity/<make>.yml` with `status: proposed` + a dossier-style report:
+   proposed matches with evidence, shared-QID nominations, no-entity list,
+   Wikidata-only entities (→ candidate queue).
+3. **Verification**: swarm pass per marque, the established shape —
+   researcher builds the report, an independent verifier re-derives a
+   weighted sample (all shared-QID and ambiguous cases at 100%, spot-check
+   the rest), maintainer applies. Statuses flip to `verified`/`no-entity`.
+
+### 3.3 THE BINDING RULE: alignment NOMINATES, never merges
+
+A shared QID is a *nomination* for the duplicate queue — it is never an
+automatic fold. Rationale, learned twice over: granularity is OURS, not
+Wikidata's (their entity model may lump generations we split — Tucson/ix35
+is ONE Wikidata entity but our two-id question needed a raw-evidence
+decision); and matching errors must not become silent merges (the LE/480-ES
+class at entity scale). Every fold still goes through the full disposition
+pair (rename fold + former_ids alias) with raw-corpus evidence.
+
+### 3.4 The three defect harvests + one coverage harvest
+
+| signal | meaning | route |
+|---|---|---|
+| two ids → one QID | duplicate nomination | duplicate queue → dossier → fold+alias |
+| id → no entity after verified search | phantom nomination OR underdocumented-real | raw-corpus check: real rows = keep (`no-entity`), artifact = removal/fold |
+| QID (in-scope marque model) → no id | coverage gap | candidate queue (PRD-QUALITY §13), NOT a defect stat |
+| our runs vs P571/P2669 disagree | enrichment discrepancy | discrepancy queue (§6.3); curation wins, disagreement recorded |
+
+### 3.5 Rollout
+
+Order by registration mass: top-50 makes ≈ 80%+ of records. **Pilot first
+(gate B2): one large live make (toyota) + one defunct make (austin)** to
+prove match-rate, false-nomination rate, and per-marque cost before scaling.
+Scale via swarm waves (PRD-QUALITY §8 topology, Opus researchers), ~5 makes
+per wave, verifier-merges-only. S2W runs the same tooling on 2W marques.
+Tail makes (<10 records): batch by country-of-origin; `no-entity` will
+dominate — that is expected and fine (stratum-3 sampling covers them).
+
+### 3.6 Holding it: the identity gate
+
+Once a make is `verified`, its identity file becomes a build input:
+- new id appearing in a verified make without an identity row → candidates
+  quarantine (§4.3), not silent publication;
+- two ids sharing a QID with neither in the duplicate queue → lint failure;
+- an id with a `verified` QID vanishing → the existing no-vanish machinery
+  (alias/manifest) plus the identity row moves with the alias.
+
+## 4. Workstream C — prevention: conventions enforced at ingest
+
+### 4.1 Machine-readable per-make conventions
+
+Today every marque decision lives in rename-line comments and NAMING.md
+prose; enforcement is the sweep-after-the-fact. Formalize:
+
+```yaml
+# overrides/conventions/<make>.yml
+tokens:                       # per-make token casings (make-scoped by design
+  GTV: caps                   #  — the LE/tS lesson forbids global rules)
+  Mk: title                   # British Mk; roman numerals fused (MkII)
+separators:
+  badge_join: closed          # MGB not "M G B"; cite the dossier
+families:
+  - pattern: '^\d{3} GT'      # optional regexes for family-specific rules
+    rule: caps_suffix
+sources:
+  - https://…                 # the citations the rules rest on
+```
+
+Generated initially FROM the existing corpus (the renames/styling decisions
++ dossier verdicts encode ~200 marque rulings already) by
+`scripts/gen_conventions.rb`, then human-curated. A new lint stage
+(`lint_conventions.rb`) checks every PUBLISHED name in a covered make
+against its rules — violations fail CI exactly like contradictions do.
+
+### 4.2 The regression-gate registry
+
+Every closed class keeps its detector in CI permanently. Formal list (the
+"quality gate" = all of these at zero-or-acked on every build):
+`find_duplicate_spellings` · `find_casing_contradictions` ·
+`find_corporate_strings` · `find_published_name_defects` (with recorded
+verdicts honored — the ë- precedent) · `lint_conventions` (new) ·
+`lint_curation` (direction wars, chains, shapes) · reachability suite ·
+gates 1–7 + hysteresis exclusions · `lint_enrich` (incl. the three-state
+insurance sweep). A class without a detector may not be scale-fixed (I-15).
+
+### 4.3 New-record quarantine
+
+A (make, slug) never published before, entering a build: if its make has
+conventions/identity coverage, it must pass both or it lands in
+`build/candidates/` flagged `first-seen` for the weekly review batch instead
+of publishing. If its make is uncovered, it publishes (today's behavior) but
+is tagged `first-seen` in the release diff so the audit stratifier
+oversamples it. This closes the gap where a fresh clerk typo ships and waits
+for the next sweep. (Implementation: reconciler check against the previous
+release catalog + candidates index; ~1 day.)
+
+### 4.4 The pipeline-change law (already learned, now binding)
+
+Any change to the casing pipeline (styling pin, normalizer edit) ships in
+the same commit as the rekey of EVERY affected rename key, enumerated by
+control build — never by the reachability test alone (it is necessary, not
+sufficient: the Fxe/f case). Cross-repo coupled changes merge
+pipeline-first, minutes apart, never spanning a scheduled build.
+
+## 5. Workstream D — decile-weighted certification
+
+### 5.1 Certification ledger
+
+Extend the §5 ledger: each certified record carries
+`{certified_at: <release>, verifier: <session>, claims: {...}}` in
+`data/review/certification/<kind>.yml` (compact, one line per record).
+Certification = the full §7 protocol + entity check. Targets:
+
+| stratum | records | target | method |
+|---|---|---|---|
+| deciles 1–3 | 2,644 | **100% certified** | swarm waves, ~150/agent-block; ≈ 6 waves per half |
+| deciles 4–6 | 6,698 | ≥25% + all first-seen + all audit-flagged | sampling + demand |
+| deciles 7–10 | 7,483 | audit sampling (A) + resolver demand (§5.3) | statistical only |
+
+### 5.2 Recertification triggers (staleness is a defect vector)
+
+A certified record loses `certified` on: display-name change, any merge
+touching it, make/kind move, identity-status change, or its make's
+convention file changing. The release diff computes the decertification
+list mechanically; recertification rides the next wave. Quarterly audit
+rounds (A) sample certified records too — certified-but-defective is the
+program's own error rate and is REPORTED (it bounds stratum-1 residual risk
+honestly).
+
+### 5.3 The demand flywheel
+
+When `/v1/resolve` ships (PRD-PAID P-1): every unresolved input and every
+low-confidence resolution is logged (consent-flagged), triaged weekly into
+(a) alias/corpus additions, (b) certification demand for touched records,
+(c) candidate-queue entries. Usage weights in §1.3 switch from registration
+proxy to measured query mass. The paying customers literally direct the
+quality spend to where it is felt — that is the flywheel PRD-PAID §4
+promised, now with a defined loop.
+
+## 6. Workstream E — the private (paid) dataset at the same bar
+
+The paid layer inherits everything above (identity claims are shared — the
+public catalog IS the paid catalog's spine). Additional, enrichment-specific:
+
+### 6.1 Claim standards (already binding, restated as gates)
+Every catalog-plus fact: same-line source citation (lint-enforced); run
+shapes through the `ended:`/`year_end_min:` schema with the symmetric
+evidence rule; researcher ≠ verifier on every landed tranche; the
+three-state insurance sweep at PR time; `dissolved` = production cessation.
+
+### 6.2 Enrichment audit stratum
+Workstream A rounds include an enrichment sub-sample: 100 enriched ids per
+round, verifier re-derives every run from its cited source (re-fetch, never
+trust the note). Tolerance: year_start/year_end exact vs cited source; a
+±1 model-year-vs-calendar-year discrepancy is recorded as `note`, not
+counted defective, IF the note says which convention the source uses.
+
+### 6.3 The Wikidata cross-check
+Workstream B's inventory pull already carries P571/P2669. Auto-diff against
+our runs per aligned id: agreement = silent corroboration (recorded in the
+identity row); disagreement = discrepancy queue entry. **Curation wins,
+always** — but an unexamined disagreement blocks `verified` status on the
+enrichment claim, not on the identity row.
+
+### 6.4 Plus-release gating
+A `plus-<VERSION>` release ships only from a build where: the quality gate
+(§4.2) is green, the release_diff has 0 orphans, and no discrepancy-queue
+entry touches a shipped run without a recorded disposition. Version-lock to
+the public release stays (DATA-CONTRACT).
+
+### 6.5 Quality AS product
+`QUALITY.md` (public dashboard, §8) + per-release audit results are
+published. The paid pitch gains: "the only vehicle dataset that publishes
+its measured defect rate, its audit protocol, and its certification
+coverage — recompute it yourself." Nobody else in this market can say it;
+saying it truthfully requires everything above, which is the moat.
+
+## 7. Division of labor and protocol
+
+S4W: car/van/truck/bus for A/B/D; owns B tooling (shared), C generation,
+this PRD. S2W: motorcycle/moped mirrors every workstream with the same
+tools; two-wheeler marque calls are theirs (the VITO/MGA rule: marque
+knowledge decides). Coordination via NEGOTIATION.md as established;
+verifier-merges-only; all swarm output → scratchpad files → PR-embedded
+dossiers → aux/research/ graduation (the durability chain that held this
+stretch). Model rule: Opus researchers, session verifies and applies.
+
+## 8. Reporting: QUALITY.md (new, repo root, public)
+
+Per release: usage-weighted defect bound with its three-strata breakdown
+(§1.3), certification coverage by decile, detector-suite status, audit-round
+summaries with links, enrichment claim coverage + discrepancy-queue size,
+and the honest caveats (§1.4) verbatim. Generated by
+`scripts/gen_quality_dashboard.rb` from the ledgers — never hand-edited.
+
+## 9. Phases, gates, acceptance
+
+| gate | deliverable | acceptance | est. effort |
+|---|---|---|---|
+| **F-0** | this PRD merged; DEBT.md current | — | done at merge |
+| **A1** | audit sampler + protocol | seeded, stratified, unit-tested; dry run 20 records | 1 block |
+| **A2** | baseline audit both halves | 800 records, ledgers published, RESULTS.md + first QUALITY.md | 3–4 blocks/half |
+| **B1** | inventory + matcher tools | pilot marque pull reproducible; matcher report format fixed | 2 blocks |
+| **B2** | pilot: toyota + austin | match/false-nomination rates measured; go/no-go + cost per marque | 2 blocks |
+| **B3** | top-50 makes aligned | ≥80% of records in covered makes; harvests dispositioned per §3.4 | ~10 waves |
+| **C1** | gen_conventions + lint | top-20 makes covered; CI-enforced; zero false failures on current catalog | 2 blocks |
+| **C2** | first-seen quarantine | reconciler change + gate; measured on one release cycle | 1 block |
+| **D1** | head certification | 2,644 records 100% certified, ledgered | ~6 waves/half |
+| **D2** | recertification mechanics | decert list in release_diff; triggers tested | 1 block |
+| **E1** | enrichment audit stratum + cross-check + plus gating | first round run | 2 blocks |
+| **F-1** | **the claim**: first release shipping QUALITY.md with the p99.999 usage-weighted bound computed from real audit + certification data | the arithmetic holds without asterisks beyond §1.4 | = A2+B3+C*+D1 |
+
+Order: A1→A2 immediately (everything else re-prioritizes on its findings);
+B1→B2 in parallel; C after B2 informs convention shapes; D waves start once
+A2 confirms the head defect profile; E rides along. No new release is
+BLOCKED on this program except the quarterly-audit rule (A3) once adopted.
+
+## 10. Risks, stated plainly
+
+- **Wikidata coverage is thin exactly where we are weakest** (tail marques).
+  Mitigated by design: `no-entity` is a recorded state, not a failure;
+  stratum-3 sampling still bounds the tail; B-002 says this is the axis.
+- **Matcher false nominations creating wrong merges** — the worst possible
+  outcome (silent wrong folds at scale). Mitigation is structural: §3.3
+  nominate-never-merge, 100% verification of shared-QID cases, and the
+  disposition pair keeping every fold evidence-backed.
+- **Certification rot** — certified-but-stale. Mitigated by §5.2 triggers +
+  the audit sampling certified records and publishing the miss rate.
+- **Program fatigue** — the failure mode of every quality program. The
+  design defends: detectors hold zeros without human attention; quarantine
+  prevents rather than sweeps; the audit is quarterly not continuous; and
+  the dashboard makes drift visible to the owner in one file.
+- **The claim being read as more than it is.** §1.4 ships verbatim in
+  QUALITY.md. We publish the construction, not just the number.
+
+## 11. Amendment
+
+By PR to this file. The §1 definitions and §3.3 nominate-never-merge are
+load-bearing: changing them requires an owner-visible PR, not a drive-by.

--- a/PRD-QUALITY.md
+++ b/PRD-QUALITY.md
@@ -1350,3 +1350,13 @@ Scattered U-items, dossier §UNCERTAINs and PR-body follow-ups are consolidated
 in `DEBT.md` (one line each, owner + source-of-record + resolution). Take an
 item → delete its line in the same PR. §17's phase table should be read
 through it.
+
+### 20.7 The program's continuation lives in PRD-FIVE-NINES.md
+
+With every self-consistency class at zero, the path to p99.999+ is external
+anchoring + measurement + prevention. The complete technical plan — the
+usage-weighted target and its honest math, the audit instrument, Wikidata
+entity anchoring (nominate-never-merge), convention enforcement at ingest,
+decile-weighted certification, and the paid-layer bar — is PRD-FIVE-NINES.md.
+This document remains the operating manual for the mechanisms; that one owns
+the program.


### PR DESCRIPTION
The owner-directed complete technical plan. Headline structure: §1 defines the target honestly (usage-weighted, three-strata construction — you cannot sample your way to five nines, so: exhaustively certified head + deterministic detector zeros + rule-of-three-bounded tail); §2 the audit instrument (seeded stratified sampling, quarterly, published with intervals); §3 Wikidata entity anchoring as the identity backbone (public CC0 map, NOMINATE-NEVER-MERGE binding rule, three defect harvests + one coverage harvest, toyota+austin pilot); §4 prevention (machine-readable per-make conventions in CI, first-seen quarantine, the pipeline-change law); §5 decile-weighted certification with recertification triggers and the resolver demand flywheel; §6 the paid layer (same spine + enrichment audit stratum, Wikidata cross-check with curation-wins, plus-release gating, quality-as-product); §9 gates A1→F-1 with acceptance criteria. Companion pointers added to PRD-QUALITY §20.7 and DEBT.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)