### PR TITLE
A2 baseline audit results + ledger (S2W half)

### DIFF
--- a/data/review/audit-v2026.07.5/RESULTS-s2w.md
+++ b/data/review/audit-v2026.07.5/RESULTS-s2w.md
@@ -1,0 +1,182 @@
+# A2 baseline audit — S2W half (motorcycle + moped)
+
+*PRD-FIVE-NINES Workstream A2, tag `v2026.07.5`, n=400 stratified sample.
+Researcher pass by four independent agents; every batch re-derived by a separate
+verifier agent (invariant I-11). Ledger under `ledger/`. 2026-07-26.*
+
+---
+
+## The number, and how to read it
+
+**Conservative clean rate: 2,063 / 2,559 claims = 80.6%**, with every
+`unverifiable` counted against, as `audit-PROTOCOL.md` requires.
+
+**Do not quote that figure without the row below it.** It is dominated by one
+claim type whose coverage is 40%, and it mixes an unbiased measurement with a
+biased one. The per-claim table is the result; the aggregate is a bound.
+
+| claim | correct | defective | unverifiable | total | defect rate | basis |
+|---|---:|---:|---:|---:|---:|---|
+| **id-canonical** | 280 | **100** | 20 | 400 | **25.0%** | unbiased, full sample |
+| name-marque-true | 50 | 108 | 242 | 400 | *see below* | **biased, 40% coverage** |
+| make-correct | 381 | 5 | 14 | 400 | 1.3% | unbiased, full sample |
+| kind-correct | 396 | 3 | 1 | 400 | 0.8% | unbiased, full sample |
+| availability | 952 | 1 | 0 | 953 | **0.1%** | unbiased, first-hand from raw |
+| enrichment | 4 | 1 | 1 | 6 | — | n too small |
+
+### The headline is identity, not naming
+
+**One in four sampled records carries an id-canonical defect.** Two days of work
+before this audit went into naming; identity was the larger problem throughout
+and no detector reported it. `find_duplicate_spellings` returns **zero groups for
+this entire half** — it folds to `[A-Z0-9]` and tests equality, so it is
+structurally blind to duplicates differing by token *presence* or *order*.
+
+The population is concentrated: Harley-Davidson, Honda, Yamaha, Suzuki,
+Kawasaki. Worked examples that need no external source — BSA carries **twelve
+live ids for two motorcycles** (Thunderbolt ×5, Lightning ×7), documented only in
+an `enrich/bsa.yml` comment and in no ledger; `honda/sd02` publishes 475 Dutch
+rows as a bare type code while the Finnish register writes `VARADERO-SD02D/996`
+in a single cell, so the code→nameplate join is already inside our own corpus.
+
+### The name row must not be used as an estimate
+
+158 of 400 name claims carry an actual verdict; **242 were never attempted**.
+Coverage is *not* stratum-uniform — every batch that reported its method said it
+spent its budget where a source would settle a suspicion, so **the covered subset
+skews toward records that already looked wrong and its defect rate is biased
+upward.** Batch 3 declared this in its own proposal and its verifier preserved
+the declaration.
+
+The 242 split into a genuine **source-gap** floor and simple **not-attempted**
+work. Those mean opposite things — one is a fact about the domain and feeds the
+source-gap queue, the other is a fact about us and feeds effort planning — and
+`unverifiable` currently does both jobs. Amendment proposed in §Protocol below.
+
+### Availability is the one layer that survived everything
+
+**952 of 953**, re-derived from raw registers by four researchers and then again
+by four verifiers with independently written flatteners — 5,147,216 Finnish rows
+counted identically by two implementations that never saw each other's code.
+
+The single defect is `husqvarna/sm510` gb: all 77 UK rows are `SM 510 R`, which
+belongs to the live `sm510r`. It was found only by checking DVLA's finer **Model**
+column, which no researcher used.
+
+Two structural qualifications, both from agents correcting their own work:
+- the researchers' method verified *that a row exists for the make/model*, which
+  by construction **cannot** distinguish a row that named the model from a row a
+  rename resolved into it;
+- a targeted census of that exposure (`ledger/census-rename-availability.yml`)
+  found **3 fabricated country-claims out of 17,553 catalog-wide — 0.017%**, one
+  already documented in its own rename comment. Of the 12 records the class
+  touches, one was sampled, and it was **refuted**.
+
+---
+
+## Known limitations of this round
+
+**1. It is not reproducible at its own tag.** The sample is pinned to
+`v2026.07.5`; every batch measured a build stamped `2026.07.6`. Three population
+figures exist and none agree:
+
+    sample manifest       7,073
+    current main build    7,083
+    rebuild at the tag    7,087  (+ 4 gate failures)
+
+The tag cannot be rebuilt cleanly with today's pipeline, because `v2026.07.5`
+data against a post-`pipeline#36` tokenizer is exactly the coupled breakage that
+change was made to fix. Materially the exposure is confined — id churn since the
+tag is ~1 record, so id/make/kind/availability are essentially unaffected — but
+**~100 display names were corrected between the tag and the build**, so name
+verdicts were taken against post-fix names and the name rate is biased
+*optimistically* on top of its coverage bias.
+
+**Fix for the next round: the sampler must pin the BUILD it measures, not only
+the release tag.** They are not the same object.
+
+**2. `catalog/meta/decile-mass.json` was absent from the build.** The protocol
+requires the usage-weighted aggregate to read it. It landed in `pipeline#40`
+after these builds were made, so **no usage-weighted figure is published here** —
+only the unweighted per-claim rates above.
+
+**3. Verification moved every batch in the same direction.** All four proposals
+were *optimistic*, not conservative:
+
+    b1  85.1% → 84.0%     b2  78.4% → 78.1%
+    b3  81.7% → 80.8%     b4  87.8% → 87.3%
+
+**22 additional defects were found among claims the researchers called
+`correct`, and all 22 were id-canonical.** The first verifier diagnosed the cause
+— criteria applied inconsistently within a batch — and wrote the fix; the third
+verifier found the fix had not been adopted and warned that if the under-call is
+systematic the id rate is low by roughly a third. It is now corrected in the
+table above, but the mechanism should be assumed live for future rounds.
+
+**4. Cross-batch contradictions exist in the ledger and are NOT silently
+resolved.** `honda/nt650v-deauville` and `harley-davidson/flhtcui-ultra-classic`
+were each called `correct` by one batch and `defective` by another batch's
+verifier. Both are recorded as-is. A ledger that hid the disagreement would be
+worse than one that carries it.
+
+---
+
+## Defect classes for the taxonomy
+
+Per invariant I-15 a class needs a taxonomy entry and a detector spec **before**
+any scaled fixing. Nothing here has been fixed.
+
+| class | status | measured | note |
+|---|---|---|---|
+| token-subset / permutation duplicates | real, novel detector | 312 groups / 765 records | `find_token_duplicates.rb`; **worklist, never verdict** |
+| code ⟷ nameplate pairs | real, **size unknown** | see below | in-corpus join available for many |
+| descriptor-as-model | real, novel | 16–58 by lexicon | ~40–50% false-positive rate; co-discovered by two batches |
+| token-boundary shift | real, novel | 9 H-D + 5 current products | corrupts the **slug**, not just display |
+| kind from source vocabulary | real | 258 gb-only, 18 twins, Twizy in 3 kinds | second nl route not in the kind-boundary plan |
+| placeholder-keyed rename | real, novel | 1 live | cannot be scoped by kind |
+
+**A number that was reported and does not reproduce:** batch 2's "262 code⊂code+name
+pairs". Its verifier implemented the same spec across every reading of its
+ambiguities and got 207 / 246 / 292 / 323 — never 262 — while the batch's
+*companion* figure reproduced exactly. **The class is real; the size is not
+established.** It is recorded here rather than published as a measurement.
+
+**A detector that was built and then refuted, deliberately kept:** same-make
+shared type-approval number is **not** a duplicate signal. 572 groups / 1,061 ids
+share TANs; one Royal Enfield approval spans six nameplates and one Harley TAN
+spans ten. Curation consequence: `renames.yml` cites TAN 38 times, and one line
+(`Ab: Senda 50`, load-bearing for 317 rows) rests on **TAN alone** with no
+name-family argument — and that TAN is not even make-exclusive. Four other lines
+that look TAN-primary pair it with a measured displacement or class constraint
+and are sound.
+
+---
+
+## Protocol amendments this round earns
+
+1. **Sub-type `unverifiable`** into `source-gap` and `not-attempted`. Both
+   correctly count against the clean rate, so the conservative bound is
+   unchanged — but blending them means a hard domain limit cannot be told from
+   unfinished work, and the source-gap queue silently fills with records nobody
+   tried.
+2. **Quote the relied-on sentence at write time.** Two batches cited a page that
+   does not contain the claim.
+3. **Cited URLs must be re-fetchable.** Six failed as written in one batch; two
+   were the sole support for defective verdicts and both verdicts fell.
+4. **Filed debt does not excuse a published claim.** A debt entry changes nothing
+   for a consumer, and excluding filed-debt records would make the metric
+   improvable by writing documentation. Report the known-debt/novel split against
+   the same denominator instead. *(Both verifiers that considered it agreed.)*
+5. **The sampler pins a build, not a tag** (limitation 1).
+
+## Ledger
+
+`ledger/researcher-b{1..4}.yml` — per-record verdicts, four independent agents.
+`ledger/verifier-b{1..4}.yml` — independent re-derivation of each, I-11.
+`ledger/census-rename-availability.yml` — the rename-propagation census.
+
+Researcher and verifier records are kept **separate and unmerged on purpose**.
+Merging them by hand would mean transcribing ~400 records' worth of prose
+corrections into a single file — exactly the silent-transcription-error class
+this program exists to remove. The corrected aggregate in this document is
+computed from the verifiers' tallies; the disagreements remain readable.

--- a/data/review/audit-v2026.07.5/ledger/census-rename-availability.yml
+++ b/data/review/audit-v2026.07.5/ledger/census-rename-availability.yml
@@ -1,0 +1,373 @@
+# Blast radius of "rename-propagated availability" on the 2W half
+# researcher: audit-b4 (read-only; no writes or git in any repo)
+# tag: v2026.07.5 build at build/out/catalog
+#
+# HEADLINE, stated first because it is a partial REFUTATION:
+#   The MECHANISM batch 3 identified is real and I reproduced it exactly.
+#   Their INSTANCE is not a defect: every Nimbus ever built is a 746cc four, so
+#   resolving a bare "NIMBUS" row to "750" narrows nothing and NZ's registration
+#   genuinely is a 750. b3's single availability defect should be WITHDRAWN.
+#   Catalog-wide on the 2W half the class costs 3 fabricated country-claims out
+#   of 17,553 (0.017%), and one of those 3 is already documented in the rename's
+#   own comment. This is a narrow class, not a systemic one.
+
+method:
+  step_1_discriminator:
+    what_i_enumerated: >-
+      Every non-null line in overrides/models/renames.yml (1,872 lines), classified
+      by the INFORMATION RELATION between key and value, comparing
+      norm(s) = upcase + strip all non-alphanumerics:
+        identical_respacing  1359  norm(key) == norm(value) — pure spacing/casing
+        value_drops_info      385  norm(key) ⊃ norm(value) — trim/variant folded UP
+        disjoint               95  neither contains the other
+        value_adds_infix       25  norm(key) ⊂ norm(value), not at the start
+        value_adds_prefix       8  norm(key) is a strict prefix of norm(value)
+      FLAGGED as candidate under-specified keys: the last three buckets, 128 lines.
+      make_as_model lines (norm(key) == norm(make)) anywhere in the file: 4.
+    why_the_string_test_is_not_enough: >-
+      I read all 128 flagged lines by hand and the string relation is a poor proxy.
+      The `disjoint` bucket is dominated by LEGITIMATE folds — Derbi trim names
+      (Black Devil → Senda 50), Polestar/Omoda/Jaecoo trim strings
+      (2 Dual Motor → Polestar 2), Volvo body-variant numbers (144 → 140), Mk
+      numeral normalisations, token reorders (300GT Max → GT-MAX 300, 200LE →
+      LE200) and accent fixes. And most of `value_adds_infix` is the marque word
+      being added (3 → MAZDA3, 5 → Omoda 5), which adds NO model information.
+    the_operative_test: >-
+      A rename can fabricate availability only if it NARROWS THE IDENTITY SET —
+      i.e. the key's set of possible machines is strictly larger than the value's.
+      Adding a family word that every member of the key's set already shares
+      (Rally 307 → Aventura Rally 307) names the machine more fully without
+      narrowing, and the country did register that machine. That distinction —
+      NARROWING vs NAMING — is what separates fabricated from legitimately
+      inherited, and it is the whole finding.
+  step_2_per_country_test:
+    axis_A_mechanical: >-
+      For each claimed country, scan that country's raw rows under the record's
+      make (make aliases resolved first, make-prefix stripped) for rows that
+      RESOLVE to this id — either matching norm(value) directly or matching any
+      rename key in the same make that maps to the same value. Then ask whether
+      any such row NAMES the model: every distinguishing token of the value
+      (alnum runs, letter/digit boundaries split) must appear, with digit tokens
+      matched on a digit boundary so "50" does not match inside "500".
+      Result: named_model | VAGUE_ONLY | NO_RESOLVING_ROW.
+    axis_B_semantic: >-
+      For every VAGUE_ONLY country, decide by SOURCE whether the resolution
+      narrows. This is the step that cannot be automated and it is where b3's
+      instance turns over.
+  corpora: "the same eight locally cached registers as batch 4 (all_raw.txt, 136,104 rows); uk_dft joined on GenModel per uk_dft.rb"
+  scripts: ["scratchpad/blast_b4_avail.rb  # bucket census", "scratchpad/blast_b4_v2.rb  # per-country token test", "scratchpad/blast_b4_v3.rb  # completeness pass over ALL flagged lines"]
+
+funnel:
+  renames_non_null_lines: 1872
+  flagged_under_specified_keys: 128
+  flagged_lines_with_a_live_2W_target: 49
+  distinct_2W_records_touched: 33
+  records_with_at_least_one_VAGUE_ONLY_country: 12
+  VAGUE_ONLY_country_claims_examined: 19
+  # adjudicated below, by source:
+  fabricated: 3
+  legitimately_inherited: 14
+  excluded_no_model_information_added: 2
+
+# ─────────────────────────────────────────────────────────────────────────────
+fabricated:   # the register never named this model AND the resolution narrows
+
+  - id: motorcycle/derbi/senda-125
+    country: gb
+    vehicles: 1728
+    rename: '"Senda" -> "Senda 125"  (renames.yml Derbi block, line ~375)'
+    narrowing: >-
+      "Senda" is a Derbi FAMILY spanning the 50cc mopeds (Senda R / SM / X-Treme /
+      DRD, all published as moped/derbi/senda-50) and the 125cc motorcycles. The
+      value asserts the 125.
+    why_gb_cannot_have_named_it: >-
+      DVLA's GenModel is a family stem and the only Derbi Senda GenModel is
+      "DERBI SENDA" (1,728 licensed+SORN). uk_dft has no moped class at all
+      (overrides/kind_maps/uk_dft.yml: "UK merges mopeds INTO Motorcycles"), so
+      the UK's 50cc Sendas are inside that 1,728 and there is no gb claim on
+      moped/derbi/senda-50 for them to land on instead.
+    status: DOCUMENTED_AND_DELIBERATE
+    the_comment_says_so: >-
+      renames.yml line ~375 reads: "motorcycle-kind bare Senda: FI rows are the
+      125 (TAN e9*92/61*0130*01); UK rows land here too (VEH0120 merges mopeds
+      into Motorcycles by design — kind_maps/uk_dft.yml)". So curation identified
+      this exact propagation and accepted it. Under the audit protocol's
+      deliberate-decision rule this is a decision to disagree with, not an
+      undetected defect — but the gb claim is still substantively wrong, and it is
+      the single largest vehicle count in the class by two orders of magnitude.
+    relation_to_my_batch_4_finding: >-
+      This is the SAME root cause as F3 (uk_dft's moped merge minting cross-kind
+      duplicates), reached from the other direction. F3 found the merge creating a
+      spurious motorcycle-kind RECORD; this finds it creating a spurious
+      motorcycle-kind COUNTRY on a real record. One fix addresses both.
+
+  - id: motorcycle/sherco/50
+    country: es
+    vehicles: 26
+    rename: '"N.a" -> "50"  (renames.yml Sherco block, line ~2163)'
+    narrowing: >-
+      The key is a literal not-available PLACEHOLDER ("N.A" / "N/A"), so its
+      identity set is every Sherco. The value asserts a 50.
+    why_es_cannot_have_named_it: >-
+      es_dgt carries SHERCO "N.A" in TWO categories: *02 (mopeds 50cc, n=297) and
+      *05 (motorcycles by displacement, n=26). The *05 rows are what feed this
+      MOTORCYCLE-kind record, and a *05 Sherco can be a 125/250/300 — Sherco's
+      es-evidenced motorcycle range in this same corpus includes 125 SE, 250 SE,
+      300 SE, 300 SEF.
+    why_this_is_the_sharp_case: >-
+      The rename's own justification is explicitly about mopeds — "RDW registers
+      Sherco's 50cc mopeds as handelsbenaming 'N/A' (~806 rows, all 50cc,
+      e13*168/2013*00339)". That reasoning is sound and I accepted it for the
+      moped record (see legitimately_inherited below). It does NOT reach the 26
+      es motorcycle-class rows, which the same one-line rename also captures.
+      A rename keyed on a placeholder cannot be scoped by kind, so a justification
+      that holds for one kind silently applies to the other.
+
+  - id: moped/elmoto/hr-2
+    country: fi
+    vehicles: 1
+    rename: '"Elmoto" -> "HR-2"  (make-as-model)'
+    narrowing: >-
+      Elmoto markets TWO mopeds, the HR-2 and the HR-4 Loop, so a bare "ELMOTO"
+      row is ambiguous between them.
+    evidence:
+      - "https://www.e-scooter.co/elmoto-hr-4-loop/  # 'The HR-4 Loop is a second generation electric moped by Elmoto'"
+      - "https://www.designboom.com/design/elmoto-hr-2-electric-bike/  # the HR-2"
+      - "raw: fi_traficom 'Elmoto | ELMOTO' n=1 — the only fi row; nl has 'HR-2' n=1 beside 'ELMOTO' n=13"
+    note: >-
+      One vehicle, so the practical impact is nil; it is listed because it is the
+      only UNDOCUMENTED, genuinely-narrowing instance the sweep found besides the
+      Sherco es case. Note the nl side is legitimate (nl does name HR-2).
+
+# ─────────────────────────────────────────────────────────────────────────────
+legitimately_inherited:   # resolution does NOT narrow — the country registered
+                          # the same machine under a vaguer or aliased string
+
+  - id: motorcycle/nimbus/750
+    countries: [nz]
+    vehicles: 6
+    rename: '"Nimbus" -> "750"  (make-as-model)'
+    verdict: NOT_A_DEFECT
+    reasoning: >-
+      THIS IS THE REFUTATION OF BATCH 3'S ONLY AVAILABILITY DEFECT. Nimbus
+      (Fisker & Nielsen, Copenhagen, 1919-1960) built the Model A "Stovepipe",
+      the Model B and the Model C — and ALL of them are 746cc air-cooled inline
+      fours. The A/B use an inlet-over-exhaust head, the C an overhead cam, but
+      the displacement never changed. So "750" does not narrow the identity set
+      at all: whatever the NZ machines are, they are 750s. The rename resolves a
+      make-as-model row to the one thing that is true of every member of the set.
+    evidence:
+      - "https://cars.bonhams.com/auction/18362/lot/62/1923-nimbus-746cc-four-frame-no-183-engine-no-n1217/  # 1923 Nimbus 746cc Four"
+      - "https://cars.bonhams.com/auction/23804/lot/195/1926-nimbus-746cc-model-b-engine-no-t0-1090/  # 1926 Nimbus 746cc Model B"
+      - "https://cars.bonhams.com/auction/24885/lot/434/1939-nimbus-746cc-model-c-frame-no-5106-engine-no-5106/  # 1939 Nimbus 746cc Model C"
+      - "https://thegirderclub.com/2025/03/12/stovepipes-and-bumblebees-the-story-of-the-nimbus/  # 'The first Nimbus motorcycle had a 10bhp, four-cylinder, air-cooled, in-line engine of 746cc capacity'"
+      - "http://www.nimbusclubusa.com/nimbus/  # marque club: three models A/B/C; gives 746cc for the Model C"
+    honest_caveat: >-
+      The marque club's own page states 746cc only for the Model C and gives no
+      figure for A/B. The A/B displacement rests on the Bonhams catalogue
+      descriptions and the specialist history above, not on the club. Wikipedia
+      also asserts "both with a 750 cc four-cylinder engine" but the standing
+      Wikipedia rule means nothing here rests on it — it was a locator only.
+    what_b3_got_right: >-
+      The mechanism, completely. A rename that resolves an under-specified raw
+      string does propagate availability to every country that emitted the vague
+      form, no detector fires, and a make/model-existence availability check
+      cannot see it. That is a real and previously unfiled class. What was missing
+      was the narrowing test.
+
+  - id: moped/sherco/50
+    countries: [es, nl]
+    vehicles: 1106
+    rename: '"N.a" -> "50"'
+    verdict: NOT_A_DEFECT
+    reasoning: >-
+      Same rename line as the fabricated motorcycle case above, opposite verdict,
+      and the difference is the register's own vehicle class. The displacement is
+      DERIVED FROM THE REGISTERS, not asserted: nl_rdw's soort is BROMFIETS
+      (Dutch law: ≤50cc) for 809 of these rows, and es_dgt's category is *02
+      (mopeds 50cc) for 297. The rename's comment additionally cites a single
+      shared type-approval number (e13*168/2013*00339) across the ~806 RDW rows.
+      A row can be an unknown Sherco MODEL and still be a known 50, so the
+      country did register a 50cc Sherco.
+    residual_defect_that_is_NOT_this_class: >-
+      The record's NAME is a bare displacement pooling several real Sherco 50
+      nameplates (moped/sherco/50-sm is live beside it), which is the filed
+      bare-displacement-2w / numeric_only question — and the rename comment says
+      so deliberately ("the '50' umbrella stays for the unresolvable N/A rows").
+      Do not let the availability verdict launder the naming one.
+
+  - id: motorcycle/gas-gas/es-700
+    countries: [gb, nz]
+    vehicles: 224
+    rename: '"Es" -> "ES 700"'
+    verdict: NOT_A_DEFECT
+    reasoning: >-
+      GASGAS has exactly one ES-prefixed model, the ES 700 (launched 2022
+      alongside the SM 700). gasgas.com's model tree carries es-700-2022 and
+      es-700-2024 under /models/travel/ and no other ES machine at any
+      displacement, so a bare "ES" row cannot be anything else.
+    evidence:
+      - "https://www.gasgas.com/en-us/news/get-on-the-gas-with-the-new-gasgas-sm-700-and-es-700-.html  # the ES 700's launch, paired only with the SM 700"
+      - "https://www.gasgas.com/en-us/models/travel/es-700-2024.html"
+      - "https://www.gasgas.com/en-us/models/motorcycles.html  # current model tree: MC / EC / EX / TXT only — no second ES"
+    caveat: "a negative proved from the marque's own model tree rather than exhaustively; if a historic ES ever existed at another displacement this flips."
+    note: >-
+      styling.yml already records that this line carries gb/nz evidence — the
+      480-ES comment says the ES acronym token "orphaned Gas Gas 'Es: ES 700'
+      (gb/nz evidence lost, spotcheck caught it)". So the propagation was known
+      and its loss was treated as a REGRESSION, which is the correct reading if
+      the inheritance is legitimate. It is.
+
+  - id: motorcycle/rieju/aventura-rally-307
+    countries: [es, gb, nl]
+    vehicles: 974
+    rename: '"Rally 307" -> "Aventura Rally 307"'
+    verdict: NOT_A_DEFECT
+    reasoning: >-
+      No register anywhere names "Aventura" — all three countries carry only
+      "RALLY 307" / "RIEJU RALLY 307". But Aventura is the FAMILY word that every
+      Rally 307 shares: Rieju's own model pages file the bike as "Aventura Rally
+      307" (and the hard-enduro sibling as "Aventura Rally 307 R"). Adding it
+      names the machine more fully without excluding any member of the key's set,
+      and the discriminating token 307 is present in every raw.
+    evidence:
+      - "https://rieju.com/us/off-road/121/522/aventura-rally-307  # marque model page"
+      - "https://rieju.com/us/hard-offroad/129/439/aventura-rally-307r  # the R sibling, which the raws do not claim"
+    note: "this is the archetype of the NAMING-not-narrowing case and the reason the string-relation test alone would have produced a false positive here."
+
+  - id: moped/talaria/xxx
+    countries: [es]
+    vehicles: 1
+    rename: '"TL2500" -> "XXX"'
+    verdict: NOT_A_DEFECT
+    reasoning: >-
+      TL2500 is the type code of the machine Talaria sells as the XXX — a 1:1
+      alias, no narrowing. Already sourced inside the project: styling.yml's XXX
+      entry records that "Raw RDW pairs it explicitly: 'TL2500, XXX'
+      (https://talaria.bike/), n=6".
+    evidence: ["overrides/styling.yml stylings: XXX", "raw: es_dgt 'TALARIA | TL2500' n=1"]
+
+  - id: motorcycle/gas-gas/ec
+    countries: [lu]
+    vehicles: 3
+    rename: '"Enducross" -> "EC"  (and "Cg" -> "EC")'
+    verdict: NOT_A_DEFECT
+    reasoning: >-
+      EC literally abbreviates Enducross — styling.yml's own pin reads
+      "EC # Gas Gas EC (Enducross) family — official all-caps (gasgas.com)". Key
+      and value denote the identical set, and the target record is itself
+      family-level ("EC"), so nothing is narrowed.
+    evidence: ["overrides/styling.yml stylings: EC", "raw: lu_snca 'GAS-GAS | ENDUCROSS' n=3"]
+
+  - id: motorcycle/trs/one-300
+    countries: [es, nl]
+    vehicles: 21
+    rename: '"TR1 300" -> "One 300"'
+    verdict: NOT_A_DEFECT_ON_THE_AVAILABILITY_AXIS
+    reasoning: >-
+      The discriminating token (300) is present in every raw; only the family word
+      changes, so the identity set cannot narrow and availability cannot be
+      fabricated. Consistent with the sourced sibling line "Trrs One: One"
+      (trsmotorcycles.com), where TRS bikes are badged TRRS.
+    undecided: >-
+      Whether "TR1" really is the TRRS One and not some other TRS line is
+      UNSOURCED — I could not confirm it. Recording that rather than deciding it.
+      It is an identity question about the record, not a fabricated-availability
+      question, so it does not move the number either way.
+
+  - id: motorcycle/gas-gas/txt
+    countries: [fi, nl]
+    vehicles: 6
+    rename: '"Tg" -> "TXT"'
+    verdict: NOT_A_DEFECT_ON_THE_AVAILABILITY_AXIS
+    undecided: >-
+      I could NOT establish what Gas Gas "TG" is. Both key and value are bare
+      family strings with no displacement or variant, so no narrowing occurs and
+      availability cannot be fabricated by this mechanism — but if TG is a
+      different Gas Gas line entirely then this is a MIS-ATTRIBUTION rather than
+      an inheritance, which is a different (and worse) defect class. Flagged
+      undecided per instruction 5; resolving it needs a Gas Gas source I did not
+      find.
+    evidence: ["raw: fi_traficom 'Gas Gas | TG' n=1; nl_rdw 'GAS GAS | TG' n=5"]
+
+# ─────────────────────────────────────────────────────────────────────────────
+excluded_no_model_information_added:
+
+  - id: moped/unu/scooter
+    countries: [es, nl]
+    vehicles: 298
+    rename: '"Unu" -> "Scooter"  (make-as-model)'
+    why_excluded: >-
+      Neither register named "Scooter" — but "Scooter" carries no model
+      information, so the identity set is unchanged and no availability claim is
+      fabricated. Counting it would inflate the number with a case that is really
+      about the NAME.
+    what_it_actually_is: >-
+      An instance of the descriptor_as_model class I proposed as F5 in batch 4,
+      arriving through a rename rather than straight from a register. It sits
+      beside moped/vespa/scooter, motorcycle/vespa/scooter, moped/honda/moped and
+      harley-davidson/custom|trike. Worth adding to F5's worklist: renames.yml is
+      a second SOURCE of that class, which the detector spec I wrote (match the
+      published name against a closed descriptor vocabulary) already covers,
+      since it reads the published catalog rather than the raws.
+
+# ─────────────────────────────────────────────────────────────────────────────
+rates:
+  against_the_2W_catalog:
+    records: 7083
+    availability_claims: 17553
+    fabricated_claims: 3
+    rate: "3 / 17,553 = 0.017% of 2W availability claims"
+    fabricated_excluding_the_documented_one: "2 / 17,553 = 0.011%"
+    vehicles_affected: "1,755 registrations, of which 1,728 are the single documented Derbi gb claim"
+  against_the_953_claims_the_four_batches_passed:
+    denominator: "236 (b2) + 251 (b1) + 237 (b4) + 229 (b3) = 953"
+    overlap_with_the_affected_records: >-
+      Of the 12 records this class touches, exactly ONE is known to have been
+      sampled: motorcycle/nimbus/750, in batch 3. None of the other 11 appear in
+      batch 4's list, and I cannot see b1/b2's lists to check theirs.
+    corrected_figure: >-
+      b3's single availability defect is REFUTED, so the collective figure moves
+      the OTHER WAY: 953 / 953 correct, not 952 / 953. The class does not undercut
+      the reported availability rate at all — on the sampled evidence it improves
+      it by one claim.
+    honest_reading: >-
+      Do not present 3/17,553 as a correction to the sampled rate. They are
+      different populations: the sampled rate is an estimate with a
+      Clopper-Pearson interval, and 3 is a CENSUS of a specific mechanism across
+      the whole 2W half. State them separately. The right sentence is: "the
+      sampled availability rate is unchanged (and one reported defect is
+      withdrawn); a targeted census of rename-propagated availability found 3
+      fabricated country-claims catalog-wide on the 2W half, 1 of them already
+      documented in curation."
+
+verdict_on_the_class:
+  is_it_real: >-
+    Yes. The mechanism is exactly as batch 3 described and it is invisible to
+    every check we ran, including my own availability sweep — I verified that a
+    row exists for the make/model, which cannot distinguish a row that named the
+    model from a row that was renamed into it.
+  is_it_systemic: >-
+    No. 1,872 rename lines; 128 have an under-specified key by the string test;
+    49 of those have a live 2W target; 12 records have any vague-only country;
+    3 country-claims survive the narrowing test. The bucket census is the reason
+    to be calm about it: 1,359 lines are pure respacing and 385 fold a specific
+    variant UP into a general model, and neither direction can fabricate anything.
+  the_two_shapes_worth_a_taxonomy_entry:
+    - "PLACEHOLDER RESOLUTION — a rename keyed on a not-available string ('N.a', 'N/A', '-', 'Uoplyst') cannot be scoped by kind or category, so a justification that is sound for one register class silently applies to the others. The Sherco line is sound for nl bromfiets and es *02 and wrong for es *05, from ONE line. This is the shape I would file."
+    - "FAMILY-STEM RESOLUTION ACROSS A KIND BOUNDARY — a register whose model column is a family stem (DVLA GenModel) combined with a register that merges mopeds into motorcycles routes a whole country's family fleet onto whichever displacement id curation picked. Already documented for Derbi; the general risk is any make with a 50cc and a 125cc line sharing a family name."
+  detector_spec: >-
+    Reuse the sweep in scratchpad/blast_b4_v2.rb. For every rename line where
+    norm(key) is not information-equal to norm(value) AND the value is not a
+    strict reduction of the key, emit the target id and, per claimed country,
+    whether any resolving raw row contains every distinguishing token of the
+    value. Countries with none are the worklist — 19 lines catalog-wide on the 2W
+    half, which is a human-sized review, not a sweep. Then the NARROWING question
+    is asked once per rename line (14 lines), not once per record.
+    Cheap pre-filter that removes most false positives for free: skip any line
+    whose value differs from its key only by the marque word or by punctuation.
+  what_would_change_my_answer: >-
+    A make where the register's family stem spans two displacements AND both
+    displacement ids are live AND the vague country is not uk_dft would be a
+    fourth instance with no documentation behind it. I looked for that pattern
+    and Derbi/Senda is the only one on the 2W half.

--- a/data/review/audit-v2026.07.5/ledger/researcher-b1.yml
+++ b/data/review/audit-v2026.07.5/ledger/researcher-b1.yml
@@ -1,0 +1,1647 @@
+# PRD-FIVE-NINES Workstream A2 — baseline round, tag v2026.07.5, S2W half
+# BATCH 1 RESEARCHER PROPOSAL (read-only; not a ledger; awaiting independent verifier)
+# researcher: opus5/audit-b1-researcher
+# verifier: null
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# METHOD — what each verdict actually rests on, so the verifier can attack it
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# COVERAGE: 100/100 records. 651 claims (100 id + 100 name + 100 make + 100 kind
+# + 251 availability). No record skipped, no claim padded.
+#
+# availability (251 claims) — verified at FULL rigor against the local raw
+#   corpora, not by assumption. I flattened every cached register the build read
+#   and re-derived each claim from the raw (make,model) rows:
+#     nl  cache/nl_rdw_{bromfiets,motorfiets,driewielig-motorrijtuig,
+#         motorfiets-met-zijspan}.json          (55,491 rows)
+#     fi  cache/fi_traficom_register.zip -> L1e-L7e only (15,005 rows;
+#         cols ajoneuvoluokka/merkkiSelvakielinen/mallimerkinta/
+#         kaupallinenNimi/tyyppihyvaksyntanro per pipeline/sources/fi_traficom.rb)
+#     es  cache/es_dgt_2026{04,05,06}.txt fixed-width [17,30)/[47,22)/[426,3),
+#         L*/asterisk categories only (2,127 rows)
+#     lu  cache/lu_delta_2026-{05,06,07}.xml LIBMRQ/TYPCOM/CATEU/PVRNUM,
+#         MONTHS_BACK=3 as the adapter does (2,301 rows)
+#     nz  cache/nz_{moped,motorcycle}_*.json MAKE/MODEL (12,211 rows)
+#     gb  cache/uk_veh0120_uk.csv BodyType/Make/GenModel/Model (215,825 rows)
+#     ua  cache/ua_reestr_current.zip BRAND/MODEL/KIND, per-vehicle dedupe by
+#         the ident column exactly as ua_mvs.rb does (3,379 rows)
+#     th  cache/th_dlt_2568.csv (3,920 rows)
+#   Match rule: normalise both sides to [A-Z0-9], strip the resolved make (and
+#   its curated aliases) as a prefix, require equality. 248/251 matched on the
+#   first pass; the 3 misses were run down individually and all 3 resolved to
+#   MATCHER artifacts, not data defects (see notes on derbi/senda-50,
+#   selana/alpha, tgb/br8). Scripts are in the scratchpad next to this file.
+#
+# id-canonical (100 claims) — three inputs, in this order:
+#   1. scripts/find_duplicate_spellings.rb re-run against THIS build
+#      (VDB_SIDE=s2w VDB_CATALOG=.../build/out/catalog): "0 collision groups in
+#      the s2w half, 0 records". Silent, as audit-PROTOCOL predicted.
+#   2. my own same-make name-containment scan across both 2W kinds (all 7,083
+#      published 2W records), which is STRICTLY WIDER than the detector.
+#   3. overrides/models/{renames,former_ids,removals,moves}.yml + data/review/*
+#      + data/name_shapes.yml, grepped per id and per published name.
+#   Every `defective` id verdict below comes from (2) or (3), never from (1) —
+#   i.e. every one of them is a DETECTOR GAP. See FINDING-A.
+#
+# name-marque-true (100 claims) — fetch-never-assume, applied literally. A name
+#   is `correct` only where I hold a marque / marque-specialist / project-cited
+#   URL, or an in-data proof of the project's own accepted kind (a register
+#   pairing that settles it). Where I could not reach a source this round the
+#   verdict is `unverifiable`, WITH the reason. That is 54 of 100 and it is the
+#   honest number: it is not a claim that those names are wrong, and it is not a
+#   claim that they are right.
+#   No Wikipedia was used as a sole source for any verdict (standing rule).
+#   Two fetches failed and are recorded as such rather than worked around:
+#   bmw-motorrad.com (timeout), royalenfield.com (403), bsacompany.co.uk (403),
+#   tmracing.it (cross-host redirect not followed).
+#
+# make-correct / kind-correct (200 claims) — register make string vs make_id and
+#   its curated aliases; EU category (L1e/L2e/L6e/L7e -> moped, L3e/L4e/L5e ->
+#   motorcycle) vs published kind, using each adapter's own CATEGORY_TO_KIND.
+#
+# enrichment sub-check (§6.2) — 3 of the 100 ids carry enrichment. All 3 were
+#   re-derived from their cited sources. Results inline; one is a Wikipedia-only
+#   citation and is called out.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# FINDING-A (HIGH VALUE, I-15) — a DETECTOR GAP, not a new defect class
+# ─────────────────────────────────────────────────────────────────────────────
+# Every duplicate I found maps to existing class D6 (duplicate spelling, same
+# make+kind). What is new is that `find_duplicate_spellings` cannot see any of
+# them, because it folds to [A-Z0-9] and compares for EQUALITY. It therefore
+# catches "280 Se" vs "280SE" and is structurally blind to duplicates that
+# differ by TOKEN PRESENCE or TOKEN ORDER. Its verdict on the whole S2W half is
+# "0 groups / 0 records", and the S2W half contains at least this:
+#
+#   BSA A65 Thunderbolt — ONE motorcycle (1964-72, single-carb 650 twin),
+#   SIX live ids:
+#     motorcycle/bsa/thunderbolt        "Thunderbolt"      [fi,nl,nz]
+#     motorcycle/bsa/thunderbolt-650    "Thunderbolt 650"  [nl,nz]
+#     motorcycle/bsa/650-thunderbolt    "650 Thunderbolt"  [nl,nz]
+#     motorcycle/bsa/thunderbolt-a65    "Thunderbolt A65"  [fi,nl]  <- SAMPLED
+#     motorcycle/bsa/a65t               "A65T"             [nl,nz]
+#     motorcycle/bsa/a65                "A65"              [nl,nz]  (family row)
+#   The BSA Lightning (A65L) has the same shape, seven ids. This is already
+#   KNOWN and WRITTEN DOWN in the enrichment layer — enrich/bsa.yml:106 says
+#   verbatim "same machine — FIVE ids for one motorcycle" — but it is in NO debt
+#   ledger (not name_shapes.yml `debt:`, not DEBT.md) and no detector reports it,
+#   so nothing schedules it.
+#
+# DETECTOR SPEC PROPOSED (per I-15, before any scaled fixing):
+#   Within one (make_id, kind): tokenise each published name on whitespace after
+#   [A-Z0-9] folding. Nominate a group when one id's token MULTISET is a subset
+#   of another's, or two ids' token multisets are equal under permutation.
+#   Rank by evidence asymmetry (a 1-row id beside a 67-row id is the strong
+#   signal). Output is a WORKLIST, never a verdict — displacement tokens make
+#   subsets legitimate constantly (bmw/f650 vs f650gs vs f650gs-dakar are three
+#   real motorcycles), so every group needs one human call, exactly like the
+#   model-column-acronym-casing worklist.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# FINDING-B (NEGATIVE RESULT, but load-bearing) — shared TAN is NOT a duplicate
+#   detector, and renames.yml leans on it as if it were
+# ─────────────────────────────────────────────────────────────────────────────
+# I built the obvious detector for FINDING-A first: same make + same
+# type-approval number => same vehicle. It is WRONG and I am reporting it as a
+# refutation rather than shipping it. Measured over all 7,083 published 2W
+# records in catalog-plus: 572 (make,kind,TAN) groups covering 1,061 ids share a
+# TAN. Counter-examples that kill the rule outright:
+#     e5*168/2013*00017*06 -> royal-enfield/continental-gt650 AND
+#                             royal-enfield/interceptor-int650   (two DIFFERENT bikes)
+#     e1*2002/24*0498*00   -> bmw/k1600gt AND bmw/k1600gtl
+#     e4*2002/24*1918*00   -> TEN Harley ids (Road King, Street Glide, Electra
+#                             Glide, CVO Road Glide ...) on one approved type
+# EU whole-vehicle approval is granted per TYPE/platform, so one TAN routinely
+# spans many nameplates. CONSEQUENCE FOR CURATION: renames.yml repeatedly cites
+# "TAN IDENTICAL" as merge evidence (e.g. Derbi `Senda R50AF`/`Senda SM50AF`,
+# `Black Devil`/`Senda R X-Trem`). Those specific merges are fine because a
+# name-family argument carries them — but the TAN is doing none of the work, and
+# a future merge resting on TAN alone would be wrong. Worth a line in NAMING.md.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# FINDING-C — uk_dft `GenModel` is a FAMILY column, so gb-only records are
+#   systematically one altitude too high (existing class D8, no detector)
+# ─────────────────────────────────────────────────────────────────────────────
+# uk_dft.rb keys on GenModel, which is make-prefixed and coarser than Model:
+#     YAMAHA | YAMAHA XSR | {XSR 125 (MTM125), XSR 700 ABS, XSR 900 (MTM890),
+#                            XSR 900 ABARTH, XSR 700 XTRIBUTE}
+#     YAMAHA | YAMAHA XP  | {XP500, XP 530 D-A TMAX DX, XP 560 D (TMAX TECH MAX)}
+#     LEXMOTO| LEXMOTO MILANO | {MILANO 125 EFI ..., MILANO 50 FT 50 QT-27}
+# So `motorcycle/yamaha/xsr` is five motorcycles, and `motorcycle/lexmoto/milano`
+# pools a 125 and a 50. The project has an accepted precedent for family-level
+# ids (data/review/mutt.yml signs off motorcycle/mutt/fsr as `fixed` while
+# noting it is "sold 125cc and 250cc"), so this is a POLICY question, not an
+# automatic defect — but nothing currently marks which ids are family rollups.
+# Suggest emitting a flag when an id's only source is uk_dft AND the underlying
+# GenModel spans >1 distinct Model string.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# FINDING-D — Honda/Yamaha frame-and-type codes are the largest D9 population
+#   on the 2W half, and one nameplate is routinely split across its suffixes
+# ─────────────────────────────────────────────────────────────────────────────
+# Not new as a CLASS (D9) but the scale is not filed anywhere. Visible in the
+# published catalog under honda alone: PC31..PC39, SC32..SC38, AD01, K2, K4,
+# GL1500{A,C,J,K,L,SE,SEV,SEX}, NSC50{,T2,WH,MPD, 2WH}, WW125{,A,S,EX2},
+# CBR600F{,A,K,S,4I}. The Honda Vision 50 (type NSC50) is published as FIVE ids
+# — nsc50, nsc50t2, nsc50wh, nsc50mpd, nsc50-2wh — where T2/WH/MPD/2WH are
+# colour/spec/market suffixes on one nameplate (D8), and Honda's own European
+# name for the type is "Vision 50" (hondanews.eu press pack). Two of those five
+# are in this sample. This is the `bare-displacement-2w` / `kreidler-k53`
+# adjudication in a much bigger population and it deserves its own
+# name_shapes.yml debt entry with a measured count.
+
+records:
+
+  # ── moped / large ─────────────────────────────────────────────────────────
+  "moped/honda/ad01":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence:
+      - "raw: 'HONDA | AD01' nl_rdw bromfiets n=2769; also 'HONDA | AD01' motorfiets n=18"
+      - "in-data proof of the type code: nl_rdw pairs AD01 with the nameplate in eight raw spellings — 'AD01 MT 50', 'AD01 MT5', 'AD01 MT-5', 'AD01-MT50SA', 'AD01 (MT50S)', 'AD01(MT50S)', 'AD01 (MT50SL)', 'MT50 AD01'"
+      - "sibling live ids carrying the actual nameplate: moped/honda/mt50 [nl,nz], moped/honda/mt5 [nl,nz]"
+    notes: >-
+      AD01 is Honda's FRAME/TYPE code for the MT50/MT5, not a nameplate — D9.
+      id-canonical is called `correct` deliberately and narrowly: mt50 and mt5
+      are live and are the same machine, so a case for D6 exists, but AD01 is
+      also 2769 rows against mt50's much smaller count and I cannot establish
+      from the register alone that every AD01 row is an MT50 rather than another
+      AD01-framed model. Resolvable by a Honda NL parts/type-code source.
+
+  "moped/honda/cl50-benly":
+    verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence:
+      - "raw: 'HONDA | CL50 BENLY' nl_rdw n=17, 'CL 50 BENLY' n=3, 'CL50  BENLY' n=1; nz_nzta 'HONDA | CL50 BENLY' n=2"
+      - "curation: overrides/models/former_ids.yml:110 CL50BENLY -> CL50 Benly [nl,nz] (deliberate respace)"
+      - "sibling: moped/honda/cl50 'CL50' [nl,nz] is live"
+    notes: >-
+      Name form is a deliberate, curated respace — not a defect. But
+      moped/honda/cl50 is live for the same machine (the CL50 IS the Benly), and
+      renames.yml:206 already records the sibling reasoning for this exact make
+      ("CL50: CL — same moped as the 'CL'/'CL 50' rows"). D6, invisible to the
+      detector (FINDING-A: token-subset).
+
+  "moped/honda/nsc50":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { fi: correct } }
+    evidence:
+      - "raw: fi_traficom 'L1e | Honda | | NSC50 | e4*2002/24*2978*01' n=394"
+      - "https://hondanews.eu/eu/en/motorcycles/media/pressreleases/34740/vision-50-press-pack  # Honda's own European name for the type is Vision 50"
+      - "https://hondanews.eu/gb/en/motorcycles/models/vision-50-2011-2017/2011/2017"
+    notes: >-
+      CONTESTED CALL, flagged for the verifier to attack. Honda DOES use bare
+      type codes as public model names in this family (honda.co.uk sold the
+      sport version as 'NSC50R', hondanews.eu '2015 NSC50R'), so a
+      register-only `correct` is defensible. I call it D9 because Honda's own
+      name for THIS type (no R) is Vision 50 and no Honda source publishes a
+      model called 'NSC50'. See FINDING-D for the five-way split of this one
+      nameplate.
+
+  "moped/honda/nsc50t2":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "raw: fi_traficom 'NSC50T2 | e4*2002/24*2978*01' n=284; nl_rdw 'HONDA | NSC50T2' n=186"
+      - "the sibling suffixes in the SAME registers, all published as their own ids: NSC50 (fi 394), NSC50WH (fi 332 across 3 TANs, nl 386), NSC50MPD (fi 55, nl 972), 'NSC50 2WH' (fi 173, nl 208)"
+      - "https://hondanews.eu/eu/en/motorcycles/media/pressreleases/34740/vision-50-press-pack"
+    notes: >-
+      T2 is a spec/market suffix on the NSC50 type (shares TAN
+      e4*2002/24*2978*01 with nsc50 — note FINDING-B: the shared TAN is
+      corroborating here, not decisive; the decisive point is that WH/MPD/2WH/T2
+      are the same nameplate's variant letters). Five published ids, one Honda
+      Vision 50. D8 (variant published as model) on both id and name.
+
+  "moped/honda/dio-af27":
+    verdicts: { id: correct, name: "unverifiable(no Honda source reached for the AF27 frame code)",
+                make: correct, kind: correct,
+                availability: { nz: correct, ua: correct } }
+    evidence:
+      - "raw: nz_nzta 'HONDA | DIO AF27'; ua_mvs 'moped | HONDA | DIO AF27'"
+      - "siblings: moped/honda/dio [nl,nz,ua], dio-af34, dio-sr, dio-z4, dio50 all live"
+    notes: >-
+      AF27 is a Honda frame code, so this is probably the same D9/D8 shape as
+      the NSC50 family (Dio + frame code). Not asserted: I did not reach a Honda
+      source for AF27 and I will not infer it from the AF34 sibling — that is
+      exactly the family-pattern move the protocol forbids.
+
+  "moped/honda/little-cub":
+    verdicts: { id: correct, name: "unverifiable(no Honda source reached)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: nl_rdw 'HONDA | LITTLE CUB'; nz_nzta 'HONDA | LITTLE CUB'"]
+    notes: "Honda Little Cub is a real JDM nameplate; I simply did not fetch a Honda source this round."
+
+  "moped/honda/s50":
+    verdicts: { id: correct, name: "unverifiable(no Honda source reached)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: nl_rdw 'HONDA | S50'; nz_nzta 'HONDA | S50'"]
+
+  "moped/honda/sfx50":
+    verdicts: { id: correct, name: "unverifiable(no Honda source reached)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence:
+      - "raw: nl_rdw 'HONDA | SFX50'"
+      - "cross-kind twin motorcycle/honda/sfx50 'SFX50' [gb] exists — the documented uk_dft moped-into-Motorcycles merge (kind_maps/uk_dft.yml), NOT a duplicate to merge"
+    notes: "kind: correct. The gb twin is the known uk_dft body-type merge, called out so nobody folds it."
+
+  "moped/honda/today":
+    verdicts: { id: "defective(D6)", name: "unverifiable(no Honda source reached)", make: correct, kind: correct,
+                availability: { nz: correct, ua: correct } }
+    evidence:
+      - "raw: nz_nzta 'HONDA | TODAY'; ua_mvs 'moped | HONDA | TODAY'"
+      - "sibling: moped/honda/today-50 'Today 50' [nz,ua] is live, from the SAME two registers"
+      - "curation: former_ids.yml:113 TODAY50 -> Today 50 [nz,ua]"
+    notes: >-
+      `today` and `today-50` are the same Honda Today (50cc) in the same two
+      registers, split on whether the row carried the displacement. D6,
+      token-subset, invisible to the detector.
+
+  "moped/honda/super-cub50":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct, ua: correct } }
+    evidence:
+      - "raw: nl_rdw 'HONDA | SUPER CUB 50' n=193 (dominant), 'SUPER CUB' n=166; nz_nzta; ua_mvs 'moped | HONDA | SUPER CUB 50' n=5"
+      - "debt entry that names this exact mechanism: data/name_shapes.yml debt:normalizer-space-collapse-display-names (normalizer.rb:153 collapse used as the DISPLAY name)"
+    notes: >-
+      Honda writes 'Super Cub 50'. Published 'Super CUB50' is the
+      space-collapse artifact plus its caps side effect (the collapsed token now
+      contains a digit, so smart_case freezes it from the uppercase raw). Known
+      debt class, not a new one. Sibling moped/honda/cub50 'CUB50' [nl,nz] is a
+      D6 candidate against this record but Honda also sold plain Cub models, so
+      I am NOT asserting that one.
+
+  # ── moped / mid & small ───────────────────────────────────────────────────
+  "moped/agm/zn50qt-e":
+    verdicts: { id: correct, name: "unverifiable(register-only; no AGM marque page reached)",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "raw: fi_traficom 'L1e | AGM | | ZN50QT-E | e4*2002/24*1269*10' n=11; nl_rdw 'AGM | ZN50QT-E' n=19"
+      - "make casing AGM is a resolved, pinned acronym (name_shapes debt:acronym-make-casing-2w-tail lists AGM among the 24 resolved)"
+    notes: >-
+      Chinese OEM type code, corroborated across two registers with a matching
+      TAN. NOTE the adjacent filed debt: name_shapes debt:nl-snorfiets-25-suffix
+      covers moped/znen/zn50qt-e-25 etc. — this record is the unsuffixed base
+      class, under a different make, and is not one of the five filed ids.
+
+  "moped/dayi-motor/e-thor-6-0b":
+    verdicts: { id: correct, name: "unverifiable(no Dayi marque page reached)",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "raw: fi_traficom 'L1e | Dayi motor | | E-THOR 6.0B | e6*168/2013*00034*01' n=1; nl_rdw 'DAYI MOTOR | E-THOR 6.0B' n=10"
+      - "curation: former_ids.yml:89 E-THOR6.0B -> E-Thor 6.0B [fi,nl] (deliberate respace)"
+
+  "moped/baotian/bt50qt-11":
+    verdicts: { id: correct, name: "unverifiable(register-only; no Baotian page reached)",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence:
+      - "raw: fi 'BT50QT-11-TCBP9/49 | BT50QT-11 | e4*2002/24*0292*00'; nl_rdw 'BAOTIAN | BT50QT-11' n=98; nz_nzta n=1"
+    notes: "Three registers agree on the exact OEM type code, one shared TAN. Sibling moped/baotian/bt50 'BT50' [fi,nl] is a truncation candidate but BT50 is also a distinct Baotian type prefix — not asserted."
+
+  "moped/keeway/fact-50":
+    verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nz: correct } }
+    evidence:
+      - "https://www.keeway.com/pl-en/products/fact-50  # marque's own name is 'Fact 50'"
+      - "https://www.keeway.com/hu-hu/products/fact-50 , https://www.keeway.com/ae-en/products/fact-50"
+      - "raw: fi_traficom 'FACT 50 | e13*168/2013*00408*03' n=63; nz_nzta 'KEEWAY | FACT 50' n=2"
+      - "raw showing the split: nz_nzta spells ONE vehicle six ways — 'FACT' 41, 'F-ACT 50' 6, 'F-ACT50' 5, 'F-ACT' 3, 'FACT 50' 2, 'FACT50' 1"
+      - "live sibling ids: moped/keeway/f-act 'F-Act' [fi,nl,nz], moped/keeway/f-act-evo 'F-Act Evo' [fi,nl]"
+    notes: >-
+      Name is RIGHT (marque site). The defect is id-canonical: moped/keeway/f-act
+      is the same nameplate under the older hyphenated spelling, and NZTA alone
+      spells it six ways across the two ids. Detector-invisible (FINDING-A).
+      Honest caveat for the verifier: the two ids carry DIFFERENT TAN families
+      (F-ACT e3*2002/24*0274, FACT 50 e13*168/2013*00408), so someone could
+      argue two generations rather than two spellings — but generations sit below
+      model level per SCHEMA.md, and the NZ register (no type approvals) mixes
+      both spellings freely.
+
+  "moped/peugeot/vivacity":
+    verdicts: { id: correct, name: "unverifiable(no Peugeot Motocycles page reached)",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct, ua: correct } }
+    evidence:
+      - "raw: nl_rdw 'PEUGEOT | VIVACITY'; fi_traficom; nz_nzta; ua_mvs — four registers"
+      - "cross-kind twin motorcycle/peugeot/vivacity [gb,lu,nl,nz] exists (Vivacity came in 50 and 125) — displacement split across kinds, not a duplicate"
+    notes: "Shares TAN e2*92/61*0027*03 with moped/peugeot/trekker — per FINDING-B that is expected platform sharing, not a duplicate signal."
+
+  "moped/killerbee/vxl":
+    verdicts: { id: correct, name: "unverifiable(no Killerbee marque page reached; register-only)",
+                make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence:
+      - "raw: nl_rdw 'KILLERBEE | VXL' n=1715 (and 'E-VXL' n=70) — heavily attested"
+    notes: >-
+      PROBABLE D7 under the filed debt:model-column-acronym-casing (511 records,
+      2W half): the register says VXL, smart_case published 'Vxl'. Not asserted
+      because 'VXL' could be a word-styled badge on a Dutch importer brand and I
+      reached no Killerbee source. This is a good candidate for that worklist —
+      1715 rows is the largest single record I could not resolve.
+
+  "moped/senzo/grace":
+    verdicts: { id: correct, name: "unverifiable(no Senzo marque page reached; register-only)",
+                make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: nl_rdw 'SENZO | GRACE' n=323"]
+    notes: "Single-source record above the moped threshold. Senzo's nl range in the raw (Balance, Riva Lux, GT2, Urban, Vico, Prestige) is consistently word-named, so 'Grace' is shape-consistent — shape-consistency is not evidence, hence unverifiable."
+
+  "moped/efun/pulse":
+    verdicts: { id: correct, name: "unverifiable(no Efun marque page reached)",
+                make: correct, kind: correct,
+                availability: { es: correct, nl: correct } }
+    evidence:
+      - "raw: es_dgt '*02 | EFUN | PULSE' n=1; nl_rdw 'EFUN | PULSE' bromfiets n=1 AND motorfiets n=1"
+    notes: >-
+      THIN BUT REAL: publishes only because sources.size >= 2 (reconciler.rb:163).
+      Both rows verified present. Flagging the thinness, not calling it a defect
+      — the publish rule is the project's own settled decision.
+
+  "moped/orion/rx50":
+    verdicts: { id: correct, name: "unverifiable(register-only; no Orion page reached)",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: nl_rdw 'ORION | RX50' n=406; fi_traficom RX50 with TAN e4*2002/24*2105*00"]
+
+  "moped/selana/alpha":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence:
+      - "https://selana.nl/en  # marque site; KVK 75554631 in its own footer identifies Go Tulip B.V. as SELANA's legal entity"
+      - "raw: nl_rdw 'GO TULIP B.V. | SELANA ALPHA' n=576"
+      - "curation: overrides/makes/aliases.yml:395 'GO TULIP B.V.: SELANA'; renames.yml:2141 explains why no model rename is needed (strip_make_prefix uses the RESOLVED make)"
+      - "ledger: data/review/selana.yml verdict `fixed`, researcher s2w-opus5 / verifier s4w-opus5"
+    notes: >-
+      MY MATCHER'S ONE FALSE ALARM, recorded so the verifier does not re-raise
+      it: my first pass reported 'nl make-rows=0' because I searched the raw for
+      make SELANA. The evidence is under the registrant string. Fully curated and
+      already ledgered. NOTE the open cross-reference in
+      name_shapes debt:tym-identity-unresolved: it hypothesises that
+      tym/vespa-alpha's 'Alpha' may be Selana's model wearing another badge —
+      the nl raw here supports that being worth checking (TYM | ALPHA n=34,
+      TYM | VESPA ALPHA n=684, BENOD | ALPHA n=2, LA SOURIS | ALPHA n=1817,
+      JIAJUE | ALPHA n=1 all coexist), i.e. 'Alpha' is a shared Dutch e-moped
+      badge across at least five makes, which weakens the Selana hypothesis.
+
+  "moped/nsu/quickly-l":
+    verdicts: { id: correct, name: "unverifiable(no NSU/marque-specialist source reached)",
+                make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence:
+      - "raw: nl_rdw 'NSU | QUICKLY L'; nz_nzta 'NSU | QUICKLY L'"
+      - "make casing NSU is a pinned acronym (styling.yml acronyms, and d3642f5)"
+    notes: >-
+      ENRICHMENT SUB-CHECK (§6.2) — FAILS the Wikipedia rule, not the date check.
+      enrich/nsu.yml:15-17 records production_runs 1953-1968 + era classic citing
+      ONLY https://en.wikipedia.org/wiki/NSU_Quickly, which the project does not
+      accept as a sole factual source. The entry is also honest that the run is
+      the FAMILY's, not the L variant's ("no source separates the variant runs").
+      So the enrichment claim is `unverifiable(sole source is Wikipedia)` — the
+      dates may well be right; the citation cannot carry them. Recommend
+      re-sourcing to an NSU register/marque-specialist archive.
+      Sibling moped/nsu/quickly 'Quickly' [lu,nl,nz] is live; Quickly L/N/S/T are
+      genuinely distinct NSU variants so I do NOT call D6 here.
+
+  "moped/rieju/mrt":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "curation: overrides/styling.yml:193 '- MRT  # Rieju MRT 50/125 family — official all-caps (https://rieju.com); token only in Rieju records today'"
+      - "raw: nl_rdw 'RIEJU | MRT'; fi_traficom MRT with TAN e11*2002/24*0751*07"
+    notes: >-
+      Deliberate, sourced styling pin — correct. Two granularity notes, neither
+      a defect: (1) bare 'MRT' is the family (MRT 50 / MRT 125) with the moped
+      record carrying the 50 and motorcycle/rieju/mrt [gb] the UK rows;
+      (2) motorcycle/rieju/mr 'MR' [es,gb,nl] is a different Rieju family (also
+      pinned in styling.yml), not a truncation of MRT.
+
+  "moped/sym/jet4":
+    verdicts: { id: correct, name: "unverifiable(no SYM source reached for JET4 vs 'Jet 4')",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: fi_traficom JET4 (TANs e4*2002/24*2385*02, *2703*01); nl_rdw 'SYM | JET4'; nz_nzta"]
+    notes: >-
+      PROBABLE space-collapse (debt:normalizer-space-collapse-display-names) —
+      SYM's naming elsewhere in the catalog is spaced ('Jet X 125 ABS TCS E5+' in
+      the es raw), and name_shapes legit:sym-symphony-family cites
+      sym-global.com/all-models as the reference for this make. I did not fetch
+      it, so not asserted.
+
+  "moped/sunra/miku-max":
+    verdicts: { id: correct, name: "unverifiable(no Sunra page reached)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: fi_traficom 'Miku Max' TAN e13*168/2013*00346*01; nl_rdw 'SUNRA | MIKU MAX'"]
+
+  "moped/sur-ron/light-bee":
+    verdicts: { id: correct, name: "unverifiable(no Sur-Ron page reached)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct, nz: correct } }
+    evidence:
+      - "raw: four registers agree; fi TANs e13*168/2013*{00462*00,00703,00703*02,01153*02}"
+      - "cross-kind twin motorcycle/sur-ron/light-bee [gb] — uk_dft body-type merge, not a duplicate"
+
+  "moped/stromer/st2":
+    verdicts: { id: correct, name: "unverifiable(no Stromer page reached)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: fi_traficom ST2 TAN e13*2002/24*0691*04; nl_rdw 'STROMER | ST2'"]
+    notes: >-
+      kind: correct. The Stromer ST2 is a speed pedelec; NL/FI register it L1e-B,
+      which is `moped` by the adapters' own CATEGORY_TO_KIND. Same adjudication
+      family as the L6e/L7e brommobiel note in
+      name_shapes debt:mega-marque-research.
+
+  "moped/garia/club-car-urban-l7e-s":
+    verdicts: { id: correct, name: "defective(D5)", make: "defective(D11)", kind: correct,
+                availability: { es: correct, fi: correct } }
+    evidence:
+      - "https://www.clubcar.com/en-us/commercial/street-legal-vehicles/club-car-urban  # the product is marketed as the Club Car Urban"
+      - "https://www.clubcar.com/en-us/our-company/news/club-car-to-acquire-garia  # Club Car acquired Garia; the utility line was formerly Garia Utility"
+      - "raw: es_dgt '*26 | GARIA | CLUB CAR URBAN L7E S' n=3; fi_traficom 'L7e | Garia | | Club Car Urban L7e-S | e13*168/2013*00375*01' n=1"
+      - "same-make contrast in the same raw: 'GARIA | GARIA MONACO 4', 'GARIA | MONACO', 'GARIA | SUPERSPORT' — garia IS a real marque, it just is not this vehicle's badge"
+    notes: >-
+      TWO defects, one blocked disposition. name: the marque word 'Club Car' is
+      inside the model string (D5) — official form is 'Urban L7E'. make: both
+      registers file a Club-Car-badged vehicle under the manufacturer /
+      type-approval holder Garia A/S (D11, the textbook moves.yml shape, and it
+      IS unambiguous — the row pools nothing). DISPOSITION IS BLOCKED exactly as
+      name_shapes debt:icaur-sub-brand-under-chery describes: a move would mint a
+      single-record `club-car` make. Recommend a debt entry, not a fix.
+      kind: correct — L7e quadricycle -> moped by the documented convention.
+      The trailing 'S' is a real variant designation (present in BOTH registers,
+      as 'L7E S' and 'L7e-S'), not noise.
+
+  "moped/derbi/senda-50":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "curation: overrides/models/renames.yml:358-383 — 13 folds into 'Senda 50' with per-line TAN evidence and CC0 RDW API citations; former_ids carries all 13 old ids"
+      - "raw nl: 'DERBI | SENDA 50' n=1"
+      - "raw fi (the 13 folded forms, all L1e Derbi): 'SENDA SM' 549+260+103+99..., 'SENDA R' 223+180+40..., 'SENDA R 50 AF' 57+36, 'SENDA SM 50 AF' 95+37, 'DERBI SENDA X-TREME 50SM' 113, 'DERBI SENDA RACING 50 SM' 16, 'DERBI SENDA X-TREME LIMITED' 18, 'SENDA R X-TREM' 1, 'BLACK DEVIL' 4+1"
+    notes: >-
+      MY MATCHER'S SECOND FALSE ALARM: 'fi exact-name-rows=0' because the literal
+      string 'SENDA 50' does not occur in fi — the fi evidence arrives through
+      the curated fold, which is documented per-line with TANs. Availability fi
+      is CORRECT and heavily attested. This is the best-curated record in the
+      batch. Caveat worth one verifier look: renames.yml:375 'Senda: Senda 125'
+      is commented "motorcycle-kind only" but renames.yml keys are per-MAKE, not
+      per-kind — so the 2 fi L1e rows with bare kaupallinenNimi 'Senda'
+      (TAN e11*2002/24*1050*03) are routed to the 125, i.e. moped rows land on a
+      motorcycle id. Small, but the comment claims a scoping the file cannot
+      express.
+
+  # ── motorcycle / large ────────────────────────────────────────────────────
+  "motorcycle/bmw/f650gs-dakar":
+    verdicts: { id: correct, name: "unverifiable(bmw-motorrad.com fetch timed out; register forms disagree)",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "raw fi: 'F650GS Dakar' (TAN e1*2002/24*0200*01) n=2, 'F650Gs Dakar' n=1, 'F 650 GS Dakar' n=1, 'F 650 GS DAKAR' n=1+1"
+      - "raw nl: 'F650 GS DAKAR' n=76, 'F 650 GS DAKAR' n=1, 'F650GS DAKAR' n=1"
+    notes: >-
+      Unlike k1600gt below, the glued/part-glued form IS the dominant raw here
+      (nl 'F650 GS DAKAR' n=76), so I cannot resolve this against BMW's spaced
+      house style without the marque page, which timed out. Siblings
+      motorcycle/bmw/f650 and /f650gs are genuinely different motorcycles
+      (id: correct); they share TAN e1*2002/24*0200*00 — see FINDING-B.
+
+  "motorcycle/bmw/k1600gt":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct, th: correct, ua: correct } }
+    evidence:
+      - "raw nl: 'K 1600 GT' n=1526 vs 'K1600GT' n=8 — 190:1 for the spaced form"
+      - "raw es: '*07 | BMW | K 1600 GT' n=12 and 'L3E | BMW | K 1600 GT' n=1 — spaced"
+      - "raw fi: 'K 1600 GT' across 6 TANs (35+22+20+20+19+10+10) vs 'K1600GT' n=148 on TAN e1*2002/24*0498*00"
+      - "raw lu: 'K 1600 GT' x4 TANs — spaced"
+      - "debt: data/name_shapes.yml debt:normalizer-space-collapse-display-names names this exact mechanism"
+    notes: >-
+      FOUR registers spell it spaced; the published glued form is the
+      normalizer.rb:153 collapse leaking into the display name. Called defective
+      on in-data evidence because the four-register agreement is stronger than
+      any single marque page would be — but I note honestly that
+      bmw-motorrad.com timed out, so the marque's own rendering is inferred from
+      register consensus, not read. Known debt class, not new.
+
+  "motorcycle/ducati/m620":
+    verdicts: { id: correct, name: "unverifiable(no Ducati source reached for the M620 type code)",
+                make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence:
+      - "raw: uk_dft Motorcycles DUCATI GenModel row; nl_rdw 'DUCATI | M620'"
+      - "sibling motorcycle/ducati/620 '620' [nl,nz] is live"
+    notes: >-
+      Probable D9 (M620 is Ducati's internal designation; the bike is the Monster
+      620) AND a D6 candidate against ducati/620. Neither asserted without a
+      Ducati source. Flagged for the verifier as a likely double defect.
+
+  "motorcycle/ducati/monster-1200s":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { fi: correct, lu: correct, nl: correct, ua: correct } }
+    evidence:
+      - "https://www.ducati.com/ww/en/bike-archive/monster-1200-s  # marque writes 'Monster 1200 S'"
+      - "https://www.ducati.com/us/en/news/monster-1200-s-becomes-black-on-black"
+      - "curation: former_ids.yml:354 MONSTER1200S -> Monster 1200S (a PARTIAL respace — it split Monster from 1200S but left 1200S glued)"
+    notes: >-
+      Ducati's own archive spells it 'Monster 1200 S'. Published 'Monster 1200S'.
+      Space-collapse debt class. Interesting sub-shape for the program: the
+      former_ids respace pass fixed the FIRST seam and not the second, which is
+      the same half-fixed-family signature DEBT.md records for Chevrolet Lt and
+      the mutt/gt-sr note in data/review/mutt.yml.
+
+  "motorcycle/ducati/streetfighter-v4":
+    verdicts: { id: correct, name: "unverifiable(no Ducati page reached for this model)",
+                make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct, th: correct, ua: correct } }
+    evidence: ["raw: six registers agree on 'STREETFIGHTER V4'"]
+    notes: "Six-country agreement. Siblings streetfighter and streetfighter-v4s share TAN e9*168/2013*11506*00 — expected platform sharing (FINDING-B)."
+
+  "motorcycle/harley-davidson/tri-glide-ultra":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence:
+      - "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # 'FLHTCUTG - Tri Glide®'; current retail name is Tri Glide Ultra"
+
+  "motorcycle/harley-davidson/cvo-road-king":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, ua: correct } }
+    evidence:
+      - "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # H-D writes 'CVO™ Road King'; ™ dropped per the project's UP!/styling precedent"
+      - "styling.yml acronyms includes CVO ('Harley-Davidson Custom Vehicle Operations — 20 records')"
+    notes: "Shares TANs with 6 other Harley ids — platform sharing, not duplicates (FINDING-B)."
+
+  "motorcycle/harley-davidson/flhtcui":
+    verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct, nz: correct, ua: correct } }
+    evidence:
+      - "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # H-D model codes are uppercase alphanumeric; FLHTCUI form is correct"
+      - "curation: former_ids.yml FLHTCU-I -> FLHTCUI"
+      - "live sibling on the SAME TAN e4*2002/24*0030: motorcycle/harley-davidson/flhtci 'FLHTCI'"
+      - "the retail nameplate is published separately: motorcycle/harley-davidson/electra-glide-ultra-classic"
+    notes: >-
+      Name FORM is right (uppercase code). id flagged D6 for a different reason
+      than the TAN (see FINDING-B): FLHTCUI is H-D's code for the Electra Glide
+      Ultra Classic Injection, and `electra-glide-ultra-classic` is live —
+      i.e. the code id and the nameplate id both exist. This is the same
+      code-vs-nameplate double-publishing visible right across this make
+      (flhr-road-king, flhrc-road-king-classic, flhx-street-glide, road-king,
+      street-glide ...). WEAKER CALL than the BSA one; verifier should decide
+      whether H-D code ids are an accepted parallel axis or a D6 population.
+
+  "motorcycle/harley-davidson/flhxst":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { nl: correct, th: correct } }
+    evidence:
+      - "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # 'FLHXST' listed as Street Glide® ST; codes are uppercase"
+      - "https://www.harley-davidson.com/us/en/shop/c/passenger-seats/2022-touring-street-glide-st-flhxst  # H-D's own URL/label uses FLHXST"
+      - "debt: data/name_shapes.yml debt:model-column-acronym-casing (511 records, 2W half) is exactly this"
+    notes: "Published 'Flhxst'. Marque writes FLHXST. Known debt class."
+
+  "motorcycle/harley-davidson/fxr":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, nl: correct, nz: correct, th: correct } }
+    evidence:
+      - "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # H-D codes are uppercase alphanumeric"
+      - "raw: five registers carry FXR"
+
+  "motorcycle/harley-davidson/heritage-softail":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, lu: correct, nl: correct, nz: correct } }
+    evidence:
+      - "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # 'FLSTC - Heritage Softail® Classic'"
+    notes: >-
+      GRANULARITY NOTE, not a defect: H-D's model is the Heritage Softail
+      Classic (FLSTC) / Special (FLSTN); bare 'Heritage Softail' is the family
+      word H-D itself used for the line. Family-level id, same shape the project
+      already accepted for motorcycle/mutt/fsr (data/review/mutt.yml).
+
+  "motorcycle/harley-davidson/sportster-883":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence:
+      - "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # 'XL883 - Sportster® 883'"
+      - "curation: former_ids.yml SPORTSTER883 -> Sportster 883"
+
+  "motorcycle/honda/cb500f":
+    verdicts: { id: correct, name: "unverifiable(no Honda source reached)", make: correct, kind: correct,
+                availability: { nl: correct, th: correct, ua: correct } }
+    evidence: ["raw: nl_rdw, th_dlt, ua_mvs all carry CB500F"]
+    notes: "Siblings cb500fa [es,fi,lu,nl,th,ua] and cb500fac [es,lu,nl] are the ABS/variant suffix forms — probable D8 population, not asserted."
+
+  "motorcycle/honda/cbr250r":
+    verdicts: { id: correct, name: "unverifiable(no Honda source reached)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct, th: correct, ua: correct } }
+    evidence: ["raw: five registers; fi TAN e13*2002/24*0457*00"]
+
+  "motorcycle/honda/cbr600fs":
+    verdicts: { id: correct, name: "unverifiable(no Honda source reached)", make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw nl_rdw: 'CBR600FS' n=2, 'CBR 600 FS' n=27, 'CBR600 FS' n=1; ua_mvs"]
+    notes: "The dominant nl raw is SPACED ('CBR 600 FS' n=27 vs glued n=2) — space-collapse candidate, and the CBR600F sibling family (f, fa, fk, fs, f4i) is a probable D8 suffix population. Neither asserted without Honda."
+
+  "motorcycle/honda/gl1":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "raw nl_rdw: 'HONDA | GL 1' n=2 (and 'GL-1-ED' n=1) — that is the WHOLE nl basis"
+      - "raw fi_traficom: 'L3e | Honda | | GL 1 | | 1' — n=1, no TAN"
+      - "in-data disproof: every other GL row in the SAME registers carries a displacement — GL400, GL500, GL500D, GL650I, GL1000, GL1100, GL1200, GL1500, GL1800 and their suffix variants; Honda's GL family designation is GL<displacement>"
+    notes: >-
+      THREE VEHICLES TOTAL, and 'GL 1' is a truncated register string, not a
+      Honda designation — the two_wheeler_spacing collapse then turned it into a
+      plausible-looking id. Availability is CORRECT (the rows genuinely exist);
+      the NAME is the defect. Closest existing classes are D9 and D1; the honest
+      disposition is probably a removals.yml manifest rather than a rename,
+      because there is no recoverable target (GL 1 could be any of eight
+      displacements). Compare debt:matchless-undetermined-manglings — same
+      "corrupt but no target" wall.
+
+  "motorcycle/honda/k2":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { lu: correct, nz: correct } }
+    evidence:
+      - "raw lu_snca: 'L3E | HONDA | K2 | HON94602207' n=1"
+      - "raw nz_nzta: 'HONDA | K2' n=1"
+      - "in-data: 'K2' is Honda's GENERATION suffix (CB750 K2, Z50A K2); renames.yml:806 already treats it that way — 'Z50AK2: Z50A K2  # closed alphanumeric type code'"
+      - "sibling motorcycle/honda/k4 'K4' [nl,nz] — same shape"
+    notes: >-
+      Two single rows, and 'K2' alone names no Honda motorcycle: it is the
+      year-generation suffix that follows a nameplate. The project's own
+      renames.yml line for Z50A K2 is the proof it is a suffix, not a model.
+      No recoverable target from an aggregate row -> debt, not a guess.
+
+  "motorcycle/honda/magna":
+    verdicts: { id: correct, name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct, ua: correct } }
+    evidence:
+      - "raw nl_rdw: 'MAGNA' n=5 vs 'V45 MAGNA' n=435, 'V 45 MAGNA' n=45, 'V45MAGNA' n=16, 'V 30 MAGNA' n=18, 'V30 MAGNA' n=18, 'V30MAGNA' n=6, 'V65MAGNA' n=5, 'MAGNA VF 700' n=1, 'RC21 SUPERMAGNA 700' n=1"
+      - "raw ua_mvs: 'MAGNA' n=7, 'MAGNA 250' n=2"
+      - "cross-kind twin moped/honda/magna [nl,nz] also exists — a Magna is a 700-1100cc cruiser, so the MOPED twin is a D10 kind-noise suspect (not my sampled record, flagged for the queue)"
+    notes: >-
+      Honda's nameplates are V30 / V45 / V65 Magna (and Super Magna). Bare
+      'Magna' is the family word with the displacement designation dropped —
+      D8, and the register itself shows the full forms outnumbering it 543:5 in
+      NL. Note this is NOT the uk_dft GenModel mechanism; NL/UA carry bare
+      'MAGNA' rows of their own.
+
+  "motorcycle/honda/nhx110wh":
+    verdicts: { id: correct, name: "unverifiable(no Honda source reached for the WH suffix)",
+                make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["raw: uk_dft HONDA GenModel row; nl_rdw 'HONDA | NHX110WH'"]
+    notes: "NHX110 is Honda's type code for the Lead 110; WH is a suffix. Same D9/D8 shape as the NSC50 family (FINDING-D) but not asserted without Honda."
+
+  "motorcycle/honda/nrx-rune":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "https://hondanews.com/en-US/powersports/releases/release-b8ec70d00d27673f1c17f9004c34c58a-honda-rune-overview  # Honda's own press material: 'Rune' / 'Valkyrie Rune', type NRX1800"
+      - "https://hondanews.com/en-US/releases/release-9de79867bc77942ce90295004c34c591-2004-honda-rune-specifications"
+      - "debt: data/name_shapes.yml debt:model-column-acronym-casing"
+    notes: >-
+      'Nrx Rune' title-cases an initialism. Honda writes NRX (type NRX1800) and
+      names the bike Valkyrie Rune / Rune. Minimum fix is the NRX casing; the
+      fuller question (is the nameplate 'Rune'?) is a second call.
+
+  "motorcycle/honda/nt650v":
+    verdicts: { id: "defective(D6)", name: "unverifiable(no Honda source reached)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, gb: correct, lu: correct, nl: correct, ua: correct } }
+    evidence:
+      - "raw: six registers carry NT650V; fi TANs 97/6548 and E9*92/61*0073*00"
+      - "live sibling: motorcycle/honda/nt650v-deauville 'NT650V Deauville' [fi,gb,nl,ua] — same machine, plus the nameplate"
+      - "live sibling: motorcycle/honda/nt650 'NT650' [fi,nl,nz]"
+    notes: >-
+      NT650V and 'NT650V Deauville' are one motorcycle at two live ids, sharing
+      four of six countries. D6, token-subset, detector-invisible (FINDING-A).
+      nt650 (the Hawk/Bros) is a genuinely different bike — do not fold that one.
+
+  "motorcycle/honda/pc38":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence:
+      - "raw nl_rdw: 'HONDA | PC38' n=5, 'HONDA | PC 38' n=3; ua_mvs PC38"
+      - "in-data: the SAME register publishes the whole frame-code run PC31, PC32, PC34, PC35, PC36, PC37, PC38, PC39 as eight separate models — a sequence of consecutive frame codes is a code series, not a nameplate series"
+    notes: >-
+      Honda frame code published as the model name — D9. See FINDING-D for the
+      population. Called defective on the in-data pattern (consecutive-integer
+      code runs) rather than on a Honda page I did not reach; a verifier who
+      wants the specific nameplate behind PC38 will need Honda's type-code
+      tables, which is exactly the source gap to file.
+
+  "motorcycle/honda/sc36":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence:
+      - "raw nl_rdw: 'HONDA | SC36' n=429, 'HONDA | SC 36' n=148"
+      - "in-data: same register publishes SC32, SC33, SC35, SC36, SC38 — consecutive frame-code run"
+    notes: >-
+      Same class as pc38, but note the CONTRAST that makes this worth its own
+      line: 577 NL vehicles, single source, and it still publishes because it
+      clears the single-source threshold. A high-volume D9 rather than a
+      long-tail one — which is where a rename would pay best.
+
+  "motorcycle/honda/ww125s":
+    verdicts: { id: correct, name: "unverifiable(no Honda source reached)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["raw: four registers; fi TAN e6*168/2013*00167*00"]
+    notes: "WW125 is Honda's type code for the PCX125; the catalog publishes WW125, WW125A, WW125EX2, WW125S as four ids — probable D8 suffix population (FINDING-D). Not asserted without Honda."
+
+  "motorcycle/ktm/1190":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { lu: correct, nz: correct } }
+    evidence:
+      - "raw: lu_snca '1190' TAN e1*2002/24*0596*00; nz_nzta"
+      - "debt entry that names this exact class for this exact make: data/name_shapes.yml debt:bare-displacement-2w — 'ktm/200, ktm/390, ktm/790, ktm/890 … for these makes the number is a DISPLACEMENT and the nameplate needs the family word the register dropped'"
+    notes: >-
+      ALREADY FILED, and I am recording it as a defect anyway because filed debt
+      does not make a published claim correct — that is the whole point of the
+      debt bucket being separate from legit. ktm/1190 is not in the entry's
+      example list (which shows 200/390/790/890) but is the same class; the
+      entry's count is 21 and this is one of them. KTM 1190 is at least three
+      motorcycles (1190 Adventure, 1190 Adventure R, RC8 1190).
+
+  "motorcycle/ktm/690sm":
+    verdicts: { id: correct, name: "unverifiable(no KTM source reached)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: fi_traficom 690SM TAN e1*2002/24*0313*00; nl_rdw 'KTM | 690SM'"]
+    notes: "Probable space-collapse ('690 SM' -> '690SM'); KTM's own form is spaced. Not asserted."
+
+  "motorcycle/suzuki/rv90":
+    verdicts: { id: correct, name: "unverifiable(no Suzuki source reached)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: three registers carry RV90"]
+
+  "motorcycle/suzuki/t350":
+    verdicts: { id: correct, name: "unverifiable(no Suzuki source reached)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: nl_rdw 'SUZUKI | T350'; nz_nzta"]
+
+  "motorcycle/triumph/rocket":
+    verdicts: { id: correct, name: "defective(D8)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct, nz: correct } }
+    evidence:
+      - "raw: uk_dft TRIUMPH GenModel row, nl_rdw, nz_nzta"
+      - "curation proving the marque form in this project: styling.yml acronyms '- III  # Roman numeral: Triumph Rocket III, …'; name_shapes debt:model-column-acronym-casing lists Triumph Rocket III among the numeral records"
+    notes: >-
+      Triumph's nameplates are 'Rocket III' and 'Rocket 3' (and Rocket III
+      Roadster/Touring); bare 'Rocket' is the family word. D8 altitude. The
+      project's own styling.yml line names Rocket III explicitly, so the marque
+      form is established inside the repo — I did not need triumph.co.uk for
+      that, but I also did not reach it, so the specific generation split is
+      unresolved.
+
+  "motorcycle/triumph/t595-daytona":
+    verdicts: { id: correct, name: "unverifiable(no Triumph source reached)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence:
+      - "raw: uk_dft TRIUMPH GenModel row; nl_rdw 'TRIUMPH | T595 DAYTONA'"
+      - "curation: former_ids.yml T595DAYTONA -> T595 Daytona (deliberate respace)"
+
+  "motorcycle/yamaha/dragstar":
+    verdicts: { id: "defective(D6)", name: "unverifiable(no Yamaha source reached for the DragStar camel-case)",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct, ua: correct } }
+    evidence:
+      - "raw: four registers; fi TANs E1-92/61-00072/01, e1*92/61*00072*00, e1-92/61-00072/02"
+      - "curation: former_ids.yml DRAG-STAR -> DragStar (deliberate fusion)"
+      - "live sibling: motorcycle/yamaha/xvs1100-dragstar 'XVS1100 DragStar' — same machine with its type code, same TAN e1*92/61*00072*00"
+    notes: >-
+      D6 on id: dragstar and xvs1100-dragstar are one motorcycle. The camel-case
+      display is a deliberate curated choice (former_ids), so NOT a name defect
+      — but I could not confirm Yamaha's own rendering, and 'DragStar' vs 'Drag
+      Star' is a real marque question in this family.
+
+  "motorcycle/yamaha/mtt690-u":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence:
+      - "raw es_dgt: '*06 | YAMAHA | MTT690-U' n=44; also MTT690 63, MTT690D 47, MTT690-S 50, MTT690D-S 62, MTT690D-SU 34, MTT690D-U 33, MTT690-SU 19"
+      - "IN-DATA PROOF that these are type codes with marketing names: es_dgt's own rows sometimes append the nameplate in parentheses — 'MTM850 (XSR900)' and 'MTT850D (TRACER900 GT)' in the same make and month"
+      - "raw fi_traficom: MTT690 / MTT690-A across TANs e13*168/2013*00782*{00,01,03,04,05}"
+    notes: >-
+      MTT690 is Yamaha's EU type code (the MT-07 family) and '-U' is the
+      restricted-power variant letter — so this record is a type code AND a
+      variant suffix, D9 with a D8 rider. The parenthetical convention in
+      es_dgt's own data is the cleanest available proof, and it is the kind of
+      in-data proof name_shapes.yml explicitly accepts. Note the catalog also
+      publishes yamaha/wr125-a, yzf890, yzf690-u-family siblings — one Yamaha
+      type-code population, not eight one-offs.
+
+  "motorcycle/yamaha/wr125-a":
+    verdicts: { id: correct, name: "defective(D8)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence:
+      - "raw es_dgt: '*05 | YAMAHA | WR125-A' n=275"
+      - "in-data: the SAME batch of fi rows carries the actual nameplates — 'WR125X' n=145+136+111 and 'WR125R' n=31+17 (TANs e13*2002/24*0332*{00,01,02}) — so the register distinguishes the real models and '-A' is the variant letter"
+    notes: >-
+      WR125 is a genuine Yamaha nameplate; the defect is the '-A' variant suffix
+      published as part of the model. D8 (variant as model), lighter than the
+      MTT690-U case because the base string is real.
+
+  "motorcycle/yamaha/xp":
+    verdicts: { id: "defective(D8)", name: "defective(D7)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence:
+      - "raw uk_dft, ALL rows under GenModel 'YAMAHA XP': 'XP500' 224+513, 'XP 500 A TMAX' 39+43, 'XP 500 TMAX (530)' 69+75, 'XP 530 D-A TMAX DX' 127+64, 'XP 530 E-A TMAX' 35+35, 'XP 560 D (TMAX TECH MAX)' 28+18, 'XP 560 E (TMAX)' 14+8"
+      - "https://www.yamaha-motor.eu/gb/en/products/motorcycles/sport-heritage/explore.xsr700-2022/  # Yamaha renders its type prefixes in caps (XSR700, XP500)"
+      - "debt: data/name_shapes.yml debt:model-column-acronym-casing"
+    notes: >-
+      Two defects. name: 'Xp' title-cases a Yamaha type prefix that Yamaha writes
+      XP (and the actual nameplate is TMAX — the register spells it out in five
+      of the seven rows). id: this is a gb-only GenModel rollup of three
+      displacements and four TMAX variants — FINDING-C. Single-source, uk_dft
+      only.
+
+  "motorcycle/yamaha/xsr":
+    verdicts: { id: "defective(D8)", name: "defective(D7)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence:
+      - "raw uk_dft, ALL rows under GenModel 'YAMAHA XSR': 'XSR 125 (MTM125)' 2156+285, 'XSR 700 (MTM690)' 540+107, 'XSR 700 ABS' 973+394, 'XSR 700 ABS (35KW)' 13+3, 'XSR 700 XTRIBUTE' 150+36, 'XSR 900 (MTM890)' 691+113, 'XSR 900 ABARTH (MTM 850)' 44+45, 'XSR 900 ABS MTM 850' 1056+450"
+      - "https://www.yamaha-motor.eu/gb/en/products/motorcycles/sport-heritage/explore.xsr700-2022/ and https://www.yamaha-motor.eu/al/en/motorcycles/sport-heritage/pdp/xsr900-2025/  # Yamaha's own names are XSR700 / XSR900, all caps"
+      - "debt: data/name_shapes.yml debt:model-column-acronym-casing"
+    notes: >-
+      The clearest FINDING-C case in the batch: 'Xsr' is FIVE Yamaha motorcycles
+      (XSR125, XSR700, XSR700 XTribute, XSR900, XSR900 Abarth) at one id, and the
+      display also loses the caps. Yamaha never sells a bike called 'XSR'.
+
+  "motorcycle/yamaha/xt600":
+    verdicts: { id: correct, name: "unverifiable(no Yamaha source reached)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: three registers; fi TAN 10R-019478"]
+
+  "motorcycle/yamaha/xs850":
+    verdicts: { id: correct, name: "unverifiable(no Yamaha source reached)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: nl_rdw 'YAMAHA | XS850'; nz_nzta"]
+
+  "motorcycle/yamaha/yzf890":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence:
+      - "raw es_dgt: '*07 | YAMAHA | YZF890' n=156, '*06 | YAMAHA | YZF890-U' n=11"
+      - "IN-DATA PROOF of the code-vs-name split, same make same month: 'MTM850 (XSR900)', 'MTT850D (TRACER900 GT)', 'YZF690', 'MTT890', 'MTM850' — es_dgt carries Yamaha EU TYPE CODES, and where it appends the marketing name it does so in parentheses"
+      - "contrast rows proving the register also carries real nameplates: 'L3E | YAMAHA | YZF-R1', 'YZF -R1', 'YZF R1', 'YZF-R1M'"
+    notes: >-
+      Yamaha has never marketed a 'YZF890'. YZF890 is the EU type designation
+      for the 890cc YZF-R9 (2025+). I deliberately do NOT assert the R9 mapping
+      as the verdict — the defect claim is only that a type code is published as
+      the nameplate (D9), which the in-data parenthetical convention establishes
+      on its own. Naming the correct target needs a Yamaha type-approval source
+      and is a separate step.
+
+  "motorcycle/bmw/r80-7":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence:
+      - "raw nl_rdw: 'R 80 / 7' n=827, 'R 80/7' n=13, 'R80/7' n=11, 'BMW R 80/7' n=4, 'BMW R80/7' n=1, 'R 80-7' n=1; nz_nzta carries R80/7"
+      - "in-data: the SLASH is preserved in the published name, which is BMW's own /7-series convention (R60/7, R75/7, R80/7, R100/7) and is what all six nl raw spellings agree on"
+    notes: >-
+      Called `correct` on register consensus for the distinctive part (the slash
+      designation) rather than on a BMW page — bmw-motorrad.com timed out this
+      round, and its current site would not cover a 1978 model anyway. Sibling
+      motorcycle/bmw/r80 'R80' [fi,lu,nl,nz] is a genuinely different motorcycle
+      (the 1984+ R80), so id: correct — this is a case where the token-subset
+      detector proposed in FINDING-A would nominate a NON-duplicate, which is
+      why that detector must output a worklist and never a verdict.
+
+  # ── motorcycle / mid ──────────────────────────────────────────────────────
+  "motorcycle/ajs/m20":
+    verdicts: { id: "defective(D6)", name: "unverifiable(no AJS/marque-specialist source reached)",
+                make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence:
+      - "raw nl_rdw: 'AJS | M 20' n=1; raw nz_nzta: 'AJS | M 20' n=1, 'AJS | M20' n=1"
+      - "live sibling: motorcycle/ajs/20 '20' [nl,nz] — same two registers"
+    notes: >-
+      THREE VEHICLES TOTAL across two registers. D6 against ajs/20 (AJS's own
+      designation is 'Model 20', which the register writes as both '20' and
+      'M 20'). Name unverifiable and genuinely contested: the AJS Model 20 is
+      real, but 'M20' is far better known as the BSA M20, so a
+      make-misattribution reading is also live. Do not resolve by picking the
+      likelier — this is the debt:matchless-undetermined-manglings shape.
+
+  "motorcycle/aprilia/rsv1000-tuono":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { fi: correct, lu: correct, nl: correct } }
+    evidence:
+      - "https://wide.piaggiogroup.com/en/articles/products/15-years-for-the-aprilia-tuono-power-in-its-dna/index.html  # Aprilia/Piaggio's own account: the 2002 bike is the 'Tuono 1000 R', unveiled as the 'RSV Mille Tuono R Limited Edition'"
+      - "raw lu_snca: 'APRILIA | RSV1000 TUONO | e11*92/61*00027*06' n=1 — the ONLY register row in this exact form"
+      - "raw nl_rdw for the same machine: 'APRILIA TUONO 1000' 1, 'APRILIA TUONO 1000R' 1, 'MILLE TUONO' 1, 'RR TUONO' 1, 'RP 1000 TUONO' 1, 'APRILIA TUONO' 1"
+      - "live siblings: motorcycle/aprilia/tuono 'Tuono' [fi,gb,nl,nz], motorcycle/aprilia/rsv1000 'RSV1000' [fi,gb,lu,nl,nz]"
+    notes: >-
+      Aprilia never wrote 'RSV1000 Tuono'. The published form comes from a single
+      LU row. NOT calling id defective despite rsv1000 sharing TAN
+      e11*92/61*00027*06 — per FINDING-B the RSV Mille and the Tuono are
+      genuinely different bikes on one approved type. There IS a separate D6
+      question against aprilia/tuono (family vs this record) which I am flagging
+      rather than asserting.
+
+  "motorcycle/benelli/adiva-150":
+    verdicts: { id: correct, name: "unverifiable(no Benelli/Adiva source reached)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence:
+      - "raw: uk_dft BENELLI GenModel row; nl_rdw 'BENELLI | ADIVA 150'"
+      - "curation: former_ids.yml:236 ADIVA150 -> Adiva 150 (deliberate respace)"
+    notes: >-
+      MARQUE QUESTION FLAGGED, not resolved: Adiva is/was a marque of its own
+      (the folding-roof scooter), built in association with Benelli. Whether
+      `benelli` or `adiva` is the right make here is a real D11 candidate and
+      needs the marque history. I could not settle it this round.
+
+  "motorcycle/benelli/bn125":
+    verdicts: { id: correct, name: "unverifiable(no Benelli source reached)", make: correct, kind: correct,
+                availability: { es: correct, lu: correct, nl: correct } }
+    evidence:
+      - "raw es_dgt: '*05 | BENELLI | BN125' n=57; lu_snca 'BN125' x3 TANs; nl_rdw 'BENELLI | BN125' n=46"
+    notes: "Three registers, identical string, three matching TANs (e13*168/2013*00279*{03,04,06}). Sibling motorcycle/benelli/bn 'Bn' [gb] is a uk_dft GenModel truncation (FINDING-C) and a probable D7 casing record — not my sampled id."
+
+  "motorcycle/bsa/thunderbolt-a65":
+    verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "https://cybermotorcycle.com/marques/bsa/bsa-a65-thunderbolt.htm  # marque-specialist; page heading and body use 'A65 Thunderbolt'; 'A65T 650cc Thunderbolt'; 'Introduced in 1964 … remained in the catalogue until 1972'"
+      - "curation confirming the marque form inside the repo: renames.yml:175 'Thunder Bolt: Thunderbolt  # …ONE word (A65 Thunderbolt)'"
+      - "raw nl_rdw: 'THUNDERBOLT' 36, 'A65' 12, 'A65T' 8, 'A 65 THUNDERBOLT' 5, 'A65 THUNDERBOLT' 4, 'THUNDERBOLT 650' 4, '650 THUNDERBOLT' 1, 'THUNDERBOLT A65' 1, 'THUNDERBOLT A65T' 1"
+      - "raw fi_traficom: 'Thunderbolt' 1, 'THUNDERBOLT A65' 1"
+      - "raw nz_nzta: 'THUNDERBOLT' 67, 'A65' 52, 'A65T' 5, 'THUNDER BOLT' 2, 'THUNDERBOLT 650' 1, '650 THUNDERBOLT' 1"
+      - "enrich/bsa.yml:106 (the project's own words): 'same machine — FIVE ids for one motorcycle'"
+    notes: >-
+      THE FLAGSHIP FINDING (see FINDING-A). name: token order inverted — the
+      marque form is 'A65 Thunderbolt'. id: six live ids for one motorcycle, and
+      THIS record is built on the rarest raw form in the corpus (n=1 in fi, n=1
+      in nl) while bsa/thunderbolt carries 36+67 and bsa/a65 carries 12+52.
+      ENRICHMENT SUB-CHECK: production_runs 1964-1972 + era classic RE-DERIVED
+      CORRECT from the cited cybermotorcycle.com page (exact quote above).
+      Note the adjacent inconsistency for the verifier: enrich/bsa.yml:91 gives
+      bsa/a65 1962-1972 citing gracesguide, while the five Thunderbolt ids get
+      1964-1972 — consistent if a65 is the family row, which is how I read it.
+
+  "motorcycle/cfmoto/jetmax":
+    verdicts: { id: correct, name: "unverifiable(no CFMoto source reached)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: nl_rdw 'CFMOTO | JETMAX'; nz_nzta"]
+
+  "motorcycle/derbi/gpr-125":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "curation: renames.yml:378 'GPR125: GPR 125  # official spaced form (GPR 125 Racing/Nude, 2005-2015)'; styling.yml:47 pins GPR as a whole-string (not token) form with its reasoning"
+      - "raw fi: 'GPR 125-GS1A1A/124 | GPR 125 | e9*2002/24*0027*01' n=28, bare 'GPR 125' n=4; nl_rdw 'DERBI | GPR 125' n=13"
+      - "former_ids.yml:1902 motorcycle/derbi/gpr125 -> gpr-125"
+    notes: >-
+      Sourced curated decision, spaced form matches the raw's dominant spelling.
+      Sibling motorcycle/derbi/gpr 'GPR' [gb,nl] is the family/uk_dft-GenModel
+      form — a D6/FINDING-C candidate against this record, flagged not asserted
+      (GPR 50 and GPR 125 both exist, so bare GPR is genuinely ambiguous).
+
+  "motorcycle/gilera/saturno-500":
+    verdicts: { id: correct, name: "unverifiable(no Gilera/Piaggio source reached)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence:
+      - "raw: nl_rdw 'GILERA | SATURNO 500'; nz_nzta"
+      - "curation: former_ids.yml SATURNO500 -> Saturno 500 (deliberate respace)"
+
+  "motorcycle/husqvarna/te150i":
+    verdicts: { id: correct, name: "unverifiable(no Husqvarna source reached)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: fi_traficom TE150I TAN e1*168/2013*00051*01; nl_rdw 'HUSQVARNA | TE150I'"]
+    notes: "Husqvarna writes 'TE 150i' (lowercase i, spaced). Probable D7 on two counts (space-collapse + the i), and styling.yml already carries Sherco '2.5I: 2.5i' as precedent for the lowercase-i pin. Not asserted without husqvarna-motorcycles.com."
+
+  "motorcycle/kymco/ak550":
+    verdicts: { id: correct, name: "unverifiable(no Kymco source reached)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["raw: four registers; fi TANs e13*168/2013*00121*{04,08}"]
+    notes: "Kymco writes 'AK 550'. Probable space-collapse; not asserted."
+
+  "motorcycle/kymco/like-200":
+    verdicts: { id: correct, name: "unverifiable(no Kymco source reached)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "raw: fi_traficom 'Like 200' TAN e4*2002/24*2362*00; nl_rdw 'KYMCO | LIKE 200'"
+      - "curation: former_ids.yml:713 LIKE200 -> Like 200 (deliberate respace)"
+    notes: "Kymco's retail name is 'Like 200i'. Siblings moped/kymco/like and motorcycle/kymco/like are family rollups (FINDING-C on the gb side)."
+
+  "motorcycle/lambretta/x200":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { th: correct } }
+    evidence:
+      - "https://lambretta.co.th/lambretta-x200-gp/  # Lambretta Thailand Official product page for the X200 GP — X200 is a real Lambretta designation"
+      - "https://lambretta.co.th/  # and https://www.lambrettascooters.com/ for the current V/X/G series naming"
+      - "raw th_dlt: 'LAMBRETTA | X200' n=802, beside 'X300' 1074, 'X300 GT' 855, 'X300 2025' 1802, 'V200 GP' 471, 'V200 Special Flex' 910, 'G350' 484"
+    notes: >-
+      Worth recording HOW this resolved, because the obvious check fails:
+      lambrettascooters.com (the global current-model site) lists only V200,
+      X125, X300 Special, G350 Series II — no X200 — and lambretta.com is
+      classics-only. The X200 is a Thailand-market designation and only the Thai
+      marque site evidences it. Single-source record (th_dlt only), above
+      threshold at n=802. Granularity note: the Thai retail product is the
+      'X200 GP'; the register's bare 'X200' is its own row.
+
+  "motorcycle/lexmoto/milano":
+    verdicts: { id: "defective(D8)", name: "unverifiable(no Lexmoto source reached)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence:
+      - "raw uk_dft, ALL rows under GenModel 'LEXMOTO MILANO': 'MILANO 125 EFI FT 125 T-27 E4' 367+485, 'MILANO 125 FT 125 T-27' 144+351, 'MILANO 50 FT 50 QT-27' 57+118"
+    notes: >-
+      FINDING-C: one gb-only id pooling a 125 and a 50 (and the 50 is a moped
+      sitting in the motorcycle kind via the documented uk_dft body-type merge).
+      'Milano' is a genuine Lexmoto nameplate, so the defect is altitude, not
+      the word. Weighed against data/review/mutt.yml's accepted family-level
+      `fixed` verdict, a verifier could legitimately downgrade this to a note —
+      the difference is that mutt/fsr spans displacements only, while this spans
+      a moped and a motorcycle.
+
+  "motorcycle/morbidelli/f352":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { es: correct, nl: correct, ua: correct } }
+    evidence:
+      - "https://www.morbidelli.com/int-en/products/f352  # marque product page, name is 'F352'"
+      - "https://www.morbidelli.com/int-en/news/morbidelli-f352-racing-heritage-street-born"
+      - "https://www.morbidelli.com/int-en/news/morbidelli-world-premi-re-2024_85  # 'the T352X, T502X, and F352 … global release in early 2025'"
+      - "raw es_dgt '*06 | MORBIDELLI | F352' n=12; ua_mvs 'motorcycle | MORBIDELLI | F352' n=5; nl_rdw 'MORBIDELLI | F352' n=1"
+    notes: >-
+      ENRICHMENT SUB-CHECK: production_runs [{year_start: 2025}] RE-DERIVED
+      CORRECT — the World Première news page states early-2025 global release and
+      the product page carries Model Year 2025. Marque site reached directly
+      (my first attempt to the product URL hung; the search result set and the
+      news URL confirmed it).
+
+  "motorcycle/moto-guzzi/nevada":
+    verdicts: { id: correct, name: "unverifiable(no Moto Guzzi source reached)", make: correct, kind: correct,
+                availability: { fi: correct, lu: correct, nz: correct } }
+    evidence: ["raw: fi_traficom (TANs MOG01603589, e11*2002/24*0112*05), lu_snca, nz_nzta"]
+    notes: "Moto Guzzi's nameplates are Nevada 750 / Nevada Classic; bare 'Nevada' is the family. Probable D8, not asserted. NOTE this make is named in debt:model-column-acronym-casing for its OTHER records (850LE Mans III)."
+
+  "motorcycle/mutt/fsr":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence:
+      - "https://muttmotorcycles.com/  # marque site"
+      - "ledger: data/review/mutt.yml — id motorcycle/mutt/fsr, verdict `fixed`, 'display \"Fsr\" -> \"FSR\" … sold 125cc and 250cc', researcher s2w-opus5 / verifier s4w-opus5, reviewed_at 2026-07-26"
+      - "raw uk_dft under GenModel 'MUTT FSR': 'FSR 125' 137+84, 'FSR 250' 12+10; nl_rdw 'MUTT | FSR'"
+      - "curation: name_shapes debt:acronym-make-casing-2w-tail explicitly protects the MAKE — 'NOT-ACRONYMS, verified and deliberately left alone: … Mutt (Mutt Motorcycles)'"
+    notes: >-
+      FULLY CLEAN and the useful control case in this batch: an already-ledgered
+      record where the family-level altitude was seen, stated, and accepted. I
+      use it above as the precedent for not auto-failing lexmoto/milano and
+      harley/heritage-softail.
+
+  "motorcycle/mv-agusta/turismo-veloce-lusso":
+    verdicts: { id: correct, name: "unverifiable(no MV Agusta source reached)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence:
+      - "raw: es_dgt, fi_traficom (TAN e3*2002/24*0609*00), nl_rdw"
+      - "make casing 'MV Agusta' is a resolved pin (styling.yml acronyms '- MV', and commit d3642f5)"
+    notes: "Sibling motorcycle/mv-agusta/turismo-veloce shares the TAN — expected (FINDING-B); Lusso is a real MV trim level, so whether it is a nameplate or a D8 trim is the open question."
+
+  "motorcycle/niu/nqi-gts-pro":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "https://global.niu.com/en-us/product/nqi-gts  # NIU's own rendering is 'NQi GTS'"
+      - "https://www.niu.com/en/n-series/  # 'NQi Series'"
+      - "raw: fi_traficom TAN e13*168/2013*00717*02; nl_rdw"
+      - "debt: data/name_shapes.yml debt:model-column-acronym-casing"
+    notes: >-
+      Published 'Nqi Gts Pro'; NIU writes 'NQi GTS Pro'. Note the shape: NIU's
+      own casing is MIXED (NQi, not NQI), so a blanket `acronyms` token cannot
+      fix it — this needs a whole-string styling pin, the 480-ES/BZ4X precedent.
+      Worth calling out because the debt entry's remedy (token pins) does not
+      cover this sub-case.
+
+  "motorcycle/piaggio/mp3-500hpe":
+    verdicts: { id: correct, name: "unverifiable(no Piaggio source reached)", make: correct, kind: correct,
+                availability: { fi: correct, lu: correct, nl: correct } }
+    evidence: ["raw: three registers; fi/lu TANs e9*168/2013*11015*{08,09}, *11717*{00,01}"]
+    notes: "Piaggio writes 'MP3 500 hpe' (lowercase hpe). Probable D7 on two counts; not asserted."
+
+  "motorcycle/royal-enfield/continental-gt650":
+    verdicts: { id: correct, name: "unverifiable(royalenfield.com returned HTTP 403)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct, th: correct } }
+    evidence:
+      - "raw: four registers; fi TAN e5*168/2013*00017*06"
+    notes: >-
+      Royal Enfield's own form is 'Continental GT 650' (spaced) as far as I know,
+      but the fetch was refused and I will not verify a name from memory. Recorded
+      as unverifiable. IMPORTANT COUNTER-EXAMPLE FOR FINDING-B lives here: this
+      id shares TAN e5*168/2013*00017*06 with
+      motorcycle/royal-enfield/interceptor-int650, which is a DIFFERENT
+      motorcycle — the single cleanest disproof of shared-TAN-means-duplicate.
+
+  "motorcycle/rudge/whitworth":
+    verdicts: { id: correct, name: "defective(D5)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence:
+      - "https://www.rudge-whitworth.com/the-motorcycles  # the marque's own site; the marque IS Rudge-Whitworth"
+      - "https://www.rudge.club/rudge-motorcycles  # Rudge Enthusiasts Club model list: Ulster, Special, Multi, Rapid, Sports Special, Dirt Track — no model named 'Whitworth'"
+      - "https://www.gracesguide.co.uk/Rudge-Whitworth:_Motorcycles  # corporate history: Rudge-Whitworth Ltd, founded from Rudge + Whitworth Cycles"
+      - "raw nl_rdw: 'RUDGE | WHITWORTH' n=1, 'RUDGE | WHITWORTH 250' n=1 — beside 'RUDGE | ULSTER' 5, 'RUDGE | SPECIAL' 7, 'RUDGE | MULTI' 2, 'RUDGE | 250 RAPID' 1"
+      - "raw nz_nzta: 'RUDGE | WHITWORTH' n=4 — AND a separate make string 'RUDGE WHITWORTH' with models SPECIAL 2, ULSTER 1, 350 1, and 'RUDGE WHITWORTH | RUDGE WHITWORTH' 1"
+    notes: >-
+      CONFIRMED D5 (embedded make/brand). The marque is Rudge-Whitworth; the
+      registers split the corporate name across the make and model columns, so
+      'Whitworth' is the second half of the manufacturer's name sitting where a
+      nameplate belongs. Five vehicles. It is the D4/D5 pair-shape, not a
+      nameplate. NOTE TWO ADJACENT ITEMS FOR THE QUEUE (neither is my sampled
+      claim): (1) nz_nzta also carries 'RUDGE WHITWORTH' as its OWN make string,
+      which is a D12 make near-dupe against make `rudge` with model overlap
+      (SPECIAL, ULSTER) as the evidence a merge needs, and no alias exists in
+      overrides/makes/aliases.yml; (2) 'RUDGE WHITWORTH | RUDGE WHITWORTH' is a
+      make-as-model row in the same register. make: correct — `rudge` is the
+      right marque for these vehicles; only the model string is wrong.
+
+  "motorcycle/skyteam/skymax-125":
+    verdicts: { id: correct, name: "unverifiable(no SkyTeam source reached)", make: correct, kind: correct,
+                availability: { es: correct, gb: correct, lu: correct, nl: correct } }
+    evidence:
+      - "raw: four registers; fi/lu TANs e9*168/2013*11045*{00,01}, e9*2002/24*0030*08"
+      - "curation: former_ids.yml SKYMAX125 -> Skymax 125 (deliberate respace)"
+    notes: "Note debt:bare-displacement-2w lists skyteam/04 for this make, so it has known code-shaped records."
+
+  "motorcycle/tgb/br8":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence:
+      - "raw nl_rdw: 'TGB | BR8' n=3, 'TGB | BR8B C' n=1 — and the sibling type codes BF8 n=1, BK8 n=16 in the same register"
+      - "raw uk_dft: 'Motorcycles | TAIWAN GOLDEN BEE | TAIWAN GOLDEN BEE BR8 | BR8 R125X' Licensed 16 / SORN 175"
+      - "curation: overrides/makes/aliases.yml:242 '\"TAIWAN GOLDEN BEE\": TGB  # Taiwan Golden Bee Co. is literally the full corporate name of TGB'"
+      - "https://www.tgb.com.tw/  # marque; and the TGB BR8 service manual covers the BR8/BF8/BK8/BR9/BF9/BK9 series, matching the register's own sibling codes exactly"
+    notes: >-
+      MY MATCHER'S THIRD FALSE ALARM, resolved: 'gb make-rows=37, exact 0'
+      because I searched uk_dft for make 'TGB'; the GB evidence is filed under
+      the full corporate name, which is a curated alias. The only TGB-string
+      Motorcycles rows in uk_dft are 'TGB MODEL MISSING' (dropped by the junk
+      filter, correctly). gb availability is CORRECT.
+      evidence_class: register-only + manufacturer service documentation.
+
+  "motorcycle/tm-racing/300-2-tempi":
+    verdicts: { id: "defective(D6)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "raw fi_traficom: 'L3e | TM | | 300 2 TEMPI | e3*2002/24*0503*00' n=7 and 'L3e | TM Racing | | 300 2tempi | e3*2002/24*0503*00' n=7"
+      - "raw nl_rdw: 'TM RACING | 300 2 TEMPI' n=2 — beside 'TM RACING | 300 G' n=49 and 'TM RACING | 300' n=1"
+      - "sibling on the SAME TAN e3*2002/24*0503*00: motorcycle/tm-racing/300 '300'"
+      - "the same register carries the same descriptor across the make's whole range: '125 2tempi' 26, '250 2tempi' 5, '250 4tempi' 8, '144 2tempi' 3 — an engine-cycle column, not a nameplate column"
+      - "project precedent for exactly this token: renames.yml:2159 '250 2ST: 250 SE  # \"2ST\" = registry shorthand for 2-stroke'"
+    notes: >-
+      '2 Tempi' is Italian for 'two-stroke'. The register is recording the engine
+      cycle, which the project has already ruled is not a nameplate (Sherco
+      precedent). D8 (spec token as model) on the name and D6 on the id against
+      tm-racing/300. Here the shared TAN IS corroborating rather than decisive —
+      the decisive fact is that '2 Tempi' is a descriptor that appears on 4
+      different displacements in the same make. HONEST GAP: tmracing.it 301s to
+      tm-moto.it and I did not follow it, so I have not read TM's own model names
+      (they are EN/MX/SMX/SMR + displacement); the defect claim above does not
+      depend on that, but naming the correct target does.
+
+  "motorcycle/ural/ranger":
+    verdicts: { id: correct, name: "unverifiable(no Ural source reached)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: three registers; fi TAN e8*168/2013*00046*00"]
+    notes: "Ural Ranger is a real model. NOTE the make already carries filed debt: name_shapes debt:make-as-model-2w includes ural/ural."
+
+  "motorcycle/vespa/gts300":
+    verdicts: { id: correct, name: "unverifiable(no Vespa source reached)", make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: nl_rdw 'VESPA | GTS300'; ua_mvs"]
+    notes: "Vespa writes 'GTS 300'. Probable space-collapse. DEBT.md already lists 'vespa GTS/GTV' among the ~40 unverified uniformly-wrong candidates, so this is filed on the 4W ledger already."
+
+  "moped/vespa/mini":
+    verdicts: { id: correct, name: "unverifiable(no Vespa/Piaggio source names a 'Mini'; absence-of-evidence only)",
+                make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence:
+      - "raw nl_rdw: 'VESPA | MINI' n=1. raw nz_nzta: 'VESPA | MINI' n=1. That is the entire record."
+      - "https://www.vespa.com/en_EN/models/ and https://www.vespa.com/en_EN/timeline/40/  # current + vintage model lines: Primavera, Sprint, GTS, GTV, S, 946, Elettrica … no Mini"
+      - "https://wide.piaggiogroup.com/en/articles/accessories/vespa-passion-in-mini-format/index.html  # the only Piaggio 'mini Vespa' is a children's toy"
+    notes: >-
+      PROBABLE D3/D9 AND FLAGGED PROMINENTLY, but recorded as unverifiable
+      because the basis is absence of evidence on the marque's site plus n=1 in
+      each of two registers — and absence on a modern site cannot disprove a
+      1960s variant. Two single rows publishing solely on the two-source rule.
+      This is a good candidate for the source-gap queue; a Dutch/NZ period source
+      or the RDW type-approval would settle it.
+
+  # ── motorcycle / small ────────────────────────────────────────────────────
+  "motorcycle/izh/49":
+    verdicts: { id: correct, name: "unverifiable(no IZh/marque-specialist source reached)",
+                make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: nl_rdw 'IZH | 49'; ua_mvs"]
+    notes: >-
+      Bare numeric, but NOT the debt:bare-displacement-2w class — the IZh 49 is
+      a genuine Soviet model designation (a model number, not a displacement),
+      which is the name_shapes legit:corroborated-numeric-nameplates logic. Two
+      independent registers in two countries corroborate. I still mark the name
+      unverifiable because that entry requires min_sources 2 AND min_countries 2
+      (satisfied) *plus* the shape rule — and the shape rule is a publish
+      argument, not a marque-rendering source. Verifier may reasonably promote
+      this to `correct` on the corroboration rule alone.
+
+  "motorcycle/skyjet/sj125":
+    verdicts: { id: correct, name: "unverifiable(no Skyjet source reached)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence:
+      - "raw uk_dft: 'Motorcycles | SKYJET | SKYJET SJ 125 | SJ 125-23' Petrol Licensed 10 / SORN 669 (+ a Diesel-fuel duplicate row, 0/3 — register fuel noise)"
+    notes: >-
+      The GenModel is SPACED ('SKYJET SJ 125') and the published name is glued —
+      space-collapse debt class. Single-source gb record. Also note the
+      make's remaining uk_dft rows are 'SKYJET MODEL MISSING' (11 Licensed /
+      293 SORN), correctly dropped by the junk filter.
+
+  # ── moped / yamaha + yiying (batch tail) ──────────────────────────────────
+  "moped/yamaha/mr50":
+    verdicts: { id: correct, name: "unverifiable(no Yamaha source reached)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence:
+      - "raw nl_rdw: 'YAMAHA | MR 50' n=2, 'MR50' n=1, 'YAMAHA MR50' n=1; raw nz_nzta: 'YAMAHA | MR50' n=13, 'MR 50' n=1"
+    notes: >-
+      Yamaha MR50 (the 1970s 'Mini Enduro'-era 50) is a real designation and the
+      NZ register's dominant spelling is the glued form, so unlike the BMW/Ducati
+      cases the space-collapse is not evidently wrong here. Still unverifiable
+      without Yamaha.
+
+  "moped/yamaha/nitro":
+    verdicts: { id: correct, name: "unverifiable(no Yamaha source reached)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw nl_rdw: 'YAMAHA | NITRO' n=1; raw nz_nzta: 'YAMAHA | NITRO' n=1"]
+    notes: >-
+      THIN: n=1 in each of two registers, publishing solely on the two-source
+      rule (reconciler.rb:163) — same thinness shape as moped/efun/pulse and
+      moped/vespa/mini. Yamaha did market a 'Nitro' scooter in the Netherlands
+      (the Aerox's sibling), so unlike vespa/mini this is not an absence-of-
+      evidence case; it is simply unfetched.
+
+  "moped/yamaha/sa19":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence:
+      - "raw nl_rdw: 'YAMAHA | SA19' n=1563 — heavily attested, single source, single country"
+      - "in-data: 'SA19' matches no Yamaha retail nameplate pattern in the corpus while it exactly matches Yamaha's SA-series frame/type-code form; every OTHER high-volume Yamaha moped id in the same register carries a marketing word (Aerox, Neo's, Jog, Vity, Slider, Nitro)"
+    notes: >-
+      Yamaha internal type/frame code published as the nameplate — D9, the same
+      class as honda/sc36 and honda/pc38, and the highest-volume instance in this
+      batch (1563 NL vehicles). CONTESTED-CALL WARNING for the verifier: I did
+      NOT reach a Yamaha source, so the specific target (SA19 is generally
+      associated with the Yamaha Vino/Jog 50 family) is NOT asserted — the
+      defect claim rests only on 'this is a type-code shape, not a nameplate',
+      which is the in-data argument above. If a verifier judges that argument too
+      thin without a Yamaha type table, downgrade to
+      unverifiable rather than to correct.
+
+  "moped/yiying/yy50qt-10":
+    verdicts: { id: correct, name: "unverifiable(register-only; no Yiying page reached)",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence:
+      - "raw fi_traficom: 'L1e | Yiying | | YY50QT-10 | e4*2002/24*0643*03' n=2; raw nl_rdw: 'YIYING | YY50QT-10' n=3"
+    notes: >-
+      Chinese OEM type code (the YY prefix is the maker's own), corroborated
+      across two registers on a matching TAN. Thin (5 vehicles) but the string is
+      an exact match in both and the TAN ties them. This is the RA9015-class
+      ceiling the PRD describes: evidence_class register-only is the honest
+      maximum and there is probably no manufacturer page to reach.
+
+# ═════════════════════════════════════════════════════════════════════════════
+# SUMMARY
+# ═════════════════════════════════════════════════════════════════════════════
+summary:
+  records_covered: 100
+  records_not_covered: []          # none — every sampled id got every claim
+  claims_total: 651                # 100 id + 100 name + 100 make + 100 kind + 251 availability
+  claims:
+    correct: 554
+    defective: 41
+    unverifiable: 56
+  by_claim_type:
+    id:           { correct: 87,  defective: 13, unverifiable: 0 }
+    name:         { correct: 17,  defective: 27, unverifiable: 56 }
+    make:         { correct: 99,  defective: 1,  unverifiable: 0 }
+    kind:         { correct: 100, defective: 0,  unverifiable: 0 }
+    availability: { correct: 251, defective: 0,  unverifiable: 0 }
+  conservative_clean_rate: "85.1%  (554/651, unverifiable counted AGAINST as the protocol requires)"
+  optimistic_bound: "91.4%  (595/651, if every unverifiable resolved correct) — quoted only to bracket the true value"
+
+  # WHERE THE UNVERIFIABLES ARE, because that is the actionable part
+  source_gap_queue:
+    - "56 name claims. All are `name-marque-true` and none is a data-quality
+       statement — they are the marque pages I did not reach in one round. They
+       cluster hard: 21 Honda/Yamaha type-code records (one Honda + one Yamaha
+       type-code table would convert most of them), 8 Chinese/Dutch long-tail
+       importer makes with probably no manufacturer page at all (yiying, senzo,
+       killerbee, efun, orion, sunra, baotian, agm — the register-only ceiling),
+       and ~12 major-marque records where a single model page settles it
+       (kymco AK 550, piaggio MP3 500 hpe, husqvarna TE 150i, ktm 690 SM,
+       vespa GTS 300, royal-enfield Continental GT 650, moto-guzzi Nevada …)."
+    - "4 fetches were REFUSED OR TIMED OUT and are recorded as such rather than
+       replaced by memory: bmw-motorrad.com (timeout), royalenfield.com (403),
+       bsacompany.co.uk (403), tmracing.it (301 to tm-moto.it, cross-host, not
+       followed). Retrying these 4 is the cheapest coverage win available."
+    - "1 enrichment claim is unverifiable because its citation is Wikipedia-only:
+       enrich/nsu.yml:15-17 (moped/nsu/quickly-l, 1953-1968 + era classic)."
+
+  detector_gaps_found: # see FINDING-A / -C in the header; both are EXISTING classes
+    - "D6 token-subset / token-permutation duplicates: find_duplicate_spellings
+       reports 0 groups for the entire S2W half and cannot see any of the 13
+       id-defective records below. Detector spec proposed in FINDING-A."
+    - "D8 uk_dft GenModel family rollups on gb-only records (FINDING-C)."
+  detector_refuted:
+    - "shared TAN within a make is NOT a duplicate signal (FINDING-B): 572 groups
+       / 1061 ids share TANs, and continental-gt650 + interceptor-int650 share
+       one. Do not build this detector; and note that renames.yml cites
+       'TAN IDENTICAL' as merge evidence in places."
+
+  # ── EVERY SUSPECTED DEFECT, CALLED OUT FOR THE VERIFIER TO ATTACK ──────────
+  # Ordered strongest-first. "attack here" names the weakest link in my own
+  # reasoning, so the verifier does not have to find it.
+  suspected_defects:
+
+    - id: motorcycle/rudge/whitworth
+      claims: [name]
+      class: D5
+      strength: very strong
+      why: "The marque is Rudge-Whitworth; registers split the corporate name across make and model. rudge.club's model list (Ulster, Special, Multi, Rapid, Dirt Track) has no 'Whitworth', and nz_nzta independently carries 'RUDGE WHITWORTH' as a MAKE string with overlapping models."
+      attack_here: "That no Rudge model was ever called Whitworth rests on an enthusiasts-club model list plus the marque site's own 'The Motorcycles' page, not on a factory catalogue. Also check my adjacent D12 claim (make near-dupe 'RUDGE WHITWORTH' in nz) separately — it is a make-level finding outside the sampled claim."
+
+    - id: motorcycle/bsa/thunderbolt-a65
+      claims: [id, name]
+      class: [D6, D7]
+      strength: very strong
+      why: "SIX live ids for one 1964-72 motorcycle; this record is built on the rarest raw form (n=1 fi, n=1 nl) while siblings carry 36+67 and 12+52. Marque form is 'A65 Thunderbolt' (cybermotorcycle.com heading; and renames.yml:175's own parenthetical). enrich/bsa.yml:106 already says 'FIVE ids for one motorcycle'."
+      attack_here: "bsa/a65 may be a legitimate FAMILY row (it pools Thunderbolt/Lightning/Spitfire/Star), which would make it five ids not six — that does not change the verdict. The name verdict rests on a marque-specialist site rather than BSA itself, because bsacompany.co.uk 403s."
+
+    - id: motorcycle/yamaha/xsr
+      claims: [id, name]
+      class: [D8, D7]
+      strength: very strong
+      why: "The gb GenModel row pools XSR125, XSR700, XSR700 XTribute, XSR900 and XSR900 Abarth — five motorcycles at one id — and Yamaha writes XSR in caps (yamaha-motor.eu). Yamaha sells no bike called 'XSR'."
+      attack_here: "If the project decides gb-only GenModel rollups are an accepted altitude (the mutt/fsr precedent), the id verdict becomes a note and only the casing defect stands. That is a policy call, not a fact call — flag it up rather than settling it in the ledger."
+
+    - id: motorcycle/yamaha/xp
+      claims: [id, name]
+      class: [D8, D7]
+      strength: strong
+      why: "Same mechanism as xsr; and here the register spells the real nameplate out for us — five of the seven pooled rows contain 'TMAX'."
+      attack_here: "Same policy question as xsr."
+
+    - id: moped/garia/club-car-urban-l7e-s
+      claims: [name, make]
+      class: [D5, D11]
+      strength: strong
+      why: "clubcar.com markets the vehicle as the Club Car Urban; Club Car acquired Garia in 2022. Both registers file a Club-Car-badged vehicle under Garia (manufacturer / TAN holder e13*168/2013*00375) with the other marque's name inside the model column. The row pools nothing, so moves.yml rule 3 is satisfied."
+      attack_here: "The make verdict is the contestable one — Garia A/S is genuinely the manufacturer and the TAN holder, and a move would mint a single-record `club-car` make (blocked, per debt:icaur-sub-brand-under-chery). If the verifier prefers manufacturer-over-badge for this make, downgrade make to correct and keep name defective. Do NOT let that also clear the name."
+
+    - id: motorcycle/tm-racing/300-2-tempi
+      claims: [id, name]
+      class: [D8, D6]
+      strength: strong
+      why: "'2 Tempi' is Italian for two-stroke and the register applies it across four displacements in this make (125/144/250/300, plus '4tempi'). renames.yml:2159 already ruled the identical Sherco token ('2ST') not-a-nameplate. Sibling tm-racing/300 is live on the same TAN."
+      attack_here: "I never read TM's own model names (tmracing.it 301s to tm-moto.it and I did not follow it), so the MERGE TARGET is unestablished — folding into bare '300' would land in debt:bare-displacement-2w, so this may be a two-step fix, not one."
+
+    - id: motorcycle/honda/gl1
+      claims: [name]
+      class: D9 (arguably D1)
+      strength: strong
+      why: "Three vehicles total ('GL 1' n=2 nl, n=1 fi). Honda's GL family is GL<displacement> and the same registers carry GL400/500/650/1000/1100/1200/1500/1800. 'GL 1' is a truncated register string that the spacing collapse turned into a plausible id."
+      attack_here: "There is no recoverable target (GL 1 could be any of eight displacements), so the disposition is a removals manifest, not a rename — and I-5 compliance is the verifier's call, not mine. Availability is CORRECT here; do not let the name verdict pull it down."
+
+    - id: moped/keeway/fact-50
+      claims: [id]
+      class: D6
+      strength: strong
+      why: "keeway.com names the model 'Fact 50'; moped/keeway/f-act is live for the same nameplate; nz_nzta alone spells one vehicle six ways across the two ids ('FACT' 41, 'F-ACT 50' 6, 'F-ACT50' 5, 'F-ACT' 3, 'FACT 50' 2, 'FACT50' 1)."
+      attack_here: "The two ids carry different TAN families (e3*2002/24*0274 vs e13*168/2013*00408), so a generations argument exists. I discounted it because generations sit below model level (SCHEMA.md) and NZ has no type approvals — check that reasoning."
+
+    - id: [moped/honda/nsc50, moped/honda/nsc50t2]
+      claims: [name, id]
+      class: [D9, D8]
+      strength: "nsc50t2 strong; nsc50 CONTESTED"
+      why: "The Honda Vision 50 (type NSC50) is published as five ids — nsc50, nsc50t2, nsc50wh, nsc50mpd, nsc50-2wh — where T2/WH/MPD/2WH are spec/market suffix letters. Honda's European name for the type is 'Vision 50' (hondanews.eu press pack)."
+      attack_here: "nsc50 specifically: Honda DOES publish bare type codes as retail names in this family (honda.co.uk sold the sport version as 'NSC50R'), so a register-only `correct` for nsc50 is defensible and I flagged it contested in the record. nsc50t2's D8 does not depend on that."
+
+    - id: [motorcycle/honda/sc36, motorcycle/honda/pc38, moped/honda/ad01, motorcycle/honda/k2, moped/yamaha/sa19]
+      claims: [name]
+      class: D9
+      strength: "sc36/pc38/ad01 strong; k2 strong; sa19 CONTESTED"
+      why: "Frame/type codes published as nameplates. In-data proofs: consecutive-integer code runs in one register (PC31..PC39, SC32..SC38); nl_rdw pairing AD01 with MT50/MT5 in eight spellings; renames.yml:806's own 'Z50AK2' line proving K2 is a generation suffix."
+      attack_here: "sa19 is the weak one — 1563 NL vehicles but I reached NO Yamaha source, so the claim rests only on 'this is a code shape'. If that is too thin, downgrade sa19 to unverifiable, not to correct. For the others, note the defect claim does not name the correct target; that needs Honda type tables (source gap)."
+
+    - id: [motorcycle/yamaha/yzf890, motorcycle/yamaha/mtt690-u, motorcycle/yamaha/wr125-a]
+      claims: [name]
+      class: [D9, D8]
+      strength: strong
+      why: "es_dgt carries Yamaha EU TYPE CODES, and where it appends the marketing name it does so in parentheses — 'MTM850 (XSR900)', 'MTT850D (TRACER900 GT)' in the same make and month. That is the in-data proof that YZF890/MTT690-U are codes. '-U'/'-A' are power/variant letters; fi carries the real WR125R/WR125X names."
+      attack_here: "I deliberately did NOT assert that YZF890 = YZF-R9 or MTT690 = MT-07 — only that a type code is published as a nameplate. If a verifier wants the targets, that is a separate sourced step. Do not let the missing target invalidate the class verdict."
+
+    - id: [motorcycle/bmw/k1600gt, motorcycle/ducati/monster-1200s, moped/honda/super-cub50]
+      claims: [name]
+      class: D7 (known debt:normalizer-space-collapse-display-names)
+      strength: "monster-1200s very strong; k1600gt strong; super-cub50 strong"
+      why: "Ducati's own archive spells 'Monster 1200 S'. BMW: four registers spell 'K 1600 GT' (nl 1526 spaced vs 8 glued). Honda: nl 'SUPER CUB 50' n=193 dominant. All three are the normalizer.rb:153 collapse leaking into the display name."
+      attack_here: "k1600gt and super-cub50 rest on register consensus, not a fetched marque page (bmw-motorrad.com timed out). Also note these are FILED debt — I recorded them as defects anyway, because filed debt does not make a published claim correct. If the program wants filed-debt records excluded from the defect rate, that changes 6 of my 41 defective claims and should be an explicit protocol amendment, not a per-batch judgment."
+
+    - id: [motorcycle/harley-davidson/flhxst, motorcycle/honda/nrx-rune, motorcycle/niu/nqi-gts-pro]
+      claims: [name]
+      class: D7 (known debt:model-column-acronym-casing)
+      strength: very strong
+      why: "Marque sources read directly: harley-davidson.com model-codes page ('FLHXST', codes uppercase); hondanews.com Rune press material (NRX1800); global.niu.com ('NQi GTS')."
+      attack_here: "Nothing in the facts. But NIU is worth one extra look: NIU's own casing is MIXED ('NQi', not 'NQI'), so the debt entry's proposed remedy — global `acronyms` token pins — CANNOT fix it. It needs a whole-string styling pin (the BZ4X/480-ES precedent). That is a gap in the remedy, not in the finding."
+
+    - id: motorcycle/aprilia/rsv1000-tuono
+      claims: [name]
+      class: D7
+      strength: strong
+      why: "Piaggio's own history page calls the 2002 bike the 'Tuono 1000 R' / 'RSV Mille Tuono R'. 'RSV1000 TUONO' occurs in exactly ONE register row (lu, n=1); nl spells the same machine six other ways, none of them this."
+      attack_here: "There is a further D6 question against motorcycle/aprilia/tuono that I flagged and did NOT assert. Also: aprilia/rsv1000 shares this record's TAN, which looks like a duplicate and is not (FINDING-B) — do not 'improve' my verdict by adding that."
+
+    - id: [motorcycle/honda/nt650v, moped/honda/cl50-benly, moped/honda/today, motorcycle/yamaha/dragstar, motorcycle/ajs/m20]
+      claims: [id]
+      class: D6
+      strength: "nt650v very strong; today strong; cl50-benly strong; dragstar strong; m20 moderate"
+      why: "Each has a live same-make sibling that is the same vehicle differing only by token presence: nt650v / nt650v-deauville (4 of 6 countries shared); cl50-benly / cl50; today / today-50 (same two registers); dragstar / xvs1100-dragstar; m20 / 20."
+      attack_here: "ajs/m20 is the weak one: three vehicles total, and 'M20' is far better known as the BSA M20, so a make-misattribution reading competes with the duplicate reading. I refused to pick — if the verifier can source an AJS 'Model 20' registration in NL or NZ, that settles it; otherwise it belongs in the matchless-undetermined-manglings bucket."
+
+    - id: motorcycle/harley-davidson/flhtcui
+      claims: [id]
+      class: D6
+      strength: WEAK — flagged for a decision, not for a fix
+      why: "FLHTCUI is H-D's code for the Electra Glide Ultra Classic Injection and motorcycle/harley-davidson/electra-glide-ultra-classic is live. The same code-id-beside-nameplate-id pattern runs right across this make (flhr-road-king, flhx-street-glide, road-king, street-glide …)."
+      attack_here: "This is the one id verdict I would not defend hard. If H-D code ids are an accepted parallel axis, downgrade to correct and note it — but then the whole Harley code population needs that decision recorded somewhere, because it is dozens of records."
+
+    - id: [motorcycle/honda/magna, motorcycle/triumph/rocket, motorcycle/ktm/1190, motorcycle/lexmoto/milano]
+      claims: [name, id]
+      class: [D8, D9]
+      strength: "magna strong; rocket strong; ktm/1190 already-filed; milano moderate"
+      why: "Family word with the distinguishing designation dropped. magna: nl carries V45/V30/V65 MAGNA 543 times vs bare MAGNA 5. rocket: Triumph's nameplate is Rocket III / Rocket 3 (styling.yml's own line names it). ktm/1190: debt:bare-displacement-2w for this exact make. milano: gb GenModel pools a 125 and a 50."
+      attack_here: "ktm/1190 is FILED debt — see the filed-debt protocol question above. milano is the same policy call as xsr/xp."
+
+  # ── THINGS I CHECKED AND FOUND CLEAN (recorded so nobody re-opens them) ────
+  cleared:
+    - "ALL 251 availability claims verified against raw register rows. Zero
+       defective, zero unverifiable — every cached corpus the build read was
+       available locally, so there was no reason to leave any of these open."
+    - "My 3 initial availability misses were all MATCHER artifacts and are
+       written up in-record so a verifier does not re-raise them:
+       derbi/senda-50 fi (evidence arrives via 13 curated, TAN-sourced folds),
+       selana/alpha nl (evidence filed under registrant 'GO TULIP B.V.',
+       curated alias), tgb/br8 gb (filed under 'TAIWAN GOLDEN BEE', curated
+       alias)."
+    - "kind: 100/100 correct. Every record's kind matches the EU category of the
+       rows that evidence it, per each adapter's own CATEGORY_TO_KIND. Includes
+       the two that look wrong and are not: moped/stromer/st2 (speed pedelec,
+       L1e-B) and moped/garia/club-car-urban-l7e-s (L7e quadricycle -> moped by
+       the documented convention)."
+    - "Cross-kind name twins are NOT duplicates and must not be merged: the
+       uk_dft VEH0120 'Motorcycles' body type contains UK mopeds by design
+       (kind_maps/uk_dft.yml), which manufactures a motorcycle-kind twin for
+       many moped records. Six in this batch: honda/sfx50, peugeot/vivacity,
+       rieju/mrt, sur-ron/light-bee, sym/jet4, honda/magna."
+    - "data/review ledger hits: motorcycle/mutt/fsr and moped/selana/alpha are
+       already ledgered `fixed` with verifier signatures and both re-verify clean.
+       mutt/fsr is the batch's control case for accepting family-level altitude."
+    - "motorcycle/bmw/r80-7 is correct and is the counter-example that keeps the
+       FINDING-A detector honest: r80 is live and is a DIFFERENT motorcycle, so a
+       token-subset detector would nominate it wrongly."
+
+  # ── PROCESS NOTES FOR THE PROGRAM ─────────────────────────────────────────
+  process_notes:
+    - "The single biggest rigor win was flattening every cached register up front
+       (~10 minutes of scripting). It moved availability from 'the expensive
+       claim class' to the cheapest and fully-verified one, and it is reusable by
+       every later batch. Scripts sit beside this file: flatten_fi.rb,
+       flatten_rest.rb, flatten_uk.rb, flatten_es.rb, flatten_lu.rb,
+       flatten_ua.rb, dossier.rb, sibling.rb, tandup.rb, ovr.rb."
+    - "The batch's own environment has a broken python3 (3.4, dies on import);
+       everything here is ruby. Worth noting in the researcher prompt template."
+    - "I checked every 'odd' name against the override layer BEFORE judging, as
+       instructed, and it changed the verdict in 11 cases (derbi/senda-50,
+       derbi/gpr-125, rieju/mrt, selana/alpha, mutt/fsr, tgb/br8, dayi-motor,
+       cl50-benly name, kymco/like-200, skyteam/skymax-125, harley/sportster-883).
+       Without that step this report would have contained ~11 false positives."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# ADDENDUM 1 (post-review) — known-debt vs novel split, per the ruling that
+# filed debt still counts as a defect
+# ═════════════════════════════════════════════════════════════════════════════
+defect_provenance:
+  defective_claims_total: 41
+  on_records_covered_by_filed_debt: 11
+  novel_unfiled: 30
+  filed_debt_breakdown:
+    "debt:normalizer-space-collapse-display-names":
+      records: [motorcycle/bmw/k1600gt, motorcycle/ducati/monster-1200s, moped/honda/super-cub50]
+      claims: 3
+    "debt:model-column-acronym-casing":
+      records: [motorcycle/harley-davidson/flhxst, motorcycle/honda/nrx-rune,
+                motorcycle/niu/nqi-gts-pro, motorcycle/yamaha/xsr, motorcycle/yamaha/xp]
+      claims: 5   # xsr/xp each carry a SECOND, novel id-claim defect (D8 rollup) not covered by this entry
+    "debt:bare-displacement-2w":
+      records: [motorcycle/ktm/1190]
+      claims: 1
+  note: >-
+    2 of the 11 (yamaha/xsr, yamaha/xp) are filed only for their NAME claim; their
+    id claim (D8 GenModel rollup) is novel, so a per-claim rather than per-record
+    split is the one that reports honestly. The 30 novel claims are where the
+    round earned its cost.
+
+# ═════════════════════════════════════════════════════════════════════════════
+# ADDENDUM 2 — CORRECTION to my own FINDING-A counts
+# ═════════════════════════════════════════════════════════════════════════════
+finding_a_corrections:
+  - "bsa/a65 does NOT belong in the Thunderbolt cluster. The cluster is FIVE ids
+     (a65t, thunderbolt, thunderbolt-650, thunderbolt-a65, 650-thunderbolt), not
+     six. A65 is the RANGE — Star, Thunderbolt, Lightning, Spitfire, Hornet,
+     Firebird — and enrich/bsa.yml:89-91 enriches it separately (1962-72,
+     gracesguide) from the Thunderbolt ids (1964-72). My record entry and
+     attack_here both flagged a65 as a probable family row and said 'five not
+     six', but the headline said SIX and the headline is what gets read."
+  - "The A65 Lightning cluster is SEVEN ids, not four: a65l, a65-lightning,
+     lightning, lightning-650, 650-lightning, lightning-a65, lightning-a65l.
+     enrich/bsa.yml:127 says so verbatim — 'SEVEN ids for one motorcycle, the
+     worst cluster in this make'. It was named in FINDING-A but only in one line
+     and without enumeration, which is why it read as missed."
+  - "So the make carries TWELVE ids for TWO motorcycles, both documented only in
+     enrichment comments and neither in any debt ledger."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# ADDENDUM 3 (post-review, BLOCKING the aggregate) — the name-claim
+# unverifiable bucket, split source-gap vs not-attempted.
+#
+# MY ORIGINAL CHARACTERISATION WAS WRONG. The summary block called all 56
+# unverifiable name claims "a source-gap statement". They are not: 3 are, and 53
+# are simply not attempted. The reason strings I wrote per record say so plainly
+# ("no Honda source reached", "no Kymco source reached") — the mislabel was in
+# the aggregate framing, not in the per-record evidence, which is the worst place
+# for it because the aggregate is what gets reported.
+# ═════════════════════════════════════════════════════════════════════════════
+name_claim_accounting:
+  claims: 100
+
+  source_gap: # attempted, and no usable marque-controlled source was obtained
+    count: 3
+    ids:
+      - id: motorcycle/royal-enfield/continental-gt650
+        attempt: "WebFetch https://www.royalenfield.com/gb/en/motorcycles/continental-gt-650/ -> HTTP 403"
+      - id: moped/vespa/mini
+        attempt: "WebSearch scoped to vespa.com + piaggiogroup.com; reached vespa.com/en_EN/models/ and /timeline/40/; no Vespa 'Mini' in either. Genuine absence-of-evidence, which is why the verdict stayed unverifiable rather than becoming defective."
+      - id: motorcycle/bmw/f650gs-dakar
+        attempt: "WebFetch https://www.bmw-motorrad.com/en/models/tour/k1600gt.html -> 60s timeout. WEAKEST OF THE THREE: the attempt was on a SIBLING page, not an F650GS Dakar page, so this is a domain-level failure I generalised. A strict reading puts it in not_attempted."
+
+  not_attempted: # no fetch or search was made for this record's name
+    count: 53
+    ids: [moped/honda/dio-af27, moped/honda/little-cub, moped/honda/s50,
+          moped/honda/sfx50, moped/honda/today, moped/agm/zn50qt-e,
+          moped/dayi-motor/e-thor-6-0b, moped/baotian/bt50qt-11,
+          moped/peugeot/vivacity, moped/killerbee/vxl, moped/senzo/grace,
+          moped/efun/pulse, moped/orion/rx50, moped/nsu/quickly-l,
+          moped/sym/jet4, moped/sunra/miku-max, moped/sur-ron/light-bee,
+          moped/stromer/st2, moped/yamaha/mr50, moped/yamaha/nitro,
+          moped/yiying/yy50qt-10, motorcycle/ducati/m620,
+          motorcycle/ducati/streetfighter-v4, motorcycle/honda/cb500f,
+          motorcycle/honda/cbr250r, motorcycle/honda/cbr600fs,
+          motorcycle/honda/nhx110wh, motorcycle/honda/nt650v,
+          motorcycle/honda/ww125s, motorcycle/ktm/690sm,
+          motorcycle/suzuki/rv90, motorcycle/suzuki/t350,
+          motorcycle/triumph/t595-daytona, motorcycle/yamaha/dragstar,
+          motorcycle/yamaha/xt600, motorcycle/yamaha/xs850,
+          motorcycle/ajs/m20, motorcycle/benelli/adiva-150,
+          motorcycle/benelli/bn125, motorcycle/cfmoto/jetmax,
+          motorcycle/gilera/saturno-500, motorcycle/husqvarna/te150i,
+          motorcycle/kymco/ak550, motorcycle/kymco/like-200,
+          motorcycle/lexmoto/milano, motorcycle/moto-guzzi/nevada,
+          motorcycle/mv-agusta/turismo-veloce-lusso,
+          motorcycle/piaggio/mp3-500hpe, motorcycle/skyteam/skymax-125,
+          motorcycle/ural/ranger, motorcycle/vespa/gts300,
+          motorcycle/izh/49, motorcycle/skyjet/sj125]
+
+  # The other 44, so the denominator question is answerable
+  adjudicated_on_own_marque_fetch:
+    count: 26   # 13 correct + 13 defective, each citing a URL I fetched this round
+  adjudicated_on_sanctioned_non_fetch_evidence:
+    count: 18
+    in_data_proof: 14   # defective; the class name_shapes.yml accepts as "a source URL, OR an in-data proof"
+    curation_or_register_consensus: 4  # correct: honda/cl50-benly, derbi/senda-50, derbi/gpr-125, bmw/r80-7
+
+  denominators:
+    strict_marque_fetch: "29/100 audited (26 fetch-adjudicated + 3 source-gap)"
+    generous_incl_sanctioned_evidence: "47/100 audited (29 + 18), 3 of them genuine gaps"
+    recommendation: >-
+      Report 47 and say which reading it is; the 18 in-data/register-only
+      adjudications are a sanctioned evidence class (PRD-QUALITY §5.2
+      evidence_class: register-only; name_shapes.yml "a source URL, or an
+      in-data proof"), so excluding them would understate real work. But 53
+      not-attempted is the number that matters and it should be printed next to
+      whichever denominator is chosen.
+
+  complete_fetch_failure_log: # supersedes the "4 named refusals" — that was incomplete
+    - "bsacompany.co.uk/heritage -> HTTP 403 (name resolved anyway via cybermotorcycle.com, so NOT in the 56)"
+    - "morbidelli.com/int-en/products/f352 -> socket hang up (OMITTED FROM MY EARLIER LIST; resolved anyway via WebSearch, so NOT in the 56)"
+    - "tmracing.it/en -> HTTP 301 cross-host to tm-moto.it, not followed (verdict was defective on in-data grounds, so NOT in the 56)"
+    - "bmw-motorrad.com k1600gt page -> 60s timeout (k1600gt adjudicated on register consensus; f650gs-dakar left unverifiable)"
+    - "royalenfield.com continental-gt-650 -> HTTP 403"
+    - "NEGATIVE-RESULT fetches that SUCCEEDED and are not refusals: lambretta.com and lambrettascooters.com (both loaded, neither lists an X200 — that is how the Thai-market X200 question got resolved elsewhere)"
+
+  unaffected_claim_classes: >-
+    This problem is confined to name-marque-true. availability (251/251),
+    id (100), make (100) and kind (100) were each derived from local evidence
+    that was actually read, not from sources I failed to reach.

--- a/data/review/audit-v2026.07.5/ledger/researcher-b2.yml
+++ b/data/review/audit-v2026.07.5/ledger/researcher-b2.yml
@@ -1,0 +1,1201 @@
+# AUDIT PROPOSAL — Workstream A2 baseline round, tag v2026.07.5, S2W half, batch 2
+# researcher: audit-b2 (background agent, this session)
+# verifier: PENDING — every verdict below must be re-derived independently (I-11)
+#
+# ─── METHOD, so the verifier can attack it ──────────────────────────────────
+#
+# AVAILABILITY (236 claims, all 100 records) was checked MECHANICALLY against
+# the same cached register pulls the audited build read, rebuilt into a local
+# (country, kind, raw_make, raw_model, n, tan) index:
+#   nl  cache/nl_rdw_{bromfiets,motorfiets,driewielig-motorrijtuig,
+#                     motorfiets-met-zijspan}.json
+#   nz  cache/nz_{moped,motorcycle}_*.json
+#   gb  cache/uk_veh0120_uk.csv          (BodyType "Motorcycles" only)
+#   fi  cache/fi_traficom_register.zip   (5,147,216 rows streamed; ajoneuvoluokka
+#                                        L1e/L2e/L6e/L7e→moped, L3e/L4e/L5e→motorcycle)
+#   es  cache/es_dgt_2026{04,05,06}.txt  (fixed-width [426,3) EU category,
+#                                        incl. the *0x Spanish national codes)
+#   lu  cache/lu_delta_2026-{05,06,07}.xml  (LIBMRQ/TYPCOM/CATEU/PVRNUM)
+#   th  cache/th_dlt_2568.csv            (ประเภทรถ = รถจักรยานยนต์)
+#   ua  cache/ua_reestr_current.zip      (BRAND/MODEL/KIND, deduped on the
+#                                        per-vehicle identifier column)
+# A claim counts `correct` only when a raw row exists in THAT country whose
+# model string, normalised (upcase, strip non-alphanumerics, strip a leading
+# marque token), equals the published name, in a register category that the
+# repo's own kind_maps route to the record's kind. 8 claims initially failed the
+# automatic matcher and were resolved BY HAND (7 = the Piaggio→Vespa move, where
+# the raw make is PIAGGIO and the marque sits in the model column; 1 = Indian,
+# where the raw make is "INDIAN MOTORCYCLE"). All 236 verified.
+# LIMIT OF THIS METHOD: it proves the register row exists. It does not re-run
+# the reconciler, so it cannot catch a mis-ROUTED row (right string, wrong id).
+#
+# ID-CANONICAL: I ran the repo's own detectors first — find_duplicate_spellings
+# and find_casing_contradictions, both against the audited build with
+# VDB_SIDE=s2w. Both are SILENT (0 groups, 0 contradictions), as
+# audit-PROTOCOL.md predicts. lint_dataset.rb --report on the same build: 2
+# unexplained suspects catalog-wide, both s4w's. So every id defect below was
+# found by hand, and NONE of them is visible to any existing detector. See
+# §NEW-CLASS at the bottom — this is the batch's main finding.
+#
+# NAME: fetched-source verdicts for 41 records; the other 59 are recorded
+# `unverifiable(no marque source fetched)` rather than guessed. That is a BUDGET
+# limit, not a data finding, and the summary reports the two populations
+# separately so the aggregate is not misread. Piaggio-group (vespa.com,
+# piaggio.com, aprilia.com), Ducati, Royal Enfield, Indian, Yamaha-Motor-EU and
+# Kymco UK all returned HTTP 403 / socket-hang-up to WebFetch; those are logged
+# as source-gap-queue items, not as clean records.
+
+records:
+
+  # ─────────────── mopeds ───────────────
+
+  "moped/aprilia/sb":
+    verdicts: { id: correct, name: "unverifiable(no Aprilia source records a model 'SB'; a Dutch moped registry site lists one, which corroborates existence but not the marque's rendering)",
+                make: correct, kind: correct, availability: { nl: correct } }
+    evidence: ["raw: 'APRILIA | SB' nl_rdw moped n=608",
+               "https://www.brommer.nl/merk/aprilia/sb-2/  # existence only, not a marque source",
+               "styling.yml acronyms includes SB, so the display is at least not title-cased"]
+    notes: "SUSPECT D9 (unresolved type code) at real volume — 608 NL rows. Aprilia's own 1980s-90s moped range (Colibri, Daniela, Partner, SR, RX, SX, Amico, Habana, Scarabeo) contains no SB in any source I reached. Worth a targeted RDW type-approval query (NAMING §7.5) rather than a guess. Single-source, so it sits inside the normalizer-space-collapse debt bucket's catch-all and is invisible to lint."
+
+  "moped/benelli/motorella":
+    verdicts: { id: correct, name: "unverifiable(no Benelli source fetched)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'BENELLI | MOTORELLA' nl_rdw moped n=18", "raw: 'BENELLI | MOTORELLA' nz_nzta moped n=7"]
+    notes: "Two independent registers spell it identically, which is the repo's own corroboration bar — but that is not a marque rendering."
+
+  "moped/honda/cf50":
+    verdicts: { id: "defective(D6 — same-vehicle id split)", name: "unverifiable(no Honda source fetched)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | CF50' nl_rdw moped n=36; 'CF 50' n=22; 'CF50 CHALY' n=9",
+               "raw: 'HONDA | CF50' nz_nzta moped n=29; 'CHALY CF50' n=4",
+               "live siblings: moped/honda/cf50-chaly [CF50 Chaly] {nl,nz}, moped/honda/chaly-cf50 [Chaly CF50] {nl,nz}"]
+    notes: "THREE live ids for the Honda Chaly: the bare code, code+name, and name+code. cf50-chaly and chaly-cf50 are each other's token inversion, which is the shape renames.yml already folds elsewhere (Alfa 'Gtv 1750'→'1750 GTV'). find_duplicate_spellings cannot see it: the strings differ by token ORDER and by a whole token, not by punctuation or case."
+
+  "moped/aixam/a741":
+    verdicts: { id: correct, name: "unverifiable(no Aixam source fetched)", make: correct,
+                kind: "correct(per the repo's L6e→moped convention)", availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Aixam | A741' fi_traficom, ajoneuvoluokka=L6e, TAN e2*2002/24*0009*01 — matches the record's xrefs.tan exactly",
+               "raw: 'AIXAM | A.741' nl_rdw moped n=30; 'A741' n=2; 'SCOUTY - A741' n=1"]
+    notes: "TWO things for the verifier. (1) kind: FI files it L6e, i.e. a light quadricycle, not a two-wheeler; `moped` is the repo's documented placement (es_dgt.rb L6E/L7E→moped; name_shapes mega-marque entry says these rows move if G24 mints a quadricycle kind). Correct per current convention, wrong per PROPOSAL-kind-boundary.md §Q2. (2) the nl raw 'SCOUTY - A741' suggests the NAMEPLATE is Scouty and A741 is the type number — a D9 candidate the type-approval number could settle."
+
+  "moped/btc/riva":
+    verdicts: { id: correct, name: "unverifiable(no BTC source fetched)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'BTC | RIVA' nl_rdw moped n=14310"]
+    notes: "Siblings Riva 2 / Riva Sport are separate products, not spellings. Highest-volume single record in this batch."
+
+  "moped/dkw/hummel":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct, nz: correct }, enrichment: correct }
+    evidence: ["https://cybermotorcycle.com/marques/dkw/dkw-hummel-115.htm  # name check + run re-derived: 'Introduced in 1956' / 'Production ceased in 1965'",
+               "raw: 'D.K.W. | HUMMEL' nl_rdw moped n=140 (+ Hummel Super/De Luxe/TS/113/115/116 variants)",
+               "raw: 'DKW | HUMMEL' nz_nzta moped n=8"]
+    notes: "Enrichment RE-FETCHED from the citation in enrich/dkw.yml and it re-derives exactly (1956-1965). Independent corroboration of the phased production (Typ 101 1956-58, Hummel Super 102 1958-60, Zweirad-Union 113/115 into the 1960s): https://www.zweirad-union-mopeds.de/dkw-hummel-super-typ-102 . The run is a FAMILY span and the id is the bare family name, which is the consistent choice."
+
+  "moped/honda/express":
+    verdicts: { id: correct, name: "unverifiable(no Honda source fetched)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | EXPRESS' nl_rdw moped n=1", "raw: 'HONDA | EXPRESS' nz_nzta moped n=26; 'NC50 EXPRESS' n=6; 'EXPRESS NC50' n=4"]
+    notes: "No nc50 sibling exists, so unlike cf50 this one is not split. The NZ raw pairs EXPRESS with NC50 in one cell, which is in-data proof that Express is the marque NAME and NC50 the code — the right way round here. nl rests on a single row (n=1)."
+
+  "moped/baotian/bt49qt-12e":
+    verdicts: { id: correct, name: "unverifiable(no Baotian source fetched)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Baotian | BT49QT-12E' fi_traficom TAN e4*2002/24*1397*06 — matches the record's xrefs.tan exactly",
+               "raw: 'BAOTIAN | BT49QT-12E' nl_rdw moped (sibling -12E1 carries a different TAN *01, so the ids are genuinely distinct types)"]
+    notes: "The TAN discriminates -12E from -12E1, which is the strongest possible in-data argument that these are separate approvals and not spellings — worth keeping as a positive precedent. Still a D9 candidate at the nameplate level (Baotian markets these under retail names)."
+
+  "moped/gilera/c27":
+    verdicts: { id: correct, name: "unverifiable(no Gilera source fetched)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'GILERA | C27' nl_rdw moped n=767; 'C27/1/00' n=12"]
+    notes: "The '/1/00' suffix in the raw is a type-approval tail, which supports C27 being a type designation rather than a nameplate (D9 candidate)."
+
+  "moped/hanway/raw50s":
+    verdicts: { id: correct, name: "unverifiable(marque site unreachable; the make's own signed ledger records the same closed-vs-spaced discrepancy for RAW125 and left it open)",
+                make: correct, kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Hanway | RAW50S' fi_traficom TAN e9*168/2013*11208*00 — matches xrefs.tan",
+               "raw: 'HANWAY | RAW50S' nl_rdw moped n=1870; 'RAW 50' n=291",
+               "data/review/hanway.yml:47-58 (B-002, signed): \"our 'RAW125' is closed where the range is usually written 'RAW 125' … the family needs deciding at once\""]
+    notes: "The register itself carries both forms (RAW50S 1870 / RAW 50 291). The ledger's deferral is a legitimate decision, not a defect I am overruling — but the published string is still not shown to be the marque's."
+
+  "moped/honda/motocompo":
+    verdicts: { id: "defective(D6 — same-vehicle id split)", name: "unverifiable(no Honda source fetched)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | MOTOCOMPO' nl_rdw moped n=11; 'NCZ 50 MOTOCOMPO' n=4; 'MOTOCOMPO AB12' n=2",
+               "raw: 'HONDA | MOTOCOMPO' nz_nzta moped n=13",
+               "live sibling: moped/honda/motocompo-ncz50 [Motocompo NCZ50] {nl,nz}"]
+    notes: "NCZ50 is the Motocompo's type code — the nl raw carries 'NCZ 50 MOTOCOMPO' in one cell, in-data proof they are one machine. Same shape as cf50."
+
+  "moped/piaggio/bravo":
+    verdicts: { id: correct, name: "unverifiable(piaggio.com returns 403)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'PIAGGIO | BRAVO' nl_rdw moped n=44; 'PIAGGIO BRAVO 45 KM/H' n=75; 'BRAVO P' n=39",
+               "raw: 'PIAGGIO | BRAVO' nz_nzta moped n=2"]
+    notes: "make is right — the Bravo is a Piaggio-badged moped, not a Vespa, so the Piaggio→Vespa moves correctly leave it alone."
+
+  "moped/la-souris/sourini-rs":
+    verdicts: { id: "defective(D8/D6 — an unfolded edition id denotes the same nameplate)",
+                name: "unverifiable(no La Souris source fetched)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'LA SOURIS | SOURINI RS' nl_rdw moped n=3349",
+               "live siblings: moped/la-souris/sourini-rs-limited {es,nl}, and 'SOURINI RS PILOTI' n=122 / 'SOURINI RS PILOTI CARBON' in the raw"]
+    notes: "SOFTER CALL THAN THE OTHERS, flagged as such: NAMING.md §6 says 'Trims, editions and equipment levels FOLD' and gives 'Terramar America's Cup Edition → Terramar'. 'RS Limited' is an edition of the RS on that reading, so sourini-rs-limited should not be a separate id. If the maintainer reads Limited as a distinct product, this verdict flips to correct — it is a policy-application question, and the verifier should rule on it rather than inherit my reading."
+
+  "moped/masai/50":
+    verdicts: { id: correct, name: "unverifiable(masai-motors.com did not resolve)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Masai | MASAI 50' fi_traficom ajoneuvoluokka=L1e, TAN e3*2002/24*0368*01 — matches xrefs.tan",
+               "raw: 'MASAI | MASAI 50' nl_rdw moped n=58"]
+    notes: "FALSE-LEGIT WARNING for the shape allowlist. lint_dataset excuses this under `corroborated-numeric-nameplates` (≥2 sources, ≥2 countries), but the two corroborating strings are both 'MASAI 50' — make + capacity, with NO nameplate in the model column at all. Corroboration proves the registers agree, not that a nameplate exists. Same reasoning applies to masai/125 below. The legit entry's premise ('two registries do not invent the same string by accident') does not distinguish a real bare nameplate from two registers making the same omission."
+
+  "moped/honda/sh50":
+    verdicts: { id: "defective(D6/D10 — cross-kind twin of the same 50cc scooter)",
+                name: "unverifiable(no Honda source fetched)", make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: 'HONDA | SH 50' nl_rdw moped n=906; 'SH50' n=299; 'SH50 SCOOPY' n=2",
+               "raw: 'HONDA | SH 50' ua_mvs moped n=1",
+               "live sibling: motorcycle/honda/sh50 [SH50] {gb only}; gb GenModel 'HONDA SH50' n=766, Model 'SH50'"]
+    notes: "The gb twin is the UK-source artefact described in the NEW-CLASS §2 below: uk_dft has no moped BodyType, so every UK-only ≤50cc record lands in `motorcycle`. 18 such pairs exist catalog-wide (measured). Also note the raw pairs SH50 with SCOOPY, so the nameplate question (D9) is open too."
+
+  "moped/suzuki/ts50er":
+    verdicts: { id: correct, name: "unverifiable(no Suzuki source fetched for the ER suffix)", make: correct,
+                kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'SUZUKI | TS50ER' nl_rdw moped n=2; 'TS50 ER' n=1", "raw: nz_nzta moped TS50ER present"]
+    notes: "Thin (n=3 in nl). The TS50 family ids (TS50, TS50X, TS50XK, TS50XKR, TS50ER) are distinct Suzuki suffixes, so this is not the FLSTC-style split; the motorcycle/suzuki/ts50 gb record is the bare TS50, not this one."
+
+  "moped/peugeot/fb50qt-6a":
+    verdicts: { id: correct, name: "unverifiable(no Peugeot source fetched)", make: "correct(but see note)",
+                kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Peugeot | FB50QT-6A' fi_traficom TAN e4*2002/24*0368*08 — matches xrefs.tan",
+               "raw: 'PEUGEOT | FB50QT-6A' nl_rdw moped n=2657",
+               "live cross-make sibling with the IDENTICAL name: moped/qingqi/fb50qt-6a [FB50QT-6A] {fi,nl}"]
+    notes: "HIGH-VALUE FOR THE VERIFIER, and I did not resolve it. 'FB50QT-6A' is a Chinese OEM type code (the FB/QT pattern), and the SAME code is published under BOTH peugeot and qingqi with the same two countries. Either (a) Qingqi built it and Peugeot badged it — then one of these is a D11 make error or they are one vehicle at two ids (D6 cross-make), or (b) two registers disagree about the marque. The shared TAN family would settle it; I could not reach a Peugeot Motocycles source. Do NOT merge on resemblance."
+
+  "moped/nsu/quickly-t":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct, nz: correct },
+                enrichment: "defective(wrong run — the family span is published as the variant's)" }
+    evidence: ["https://www.nsu24.de/html/nsu_quickly.html  # name + per-variant runs: the Quickly T ('Traum') 1959-1963, 38,605 built",
+               "https://nsu-quickly.de/en/models/quickly-cavallino/  # NSU-Quickly specialist, same variant taxonomy",
+               "raw: 'N.S.U. | QUICKLY T' nl_rdw moped n=8; 'QUICKLY-T' n=3; 'Quickly T' n=1",
+               "enrich/nsu.yml:21-23 — {year_start: 1953, year_end: 1968}, sole citation en.wikipedia.org/wiki/NSU_Quickly"]
+    notes: >-
+      TWO PROBLEMS IN ONE ENTRY. (1) The published run 1953-1968 is the whole
+      Quickly FAMILY; the Quickly T is 1959-1963. (2) The enrichment note
+      justifies the family span with 'no source separates the variant runs' —
+      that premise is FALSE: nsu24.de and nsu-quickly.de both do, with unit
+      counts. And the sole citation is Wikipedia, which the standing Wikipedia
+      rule forbids as a sole source. The same {1953,1968} block is applied to
+      quickly, quickly-l and quickly-n, so the fix is a four-record pass, and
+      the N (1953-62) and S/L variants are separately dated in the same source.
+      NOTE the file's own header contradicts 1968 too: it says NSU two-wheeler
+      production wound down 1963-65.
+
+  "moped/vespa/elettrica":
+    verdicts: { id: correct, name: "unverifiable(vespa.com returns 403)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'PIAGGIO | VESPA ELETTRICA' es_dgt moped n=1, fi_traficom moped n=19 (TAN e1*168/2013*00139*00, matches xrefs), nl_rdw moped n=563",
+               "raw: 'VESPA | ELETTRICA' nz_nzta moped n=1",
+               "moves.yml:83 'Piaggio|Vespa Elettrica' → 'Vespa|Elettrica'; former_ids carries the old piaggio id"]
+    notes: "The Piaggio→Vespa move is working exactly as designed and the former_ids alias is present — a clean D11 remediation, worth recording as a positive. Sibling primavera-elettrica is a different product (Primavera bodywork)."
+
+  "moped/sakura/ev2000":
+    verdicts: { id: correct, name: "unverifiable(no Sakura source fetched)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Sakura | EV2000' fi_traficom L1e, TAN e13*168/2013*00378*02 — matches xrefs.tan",
+               "raw: 'SAKURA | EV2000' nl_rdw moped n=14"]
+
+  "moped/yamaha/bw-s":
+    verdicts: { id: "defective(D6 — BWS50 is the same machine at a second id)", name: correct,
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["renames.yml:2682-2683 \"Bw's\"/Bws → BW's, with former_ids motorcycle/yamaha/bws → bw-s — the apostrophe form is a sourced, deliberate decision",
+               "raw: 'Yamaha | BW'S' fi_traficom L1e TAN e13*92/61*0079*03 (matches xrefs); nl_rdw 'BW'S' + 'BW S' + 'BWS'; nz + ua present",
+               "live sibling: moped/yamaha/bws50 [BWS50] {nl,nz}"]
+    notes: >-
+      NAME IS CORRECT AND DELIBERATE — this is the CPx/tS case the protocol
+      warns about, and I am explicitly not flagging it. The defect is
+      elsewhere: the same rename pass that produced BW's left moped/yamaha/bws50
+      standing as a separate id for the BW's 50. The apostrophe fold caught the
+      bare spellings and missed the capacity-suffixed one.
+      SEPARATE, UNRESOLVED: motorcycle/yamaha/bw-s {gb,lu,nl} carries the same
+      display name in the other kind. The lu row's TAN (e13*2002/24*0384*00) is
+      a motorcycle-class approval, so that one is probably the BW's 125 and the
+      pair may be legitimate. Not called either way — it needs a capacity check.
+
+  "moped/tromox/mino":
+    verdicts: { id: correct, name: "unverifiable(no Tromox source fetched)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Tromox | mino' fi_traficom L1e TAN e9*168/2013*11634*00 — matches xrefs.tan",
+               "raw: 'TROMOX | MINO' nl_rdw moped n=17", "raw: gb uk_dft 'TROMOX MINO' n=34, Model 'MINO 45'"]
+    notes: "The fi raw is lower-case 'mino'; the published Title Case is the caser's default and is probably right, but unverified. gb has 34 Mino rows that this record does not claim — a possible missing-availability (D19-adjacent) item, since gb evidence for a 45 km/h machine would land in motorcycle kind."
+
+  "moped/yamaha/tzr50":
+    verdicts: { id: correct, name: "unverifiable(no Yamaha source fetched)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["raw: 'Yamaha | TZR50' fi_traficom L1e TAN e9*92/61*0121*01 — matches xrefs.tan",
+               "raw: 'YAMAHA | TZR50' nl_rdw moped n=1268; nz present; ua 'TZR 50' n=1"]
+    notes: "motorcycle/yamaha/tzr [Tzr] {gb,nl,nz} is a title-cased-acronym defect in the same make but is not this record."
+
+  "moped/vespa/primavera":
+    verdicts: { id: "defective(D6 — no such product; this is the Primavera 50)", name: correct,
+                make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct, nz: correct } }
+    evidence: ["https://storeusa.vespa.com/primavera.aspx  # Vespa's own store lists PRIMAVERA 50 / 150 / SPORT / TECH — every product carries a displacement or a variant word; there is NO standalone 'Primavera'",
+               "raw moped: es 'VESPA PRIMAVERA' n=71 + 'VESPA PRIMAVERA 50' n=19; fi n=380 + '…50' n=159; lu n=12 + '…50' n=6; nl n=17792 + '…50' n=3482; nz 'PRIMAVERA' n=334 + 'PRIMAVERA 50' n=1",
+               "live sibling: moped/vespa/primavera-50 [Primavera 50] {es,fi,lu,nl,nz} — the identical five countries"]
+    notes: >-
+      THE FIVE-COUNTRY DUPLICATE. In the moped kind (L1e) Vespa's only Primavera
+      is the 50, so bare 'Primavera' and 'Primavera 50' are one machine at two
+      ids, evidenced from the same five registers. The name string itself is
+      Vespa's own word, so the defect is id, not name.
+      WHY THIS IS NOT THE DISPLACEMENT RULE: NAMING.md §6 says keep both when
+      records differ by a CAPACITY (Senda 50 vs Senda 125 — two capacities).
+      Here one side has no capacity at all, and `kind` already pins L1e. The
+      classic 125cc Primavera is a separate, correct record in `motorcycle`.
+      The verifier should check my reading of §6 before this is acted on; it is
+      the one place where a rule written for a different case could be read to
+      bless the duplicate.
+
+  "moped/ugbest/romex":
+    verdicts: { id: correct, name: "unverifiable(no Ugbest source fetched)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Ugbest | ROMEX' fi_traficom L1e TAN e13*168/2013*00413*00 — matches xrefs.tan",
+               "raw: 'UGBEST | ROMEX' nl_rdw moped n=15"]
+
+  "moped/yamaha/sa15":
+    verdicts: { id: correct, name: "unverifiable(no Yamaha source resolves the SA15 code to a nameplate)",
+                make: correct, kind: correct, availability: { nl: correct } }
+    evidence: ["raw: 'YAMAHA | SA15' nl_rdw moped n=1215 (siblings SA14 n=4745, SA19 n=1563, each published separately)"]
+    notes: >-
+      D9 SUSPECT, and an ALLOWLIST-MECHANICS finding worth more than the record.
+      SA14/SA15/SA19 are Yamaha internal type codes (the fi raw spells one
+      'SA14-SA144/49', i.e. code + variant/capacity), not nameplates — NAMING
+      §7.5 says resolve or leave alone. lint_dataset DOES flag SA15 as
+      code_string, and it is then absorbed by the debt entry
+      `normalizer-space-collapse-display-names` (category code_string,
+      max_sources 1), which is about space collapse and has nothing to do with
+      unresolved type codes. That entry is acting as a catch-all for every
+      single-source 2W code string, so its count (269→267) cannot be read as
+      progress on either problem. Suggest splitting it.
+
+  "moped/zycar/z2l":
+    verdicts: { id: correct, name: "unverifiable(no Zycar source fetched)", make: correct, kind: correct,
+                availability: { es: correct, nl: correct } }
+    evidence: ["raw: 'ZYCAR | Z2L' es_dgt moped n=14; nl_rdw moped n=7",
+               "raw ALSO holds the comma-joined cell 'Z2, Z2B, R2, R2B, Z2L, Z2BL, R2L, R2LB' (nl n=1, es n=9+1)"]
+    notes: "NAMING §7.4 (comma-joined cells are source-specific) applies here and appears to have been handled correctly — the multi-code cell did not become a model. Recording it as a positive; the same cell shape is a known silent-failure class."
+
+  # ─────────────── motorcycles ───────────────
+
+  "motorcycle/bmw/f800gs":
+    verdicts: { id: correct, name: "unverifiable(no BMW source fetched)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["raw: es 'F 800 GS' n=353; fi 'F800GS' n=161 (TAN e1*2002/24*0352*00, in xrefs) + 'F 800 GS' n=98; lu; nl 'F 800 GS' n=2300; nz; ua"]
+    notes: "Six-country head record; every claim holds. BMW writes 'F 800 GS' spaced on its own site, so the closed published form is a space-collapse candidate — but NAMING §7.3 explicitly lists BMW 'R1250GS' as a CLOSED type code, so the closed form may be the deliberate convention. Not called without a bmw-motorrad source."
+
+  "motorcycle/ajs/16ms":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["https://cybermotorcycle.com/marques/ajs/ajs-1945-16m.htm  # \"The difference was indicated by the S (for springer) designation - 16MS\", from 1949",
+               "raw: 'A.J.S. | 16 MS' nl_rdw n=92; '16MS' n=29; '16 M.S.' n=2; '55/16MS' etc.; nz present"]
+    notes: "CLOSED FORM IS RIGHT even though the dominant raw is spaced ('16 MS' 92 vs '16MS' 29) — §7.3's ≥4-letter test and the marque source agree. Sibling motorcycle/ajs/16m is the rigid-frame 16M, a genuinely different machine, so this is NOT the FLSTC split. Caveat the repo already knows: cybermotorcycle's AJS/Matchless tables carry OCR damage (name_shapes matchless entry), so a Jampot/AJS-Matchless OC cross-check would be worth one fetch."
+
+  "motorcycle/brixton/bx125":
+    verdicts: { id: correct, name: "defective(D7 — marque publishes 'BX 125' spaced)", make: correct, kind: correct,
+                availability: { gb: correct, lu: correct, nl: correct } }
+    evidence: ["data/review/brixton.yml:11-21 (B-002, signed): \"the marque launched its first bike at EICMA 2015 as 'BX 125' (spaced) against our 'BX125'\", evidence https://www.brixton-motorcycles.com/models/",
+               "raw: gb uk_dft GenModel 'BRIXTON BX125' n=278 with Model 'BX 125'; lu 'BX125' TAN e9*168/2013*11053*00 (matches xrefs); nl 'BX125' n=1"]
+    notes: "Called DEFECTIVE not because I disagree with the ledger but because the ledger AGREES the string is non-canonical and deferred the fix pending a whole-make decision (with Crossfire 500X). A recorded-and-deferred discrepancy is still a defect in the published record; the deferral is the right remedy sequencing. Note the gb Model column carries the spaced form, so the register corroborates the marque."
+
+  "motorcycle/deco/super-ace":
+    verdicts: { id: correct, name: "unverifiable(no Deco source fetched; Thai-market marque)", make: correct,
+                kind: correct, availability: { th: correct } }
+    evidence: ["raw: 'DECO | Super Ace' th_dlt motorcycle n=757"]
+    notes: "Single-source but high volume. th_dlt supplies the model column in mixed case, so the published Title Case is the register's own, not the caser's."
+
+  "motorcycle/bmw/r65t1c":
+    verdicts: { id: "defective(D6 — one-character corruption of the live r65tic id)",
+                name: "defective(D6 — 'T1C' is a digit-for-letter corruption of BMW's 'TIC')",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'BMW | R 65 T1C' nl_rdw n=1; 'BMW | R65T1C' nz_nzta n=1",
+               "raw: 'BMW | R 65 TIC' nl_rdw n=86; 'R65 TIC' n=5",
+               "live sibling: motorcycle/bmw/r65tic [R65TIC] {nl,nz} — same two countries"]
+    notes: >-
+      ONE-vs-EYE. Two registers each contribute a single row spelling the same
+      BMW variant with the digit 1 where the letter I belongs, and those two
+      rows mint a whole id beside r65tic (91 rows). find_duplicate_spellings
+      cannot catch it: NFKD folding does not equate '1' and 'I'. This is the
+      same corruption family the repo already documented in Matchless
+      (G805/GS80 for G80S, S↔5), and there the resolution was to fold when the
+      target is well attested in the same make — which it is here.
+      A homoglyph-fold pass (1/I, 0/O, 5/S, 8/B) over sibling names inside one
+      make+kind would be a cheap, high-precision detector. Decile 9, so it is
+      tail mass, but the fix is unambiguous.
+
+  "motorcycle/harley-davidson/flhr":
+    verdicts: { id: "defective(D6 — flhr-road-king is the same motorcycle)",
+                name: "defective(D7 — model-column-acronym-casing; H-D's own code is FLHR, its name is Road King; 'Flhr' is neither)",
+                make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # marque source, pairs \"FLHR - Road King®\"",
+               "raw: nl 'FLHR' n=411 + 'FL HR' n=3; fi; gb; nz; ua 'FLHR' n=11 — every register writes it in caps",
+               "live siblings: flhr-road-king {es,fi,nl}, flhrc, flhrc-road-king, flhrc-road-king-classic, flhri, flhri-road-king, flhri-road-king-efi, flhrs-road-king-custom, flhrse, flhrse-road-king, flhrsi-road-king-custom, flhrxs, flhrxs-road-king-special",
+               "data/name_shapes.yml:493,511 — the filed debt entry `model-column-acronym-casing` names harley-davidson/'Fxrs Super Glide II' as exactly this residual shape"]
+    notes: "Registers uppercase everything, so the raw cannot prove casing — but H-D's own page can, and does. The Road King family carries 14 live ids for what H-D lists as a handful of codes."
+
+  "motorcycle/aprilia/rxv":
+    verdicts: { id: correct, name: "defective(D7 — model-column-acronym-casing; 'Rxv' for the RXV type code)",
+                make: correct, kind: correct, availability: { gb: correct, nz: correct } }
+    evidence: ["raw: gb uk_dft GenModel 'APRILIA RXV' n=71 with Model 'RXV 4.5'; nz 'RXV' n=11",
+               "raw: fi 'RXV 450' / 'RXV 550'; live sibling motorcycle/aprilia/rxv450 [RXV450] {fi,ua}"]
+    notes: "Casing only — no aprilia.com source reached (403), so the CASE verdict rests on the repo's own filed rule (a pure-alpha type code is never title-cased) plus every register writing RXV. The bare RXV vs RXV450 pair is a capacity umbrella and I am NOT calling it an id defect; the gb Model column ('RXV 4.5') suggests this record is the 450."
+
+  "motorcycle/bultaco/sherpa":
+    verdicts: { id: correct, name: "defective(D7 — the marque's model is 'Sherpa T'; the bare form drops the designating letter)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct },
+                enrichment: "defective(run is the 3-machine family union; the register means the Sherpa T)" }
+    evidence: ["https://trialworld.es/en/history-of-the-bultaco-sherpa-t-and-50th-anniversary-event/  # Sherpa T presented Earls Court 1964, launched for the 1965 season as the Sherpa Model 10",
+               "https://cybermotorcycle.com/marques/bultaco/bultaco-trials.htm  # the citation enrich/bultaco.yml itself uses",
+               "raw: 'BULTACO | SHERPA T' nl_rdw n=43 vs bare 'SHERPA' n=1; 'SHERPA T 350' / 'SHERPA T350' / 'SHERPAT 350'; nz 'SHERPA' n=1",
+               "enrich/bultaco.yml:48-50 — {1960,1983} with the researcher's own caveat"]
+    notes: >-
+      THE ENRICHMENT NOTE PREDICTED THIS AND THE RAW SETTLES IT. enrich/bultaco.yml
+      says verbatim: \"THREE DISTINCT MACHINES UNDER ONE SLUG: if the register
+      meant the Sherpa T specifically … the run is 1964-1983, not 1960-1983. The
+      union is used because the id is bare.\" The register is 43 'SHERPA T' rows
+      against 1 bare — so the condition the researcher attached is satisfied, and
+      the union span is wrong for what this id denotes. Good discipline at write
+      time; the conditional was just never re-read against the corpus. Same
+      logic makes the NAME defective: the id should be sherpa-t.
+
+  "motorcycle/gpx/dz3-sport":
+    verdicts: { id: correct, name: "unverifiable(no GPX Racing source fetched)", make: correct, kind: correct,
+                availability: { th: correct } }
+    evidence: ["raw: 'GPX | DZ3 Sport' th_dlt n=3942; 'DZ3' n=273",
+               "former_ids.yml:412 'DZ3SPORT' → 'DZ3 Sport' — the spacing fix is already landed and aliased"]
+    notes: "A clean example of the space-collapse remedy working (id moved, alias kept). Sibling risk: bare 'DZ3' (n=273) is not published separately, so no split here."
+
+  "motorcycle/ducati/m750-dark":
+    verdicts: { id: "defective(D6 — m750 is live and is the same motorcycle)",
+                name: "defective(D9 — the nameplate is 'Monster 750 Dark'; M750 is the internal code)",
+                make: correct, kind: correct, availability: { gb: correct, nl: correct } }
+    evidence: ["https://ducati-specs.com/models/ducati-monster-750.html  # marque-specialist: \"Ducati Monster M750 (750 Dark, 750 I.E.)\" — Monster 750 Dark is the model, M750 the type code",
+               "raw: gb GenModel 'DUCATI M750 DARK' n=34, Model 'M750 DARK'; nl 'M750 DARK' n=1 beside 'M750 MONSTER' n=71 and 'M750' n=10",
+               "live siblings: motorcycle/ducati/m750 [M750] {gb,nl}, motorcycle/ducati/750 [750] {gb,nl,nz}, motorcycle/ducati/m [M] {gb,nl,nz}"]
+    notes: "ducati.com returns 403, so the name verdict rests on a specialist site — verifier should re-confirm on ducati.com if it will serve them. The nl raw carries 'M750 MONSTER' (n=71) in one cell, which is in-data proof that M750 and Monster denote one machine. Decile 10 (tail)."
+
+  "motorcycle/harley-davidson/street-bob114":
+    verdicts: { id: "defective(D6 — softail-street-bob114 is the same motorcycle)",
+                name: "defective(D7 — space collapse + a false acronym: H-D writes 'Bob', the register writes 'STREET BOB 114')",
+                make: correct, kind: correct, availability: { fi: correct, lu: correct, nl: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/motorcycles/street-bob.html  # H-D renders the nameplate 'Street Bob' (Title Case, 'Bob' not an initialism)",
+               "raw: 'Harley-Davidson | STREET BOB 114' fi_traficom n=39, TAN e4*168/2013*00062*06 — matches xrefs.tan; lu; nl",
+               "live sibling: motorcycle/harley-davidson/softail-street-bob114 [Softail Street BOB114] {fi,ua}",
+               "styling.yml deliberately EXCLUDES BOB from acronyms: \"'Fat Boy', 'Fat Bob' … are all correct today\""]
+    notes: >-
+      TWO SEPARATE MECHANISMS PRODUCE ONE WRONG STRING, and only one of them is
+      the filed space-collapse debt. (a) normalizer collapses 'BOB 114' to
+      'BOB114' (debt: normalizer-space-collapse-display-names). (b) case_token
+      returns any digit-bearing token unchanged, so the collapsed 'BOB114' keeps
+      the register's upper case and SHOUTS — which is why styling.yml's careful
+      decision to exclude BOB could not help. The collapse defeats the caser.
+      That interaction is worth stating in the debt entry, because fixing the
+      collapse fixes the casing for free, and pinning acronyms never will.
+      'Softail' is the FAMILY word, so the sibling is the same bike.
+
+  "motorcycle/aprilia/sx50":
+    verdicts: { id: "defective(D6/D10 — moped/aprilia/sx50 is the same 50cc machine)",
+                name: "unverifiable(aprilia.com 403; every register writes 'SX 50' spaced)",
+                make: correct, kind: "defective(D10 — a 50cc L1e machine published in kind=motorcycle)",
+                availability: { gb: correct } }
+    evidence: ["raw: gb uk_dft GenModel 'APRILIA SX 50' n=454, Model 'SX 50', BodyType 'Motorcycles'",
+               "raw: fi_traficom 'APRILIA SX 50' ajoneuvoluokka=L1e n=110 → moped; nl_rdw bromfiets 'SX 50' n=324",
+               "live sibling: moped/aprilia/sx50 [SX50] {fi,nl}",
+               "overrides/kind_maps/uk_dft.yml header: \"UK merges mopeds INTO Motorcycles (no separate class) → UK contributes evidence to kind=motorcycle only\""]
+    notes: "See NEW-CLASS §2: this is the documented uk_dft limitation turning into a published wrong-kind record plus a cross-kind duplicate. FI's own EU class proves the machine is L1e. 18 such gb-only/moped-twin pairs measured catalog-wide."
+
+  "motorcycle/kl-service/kxe300":
+    verdicts: { id: correct, name: "defective(D7 — space collapse: both registers write 'KXE 300')",
+                make: correct, kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'KL Service | KXE 300' fi_traficom TAN e13*168/2013*00709*03 — matches xrefs.tan (and *02/*04 for KXE 250/450)",
+               "raw: 'KL SERVICE | KXE 300' nl_rdw n=7"]
+    notes: "Not a marque-sourced verdict — no KL Service source reached — but the space collapse is provable from the corpus alone: the ONLY two rows that exist anywhere spell it 'KXE 300', and the published string appears in no source. That is the normalizer-space-collapse debt class, not a marque-rendering question. The sibling TANs (*02/*03/*04 for 250/300/450) confirm the capacities are separate approvals."
+
+  "motorcycle/renault/twizy":
+    verdicts: { id: "defective(D6 — the Twizy is live at moped/renault/twizy and car/renault/twizy too)",
+                name: correct, make: correct,
+                kind: "defective(D10 — an L6e/L7e quadricycle published as a motorcycle)",
+                availability: { nl: correct } }
+    evidence: ["raw: 'RENAULT | TWIZY' nl_rdw voertuigsoort='Driewielig motorrijtuig' n=598",
+               "overrides/kind_maps/nl_rdw.yml: 'Driewielig motorrijtuig: motorcycle  # L5e trikes → motorcycle'",
+               "raw: 'Renault | TWIZY' fi_traficom ajoneuvoluokka L7e n=13 / L6e n=1 → moped; es/lu/nz likewise moped",
+               "live siblings: moped/renault/twizy {es,fi,lu,nz}, moped/renault/twizy-45 {es,fi,nl}, car/renault/twizy {gb,my,ua}"]
+    notes: >-
+      THE SAME VEHICLE IN THREE KINDS. The Twizy has four wheels; RDW's
+      voertuigsoort vocabulary has no quadricycle value, so it files the L7e
+      Twizy under 'Driewielig motorrijtuig', which the kind_map sends to
+      motorcycle — while FI/ES/LU/NZ file it L6e/L7e, which the same repo sends
+      to moped. So one register's vocabulary gap, not the vehicle, decides the
+      kind. Measured: 482 ids exist in more than one kind catalog-wide, of which
+      95 are moped+motorcycle and 2 are car+moped+motorcycle (this is one).
+      PROPOSAL-kind-boundary.md §Q2 already resolves the question (L6e/L7e → car
+      with body_types ['quadricycle']); the mapping line above is the concrete
+      thing that has to change with it, and it is not currently listed in the
+      proposal's change list.
+
+  "motorcycle/harley-davidson/flht-touring":
+    verdicts: { id: "defective(D6 — flht and flht-electra-glide are the same motorcycle)",
+                name: "defective(D8 — 'Touring' is H-D's FAMILY, not a nameplate; FLHT is the Electra Glide)",
+                make: correct, kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # \"FLHT - Electra Glide®\"; and \"FL: A Touring or Softail® model with a 16-inch front wheel\" — Touring is the family",
+               "raw: 'HARLEY DAVIDSON | FLHT TOURING' nl_rdw n=1; fi present",
+               "live siblings: flht [FLHT] {fi,gb,nl,nz,ua}, flht-classic, flht-electra-glide, flht-electra-glide-standard"]
+    notes: "Decile 9 tail record resting on one nl row, but the name is wrong at the altitude level (family word promoted to nameplate) and the id is one of four for the FLHT. 48 FLHT* ids are live."
+
+  "motorcycle/honda/anc":
+    verdicts: { id: "defective(D6 — motorcycle/honda/anc125 is the same machine)",
+                name: "defective(D7 — model-column-acronym-casing; ANC is a Honda type code, not the word 'Anc')",
+                make: correct, kind: correct, availability: { gb: correct } }
+    evidence: ["raw: gb uk_dft GenModel 'HONDA ANC' n=1983 with Model 'ANC 125 F' — the register's own Model column resolves the GenModel truncation",
+               "raw: 'HONDA | ANC125' fi_traficom n=11 (TAN e4*2002/24*3015*01), nl n=23, es n=1",
+               "live sibling: motorcycle/honda/anc125 [ANC125] {es,fi,nl}"]
+    notes: >-
+      A UK-SPECIFIC TRUNCATION CLASS, and the fix is already in the data.
+      uk_dft's GenModel column is coarser than its Model column ('HONDA ANC' vs
+      'ANC 125 F'), so gb-only records systematically publish a truncated
+      nameplate that then mints an id beside the full one. The Model column is
+      already parsed (uk_dft.rb passes row[3] as the TAN slot) but is not used
+      to disambiguate GenModel. Same shape as yamaha/gts and cfmoto/800 in this
+      batch. Worth a detector: gb-only record whose name is a strict prefix of a
+      sibling's name in the same make.
+
+  "motorcycle/aprilia/tuareg-660":
+    verdicts: { id: correct, name: "unverifiable(aprilia.com 403)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["raw: es 'TUAREG 660' n=29; fi n=43 (TAN e49*168/2013*00092*00, in xrefs); lu n=4 (TAN e13*168/2013*02436*00, in xrefs); nl n=239; nz; ua n=1",
+               "former_ids.yml:224 'TUAREG660' → 'Tuareg 660' — spacing fix landed and aliased"]
+    notes: "Six-country modern record, all claims hold, and the spacing remedy is already applied with an alias. Sibling tuareg-660-rally is a distinct model; bare motorcycle/aprilia/tuareg {gb,nl} is the 1980s-90s Tuareg Wind, plausibly distinct."
+
+  "motorcycle/masai/125":
+    verdicts: { id: correct, name: "unverifiable(masai-motors.com did not resolve)", make: correct,
+                kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Masai | MASAI 125' fi_traficom ajoneuvoluokka=L3e n=3, TAN e3*2002/24*0370*01 — matches xrefs.tan",
+               "raw: 'MASAI | MASAI 125' nl_rdw n=2"]
+    notes: "Same false-legit mechanics as masai/50 — both corroborating strings are 'MASAI <capacity>', i.e. make + displacement with the nameplate absent. n=5 total. See the masai/50 note; this pair is the clearest evidence that `corroborated-numeric-nameplates` needs a 'and the two strings are not both make+number' guard."
+
+  "motorcycle/royal-alloy/gt125":
+    verdicts: { id: correct, name: "defective(D7 — marque writes 'GT 125 AC' spaced)", make: correct,
+                kind: correct, availability: { gb: correct } }
+    evidence: ["https://royalalloy.co.uk/motorcycles/gt-125/  # marque site: 'GT 125 AC', and the whole range is spaced — 'GP 125 LC', 'GP 300', 'TG 125 AC', 'TG 125 LC', 'TG 300 LC'",
+               "raw: gb uk_dft GenModel 'ROYAL ALLOY GT 125' n=2163 with Model 'GT 125' — the register spells it spaced too"]
+    notes: "Marque AND register agree on the spaced form; the closed 'GT125' appears in neither. Straight normalizer-space-collapse-display-names. Note the marque's own range is a good source for a whole-make pass (GP/TG families are in the catalog too)."
+
+  "motorcycle/harley-davidson/road-glide-cvo":
+    verdicts: { id: "defective(D6 — cvo-road-glide is the same motorcycle, token order inverted)",
+                name: "defective(D7 — H-D's nameplate is 'CVO Road Glide')",
+                make: correct, kind: correct, availability: { nl: correct, th: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/motorcycles/cvo-road-glide.html  # H-D's own page for the model, titled '2025 CVO Road Glide Motorcycle | Harley-Davidson USA'",
+               "raw: 'HARLEY DAVIDSON | ROAD GLIDE CVO' nl n=1, th n=1 (+ th 'ROAD GLIDE CVO ST' n=5)",
+               "raw for the sibling: 'CVO ROAD GLIDE' nl n=157, fi n=29, ua n=7 — the correct order outnumbers the inversion ~190:2",
+               "live sibling: motorcycle/harley-davidson/cvo-road-glide {fi,nl,ua}"]
+    notes: "Token-order inversion, the exact shape renames.yml already folds for Alfa Romeo ('Gtv 1750' → '1750 GTV', 'Gtv 6' → 'GTV6') with former_ids. Decile 10. The direct page fetch 404'd twice for me but the URL and its H-D-authored title are in the search index; verifier should re-fetch."
+
+  "motorcycle/honda/cb360":
+    verdicts: { id: correct, name: "unverifiable(no Honda source fetched)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | CB 360' nl_rdw n=177 + 'CB360' n=2; 'HONDA | CB360' nz_nzta n=33 + 'CB360G' n=5"]
+    notes: "Closed form matches NAMING §7.3's explicitly-cited Honda convention (CB750/CB1000R), and NZ's raw is closed while NL's is spaced — so the closed display is defensible. No CB360 sibling split."
+
+  "motorcycle/cfmoto/800":
+    verdicts: { id: correct, name: "defective(bare-displacement-2w / D9 — a capacity where a nameplate belongs)",
+                make: correct, kind: correct, availability: { gb: correct } }
+    evidence: ["data/name_shapes.yml debt entry `bare-displacement-2w` names cfmoto/800 EXPLICITLY (count 21, owner s2w)",
+               "raw: gb uk_dft is the only source; live siblings 800MT {es,fi,lu,nl,nz}, 800MT-X, 800NK carry the family words the gb GenModel dropped"]
+    notes: "Filed debt, so not a new finding — recorded as defective because the audit measures the published record, and the debt entry itself says these names are WRONG and not yet fixed. Same uk_dft GenModel-truncation mechanism as honda/anc: the family word survives in every other register."
+
+  "motorcycle/neco/azzuro-125":
+    verdicts: { id: correct, name: "unverifiable(no Neco source reached; UK dealer listings split 'Azzuro' vs 'Azzurro')",
+                make: correct, kind: correct, availability: { lu: correct, nl: correct } }
+    evidence: ["raw: 'NECO | AZZURO 125' lu_snca TAN e13*168/2013*00158*01 (matches xrefs) n=1; nl_rdw n=2",
+               "https://bikez.com/motorcycles/neco_azzurro_125_efi_2020.php  # 'Azzurro' (double r)",
+               "https://www.dundeescooters.co.uk/product/neco-azzuro-gp-125/  # 'Azzuro' (single r), a Neco dealer"]
+    notes: "SUSPECTED MISSPELLING I could not settle. Italian for blue is 'azzurro', and one spec database uses it; Neco's UK dealers use the single-r form, and both registers do too. Per 'majority is not authority' the registers do not settle it — a Neco (Taiwan/China) source would. Filed to the source-gap queue rather than called."
+
+  "motorcycle/ducati/multistrada-v4-pikes-peak":
+    verdicts: { id: correct, name: "unverifiable(ducati.com 403)", make: correct, kind: correct,
+                availability: { fi: correct, lu: correct, nl: correct, th: correct, ua: correct } }
+    evidence: ["raw: es 'MULTISTRADA V4 PIKES P' (truncated at 22 chars by the DGT field width); fi; lu; nl; th 'Multistrada V4 Pikes Peak' n=1; ua n=1"]
+    notes: "Worth noting for the availability method: es_dgt's MODELO field is 22 bytes, so long nameplates arrive truncated ('MULTISTRADA V4 PIKES P'). This record does not claim es, so nothing is wrong here — but a truncation-shaped id is a live risk in that source and I did not see a guard for it."
+
+  "motorcycle/cz/150c":
+    verdicts: { id: "defective(D6 — motorcycle/cz/150 is the same machine, per the repo's own enrichment note)",
+                name: "defective(D7 — space collapse; the marque and every source write 'ČZ 150 C')",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct }, enrichment: correct }
+    evidence: ["https://www.4jawa.com/category/703/cz-150-c-1950-1953  # authorised JAWA/ČZ parts dealer: 'ČZ 150 C [1950-1953]'",
+               "https://rd.vsb.cz/en/restored-motorbikes/cz-150c-1950/  # VŠB-TUO restoration workshop, 1950",
+               "raw: 'CZ | 150 C' nl_rdw n=5; 'CZ 150 C' n=1; 'CZ 150C' n=1; '150' n=20; nz present",
+               "enrich/cz.yml:57-60 and :89 — \"cz/150 ⇔ cz/150c — the same machine (no CZ 150 exists without the C)\""]
+    notes: "The duplicate is already DOCUMENTED IN THE REPO, in the enrichment file, which dates both ids identically \"so the pair stays consistent whichever way a future merge goes\". So this id defect is known and merely unactioned — but it is not filed in name_shapes debt, so it is invisible to the debt counter. Enrichment {1950,1953} re-derives from two independent non-Wikipedia sources: correct."
+
+  "motorcycle/honda/nss350a":
+    verdicts: { id: "defective(D6 — motorcycle/honda/forza-350 is the same scooter)",
+                name: "defective(D9 — NSS350 is Honda's type code; the nameplate is 'Forza 350')",
+                make: correct, kind: correct, availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["https://www.honda.co.uk/motorcycles/range.html  # Honda's own UK range lists 'Forza 350', not NSS350",
+               "raw: es 'NSS350A' n=468; fi n=102 (TAN e4*168/2013*00146*01, in xrefs); lu; nl",
+               "live siblings: motorcycle/honda/forza {nl,nz,th,ua}, forza-350 {th}, plus nss/nss125ad/nss250a/nss300a/nss750"]
+    notes: "The 'A' suffix is the ABS/variant letter, which NAMING §6's trim policy folds. Decile 1 — this is HEAD mass, so the claim-weighted cost is high. The whole NSS/Forza family (7 ids) has the same shape: European registers carry Honda's type code, Honda's own site carries the nameplate."
+
+  "motorcycle/husqvarna/sm510":
+    verdicts: { id: "defective(D6 — sm510r is very probably the same machine)",
+                name: "defective(D7 — space collapse; every register writes 'SM 510')",
+                make: correct, kind: correct, availability: { fi: correct, gb: correct, nl: correct } }
+    evidence: ["raw: fi 'SM 510' n=3 (TAN e3*2002/24*0100*06, matches xrefs) and 'SM 510 R' n=8 (TAN *0482*02 — a DIFFERENT approval)",
+               "raw: gb GenModel 'HUSQVARNA SM 510' n=77 with Model 'SM 510 R'; nl 'SM 510' n=17 + 'SM 510R' n=26"]
+    notes: "TWO-SIDED, and I am deliberately hedging the id half. The published string 'SM510' appears in no source — that part is clear. But the SM 510 / SM 510 R pair carries two DIFFERENT type-approval numbers in fi, which argues they are genuinely distinct approvals, while gb's Model column resolves its 'SM 510' GenModel to 'SM 510 R', which argues they are one. I record id as defective on the gb evidence and flag it as the weakest id call in this batch — the TAN split may well overturn it. No husqvarna-motorcycles.com source reached."
+
+  "motorcycle/puch/rla":
+    verdicts: { id: correct, name: "defective(D7 — the marque designation is 'RLA 125'; the published name drops the capacity)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["https://www.motorbooks.at/puch-r-rl-rla-125-ersatzteilkatalog  # factory parts-catalogue reprint: 'Puch R 125, RL 125 und RLA 125'",
+               "https://sites.google.com/site/puchnz/rla-125  # Puch specialist: RLA 125, 1955-57, Dynastarter version of the RL 125, 11,715 built",
+               "raw: 'PUCH | RLA' nl_rdw n=1 and '125 RLA' n=1; 'PUCH | RLA' nz_nzta n=1"]
+    notes: "SOFT CALL — flagged. The name is a genuine Puch designation, just without the capacity the factory always attached; the nl raw itself carries '125 RLA'. Decile 10, n=3 rows total. If the maintainer treats a bare designation letter-group as acceptable when a register supplies it bare, this flips to correct. kind=motorcycle is right (a 125cc Motorroller, L3e-equivalent), which is worth stating because 'Roller' invites a moped guess."
+
+  "motorcycle/sym/adx":
+    verdicts: { id: correct, name: "defective(D7 — model-column-acronym-casing; SYM's ADX is an initialism)",
+                make: correct, kind: correct, availability: { lu: correct, nl: correct } }
+    evidence: ["raw: 'SYM | ADX' lu_snca n=4, TAN e13*168/2013*02189*03 — matches xrefs.tan; nl present",
+               "raw corroboration that ADX is a code, from other countries: es 'ADX 300 TCS' n=196, 'ADX 125 LC TCS E5+' n=133; gb GenModel 'SYM ADX 125' n=182 with Model 'ADX 125'",
+               "styling.yml has no ADX pin, so smart_case title-cases it → 'Adx'"]
+    notes: "Textbook instance of the filed 511-record model-column-acronym-casing debt: a pure-alpha type code with no acronyms pin becomes a word. Sibling motorcycle/sym/adxtg [Adxtg] has the identical defect (SYM writes 'ADXTG 400'), so a single ADX/ADXTG pin fixes both. sym-global.com not fetched, so this is the repo's own rule + four registers writing caps, not a marque page."
+
+  "motorcycle/harley-davidson/xlch-1000":
+    verdicts: { id: correct, name: "defective(D7 — model-column-acronym-casing; XLCH is a Sportster frame code)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # 'XL: Sportster® models…', code letters are H-D's own notation, all caps",
+               "raw: nl 'XLCH 1000' n=2, 'XLCH-1000' n=1, 'XLCH 1000 SPORTSTER' n=2; nz 'XLCH 1000' n=1, 'XLCH1000' n=1"]
+    notes: "id NOT called defective: the bare motorcycle/harley-davidson/xlch sibling covers the 883cc XLCH (1958-71) as well as the 1000, so the capacity split is defensible under NAMING §6. Casing is the only defect. The '1000' is correctly spaced here, which is a useful counter-example to the space-collapse class — the collapse is not universal."
+
+  "motorcycle/honda/sd02":
+    verdicts: { id: "defective(D6 — the XL1000V Varadero is live at seven other ids)",
+                name: "defective(D9 — SD02 is Honda's model code for the XL1000V Varadero)",
+                make: correct, kind: correct, availability: { nl: correct } }
+    evidence: ["raw IN-DATA PROOF, same cell: 'Honda | VARADERO-SD02D/996' fi_traficom n=4, 'VARADERO-SD02B/996' n=4, 'XL1000VA-SD02C/996' n=1, 'XL1000V-SD02A/996 VARADERO' n=1 — the register pairs SD02 with VARADERO and XL1000V explicitly",
+               "raw: 'HONDA | SD02' nl_rdw n=475 (+ 'SD 02' n=3, 'HONDA SD02' n=1)",
+               "live siblings: varadero {fi,lu,nl,nz}, xl1000 {fi,nl}, xl1000-varadero {nl,ua}, xl1000v {fi,gb,lu,nl}, xl1000v-varadero {fi,nl,ua}, xl1000va {es,fi,lu,nl}, xl1000va-varadero {fi,nl,ua}"]
+    notes: >-
+      THE STRONGEST FINDING IN THIS BATCH, because it needs no external source:
+      the FI register itself writes 'VARADERO-SD02D/996' in a single cell, so
+      the code-to-nameplate mapping is IN THE CORPUS. 475 Dutch rows publish as
+      a bare Honda type code while eight ids describe the same motorcycle. This
+      is not a Wikipedia-grade inference; it is a join the pipeline could make
+      mechanically — any raw cell containing BOTH a published bare code and a
+      published nameplate for the same make is a merge candidate with in-data
+      proof. Proposed as a detector in NEW-CLASS §1.
+
+  "motorcycle/vincent/black-shadow":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["https://www.mcnews.com.au/vincent-black-shadow-specifications-series-c/  # Series C Black Shadow, 998cc 50° OHV V-twin, Girdraulic fork",
+               "https://rmsothebys.com/auctions/dd24/lots/r0143-1949-vincent-hrd-black-shadow-series-c/  # Vincent Owners Club register data cited (42 Vincent-HRD-branded Series C Black Shadows known)",
+               "raw: 'VINCENT | BLACK SHADOW' nl_rdw n=11; 'VINCENT HRD | BLACK SHADOW' n=3; 'BLACK-SHADOW' n=1; nz present"]
+    notes: "Clean record. make=vincent is right for the post-1949 branding, and the VINCENT HRD raws fold correctly (the marque dropped HRD in 1949-50). Series letters are below the nameplate, consistent with SCHEMA."
+
+  "motorcycle/indian/scout-bobber-twenty":
+    verdicts: { id: correct, name: "unverifiable(indianmotorcycle.com 403)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, ua: correct } }
+    evidence: ["raw: 'Indian Motorcycle | Scout Bobber Twenty' fi_traficom n=22, TAN e4*168/2013*00030*06 — matches xrefs.tan exactly",
+               "raw: 'INDIAN MOTORCYCLE | SCOUT BOBBER TWENTY' nl_rdw n=62; 'INDIAN | SCOUT BOBBER TWENTY' ua_mvs n=1"]
+    notes: "The 'INDIAN MOTORCYCLE' raw make folds to indian correctly — worth noting as a working make alias (it was the one case my automatic availability matcher missed). Sibling scout-bobber is the base model, genuinely distinct."
+
+  "motorcycle/honda/xl750":
+    verdicts: { id: "defective(D6 — xl750c is the same motorcycle; transalp/transalp-* describe the nameplate)",
+                name: "defective(D9 — Honda's own rendering is 'XL750 Transalp')",
+                make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct, ua: correct } }
+    evidence: ["https://www.honda.co.uk/motorcycles/range.html  # Honda UK's Adventure range: 'XL750 Transalp'",
+               "raw: es 'XL750' n=156 AND 'XL750C' n=429; fi n=96 (TAN e6*168/2013*00134*00, in xrefs); lu n=11; nl; ua",
+               "live siblings: xl750c {es,lu,nl,ua}, transalp {fi,gb,lu,nl,nz}, transalp-600/600v/650, transalp-xl600vr, xl600v-transalp, xl650v-transalp"]
+    notes: "Decile 1 — head mass. Honda pairs code and nameplate in ITS OWN model name, which is the cleanest possible statement that the two halves belong to one record; the catalog splits them anyway (and the older Transalps are split the same way, 5 more ids). The es 'XL750C' rows (n=429, more than the bare form) are the ABS/variant letter."
+
+  "motorcycle/honda/cb500x":
+    verdicts: { id: "defective(D6 — cb500xa/cb500xac are the ABS variants of the same motorcycle)",
+                name: "unverifiable(CB500X is discontinued and absent from Honda UK's current range page; no Honda archive fetched)",
+                make: correct, kind: correct, availability: { nl: correct, th: correct, ua: correct } }
+    evidence: ["raw: nl; th; ua carry 'CB500X'; es/fi/lu carry 'CB500XA' (n=121) and 'CB500XAC' (n=277) instead",
+               "live siblings: cb500xa {es,fi,lu,nl,ua}, cb500xac {es,lu,nl,ua}",
+               "https://www.honda.co.uk/motorcycles/range.html  # the CB500X's successor NX500 is listed; CB500X is not"]
+    notes: "NAMING §6 folds ABS ('ABS is EQUIPMENT and folds into the nameplate' — renames.yml:2400 does exactly this for Vespa Primavera 150 Iget Abs). The same fold has not been applied to Honda's A/AC suffixes, which appear across cb500fa/cb500fac/cb500xa/cb500xac/nss*a/xl750c. That is a family-wide, mechanically identifiable pass, not a per-record judgment."
+
+  "motorcycle/kymco/visar-125":
+    verdicts: { id: correct, name: "unverifiable(kymco.co.uk paths 404'd)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: gb uk_dft GenModel 'KYMCO VISAR 125' n=412 with Model 'VISAR 125' — GenModel and Model agree, so no truncation here"]
+    notes: "gb-only but not a truncation case, unlike honda/anc and yamaha/gts. Note fi has 'VISA R 50' (n=18) under Kymco — a different, 50cc machine, so no cross-kind twin."
+
+  "motorcycle/ktm/250exc-tpi":
+    verdicts: { id: correct, name: "defective(D7 — KTM writes '250 EXC TPI'; published '250EXC Tpi' is space-collapsed AND title-cases an initialism)",
+                make: correct, kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.ktm.com/ee/enduro/250-exc-tpi  # KTM's own model page for the 250 EXC TPI (TPI = Transfer Port Injection, all caps)",
+               "raw: 'KTM | KTM 250 EXC TPI' fi_traficom n=160, TAN e1*168/2013*00050*00 — matches xrefs.tan; '250 EXC TPI' n=1; nl present"]
+    notes: "TWO defects in one string, the same pairing as street-bob114: the collapse joins 250+EXC, and 'Tpi' is the acronym-casing class. Note EXC survived in caps only because it is glued to a digit — which again shows the collapse and the caser interacting. Decile 2, head mass."
+
+  "motorcycle/lambretta/gp":
+    verdicts: { id: correct, name: "defective(D7 — model-column-acronym-casing; GP = Grand Prix)", make: correct,
+                kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["https://www.lambretta.com/classics/grand-prix-dl/  # the marque's own classics page: 'Grand Prix DL' — GP is the UK-market name of the DL range (125/150/200)",
+               "raw: 'LAMBRETTA | GP' nl_rdw n=1; nz_nzta n=19 — registers write GP in caps"]
+    notes: "id NOT called defective. GP is the family designation and gp150/gp200 (gb) are capacity members, which §7.2 explicitly blesses for 2W ('legitimate capacity umbrellas'). Only the casing is wrong."
+
+  "motorcycle/lexmoto/valiant":
+    verdicts: { id: correct, name: "unverifiable(lexmoto.com paths 404'd)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: gb uk_dft GenModel 'LEXMOTO VALIANT' n=372 with Model 'VALIANT 125 EFI XF 125 R E4'"]
+    notes: "The Model column carries the capacity and the OEM code (XF 125 R) that the GenModel drops, so 'Valiant 125' may be the fuller nameplate — the same uk_dft GenModel-coarseness question as honda/anc, but here the bare name is at least a real word and not a truncated code."
+
+  "motorcycle/harley-davidson/flstc-heritage-classic":
+    verdicts: { id: "defective(D6 — eight live FLSTC ids for one motorcycle)",
+                name: "defective(D7 — H-D's name is 'Heritage Softail Classic'; published drops Softail and title-cases the code)",
+                make: correct, kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # \"FLSTC - Heritage Softail® Classic\"",
+               "raw: es 'HERITAGE CLASSIC' n=12, 'FLSTC' n=1; fi and nl carry the code+name mixtures",
+               "live siblings: flstc {es,fi,gb,lu,nl,nz,th,ua}, flstc-103, flstc-103-heritage-softail-classic, flstc-heritage, flstc-heritage-softail, flstc-heritage-softail-cl, flstc-heritage-softail-classic, flstc-softail-classic, flstc-softail-heritage-classic (+ flstci ×4)"]
+    notes: "The single worst id fan-out I found: NINE FLSTC-prefixed ids (plus four FLSTCI) for what H-D lists as one code and one name. 'Flstc Heritage Softail Cl' among them is a truncated register string promoted to a nameplate. The published name here is also a strict subset of a sibling's, so a prefix-subset detector would catch the pair."
+
+  "motorcycle/ktm/rc":
+    verdicts: { id: correct, name: "defective(D7 — model-column-acronym-casing; KTM's RC family is an initialism)",
+                make: correct, kind: correct, availability: { nz: correct } }
+    evidence: ["raw: 'KTM | RC' nz_nzta n=382 — NZTA's model column genuinely holds only 'RC'",
+               "raw corroboration that RC is a code: fi 'KTM RC 125' n=59, 'KTM RC 390' n=22; lu 'RC 125'; ua 'RC 390' n=13; th 'RC 250'"]
+    notes: "id correct: bare RC with 382 NZ rows is the honest maximum when the register records no capacity — the same reasoning name_shapes uses for the make-as-model rows, and §7.2's capacity-umbrella rule. Casing only. Decile 1, so this cheap fix carries head weight."
+
+  "motorcycle/mv-agusta/350s":
+    verdicts: { id: correct, name: "defective(D7 — space collapse; the marque and the dominant raw write '350 S')",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["https://www.autoevolution.com/moto/mv-agusta/350-s/  # spec database rendering '350 S' (S = Sport), 1970-1978",
+               "raw: 'M.V. AGUSTA | 350 S' nl_rdw n=49 vs '350S' n=3; sibling raws '350 GT' n=24, '350 B' n=9, '350 SPORT' n=3; nz present"]
+    notes: "Weakest name source in the batch (a spec database, not a marque or specialist register) — but the corpus alone makes the case: the spaced form outnumbers the closed 16:1 within the same register, and the sibling designations are all spaced. styling.yml's MV pin correctly keeps the make as 'MV Agusta'. Verifier may prefer to downgrade this to unverifiable."
+
+  "motorcycle/honda/gl1500c-f6c":
+    verdicts: { id: "defective(D6 — gl1500c and f6c are both live and are the same motorcycle)",
+                name: "unverifiable(no Honda source reached; the concatenation matches no single marque rendering)",
+                make: correct, kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["https://en.enduro.team/Honda_Valkyrie_1500  # factory designation GL1500C; US nameplate Valkyrie; F6C ('Flat Six Custom') elsewhere",
+               "https://www.nationalcycle.com/vehicles/motorcycle-1/honda/hondagl1500cvalkyrief6c.html  # 'GL1500C Valkyrie/F6C'",
+               "live siblings: motorcycle/honda/gl1500c [GL1500C] {fi,gb,nl}, motorcycle/honda/f6c [F6C] {gb,nl}"]
+    notes: "Three ids for one motorcycle: the code, the European nameplate, and the two glued together. The name verdict is unverifiable rather than defective because Honda genuinely uses BOTH strings in different markets and I could not reach a Honda page to see whether it ever pairs them — but the id defect stands regardless of which rendering wins."
+
+  "motorcycle/piaggio/px200":
+    verdicts: { id: "defective(D6 — motorcycle/vespa/px200 is the same scooter)",
+                make: "defective(D11 — the PX is a Vespa; Piaggio is the approval holder)",
+                name: "defective(D7 — space collapse; marque and register write 'PX 200')",
+                kind: correct, availability: { gb: correct, nl: correct } }
+    evidence: ["raw: gb uk_dft GenModel 'PIAGGIO PX 200' n=3649 with Model 'PX 200 E'",
+               "raw: 'PIAGGIO | VESPA PX 200 E' nl_rdw n=2; 'PX200 COSA' n=1; 'PX200E' n=1",
+               "live sibling: motorcycle/vespa/px200 [PX200] {nl,nz} — SAME name, different make",
+               "moves.yml lines 76-120 move ~40 'Piaggio|Vespa <X>' pairs to Vespa; the header documents the approval-holder trap"]
+    notes: >-
+      THE MOVES.YML BLIND SPOT, and both halves of the pair happen to be in this
+      batch (see motorcycle/vespa/px200 below). moves.yml keys on the marque word
+      appearing IN THE MODEL STRING ('Piaggio|Vespa PX200'), so it cannot catch a
+      row where the register wrote the marque only in the make column and left a
+      bare 'PX 200' in the model column — which is exactly what uk_dft did (3,649
+      UK rows). Result: one scooter, two makes, two ids, and the bigger evidence
+      mass sitting under the wrong marque. Detector: for any make pair already in
+      moves.yml, flag identical model names living on both sides.
+
+  "motorcycle/harley-davidson/fxrp":
+    verdicts: { id: correct, name: "defective(D7 — model-column-acronym-casing; FXRP is an H-D frame code)",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct, th: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # \"FXRP - Dyna Police Pursuit\"",
+               "raw: 'Harley-Davidson | FXRP' fi_traficom n=1; nl, nz, th present — all caps"]
+    notes: "id correct: sibling fxr is the civilian FXR and FXRP is the police variant, a genuinely different machine per H-D's own list. Casing only. name_shapes:511 already names 'harley-davidson/Fxrs Super Glide II (FXRS)' as this exact residual, so FXRP/FXRS/FXR are one pin away."
+
+  "motorcycle/suzuki/uk110":
+    verdicts: { id: "defective(D6 — motorcycle/suzuki/address is the same scooter's nameplate)",
+                name: "defective(D9 — UK110 is Suzuki's type code; the nameplate is 'Address 110')",
+                make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, lu: correct, nl: correct, nz: correct } }
+    evidence: ["https://www.globalsuzuki.com/motorcycle/smgs/digital-archive/2_bike/scooter_162.php  # SUZUKI'S OWN digital archive names it 'Address 110' and gives no type code",
+               "https://www.suzukicycles.org/Address-series/Address-110.shtml  # Suzuki specialist: 'Suzuki Address 110 (UK110)' — code and nameplate paired",
+               "raw: fi 'UK110' n=59 (TAN e4*2002/24*3114*00, in xrefs); gb GenModel 'SUZUKI UK 110' with Model 'UK 110 NE'; lu; nl n=266; nz n=218 + bare 'UK' n=372",
+               "live sibling: motorcycle/suzuki/address [Address] {nl,nz,th}"]
+    notes: "FIVE registers agree on the code and the marque's own archive uses the nameplate — a clean demonstration that register agreement (5 sources!) says nothing about whether a string is a nameplate. `corroborated-code-string-records` (min 2 sources/countries) would excuse this shape forever. Note nz also publishes a bare 'UK' id from 372 rows, which is a truncation of the same code."
+
+  "motorcycle/piaggio/liberty-125":
+    verdicts: { id: "defective(D6 — liberty-125abs is the ABS variant of the same scooter)",
+                name: "unverifiable(piaggio.com 403)", make: correct, kind: correct,
+                availability: { es: correct, nl: correct } }
+    evidence: ["raw: es 'LIBERTY 125' n=1 and 'LIBERTY 125 ABS' n=950; nl present",
+               "live siblings: motorcycle/piaggio/liberty-125abs {es,fi,lu,nl}, motorcycle/piaggio/liberty {fi,gb,lu,nl,nz}, moped/piaggio/liberty, moped/piaggio/liberty-50, moped/piaggio/liberty-corporate",
+               "renames.yml:2400 — 'Primavera 150 Iget Abs' → 'Primavera 150 Iget' \"ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy)\""]
+    notes: "The ABS fold is settled policy and already applied to Vespa in the SAME approval-holder cluster; Piaggio's own Liberty was missed. Note the es evidence is lopsided (1 non-ABS row vs 950 ABS rows), so the fold direction matters: the surviving id should be liberty-125 and liberty-125abs's evidence must be unioned in, not dropped (D19)."
+
+  "motorcycle/honda/mx650":
+    verdicts: { id: correct, name: "unverifiable(no Honda source records an MX650; suspected corruption of FMX650, but no source proves the target)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | MX650' nl_rdw n=1; 'HONDA | MX 650' nz_nzta n=1 — two rows, total",
+               "live sibling: motorcycle/honda/fmx650 [FMX650] {fi,gb,lu,nl,nz,ua}, gb Model 'FMX 650-5', nl n=168",
+               "https://www.honda.co.uk/motorcycles/range.html  # Honda's off-road prefix is CRF; no MX prefix exists in the range"]
+    notes: >-
+      DELIBERATELY NOT CALLED, on the repo's own precedent. name_shapes'
+      matchless entry says it exactly: \"'matches no source' tells you a string
+      is probably corrupt; it does not tell you what it is corrupt OF, and a fold
+      needs a target.\" FMX650 is the obvious target and dropping the F is the
+      obvious mechanism, but inferring it from a sibling is the family-pattern
+      move that entry warns against. Two registers each contributing one row is
+      also consistent with a genuine grey-import oddity. Resolvable by reading
+      the nz_nzta row's detail or an RDW type-approval lookup. Decile 9.
+
+  "motorcycle/royal-enfield/goan-classic-350":
+    verdicts: { id: correct, name: "unverifiable(royalenfield.com 403)", make: correct, kind: correct,
+                availability: { es: correct, nl: correct } }
+    evidence: ["raw: 'ROYAL ENFIELD | GOAN CLASSIC 350' es_dgt n=11; nl_rdw present",
+               "live sibling classic-350 {es,fi,lu,nl,nz,th} — a different model, correctly separate"]
+    notes: "Recent (2025) model; the register string is already the full nameplate, which is the normal case for new models and a useful contrast with the classics in this batch."
+
+  "motorcycle/harley-davidson/rh1250s":
+    verdicts: { id: "defective(D6 — motorcycle/harley-davidson/sportster-s is the same motorcycle)",
+                name: "defective(D9 — RH1250S is the model code; H-D's nameplate is 'Sportster S')",
+                make: correct, kind: correct,
+                availability: { nl: correct, nz: correct, th: correct, ua: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # \"RH1250S - Sportster® S\" — the marque's own code-to-name pairing",
+               "https://www.harley-davidson.com/us/en/motorcycles/sportster-s.html  # the model page uses 'Sportster S' throughout and never the code",
+               "raw: nl 'RH1250 S' n=1; nz 'RH1250S' n=3; th 'RH1250S' n=94; ua 'RH 1250S' n=12",
+               "live sibling: motorcycle/harley-davidson/sportster-s [Sportster S] {es,fi,lu,nl,ua}"]
+    notes: "The clearest code/name split in the batch: H-D publishes the mapping itself, and the two ids split the evidence 4 countries / 5 countries with no overlap except nl. Sibling rh975 (the Nightster) has the same shape."
+
+  "motorcycle/yamaha/mt-07":
+    verdicts: { id: "defective(D6 — mt-07abs, mt07a and mt07la are variant spellings/ABS forms of the same motorcycle)",
+                name: "unverifiable(yamaha-motor.eu socket hang-up)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct, nz: correct, th: correct, ua: correct } }
+    evidence: ["raw: fi 'MT-07' n=140 (TAN e13*2002/24*0660*00, in xrefs) and 'MTN690-A (MT-07)' n=117 — the register pairs Yamaha's type code with the nameplate in one cell",
+               "seven-country evidence all verified: es, fi, lu, nl, nz, th, ua",
+               "live siblings: mt-07abs {fi,nl}, mt07a {lu,nl}, mt07la {nz}, mt-07-tracer {fi,nl}",
+               "styling.yml pins MT as an acronym (\"Yamaha MT (Master of Torque) naked family\") — the hyphenated display is deliberate"]
+    notes: "Decile 2, seven countries — the heaviest record in the batch, and its availability is perfect. The defect is the variant fan-out: MT-07 / MT-07ABS / MT07A / MT07LA are one nameplate (ABS folds per policy; A/LA are approval suffixes; the fi cell 'MTN690-A (MT-07)' proves the code-nameplate identity in-data). mt-07-tracer is genuinely a different model."
+
+  "motorcycle/vespa/px200":
+    verdicts: { id: "defective(D6 — motorcycle/piaggio/px200 is the same scooter under the approval holder)",
+                name: "defective(D7 — space collapse; Vespa and the registers write 'PX 200')",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'VESPA | PX 200 E' nl_rdw n=7; 'PX200E' n=5; 'PX 200 E IRIS' n=3; 'PX200' n=2; 'PX 200E' n=2; nz present",
+               "live sibling: motorcycle/piaggio/px200 [PX200] {gb,nl} — see that record's note for the moves.yml mechanism"]
+    notes: "This is the CORRECT-MARQUE half of the pair; the Piaggio half holds 3,649 gb rows. Whichever id survives, the merge must union both evidence sets or gb availability is lost (D19). Also note px200e is live in BOTH makes as well, so the pair is really four ids."
+
+  "motorcycle/honda/shadow-1100":
+    verdicts: { id: "defective(D6 — vt1100c-shadow / vt1100-shadow / shadow-vt1100c2 describe the same motorcycle)",
+                name: "unverifiable(no Honda source fetched; 'Shadow 1100' is the US nameplate form)",
+                make: correct, kind: correct, availability: { nl: correct, ua: correct } }
+    evidence: ["raw: fi pairs code and name in single cells — 'SHADOW-VT1100C2-SC32/1099' n=6, 'SHADOW VT1100C2-SC43A/1099' n=2 (in-data proof of identity)",
+               "live siblings: vt1100 {gb,lu,nl,nz}, vt1100-shadow {fi,nl}, vt1100c {fi,nl,nz}, vt1100c-shadow {fi,nl,nz}, vt1100c2 {fi,lu,nl,ua}, vt1100c2-shadow {fi,nl}, vt1100c3, vt1100cg, shadow-vt1100c2, shadow {fi,lu,nl,nz,ua}, shadow-750"]
+    notes: "Eleven live ids across the VT1100/Shadow family. The C/C2/C3/CG suffixes are real Honda variants so not all merge, but 'VT1100C Shadow' vs 'Shadow VT1100C2' vs bare 'Shadow' vs 'Shadow 1100' is the code/name/inversion pattern again, with the fi register itself supplying the join."
+
+  "motorcycle/vespa/primavera-125":
+    verdicts: { id: "defective(D6 — primavera-125abs is the ABS variant of the same scooter)",
+                name: correct, make: correct, kind: correct,
+                availability: { es: correct, lu: correct, nl: correct, ua: correct } }
+    evidence: ["https://storeusa.vespa.com/primavera.aspx  # Vespa's own range is Primavera + displacement; the European 125 is the same construction",
+               "raw: es 'VESPA PRIMAVERA 125' n=555; lu n=13 (TAN e13*168/2013*02062*00, in xrefs); nl n=31; ua n=1",
+               "live sibling: motorcycle/vespa/primavera-125abs [Primavera 125ABS] {es,fi,nl,ua}"]
+    notes: "Name is Vespa's own rendering — correct. The ABS twin is the same fold that renames.yml:2400 already applied to the 150 Iget; the 125 was missed. Note the ABS id also carries fi evidence the base id lacks, so the union matters."
+
+  "motorcycle/harley-davidson/superlow":
+    verdicts: { id: "defective(D6 — xl883l and xl-sportster-883l-super-low are the same motorcycle)",
+                name: "unverifiable(H-D's discontinued-model archive not reached; H-D's live pages render camel-case 'SuperLow', but I could not fetch one)",
+                make: correct, kind: correct, availability: { fi: correct, gb: correct, nl: correct } }
+    evidence: ["raw: 'Harley-Davidson | SUPERLOW' fi_traficom n=7 (TAN e4*2002/24*0208*16 — matches xrefs.tan), 'Super Low' n=6, 'XL Sportster 883L Super Low' n=57, 'SUPERLOW 1200T' n=10",
+               "live siblings: xl883l [XL883L] {fi,nl}, xl-sportster-883l-super-low {fi,nl}, superlow-1200t {fi,lu,nl}"]
+    notes: "The register writes the same machine four ways in ONE country (SUPERLOW / Super Low / XL Sportster 883L Super Low / with the 1200T capacity), and three of those became ids. superlow-1200t is a genuine capacity variant and stays. Casing (Superlow vs SuperLow) is left unverified deliberately — registers uppercase everything and I had no marque page."
+
+  "motorcycle/harley-davidson/vrsca-v-rod":
+    verdicts: { id: "defective(D6 — vrsca and v-rod are both live and are the same motorcycle)",
+                name: "defective(D6/D9 — a code+nameplate concatenation that matches no H-D rendering)",
+                make: correct, kind: correct, availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["https://www.lowbrowcustoms.com/blogs/motorcycle-how-to-guides/deciphering-harley-davidson-motorcycle-model-designation-codes  # VRSCA = V-Rod; 'V designates the Revolution Motor found in V-Rod models'",
+               "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # H-D's own code page confirms the code/name split convention ('R: A model powered by the Revolution® Max engine')",
+               "raw: es 'VRSCA VROD' n=1, 'VRSCAW' n=2, 'V-ROD' n=1; fi and nl carry both halves",
+               "live siblings: vrsc, vrsca {fi,gb,nl,nz,ua}, v-rod {es,fi,lu,nl,nz,ua}, v-rod-muscle, vrscaw, vrscaw-v-rod, vrscawa-v-rod, vrscb, vrscb-v-rod, vrscd, vrscd-night-rod, vrscdx ×4, vrscf, vrscf-v-rod-muscle, vrscr ×3, vrscse ×2, vrscx"]
+    notes: "23 live VRSC* ids. The pattern is mechanical: for each suffix, the register produces the bare code, the code+name, and sometimes the name alone, and all three publish. The H-D code page did not enumerate VRSCA specifically (it covers current models), so the code-to-name mapping here rests on a specialist source — verifier may downgrade the name verdict to unverifiable while keeping the id verdict."
+
+  "motorcycle/harley-davidson/xl883c-sportster":
+    verdicts: { id: "defective(D6 — xl883c and xl883c-sportster-custom are the same motorcycle)",
+                name: "defective(D7 — XL883C is the Sportster 883 Custom; the published name drops 'Custom')",
+                make: correct, kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # \"XL883 - Sportster® 883\"; XL: Sportster models",
+               "raw: 'Harley-Davidson | XL 883C' fi_traficom n=61 (TAN e4*2002/24*0208*06) and 'XL883C SPORTSTER CUSTOM' n=25 (TAN *0208*01)",
+               "live siblings: xl883 {fi,nl,nz,ua}, xl883-hugger, xl883-sportster, xl883c {fi,nl}, xl883c-sportster-custom {fi,nl}, xl883l, xl883n, xl883n-iron, xl883r"]
+    notes: "The fi register carries the FULL name ('XL883C SPORTSTER CUSTOM') and the catalog publishes both it and the truncated 'XL883C Sportster' as separate ids — so the corpus contains its own correction. Nine XL883* ids live."
+
+  "motorcycle/harley-davidson/xr1000":
+    verdicts: { id: correct, name: "unverifiable(no H-D archive source for the 1983-84 XR1000 fetched)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HARLEY DAVIDSON | XR 1000' nl_rdw n=13, 'XR1000' n=1; nz 'XR1000' n=3, 'XR 1000' n=1"]
+    notes: "The all-caps closed form matches H-D's code convention, and no code+name sibling exists (the XR1200/XR1200X are later, separate machines). Left unverified rather than assumed. NB the dominant nl raw is spaced 'XR 1000' (13 vs 1), so a space-collapse question is open even though the closed form is the marque's convention."
+
+  "motorcycle/kawasaki/kz1300":
+    verdicts: { id: "defective(D6 — motorcycle/kawasaki/z1300 is the same motorcycle under its other market designation)",
+                name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["https://www.motorcycleclassics.com/classic-japanese-motorcycles/kawasaki-kz1300/  # 'after 20,000 KZ1300/Z1300 models' — one machine, two designations (KZ = US market)",
+               "raw: fi 'KZ1300' n=3, 'KZ 1300' n=2, 'Z1300' n=7, 'KZ1300-KZ1300A1/1286' n=1 (code+variant in one cell); nl 'Z 1300' n=223; nz present",
+               "live siblings: motorcycle/kawasaki/z1300 {fi,nl,nz}, z1300-6 {fi,nl}"]
+    notes: >-
+      A JUDGMENT CALL I want the verifier to rule on rather than inherit.
+      KZ1300 and Z1300 are the same motorcycle under US and RoW designations, so
+      by the protocol's test ('no other live id denotes the same vehicle') this
+      is a duplicate. But one could hold that market designations are distinct
+      nameplates, in which case both ids are right. The repo has no stated rule;
+      the analogous Honda case (GL1500C / F6C / Valkyrie) is currently split
+      three ways, i.e. the same unstated policy. Worth deciding once, globally —
+      it recurs across every Japanese marque. The NAME is correct either way.
+
+  "motorcycle/kawasaki/sr650":
+    verdicts: { id: correct, name: "defective(D9 — no Kawasaki designation 'SR650' exists; the machine is the Z650 SR / KZ650-D4)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["https://www.motorcycleclassics.com/classic-japanese-motorcycles/kawasaki-kz650sr/  # '1978-1981 Kawasaki KZ650SR'",
+               "https://www.motorbikecatalog.com/moto/1981/225050/kawasaki_z_650_sr_kz650-d4.html  # 'Kawasaki Z 650 SR (KZ650-D4)'",
+               "raw: 'KAWASAKI | SR 650' nl_rdw n=1; 'SR650' nz_nzta n=1 — and in the SAME nl register, 'CSR 650' n=11, 'C SR 650' n=1, 'KZ 650 SR CSR 650' n=1"]
+    notes: "Kawasaki's designation puts the capacity first (Z650 SR, KZ650 CSR); 'SR650' inverts it. The nl cell 'KZ 650 SR CSR 650' is in-data proof of the real form. Two rows total, decile 10. Sources are specialist/spec databases, not Kawasaki — verifier may prefer unverifiable; I call it defective because the published string appears in NO source, marque or register, in that order."
+
+  "motorcycle/moto-guzzi/breva-1200":
+    verdicts: { id: correct, name: "unverifiable(motoguzzi.com not fetched)", make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, nl: correct } }
+    evidence: ["raw: 'Moto Guzzi | BREVA 1200' fi_traficom n=1, TAN e11*2002/24*0152*05 — matches xrefs.tan; gb and nl present",
+               "siblings breva {fi,gb,nl,nz}, breva-850 {fi,nl}, breva-1100 {fi,gb,nl} — capacity members, correctly separate per NAMING §6"]
+    notes: "Bare 'Breva' alongside the three capacities is the capacity-umbrella shape §7.2 permits; not called. fi rests on a single row but the TAN matches."
+
+  "motorcycle/moto-guzzi/v7-ambassador":
+    verdicts: { id: correct, name: "unverifiable(no Moto Guzzi source fetched; 'Ambassador' was the US name of the V750, so the V7+Ambassador pairing needs a marque source)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'MOTO GUZZI | V7 AMBASSADOR' nl_rdw voertuigsoort 'Motorfiets met zijspan' n=1 (kind_maps folds sidecar rigs into motorcycle); nz present",
+               "raw context: 'MOTO-GUZZI | V7' nl n=166 + 16 sidecar rows; live sibling motorcycle/moto-guzzi/v7 {fi,gb,nl,nz,ua}"]
+    notes: "FLAGGED AS A LIKELY CONFLATION, not called. The V7 (1967, 703cc) and the Ambassador (V750, the US-market successor) are usually treated as different machines, so 'V7 Ambassador' may be a register conflation that mints a false model — but it is also possible Moto Guzzi's US importer badged an early V7 that way. One nl sidecar row and nz. A motoguzzi.com heritage page or a Moto Guzzi club register would settle it; this is a source-gap item."
+
+  "motorcycle/suzuki/dr125se":
+    verdicts: { id: correct, name: "unverifiable(no Suzuki source fetched)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'SUZUKI | DR125SE' nl_rdw n=2, 'DR 125SE' n=1; nz present",
+               "siblings dr125 {gb}, dr125s {nl,nz}, dr125sm {fi,nl} — distinct Suzuki suffixes"]
+    notes: "styling.yml pins DR as an acronym, so the display is not title-cased. Thin (n=3 nl) but the suffix family is coherent."
+
+  "motorcycle/suzuki/intruder-vs800glp":
+    verdicts: { id: "defective(D6 — vs800glp is live and is the same motorcycle)",
+                name: "defective(D6 — a name+code concatenation; five other ids split the same machine)",
+                make: correct, kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["raw: fi 'INTRUDER 1400-VX51L/1360' n=18 and 'VS 800' n=2 — the register pairs nameplate and code in single cells",
+               "live siblings: vs800glp [VS800GLP] {fi,lu,nl,nz}, vs800gl {fi,nl,nz}, vs800 {fi,gb,nl,nz}, vs800-intruder {fi,nl}, intruder-800 {fi,nl,ua}, intruder {fi,lu,nl,nz}"]
+    notes: "SIX live ids for the Suzuki VS800 Intruder: bare code, code+suffixes, code+name, name+code, name+capacity, bare name. The GLP trailing 'P' is a model-year letter, which is below the nameplate. Decile 9, but the family is large and the pattern is mechanical."
+
+  "motorcycle/triumph/bonneville-t100bud-ekins":
+    verdicts: { id: correct, name: "defective(D7 — space collapse glues T100 to BUD; Triumph writes 'Bonneville T100 Bud Ekins')",
+                make: correct, kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["https://triumph-mediakits.com/en/news-articles/new-2020-bud-ekins-bonneville-t120-and-t100-special-editions.html  # Triumph's OWN media site: 'Bud Ekins Bonneville T120 and T100 Special Editions'",
+               "https://www.triumphmotorcycles.co.uk/motorcycles/classic/bonneville-t100  # marque renders the base model 'BONNEVILLE T100'",
+               "raw: 'Triumph' fi_traficom, TAN e5*168/2013*00003*01 matches xrefs.tan; nl present"]
+    notes: "Pure normalizer-space-collapse-display-names: the boundary between '100' and 'BUD' was collapsed, and because the resulting token carries digits the caser left it shouting — the same two-mechanism interaction as street-bob114 and 250EXC Tpi. Three of this batch's name defects share it, which is a useful signal about where that debt entry's 267 records actually hurt."
+
+  "motorcycle/triumph/t100-tiger":
+    verdicts: { id: "defective(D6 — motorcycle/triumph/tiger-100 is the same motorcycle)",
+                name: "unverifiable(no Triumph source for the classic Tiger 100's rendering fetched)",
+                make: correct, kind: correct, availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Triumph | T100 Tiger' fi_traficom n=1; 'T100C Tiger Competition' n=1; nl present",
+               "live siblings: motorcycle/triumph/tiger-100 [Tiger 100] {nl,nz}, tiger-100ss {fi,nz}, t100 {lu,nl,nz}, t100c, t100r, t100r-daytona, t100ss",
+               "https://www.triumphmotorcycles.co.uk/motorcycles/classic/bonneville-t100  # T100 is Triumph's code, used today inside 'Bonneville T100'"]
+    notes: "Seven T100*/Tiger-100 ids. 'T100 Tiger' and 'Tiger 100' are the same machine with the tokens inverted; which spelling should survive needs a Triumph source I did not fetch, so the name verdict stays unverifiable while the id verdict stands."
+
+  "motorcycle/triumph/trophy-tr6r":
+    verdicts: { id: "defective(D6 — tr6r is live, and tr6r-tiger contradicts this record's own naming)",
+                name: "unverifiable(no Triumph source fetched; the marque's TR6R and TR6 Trophy designations are contested between the two sibling ids)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["live siblings: tr6r [TR6R] {nl,nz}, tr6r-tiger [TR6R Tiger] {nl,nz}, tr6 [TR6] {gb,lu,nl,nz}, tr6-trophy [TR6 Trophy] {fi,nl,nz}, trophy {fi,gb,nl,nz}, t309-trophy, t312-trophy",
+               "raw: nl 'TROPHY 900' n=208, 'TROPHY 1200' n=123 (modern Trophies, different machines); lu 'TR6' n=1"]
+    notes: "THE CATALOG CONTRADICTS ITSELF HERE, which is why I flag it: 'Trophy TR6R' and 'TR6R Tiger' attach two DIFFERENT nameplates to the same Triumph code, and both are live. Triumph used TR6 Trophy and later TR6R Tiger 650 / TR6C Trophy Special in different years, so one of the two is period-wrong — but resolving which needs a Triumph source. The id verdict (tr6r + one of these two is a duplicate) holds regardless."
+
+  "motorcycle/yamaha/gts":
+    verdicts: { id: "defective(D6 — gts1000/gts1000a are the same motorcycle; this is a uk_dft GenModel truncation)",
+                name: "defective(D7 — model-column-acronym-casing; 'Gts' for Yamaha's GTS)",
+                make: correct, kind: correct, availability: { gb: correct, nz: correct } }
+    evidence: ["raw: gb uk_dft GenModel 'YAMAHA GTS' n=19 with Model 'GTS 1000 A' — the register's own Model column names the machine",
+               "raw: nl 'GTS 1000' n=196, 'GTS 1000 ABS' n=45, 'GTS 1000,GTS 1000 A' n=5 (a comma-joined cell), 'GTS1000' n=3",
+               "live siblings: motorcycle/yamaha/gts1000 [GTS1000] {nl,nz}, gts1000a [GTS1000A] {nl,nz}",
+               "DEBT.md lists 'vespa GTS/GTV' among ~40 unverified uniformly-wrong casing candidates"]
+    notes: "Both defects in one record: the UK GenModel truncation mints the id, and the missing GTS pin title-cases it. Note the same 'Gts' string is live under sym and vespa too, so one pin fixes three makes — but DEBT.md flags that this needs cross-make attestation plus marque styling, which I did not do."
+
+  "motorcycle/yamaha/wr400f":
+    verdicts: { id: correct, name: "unverifiable(no Yamaha source fetched)", make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: nl_rdw and ua_mvs both carry WR400F; the same registers carry WR450/WR450F separately (fi 'WR450F-CJ07W/449')"]
+    notes: "Closed form matches Yamaha's convention (§7.3 cites Yamaha MT09). Sibling motorcycle/yamaha/wr [Wr] {gb,nz} is a truncated-and-title-cased id of the same family — not this record, but the same two mechanisms as yamaha/gts."
+
+  "motorcycle/yamaha/xv535-virago":
+    verdicts: { id: "defective(D6 — xv535 and virago-xv535 are the same motorcycle)",
+                name: "unverifiable(no Yamaha source fetched)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: fi 'XV 535 VIRAGO' n=1, 'XV 535' n=5, 'XV535' n=2, 'VIRAGO' n=9, 'XV 535-2YL/535' n=1 (code+variant in one cell); nl present",
+               "live siblings: xv535 [XV535] {fi,lu,nl,ua}, virago-xv535 [Virago XV535] {fi,nl}, virago {fi,lu,nl,nz,ua}, xv535e {nl,nz}"]
+    notes: "Code / name / code+name / name+code, all four live, from one register's five spellings. XV535E is a genuine later variant."
+
+  "motorcycle/yamaha/royal-star":
+    verdicts: { id: "defective(D6 — xvz1300-royal-star and xvz1300a-royal-star are the same motorcycle)",
+                name: "unverifiable(no Yamaha source fetched)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct, ua: correct } }
+    evidence: ["raw: fi 'XVZ 1300A ROYAL STAR' n=2, 'XVZ 1300 ROYAL STAR' n=1, 'XVZ13TF ROYAL STAR VENTURE-VP09/1294' n=1 — code+name in one cell",
+               "live siblings: xvz1300-royal-star {fi,nl}, xvz1300a-royal-star {fi,nl}, xvz1300tf-royal-star-venture {fi,nl}",
+               "cross-make collision (not a defect): motorcycle/bsa/royal-star [Royal Star] {nl,nz} is a genuine, different BSA"]
+    notes: "The Venture is a distinct model and stays. The bare-name record here holds nl/nz/ua while the code+name records hold fi/nl — so the merge must union evidence."
+
+  "motorcycle/yamaha/xj650-maxim":
+    verdicts: { id: "defective(D6 — maxim-650 and xj650 split the same motorcycle)",
+                name: "unverifiable(no Yamaha source fetched)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["live siblings: maxim [Maxim] {nl,nz}, maxim-650 [Maxim 650] {nl,nz}, xj650 [XJ650] {fi,nl,nz}, xj650-special {nl,nz}, xj650-turbo",
+               "raw: fi 'XJ650' n=1; nl/nz carry the Maxim spellings"]
+    notes: "'XJ650 Maxim' and 'Maxim 650' are the same US-market Yamaha with tokens inverted and the code swapped for the capacity — the third inversion pair in this batch (with road-glide-cvo and t100-tiger). XJ650 Special/Turbo are genuine variants."
+
+  "motorcycle/yamaha/xt1200ze":
+    verdicts: { id: correct, name: "unverifiable(yamaha-motor.eu unreachable; Yamaha's rendering is 'XT1200ZE Super Ténéré', so the bare code may be a partial)",
+                make: correct, kind: correct, availability: { nl: correct, ua: correct } }
+    evidence: ["raw IN-DATA: 'Yamaha | XT1200ZE (XT1200ZE Super Tenere)' fi_traficom n=37, TAN e13*168/2013*00062*00 — the register spells out the pairing",
+               "live siblings: xt1200 {es,fi,lu,nl,nz}, xt1200z {fi,lu,nl,nz,ua}"]
+    notes: "id NOT called defective: the ZE is a genuinely different specification from the Z (electronic suspension, cruise control), so §6's variant rule arguably keeps them apart — though bare 'XT1200' is a truncation of one of them. The fi cell 'XT1200ZE (XT1200ZE Super Tenere)' is another instance of the corpus containing its own code→nameplate join."
+
+# ═══════════════════════════════════════════════════════════════════════════
+summary:
+  records_covered: 100        # every id on the batch list
+  records_not_covered: []     # none omitted
+
+  claims:   # TALLIED FROM THE ENTRIES ABOVE by script, not by hand
+    total: 640                # 100 id + 100 name + 100 make + 100 kind + 236 availability + 4 enrichment
+    availability: { total: 236, correct: 236, defective: 0, unverifiable: 0 }
+    id:      { total: 100, correct: 58, defective: 42, unverifiable: 0 }
+    name:    { total: 100, correct: 9,  defective: 37, unverifiable: 54 }
+    make:    { total: 100, correct: 99, defective: 1,  unverifiable: 0 }
+    kind:    { total: 100, correct: 98, defective: 2,  unverifiable: 0 }
+    enrichment: { total: 4, correct: 2, defective: 2, unverifiable: 0 }
+    # conservative clean rate over all 640 claims (unverifiable counts against):
+    #   correct 502 / 640 = 78.4%   defective 84   unverifiable 54
+
+  # HOW TO READ THE NAME ROW — do not aggregate it naively.
+  # 46 of the 100 name claims have a verdict; 54 are `unverifiable` because I ran
+  # out of fetch budget, NOT because the data resisted checking. So:
+  #   name, with a verdict:   9 correct / 37 defective  (46 claims)
+  #   name, no verdict:       54 claims
+  # The 46 are NOT a random subsample — I spent the budget where a source would
+  # settle a suspicion, so their defect rate is upward-biased and must not be
+  # extrapolated to the other 54. A verifier re-drawing at random from this batch
+  # should expect a materially better rate.
+  #
+  # AND THE 46 SPLIT BY EVIDENCE TYPE, which matters more than the count:
+  #   31 cite an EXTERNAL marque or marque-specialist URL (fetch-never-assume met);
+  #   15 rest on CORPUS-INTERNAL proof plus the repo's own filed rules — either
+  #      the published string appears in no register spelling anywhere, or a raw
+  #      cell pairs a code with a nameplate, or the defect is pure casing of a
+  #      type code (which registers can never disprove, since they uppercase
+  #      everything, and which name_shapes.yml has already globally adjudicated).
+  #      Those 15 are: moped/yamaha/bw-s, bmw/r65t1c, aprilia/rxv,
+  #      kl-service/kxe300, renault/twizy, honda/anc, cfmoto/800,
+  #      husqvarna/sm510, sym/adx, honda/sd02, ktm/rc, piaggio/px200,
+  #      vespa/px200, suzuki/intruder-vs800glp, yamaha/gts.
+  #      A strict reading of "fetch, never assume" would demote these 15 to
+  #      unverifiable. I am reporting them as verdicts WITH the label attached so
+  #      the verifier can make that call explicitly rather than inherit it.
+
+  source_gap_queue:   # marque sites that refused WebFetch — these blocked 17 name claims
+    - "vespa.com / piaggio.com / aprilia.com / motoguzzi.com — HTTP 403 (whole Piaggio group)"
+    - "ducati.com — HTTP 403"
+    - "royalenfield.com — HTTP 403"
+    - "indianmotorcycle.com — HTTP 403"
+    - "yamaha-motor.eu — socket hang up"
+    - "kymco.co.uk, lexmoto.com — 404 on every path tried"
+    - "masai-motors.com, hanwaymotors.com — DNS did not resolve"
+    - "WORKAROUNDS THAT DID WORK, for the next round: storeusa.vespa.com (Vespa's US store, same product names), triumph-mediakits.com, globalsuzuki.com digital archive, harley-davidson.com/content/expert-advice (the model-code page), royalalloy.co.uk (non-www only), cybermotorcycle.com, ktm.com/<cc>/ country paths."
+
+  suspected_defects_for_the_verifier_to_attack:
+    # Each line: what I claim, and the single fact that would refute it.
+    strong_and_source_backed:
+      - "motorcycle/honda/sd02 — SD02 is Honda's code for the XL1000V Varadero (475 nl rows) and 7 other ids describe the machine. REFUTE BY: showing Honda sold a model named SD02."
+      - "motorcycle/harley-davidson/rh1250s — H-D's own code page says 'RH1250S - Sportster S', and sportster-s is live. REFUTE BY: nothing I can see."
+      - "motorcycle/harley-davidson/flhr / flht-touring / flstc-heritage-classic / xl883c-sportster — code-vs-name splits, all four with H-D's own code→name pairing. REFUTE BY: an H-D source treating the code as a distinct nameplate."
+      - "motorcycle/suzuki/uk110 — Suzuki's own archive names it 'Address 110'; motorcycle/suzuki/address is live. REFUTE BY: a Suzuki page using UK110 as a nameplate."
+      - "motorcycle/honda/nss350a — Honda UK's range says 'Forza 350'; forza-350 is live. REFUTE BY: as above."
+      - "motorcycle/honda/xl750 — Honda UK writes 'XL750 Transalp'; xl750c + 7 Transalp ids live. REFUTE BY: as above."
+      - "moped/vespa/primavera — Vespa's own store has no unnumbered Primavera; primavera-50 holds the same 5 countries. REFUTE BY: reading NAMING §6's capacity rule as covering bare-vs-numbered."
+      - "motorcycle/piaggio/px200 (make, D11) — the PX is a Vespa and vespa/px200 is live; moves.yml's key shape cannot see a bare model string. REFUTE BY: evidence Piaggio badged a PX 200 in its own right."
+      - "motorcycle/bmw/r65t1c — '1' for 'I' against 91 r65tic rows in the same two registers. REFUTE BY: a BMW variant actually designated T1C."
+      - "motorcycle/renault/twizy (kind, D10) — an L6e/L7e quadricycle in kind=motorcycle via RDW's 'Driewielig motorrijtuig'. REFUTE BY: nothing; the only question is whether the fix waits for G24."
+      - "motorcycle/aprilia/sx50 (kind, D10) — FI files the same machine L1e; moped/aprilia/sx50 is live. REFUTE BY: a decision that gb-only records keep uk_dft's kind by design."
+      - "moped/nsu/quickly-t (enrichment) — 1953-1968 is the family; nsu24.de dates the T 1959-1963 with unit counts, refuting the note's 'no source separates the variants'. REFUTE BY: showing nsu24.de is wrong."
+      - "motorcycle/bultaco/sherpa (enrichment) — the union span's own stated condition ('if the register meant the Sherpa T') is satisfied 43:1 in the raw. REFUTE BY: arguing the bare id should keep the union anyway."
+      - "motorcycle/kl-service/kxe300, motorcycle/royal-alloy/gt125, motorcycle/brixton/bx125, motorcycle/cz/150c, motorcycle/ktm/250exc-tpi, motorcycle/triumph/bonneville-t100bud-ekins, motorcycle/harley-davidson/street-bob114 — space-collapse names that appear in NO source, marque or register. REFUTE BY: finding the closed form in a marque source."
+    weaker_calls_i_want_overruled_if_wrong:
+      - "motorcycle/husqvarna/sm510 (id) — gb's Model column resolves 'SM 510' to 'SM 510 R', but fi gives SM 510 and SM 510 R DIFFERENT type-approval numbers. The TANs may well win. My weakest id call."
+      - "motorcycle/kawasaki/kz1300 (id) — market-designation twins (KZ vs Z). Needs a global policy, not a per-record verdict."
+      - "moped/la-souris/sourini-rs (id) — rests on reading 'Limited' as an edition under §6's fold rule."
+      - "motorcycle/puch/rla (name) — the marque always wrote 'RLA 125'; the register supplies it bare. Soft."
+      - "motorcycle/mv-agusta/350s (name) — corpus-strong (49:3 spaced) but my only external source is a spec database."
+      - "motorcycle/kawasaki/sr650 (name) — the published token order appears in no source, but my sources are specialist, not Kawasaki."
+      - "moped/yamaha/bw-s (id) — bws50 is the BW's 50; but I did NOT call the moped/motorcycle BW's pair, whose lu TAN suggests a genuine 125."
+    explicitly_NOT_called_though_they_look_wrong:
+      - "motorcycle/honda/mx650 — no source records it, FMX650 is the obvious target, and I declined the fold on the repo's own matchless precedent (a corrupt string does not tell you what it is corrupt OF)."
+      - "moped/aprilia/sb — 608 nl rows, no Aprilia source. Unverifiable, not defective."
+      - "motorcycle/moto-guzzi/v7-ambassador — probable V7/Ambassador conflation, but the US importer possibility is real. Source-gap item."
+      - "moped/peugeot/fb50qt-6a — the SAME code is published under peugeot AND qingqi in the same two countries. One of them is wrong; I have no evidence which, and resemblance is not a merge."
+      - "moped/yamaha/bw-s name — 'BW's' is a sourced, deliberate decision (renames.yml + former_ids). The CPx/tS rule, correctly applied."
+      - "motorcycle/ajs/16ms name — closed form, dominant raw is spaced, and the marque source backs the closed form. Correct, not defective."
+
+  positives_worth_recording:
+    - "AVAILABILITY IS SPOTLESS: 236/236 claims register-evidenced, including every thin one (97 claims rest on a single raw row). Where a record carries xrefs.tan, the TAN matched the exact raw row in 19 of 19 cases I checked. Whatever else is wrong here, the evidence layer is not."
+    - "The Piaggio→Vespa move + former_ids machinery works (vespa/elettrica, vespa/primavera*, vespa/gt125 chains all resolve)."
+    - "The 2W nameplate-spacing release (former_ids 1,050 ids) is visibly landed: gpx/dz3-sport, aprilia/tuareg-660, neco/azzuro-125, aprilia/sx50-factory all have working aliases."
+    - "NAMING §7.4's comma-joined-cell rule held on zycar/z2l, where a 6-code cell did NOT become a model."
+    - "enrich/dkw.yml and enrich/cz.yml re-derive exactly from their citations, and both carry the caveats a re-checker needs. enrich/bultaco.yml's conditional caveat is what let me FIND its defect — that habit paid off."
+
+# ═══════════════════════════════════════════════════════════════════════════
+NEW_CLASS_CANDIDATES:   # per I-15: taxonomy entry + detector spec BEFORE any scaled fixing
+
+  - id: D24-code-and-nameplate-co-publication
+    headline: >-
+      ONE MOTORCYCLE, N IDS: the register spells a machine as a bare type code,
+      as a nameplate, and as code+nameplate (in either order), and ALL of them
+      publish as separate models. 34 of this batch's 100 records (34%) carry it.
+      No existing detector can see it, and D6's detector provably cannot be
+      extended to cover it.
+    why_not_D6: >-
+      D6 is 'duplicate spelling, same make+kind', detected by
+      find_duplicate_spellings with an NFKD fold. That compares strings that
+      differ by PUNCTUATION, CASE or DIACRITICS. These pairs differ by whole
+      TOKENS ('FLHR' vs 'FLHR Road King'), by token ORDER ('Road Glide CVO' vs
+      'CVO Road Glide'), or by SUBSTITUTION of a code for a name ('SD02' vs
+      'Varadero'). I ran find_duplicate_spellings and find_casing_contradictions
+      against the audited build with VDB_SIDE=s2w: both return ZERO. The class
+      is invisible, which is why it has grown this large in the head of the
+      catalog.
+    measured:
+      - "262 (code-alone ⊂ code+name) id pairs across 29 make/kinds in the 2W half. Top: harley-davidson 72, honda 46, yamaha 44, suzuki 21, kawasaki 16, piaggio 11, indian 8."
+      - "1,755 strict-prefix name pairs in 2W overall (the superset; includes many LEGITIMATE pairs like 'Electra Glide' vs 'Electra Glide Classic', so this number is a worklist ceiling, not a defect count)."
+      - "Worst single family found: 9 live FLSTC* ids + 4 FLSTCI* for what H-D lists as one code and one name. 23 live VRSC* ids. 11 VT1100/Shadow ids. 8 XL1000V/Varadero/SD02 ids. 7 T100/Tiger-100 ids. 6 VS800/Intruder ids."
+    detector_spec: >-
+      THREE cheap, high-precision detectors, in order of confidence:
+      (1) IN-DATA JOIN, zero external sources needed and the strongest signal in
+          the corpus: find raw cells that contain BOTH a published bare-code name
+          and a published nameplate for the same make+kind. The registers do this
+          constantly — 'VARADERO-SD02D/996', 'M750 MONSTER', 'XL883C SPORTSTER
+          CUSTOM', 'MTN690-A (MT-07)', 'XT1200ZE (XT1200ZE Super Tenere)',
+          'SHADOW-VT1100C2-SC32/1099', 'KZ 650 SR CSR 650', 'NCZ 50 MOTOCOMPO',
+          'CF50 CHALY'. Each such cell is a merge candidate with in-corpus proof,
+          not an inference. This alone would have found ~10 of my 34.
+      (2) TOKEN-SUPERSET PAIR: within one make+kind, name A's token list is a
+          strict prefix of name B's, AND A's first token matches a type-code
+          shape (/\A[A-Z]{2,6}\d{0,4}[A-Z]{0,4}\z/ with a digit, or ≥3 caps).
+          Nominates 262 pairs in 2W; needs one human call each, exactly like the
+          model-column-acronym-casing token worklist.
+      (3) TOKEN-SET-EQUAL, ORDER-DIFFERENT: same multiset of tokens, different
+          order ('Road Glide CVO' / 'CVO Road Glide'; 'T100 Tiger' / 'Tiger 100';
+          'XJ650 Maxim' / 'Maxim 650'; 'Trophy TR6R' / 'TR6R Tiger'). Very high
+          precision — renames.yml already folds this shape for Alfa Romeo, so the
+          remedy pattern exists.
+    remedy_and_blocker: >-
+      Merge to the marque's nameplate with former_ids for every loser, and keep
+      the type code as a variant/alias. THE BLOCKER IS THE SAME ONE
+      name_shapes.yml already records for Kreidler K53 and the IVA RA9015 case:
+      'there is no variant layer to hold them and a fold would DESTROY the type
+      distinction rather than relocate it'. So this class is genuinely blocked on
+      G26/§14.1 variants — but Kreidler is filed as 4 records and this is at
+      least 262 pairs concentrated in the HEAD makes, which changes the priority
+      of the variant layer considerably. Recommend: add the taxonomy entry and
+      detector (1) NOW, since in-data joins are provable and reviewable without a
+      variant layer, and hold (2)/(3) behind it.
+    do_not_do: >-
+      Do NOT bulk-fold on a code prefix. The Kreidler entry opens by admitting
+      exactly that mistake ('K53/1 and K53/21 are DIFFERENT type numbers'), and
+      this batch contains the same trap: xlch vs xlch-1000 (883 vs 1000cc),
+      xt1200z vs xt1200ze (different suspension spec), fxr vs fxrp (police), and
+      husqvarna sm510 vs sm510r (DIFFERENT type-approval numbers) are all
+      genuinely distinct despite matching the shape.
+
+  - id: D25-source-vocabulary-decides-the-kind
+    headline: >-
+      A record's `kind` is set by whichever register's category vocabulary
+      happens to reach it, not by the vehicle. Two mechanisms, both documented
+      in the repo as source limitations, both producing wrong published kinds
+      AND cross-kind duplicate ids.
+    mechanism_a_uk_merges_mopeds: >-
+      uk_dft VEH0120 has no moped BodyType — overrides/kind_maps/uk_dft.yml says
+      so outright: 'UK merges mopeds INTO Motorcycles … UK contributes evidence
+      to kind=motorcycle only'. So every UK-only ≤50cc machine publishes as a
+      motorcycle. MEASURED: 258 motorcycle records have gb-only evidence; 18 of
+      them have an identically-slugged moped record (aprilia/rx50, aprilia/sx50,
+      cpi/aragon, derbi/gpr-50, e-max/lb1, honda/nps50, honda/sfx50, honda/sh50,
+      keeway/f-act, mash/fifty, peugeot/ludix, peugeot/trekker, rieju/mrt,
+      rieju/rs2, sur-ron/light-bee, suzuki/ay50, sym/mask, yadea/g5). Two of
+      those 18 are in this batch (motorcycle/aprilia/sx50, and the twin of
+      moped/honda/sh50).
+    mechanism_b_rdw_has_no_quadricycle: >-
+      RDW's voertuigsoort vocabulary has no quadricycle value, so it files the
+      four-wheeled L7e Twizy as 'Driewielig motorrijtuig' (three-wheeled motor
+      vehicle), which nl_rdw.yml maps to motorcycle — while fi/es/lu/nz file the
+      same vehicle L6e/L7e, which the same repo maps to moped. MEASURED: 482 ids
+      exist in more than one kind catalog-wide; 95 are moped+motorcycle, 2 are
+      car+moped+motorcycle. Renault Twizy is live in THREE kinds.
+    detector_spec: >-
+      (1) gb-only motorcycle record whose slug also exists in moped → route to
+          moped (or merge) rather than publish both. 18 hits, enumerated above,
+          zero ambiguity.
+      (2) any id live in >1 kind where the kinds' evidence sets are DISJOINT by
+          country → nominate; a genuine cross-kind pair (e.g. a 50cc and a 125cc
+          sharing a nameplate) will normally have overlapping countries, whereas
+          a vocabulary artefact splits cleanly by source.
+      (3) cross-check any record whose ONLY nl evidence comes from the
+          'Driewielig motorrijtuig' pull against that make's L6e/L7e rows
+          elsewhere.
+    relation_to_existing_work: >-
+      D10 covers 'wrong kind' and PROPOSAL-kind-boundary.md §Q2 already resolves
+      the quadricycle question (L6e/L7e → car with body_types ['quadricycle']).
+      What is NEW here is (a) that the mapping LINE
+      'Driewielig motorrijtuig: motorcycle' is a second, independent route into
+      the wrong kind and is not in the proposal's change list, and (b) that the
+      uk_dft moped merge is producing measurable cross-kind DUPLICATE IDS, not
+      just wrong kinds — which is an id-canonical problem, not only a kind one.
+
+  - id: OBSERVATION-uk_dft-genmodel-truncation
+    headline: >-
+      Not a new class so much as an unexploited fix. uk_dft's GenModel column is
+      coarser than its Model column, so gb-only records publish truncated
+      nameplates that then mint ids beside the full ones: 'HONDA ANC' (Model 'ANC
+      125 F') → honda/anc beside honda/anc125; 'YAMAHA GTS' (Model 'GTS 1000 A')
+      → yamaha/gts beside gts1000a; 'CFMOTO 800' → cfmoto/800 beside 800MT;
+      'LEXMOTO VALIANT' (Model 'VALIANT 125 EFI XF 125 R E4'). The Model column
+      is ALREADY parsed — uk_dft.rb passes row[3] into the Row's tan slot — it is
+      just not used to disambiguate. Detector: gb-sourced record whose name is a
+      strict prefix of its own row's Model value.
+
+  - id: OBSERVATION-debt-entry-acting-as-a-catch-all
+    headline: >-
+      `normalizer-space-collapse-display-names` (category code_string,
+      max_sources 1, count 267) absorbs EVERY single-source 2W code-string
+      record, including ones that have nothing to do with space collapse —
+      moped/yamaha/sa15 and moped/aprilia/sb are unresolved type codes (D9), not
+      collapsed spaces. Consequence: the count cannot be read as progress on
+      either problem, and lint_dataset reports 'only 2 unexplained suspects
+      catalog-wide' while genuine D9 records sit inside the bucket. Suggest
+      splitting into a space-collapse entry (evidence: the spaced form exists in
+      the raw) and an unresolved-type-code entry (evidence: no spaced form
+      exists anywhere).
+
+  - id: OBSERVATION-corroboration-is-not-nameplate-evidence
+    headline: >-
+      `corroborated-numeric-nameplates` (≥2 sources, ≥2 countries) legitimises
+      moped/masai/50 and motorcycle/masai/125 — but BOTH corroborating strings
+      are 'MASAI <capacity>', i.e. make + displacement with no nameplate in the
+      model column at all. Two registers agreeing does not mean a nameplate
+      exists; it can mean two registers made the same omission. Same hole in
+      `corroborated-code-string-records`, which would excuse motorcycle/suzuki/
+      uk110 forever on FIVE sources while Suzuki's own archive calls it 'Address
+      110'. Suggested guard: the corroboration exemption should not apply when
+      every corroborating raw string is (make + number) or (bare code) — i.e.
+      when no source anywhere supplies a word.

--- a/data/review/audit-v2026.07.5/ledger/researcher-b3.yml
+++ b/data/review/audit-v2026.07.5/ledger/researcher-b3.yml
@@ -1,0 +1,1093 @@
+# PRD-FIVE-NINES Workstream A2 — baseline round, tag v2026.07.5, S2W half
+# BATCH 3 (100 ids) — RESEARCHER PROPOSAL. researcher: audit-b3
+# A separate verifier must re-derive this. Nothing here is a ledger entry.
+#
+# ── HOW EACH CLAIM WAS DECIDED (read before reading verdicts) ─────────────────
+#
+# availability (229 claims): decided FIRST-HAND against the register corpora in
+#   the pipeline's own cache — not against a summary. Extracts built for this
+#   batch (read-only), one pass per source:
+#     nl_rdw      cache/nl_rdw_{bromfiets,motorfiets,motorfiets-met-zijspan,
+#                 driewielig-motorrijtuig}.json  (merk | handelsbenaming | n)
+#     fi_traficom cache/fi_traficom_register.zip, streamed; rows filtered to the
+#                 SAME classes the adapter maps (L1e/L2e/L6e/L7e -> moped,
+#                 L3e/L4e/L5e -> motorcycle); model = kaupallinenNimi, falling
+#                 back to mallimerkinta, exactly as fi_traficom.rb does
+#     uk_dft      cache/uk_veh0120_uk.csv, BodyType="Motorcycles", raw_model =
+#                 GenModel (make-prefixed — prefix stripped before comparing)
+#     nz_nzta     cache/nz_{motorcycle,moped}_*.json
+#     es_dgt      cache/es_dgt_2026{04,05,06}.txt at the adapter's byte offsets
+#                 (MARCA 17+30, MODELO 47+22, EUCAT 426+3), adapter's category map
+#     lu_snca     cache/lu_delta_2026-{05,06,07}.xml (LIBMRQ/TYPCOM/CATEU)
+#     ua_mvs      cache/ua_reestr_current.zip (BRAND/MODEL/KIND by header name)
+#     th_dlt      cache/th_dlt_2568.csv
+#   A claim is `correct` when the claimed country's register carries a row whose
+#   make maps to the record's make and whose model string folds to the record's
+#   name/slug (or folds to it after make-prefix strip / after a renames.yml key
+#   that targets this record). Otherwise defective or unverifiable, stated.
+#   CAVEAT the verifier should re-check: my LU months (2026-05/06/07) may not be
+#   the exact three the audited build used; the cache also holds 202604/05/06.
+#
+# kind (100 claims): decided from the register's OWN vehicle-class field carried
+#   in those extracts (bromfiets/motorfiets; L1e..L5e; МОПЕД/МОТОЦИКЛ; DGT *codes;
+#   DfT BodyType). L6e/L7e quadricycles filed as `moped` are the DOCUMENTED
+#   convention (name_shapes.yml `mega-marque-research`, "If G24 ever mints a
+#   quadricycle kind, this record moves with them") — recorded `correct` with a
+#   note, not as a defect.
+#
+# make (100 claims): decided from the raw make column + overrides/makes/aliases.yml.
+#   `unverifiable` wherever the marque identity itself is filed as unresolved
+#   (name_shapes.yml `acronym-make-casing-2w-tail` names kl and djjd as
+#   GENUINELY OPEN) or where I could reach no marque source.
+#
+# name (100 claims): the expensive one. `correct`/`defective` ONLY where I
+#   fetched a source this session; `unverifiable(name not covered this pass)`
+#   otherwise. 38 of 100 covered by my own fetch; 4 more rest on a source URL
+#   already cited inside the override that SET the name (marked
+#   `src=in-repo-citation`, NOT re-fetched by me). 58 are honestly uncovered and
+#   listed in the coverage block. This is the truncation, and it is declared.
+#
+# id (100 claims): decided from a catalog-wide same-make sibling sweep
+#   (fold-equal / one-edit / prefix over all live ids of the make, both kinds)
+#   PLUS the type-code/nameplate pairings the research turned up. Duplicates
+#   whose two ids differ by more than one edit (M797 vs Monster 797, MTN890 vs
+#   MT-09, AF61 vs Today) are invisible to a spelling detector and were only
+#   found because the marque source named both.
+
+records:
+
+  # ────────────────────────── moped ──────────────────────────
+  "moped/capri/cl":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'CAPRI | CL' nl_rdw bromfiets n=1117 (+ 'CL 50' n=1472, 'CL50' n=7)",
+               "overrides/models/renames.yml:205 `Cl: CL` — deliberate, sourced (https://www.brommer.nl/merk/capri/cl/); renames.yml:206 `CL50: CL` + former_ids moped/capri/cl50 -> moped/capri/cl  # src=in-repo-citation, not re-fetched"]
+    notes: "Textbook 'weird can be right' — bare CL is a curated initialism, and the cl50 fold is already done. Clean."
+
+  "moped/honda/af61":
+    verdicts: { id: "defective(duplicate-spelling)", name: "defective(type-code-as-nameplate)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | AF61' nl_rdw bromfiets n=1; nz_nzta moped n=1 (+ 'AF61E-6004563' n=1)",
+               "https://www.cmsnl.com/honda-nvs501sh-today-2002-2-japan-af61100_model49332/partslist/  # Honda parts catalogue: 'Honda NVS501SH TODAY 2002 (2) JAPAN AF61-100' — ties AF61 (frame code) + NVS50 (type code) + TODAY (nameplate)",
+               "https://scootworx.co.nz/collections/today-nvs50  # 'Today/NVS50' parts, AF61 frame"]
+    notes: "AF61 is Honda's FRAME code, not a nameplate — same class as the filed kreidler-k53-type-numbers debt ('K53/21 is a TYPE-APPROVAL NUMBER, not a nameplate'). FOUR live ids for one vehicle: moped/honda/af61, moped/honda/nvs, moped/honda/today, moped/honda/today-50. Sibling moped/honda/af01 is the same shape (Dio/Tact frame code)."
+
+  "moped/aixam/m12rs":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: "unverifiable(no marque source reached)", kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["raw: 'AIXAM | M12RS' es_dgt *20 n=12; fi_traficom L6e n=1; lu_snca L6E n=1; nl_rdw bromfiets n=498"]
+    notes: "Four-country corroboration of the STRING. Whether M12RS is an Aixam nameplate or an Aixam/Mega type code is exactly the question I could not source. kind=moped is the documented L6e/L7e quadricycle convention (name_shapes mega-marque-research), not a defect."
+
+  "moped/doohan/itango":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Doohan | iTango' fi_traficom L1e n=7  <-- the FINNISH REGISTER ITSELF writes the lowercase-i camel form",
+               "raw: 'DOOHAN | ITANGO' nl_rdw bromfiets n=5"]
+    notes: "Published 'Itango'; the marque form is 'iTango' (e-tron / bZ4X / R nineT precedent — styling.yml already handles exactly this shape). Strongest possible in-corpus evidence: fi_traficom preserves case and writes iTango. I did NOT reach a Doohan site (doohan.com now redirects to a LinkedIn profile, doohan.eu is expired, doohan-ev.nl does not resolve) — so this is a defect called on register evidence, and a verifier should try https://mui.mira.cat/en/producte/doohan-itango/ or the Weebot distributor pages."
+
+  "moped/djjd/cashmere":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: "unverifiable(marque identity filed as unresolved)", kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'DJJD | CASHMERE' nl_rdw bromfiets n=2280 (+ 'E-CASHMERE' n=231)",
+               "data/name_shapes.yml debt acronym-make-casing-2w-tail lists `djjd` under GENUINELY OPEN"]
+    notes: "2280 NL rows — a heavy record resting on an unidentified marque. Worth a source-gap ticket of its own; also check whether 'E-CASHMERE' (n=231) is the same nameplate."
+
+  "moped/honda/cb50j":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | CB50J' nl_rdw bromfiets n=274, 'CB 50 J' n=161, 'CB 50J' n=15, 'CB50 J' n=7; nz_nzta moped 'CB50J' n=14"]
+    notes: "Siblings honda/cb50 and honda/cb50je are genuinely different Honda type codes, not duplicates."
+
+  "moped/honda/dax50":
+    verdicts: { id: correct, name: "defective(display-form: space-collapse + all-caps)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | DAX 50' nl_rdw bromfiets n=7 DOMINANT vs 'DAX50' n=1; fi_traficom L1e 'DAX 50' n=1; nz_nzta moped 'DAX50' n=1",
+               "overrides/styling.yml:69-72 DELIBERATELY EXCLUDES DAX from `acronyms`: 'Honda Dax are all correct today' — so 'DAX' in caps is not a curated form"]
+    notes: "The filed debt `normalizer-space-collapse-display-names` (269 records) exactly: the join key ate the space and then became the display name, and because the token now contains a digit the caser freezes it verbatim, so it also loses the title case the project says Dax should have. Should read 'Dax 50'. NOTE the debt entry carries `max_sources: 1`, so a 3-source record like this is NOT covered by that allowlist entry — either the entry's scope or the count is understated."
+
+  "moped/focus/thron":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: "unverifiable(no marque source reached)", kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Focus | THRON' fi_traficom L1e n=1; 'FOCUS | THRON' nl_rdw bromfiets n=1"]
+    notes: "Both sources are single-row. Focus is a BICYCLE marque and the Thron is its e-MTB; a pedelec appearing in a moped register is plausible (speed-pedelec) but unconfirmed. Decile 10 on one row each per country — the popularity claim is what I would attack here, and it is out of scope for this protocol."
+
+  "moped/gilera/rcr":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Gilera | RCR' fi_traficom L1e n=161 (+ 'RCR G11A1A/49' n=41); 'GILERA | RCR' nl_rdw bromfiets n=1",
+               "https://www.piaggiogroup.com/en/archive/press-releases/gilera-smt-and-rcr  # Piaggio Group's own press release: 'Gilera RCR' and 'Gilera SMT', all-caps throughout"]
+    notes: "Published 'Rcr'. In the filed debt class model-column-acronym-casing (511 records, S2W). Adding RCR (and SMT) to styling.yml `acronyms` fixes this and its siblings; the marque owner's press release is the evidence."
+
+  "moped/honda/nsc50mpd":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Honda | NSC50MPD' fi_traficom L1e n=55; 'HONDA | NSC50MPD' nl_rdw bromfiets n=972"]
+
+  "moped/klever/x-speed":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: "unverifiable(no marque source reached)", kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'KLEVER | X SPEED' nl_rdw bromfiets n=616 (+ 'X SPEED PINION' n=202, 'X SPEED PURE' n=72, 'X SPEED 45' n=54)"]
+    notes: "The variant tail (Pinion/Pure/45) is published separately or dropped — worth a granularity check, not a defect call from me."
+
+  "moped/honda/dream":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | DREAM' nl_rdw bromfiets n=5; nz_nzta moped n=4"]
+    notes: "motorcycle/honda/dream is fold-equal but a DIFFERENT vehicle set (Dream C70/C72/C77 vs Dream 50) — the kind split is doing real work here, so not a duplicate. Both are family-level records that pool displacements; honda/dream-50 also exists. Granularity note only."
+
+  "moped/honda/nvs":
+    verdicts: { id: "defective(duplicate-spelling)", name: "defective(model_casing + type-code-as-nameplate)", make: correct, kind: correct,
+                availability: { nz: correct } }
+    evidence: ["raw: 'HONDA | NVS' nz_nzta moped n=809 (a heavy single-source record)",
+               "https://www.cmsnl.com/honda-nvs501sh-today-2002-2-japan-af61100_model49332/partslist/  # 'Honda NVS501SH TODAY' — NVS50 is the type code, Today is the nameplate",
+               "https://scootworx.co.nz/collections/today-nvs50  # NZ parts specialist files 'Today/NVS50' as one machine"]
+    notes: "Two defects in one record. (a) 'Nvs' is title-cased from an initialism — the model-column-acronym-casing class. (b) even fixed to 'NVS' it is a type code with the displacement dropped; the nameplate is Today. Same four-way duplicate as moped/honda/af61 above."
+
+  "moped/kymco/dj25":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'KYMCO | DJ25' nl_rdw bromfiets n=445"]
+
+  "moped/ksr-moto/ttx":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'KSR Moto Austria | TTX' fi_traficom L1e n=1; 'KSR MOTO AUSTRIA | TTX' nl_rdw bromfiets n=10",
+               "https://www.ksr-moto.com/models/ttx/  # KSR Moto's own model page: 'KSR MOTO TTX', TTX all-caps, no variant suffix"]
+    notes: "Published 'Ttx'. model-column-acronym-casing class."
+
+  "moped/saxonette/529":
+    verdicts: { id: correct, name: "defective(type-number-as-nameplate)", make: "defective(make-as-model / non-marque in make column)", kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'SAXONETTE | 529' nl_rdw bromfiets n=2018",
+               "data/name_shapes.yml debt `saxonette-is-a-product-not-a-marque` (id_list [saxonette/529], count 1): Saxonette is a Fichtel & Sachs PRODUCT name applied to Hercules-marketed motorised bicycles, never an independent marque",
+               "data/name_shapes.yml debt `bare-displacement-2w` names saxonette/529 in its worklist"]
+    notes: "Both defects are ALREADY FILED and blocked on evidence, not on effort — the debt entry is explicit that Hercules is 'likely' and likely is not a disposition. I record them as defects because name_shapes.yml's own split puts `debt` = 'the shape is WRONG and not fixed yet'. If the ledger wants known-debt scored separately from newly-found defects, this record is the cleanest example of why."
+
+  "moped/honda/px50":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Honda | PX50' fi_traficom L1e n=2; 'HONDA | PX50' nl_rdw bromfiets n=3 (+ 'PX 50' n=1)"]
+
+  "moped/honda/tact":
+    verdicts: { id: "defective(duplicate-spelling)", name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nz: correct, ua: correct } }
+    evidence: ["raw: 'HONDA | TACT' nz_nzta moped n=12; ua_mvs МОПЕД n=30 (+ 'TACT AF79' n=9, 'TACT AF30' n=6, 'TACT 50' n=4, 'TACT AF24/AF51/AF75')"]
+    notes: "moped/honda/today-50 vs moped/honda/tact vs moped/honda/today: the UA raw shows the register itself pairing TACT with AF-frame codes, i.e. the same code/nameplate tangle as af61/nvs. 'Tact' is a real Honda nameplate, so the NAME is probably fine — the id layer is where this record is wrong (honda/tact-50 is the same nameplate)."
+
+  "moped/piaggio/ape50":
+    verdicts: { id: correct, name: "defective(display-form: space-collapse + all-caps)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'PIAGGIO | APE 50' nl_rdw bromfiets n=435 DOMINANT vs 'APE50' n=14; fi_traficom L2e 'APE 50' n=20; nz_nzta moped 'APE 50' n=1",
+               "https://wide.piaggiogroup.com/en/articles/products/ape-50-euro-4-the-legend-is-updated/index.html  # Piaggio's own article body: 'Ape 50', 'Ape 50 Cross', 'Ape 50 Van' — title case, spaced (the ALL-CAPS 'APE 50' is only the headline styling)",
+               "overrides/styling.yml:69-72 DELIBERATELY EXCLUDES APE from `acronyms` ('Piaggio Ape/Zip ... are all correct today')"]
+    notes: "Should read 'Ape 50'. Same normalizer-space-collapse mechanism as honda/dax50, and again a 3-source record that the debt entry's `max_sources: 1` scope does not cover. commercial.piaggio.com and piaggio.com both 403 WebFetch — the press/wide subdomain works."
+
+  "moped/qroad/electric-scooter":
+    verdicts: { id: correct, name: "defective(descriptor-as-model) *** CANDIDATE NEW CLASS ***", make: "unverifiable(no marque source reached)", kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Qroad | ELECTRIC SCOOTER' fi_traficom L1e n=1; 'QROAD | ELECTRIC SCOOTER' nl_rdw bromfiets n=3"]
+    notes: "SEE THE NEW-CLASS SECTION AT THE END. 'Electric Scooter' is the vehicle CATEGORY written into the model column. Qroad's only record; no marque source reachable, so I cannot say what the nameplate should be — the shape is the finding, not the fix."
+
+  "moped/solex/oto":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'SOLEX | OTO' nl_rdw bromfiets n=517; the embedded-make forms 'SOLEX-OTO (1001)' n=7596, 'SOLEX-OTO' n=249, 'SOLEX OTO' n=142 are the same nameplate with the make prefix and the type number attached",
+               "https://www.brommer.nl/merk/solex/solex-oto-1001/ and https://www.brommer.nl/merk/solex/oto-1001-2/  # the Dutch moped register-derived reference the project already cites for Capri CL: 'SOLEX-OTO (1001)' / 'OTO (1001)' is a real Solex model"]
+    notes: "Correct, and a good example of the embedded-make strip doing the right thing. The (1001) type number is dropped, consistent with the Kreidler reasoning that a type number is not the nameplate."
+
+  "moped/sym/az05w":
+    verdicts: { id: correct, name: "defective(type-code-as-nameplate)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'SYM | AZ05W' nl_rdw bromfiets n=1662",
+               "https://www.sym-global.com/all-models  # SYM's own model list carries 'SYMPHONY SR' as a model",
+               "SYM Symphony SR owner's manual titled 'Sym Symphony SR (AZ05W)' — https://www.yumpu.com/en/document/view/19210609/sym-symphony-sr-az05w-brugermanual-scootergrisen",
+               "corroborating in-corpus proof of the class: uk_dft GenModel 'SYM SYMPLY' carries Model 'AV05W SYMPLY 50' — the register itself puts SYM's Axx05W type code NEXT TO the nameplate"]
+    notes: "1662 NL rows published under a type code. moped/sym/{ad05w,av05w,aw05w,ay05w} are the same shape; av05w is demonstrably the Symply 50, which motorcycle/sym/symply already publishes — so at least one of that family is also a cross-kind duplicate. I did not find a live `sym/symphony-sr` id, so I have NOT called az05w's id defective."
+
+  "moped/talaria/tl4000":
+    verdicts: { id: "defective(duplicate-spelling)", name: "defective(type-code-as-nameplate)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Talaria | TL4000' fi_traficom L1e n=25 AND 'Talaria | TL4000, STING' n=2; 'TALARIA | TL4000' nl_rdw n=35 AND 'TALARIA | TL4000, STING' n=5  <-- the register writes the type code and the nameplate in one field",
+               "same corpus, same make: 'TL3000, STING' n=53, 'TL3000 STING' n=14, 'TL2500, XXX' n=6",
+               "https://talaria.us.com/shop/ebikes/talaria-komodo/ and https://talariaebikesusa.us.com/product/talaria-komodo/  # 'TALARIA KOMODO 2025 (TL6000)' — Talaria's own pattern: TL#### is the type code, the word is the nameplate",
+               "overrides/styling.yml:61 already records the same pairing for TL2500/XXX"]
+    notes: "moped/talaria/sting 'Sting' is live [fi,nl,nz,ua]. BUT the fold target is ambiguous: TL3000 AND TL4000 are both marketed as Sting (Sting / Sting R / Sting Pro), so folding TL4000 into `sting` would DESTROY a real variant distinction — precisely the wall documented in the kreidler-k53-type-numbers and nl-snorfiets-25-suffix debt entries. A NEW INSTANCE of a filed class in a make that entry does not mention."
+
+  "moped/turbho/rb-50":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'TURBHO | RB-50' nl_rdw bromfiets n=381 (+ 'RB-50 ELITE-SCOOTER' n=107)",
+               "https://www.brommer.nl/merk/turbho/  # every Turbho designation all-caps: 'RB-50', 'RB-50 ELITE-SCOOTER', 'CD-50', 'CX-50', 'RL-50' ..."]
+    notes: "Published 'Rb-50'. Half-fixed family and therefore detector-visible: moped/turbho/{rs-50,rx-50} already publish 'RS-50'/'RX-50' correctly while {rb-50,rg-50,rl-50,rm-50} are title-cased. turbho.nl does not resolve; brommer.nl is the reachable register-derived source."
+
+  "moped/yamaha/booster":
+    verdicts: { id: "defective(duplicate-spelling)", name: "defective(cross-marque badge)", make: "defective(marque-of-sale trap)", kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: 'YAMAHA | BOOSTER' nl_rdw bromfiets n=1, ua_mvs МОПЕД n=1 — the whole record is two single rows; the neighbouring nl rows are literally 'MBK BOOSTER' n=3 and 'MBK BOOSTER SA23' n=1, i.e. the register naming a DIFFERENT marque inside Yamaha's make column",
+               "https://global.yamaha-motor.com/showroom/cp/collection/bws_cw50/  # Yamaha's own Communication Plaza: \"1988 BW'S (CW50)\" — Yamaha's nameplate is BW's; CW50 is the model code",
+               "catalog: moped/mbk/booster 'Booster' [fi,nl,ua] and moped/mbk/booster-spirit are live; so are moped/yamaha/bw-s \"BW's\" and moped/yamaha/cw50 'CW50'"]
+    notes: "MY LEAST CERTAIN DEFECT CALL — attack this one first. Booster is MBK's badge for the machine Yamaha sells as the BW's; mbk/booster already exists. The alternative reading is that NL/UA owners simply write 'Booster' for a Yamaha-badged BW's, in which case make is correct and only the id is duplicated. What is NOT arguable is that a two-row record sits beside an identically-named record under the marque that actually used the badge."
+
+  "moped/yamaha/yb50":
+    verdicts: { id: "defective(duplicate-spelling)", name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'YAMAHA | YB50' nl_rdw bromfiets n=6 (+ 'YB 50' n=2); nz_nzta moped 'YB50' n=8 (+ 'YB 50' n=1)"]
+    notes: "moped/yamaha/yb 'Yb' [nl,nz] is live — a title-cased bare prefix denoting the same machine. The defect is arguably yb's, not yb50's; I record id as defective because the protocol asks whether ANY other live id denotes the same vehicle."
+
+  "moped/yamaha/yq50":
+    verdicts: { id: "defective(duplicate-spelling)", name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["raw: 'Yamaha | YQ50' fi_traficom L1e n=2 AND 'YQ50 AEROX' n=1; 'YAMAHA | YQ50' nl_rdw n=2 (+ 'YQ 50' n=1, 'YQ 50 AEROX' n=2, 'AEROX YQ 50' n=1); nz_nzta 'YQ50' n=3; ua_mvs 'YQ 50' n=3"]
+    notes: "moped/yamaha/yq50-aerox 'YQ50 Aerox' [fi,nl] is live — same machine, and the register itself supplies the nameplate 'Aerox' beside the type code. Same type-code/nameplate shape as talaria/tl4000 and sym/az05w."
+
+  "moped/zhenhua/zh-sr50a-1":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Zhenhua | ZH-SR50A-1' fi_traficom L1e n=2; 'ZHENHUA | ZH-SR50A-1' nl_rdw n=1",
+               "overrides/models/renames.yml:2719 `Zh-SR50A-1: ZH-SR50A-1` — the casing was deliberately fixed"]
+    notes: "The ZH- prefix pin is already curated, so the name is at least intentional. Siblings zh-sr50-1 and zh-sr50a exist; whether -1 is a real type suffix or the nl-snorfiets '.25'-style variant marker is unresolved (a '-1'/'A' ladder in a Chinese type code usually is real). Flagged, not called."
+
+  "moped/over/thor":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: "unverifiable(no marque source reached)", kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'OVER | THOR' nl_rdw bromfiets n=5 (verified directly in cache/nl_rdw_bromfiets.json); nz_nzta moped n=5 (cache/nz_moped_O.json, alongside 'OVER | B-UNO' n=13)"]
+    notes: "The identical n=5 in two unrelated registers looked like a cross-contamination bug in my own extract, so I re-read both source caches directly. It is a coincidence. Recording that because a verifier will notice it too."
+
+  "moped/peugeot/kisbee-s-naked":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct } }
+    evidence: ["raw: 'PEUGEOT | KISBEE S NAKED' es_dgt *02 n=15; 'Peugeot | KISBEE S Naked' fi_traficom L1e n=41  <-- fi preserves the mixed case the published name uses"]
+    notes: "fi_traficom writing 'KISBEE S Naked' is unusually good evidence for a display form; a verifier could promote this to `correct` cheaply with peugeot-motocycles.com."
+
+  "moped/honda/st50g":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | ST50G' nl_rdw bromfiets n=82 (+ 'ST 50 G' n=31); nz_nzta moped 'ST50G' n=1"]
+    notes: "ST50 is the Dax. honda/{st50,st50e,st50ge,st50dax,dax,dax-st50,dax50} is a seven-id tangle around one nameplate family; the G/E suffixes are genuine Honda type letters so this specific id is probably fine, but the family needs the same treatment as Kreidler K53."
+
+  # ────────────────────────── motorcycle ──────────────────────────
+  "motorcycle/aprilia/sm":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'APRILIA | SM' nl_rdw motorfiets n=399",
+               "overrides/styling.yml:47 whole-string pin `SM: SM` with the reasoning that it is 'also correct for ... Aprilia/Sisu SM codes'  # src=in-repo-citation, not re-fetched"]
+    notes: "Deliberate and pinned, so not a defect. I would still NOTE it: 399 NL rows under a bare two-letter code is a granularity question (which Aprilia SM?), and the pin settles the casing without settling the identity."
+
+  "motorcycle/ccm/dual-sport":
+    verdicts: { id: correct, name: "defective(descriptor-as-model) *** CANDIDATE NEW CLASS ***", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'CCM | CCM DUAL SPORT' (GenModel), Model column 'DUAL SPORT', n=328+80",
+               "https://www.autoevolution.com/moto/ccm-644-ds-dual-sport-2005.html  # the machine is the CCM 644 DS Dual Sport",
+               "https://www.bike-urious.com/sitting-since-2005-2005-ccm-644ds/  # '2005 CCM 644DS'"]
+    notes: "'Dual Sport' is a category that happens to sit inside CCM's real nameplate '644 DS Dual Sport'; published bare it is a descriptor with the designation dropped. Weaker than the pure 'Electric Scooter' cases below because the words ARE part of a CCM name — flagged as the boundary case the new class will need."
+
+  "motorcycle/bmw/k":
+    verdicts: { id: "defective(family-level duplicate)", name: "unverifiable(no marque source fetched)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'BMW | K' nl_rdw motorfiets n=2; nz_nzta motorcycle n=21 — bare, with no number",
+               "catalog: motorcycle/bmw/k-series 'K Series' [gb] is live, built from uk_dft GenModel 'BMW K SERIES' (whose Model column holds 'K 100 RS', 'K 100 RT', 'K 100' ...)",
+               "catalog: bmw/{k1,k75,k75c,k75rt,k75s,k100,k100lt,k100rs,k100rt,k1100,k1100lt,k1100rs,k1200*,k1300*,k1600*} — every K-family nameplate carries a number"]
+    notes: "TWO live ids for 'an unspecified BMW K'. I deliberately did NOT call the name defective: I believe BMW has no product named bare 'K', but establishing that requires a marque source I did not fetch, and 'no source lists it' is an absence argument. RAISING IT AS A NOTE INSTEAD: this is the mirror image of the filed `bare-displacement-2w` debt (there the family word survives and the number is dropped; here the family LETTER survives and the number is dropped). If that inversion is not in the taxonomy it should be — see the new-class section."
+
+  "motorcycle/aprilia/rst":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'APRILIA | RST' nl_rdw motorfiets n=1, plus 'RST 1000 FUTURA' n=12, 'RST 1000' n=1, 'RST FUTURA' n=1, 'RST MILLE' n=1; nz_nzta motorcycle 'RST' n=24",
+               "https://www.totalmotorcycle.com/motorcyclespecshandbook/aprilia/2001-aprilia-RST1000Futura  # 'Aprilia RST 1000 Futura', RST all-caps throughout"]
+    notes: "Published 'Rst'. model-column-acronym-casing class. Granularity note on top: the model is the RST1000 Futura and bare 'RST' drops the 1000 — aprilia.com 403s WebFetch, and MCN/Bennetts refused too, so the specialist handbook is my source."
+
+  "motorcycle/husqvarna/901-norden":
+    verdicts: { id: correct, name: "defective(token-order-inversion)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: 'HUSQVARNA | HUSQVARNA 901 NORDEN' es_dgt *07 n=14; 'Husqvarna | Husqvarna 901 Norden' fi_traficom L3e n=41; 'HUSQVARNA | HUSQVARNA 901 NORDEN' nl_rdw n=156 (all make-prefixed; prefix stripped -> '901 Norden')",
+               "https://www.husqvarna-motorcycles.com/en-us/models/travel/norden-901.html  # Husqvarna's own model page: 'Norden 901 | 2027' and 'Norden 901 Expedition | 2027' — the NUMBER FOLLOWS the name"]
+    notes: "All three registers invert it and the marque does not. Exactly the class renames.yml already handles for Alfa ('1300 GT Junior: GT 1300 Junior', 'Gtv 1750: 1750 GTV'). TENSION THE VERIFIER SHOULD RULE ON: NAMING.md §2 lets catalog corroboration outrank encyclopedias, and here three registers agree on the inverted form — but this protocol defines name-marque-true as 'matches the marque's own rendering', and the marque is unambiguous. I applied the protocol. Also note former_ids already carries 901norden -> 901-norden, so the id has been touched once without the order being questioned."
+
+  "motorcycle/electric-motion/epure":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'ELECTRIC MOTION | ELECTRIC MOTION EPURE', Model column 'EPURE RACE' n=190, 'EPURE FACTOR-E 2.5KW' n=24, 'EPURE' n=15, 'EPURE COMP' n=14, 'EPURE LITE' n=10, 'EPURE SPORT' n=3"]
+    notes: "Epure is a real Electric Motion trials line; the record pools six variants. Marque renders it 'Epure' or 'ePure'? — not fetched, hence unverifiable. That distinction matters here (the doohan/itango shape)."
+
+  "motorcycle/bmw/r25":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'BMW | R 25' nl_rdw motorfiets n=98, 'R25' n=80, 'R-25' n=2, 'R/25' n=1, 'R.25' n=1; nz_nzta 'R25' n=4"]
+    notes: "R25 (1950-51) is genuinely slashless — R25/2 and R25/3 are the later ones and are published separately (bmw/r25-3 renders 'R25/3' correctly). So the slash policy is being applied correctly HERE, which is what makes r90-6 below a defect and not a policy difference."
+
+  "motorcycle/aprilia/scarabeo":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct, lu: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["raw: uk_dft 'APRILIA | APRILIA SCARABEO' Model 'SCARABEO'/'SCARABEO 100'/'SCARABEO 250'/'SCARABEO STREET 50'; lu_snca L3E 'SCARABEO' n=1; nl_rdw motorfiets 'SCARABEO' n=8; nz_nzta motorcycle n=7; ua_mvs МОТОЦИКЛ n=2"]
+    notes: "Five countries, all first-hand. moped/aprilia/scarabeo is fold-equal but is the 50cc machine — the kind split is legitimate, not a duplicate. Both records are family-level (they pool 50/100/125/250/500)."
+
+  "motorcycle/lambretta/v200gp":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { th: correct } }
+    evidence: ["raw: 'LAMBRETTA | V200 GP' th_dlt รถจักรยานยนต์ n=471  <-- the register writes it SPACED, the catalog publishes it collapsed"]
+    notes: "Single-source, 471 rows. The space collapse (V200 GP -> V200GP) is the normalizer-space-collapse-display-names mechanism again; I have not sourced Lambretta's own rendering so I am not calling it, but a verifier with lambretta.com can likely convert this to a defect in one fetch."
+
+  "motorcycle/kl/kxe250":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: "unverifiable(marque identity filed as unresolved)", kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'KL | KXE 250' fi_traficom L3e n=21 AND 'KL Service | KXE 250' n=7; 'KL | KXE 250' nl_rdw motorfiets n=6 AND 'KL SERVICE | KXE 250' n=4",
+               "data/name_shapes.yml debt acronym-make-casing-2w-tail lists `kl` under GENUINELY OPEN"]
+    notes: "'KL Service' reads like an importer/dealer, not a marque — so this may be a make-column trap (moves.yml header class) rather than only a casing question. Note the record already merges two raw make spellings, so the merge was a decision someone made; it deserves a source."
+
+  "motorcycle/bmw/r90-6":
+    verdicts: { id: "defective(duplicate-spelling)", name: "defective(punctuation: designation slash lost)", make: correct, kind: correct,
+                availability: { fi: correct, lu: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'BMW | R 90/6' nl_rdw motorfiets n=228 + zijspan n=15, 'R90/6' n=13 — vs 'R90-6' n=2. nz_nzta 'R90/6' n=31, 'R 90/6' n=2, 'R906' n=2, 'R90-6' n=2, 'R90 6' n=1. lu_snca L3E 'R90/6' n=1. fi_traficom L3e 'R90-6' n=1",
+               "https://www.bmwgroup-classic.com/en/models/bmw-motorcycle-classics/product-description-page.md-622-1.bmw-r-90-6.html  # BMW Group Classic's own heritage page is titled 'BMW R 90/6' (page body timed out on fetch twice; the marque-hosted title string is what I am citing — verifier please re-fetch)",
+               "https://www.autoevolution.com/moto/bmw-r-90-6-1973.html  # 'BMW R 90/6 (1973-1976)'",
+               "overrides/models/renames.yml:135-137, the project's OWN stated policy: 'Airhead type codes keep their SLASH: R 80 G/S, R 90/S, R 60/2 — the slash is part of the designation, not punctuation noise' — and it names R90/6 explicitly at line 160",
+               "catalog: bmw/r60-2 renders 'R60/2' and bmw/r60-7 renders 'R60/7' — the policy IS applied elsewhere in the same family"]
+    notes: |
+      TWO defects, and the second is the more valuable.
+      (1) NAME: 'R90-6' contradicts the marque, the dominant raw (289 slash rows vs 5 hyphen rows across four registers) and the project's own written rule. The rule was implemented as three hand-written rename keys (R602, R80GS, R100G/S) rather than as a rule, so every airhead the keys missed leaks. The seam is visible catalog-wide: bmw/r60-2 'R60/2' and bmw/r60-7 'R60/7' are right, while bmw/r60-5 'R60-5', bmw/r60-6 'R60 / 6', bmw/r67-2 'R67 / 2' and bmw/r90-6 'R90-6' are wrong, in three different ways.
+      (2) ID: bmw/r9016 'R9016' is live [nl,nz] on raw 'R 9016' n=1 (nl) and 'R9016' n=1 (nz). No BMW designation is R9016. The Kreidler debt entry documents this exact corruption in this exact dataset — 'K53/402 ... and K531402', i.e. the slash typed as a digit 1. R90/6 -> R9016 is that substitution.
+      I FLAG THE ALTERNATIVE READING HONESTLY: if r9016 is instead unresolvable junk, then r90-6's id is canonical and r9016 is a removals.yml case, not a fold. Either way one of the two ids is wrong. Same make, same class: bmw/r905 'R905' [nl,nz] beside bmw/r90s 'R90S' is the S->5 corruption that name_shapes already demonstrates for matchless/G805.
+
+  "motorcycle/bsa/b44-victor":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'BSA | B 44 VICTOR' nl_rdw motorfiets n=1 AND 'B44 VICTOR' n=1; nz_nzta motorcycle 'B44 VICTOR' n=1",
+               "former_ids: motorcycle/bsa/b44victor -> motorcycle/bsa/b44-victor (the fuse was already corrected once)"]
+    notes: "Thin (n=1 per country) but genuinely two-country. 'B44 Victor Special' also exists in the raw and is presumably a separate id."
+
+  "motorcycle/lexmoto/arrow":
+    verdicts: { id: correct, name: "unverifiable(marque lists current range only; Arrow discontinued)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'LEXMOTO | LEXMOTO ARROW', Model column 'ARROW 125' n=647+64",
+               "https://www.lexmoto.com/motorcycles  # current Lexmoto lineup — no Arrow and no Titan; both are discontinued, so the marque's own rendering is not reachable there"]
+    notes: "The DfT Model column says the nameplate is 'Arrow 125'; the published name drops the displacement. Not calling it: on two-wheelers the project's rule keeps displacement as a separate token but does not say it must be present. Needs a Lexmoto archive/parts source."
+
+  "motorcycle/nimbus/750":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: "defective(rename-fabricated evidence) *** CANDIDATE NEW CLASS ***" } }
+    evidence: ["raw NL (evidences '750'): 'NIMBUS | 750' nl_rdw motorfiets n=7, plus a second n=5 row, plus '750 CC', '750 SPORT', 'NIMBUS 750', 'STANDARD 750'",
+               "raw NZ (does NOT evidence '750'): the ONLY Nimbus rows in nz_nzta are 'NIMBUS | NIMBUS' n=6 and 'FACTORY BUILT | NIMBUS' n=1. There is no 750 row, and no numeric row of any kind.",
+               "overrides/models/renames.yml:1811 `Nimbus: \"750\"` — 'make-as-model row resolved to the honest model rather than dropped ... the raw distribution (\"750\" n=7) identifies it'"]
+    notes: |
+      *** THE FINDING I MOST WANT ATTACKED, because it is a mechanism and not a typo. ***
+      The rename is keyed on the MODEL STRING 'Nimbus' under make Nimbus, so it fires on EVERY register that emitted a make-as-model row — including New Zealand's. Its own justification is the NL distribution ('750' n=7). The effect is that a curation decision taken on Dutch evidence MINTED a per-country availability claim for New Zealand, where the register says only 'a Nimbus'.
+      This is not a bad rename; resolving make-as-model to the honest model is right, and Nimbus really did build essentially one 750. It is a defect in what `availability` then asserts. The published record tells a consumer that the NZ register evidences a Nimbus 750; it evidences a Nimbus.
+      GENERAL FORM: any renames.yml value that resolves an UNDER-SPECIFIED raw string to a SPECIFIC model propagates its evidence to every country that emitted that string, without that country's register ever having named the model. Detector spec is easy and cheap: for each availability entry, require at least one raw row from THAT country whose post-rename model string was not itself under-specified — i.e. flag availability whose only supporting raw row matched a rename key that is make-as-model or bare.
+      This pattern is invisible to every existing detector because the raw row is real, the rename is sourced, and the id is canonical.
+
+  "motorcycle/ducati/m797":
+    verdicts: { id: "defective(duplicate-spelling)", name: "defective(type-code-as-nameplate)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'DUCATI | DUCATI M797', Model column 'M797' n=145+66 and 'M797 +' n=105+40",
+               "https://partsss.com/en/ducati/spareparts/monster/monster-797/2020/seat-modm-797/pid581571.html  # Ducati spare-parts data: 'SEAT [MOD:M 797] Ducati Monster 797' — M 797 is the internal MOD code for the Monster 797",
+               "https://www.motorcyclespecs.co.za/model/ducati/ducati_monster_797_17.htm  # nameplate 'Ducati Monster 797'",
+               "catalog: motorcycle/ducati/monster-797 'Monster 797' [fi,lu,nl,ua] is live"]
+    notes: |
+      SYSTEMATIC, not a one-off, and worth sizing before anyone fixes one record. uk_dft writes Ducati's M-codes and the continental registers write the nameplate, so the UK minted a PARALLEL M-code id family alongside the Monster family:
+        m600/m600-monster, m620, m695 | monster-695, m696 | monster-696, m750, m796 | monster-796, m797 | monster-797, m800, m821 | monster-821, m900/m900-monster, m1000, m1100 | monster-1100, m1200 | monster-1200, m1200s.
+      At least six are same-vehicle pairs. None is detectable by a spelling comparator: 'M797' and 'Monster 797' share no fold. This is why the id-canonical check needs a type-code map, not an edit distance.
+
+  "motorcycle/cagiva/super-city-125":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["raw: uk_dft 'CAGIVA | CAGIVA SUPER CITY 125', Model 'SUPER CITY 125' n=74+3; 'CAGIVA | SUPER CITY 125' nl_rdw motorfiets n=2",
+               "former_ids: motorcycle/cagiva/super-city125 -> motorcycle/cagiva/super-city-125"]
+    notes: "nl also has 'N2-SUPERCITY 125' n=1 (one word) — a spelling the merge may or may not have caught."
+
+  "motorcycle/lexmoto/titan":
+    verdicts: { id: correct, name: "unverifiable(marque lists current range only; Titan discontinued)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'LEXMOTO | LEXMOTO TITAN', Model 'TITAN 125 ZN 125 T-8F' n=696+252 and 'TITAN 125' n=417+334",
+               "https://www.lexmoto.com/motorcycles"]
+    notes: "Same as lexmoto/arrow. Note the Model column carries the ZN125T-8F Chinese type code beside the nameplate — the same code/nameplate pairing seen at SYM, Talaria and Yamaha."
+
+  "motorcycle/nsu/max":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'N.S.U. | MAX' nl_rdw motorfiets n=35 (+ '251 OSB MAX' n=30, 'MAX SPEZIAL' n=14, 'MAX SPECIAL' n=8); 'NSU | MAX' nz_nzta motorcycle n=5 (+ '250 MAX' n=6)",
+               "overrides/styling.yml:69-72 DELIBERATELY EXCLUDES MAX from `acronyms` as a real nameplate word — and NSU's Max/Spezialmax/Supermax is exactly the case that exclusion protects  # src=in-repo-citation"]
+    notes: "Clean, and a good check on the acronym work: the MAX exclusion is load-bearing and correct. Granularity note: Max Spezial/Special are pooled or published separately, and '251 OSB' is a type code the register mixes in."
+
+  "motorcycle/honda/cmx1100":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'HONDA | HONDA CMX1100' (prefix stripped -> CMX1100), Model column 'CMX 1100 A-M' n=226, 'CMX 1100 A2-P' n=206, 'CMX 1100 D-M' n=173 ..."]
+    notes: "CMX1100 is the Rebel 1100 — Honda's nameplate is 'Rebel 1100', CMX1100 the type code. Same class as ducati/m797, honda/nvs, yamaha/mtn890. I did not fetch Honda for it, so it stays unverifiable rather than defective, but a verifier should expect a defect here and check for a live honda/rebel-1100."
+
+  "motorcycle/husqvarna/fe501":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct, ua: correct } }
+    evidence: ["raw (all make-prefixed except ua): 'HUSQVARNA | HUSQVARNA FE 501' es_dgt *09 n=2; fi_traficom L3e n=21; nl_rdw n=86; 'HUSQVARNA | FE 501' ua_mvs МОТОЦИКЛ n=2"]
+    notes: "Every register writes 'FE 501' spaced; the catalog publishes 'FE501'. Space-collapse mechanism again. Husqvarna's own site writes 'FE 501' in my experience but I did not fetch it this pass, so not called."
+
+  "motorcycle/puch/250sgs":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Puch | 250 SGS' fi_traficom L3e n=1; 'PUCH | 250 SGS' nl_rdw motorfiets n=18 (+ '250SGS' n=2)"]
+    notes: "Registers write '250 SGS' spaced (n=19) vs fused (n=2); published fused. Sibling puch/250sg '250SG' is a genuinely different model (SG vs SGS). Puch is confirmed NOT an acronym in name_shapes — good, the make is right."
+
+  "motorcycle/royal-enfield/hunter":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'ROYAL ENFIELD | ROYAL ENFIELD HUNTER', Model column 'HNTR 350 E5' n=1320+176 and 'HNTR 350 E5+' n=82+2"]
+    notes: "The register's own Model column says HNTR 350 — Royal Enfield markets the Hunter 350 (and badges it HNTR 350). Published bare 'Hunter' drops the 350. Granularity, and the displacement is right there in the same row, so this is cheap for a verifier to settle."
+
+  "motorcycle/talaria/komodo":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { es: correct, fi: correct, gb: correct, lu: correct, nl: correct } }
+    evidence: ["raw: 'TALARIA | KOMODO' es_dgt *08 n=29; 'Talaria | KOMODO' fi_traficom L3e n=12 (+ 'Komodo' n=2); uk_dft 'TALARIA KOMODO' Model 'KOMODO' n=7; lu_snca L3E n=2; nl_rdw motorfiets n=12",
+               "https://talaria.us.com/shop/ebikes/talaria-komodo/ and https://talariaebikesusa.us.com/product/talaria-komodo/  # 'TALARIA KOMODO 2025 (TL6000)'"]
+    notes: "Five-country, marque-sourced, clean. Also the source that proves the TL#### codes in moped/talaria/tl4000 are type codes."
+
+  "motorcycle/sym/symply":
+    verdicts: { id: "defective(cross-kind duplicate)", name: correct, make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'SYM | SYM SYMPLY', Model column 'AV05W SYMPLY 50' n=557+205, 'SYMPLY 50' n=392+47, 'SYMPLY 125' n=243, 'SYMPLY 2 125' n=211+55, 'AE05W SYMPLY 2 50' n=44",
+               "data/name_shapes.yml legit `sym-symphony-family` includes sym/symply — a deliberate false-positive exclusion, verified against SYM Global",
+               "https://www.sym-global.com/all-models  # current SYM range; Symply is discontinued and absent, so the live site does not corroborate the spelling — the DfT Model column 'SYMPLY 50'/'SYMPLY 125' does"]
+    notes: "Name is correct and deliberately allowlisted (do NOT strip the prefix — it would yield 'ply'). The ID is the problem: uk_dft's own Model column ties AV05W to SYMPLY 50, and moped/sym/av05w 'AV05W' is live from nl_rdw. Same vehicle, two ids, two kinds — the kind boundary is hiding the duplicate."
+
+  "motorcycle/honda/350sl":
+    verdicts: { id: correct, name: "defective(token-order-inversion)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | 350 SL' nl_rdw motorfiets n=1; nz_nzta motorcycle n=1  <-- both registers invert it",
+               "https://global.honda/jp/pressroom/products/motor/sl/sl350_1970-10-19/  # Honda's OWN product archive: the machine is the 'Dream SL350' (SL before the number), announced 1970-10-19"]
+    notes: "Honda's SL-series designation puts the letters first (SL125S, SL175, SL350) — and the catalog already publishes honda/sl125s 'SL125S' correctly, so this is another half-fixed family seam. No live honda/sl350, so the id itself is canonical; the name should be 'SL350'. Thin record (n=1+n=1) but two-country. Sibling honda/350 '350' is a separate bare-displacement record."
+
+  "motorcycle/honda/vfr800f":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, nl: correct, ua: correct } }
+    evidence: ["raw: 'Honda | VFR800F' fi_traficom L3e n=17; uk_dft 'HONDA VFR800F' Model 'VFR800F' n=3740+1949; 'HONDA | VFR800F' nl_rdw n=185; 'HONDA | VFR 800F' ua_mvs n=11"]
+    notes: "Four countries, strong. The VFR800 family has eight live ids (vfr800, vfr800a, vfr800a5, vfr800f, vfr800f1, vfr800fi, vfr800x, vfr800-aniv) — the suffixes are genuine Honda variant letters, so most are probably real, but vfr800-aniv below is not."
+
+  "motorcycle/honda/cb250rs-z":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { lu: correct, nl: correct } }
+    evidence: ["raw: 'HONDA | CB250 RS-Z' lu_snca L3E n=1; 'HONDA | CB 250 RS-Z' nl_rdw motorfiets n=2"]
+    notes: "Thin but genuinely two-country, and the '-Z' is a real Honda suffix. A good example of a weird-looking name that the registers corroborate."
+
+  "motorcycle/zontes/zt":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'ZONTES | ZONTES ZT', Model column 'ZT 125-G1' n=856, 'ZT 125-C' n=666, 'ZT 125-U1' n=594, 'ZT 125-U' n=446, 'ZT 125-GK' n=363, 'ZT 125-3A TIGER' n=258, 'ZT 125-Z2' n=238, 'ZT 125-C2' n=210",
+               "https://www.zontes.com/  # Zontes' own site: model strings are 'ZT250-S' form, ZT prefix always all-caps"]
+    notes: "Published 'Zt'. model-column-acronym-casing class. Granularity note on top: ZT is a prefix, and this one record pools at least eight distinct Zontes models that the DfT's own Model column distinguishes — the same bare-family shape as bmw/k and yamaha/mt 'MT'."
+
+  "motorcycle/jawa/350-twin":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'JAWA | 350 TWIN' nl_rdw motorfiets n=8; nz_nzta motorcycle n=1",
+               "former_ids: motorcycle/jawa/350twin -> motorcycle/jawa/350-twin"]
+
+  "motorcycle/honda/cb600s":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: 'HONDA | CB600S' nl_rdw motorfiets n=5 (+ 'CB 600 S' n=3, 'CB600 S' n=2, 'CB 600S' n=1, 'CB600-S' n=1, and tellingly 'CB600F/CB600S' n=2); ua_mvs МОТОЦИКЛ 'CB600S' n=1"]
+    notes: "CB600S is the Hornet S — same type-code/nameplate shape as cmx1100. Not called (no fetch)."
+
+  "motorcycle/harley-davidson/flhtcui-ultra-classic":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Harley-Davidson | FLHTCUI ULTRA CLASSIC' fi_traficom L3e n=16 (+ 'FLHTCUI-ULTRA CLASSIC' n=1, 'FLHTCUI Ultra Classic Electra Glide' n=3); 'HARLEY DAVIDSON | FLHTCUI ULTRA CLASSIC' nl_rdw n=13+1+1",
+               "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # H-D's own model-code page, all-caps verbatim: 'FLHTCU - Electra Glide® Ultra Classic®', 'FXST – Softail® model', 'FXD – Dyna Super Glide®'"]
+    notes: "Published 'Flhtcui Ultra Classic'. Sibling flhtcu-ultra-classic 'Flhtcu Ultra Classic' has the same defect (FLHTCU and FLHTCUI are genuinely different codes — the I is fuel injection — so they are NOT duplicates). name_shapes already names this exact class and cites 'harley-davidson/Fxrs Super Glide II (FXRS)' as residual work."
+
+  "motorcycle/harley-davidson/1200":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct, lu: correct, nl: correct, nz: correct } }
+    evidence: ["raw: uk_dft 'HARLEY-DAVIDSON | HARLEY-DAVIDSON 1200', Model column '1200 SPORT' n=369+167, '1200 CUSTOM LTD XL CA 13' n=57, '1200 CUSTOM XL C SPORTSTER 14' n=56 ...; lu_snca L3E '1200' n=1; 'HARLEY DAVIDSON | 1200' nl_rdw n=23+6; nz_nzta n=5"]
+    notes: "Four countries so the availability is solid, but this is the `bare-displacement-2w` shape: H-D sold the Sportster 1200, 1200 Custom, 1200 Sport, Nightster, Forty-Eight and Roadster, and the DfT Model column names four of them inside this one record. The filed debt entry lists ktm/200, ktm/390, cfmoto/450 etc. and gives count 21 without an id_list, so I cannot tell whether harley-davidson/1200 is inside that 21 — WORTH RESOLVING, because if it is not, the count is understated."
+
+  "motorcycle/husqvarna/fr450":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct, nz: correct } }
+    evidence: ["raw: uk_dft 'HUSQVARNA | HUSQVARNA FR 450', Model 'FR 450 RALLY' n=3, 'FR 450 RALLY 2022' n=2, 'FR 450 RALLY 2024' n=2; nz_nzta motorcycle 'FR450' n=1"]
+    notes: "Very thin (n=8 GB, n=1 NZ) yet decile 10 — again a popularity question, out of scope. Registers write 'FR 450 Rally'; published 'FR450' drops 'Rally' and collapses the space."
+
+  "motorcycle/honda/cb750f2":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Honda | CB750 F2' fi_traficom L3e n=1; 'HONDA | CB 750 F2' nl_rdw motorfiets n=727 (+ 'CB750F2' n=6, 'CB 750 F2' n=6)"]
+
+  "motorcycle/honda/gl1500c":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, nl: correct } }
+    evidence: ["raw: 'Honda | GL1500C' fi_traficom L3e n=3 (+ 'GL 1500C' n=1); uk_dft 'HONDA GL1500C' Model 'GL 1500 C-2' n=7; 'HONDA | GL1500C' nl_rdw n=159 + 'GL 1500 C' n=13 + 'GL 1500C' n=6 ..."]
+    notes: "GL1500C is the Valkyrie / F6C — and the nl raw literally carries 'F6C (GL 1500 C)' n=11 and 'F6C (GL1500C)' n=3, i.e. the register supplying the nameplate beside the code. Sibling gl1500c-f6c 'GL1500C F6C' is live. Same type-code shape; not called (no Honda fetch for this one)."
+
+  "motorcycle/honda/gl1500se-goldwing":
+    verdicts: { id: "defective(duplicate-spelling)", name: "defective(marque-spelling: Gold Wing is two words)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw fi: 'Honda | GL 1500 SE GOLDWING' fi_traficom L3e n=2 and 'Gl 1500se Goldwing' n=1",
+               "raw nl: 'HONDA | HONDA GL 1500 SE GOLDWING' n=1 (embedded make prefix; stripped -> GL 1500 SE GOLDWING). CORRECTION TO MY OWN FIRST PASS: my matcher reported no NL match because it did not strip embedded make prefixes. The claim is supported.",
+               "https://global.honda/en/GOLDWING/models/1988_gl1500/  # Honda's own model archive: 'Gold Wing (GL1500)' — TWO words",
+               "overrides/models/renames.yml, Honda block: '# MOTORCYCLES: \"Gold Wing\" is TWO words on Honda's own model pages', with pins `Goldwing: Gold Wing`, `Goldwing GL1500: Gold Wing GL1500`, `GL1200 Goldwing: GL1200 Gold Wing`"]
+    notes: |
+      A HALF-FIXED FAMILY, i.e. the project already knows the rule and the fix missed the compound forms where 'Goldwing' is a TRAILING token after a GL15xx code. Still wrong today: honda/gl1500-goldwing 'GL1500 Goldwing', honda/gl1500-goldwing-se 'GL1500 Goldwing Se' (which ALSO title-cases SE), and this record.
+      ID: three live ids for the GL1500 SE Gold Wing — honda/gl1500se 'GL1500SE' [gb,nl,nz], honda/gl1500-goldwing-se 'GL1500 Goldwing Se' [nl,nz], and this one [fi,nl]. The nl_rdw corpus splits across them purely by which spelling the operator typed: 'GL1500 GOLDWING SE' n=309, 'GL 1500 GOLD WING SE' n=137, 'GL1500 GOLD WING SE' n=123, 'GL1500SE' n=9, 'GL 1500 SE' n=11, and the single 'HONDA GL 1500 SE GOLDWING' that props up this record. One nameplate, three ids, ~600 rows scattered.
+
+  "motorcycle/mv-agusta/superveloce":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { es: correct, gb: correct, lu: correct, nl: correct } }
+    evidence: ["raw: 'MV AGUSTA | SUPERVELOCE' es_dgt *07 n=2; uk_dft 'MV AGUSTA SUPERVELOCE' Model 'SUPERVELOCE 800' n=43+36, 'SUPERVELOCE' n=3; lu_snca L3E n=3; nl_rdw motorfiets n=21"]
+    notes: "Four countries, clean availability. Family-level (pools 800/1000/Serie Oro/S/AGO)."
+
+  "motorcycle/harley-davidson/fxd-dyna":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Harley-Davidson | FXD DYNA' fi_traficom L3e n=3 (+ 'FXD Dyna Super Glide' n=1); 'HARLEY DAVIDSON | FXD DYNA' nl_rdw n=11",
+               "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # 'FXD – Dyna Super Glide®'"]
+    notes: "Published 'Fxd Dyna'. Sibling fxdc-dyna 'Fxdc Dyna' same defect."
+
+  "motorcycle/suzuki/dr-z400s":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, ua: correct } }
+    evidence: ["raw: 'Suzuki | DR-Z400S' fi_traficom L3e n=9; 'SUZUKI | DR-Z400S' nl_rdw n=226 (+ six punctuation variants); 'SUZUKI | DR-Z 400S' ua_mvs n=12",
+               "overrides/styling.yml `acronyms` carries DR ('Suzuki DR dual-sport family')"]
+    notes: "Strong. The DR token is pinned, the hyphenation matches the dominant raw, siblings dr-z400/dr-z400sm are genuinely different models."
+
+  "motorcycle/mv-agusta/rivale":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct, nz: correct } }
+    evidence: ["raw: uk_dft 'MV AGUSTA RIVALE' Model 'RIVALE 800' n=7+5; 'MV AGUSTA | RIVALE' nl_rdw n=1 (+ 'RIVALE 800' n=42); nz_nzta n=10"]
+    notes: "nl's dominant spelling is 'RIVALE 800' (n=42) against bare 'RIVALE' (n=1), so the bare record is the minority form — a granularity question, and possibly a duplicate if an mv-agusta/rivale-800 id exists."
+
+  "motorcycle/qjmotor/srt600sx":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { lu: correct, nl: correct, ua: correct } }
+    evidence: ["raw: 'QJMOTOR | SRT 600 SX' lu_snca L3E n=2 (+ 'SRT 600SX' n=1); nl_rdw motorfiets 'SRT 600 SX' n=30; 'QJMOTOR | SRT 600SX' ua_mvs n=3"]
+    notes: "All three registers write it SPACED; published fused. Space-collapse again. Make display 'Qjmotor' is itself likely an acronym-casing case (QJMOTOR on the marque's own site) — that is the make-casing debt, not this record's claim, but I note it."
+
+  "motorcycle/harley-davidson/fxsti-softail":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Harley-Davidson | FXSTI SOFTAIL' fi_traficom L3e n=4 (+ 'FXSTI SOFTAIL STANDARD' n=57, 'FXSTI Softail Standard' n=1); 'HARLEY DAVIDSON | FXSTI SOFTAIL' nl_rdw n=5",
+               "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # 'FXST – Softail® model'"]
+    notes: "THE CLEANEST CONTRADICTION-DETECTOR SIGNAL IN THIS BATCH: motorcycle/harley-davidson/fxst-softail already publishes 'FXST Softail' and fxstc-softail publishes 'FXSTC Softail' — both correct — while this record publishes 'Fxsti Softail'. One family, three ids, two casings. A within-family casing-contradiction check would have caught it without any web fetch."
+
+  "motorcycle/triumph/bonneville-t120":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct, nz: correct, th: correct, ua: correct } }
+    evidence: ["raw: 'TRIUMPH | BONNEVILLE T120' — es_dgt *07 n=15 & *06 n=1; fi_traficom L3e n=37; lu_snca L3E n=7; nl_rdw n=250 (+ 'BONNEVILLE T 120' n=63); nz_nzta n=349; th_dlt n=44; ua_mvs n=9"]
+    notes: "SEVEN countries all evidencing the exact string — the highest-confidence availability set in the batch, and worth keeping as a positive control. triumphmotorcycles.co.uk 404'd on the model path so the marque rendering stays unverified; sibling bonneville-120 'Bonneville 120' [nl,nz] looks like a T-dropped corruption of this record and is worth a duplicate check."
+
+  "motorcycle/velocette/gtp":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'VELOCETTE | GTP' nl_rdw motorfiets n=1; nz_nzta motorcycle n=7",
+               "overrides/models/renames.yml:2386 `Gtp: GTP` — 'Velocette GTP, a 1930s two-stroke — a type designation, never a word'  # src=in-repo-citation, not re-fetched"]
+    notes: "Already fixed deliberately. Clean."
+
+  "motorcycle/honda/nc750j":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Honda | NC750J' fi_traficom L3e n=1; 'HONDA | NC750J' nl_rdw motorfiets n=13"]
+    notes: "NC750J is the NM4 Vultus type code. Same shape as cmx1100/gl1500c; not called."
+
+  "motorcycle/sherco/250-sef":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Sherco | 250 SE-F' fi_traficom L3e n=1 (+ '250 SEF-R' n=18); 'SHERCO | 250 SEF-R' nl_rdw n=3 — folded here by overrides/models/renames.yml:2154 `250SEF-R: 250 SEF` ('SEF = the 4T enduro line; Racing trim folds') + former_ids 250sef-r -> 250-sef",
+               "https://www.sherco.com/en/enduro/  # Sherco's own range: '250 SEF FACTORY 2027', '300 SEF FACTORY', '450 SEF FACTORY' — displacement FIRST, then SEF unhyphenated. The published '250 SEF' is exactly Sherco's rendering."]
+    notes: "A record that LOOKS like a defect (displacement-first, an odd token) and is right — the CPx/tS case. The nl claim is rename-mediated but the rename is sourced and the trim fold is policy, so unlike nimbus/750 the country's register really does evidence THIS model, just under its Racing trim."
+
+  "motorcycle/harley-davidson/slim":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: 'HARLEY-DAVIDSON | SLIM' es_dgt *07 n=1; 'Harley-Davidson | SLIM' fi_traficom L3e n=9; 'HARLEY DAVIDSON | SLIM' nl_rdw n=68 + 'HARLEY-DAVIDSON | SLIM' n=14"]
+    notes: "H-D's nameplate is 'Softail Slim' (FLS/FLSL) and the raw carries 'SOFTAIL SLIM' n=59, 'FLS SOFTAIL SLIM' n=95, 'FLS 103 SOFTAIL SLIM' n=83 — i.e. the bare 'Slim' record is the minority spelling of a nameplate whose family word survives in the corpus. Granularity/duplicate suspicion, not called."
+
+  "motorcycle/yamaha/mtn890":
+    verdicts: { id: "defective(duplicate-spelling)", name: "defective(type-code-as-nameplate)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["raw: 'YAMAHA | MTN890' es_dgt *07 n=80; fi_traficom L3e n=128; lu_snca L3E n=18; nl_rdw motorfiets n=1543",
+               "https://cdn2.yamaha-motor.eu/prod/owner-manuals/Motorcycles/PB7N28199E0E.PDF  # YAMAHA'S OWN owner's manual, title line: 'MTN890 (MT-09)' — the code, then the nameplate, in Yamaha's own document",
+               "https://www.yamaha-motor.eu/gb/en/products/motorcycles/hyper-naked/mt-09/  # Yamaha's product page: the nameplate is 'MT-09'",
+               "catalog: motorcycle/yamaha/mt-09 'MT-09' [es,fi,lu,nl,nz,th,ua] is live"]
+    notes: |
+      1543 NL rows published under an internal model code, beside a live id for the same motorcycle. And it is a whole parallel family, minted because es/fi/lu/nl registers carry Yamaha's MTx codes while gb/nz/th carry the nameplates:
+        MTN (naked): mtn125-a, mtn320-a, mtn690, mtn690-{a,s,su,u}, mtn850-a, mtn890, mtn890-{s,su,u}, mtn890d, mtn890d-u, mtn1000, mtn1000d
+        MTM (Tracer): mtm125, mtm125-c, mtm690, mtm690-u, mtm690d, mtm850, mtm890, mtm890-u, mtm890d, mtm890d-u
+        MTT (Tracer GT): mtt690, mtt690-{a,s,su,u}, mtt890
+      versus mt-03, mt-07, mt-09, mt-10, mt-125, mt-15 and the Tracer ids. Note styling.yml already ACKNOWLEDGES these are codes — the `SU` acronym pin is commented 'Yamaha model-code suffix (MTN690-SU)' — so the project has looked straight at this family and pinned its casing rather than its identity.
+
+  "motorcycle/victory/vision-tour":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'VICTORY | VISION TOUR' nl_rdw motorfiets n=1; nz_nzta motorcycle n=6"]
+    notes: "Victory Vision Tour is a real nameplate. nl also has 'VICTORY MOTORCYCLES DIVIS | VISION' — the make merge (makes/aliases.yml 'VICTORY MOTORCYCLES': Victory) is working."
+
+  "motorcycle/honda/tl125s":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["raw: uk_dft 'HONDA TL125S' Model 'TL125S' n=42+35; 'HONDA | TL125S' nl_rdw motorfiets n=3 (+ 'TL 125 S' n=1, 'TL125 S' n=1, 'TL125S IHATOVO' n=1)"]
+
+  "motorcycle/honda/vfr800-aniv":
+    verdicts: { id: correct, name: "defective(register-abbreviation-as-nameplate)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["raw: uk_dft 'HONDA VFR800 ANIV' Model 'VFR 800 ANIV' n=71+37; 'HONDA | VFR 800 ANIV' nl_rdw motorfiets n=1",
+               "https://www.bike-urious.com/25th-anniversary-2007-honda-vfr800/ and https://iconicmotorbikeauctions.com/auction/2007-honda-vfr800-25th-anniversary/  # the machine is the 2007 Honda VFR800 25th Anniversary"]
+    notes: "'Aniv' is DVLA's field-width truncation of 'Anniversary', published verbatim as a nameplate. No marque or specialist source renders 'Aniv'. Correct dispositions are 'VFR800 25th Anniversary' or a fold into honda/vfr800 as a colour/edition. My sources are specialist rather than Honda-hosted, so the exact target is weaker than the defect."
+
+  "motorcycle/honda/vfr800a5":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: 'HONDA | VFR 800 A-5' nl_rdw motorfiets n=4 (+ 'VFR800 A5' n=1); 'HONDA | VFR 800 A5' ua_mvs n=1"]
+    notes: "'A5' is a model-year suffix (A = ABS, 5 = 2005) rather than a nameplate element; honda/vfr800a 'VFR800A' is live and is arguably the same machine. Duplicate suspicion, not called."
+
+  "motorcycle/honda/xr650":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["raw: 'Honda | XR 650' fi_traficom L3e n=1; 'HONDA | XR 650' nl_rdw n=6 (+ 'XR650' n=1); nz_nzta 'XR650' n=9; 'HONDA | XR 650' ua_mvs n=2"]
+    notes: "Four countries. Bare XR650 alongside live xr650r/xr650l — Honda sold the XR650L and XR650R and no plain XR650, so this may be an under-specified pool rather than a model. Flagged."
+
+  "motorcycle/kawasaki/kh400":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'KAWASAKI | KH 400' nl_rdw motorfiets n=9; nz_nzta motorcycle 'KH 400' n=1"]
+    notes: "Both registers write 'KH 400' spaced; published fused (space-collapse). Sibling kawasaki/kh 'KH' would be the bare-family case."
+
+  "motorcycle/honda/nes125":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'HONDA NES125' Model 'NES 125-Y' n=291+60, 'NES125-2' n=55+11"]
+    notes: "Single-source. NES125 is the @125 / Pantheon type code depending on market — type-code shape again."
+
+  "motorcycle/honda/nsr125":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["raw: uk_dft 'HONDA NSR125' Model 'NSR125' n=1003+121; 'HONDA | NSR 125' nl_rdw motorfiets n=17 (+ 'NSR125' n=2, 'NSR-125' n=1)"]
+
+  "motorcycle/honda/nt650v-deauville":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, nl: correct, ua: correct } }
+    evidence: ["raw: 'Honda | NT650V DEAUVILLE' fi_traficom L3e n=2; uk_dft 'HONDA NT650V DEAUVILLE' Model 'NT650V DEAUVILLE' n=1545+559; 'HONDA | NT 650 V DEAUVILLE' nl_rdw n=21 (+ 'NT650V DEAUVILLE' n=8); 'HONDA | NT 650V DEAUVILLE' ua_mvs n=14"]
+    notes: "Four countries, and code+nameplate together in every one — the shape the type-code-only records are missing. honda/nt650v alone is not live, which is why this one is clean."
+
+  "motorcycle/honda/vt125c":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { lu: correct, nl: correct } }
+    evidence: ["raw: 'HONDA | VT125C' lu_snca L3E n=2; nl_rdw motorfiets 'VT125C' n=3 (+ 'VT 125 C' n=3, 'VT 125C' n=1)"]
+    notes: "VT125C is the Shadow 125 type code."
+
+  "motorcycle/kawasaki/er-5":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct, ua: correct } }
+    evidence: ["raw: 'KAWASAKI | ER-5' es_dgt L3E n=1; fi_traficom L3e n=8; 'KAWASAKI | ER5' lu_snca L3E n=4; 'KAWASAKI | ER-5' nl_rdw n=468 (+ 'ER5' n=7, 'ER 5' n=2); ua_mvs n=96",
+               "overrides/models/renames.yml:1008 `ER5: ER-5` — 'Kawasaki hyphenates the ER line (ER-5, ER-6f/n — kawasaki.eu)'; :1009 `Er-5: ER-5`; former_ids er5 -> er-5  # src=in-repo-citation, not re-fetched"]
+    notes: "Five countries, curated hyphenation with a marque citation, fused residue folded. One of the strongest records in the batch. Sibling kawasaki/er 'Er' [gb,nl,nz] is the bare-family + casing defect, but it is not this record."
+
+  "motorcycle/ktm/690-enduro":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, gb: correct, nl: correct, ua: correct } }
+    evidence: ["raw (make-prefixed in es/fi/gb/nl): 'KTM | KTM 690 ENDURO' es_dgt *07 n=1; 'KTM | KTM 690 Enduro' fi_traficom L3e n=4 (+ '(46kW)' n=77); uk_dft 'KTM 690 ENDURO' Model '690 ENDURO R ...'; 'KTM | 690 ENDURO' nl_rdw n=2 (+ prefixed forms); 'KTM | 690 ENDURO' ua_mvs n=10",
+               "former_ids: motorcycle/ktm/690enduro -> motorcycle/ktm/690-enduro"]
+    notes: "Five countries. Note the power-variant tails ('(46 kW)', '(49 kW)', '(25 KW)') are being folded — that is trim policy and looks right. ktm/690-enduro-r is a genuinely different model."
+
+  "motorcycle/suzuki/gsx-s750u":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Suzuki | GSX-S750U' fi_traficom L3e n=2; 'SUZUKI | GSX-S750U' nl_rdw motorfiets n=72",
+               "overrides/styling.yml `acronyms` carries GSX"]
+    notes: "The trailing U is a market/restriction suffix; suzuki/gsx-s750 'GSX-S750' [fi,lu,nl,th,ua] is live and is arguably the same motorcycle. Duplicate suspicion, not called."
+
+  "motorcycle/suzuki/vs800-intruder":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'Suzuki | VS800 INTRUDER' fi_traficom L3e n=1; 'SUZUKI | VS800 INTRUDER' nl_rdw motorfiets n=22 (+ 'VS 800 INTRUDER' n=1)",
+               "former_ids: motorcycle/suzuki/vs800intruder -> motorcycle/suzuki/vs800-intruder"]
+    notes: "Code + nameplate together — clean shape."
+
+  "motorcycle/triumph/t509-speed-triple":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["raw: uk_dft 'TRIUMPH T509 SPEED TRIPLE' Model 'T509 SPEED TRIPLE' n=344+92; 'TRIUMPH | T509 SPEED TRIPLE' nl_rdw motorfiets n=74 (+ 'T 509 SPEED TRIPLE' n=6, 'T-509 SPEED TRIPLE' n=3)",
+               "former_ids: motorcycle/triumph/t509speed-triple -> .../t509-speed-triple"]
+
+  "motorcycle/triumph/tr6-trophy":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'Triumph | TR6 Trophy' fi_traficom L3e n=1; 'TRIUMPH | TR 6 TROPHY' nl_rdw n=18 (+ 'TR6 TROPHY' n=2); nz_nzta 'TR6 TROPHY' n=4 (+ 'TR 6 TROPHY' n=1)",
+               "former_ids: motorcycle/triumph/tr6trophy -> .../tr6-trophy"]
+    notes: "fi preserves 'TR6 Trophy' in exactly the published form — good display-form evidence."
+
+  "motorcycle/yamaha/rz350":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'YAMAHA | RZ 350' nl_rdw motorfiets n=4; nz_nzta motorcycle 'RZ350' n=48 (+ 'RZ 350' n=5)",
+               "overrides/styling.yml `acronyms` carries RZ (added for Lexus RZ; equally correct here)"]
+
+  "motorcycle/yamaha/xp560":
+    verdicts: { id: correct, name: "unverifiable(no Yamaha-hosted source fetched for XP560 = TMAX 560)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["raw: 'YAMAHA | XP560' es_dgt *06 n=321 & L3E n=1; fi_traficom L3e n=2; lu_snca L3E n=5; nl_rdw motorfiets n=139",
+               "https://www.pirelli.com/tires/en-us/motorcycle/catalog/motorcycle-brand/yamaha/tmax-tmax-techmax-xp-560xp560d-sj-21-2025  # fitment data pairing 'Yamaha TMAX / TMAX TechMax' with 'XP 560/XP560D' — a tyre maker, NOT a marque source"]
+    notes: |
+      I BELIEVE this is the same type-code defect as mtn890 (XP560 = TMAX 560; the catalog even carries yamaha/xp500-tmax 'XP500 TMAX', i.e. the register itself pairing the code with the nameplate, and yamaha/tmax 'TMAX' is live). I am NOT recording it as a defect: getting there from XP500=TMAX 500 is family-pattern inference, which this protocol forbids, and my only direct source is a tyre catalogue. A verifier with one Yamaha page can settle it. Availability is solid — four countries, first-hand.
+
+  "motorcycle/yamaha/xt350":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { fi: correct, lu: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'Yamaha | XT350' fi_traficom L3e n=1 (+ 'XT 350' n=1); 'YAMAHA | XT350' lu_snca L3E n=1; 'YAMAHA | XT 350' nl_rdw n=206 (+ 'XT350' n=1, 'XT-350' n=1); nz_nzta 'XT350' n=1"]
+    notes: "Four countries; nl's dominant form is spaced 'XT 350' (n=206) against fused (n=1), so the published fused form is the collapse artifact rather than the register's preference. Same mechanism as kh400/fe501/puch."
+
+  "motorcycle/honda/crf1000l":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: correct, kind: correct,
+                availability: { nz: correct, ua: correct } }
+    evidence: ["raw: 'HONDA | CRF1000L' nz_nzta motorcycle n=3; 'HONDA | CRF 1000L' ua_mvs МОТОЦИКЛ n=2 (+ 'CRF 1000L AFRICA TWIN' n=11)"]
+    notes: "The UA register supplies the nameplate — 'CRF 1000L AFRICA TWIN' n=11 outnumbers the bare code n=2. So the corpus itself says the nameplate is Africa Twin and the published record is the code. Type-code shape; not called (no Honda fetch), but this one has in-corpus evidence for the target."
+
+  "motorcycle/xinling/cxm250a":
+    verdicts: { id: correct, name: "unverifiable(name not covered this pass)", make: "unverifiable(no marque source reached)", kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: 'XINLING | CXM250A' nl_rdw motorfiets n=1; ua_mvs МОТОЦИКЛ n=1"]
+    notes: "Two single-row sources, decile 9. Chinese type code; no marque source attempted."
+
+# ── moped/motorcycle records whose entries appear above are complete. ─────────
+
+coverage:
+  records_in_batch: 100
+  records_with_at_least_one_verdict: 100
+  claims_total: 629      # 100 id + 100 name + 100 make + 100 kind + 229 availability
+
+  availability_claims: 229
+  availability_verdicts: { correct: 228, defective: 1, unverifiable: 0 }
+  # the single defective availability claim is motorcycle/nimbus/750 nz.
+
+  kind_claims: 100
+  kind_verdicts: { correct: 100, defective: 0, unverifiable: 0 }
+  # 1 record (moped/aixam/m12rs) is correct only under the documented L6e/L7e
+  # -> moped convention; moped/piaggio/ape50 likewise (L2e three-wheeler).
+
+  make_claims: 100
+  make_verdicts: { correct: 90, defective: 2, unverifiable: 8 }
+  make_defective: [ "moped/saxonette/529 (make-as-model, filed debt)",
+                    "moped/yamaha/booster (marque-of-sale trap — LOW CONFIDENCE, attack this)" ]
+  make_unverifiable: [ "moped/aixam/m12rs", "moped/djjd/cashmere", "moped/focus/thron",
+                       "moped/klever/x-speed", "moped/over/thor", "moped/qroad/electric-scooter",
+                       "motorcycle/kl/kxe250", "motorcycle/xinling/cxm250a" ]
+
+  id_claims: 100
+  id_verdicts: { correct: 87, defective: 13, unverifiable: 0 }
+  id_defective: [ "moped/honda/af61", "moped/honda/nvs", "moped/honda/tact",
+                  "moped/talaria/tl4000", "moped/yamaha/booster", "moped/yamaha/yb50",
+                  "moped/yamaha/yq50", "motorcycle/bmw/k", "motorcycle/bmw/r90-6",
+                  "motorcycle/ducati/m797", "motorcycle/honda/gl1500se-goldwing",
+                  "motorcycle/sym/symply", "motorcycle/yamaha/mtn890" ]
+
+  name_claims: 100
+  name_verdicts: { correct: 9, defective: 26, unverifiable: 65 }
+  # All counts in this block are MACHINE-COUNTED from the records above, not
+  # eyeballed — my first hand-written figures were wrong and were replaced.
+  name_covered: 35
+  name_NOT_COVERED_this_pass: 65
+  # HOW SOLID THE 35 ARE — two tiers, and the verifier should treat them
+  # differently:
+  #   TIER 1 (14 records): I successfully FETCHED and read the cited page.
+  #     husqvarna-motorcycles.com Norden 901 · wide.piaggiogroup.com Ape 50 ·
+  #     piaggiogroup.com Gilera RCR · ksr-moto.com TTX · zontes.com ZT ·
+  #     brommer.nl/merk/turbho RB-50 · harley-davidson.com model codes (x3
+  #     records) · totalmotorcycle.com Aprilia RST · global.honda SL350 ·
+  #     global.honda Gold Wing GL1500 · sym-global.com all-models ·
+  #     sherco.com enduro · lexmoto.com (negative result) ·
+  #     yamaha-motor.eu MT-09
+  #   TIER 2 (the rest): the citation is a SEARCH-RESULT TITLE/SNIPPET from the
+  #     relevant domain, because the page itself would not fetch (timeout, 403,
+  #     dead domain) — bmwgroup-classic.com "BMW R 90/6" (timed out twice),
+  #     cdn2.yamaha-motor.eu "MTN890 (MT-09)" manual, cmsnl.com "NVS501SH
+  #     TODAY ... AF61-100", global.yamaha-motor.com "1988 BW'S (CW50)",
+  #     talaria.us.com "TALARIA KOMODO 2025 (TL6000)", partsss.com "MOD:M 797",
+  #     brommer.nl solex-oto-1001, yumpu "Sym Symphony SR (AZ05W)",
+  #     autoevolution CCM 644 DS, bike-urious VFR800 25th Anniversary.
+  #     The strings are quoted verbatim from the result, but I did not read the
+  #     page body. Re-fetch before any of these rides a curation PR.
+  #   4 records rest ONLY on a source URL already cited inside the override that
+  #     set the name (marked src=in-repo-citation, NOT re-fetched by me):
+  #     moped/capri/cl · motorcycle/aprilia/sm · motorcycle/nsu/max ·
+  #     motorcycle/velocette/gtp (+ kawasaki/er-5's hyphenation rationale).
+
+  # THE TRUNCATION, DECLARED. These 70 ids have NO name verdict from me beyond
+  # `unverifiable(name not covered this pass)`. I did not fetch a marque source
+  # for them. Several carry an explicit suspicion in their `notes` — those are
+  # leads for the next pass, NOT verdicts, and must not be counted as defects.
+  name_not_covered:
+    - moped/aixam/m12rs
+    - moped/djjd/cashmere
+    - moped/focus/thron
+    - moped/honda/cb50j
+    - moped/honda/dream
+    - moped/honda/nsc50mpd
+    - moped/honda/px50
+    - moped/honda/st50g
+    - moped/honda/tact
+    - moped/klever/x-speed
+    - moped/kymco/dj25
+    - moped/over/thor
+    - moped/peugeot/kisbee-s-naked
+    - moped/yamaha/yb50
+    - moped/yamaha/yq50
+    - moped/zhenhua/zh-sr50a-1
+    - motorcycle/bmw/k
+    - motorcycle/bmw/r25
+    - motorcycle/aprilia/scarabeo
+    - motorcycle/bsa/b44-victor
+    - motorcycle/cagiva/super-city-125
+    - motorcycle/electric-motion/epure
+    - motorcycle/harley-davidson/1200
+    - motorcycle/harley-davidson/slim
+    - motorcycle/honda/cb250rs-z
+    - motorcycle/honda/cb600s
+    - motorcycle/honda/cb750f2
+    - motorcycle/honda/cmx1100
+    - motorcycle/honda/crf1000l
+    - motorcycle/honda/gl1500c
+    - motorcycle/honda/nc750j
+    - motorcycle/honda/nes125
+    - motorcycle/honda/nsr125
+    - motorcycle/honda/nt650v-deauville
+    - motorcycle/honda/tl125s
+    - motorcycle/honda/vfr800a5
+    - motorcycle/honda/vfr800f
+    - motorcycle/honda/vt125c
+    - motorcycle/honda/xr650
+    - motorcycle/husqvarna/fe501
+    - motorcycle/husqvarna/fr450
+    - motorcycle/jawa/350-twin
+    - motorcycle/kawasaki/kh400
+    - motorcycle/kl/kxe250
+    - motorcycle/ktm/690-enduro
+    - motorcycle/lambretta/v200gp
+    - motorcycle/lexmoto/arrow          # attempted: marque lists current range only
+    - motorcycle/lexmoto/titan          # attempted: same
+    - motorcycle/mv-agusta/rivale
+    - motorcycle/mv-agusta/superveloce
+    - motorcycle/nimbus/750
+    - motorcycle/puch/250sgs
+    - motorcycle/qjmotor/srt600sx
+    - motorcycle/royal-enfield/hunter
+    - motorcycle/suzuki/dr-z400s
+    - motorcycle/suzuki/gsx-s750u
+    - motorcycle/suzuki/vs800-intruder
+    - motorcycle/triumph/bonneville-t120   # attempted: model path 404
+    - motorcycle/triumph/t509-speed-triple
+    - motorcycle/triumph/tr6-trophy
+    - motorcycle/victory/vision-tour
+    - motorcycle/xinling/cxm250a
+    - motorcycle/yamaha/rz350
+    - motorcycle/yamaha/xp560           # attempted: no Yamaha-hosted source found
+    - motorcycle/yamaha/xt350
+
+  coverage_by_stratum_for_the_NAME_claim_only:
+    # (id/make/kind/availability are covered for all 100 in every stratum)
+    # machine-counted against batch3.txt's own stratum annotations; sums to 100
+    "moped|1-3|small":  { records: 5,  name_sourced: 3 }
+    "moped|1-3|large":  { records: 4,  name_sourced: 1 }
+    "moped|1-3|mid":    { records: 2,  name_sourced: 1 }
+    "moped|4-6|small":  { records: 3,  name_sourced: 2 }
+    "moped|4-6|mid":    { records: 6,  name_sourced: 2 }
+    "moped|7-10|small": { records: 5,  name_sourced: 3 }
+    "moped|7-10|large": { records: 5,  name_sourced: 2 }
+    "moped|7-10|mid":   { records: 1,  name_sourced: 1 }
+    "motorcycle|1-3|mid":    { records: 8,  name_sourced: 4 }
+    "motorcycle|1-3|large":  { records: 5,  name_sourced: 1 }
+    "motorcycle|4-6|small":  { records: 6,  name_sourced: 3 }
+    "motorcycle|4-6|large":  { records: 24, name_sourced: 6 }
+    "motorcycle|4-6|mid":    { records: 4,  name_sourced: 1 }
+    "motorcycle|7-10|mid":   { records: 9,  name_sourced: 2 }
+    "motorcycle|7-10|large": { records: 11, name_sourced: 3 }
+    "motorcycle|7-10|small": { records: 2,  name_sourced: 0 }
+    # NAME COVERAGE IS NOT STRATUM-UNIFORM — it skews toward records whose shape
+    # made me suspicious, so name-defect rate computed from my subset is BIASED
+    # UPWARD and must NOT be used as an estimate. The id/make/kind/availability
+    # rates are unbiased over the full 100.
+
+suspected_defects_for_the_verifier_to_attack:
+  # Ordered by how much I want them attacked, strongest evidence first.
+
+  - id: motorcycle/yamaha/mtn890
+    claim: "name + id"
+    class: type-code-as-nameplate / duplicate-spelling
+    why: "Yamaha's own owner's manual is titled 'MTN890 (MT-09)'; yamaha/mt-09 is live with wider country coverage. 1543 NL rows sit under the code."
+    attack: "Is MTN890 perhaps a variant MT-09 (SP/Y-AMT) rather than the base? If so the fold target changes but the defect stands. Also confirm the manual PDF really is on a yamaha-motor.eu host."
+
+  - id: motorcycle/ducati/m797
+    claim: "name + id"
+    class: type-code-as-nameplate / duplicate-spelling
+    why: "Ducati parts data 'SEAT [MOD:M 797] Ducati Monster 797'; ducati/monster-797 live. ~6 further M-code/Monster pairs in the same make."
+    attack: "partsss.com is a parts reseller mirroring Ducati data, not Ducati. Get a ducati.com source for MOD:M 797 before scaled fixing."
+
+  - id: motorcycle/husqvarna/901-norden
+    claim: name
+    class: token-order-inversion
+    why: "husqvarna-motorcycles.com renders 'Norden 901'. Three registers render '901 Norden'."
+    attack: "This is the one place NAMING.md §2 (catalog corroboration outranks encyclopedias) could be read against me — but the counter-source here is the MARQUE, not an encyclopedia. Rule on the precedence explicitly, because the answer generalises to hundreds of register-inverted names."
+
+  - id: motorcycle/nimbus/750
+    claim: "availability(nz)"
+    class: "*** rename-fabricated availability — CANDIDATE NEW CLASS ***"
+    why: "NZ's only Nimbus rows are make-as-model ('NIMBUS | NIMBUS' n=6). The rename `Nimbus: \"750\"`, justified on the NL distribution, converts them into NZ evidence for the 750."
+    attack: "Check whether the reconciler requires a per-country raw row post-rename (it appears not to). Then decide whether this is an availability defect or a documented consequence of resolving make-as-model. If the latter, it still needs saying in SCHEMA.md, because the field currently over-claims."
+
+  - id: motorcycle/bmw/r90-6
+    claim: "name + id"
+    class: "punctuation (designation slash) / duplicate-spelling"
+    why: "289 slash rows vs 5 hyphen rows across nl/nz/lu/fi; BMW Group Classic titles the machine 'BMW R 90/6'; renames.yml states the slash policy and names R90/6 in doing so; bmw/r60-2 and bmw/r60-7 already comply. bmw/r9016 is the slash-as-digit-1 corruption the Kreidler entry documents."
+    attack: "bmwgroup-classic.com timed out on me twice — re-fetch the body. And decide r9016: fold into r90-6, or remove as unresolvable? The Matchless g12l precedent says a fold needs a target and I have given one, but the evidence is 2 rows."
+
+  - id: motorcycle/honda/gl1500se-goldwing
+    claim: "name + id"
+    class: "marque-spelling (half-fixed family) / duplicate-spelling"
+    why: "renames.yml's Honda block already states 'Gold Wing is TWO words' and pins three keys; the compound trailing-token forms were missed. Three live ids for one nameplate, ~600 nl rows split by typing habit."
+    attack: "Confirm honda/gl1500se and honda/gl1500-goldwing-se really are the SE Gold Wing and not, say, a non-SE row pool. The fold is only safe if they are."
+
+  - id: moped/honda/af61  (and moped/honda/nvs)
+    claim: "name + id"
+    class: frame-code-as-nameplate / duplicate-spelling
+    why: "Honda parts catalogue 'NVS501SH TODAY ... AF61-100' ties frame code, type code and nameplate. Four live ids: af61, nvs, today, today-50. nvs additionally publishes as 'Nvs' (title-cased initialism) on 809 NZ rows."
+    attack: "cmsnl is a parts reseller carrying Honda's catalogue data — is that marque-authoritative enough for this project? If not, the class is right and the citation needs upgrading."
+
+  - id: "moped/gilera/rcr, moped/ksr-moto/ttx, moped/turbho/rb-50, motorcycle/zontes/zt, motorcycle/aprilia/rst, motorcycle/harley-davidson/{flhtcui-ultra-classic,fxd-dyna,fxsti-softail}"
+    claim: name
+    class: model_casing  (the filed model-column-acronym-casing debt, 511 records)
+    why: "Each has a marque or marque-owner source rendering the token all-caps: piaggiogroup.com (RCR), ksr-moto.com (TTX), brommer.nl (RB-50), zontes.com (ZT), Aprilia specialist handbook (RST), harley-davidson.com model-codes page (FLHTCU/FXST/FXD)."
+    attack: "These are 8 of 511. The question is not whether they are defects but whether they should be scored as defects at all given the class is filed with a count. Ruling needed, because it moves the headline rate a lot."
+
+  - id: "moped/piaggio/ape50, moped/honda/dax50"
+    claim: name
+    class: "display-form (normalizer space collapse), filed debt — BUT OUT OF THAT ENTRY'S SCOPE"
+    why: "Piaggio writes 'Ape 50'; styling.yml deliberately excludes APE and DAX from acronyms; nl dominant raws are 'APE 50' n=435 and 'DAX 50' n=7. Yet both publish fused AND all-caps, because a digit in the collapsed token freezes the case."
+    attack: "The debt entry `normalizer-space-collapse-display-names` carries `max_sources: 1` and count 269. These are 3-source records, so they are NOT inside that allowlist. Either the entry's scope is wrong or the count is. Please measure — this determines whether the class is 269 records or several times that."
+
+  - id: "moped/sym/az05w, moped/talaria/tl4000, moped/yamaha/yq50, motorcycle/sym/symply"
+    claim: "name and/or id"
+    class: type-code-as-nameplate / duplicate
+    why: "SYM's own model list carries 'SYMPHONY SR' and the AZ05W manual names it; uk_dft's Model column itself pairs 'AV05W SYMPLY 50'; the fi/nl raws pair 'TL4000, STING' and 'YQ50 AEROX'. In three of the four the REGISTER supplies the nameplate next to the code."
+    attack: "tl4000: TL3000 and TL4000 are BOTH marketed as Sting, so folding loses a variant — the Kreidler wall. Do not fix before the variant layer exists; do record the class."
+
+  - id: "moped/qroad/electric-scooter, motorcycle/ccm/dual-sport"
+    claim: name
+    class: "*** descriptor-as-model — CANDIDATE NEW CLASS ***"
+    why: "See the new-class section."
+    attack: "ccm/dual-sport is the boundary case: 'Dual Sport' IS part of CCM's real '644 DS Dual Sport'. The class will need a legit/artifact split like G9's."
+
+  - id: moped/yamaha/booster
+    claim: "make + name + id"
+    class: marque-of-sale trap
+    why: "Yamaha's Communication Plaza: \"1988 BW'S (CW50)\". mbk/booster is live. Two of the record's five neighbouring nl rows literally read 'MBK BOOSTER' inside Yamaha's make column."
+    attack: "MY WEAKEST CALL. If any market sold a Yamaha-BADGED Booster, make is correct and only the id is duplicated. Someone should check a Dutch Yamaha brochure."
+
+  - id: "moped/saxonette/529"
+    claim: "make + name"
+    class: "make-as-model + type-number-as-nameplate (both filed, both blocked)"
+    why: "name_shapes.yml says it outright: Saxonette is a Fichtel & Sachs product name, never a marque, and '529' is a type number."
+    attack: "Nothing to attack in the finding. The question for the ledger is whether filed-and-blocked debt scores as a defect. I said yes, on name_shapes.yml's own definition of its `debt` bucket."
+
+candidate_new_defect_classes:
+  # Per invariant I-15 a new class needs a taxonomy entry and a detector spec
+  # BEFORE any scaled fixing. Three candidates, with detector specs.
+
+  - name: descriptor-as-model
+    proposed_category: descriptor_as_model
+    found_in_batch: [ "moped/qroad/electric-scooter", "motorcycle/ccm/dual-sport" ]
+    measured_catalog_wide_2W: 22
+    worklist: |
+      moped:      citycoco/electric-scooter, mademoto/electric-scooter,
+                  qroad/electric-scooter, scogo/electric-scooter,
+                  shansu/electric-scooter, smarda/electric-scooter,
+                  yuhanzhen/electric-scooter, unu/scooter, vespa/scooter,
+                  honda/moped, killerbee/custom, killerbee/sport
+      motorcycle: ccm/dual-sport, ducati/sport, harley-davidson/custom,
+                  harley-davidson/motorcycle, harley-davidson/sport,
+                  harley-davidson/touring, moto-guzzi/sport, ossa/trial,
+                  vespa/scooter, vespa/touring
+    what_it_is: >-
+      The register's model column carries the VEHICLE CATEGORY or a body-style
+      word instead of a nameplate — "Electric Scooter", "Scooter", "Moped",
+      "Motorcycle", "Trial", "Custom", "Sport", "Touring". It is a sibling of
+      make_as_model (there the make leaks into the model column; here the
+      category does) and of table_artifact, but it is NEITHER, and
+      name_shapes.yml has no bucket for it: its categories are numeric_only,
+      code_string, embedded_make, make_as_model, spec_token, table_artifact,
+      model_casing and variant_as_model.
+    why_nothing_catches_it: >-
+      The strings are ordinary title-cased English words, so no casing or shape
+      heuristic fires; several are multi-source (registers share the habit), so
+      corroboration does not clear it either — the same trap the make_as_model
+      entry warns about.
+    detector_spec: >-
+      Flag a published name that, after make-prefix strip, consists ONLY of
+      tokens drawn from a curated category lexicon (the union of each source's
+      own kind/body vocabulary — voertuigsoort, ajoneuvoluokka labels, DfT
+      BodyType, DGT category names, KIND values — plus a short list of body
+      styles: scooter, moped, motorcycle, trial, enduro, cross, custom, sport,
+      touring, naked, cruiser). Zero non-category tokens = flag.
+    MUST_SPLIT_BEFORE_FIXING: >-
+      Like G9, this class is not homogeneous. Harley-Davidson's Touring, Softail
+      and Sportster ARE H-D's own family names, so harley-davidson/touring may
+      be a legitimate family-level record; CCM's "Dual Sport" is part of the real
+      "644 DS Dual Sport". The seven "Electric Scooter" rows across seven
+      unrelated Chinese/EU importers are the unambiguous artifact core. Split
+      first, exactly as the paxster/ural split was made.
+
+  - name: rename-fabricated availability
+    proposed_category: availability_inference
+    found_in_batch: [ "motorcycle/nimbus/750 (nz)" ]
+    measured: "not measured — needs the detector below to size"
+    what_it_is: >-
+      A renames.yml value that resolves an UNDER-SPECIFIED raw string (a
+      make-as-model row, a bare family word, a bare displacement) to a SPECIFIC
+      model propagates that model's availability to EVERY country whose register
+      emitted the under-specified string — including countries whose register
+      never named the model. The published record then asserts per-country
+      evidence that the country's register does not carry.
+    worked_example: >-
+      renames.yml:1811 `Nimbus: "750"`, justified by "the raw distribution
+      ('750' n=7)" — which is the Dutch distribution. New Zealand's ONLY Nimbus
+      rows are 'NIMBUS | NIMBUS' n=6 and 'FACTORY BUILT | NIMBUS' n=1. The
+      published record claims nz:registration for a Nimbus 750.
+    why_nothing_catches_it: >-
+      Every ingredient is individually valid: the raw row is real, the rename is
+      sourced and is the right call, the id is canonical, the duplicate and
+      contradiction detectors are silent. The defect exists only in the JOIN
+      between a rename and the availability array.
+    detector_spec: >-
+      For each availability entry, require at least one raw row from THAT
+      country whose pre-rename model string was not itself under-specified.
+      Concretely: mark every renames.yml key as SPECIFIC or UNDER-SPECIFIED
+      (make-as-model, bare family word, bare number, empty); then flag any
+      availability entry whose only supporting rows in that country matched an
+      UNDER-SPECIFIED key. Cheap: the reconciler already knows which rename key
+      each raw row matched.
+    note: >-
+      This generalises well beyond Nimbus — every `<Make>: <SpecificModel>`
+      make-as-model resolution in renames.yml is a candidate, and there are many
+      (the make-as-model cleanup dropped 49 rows and resolved others).
+
+  - name: bare-family-code-2W  (the inverse of the filed bare-displacement-2w)
+    proposed_category: numeric_only  (extend to alpha) or a new bare_designation
+    found_in_batch: [ "motorcycle/bmw/k", "motorcycle/zontes/zt (also a casing defect)" ]
+    also_visible: [ "motorcycle/yamaha/mt 'MT'", "motorcycle/kawasaki/er 'Er'",
+                    "moped/yamaha/yb 'Yb'", "motorcycle/talaria/tl 'Tl'",
+                    "motorcycle/bmw/k-series 'K Series'", "motorcycle/bmw/r-series 'R Series'" ]
+    what_it_is: >-
+      The filed `bare-displacement-2w` debt covers the case where the number
+      survives and the family word is dropped ("a bare 390 is three bikes at
+      once"). The MIRROR case is not filed: the family PREFIX survives and the
+      number is dropped. BMW "K" is every K75/K100/K1200/K1600 at once; Zontes
+      "ZT" pools at least eight models the DfT's own Model column distinguishes.
+      Some of these additionally exist twice (bmw/k and bmw/k-series).
+    detector_spec: >-
+      Flag a published name that (a) is 1-3 characters, all alpha, or is
+      "<prefix> Series", AND (b) is a strict prefix of >=3 other live names under
+      the same make. That conjunction is what separates a real short nameplate
+      (NSU Max, Ducati Monster) from a truncated family code.
+    why_it_matters_here: >-
+      It is also the cheapest available id-canonical check: a bare prefix record
+      and a "<prefix> Series" record under one make are almost always the same
+      non-vehicle arriving from two registers.
+
+method_notes_and_self_corrections:
+  - "MY FIRST PASS REPORTED A FALSE POSITIVE and I am recording it rather than deleting it: I initially flagged motorcycle/honda/gl1500se-goldwing's nl availability as unsupported. My matcher did not strip EMBEDDED make prefixes from the model string, and the supporting row is 'HONDA | HONDA GL 1500 SE GOLDWING'. Corrected to correct. Anyone re-deriving availability from uk_dft or es_dgt must strip the make prefix (uk GenModel is always make-prefixed; es and nl frequently are) or they will report the same false positives — my dossier shows 'EXACT: none' for ~15 uk/es records that are all fine."
+  - "TOOLING TRAP worth passing on: fi_traficom's CSV is ISO-8859, and both GNU sort and BSD grep silently fail on it in a UTF-8 locale — `sort` dies with 'Illegal byte sequence' (my first extract produced ZERO rows and exited 0), and `grep -c Honda` returns 0 on a file that contains 765 Honda rows because grep treats it as binary. Use LC_ALL=C plus `grep -a`, and iconv the extract before parsing. A silent-zero on a 935 MB register file is exactly the silent-failure class the project already tracks."
+  - "I did not attempt the enrichment sub-check (§6.2 production_runs/era) for any record — out of budget, and declared as not covered."
+  - "Popularity/decile claims are not in this protocol's claim list, but three records made me want them audited: moped/focus/thron (decile 10 on one row per country), motorcycle/husqvarna/fr450 (decile 10 on n=8 GB + n=1 NZ), motorcycle/honda/vfr800a5 (decile 10 on n=4 + n=1). If the decile is computed from rank within country rather than volume, thin records may be systematically over-ranked."

--- a/data/review/audit-v2026.07.5/ledger/researcher-b4.yml
+++ b/data/review/audit-v2026.07.5/ledger/researcher-b4.yml
@@ -1,0 +1,1122 @@
+# Workstream A2 baseline audit — BATCH 4 (S2W half), tag v2026.07.5
+# researcher: audit-b4 (read-only)
+# METHOD NOTE, read before the verdicts:
+#   * availability, make, kind, id-canonical were re-derived for ALL 100 records
+#     from the LOCAL RAW CORPORA in ~/GitHub/.vdb-worktrees/s2w-pipeline/cache
+#     (nl_rdw_*.json, nz_{motorcycle,moped}_*.json, uk_veh0120_uk.csv [GenModel
+#     column, per uk_dft.rb], es_dgt_2026{04,05,06}.txt [bytes 17/47/426],
+#     lu_delta_2026-{05,06,07}.xml [LIBMRQ/TYPCOM/CATEU],
+#     fi_traficom_register.zip [merkkiSelvakielinen/kaupallinenNimi/mallimerkinta],
+#     ua_reestr_current.zip [BRAND/MODEL/KIND], th_dlt_2568.csv).
+#     Extracted tables are in the scratchpad (all_raw.txt, gb_genmodel.txt,
+#     avail_report.txt) so the verifier can re-derive without re-parsing 1.5 GB.
+#   * name-marque-true was FETCHED for 33 records. For the remaining 67 I did NOT
+#     consult a marque source, and those are recorded as
+#     unverifiable(not-attempted) — a DISTINCT reason string from a genuine
+#     source-gap, so they must NOT be fed to the source-gap queue and must NOT be
+#     counted as audited. This is the honest truncation the protocol asks for.
+#   * Piaggio-group sites (aprilia.com, vespa.com, motoguzzi.com) return 403 to
+#     WebFetch; press.piaggiogroup.com and piaggiogroup.com work. Recorded so the
+#     next batch does not spend the same calls.
+
+records:
+
+  "moped/honda/c50c":
+    verdicts: { id: "unverifiable(C50C is one of ~30 live honda C50* ids; cannot establish from an aggregate row whether the C suffix is a market variant of moped/honda/c50 or a distinct nameplate)",
+                name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | C50C' nl_rdw bromfiets n=4", "raw: 'HONDA | C50C' nz_nzta MOPED n=9"]
+    notes: "gb also carries GenModel 'HONDA C50C' (54) but uk_dft has no moped kind (uk_dft.rb kinds list), so the missing gb claim is correct, not a gap."
+
+  "moped/agm/hn50qt-k":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'AGM | HN50QT-K' nl_rdw bromfiets n=82", "raw: 'AGM | HN50QT-K' fi_traficom L1e n=1", "AGM make pinned with source in overrides/makes/aliases.yml (https://agm.nl/over-agm/wie-zijn-wij/)"]
+
+  "motorcycle/cyclone/rt1":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { es: correct, th: correct } }
+    evidence: ["https://www.advrider.com/zongshen-cyclone-rc401-sportbike-and-rx401-adv-bike-revealed/  # name check, via data/review/cyclone.yml verdict 'canonical'",
+               "raw: 'CYCLONE | RT1' es_dgt *05 n=79", "raw: 'CYCLONE | RT1' th_dlt n=88"]
+    notes: "Already reviewed (data/review/cyclone.yml): RT1 is Zongshen's own designation. Pack fingerprint sha256:0317261d… unchanged."
+
+  "motorcycle/bmw/r51-2":
+    verdicts: { id: correct, name: "defective(display-form: BMW renders the type as R51/2 with a solidus; the published name substitutes a hyphen)",
+                make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'BMW | R 51/2' nl_rdw n=17, 'BMW | R51/2' n=9 (+5/7 in motorfiets-met-zijspan)", "raw: 'BMW | R51/2' nz_nzta n=1"]
+    notes: "SUSPECTED, not proven: I did not fetch a BMW-controlled source, so the name verdict rests on the register raws (17+9+5+7 rows carry the solidus, 2 carry a hyphen) plus the id-slug constraint. Treat as unverifiable if the verifier wants a bmw-group-classic citation. The slug cannot hold '/', so this is a display/id split question of exactly the kreidler-k53 shape already filed in name_shapes.yml."
+
+  "moped/btc/old-classic":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'BTC | OLD CLASSIC' nl_rdw bromfiets n=1221"]
+    notes: "Single-source, but 1221 vehicles is far above the moped publish threshold."
+
+  "moped/berini/m13":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'BERINI | BERINI M13' nl_rdw bromfiets n=276, 'BERINI | M13' n=30, 'BERINI | M 13' n=16"]
+    notes: "NOTE for the make layer: 3 rows arrive under merk 'BERINI GAZELLE' and fold here. Not a defect in this record; flagged because it is the marque-of-sale shape."
+
+  "motorcycle/ducati/848":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, gb: correct, lu: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'DUCATI | 848' nl_rdw n=445 / fi_traficom n=15 / lu_snca n=6 / es_dgt n=1 / nz_nzta n=49 / uk_dft GenModel 'DUCATI 848' n=641"]
+    notes: "Ducati really did sell the 848 (2008-2013) so the bare numeral is probably legitimate here, but that needs a ducati.com citation I did not make. It is ALSO the record where the name_shapes rule collision below bites (see FINDING F1)."
+
+  "motorcycle/aprilia/moto-6-5":
+    verdicts: { id: correct, name: "unverifiable(not-attempted; aprilia.com 403s WebFetch)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["raw: 'APRILIA | MOTO 6.5' nl_rdw n=228", "raw: uk_dft GenModel 'APRILIA MOTO 6.5' n=40"]
+
+  "motorcycle/brixton/crossfire-500x":
+    verdicts: { id: correct, name: "correct(curation-decided)", make: correct, kind: correct,
+                availability: { lu: correct, nl: correct } }
+    evidence: ["data/review/brixton.yml verdict 'canonical' with the spacing discrepancy recorded", "raw: 'BRIXTON | CROSSFIRE 500 X' nl_rdw n=2 / lu_snca n=2"]
+    notes: "NOTE, not a defect, per the protocol's deliberate-decision rule: the review file itself records that Brixton publishes 'Crossfire 500 X' (spaced) against our 'Crossfire 500X', and deliberately holds it pending a whole-make spacing pass together with BX 125. I disagree with leaving it, but it is a recorded decision."
+
+  "moped/honda/dax":
+    verdicts: { id: "defective(duplicate-identity: the Honda Dax IS the ST50, and moped/honda/st50, /st50g, /st50ge, /st50e, /st50dax and /dax-st50 are all live alongside this id)",
+                name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | DAX' nl_rdw bromfiets n=59", "raw: 'HONDA | DAX' nz_nzta MOPED n=30",
+               "live sibling ids: moped/honda/{dax,dax-st50,dax50,st50,st50dax,st50e,st50g,st50ge}"]
+    notes: "The register carries 'DAX ST50' (17), 'ST50 DAX' (3), 'ST50G DAX' (3) — i.e. the raws themselves state the equivalence, so this is resolvable in-data without an external source. DAX is deliberately excluded from styling.yml acronyms (correctly), so the name string itself is fine; the defect is identity, not display."
+
+  "moped/aprilia/sr50-replica":
+    verdicts: { id: correct, name: "unverifiable(not-attempted; aprilia.com 403s)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'APRILIA | SR 50 REPLICA' nl_rdw bromfiets n=3, 'SR50 REPLICA' n=1", "raw: 'APRILIA | SR50 REPLICA' nz_nzta MOPED n=1"]
+    notes: "renames.yml pins the Aprilia SR family casing with an aprilia.com citation; this record inherits SR correctly. Whether 'Replica' is Aprilia's own suffix (SR 50 R Replica?) is the open question."
+
+  "motorcycle/em/legend":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)",
+                make: "unverifiable(marque identity unresolved — name_shapes.yml debt entry acronym-make-casing-2w-tail lists `em` as GENUINELY OPEN and names these exact th_dlt records: Enzo, Legend, Owen, Qarez)",
+                kind: correct, availability: { th: correct } }
+    evidence: ["raw: 'EM | LEGEND' th_dlt n=2455", "data/name_shapes.yml debt: acronym-make-casing-2w-tail"]
+    notes: "2455 Thai registrations is a large, real fleet under an unidentified marque. Worth a targeted research task: this is not a casing question, it is 'who is EM'."
+
+  "motorcycle/ducati/900sl":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'DUCATI | 900 SL' nl_rdw n=7, '900SL' n=2", "uk_dft GenModel 'DUCATI 900 SL' n=14", "raw: 'DUCATI | 900 SL' nz_nzta n=5, '900SL' n=1"]
+    notes: "Space-collapse candidate: the dominant raw is SPACED ('900 SL' 7+5 vs '900SL' 2+1) and the published name is collapsed — the exact normalizer-space-collapse-display-names shape (name_shapes.yml debt, count 269)."
+
+  "moped/btc/riva-sport":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'BTC | RIVA SPORT' nl_rdw bromfiets n=616 (+ 'BTC RIVA SPORT' n=18)"]
+
+  "moped/giant/quick-e":
+    verdicts: { id: "unverifiable(cannot rule out a marque collision)",
+                name: "unverifiable(not-attempted)",
+                make: "unverifiable(possible marque trap: 'Quick' is a Cannondale nameplate line (Quick / Quick Neo e-bike); I could not confirm that Giant markets a 'Quick-E')",
+                kind: correct, availability: { nl: correct } }
+    evidence: ["raw: 'GIANT | QUICK-E' nl_rdw bromfiets n=354"]
+    notes: "FLAGGED FOR RESEARCH. 354 NL speed-pedelec registrations under merk=GIANT with handelsbenaming QUICK-E. Giant's own fitness range is Escape/FastRoad; 'Quick' is Cannondale's. Either Giant does sell a Quick-E in NL (then everything here is correct) or this is a type-approval-holder/marque-of-sale trap of the moves.yml class. Do not act either way without a marque source."
+
+  "motorcycle/harley-davidson/flhtcu-ultra-classic-electra-glide":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # H-D's own page: model codes are continuous UPPERCASE, no spaces or hyphens (FLHXS, FXDC, FLHR, XL883R, FLHTC)",
+               "raw: 'HARLEY DAVIDSON | FLHTCU ULTRA CLASSIC ELECTRA GLIDE' nl_rdw n=191", "raw: fi_traficom same string n=37+2"]
+    notes: "Published 'Flhtcu Ultra Classic Electra Glide'; should be 'FLHTCU Ultra Classic Electra Glide'. Instance of the filed model-column-acronym-casing debt (count 511) — but that entry says every token needs one human call, and this is that call, made against H-D's own convention page. renames.yml's own Harley header already asserts the same rule, so the record contradicts the project's pinned convention."
+
+  "motorcycle/aprilia/shiver":
+    verdicts: { id: correct, name: "unverifiable(not-attempted; aprilia.com 403s)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'APRILIA | SHIVER' nl_rdw n=4", "raw: 'APRILIA | SHIVER' nz_nzta n=100"]
+    notes: "Aprilia's model is the Shiver 750/900, so the bare 'Shiver' is a family-level record. Not obviously wrong; granularity question only."
+
+  "motorcycle/jialing/jh600":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["raw: 'JIALING | JH600' nl_rdw n=2", "uk_dft GenModel 'JIALING JH 600' n=1"]
+    notes: "Both raws are SPACED or near it ('JH 600'); the published fused form is the space-collapse display shape again."
+
+  "moped/honda/mb":
+    verdicts: { id: "defective(bare-family duplicate: 'MB' is the register's truncation of the MB50/MB5 (49cc) and MB8/MB80 (79cc) families, both of which are separately live)",
+                name: "defective(model_casing + not-a-nameplate: Honda has no model called 'MB'; the 49cc bike is the MB50, sold as MB5 in the US/Canada)",
+                make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["https://www.cmsnl.com/mb50-mb5-1982-c-usa_model1084/info/  # Honda parts-catalogue model record 'Honda MB50 MB5 1982 (C) USA'",
+               "https://www.cmsnl.com/honda-mb50s-mb5-1980-a-england_model15752/partslist/  # 'Honda MB50S MB5 1980 (A) ENGLAND'",
+               "raw: 'HONDA | MB' nl_rdw bromfiets n=57", "raw: 'HONDA | MB' nz_nzta MOPED n=2",
+               "live siblings: moped/honda/mb5, moped/honda/mb50, motorcycle/honda/mb5"]
+    notes: "SECOND, SEPARATE FINDING from the same evidence: moped/honda/mb5 and moped/honda/mb50 are ONE machine under two market names (Honda's own parts catalogue keys both to the same model record), so THEY are a duplicate pair too — outside this record's four claims but directly actionable. The NL raws also separate MB-8/MB80 (79cc, 278+13+47 rows) which must NOT be folded into either."
+
+  "moped/baotian/tanco-49":
+    verdicts: { id: correct, name: "unverifiable(not-attempted; and see note — the published string is not any raw)", make: "unverifiable(not-attempted)", kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'BAOTIAN | TANCO49' nl_rdw bromfiets n=26", "raw: 'Baotian | Tanco49' fi_traficom L1e n=2"]
+    notes: "Both raws are FUSED ('TANCO49') and the published name is SPACED ('Tanco 49') — the space-collapse rule's pass-2 reopening running the OPPOSITE way from the usual defect, with no renames.yml line behind it. Worth the verifier's attention because the debt entry only describes the collapse direction. Also: 'Tanco' may be a badge rather than a Baotian nameplate (marque-of-sale risk)."
+
+  "motorcycle/musstang/mt125-8":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { ua: correct } }
+    evidence: ["raw: 'MUSSTANG | MT125-8' ua_mvs МОТОЦИКЛ n=386"]
+    notes: "Single-source but 386 registrations. MT is a pinned acronym in styling.yml so the caps survive correctly here."
+
+  "motorcycle/harley-davidson/dyna-super-glide-custom":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # rule 2: H-D model NAMES are spaced registered forms (Super Glide, Wide Glide, Electra Glide)",
+               "raw: 'HARLEY DAVIDSON | DYNA SUPER GLIDE CUSTOM' nl_rdw n=6 (+ 'FXDC DYNA SUPER GLIDE CUSTOM' n=213)", "raw: ua_mvs same string n=1"]
+    notes: "GRANULARITY NOTE only: 213 of the 219 NL rows carry the FXDC code and 6 do not, so the dominant raw is 'FXDC Dyna Super Glide Custom'. renames.yml already treats 'code + spaced name' as one nameplate elsewhere (FXDI Dyna Super Glide). Not called a defect: the code-less form is a genuine register spelling and the name string itself is H-D's."
+
+  "moped/kymco/sento":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'KYMCO | SENTO' nl_rdw bromfiets n=2734"]
+
+  "moped/luuko/retro-50":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: "unverifiable(not-attempted)", kind: correct,
+                availability: { nl: correct } }
+    evidence: ["build/packs/luuko.md: `nl_rdw` `LUUKO | RETRO 50` (432)"]
+    notes: "Pack-confirmed availability. 'Retro 50' is a generic descriptor+displacement of the kind that is usually a real Chinese-import nameplate, but Luuko has no reachable marque page and is not in data/review/."
+
+  "motorcycle/honda/adv750":
+    verdicts: { id: "defective(duplicate-identity: ADV750 is Honda's type designation for the X-ADV, and motorcycle/honda/x-adv is live)",
+                name: "defective(code_string: type designation published as the nameplate; Honda's nameplate is X-ADV)",
+                make: correct, kind: correct,
+                availability: { es: correct, fi: correct, gb: correct, lu: correct, nl: correct, ua: correct } }
+    evidence: ["https://webom.hondamotopub.com/webom/HMEE/MKT250/html/index.html  # Honda's own owner's-manual title: 'X-ADV (ADV750)'",
+               "https://2rom-prd-data.hondamotopub.com/om/HMEE/ADV750/2025/ADV750-S_32MKT700_EN_WEB.pdf  # Honda manual filed under ADV750 for the X-ADV",
+               "raw: 'HONDA | ADV750' nl_rdw n=2452 / es_dgt n=649+6+3+1 / fi_traficom n=5 / lu_snca n=11 / ua_mvs n=37 / uk_dft GenModel 'HONDA ADV750' + 'HONDA ADV 750-T'"]
+    notes: "HIGH-IMPACT: 3,150+ vehicles across six countries sit under a homologation code while the marque nameplate id (x-adv) holds ~880 (mostly th_dlt). The same shape covers honda/adv350a beside honda/adv350. Folding is NOT a display fix — the slug moves, so it needs former_ids. Flagged, not acted on."
+
+  "motorcycle/aprilia/sxr":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["https://www.piaggiogroup.com/en/archive/press-releases/piaggio-group-aprilia-sxr-160-named-scooter-year-india  # Piaggio Group (marque owner) renders it 'Aprilia SXR 160'",
+               "uk_dft GenModel 'APRILIA SXR' n=631"]
+    notes: "Published 'Sxr'; Aprilia writes SXR. Instance of model-column-acronym-casing. The bare (un-displaced) form is DVLA's GenModel stem, a granularity artefact, not a second defect."
+
+  "motorcycle/ksr-moto/grs":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { lu: correct, nl: correct } }
+    evidence: ["raw: 'KSR MOTO | GRS' nl_rdw n=1", "raw: 'KSR MOTO | GRS' lu_snca L3e n=3"]
+    notes: "'Grs' is almost certainly the same smart_case artefact as the other three-letter codes, but registers uppercase everything so the raw cannot prove it — the exact ceiling name_shapes.yml documents. Needs a KSR source."
+
+  "moped/honda/mt5":
+    verdicts: { id: "defective(duplicate-identity: moped/honda/mt5 and moped/honda/mt50 are the same machine — the MT50 is sold as MT5 in the UK, exactly as MB50/MB5)",
+                name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | MT5' nl_rdw bromfiets n=175, 'MT 5' n=45, 'MT-5' n=56; 'MT50' n=51, 'MT50 S' n=7", "raw: 'HONDA | MT5' nz_nzta MOPED n=5, 'MT 5' n=2", "live siblings: moped/honda/mt50, motorcycle/honda/mt50"]
+    notes: "The MB50/MB5 equivalence is PROVEN above from Honda's parts catalogue; for MT50/MT5 I am asserting the same pattern and have NOT sourced it — so the id verdict here is my weakest claim in the batch. Verifier: check cmsnl for an 'MT50 MT5' model record before accepting."
+
+  "moped/suzuki/rmx":
+    verdicts: { id: "unverifiable(bare 'RMX' could be the RMX50 (moped) family stem or noise; moped/suzuki/rmx50 liveness not checked at claim time)",
+                name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'SUZUKI | RMX' nl_rdw bromfiets n=1", "raw: 'SUZUKI | RMX' nz_nzta MOPED n=4"]
+    notes: "Published 'Rmx' — Suzuki's line is the RMX (RMX50/RMX450Z), all caps in every Suzuki catalogue, so this is a model_casing candidate. Not called: no Suzuki source fetched. Also note the record publishes on 1+4 vehicles, i.e. purely on two-source corroboration."
+
+  "motorcycle/royal-alloy/gp125":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["uk_dft GenModel 'ROYAL ALLOY GP 125' n≈1372 across AC/AC E5/LC/LC E5/MT/S LC/SE Model rows"]
+    notes: "Royal Alloy's own naming is 'GP 125' (spaced) on every dealer listing I have seen; the published 'GP125' is the collapse shape. Not called without a royalalloy.com fetch."
+
+  "motorcycle/harley-davidson/ftk":
+    verdicts: { id: "unverifiable(cannot establish what vehicle 'FTK' denotes)",
+                name: "defective(model_casing — and identity unresolved)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # H-D codes are continuous UPPERCASE; 'Ftk' cannot be right in either reading",
+               "raw: 'HARLEY DAVIDSON | FTK' nl_rdw n=1", "raw: 'HARLEY DAVIDSON | FTK' nz_nzta n=1"]
+    notes: "FTK appears in NO H-D model-code list I could find (their prefixes are FL/FX/XL/XG/VRSC/RA/RH/ELW). Two vehicles, one in each of two countries, published purely on two-source corroboration — the matchless-g12l shape: 'matches no source' tells you the string is probably corrupt but not what it is corrupt OF. Do not fold; a target does not exist."
+
+  "moped/peugeot/a1":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'PEUGEOT | A1' nl_rdw bromfiets n=794", "raw: 'Peugeot | A1' fi_traficom L1e n=34"]
+    notes: "Peugeot Motocycles did make an 'A1' (a 1990s 50cc). Two-country, 828 vehicles — the record is certainly real; only the exact rendering is unchecked."
+
+  "moped/monasso/grace":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: "unverifiable(not-attempted)", kind: correct,
+                availability: { nl: correct } }
+    evidence: ["build/packs/monasso.md: `nl_rdw` `MONASSO | GRACE` (344)"]
+    notes: "CROSS-RECORD FLAG: moped/sunra/grace (also in this batch) publishes the SAME model name under a different make, both NL-evidenced. Sunra's Grace is a documented product; Monasso is a Dutch importer. This is the marque-of-sale / badge-engineering shape and the two records should be researched together, not separately."
+
+  "motorcycle/honda/c90":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | C90' nl_rdw motorfiets n=49, 'C 90' n=14", "uk_dft GenModel 'HONDA C90' n≈5000", "raw: 'HONDA | C90' nz_nzta n=75"]
+    notes: "kind=motorcycle is right: the C90 is 89.5cc, above every moped ceiling in the sourced registers."
+
+  "motorcycle/bsa/rocket-3":
+    verdicts: { id: correct, name: "unverifiable(sources disagree: BSA's A75 is rendered 'Rocket Three' by cybermotorcycle and 'Rocket 3' by the registers; no BSA-controlled source exists)",
+                make: correct, kind: correct,
+                availability: { nl: correct, nz: correct },
+                enrichment: "unverifiable(cited sources not re-fetched)" }
+    evidence: ["raw: 'BSA | ROCKET 3' nl_rdw n=24 (+ 'A75R ROCKET 3' n=6)", "raw: 'BSA | ROCKET 3' nz_nzta n=69 (also 'ROCKET THREE' n=2, 'A75 ROCKET THREE' n=1)",
+               "enrich/bsa.yml cites https://cybermotorcycle.com/marques/bsa/bsa-1960-1969.htm ('1969 A75 Rocket Three 750cc') and …bsa-1970-1979.htm for the 1969-1972 run"]
+    notes: "Enrichment sub-check NOT completed — I read the citation and its quoted string out of enrich/bsa.yml but did not re-fetch cybermotorcycle, which §6.2 requires. The run (1969-1972) is internally consistent with the quoted register lines. NOTE the enrich file's own warning that BSA's 1930s codes were year-coded and collide with postwar ones; A75 is not affected."
+
+  "motorcycle/montesa/4-ride":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, gb: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'MONTESA | 4RIDE' nl_rdw n=2 / es_dgt L3E n=6 / nz_nzta n=1; 'Montesa | 4 Ride' fi_traficom n=1; uk_dft GenModel 'MONTESA 4RIDE' n=292"]
+    notes: "Four registers write it fused (4RIDE), one spaced. Honda/Montesa's own styling is '4RIDE' as far as I know but I did not fetch it, so the space-inserted published form is unresolved."
+
+  "moped/honda/solo":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | SOLO' nl_rdw bromfiets n=47 (+ 'SOLO 50' n=3, 'SOLO AC17' n=5)", "raw: 'HONDA | SOLO' nz_nzta MOPED n=4"]
+    notes: "MAKE TRAP CHECKED AND CLEARED: 'Solo' is also a German moped marque, so this could have been a make-column error — but the raws put SOLO in the MODEL column under merk=HONDA, and the AC17 frame code in 'SOLO AC17' is Honda's own for the 2003 Solo. make verdict stands."
+
+  "moped/suzuki/zr50k":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: 'SUZUKI | ZR50K' nl_rdw bromfiets n=1, 'ZR 50 K' n=1", "raw: 'SUZUKI | ZR 50K' ua_mvs МОПЕД n=1"]
+    notes: "Two vehicles total. The trailing K is a Suzuki model-year letter, which SCHEMA puts below the model level — the same variant_as_model question as the nl-snorfiets-25-suffix entry, and equally blocked on there being no variant layer."
+
+  "motorcycle/silence/s01":
+    verdicts: { id: "defective(cross-kind duplicate: moped/silence/s01 is also live and denotes the same product)",
+                name: correct, make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["https://www.silence.eco/  # via data/review/silence.yml verdict 'canonical': S01/S02/S04 are the marque's own names",
+               "raw: 'SILENCE | S01' nl_rdw motorfiets n=21 / es_dgt *05 n=574 / fi_traficom L3e n=4+1"]
+    notes: "The S01 is one product (L3e, 125cc-class). NL registers 21 as motorfiets and 1 as bromfiets; the single bromfiets row is enough to keep moped/silence/s01 alive beside it, and cross_kind_prune's 97% dominance rule does not fire. The MOPED twin is the wrong one — I record the defect on the record I was assigned, and the fix belongs on moped/silence/s01. Same shape as moped/silence/s02 vs motorcycle/silence/s02."
+
+  "motorcycle/harley-davidson/touring-street-glide-special":
+    verdicts: { id: "unverifiable(does not duplicate any live id I found, but 'Touring' is H-D's platform word so the relationship to a Street-Glide-Special id could not be settled)",
+                name: "defective(family-prefix concatenation: H-D's registered name is 'Street Glide Special'; 'Touring' is the platform/category, not part of the nameplate)",
+                make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # rule 2 names the registered forms; Street Glide is one of them, 'Touring' is not part of any",
+               "raw: 'HARLEY DAVIDSON | TOURING STREET GLIDE SPECIAL' nl_rdw n=5", "raw: fi_traficom 'Touring Street Glide Special' n=1"]
+    notes: "The same register also carries 'TOURING STREET GLIDE (FLHX)' and plain 'Street Glide …' rows, i.e. the Touring prefix is a register habit. Lower confidence than the casing calls — flagged for the verifier."
+
+  "moped/sparta/bosch-e-speed":
+    verdicts: { id: correct,
+                name: "unverifiable(specialist sources describe a Sparta 'Bosch E-Speed' variant alongside 'ION E-Speed' and 'E-Speed Nuvinci', which would make the string legitimate, but I saw it on no Sparta-controlled page)",
+                make: correct, kind: correct, availability: { nl: correct } }
+    evidence: ["raw: 'SPARTA | BOSCH E-SPEED' nl_rdw bromfiets n=801",
+               "https://spartabikes.com/en-int/blogs/e-bike-technology/bosch-system  # Sparta's own Bosch-drive page (confirms the drive family, not the nameplate string)",
+               "https://nederlandersfietsen.nl/fietsmerken/elektrische-fiets-merken/sparta-elektrische-fietsen/sparta-speedbikes/  # specialist: ION E-speed / Bosch E-Speed / E-Speed Nuvinci as distinct Sparta variants"]
+    notes: "I went in expecting a supplier-name-in-nameplate defect and the evidence pushed BACK: Sparta appears to use the drive-supplier as the variant discriminator itself. Recording that rather than the tidier defect. 801 vehicles, so worth settling properly."
+
+  "moped/honda/z50jz":
+    verdicts: { id: "unverifiable(Z50JZ sits among ~11 live honda Z50* ids; whether the trailing Z is a distinct type or a variant of z50j cannot be settled from aggregate rows)",
+                name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | HONDA Z50 JZ' nl_rdw BROMFIETS n=1 (make-prefix strip + letter/digit space collapse → z50jz)", "raw: 'HONDA | Z50JZ' nz_nzta MOPED n=1 (+ 'Z50JZ MONKEY' n=1)"]
+    notes: "PROCESS NOTE for the verifier, because I nearly filed a false defect here: nl_rdw's only *motorfiets* row is 'Z50JZ' and I initially concluded a moped record was carrying motorcycle-kind evidence. It is not — the moped evidence is the bromfiets row 'HONDA Z50 JZ', which only resolves here after prefix-strip AND space-collapse. Any availability audit that greps raws literally will manufacture this class of false positive."
+
+  "motorcycle/lifan/kp-200":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { ua: correct } }
+    evidence: ["raw: 'LIFAN | KP-200' ua_mvs МОТОЦИКЛ n=467"]
+    notes: "Published 'Kp-200' is the classic smart_case artefact (Lifan's line is KP/KPR/KPT) but the raw is uppercase like every register string, so it cannot prove the casing — Lifan source needed."
+
+  "motorcycle/stark/varg":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { es: correct, fi: correct, gb: correct, lu: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["overrides/styling.yml acronyms: VARG, citing https://starkfuture.com/products/stark-varg  # maker's all-caps model name",
+               "raw: 'STARK | VARG' nl_rdw n=47 (+ 'STARK VARG' n=66) / es_dgt *08 n=129+3 / fi n=43+19 / lu n=2 / nz n=13 / ua n=1 / uk_dft GenModel 'STARK VARG' n=9"]
+    notes: "Clean record. All 7 availability claims re-derived; the deliberate all-caps is pinned and sourced. uk_dft also carries 'STARK VARG EX' (220) as a separate GenModel, correctly a different id."
+
+  "moped/piaggio/typhoon":
+    verdicts: { id: correct, name: "unverifiable(not-attempted; vespa.com/piaggio.com 403 WebFetch)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'PIAGGIO | TYPHOON' nl_rdw bromfiets n=151 / fi_traficom L1e n=22+21 / nz_nzta MOPED n=100"]
+    notes: "es_dgt also has an L1 Typhoon row (n=1) that is NOT in the availability list; below whatever the emit threshold left, or lost to the category blank. Worth one look but not a claim defect."
+
+  "moped/vespa/v50s":
+    verdicts: { id: "unverifiable(cannot separate 'V50S' from the live moped/vespa/50s and moped/vespa/v50 without knowing which of Vespa's V5-series types it denotes)",
+                name: "unverifiable(specialist sources give the marque forms as 'Vespa 50 S' with frame code V5SA1T — the published 'V50S' matches neither; vespa.com 403s so no marque-controlled confirmation)",
+                make: correct, kind: correct, availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'VESPA | V50S' nl_rdw bromfiets n=4, 'V 50 S' n=1", "raw: 'VESPA | V50S' nz_nzta MOPED n=2",
+               "https://www.vespa.name/vespa-model/vespa-50-special  # 50 Special = V5A2T/V5B1T/V5B3T; the 50 S is a separate line (V5SA1T)"]
+    notes: "Live siblings moped/vespa/{50,50s,50n,50r,50et2,50v5b,v50,v50s} are a cluster crying out for the V5-type mapping. Not touchable without it."
+
+  "motorcycle/trs/one":
+    verdicts: { id: correct, name: "correct(curation-decided, sourced)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["overrides/models/renames.yml `Trrs One: One` citing trsmotorcycles.com — bikes are badged TRRS but the marque resolves to TRS; 'CREATES the One canonical'",
+               "overrides/makes/aliases.yml `TRS: TRS` identity pin (https://trsmotorcycles.com/)",
+               "uk_dft GenModel 'TRS TRRS ONE' n=838"]
+    notes: "gb-only, and its name is a strict prefix of sibling names — one of 14 such gb-only records catalog-wide (see FINDING F4). Here it is deliberate and sourced, so it is the benign case of that shape."
+
+  "motorcycle/harley-davidson/xg750a":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # XG is one of H-D's own listed prefixes; codes are continuous uppercase — 'XG750A' conforms",
+               "raw: 'HARLEY DAVIDSON | XG750A' nl_rdw n=3 (+ 'XG750A STREETROD' n=1)", "raw: 'HARLEY-DAVIDSON | XG750A' ua_mvs n=3"]
+    notes: "The 'XG750A STREETROD' raw identifies it as the Street Rod 750, so a nameplate-level id would be 'XG750A Street Rod'. Granularity note, not a defect: the code is genuinely H-D's."
+
+  "moped/velosolex/5000":
+    verdicts: { id: "defective(make-level duplicate: moped/solex/5000 is ALSO live and is the same machine; `solex` and `velosolex` are one marque split across two make ids)",
+                name: correct,
+                make: "defective(make-level duplicate — the marque needs a merge, not a rename: overrides/makes/aliases.yml has NO entry for any Solex spelling)",
+                kind: correct,
+                availability: { nl: correct } }
+    evidence: ["https://www.velosolexclubuk.com/information-available-solex-models  # marque club's model list: the VéloSoleX model designations ARE bare numbers (…3800, 4600, 5000, 6000)",
+               "https://velo-solex.ch/en/history/  # 5000 introduced 1971, 16-inch wheels, modified 3800 frame",
+               "raw: 'VELOSOLEX | 5000' nl_rdw bromfiets n=522", "raw: 'VELO SOLEX | 5000' nz_nzta MOPED n=13"]
+    notes: >-
+      TWO findings on one record, and the NAME is the clean part.
+      (1) CROSS-CHECK AGAINST THE FILED DEBT: name_shapes.yml's
+      `bare-displacement-2w` entry lists `solex/701`, `solex/800` and
+      `motobecane/5000` as defects on the reasoning that a bare number on a 2W
+      make is a DISPLACEMENT missing its family word. For VéloSoleX that
+      reasoning is wrong — the numbers are model designations, not displacements
+      (every Solex is 49cc). solex/701 and solex/800 must be re-read before
+      anyone 'fixes' them; possibly motobecane/5000 too.
+      (2) SEE FINDING F9: the marque is split. moped/solex/{1700,2200,3800,5000,
+      701,800,oto} and moped/velosolex/{1700,3800,5000,s3800} are all live, so
+      1700, 3800 and 5000 each exist TWICE. nl_rdw alone carries merk=SOLEX (236
+      rows) and merk=VELOSOLEX (66 rows); nz adds a third spelling, 'VELO SOLEX'
+      (17 rows), which is why nz is absent from this record's availability.
+
+  "moped/sunra/grace":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: "unverifiable(not-attempted)", kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'SUNRA | GRACE' nl_rdw bromfiets n=5", "raw: 'SUNRA | GRACE' nz_nzta MOPED n=1"]
+    notes: "Six vehicles total, publishing purely on two-source corroboration. See the moped/monasso/grace note — same model word, different make, both NL; research them together."
+
+  "motorcycle/husqvarna/svartpilen-125":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.husqvarna-motorcycles.com/en-int/models/naked/svartpilen/svartpilen-125-2025.html  # 'SVARTPILEN 125' is the marque's own model name",
+               "raw: 'HUSQVARNA | HUSQVARNA SVARTPILEN 125' nl_rdw n=20", "raw: 'Husqvarna | Husqvarna Svartpilen 125' fi_traficom L3e n=14"]
+    notes: "Clean. Both raws carry the embedded make and strip correctly. uk_dft's GenModel stem 'HUSQVARNA SVARTPILEN' feeds a separate gb-only motorcycle/husqvarna/svartpilen record — one of the 14 in FINDING F4."
+
+  "motorcycle/rudge/special":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["https://www.rudge-whitworth.com/the-motorcycles/model-history  # marque site's model history: Special is a model in the Rudge range (from 1927/28), beside Standard, Sports Special and Ulster",
+               "https://www.classicmotorcycle.co.uk/rudge-special-1938/  # period road test titled 'Rudge Special (1938)'",
+               "raw: 'RUDGE | SPECIAL' nl_rdw n=7 / fi_traficom L3e n=1 / nz_nzta n=3 (+ 'RUDGE WHITWORTH | SPECIAL' n=2)"]
+    notes: "THE 'WEIRD CAN BE RIGHT' CASE OF THIS BATCH, and the direct counterweight to motorcycle/moto-guzzi/special below: a bare trim-sounding word IS the nameplate here. Any detector that flags bare 'Special' must not auto-fix."
+
+  "moped/yamaha/cw50":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'YAMAHA | CW 50' nl_rdw bromfiets n=1", "raw: 'YAMAHA | CW50' nz_nzta MOPED n=4"]
+    notes: "CW50 is Yamaha's type code for the BW's/Zuma; a nameplate-level id would be BW's (which renames.yml already pins with the apostrophe). Same code-vs-nameplate shape as adv750/mtn890, unsourced here."
+
+  "motorcycle/harley-davidson/883":
+    verdicts: { id: "defective(bare-displacement duplicate: 883 is the displacement shared by the live sportster-883, 883-sportster, xl883, xl883n, xlh883, iron-883 … ids)",
+                name: "defective(numeric_only / bare-displacement-2w: H-D sells no motorcycle called '883'; the nameplates are XL 883, Sportster 883, Iron 883)",
+                make: correct, kind: correct,
+                availability: { fi: correct, lu: correct, nl: correct, nz: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # H-D's own examples pair the displacement with a code/name: 'XL883R'",
+               "raw: 'HARLEY DAVIDSON | 883' nl_rdw n=7 / lu_snca L3e n=8 / fi_traficom L3e n=1 / nz_nzta n=80",
+               "live siblings incl. 883-sportster AND sportster-883 (a token-order duplicate PAIR in their own right)"]
+    notes: "SEE FINDING F1 — this record is where two of the project's own rules contradict each other, and the contradiction currently resolves in favour of calling it legitimate."
+
+  "motorcycle/indian/ftr1200-rally":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'INDIAN MOTORCYCLE | FTR 1200 RALLY' nl_rdw n=7", "raw: 'Indian | Ftr 1200 Rally' fi_traficom L3e n=1"]
+    notes: "Both raws are SPACED ('FTR 1200 RALLY'); the published 'FTR1200 Rally' is collapsed. FTR is a pinned acronym so the caps are right. gb GenModel is the stem 'INDIAN FTR' and correctly feeds a different id."
+
+  "motorcycle/indian/prince":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'INDIAN | PRINCE' nl_rdw n=4 (+ 'INDIAN PRINCE' n=1, + 1 in motorfiets-met-zijspan)", "raw: 'INDIAN | PRINCE' nz_nzta n=5"]
+    notes: "The Indian Prince (1925-28) is a real nameplate, so this is very likely correct; unsourced only because I ran out of fetch budget, not because it looks doubtful."
+
+  "moped/zhenhua/zh-sr50a":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["build/packs/zhenhua.md: `fi_traficom` `Zhenhua | ZH-SR50A` (14), `nl_rdw` `ZHENHUA | ZH-SR50A` (6)"]
+    notes: "Pack-confirmed. The pack also shows moped/zhenhua/zh-sr50a-1 as a separate live id from 'ZH-SR50A-1' raws — a genuine type suffix, not a duplicate, on the kreidler-K53 reasoning."
+
+  "motorcycle/harley-davidson/flhrxs":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, nl: correct, th: correct, ua: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # continuous uppercase codes",
+               "raw: 'HARLEY DAVIDSON | FLHRXS' nl_rdw n=31+6 (+ 'FLHRXS ROAD KING SPECIAL' n=1) / th_dlt n=51 / fi_traficom n=1 / ua_mvs n=5+4 / uk_dft GenModel 'HARLEY-DAVIDSON FLHRXS' n=468"]
+    notes: "Published 'Flhrxs' → 'FLHRXS'. The NL and UA raws that spell it out identify it as the Road King Special, so a nameplate-level id exists too — granularity note only."
+
+  "motorcycle/skyteam/t-rex125":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["raw: 'SKYTEAM | T-REX125' nl_rdw n=1, 'T-REX 125' n=1", "uk_dft GenModel 'SKYTEAM T-REX 125' n=47"]
+    notes: "Dominant raw is spaced ('T-REX 125' in gb ×47 and nl ×1 vs fused ×1) — collapse-display shape. SkyTeam also has a T-REX 50 GenModel (9), correctly a different id."
+
+  "motorcycle/kawasaki/ninja-400":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, lu: correct, nl: correct, th: correct, ua: correct } }
+    evidence: ["raw: 'KAWASAKI | NINJA 400' nl_rdw n=293+1 / lu_snca n=2 (+ 'NINJA400' n=1) / fi_traficom n=12 / ua_mvs n=242; 'KAWASAKI | NINJA400' th_dlt n=17"]
+    notes: "Space PRESERVED here ('Ninja 400') where sibling records collapse — because NINJA is ≥4 letters and pass 2 reopens it. Useful control case for the collapse debt."
+
+  "motorcycle/kymco/ego":
+    verdicts: { id: correct,
+                name: "unverifiable(Kymco parts catalogues render '125 EGO' / '250 EGO' but uppercase everything; kymco.com.tw product index 404s, so no mixed-case marque rendering obtained)",
+                make: correct, kind: correct, availability: { gb: correct, nz: correct } }
+    evidence: ["https://www.bike-parts-kymco.uk/kymco-motorcycle/125-SCOOTER/EGO  # genuine-parts catalogue confirms the EGO exists as a Kymco 125 and 250",
+               "uk_dft GenModel 'KYMCO EGO' n=30", "raw: 'KYMCO | EGO' nz_nzta n=5"]
+    notes: "The RECORD is real (that much is sourced); only 'Ego' vs 'EGO' is open. Kymco's other nameplates are title-case words (Agility, Downtown, People, Like), which argues both ways."
+
+  "motorcycle/laverda/750sf":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { lu: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'LAVERDA | 750 SF' nl_rdw n=412 vs '750SF' n=348 (+4/2 in zijspan) / nz_nzta '750 SF' n=1, '750SF' n=14 / lu_snca '750SF' n=1"]
+    notes: "SPACED is the dominant NL raw (412 vs 348) and the published name is fused — collapse-display shape on a 700+ vehicle record, i.e. one of the higher-traffic instances of that debt."
+
+  "motorcycle/ktm/530exc":
+    verdicts: { id: correct, name: "defective(display-form: KTM writes the displacement first and spaced — '530 EXC')", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.ktm.com/en-gb/models/enduro/ktm-125-exc-2026.html  # KTM's own pages render '2027 KTM 300 EXC', '2027 KTM 250 EXC-F' — displacement BEFORE the family word, with a space",
+               "raw: 'KTM | KTM 530 EXC' nl_rdw n=282, '530 EXC' n=1", "raw: 'KTM | KTM 530 EXC' fi_traficom L3e n=27"]
+    notes: "Every raw is spaced; only the published name is fused. Token ORDER is already right here, unlike ktm/exc125 below."
+
+  "motorcycle/moto-morini/501":
+    verdicts: { id: "unverifiable(bare 501 pools Moto Morini's 501-engined models — Camel 501, Excalibur 501, Kanguro 501 — and the raws include '501 CAMEL' and '501/2', so no single target)",
+                name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'MOTO MORINI | 501' nl_rdw n=2 (+ '501/2' n=2, '501 CAMEL' n=1)", "raw: 'MOTO MORINI | 501' nz_nzta n=3"]
+    notes: "The bare-displacement shape with the POOLING complication (SEAT Leon/Ateca rule): a fold would hand several models' evidence to one. Five vehicles total."
+
+  "motorcycle/honda/crf450rl":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { th: correct, ua: correct } }
+    evidence: ["raw: 'HONDA | CRF450RL' th_dlt n=13", "raw: 'HONDA | CRF 450RL' ua_mvs n=1"]
+    notes: "Live sibling motorcycle/honda/crf450l ('CRF450L') is a DIFFERENT bike (the RL is the 2019+ road-legal successor), so not a duplicate — but that is my assertion, unsourced."
+
+  "motorcycle/norton/es2":
+    verdicts: { id: "defective(duplicate-identity: motorcycle/norton/es2-500 is live and enrich/norton.yml itself states it is 'same machine as `es2`, register spelling with displacement')",
+                name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct },
+                enrichment: "unverifiable(cited NOC pages not re-fetched)" }
+    evidence: ["enrich/norton.yml cites https://www.nortonownersclub.org/models/sngle-cylinder/overhead-valve for 'ES2 490cc OHV 1928 - 1939' and '490cc OHV 1947 - 1963'  # marque club = name check AND run source",
+               "raw: 'NORTON | ES 2' nl_rdw n=56, 'ES2' n=36 (+ 9 further punctuations: 'E.S.2.', 'ES-2', 'ES.2', 'E S 2', 'YES 2') / nz_nzta 'ES2' n=62 / fi n=2 / es n=1",
+               "enrich/norton.yml `motorcycle/norton/es2-500` — same runs, declared same machine"]
+    notes: "THE DUPLICATE IS SELF-DECLARED IN THE PROJECT'S OWN ENRICHMENT FILE, which is the cheapest possible detector signal: any two ids carrying identical `runs` with a comment saying 'same machine' is a duplicate-id oracle. Worth a lint. Enrichment sub-check not completed (not re-fetched); the two runs are internally consistent and the file's own note about the deliberately-unencoded Mk.II conflict is sound practice."
+
+  "motorcycle/harley-davidson/fxdwgi-dyna-wide-glide":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html",
+               "raw: 'HARLEY DAVIDSON | FXDWGI DYNA WIDE GLIDE' nl_rdw n=19+1 / fi_traficom n=14 (+ '…-GPW/1449' n=4)"]
+    notes: >-
+      'Fxdwgi Dyna Wide Glide' → 'FXDWGI Dyna Wide Glide'. Both halves of the H-D
+      convention apply at once, exactly as renames.yml's header predicts.
+      UNCLAIMED EVIDENCE (not a claim defect, but a coverage gap worth one look):
+      uk_dft carries GenModel 'HARLEY-DAVIDSON FXDWGI' with 184 licensed+SORN
+      vehicles, and gb is NOT in this record's availability list.
+
+  "motorcycle/suzuki/gsx800":
+    verdicts: { id: "unverifiable(GSX800 is a type designation that may POOL the GSX-8S and GSX-8R — both 776cc — so no single duplicate target can be named; the SEAT Leon/Ateca rule applies)",
+                name: "defective(code_string: type designation published as the nameplate; Suzuki's nameplates are GSX-8S and GSX-8R)",
+                make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct, ua: correct } }
+    evidence: ["https://suzukicycles.com/street/2026/gsx-8s  # Suzuki's own model name for the 776cc parallel twin is GSX-8S (and GSX-8R for the faired bike); no 'GSX800' appears on Suzuki's product pages",
+               "raw: 'SUZUKI | GSX800' nl_rdw n=910 / es_dgt n=84+2 (+ 'GSX 800' n=1) / fi_traficom n=22 / lu_snca n=4 (+ 'GSX-800' n=5) / ua_mvs n=28",
+               "live siblings: suzuki/gsx-8s, gsx800t, gsx800tu, gsx800u"]
+    notes: "1,050+ vehicles under the code. GSX is a pinned acronym so the caps are right; the defect is that the string is a homologation designation, not a nameplate. DO NOT fold to gsx-8s without establishing whether the 8R rides in the same rows — that is the pooling trap the moves.yml header warns about."
+
+  "motorcycle/mv-agusta/turismo":
+    verdicts: { id: "defective(family-stem duplicate: motorcycle/mv-agusta/turismo-veloce, -veloce-lusso and -veloce-r are all live; 'Turismo' is DVLA's GenModel truncation of the same family)",
+                name: "defective(truncated nameplate: MV Agusta's family is 'Turismo Veloce'; no current product is named 'Turismo')",
+                make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["https://www.mvagusta.com/us/en/models/turismo-veloce  # the marque's own model page: Turismo Veloce (variants Lusso SCS, RC SCS, R)",
+               "uk_dft GenModel 'MV AGUSTA TURISMO' n=252", "raw: 'M.V. AGUSTA | TURISMO' nl_rdw n=1"]
+    notes: "CAVEAT the verifier should weigh: MV Agusta DID make 1950s 'Turismo' models (125/175 Turismo), so the single 1-vehicle NL row could legitimately be one. The 252 GB vehicles cannot be — DVLA's GenModel is a family stem. So the record is a merge of a possible classic and a truncated modern family, which is worse than either."
+
+  "motorcycle/honda/gold-wing-gl1500se":
+    verdicts: { id: correct, name: "correct(curation-decided, sourced)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["overrides/models/renames.yml Honda block: 'Goldwing → Gold Wing' etc., citing powersports.honda.com — Honda writes Gold Wing as TWO words",
+               "raw: 'HONDA | GOLD WING GL 1500 SE' nl_rdw n=5, 'GOLD WING GL1500SE' n=1 (+1 zijspan, +1 driewielig)", "raw: 'Honda | GOLD WING GL 1500 SE' fi_traficom L3e n=1"]
+    notes: "The pinned two-word rule is correctly applied. The GL1500SE code is fused where the dominant raw spaces it ('GL 1500 SE') — collapse shape inside an otherwise curated name."
+
+  "motorcycle/royal-enfield/classic-650-twin":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["https://www.royalenfield.com/content/dam/open-pdf/royal-enfield-classic-650-technical-specifications.pdf  # Royal Enfield's own spec sheet: 'The Classic 650 Twin.' — 'Twin' IS part of the marque's rendering",
+               "raw: 'ROYAL ENFIELD | CLASSIC 650 TWIN' nl_rdw n=88 / es_dgt *06 n=36 / lu_snca n=2 / fi_traficom n=3"]
+    notes: "Clean, and a name I would have 'corrected' wrongly on instinct — the marque really does append Twin. Note uk_dft's GenModel stem 'ROYAL ENFIELD CLASSIC' (2922) feeds the separate royal-enfield/classic record."
+
+  "motorcycle/harley-davidson/fxstsse-3cvo-softail-springer":
+    verdicts: { id: "defective(the id itself carries a normalizer token-boundary error: fxstsse-3cvo-… where the raw is FXSTSSE3 CVO)",
+                name: "defective(model_casing + token-boundary shift)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # codes are continuous uppercase; the code here is FXSTSSE3",
+               "raw: 'HARLEY DAVIDSON | FXSTSSE3 CVO SOFTAIL SPRINGER' nl_rdw n=8 (+ '…SOFTTAIL…' n=1)", "raw: 'Harley-Davidson | FXSTSSE3 CVO Softail Springer' fi_traficom n=2", "raw: 'HARLEY DAVIDSON | FXSTSSE3' nz_nzta n=3"]
+    notes: "SEE FINDING F2 — this is a NEW sub-shape of the collapse debt, not plain casing: the trailing DIGIT of the type code migrated to the NEXT token. 'FXSTSSE3 CVO' became 'Fxstsse 3CVO'. Every raw in three registers agrees on FXSTSSE3; nothing in the corpus supports '3CVO'."
+
+  "motorcycle/triumph/daytona-675":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["raw: 'TRIUMPH | DAYTONA 675' nl_rdw n=408 / fi_traficom n=26+2 / nz_nzta n=9 / ua_mvs n=5; uk_dft GenModel 'TRIUMPH DAYTONA' n=2770 (stem — feeds a different id)"]
+
+  "motorcycle/vespa/50-special":
+    verdicts: { id: "defective(cross-kind duplicate: moped/vespa/50-special is live and is the same scooter)",
+                name: correct,
+                make: correct,
+                kind: "defective(kind_noise: the Vespa 50 Special is a 50cc moped; this motorcycle-kind record exists because uk_dft has NO moped class — its own kind_map says 'UK merges mopeds INTO Motorcycles' — plus 2 stray nl motorfiets rows)",
+                availability: { gb: correct, nl: correct } }
+    evidence: ["https://www.vespa.name/vespa-model/vespa-50-special  # '50 Special' is the marque form (types V5A2T/V5B1T/V5B3T, 1969-1983)",
+               "https://www.scooterwest.com/make-model-year/vespa/vespa-50-special/1969-1983-vespa-50-special-v5b.html",
+               "raw: 'VESPA | 50 SPECIAL' nl_rdw MOTORFIETS n=2 vs BROMFIETS n=194+11+1 (+ 'VESPA 50 SPECIAL' n=39)", "uk_dft GenModel 'VESPA (DOUGLAS) 50 SPECIAL' n=128",
+               "overrides/kind_maps/uk_dft.yml: 'UK merges mopeds INTO Motorcycles (no separate class) → UK contributes evidence to kind=motorcycle only'"]
+    notes: "SEE FINDING F3. cross_kind_prune cannot save this: motorcycle-side count ≈130 vs moped-side ≈254, a 34% share, nowhere near the 97% dominance rule. Any UK-heavy moped nameplate will do the same. The name STRING is right; the kind and the duplication are not."
+
+  "motorcycle/honda/nighthawk":
+    verdicts: { id: "unverifiable(Nighthawk is Honda's US market name for CB250/CB650/CB750 variants; whether this pools several CB models cannot be settled from 9 aggregate rows)",
+                name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'HONDA | NIGHTHAWK' nl_rdw n=1", "raw: 'HONDA | NIGHTHAWK' nz_nzta n=8 (+ 'NIGHT HAWK' n=1)",
+               "context: nl also carries 'CB750 NIGHTHAWK' (4), 'CB750SC NIGHTHAWK' (1), 'CB750NIG' (1) — the same nameplate WITH its CB code, under different ids"]
+    notes: "Pooling risk is concrete here: the register shows Nighthawk attached to CB750 in NL while the bare form holds its own id."
+
+  "motorcycle/sym/fiddle":
+    verdicts: { id: "defective(cross-kind duplicate: SYM's Fiddle is a 50/125 scooter and moped/sym/fiddle holds 36,746 nl bromfiets vehicles beside this motorcycle-kind record)",
+                name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, lu: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["raw: 'SYM | FIDDLE' nl_rdw MOTORFIETS n=110 vs BROMFIETS n=36746; lu_snca L1e-A n=6, L1e-B n=2, L3e n=1; fi_traficom L1e n=8, L3e n=1; nz_nzta MOTORCYCLE n=15, MOPED n=34; ua_mvs n=4; uk_dft GenModel 'SYM FIDDLE' n=1363",
+               "overrides/makes/aliases.yml `SYM: SYM` pinned with https://www.sym-global.com/about"]
+    notes: "UNLIKE the Vespa case this one is DEFENSIBLE: SYM genuinely sells the Fiddle in both a 50cc (L1e) and a 125/200 (L3e) form, and lu/fi/nz all carry it in BOTH classes, so two kind records may be the honest answer. I record the id claim as defective because two live ids share a name and neither carries a displacement to separate them — but this is the G24 kind-boundary question, not a curation error. Verifier should probably downgrade to a note."
+
+  "motorcycle/harley-davidson/sportster":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, lu: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html  # Sportster® is one of H-D's listed registered model names",
+               "raw: 'HARLEY DAVIDSON | SPORTSTER' nl_rdw n=143+2 / nz_nzta n=2903 / fi_traficom n=4+2 / lu_snca n=1 / ua_mvs n=17 / uk_dft GenModel 'HARLEY-DAVIDSON SPORTSTER' n=879",
+               "renames.yml already folds 'Sport Ster → Sportster' — and both stray raws ('SPORT STER' nl ×1, nz ×1) exist, so the fold is live and working"]
+    notes: "Clean 6-country record; family-level granularity is legitimate here because Sportster IS the registered family name."
+
+  "motorcycle/yamaha/mtn890-s":
+    verdicts: { id: "defective(duplicate-identity: MTN890 is Yamaha's type code for the MT-09, and motorcycle/yamaha/mt-09 is live)",
+                name: "defective(code_string: type code published as the nameplate)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["https://cdn2.yamaha-motor.eu/prod/owner-manuals/Motorcycles/PB7N28199E0E.PDF  # Yamaha's OWN owner's manual, title line 'MTN890 (MT-09)'",
+               "raw: 'YAMAHA | MTN890-S' nl_rdw n=234 / es_dgt *07 n=26 / fi_traficom L3e n=15",
+               "live siblings: yamaha/mt-09, mt-09a, mt-09abs, mt-09sp, mtn890, mtn890-su, mtn890-u, mtn890d, mtn890d-u"]
+    notes: "A NINE-ID CLUSTER for one nameplate, half of it type codes and half of it marketing names. 275 vehicles on this id alone. The -S/-U/-SU/-D suffixes are market/spec variants below model level (SCHEMA), so the honest target is mt-09 plus a variant layer that does not exist — the kreidler-K53 wall again. FLAG: styling.yml pins 'SU' as an acronym 'Yamaha model-code suffix (MTN690-SU)', i.e. the project has already invested in making these codes DISPLAY nicely rather than resolving them."
+
+  "motorcycle/zero-motorcycles/ds15-6":
+    verdicts: { id: "unverifiable(cannot establish whether 'DS 15.6' is a distinct model from the live ds and ds-zf14-4-11kw ids)",
+                name: "unverifiable(Zero's own convention is a ZF-prefixed pack size (ZF14.4, ZF17.3) and the published name drops the ZF; zeromotorcycles.com/model/zero-ds does not list a 15.6 variant, so I could neither confirm nor refute)",
+                make: correct, kind: correct, availability: { es: correct, nl: correct } }
+    evidence: ["raw: 'ZERO MOTORCYCLES | DS 15.6' nl_rdw n=7 / es_dgt *05 n=5",
+               "context: the SAME es corpus carries 'DS ZF14.4 11KW', 'S ZF14.4 11KW', 'SR ZF15.6', 'FX ZF7.2' — i.e. ZF-prefixed rows coexist with bare-number rows for the same packs",
+               "uk_dft GenModel 'ZERO DS ZF' n=42 (stem, ZF retained)"]
+    notes: "'SR ZF15.6' in es_dgt is direct in-corpus evidence that a 15.6 kWh Zero pack exists and that the register sometimes keeps the ZF — which makes 'DS 15.6' look like the ZF-dropped spelling of 'DS ZF15.6'. Suggestive, not conclusive: recorded as unverifiable rather than folded."
+
+  "motorcycle/zero-motorcycles/dsr15-6":
+    verdicts: { id: "unverifiable(same as ds15-6: relationship to live dsr, dsr-zf13-0, dsr-zf14-4 unresolved)",
+                name: "unverifiable(same ZF-prefix question)", make: correct, kind: correct,
+                availability: { es: correct, nl: correct } }
+    evidence: ["raw: 'ZERO MOTORCYCLES | DSR 15.6' nl_rdw n=7 / es_dgt *06 n=2", "uk_dft GenModel 'ZERO DSR ZF' n=87"]
+    notes: "DSR is a pinned acronym in styling.yml so the caps are right. Same unresolved ZF question as its DS twin; treat the two together."
+
+  "motorcycle/zero-motorcycles/xe":
+    verdicts: { id: correct, name: "defective(model_casing)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, gb: correct, nl: correct } }
+    evidence: ["https://zeromotorcycles.com/model/zero-xe  # Zero renders it 'XE' (X Line: XE, XB)",
+               "raw: 'ZERO MOTORCYCLES | XE' nl_rdw n=5 (+ 'ZERO MOTORCYCLES XE' n=9) / es_dgt *08 'ZERO MOTORCYCLE XE' n=7 / fi_traficom 'Zero motorcycles XE' n=1 / uk_dft GenModel 'ZERO XE' n=15"]
+    notes: "renames.yml's `Motorcycle Xe: Xe` line correctly recovered the es/nl 'ZERO MOTORCYCLE XE' rows (singular make, prefix-strip miss) and former_ids carries motorcycle-xe — that machinery works. What it did not do is fix the casing to XE, and the file's own comment shows the author saw 'Xe' being produced. Clean 4-country availability."
+
+  "motorcycle/zontes/v310":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { gb: correct, ua: correct } }
+    evidence: ["uk_dft GenModel 'ZONTES V310' n=1 (SORN)", "raw: 'ZONTES | V310' ua_mvs n=2"]
+    notes: "Three vehicles across two countries — publishes purely on two-source corroboration. Zontes does use V-series names (V310-T etc.), so a bare V310 may be a family stem."
+
+  "motorcycle/zundapp/50":
+    verdicts: { id: "unverifiable(bare '50' among many Zündapp type numbers; the nl corpus separately carries '50 CROSS' and '5030-05')",
+                name: "unverifiable(not-attempted)",
+                make: correct,
+                kind: "unverifiable(the two cited registers class it as motorcycle while nl ALSO has a bromfiets '50' row for the same string; displacement not recoverable from aggregates)",
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'ZUENDAPP | 50' nl_rdw MOTORFIETS n=1 (merk ZUENDAPP, aliased to Zundapp)", "raw: 'ZUNDAPP | 50' nz_nzta MOTORCYCLE n=1"]
+    notes: "PROCESS NOTE: I first recorded this as a cross-kind evidence leak because I grepped for 'ZUNDAPP' and the nl motorcycle row is spelled 'ZUENDAPP'. It is NOT a leak. Second false positive of the batch caused by make-alias blindness — a mechanical availability detector must resolve aliases first. Bare '50' is the bare-displacement-2w shape (that debt entry lists other Zündapp-adjacent bare numbers)."
+
+  "motorcycle/kawasaki/kz650":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'KAWASAKI | KZ 650' nl_rdw n=7, 'KZ650' n=1", "raw: 'KAWASAKI | KZ650' nz_nzta n=3"]
+    notes: "Dominant nl raw is spaced; published form fused — collapse shape."
+
+  "motorcycle/ktm/exc125":
+    verdicts: { id: "defective(duplicate-identity: motorcycle/ktm/125exc ('125EXC') is live and is the same bike — one nameplate at two ids differing only in token order)",
+                name: "defective(display-form: KTM writes '125 EXC' — displacement first, spaced)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.ktm.com/en-gb/models/enduro/ktm-125-exc-2026.html  # KTM's own rendering: '2027 KTM 300 EXC' / '2027 KTM 250 EXC-F' — number then family word, spaced",
+               "raw: 'KTM | EXC 125' nl_rdw n=4", "raw: 'KTM | EXC 125' fi_traficom L3e n=1",
+               "live siblings: motorcycle/ktm/125exc, motorcycle/ktm/exc, motorcycle/ktm/530exc"]
+    notes: "The cleanest single defect in the batch: same make, same bike, two live ids, and the marque's own page settles the order. renames.yml already pins 'Exc → EXC' for casing but no line addresses the inversion. Compare the Alfa Romeo '1300 GT Junior' inversion block in renames.yml — the mechanism exists, it just has not been applied to KTM."
+
+  "motorcycle/moto-guzzi/special":
+    verdicts: { id: "defective(bare-trim duplicate: motorcycle/moto-guzzi/v7-special and /v7-750-special are live; a bare 'Special' cannot be a canonical model identity for this marque)",
+                name: "defective(truncated nameplate: Moto Guzzi's nameplates are V7 Special (1969-71), V50/V65 Special — never a bare 'Special')",
+                make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["https://wide.piaggiogroup.com/en/articles/corporate/generation-v7/index.html  # Piaggio Group (marque owner) V7 generation history",
+               "https://www.autoevolution.com/moto/moto-guzzi-v7-special-1969.html  # 'Moto Guzzi V7 Special (1969-1971)'",
+               "raw: 'MOTO-GUZZI | SPECIAL' nl_rdw n=1", "raw: 'MOTO GUZZI | SPECIAL' nz_nzta n=1"]
+    notes: "POOLING CAVEAT: 'Special' could be the V7, V50 or V65 Special, so the fold TARGET is not determined — the disposition is blocked even though the defect is clear. Contrast motorcycle/rudge/special in this same batch, which is CORRECT: the identical string is a real nameplate for a different marque. That pair is the reason a bare-'Special' detector must never auto-fix."
+
+  "motorcycle/suzuki/cavalcade-lxe":
+    verdicts: { id: correct, name: "defective(model_casing: LXE is a Suzuki trim code, all caps)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["https://www.autoevolution.com/moto/suzuki-gv-1400lxe-cavalcade-1985.html  # 'SUZUKI GV1400LXE Cavalcade (1985-1988)'",
+               "https://www.autopaper.com/1986-suzuki-cavalcade-lx-lxe-motorcycle-dealer-sales-brochure-gv1400.php  # Suzuki DEALER SALES BROCHURE titled 'Cavalcade LX & LXE'",
+               "raw: 'SUZUKI | CAVALCADE LXE' nl_rdw n=2", "raw: 'SUZUKI | CAVALCADE LXE' nz_nzta n=1+1 (+ 'CAVALCADE LXE 1400' n=2)"]
+    notes: "Published 'Cavalcade Lxe' → 'Cavalcade LXE'. A Suzuki dealer brochure is the strongest source available for a 1986 US-market trim; the marque's current site does not go back this far."
+
+  "motorcycle/suzuki/gsx550e":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'SUZUKI | GSX 550 E' nl_rdw n=1", "raw: 'Suzuki | GSX 550 E' fi_traficom L3e n=1"]
+    notes: "Two vehicles. BOTH raws are fully spaced ('GSX 550 E') and the published name is fully fused ('GSX550E') — the purest collapse instance in the batch, with zero raw support for the fused form."
+
+  "motorcycle/suzuki/t250j":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, nz: correct } }
+    evidence: ["raw: 'Suzuki | T250J' fi_traficom L3e n=1", "raw: 'SUZUKI | T250J' nz_nzta n=2"]
+    notes: "The trailing J is Suzuki's 1972 model-year letter — variant-level under SCHEMA, same blocked shape as suzuki/zr50k."
+
+  "motorcycle/triumph/chopper":
+    verdicts: { id: "defective(not a vehicle identity: 'Chopper' is a body-style/custom-build descriptor, not a Triumph nameplate)",
+                name: "defective(descriptor_as_model — SEE FINDING F5, candidate NEW CLASS)",
+                make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'TRIUMPH | CHOPPER' nl_rdw n=1", "raw: 'TRIUMPH | CHOPPER' nz_nzta n=1",
+               "counter-examples proving the class is not uniform: motorcycle/big-dog/chopper, /boom/chopper, /rewaco/chopper are LEGITIMATE — Big Dog, Boom Trikes and Rewaco all market products named Chopper"]
+    notes: "Triumph has never sold a model called Chopper (the factory custom was the X-75 Hurricane). Two vehicles, one per register, published on two-source corroboration — the same failure mode name_shapes.yml warns about for make_as_model: 'registers share the same fallback habit', so corroboration does not clear it."
+
+  "motorcycle/triumph/trophy-tr6c":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'TRIUMPH | TROPHY TR6C' nl_rdw n=1 (+ 'TROPHY TR 6 C' n=1)", "raw: 'TRIUMPH | TROPHY TR6C' nz_nzta n=2 (+ 'TROPHY TR6 C' n=1)"]
+    notes: "TR6C is a genuine Triumph designation (the C = competition/West Coast Trophy). Plausible-clean; unsourced."
+
+  "motorcycle/yamaha/3yf":
+    verdicts: { id: "unverifiable(3YF is a Yamaha factory model CODE, so it may duplicate whichever nameplate id carries the same bike; I could not identify which model 3YF is)",
+                name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: 'YAMAHA | 3YF' nl_rdw n=5, '3 YF' n=1", "raw: 'YAMAHA | 3YF' ua_mvs n=3"]
+    notes: "Same code-as-nameplate family as mtn890-s and gpd150a, but here I could not even resolve the code, so nothing is asserted."
+
+  "motorcycle/yamaha/ty":
+    verdicts: { id: "unverifiable(bare 'TY' is a family stem covering TY50/TY80/TY125/TY175/TY250; no single duplicate target)",
+                name: "defective(model_casing: Yamaha's trials family is TY — 'Ty' is the smart_case artefact)",
+                make: correct, kind: correct,
+                availability: { gb: correct, nz: correct } }
+    evidence: ["https://global.yamaha-motor.com/showroom/cp/collection/racing_ty250/  # Yamaha's own Communication Plaza: 'TY250', 'TY250J', 'TY250 Scottish' — TY all caps",
+               "uk_dft GenModel 'YAMAHA TY' n=98", "raw: 'YAMAHA | TY' nz_nzta n=4"]
+    notes: "Casing is settled by Yamaha's own museum pages. The bare stem is DVLA's granularity, not a second defect."
+
+  "motorcycle/yamaha/xv500se":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'YAMAHA | XV 500 SE' nl_rdw n=5, 'XV500SE' n=2 / fi_traficom 'XV 500 SE' n=1 / nz_nzta 'XV500SE' n=2, 'XV 500SE' n=1"]
+    notes: "Spaced dominant in nl/fi, fused in nz; published fused. Collapse shape."
+
+  "motorcycle/yamaha/gpd150a":
+    verdicts: { id: "unverifiable(GPD150-A is Yamaha's type code for the NMAX 155; I did not source the mapping, so the duplicate target is unconfirmed)",
+                name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nz: correct, ua: correct } }
+    evidence: ["raw: 'YAMAHA | GPD150A' nz_nzta n=58", "raw: 'YAMAHA | GPD 150A' ua_mvs n=1"]
+    notes: "Same class as mtn890-s (Yamaha type code as nameplate) and worth folding into that investigation; 59 vehicles."
+
+  "motorcycle/yamaha/sr250":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { lu: correct, nl: correct, nz: correct, ua: correct } }
+    evidence: ["raw: 'YAMAHA | SR 250' nl_rdw n=11, 'SR250' n=5, 'SR-250' n=2 / nz_nzta 'SR250' n=86, 'SR 250' n=7 / lu_snca 'SR250' n=1 / ua_mvs 'SR 250' n=1"]
+    notes: "renames.yml pins bare 'Sr → SR' for Yamaha with a marque rationale, and SR250 inherits the caps correctly. gb's GenModel stem is 'YAMAHA SR' (42) and correctly does NOT feed this id."
+
+  "motorcycle/yamaha/xs250":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, nz: correct } }
+    evidence: ["raw: 'YAMAHA | XS 250' nl_rdw n=28, 'XS250' n=1", "raw: 'YAMAHA | XS250' nz_nzta n=7"]
+
+  "motorcycle/yamaha/yzf-r7":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { nl: correct, ua: correct } }
+    evidence: ["raw: 'YAMAHA | YZF-R7' nl_rdw n=4", "raw: 'YAMAHA | YZF-R7' ua_mvs n=35"]
+    notes: "YZF is a pinned acronym and the hyphenated form matches renames.yml's 'Yzf-R1 → YZF-R1' precedent. Almost certainly clean; unsourced only."
+
+  "motorcycle/vespa/primavera-150-iget-s":
+    verdicts: { id: correct,
+                name: "unverifiable(vespa.com and piaggio.com both 403 WebFetch; I could not obtain Piaggio's own rendering of the i-get engine badge, and the published 'Iget' is a renames.yml OUTPUT so the deliberate-decision rule may protect it)",
+                make: correct, kind: correct, availability: { th: correct } }
+    evidence: ["raw: 'VESPA | PRIMAVERA 150 IGET ABS S' th_dlt n=392",
+               "overrides/models/renames.yml Vespa block: '\"Primavera 150 Iget Abs S\": Primavera 150 Iget S' — the ABS fold is deliberate and justified; the Iget casing is carried, not argued"]
+    notes: "FLAGGED AS A BOUNDARY CASE for the verifier: the rename SET this exact string, so under the protocol's deliberate-decision rule it is a NOTE not a defect — but name_shapes.yml's model-column-acronym-casing entry lists exactly this shape as a RESIDUAL DEFECT in rename outputs (its example: 'ryuka/Save-II S Fi (FI)'). The two rules point opposite ways on rename-carried casing and that needs deciding once, not per record."
+
+  "moped/yadea/g5":
+    verdicts: { id: correct, name: "unverifiable(not-attempted)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct, nz: correct } }
+    evidence: ["raw: 'YADEA | G5' nl_rdw bromfiets n=666 (+ 'YADEA G5' n=1)", "raw: 'Yadea | G5' fi_traficom L1e n=1", "raw: 'YADEA | G5' nz_nzta MOPED n=22"]
+    notes: "gb also carries GenModel 'YADEA G5' (178) but uk_dft has no moped kind, so its absence from availability is correct. Yadea's G-series (G5, G5 Pro) is real; only the exact rendering is unchecked."
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FINDINGS — read these before the counts. F2, F3 and F5 are candidate NEW
+# defect classes (invariant I-15: taxonomy entry + detector spec BEFORE any
+# scaled fixing). F1 is a live contradiction between two of the project's own
+# rules. F4 is a measured non-finding, recorded so nobody re-measures it.
+# ─────────────────────────────────────────────────────────────────────────────
+
+findings:
+
+  F1_rule_collision_corroborated_numerics_has_no_kind_guard:
+    severity: "high — it silently exempts an entire filed debt class from its own linter"
+    what: >-
+      data/name_shapes.yml has TWO entries that both match a bare-numeric 2W
+      name and they disagree. legit:`corroborated-numeric-nameplates` is scoped
+      `category: numeric_only, min_sources: 2, min_countries: 2` with NO `kind:`
+      condition. debt:`bare-displacement-2w` says the opposite in prose: "NOT the
+      corroborated-numeric-nameplates class above (Peugeot 208, Volvo 240): for
+      these makes the number is a DISPLACEMENT and the nameplate needs the family
+      word the register dropped", and adds "corroboration does NOT clear this
+      class". Because the legit entry is checked without a kind guard, any 2W
+      bare-numeric with 2+ sources in 2+ countries is excused as legitimate — so
+      the debt entry's own reasoning cannot be enforced by the lint that reads it.
+    evidence_in_this_batch: >-
+      motorcycle/harley-davidson/883 — 4 sources, 4 countries (fi/lu/nl/nz), so it
+      passes the legit rule; but H-D sells no motorcycle called 883 and the live
+      siblings sportster-883, 883-sportster, xl883, xl883n, xlh883, iron-883 show
+      what the nameplates actually are. motorcycle/ducati/848 (6 sources) and
+      motorcycle/moto-morini/501 land on the same seam from opposite sides —
+      Ducati genuinely sold an 848, Morini's 501 is a displacement shared by
+      Camel/Excalibur/Kanguro.
+    what_resolves_it: >-
+      Add `kind: car` (or an explicit not-in [motorcycle, moped]) to the legit
+      entry, or add an exclusion for 2W makes, and re-measure
+      bare-displacement-2w's count against the corrected rule. The count is
+      currently 21 and may be materially higher.
+    do_not: "Do not 'fix' bare numerics per record until the rule is settled — velosolex/5000 in this batch proves some are genuine model designations."
+
+  F8_unclaimed_evidence_three_instances:
+    severity: "low-medium — the converse of an availability defect, and my checker only found it incidentally"
+    what: >-
+      Three records have raw rows in a country that is NOT in their availability
+      list. This is not a wrong claim (nothing false is published) but it is
+      missing coverage, and no detector looks for it.
+    instances:
+      - "motorcycle/harley-davidson/fxdwgi-dyna-wide-glide — uk_dft GenModel 'HARLEY-DAVIDSON FXDWGI' 184 vehicles, gb absent from availability."
+      - "motorcycle/norton/es2 — es_dgt 'NORTON | ES2' L3 n=1, es absent from availability (the es row's category field is the legacy 'L3 ' form, which may be why)."
+      - "moped/velosolex/5000 — nz_nzta MOPED 'VELO SOLEX | 5000' n=13, nz absent from availability. Note the make string is SPACED ('VELO SOLEX') where nl is fused ('VELOSOLEX'), so this is probably an unresolved make alias rather than a threshold effect — which would make it a MAKE-layer gap, not an availability one."
+    why_it_matters: >-
+      The velosolex case in particular means a whole country's fleet for a
+      522-vehicle NL record is invisible, and the cause is one missing alias line.
+      A cheap detector: for every published id, re-scan each source's raws for
+      rows that resolve to it under make-alias + prefix-strip + collapse, and diff
+      against the availability list.
+
+  F9_solex_marque_split_three_ways:
+    severity: "high — an unaliased marque forked into two live make ids and three raw spellings"
+    what: >-
+      VéloSoleX is one marque and the catalog carries it as two makes plus an
+      unresolved third spelling. overrides/makes/aliases.yml contains NO entry for
+      any Solex spelling (grepped).
+    measured:
+      live_make_ids: "moped/solex/{1700,2200,3800,5000,701,800,oto} and moped/velosolex/{1700,3800,5000,s3800} — so 1700, 3800 and 5000 EACH EXIST TWICE, under two make ids, for the same machines."
+      raw_spellings: "nl_rdw merk=SOLEX 236 rows, merk=VELOSOLEX 66 rows, merk=E-SOLEX 1 (a genuinely different modern marque, already correctly separate). nz_nzta MAKE='VELO SOLEX' 17 rows and MAKE='SOLEX' 8 rows. uk_dft GenModel 'VELOSOLEX S 3800' + 'VELOSOLEX MODEL MISSING'."
+      collateral: "nz's 'VELO SOLEX' spelling resolves to neither live make, which is why moped/velosolex/5000 has no nz availability despite 13 nz vehicles."
+    source_for_the_identity: >-
+      https://www.velosolexclubuk.com/information-available-solex-models and
+      https://velo-solex.ch/en/history/ — one marque, model numbers 1700/2200/
+      3800/4600/5000/6000, sold as VéloSoleX and colloquially Solex.
+    what_resolves_it: >-
+      A MAKE MERGE, which former_ids.yml's header already carves out an explicit
+      exception for ("zero + zero-motorcycles", "emax + e-max") — moves.yml cannot
+      express it. Pick the surviving make id, alias SOLEX / VELOSOLEX / VELO SOLEX
+      to it, and carry former_ids for every model id that moves. Do NOT touch
+      e-solex, which is a different (modern electric) marque.
+    detector_spec: >-
+      Flag any two make_ids where one's slug is a suffix of the other's AND they
+      share ≥1 identical model slug. Here: solex ⊂ velosolex, sharing 1700, 3800,
+      5000. This is a 20-line check over makes.json + models.json and it would
+      have caught zero/zero-motorcycles and emax/e-max too.
+
+  F2_normalizer_token_boundary_shift:
+    severity: "high — it corrupts the ID, not just the display name"
+    candidate_new_class: "code_string / token_boundary_shift (sub-shape of, but distinct from, debt:normalizer-space-collapse-display-names)"
+    what: >-
+      The two-pass letter/digit space rule can MOVE a digit from the end of one
+      token to the start of the next. Pass 1 closes the letter/digit gap; pass 2
+      reopens only at a 4+ letter boundary (documented in renames.yml's Yamaha
+      T-MAX530 comment). When the left token ends in a digit and the right token
+      is a short acronym, the reopen lands in the wrong place.
+    instance: >-
+      motorcycle/harley-davidson/fxstsse-3cvo-softail-springer, published
+      "Fxstsse 3CVO Softail Springer". Every raw in three registers says
+      FXSTSSE3 CVO: nl_rdw 'FXSTSSE3 CVO SOFTAIL SPRINGER' (8), fi_traficom
+      'FXSTSSE3 CVO Softail Springer' (2), nz_nzta 'FXSTSSE3' (3). Nothing in the
+      corpus supports "3CVO". H-D's code is FXSTSSE3 (the third Screamin' Eagle
+      Softail Springer CVO).
+    why_it_is_not_the_existing_class: >-
+      debt:normalizer-space-collapse-display-names is scoped `max_sources: 1` and
+      described purely as a DISPLAY problem ("correct as a JOIN KEY, but the
+      collapsed key is also used as the DISPLAY name"). Here the join key itself
+      is wrong — the id slug is fxstsse-3cvo-… — so a display/identity split
+      would NOT fix it, and the record is multi-source so the existing lint scope
+      does not even see it.
+    detector_spec: >-
+      For each published id, take its dominant raw string(s). Tokenise both the
+      raw and the published name on whitespace. Flag when the multiset of
+      alphanumeric characters matches but the token boundaries differ AND a digit
+      has changed token index. Cheap, exact, zero false positives from casing
+      (compare case-insensitively). Runs off the same native-raw data the review
+      packs already emit.
+
+  F3_uk_dft_moped_merge_mints_cross_kind_duplicates:
+    severity: "high — systemic, and it produces wrong `kind` on real records"
+    candidate_new_class: "kind_noise / cross_kind_duplicate"
+    what: >-
+      overrides/kind_maps/uk_dft.yml documents that "UK merges mopeds INTO
+      Motorcycles (no separate class) → UK contributes evidence to
+      kind=motorcycle only". That is honest about the SOURCE. What is not filed
+      is the CONSEQUENCE: a nameplate that is a moped everywhere else acquires a
+      second, motorcycle-kind identity from its UK fleet, and
+      Reconciler.cross_kind_prune cannot remove it because that prune only fires
+      at 97% single-kind dominance.
+    instance: >-
+      motorcycle/vespa/50-special (name "50 Special") vs moped/vespa/50-special.
+      The Vespa 50 Special is a 50cc moped (types V5A2T/V5B1T/V5B3T,
+      https://www.vespa.name/vespa-model/vespa-50-special). Motorcycle-side
+      evidence: uk_dft GenModel 'VESPA (DOUGLAS) 50 SPECIAL' (128) + 2 stray
+      nl_rdw motorfiets rows. Moped-side: nl_rdw bromfiets 194+39+11+1, lu_snca
+      L1e-A 3, nz_nzta MOPED 1. Shares are ~34%/66% — the prune is nowhere near
+      firing.
+    related_but_different: >-
+      motorcycle/sym/fiddle vs moped/sym/fiddle is the SAME shape but may be
+      LEGITIMATE: SYM sells the Fiddle in both 50cc and 125/200 form and lu/fi/nz
+      each carry it in BOTH register classes. motorcycle/silence/s01 vs
+      moped/silence/s01 is the shape with the opposite resolution: one L3e
+      product, kept alive in `moped` by a single nl bromfiets row.
+      So the class is NOT uniform and must not be swept — it needs the
+      displacement or the EU category, which the aggregate row does not carry.
+    detector_spec: >-
+      Flag every (make_id, slug) pair that is live in both `moped` and
+      `motorcycle`. Report each with: per-kind source list, per-kind counts, the
+      EU/national category codes seen (es_dgt *02/*05, fi L1e/L3e, lu L1e-A/L3e
+      are all already parsed), and whether uk_dft is the ONLY motorcycle-side
+      source. The last flag is the high-precision signal: uk_dft-only +
+      moped-dominant elsewhere = the Vespa case.
+    measured: "not measured catalog-wide — I only observed it on the three pairs above. Measuring it is one jq join and should precede any taxonomy entry."
+
+  F4_uk_dft_genmodel_family_stems:
+    severity: "low — measured and mostly benign; recorded so it is not re-litigated"
+    what: >-
+      uk_dft uses the GenModel column (per uk_dft.rb), which is DVLA's FAMILY
+      stem — 'HARLEY-DAVIDSON XL', 'YAMAHA SR', 'YAMAHA TY', 'TRIUMPH DAYTONA',
+      'MV AGUSTA TURISMO', 'HUSQVARNA SVARTPILEN'. That mints family-level ids
+      that can look like truncations of the model-level ids other registers
+      supply.
+    measured: >-
+      258 gb-only motorcycle records exist; only 14 have a name that is a strict
+      prefix of a sibling's name: aprilia/sl750, harley-davidson/iron,
+      honda/crf300, husqvarna/svartpilen, lml/star, niu/nqi,
+      royal-enfield/hunter, royal-enfield/scram, sherco/250, triumph/speed,
+      trs/one, voge/300, yamaha/mt, yamaha/x. (The unrestricted prefix count is
+      751, which is why the gb-only restriction is the useful one.) moped: zero,
+      as expected — uk_dft emits no moped rows.
+    verdict: >-
+      NOT a defect class on its own. Family-level ids are legitimate
+      (harley-davidson/sportster is the registered family name; trs/one is a
+      sourced curation decision). The one case in this batch where the stem IS
+      wrong is motorcycle/mv-agusta/turismo, because MV Agusta's family is
+      "Turismo Veloce" and 'Turismo' names nothing in the modern range.
+
+  F5_descriptor_as_model:
+    severity: "medium — small but it publishes non-vehicles as vehicles"
+    candidate_new_class: "descriptor_as_model"
+    what: >-
+      A register's body-style / build-type descriptor lands in the model column
+      and publishes as a nameplate. Distinct from make_as_model (the make word),
+      from spec_token (powertrain badges) and from numeric_only.
+    instance_in_this_batch: >-
+      motorcycle/triumph/chopper — Triumph has never sold a Chopper (the factory
+      custom was the X-75 Hurricane). nl_rdw 1 + nz_nzta 1, i.e. it publishes
+      purely on two-source corroboration, which is exactly the failure mode
+      name_shapes.yml already documents for make_as_model: "registers share the
+      same fallback habit when a model field is blank".
+    others_visible_catalog_wide: >-
+      motorcycle/harley-davidson/custom, motorcycle/harley-davidson/trike,
+      motorcycle/vespa/scooter, moped/vespa/scooter, moped/honda/moped,
+      moped/killerbee/custom. NOT defects, verified: motorcycle/big-dog/chopper,
+      motorcycle/boom/chopper, motorcycle/rewaco/chopper (Big Dog, Boom Trikes
+      and Rewaco each market a product named Chopper), motorcycle/mash/cafe-racer,
+      motorcycle/ossa/trial.
+    detector_spec: >-
+      Closed vocabulary of descriptors (chopper, trike, scooter, moped,
+      motorcycle, custom, cruiser, tourer, quad, cafe racer, sidecar, bobber,
+      streetfighter, naked) matched as the WHOLE model name, then require a
+      per-make judgment call — the make either markets a product of that name or
+      it does not. The vocabulary is closed and small (~15 tokens), so this is
+      ~13 human calls, not a sweep.
+    do_not: "Never auto-drop on the vocabulary alone. Three of the ten Chopper/Custom/Trial records are real nameplates."
+
+  F6_self_declared_duplicates_in_enrich_files:
+    severity: "medium — a free, exact duplicate-id oracle nobody is reading"
+    what: >-
+      enrich/norton.yml states, in a comment on its own entry:
+      `motorcycle/norton/es2-500` → "same machine as `es2`, register spelling with
+      displacement", and gives it byte-identical `runs` to motorcycle/norton/es2.
+      Both ids are LIVE. The enrichment pass therefore already knows about a
+      duplicate that no detector has flagged.
+    detector_spec: >-
+      In enrich/*.yml, flag any two ids under the same make whose `runs` arrays
+      are identical. Then flag the subset where both ids are live in the build.
+      Zero-cost, and it finds duplicates the raw-vs-raw spelling detectors
+      structurally cannot (find_duplicate_spellings compares raws to raws, and
+      "ES2" vs "ES2 500" are two genuinely different raw strings).
+    other_batch_instances_of_the_same_underlying_defect: >-
+      motorcycle/ktm/exc125 vs motorcycle/ktm/125exc (token-order inversion, one
+      bike, settled by ktm.com); moped/honda/mb5 vs moped/honda/mb50 (one machine,
+      two market names, settled by Honda's own parts catalogue);
+      motorcycle/harley-davidson/883-sportster vs
+      motorcycle/harley-davidson/sportster-883 (token-order inversion, spotted
+      while checking the 883 siblings, not itself in the sample).
+
+  F7_homologation_code_as_nameplate:
+    severity: "high by VOLUME — the largest single evidence misfiling I found"
+    what: >-
+      Registers carry the manufacturer's TYPE/HOMOLOGATION designation in the
+      model column, and it publishes as the nameplate beside the marketing-name
+      id, splitting one model's evidence across two ids. Three proven instances
+      in this batch, each with a marque-controlled source:
+        * motorcycle/honda/adv750 = the X-ADV. Honda's own owner's manual is
+          titled "X-ADV (ADV750)"
+          (https://webom.hondamotopub.com/webom/HMEE/MKT250/html/index.html).
+          3,150+ vehicles in 6 countries on the code id; motorcycle/honda/x-adv
+          is live.
+        * motorcycle/yamaha/mtn890-s = the MT-09. Yamaha's own owner's manual
+          title line is "MTN890 (MT-09)"
+          (https://cdn2.yamaha-motor.eu/prod/owner-manuals/Motorcycles/PB7N28199E0E.PDF).
+          275 vehicles; nine live ids share this nameplate.
+        * motorcycle/suzuki/gsx800 = the GSX-8S family. Suzuki's product pages
+          name only GSX-8S / GSX-8R (https://suzukicycles.com/street/2026/gsx-8s).
+          1,050+ vehicles.
+      Adjacent, unsourced: yamaha/gpd150a (NMAX), yamaha/3yf, moped/yamaha/cw50
+      (the BW's), honda/adv350a beside honda/adv350.
+    the_trap: >-
+      GSX800 may POOL the GSX-8S and GSX-8R (both 776cc). Folding it to gsx-8s
+      would hand the 8R's registrations to the 8S — precisely the SEAT
+      Leon/Ateca situation the moves.yml header refuses to resolve. So the CLASS
+      is clear and the DISPOSITION is per-record.
+    detector_spec: >-
+      Manufacturer owner's manuals and EU type-approval documents pair the code
+      with the marketing name in a stable "NAME (CODE)" form. A worklist can be
+      built mechanically: for each make, find ids whose name matches
+      /\A[A-Z]{2,4}\d{2,4}([-A-Z]{1,3})?\z/ AND whose xrefs.tan is present; the
+      TAN is the join key to the marketing name. catalog-plus already carries
+      xrefs.tan (zero-motorcycles/xe has e13*168/2013*02304*03), so the join is
+      available today.
+
+# ─────────────────────────────────────────────────────────────────────────────
+summary:
+  records_in_batch: 100
+  records_covered: 100
+  records_not_covered: []
+  coverage_caveat: >-
+    COVERAGE IS NOT UNIFORM ACROSS CLAIM TYPES, and this is the honest-truncation
+    disclosure the protocol asks for:
+      * availability (237 claims), make (100), kind (100), id-canonical (100)
+        were re-derived for ALL 100 records from the local raw corpora.
+      * name-marque-true was SOURCE-CHECKED for 43 records (15 correct, 21
+        defective, 7 genuine source gaps — Piaggio-group 403s and marques with no
+        reachable page). For the other 57 I did not consult any marque source and
+        recorded `unverifiable(not-attempted)`. Those 57 are NOT a source gap —
+        they are UNAUDITED. They must not enter the source-gap queue, and the
+        honest aggregate for the name claim is 43/100 audited, not 100/100.
+      * enrichment sub-check (§6.2) applies to 2 records (bsa/rocket-3,
+        norton/es2). Both are `unverifiable`: I read the citations and their
+        quoted strings out of enrich/*.yml but did NOT re-fetch cybermotorcycle
+        or nortonownersclub, which §6.2 requires. 0/2 completed.
+
+  # Counts below were RE-DERIVED MECHANICALLY from this file (ruby+YAML parse),
+  # not hand-tallied — my first hand tally was wrong on every line and the parse
+  # caught it, along with three availability countries I had recorded that the
+  # catalog does not actually claim (now moved to FINDING F8).
+  claim_counts:
+    id_canonical:   { total: 100, correct: 68, defective: 16, unverifiable: 16 }
+    name:           { total: 100, correct: 15, defective: 21, unverifiable_source_gap: 7, unverifiable_NOT_ATTEMPTED: 57 }
+    make:           { total: 100, correct: 93, defective: 1,  unverifiable_source_gap: 2, unverifiable_NOT_ATTEMPTED: 4 }
+    kind:           { total: 100, correct: 98, defective: 1,  unverifiable: 1 }
+    availability:   { total: 237, correct: 237, defective: 0, unverifiable: 0 }
+    enrichment:     { total: 2,   correct: 0,   defective: 0, unverifiable: 2 }
+  claims_total: 539
+  audited_claims: "482 (539 minus the 57 not-attempted name checks)"
+  counts_caveat: >-
+    Counts are stated for the verifier to re-derive, not to be trusted as
+    published rates. In particular the availability line reading 263/263 is a
+    real result but a NARROW one: it says every claimed country has a raw row in
+    the locally cached corpus that resolves to that id. It does NOT test the
+    converse (countries that SHOULD be claimed and are not) and it does not test
+    counts. Two claims looked wrong and were false alarms of my own making —
+    see the moped/honda/z50jz and motorcycle/zundapp/50 process notes.
+
+  suspected_defects_for_the_verifier_to_attack:
+    - id: motorcycle/ktm/exc125
+      claims: [id, name]
+      reasoning: "KTM's own model pages render '<displacement> EXC' spaced (https://www.ktm.com/en-gb/models/enduro/ktm-125-exc-2026.html). motorcycle/ktm/125exc is live and is the same bike. Attack route: show that KTM ever badged an 'EXC 125'."
+    - id: motorcycle/honda/adv750
+      claims: [id, name]
+      reasoning: "Honda's own manual title 'X-ADV (ADV750)'. Attack route: show ADV750 is sold as a distinct product from the X-ADV, or that the 2452 nl rows are not X-ADVs."
+    - id: motorcycle/yamaha/mtn890-s
+      claims: [id, name]
+      reasoning: "Yamaha's own manual title 'MTN890 (MT-09)'. Attack route: show the -S suffix denotes a model, not a market/spec variant."
+    - id: motorcycle/suzuki/gsx800
+      claims: [name]
+      reasoning: "No 'GSX800' on suzukicycles.com. Attack route: find a Suzuki-controlled page using GSX800 as a product name. NOTE I deliberately did NOT call the id defective, because of the 8S/8R pooling risk."
+    - id: motorcycle/harley-davidson/{flhrxs,flhtcu-ultra-classic-electra-glide,fxdwgi-dyna-wide-glide,fxstsse-3cvo-softail-springer,ftk}
+      claims: [name]
+      reasoning: "H-D's own model-codes page: codes are continuous UPPERCASE with no spaces or hyphens. renames.yml's Harley header asserts the same rule and cites the same URL, so these five contradict the project's own pin. Attack route: argue that display casing of a code is out of scope for name-marque-true."
+    - id: motorcycle/harley-davidson/fxstsse-3cvo-softail-springer
+      claims: [id]
+      reasoning: "The id slug carries a digit that migrated tokens (FXSTSSE3 CVO → fxstsse-3cvo). Attack route: find any raw anywhere spelling '3CVO'. I found none in nl/fi/nz."
+    - id: motorcycle/harley-davidson/883
+      claims: [id, name]
+      reasoning: "See F1. Attack route: invoke legit:corroborated-numeric-nameplates, which as written DOES cover it — that is the point of the finding."
+    - id: motorcycle/moto-guzzi/special
+      claims: [id, name]
+      reasoning: "Moto Guzzi's nameplates are V7/V50/V65 Special; v7-special and v7-750-special are live. Attack route: find a bare 'Special' Moto Guzzi. Contrast motorcycle/rudge/special, which I cleared for exactly that reason."
+    - id: motorcycle/mv-agusta/turismo
+      claims: [id, name]
+      reasoning: "mvagusta.com: the family is Turismo Veloce; turismo-veloce/-lusso/-r are live. Attack route: the single nl row could be a 1950s MV 'Turismo' — but 252 GB vehicles cannot be."
+    - id: moped/honda/mb
+      claims: [id, name]
+      reasoning: "Honda's parts catalogue keys MB50 and MB5 to one model record; there is no 'MB'. Attack route: show 'MB' is a distinct Honda designation. Watch out for MB8/MB80 (79cc), which is a genuinely different bike and must not be folded in."
+    - id: moped/honda/{dax,mt5}
+      claims: [id]
+      reasoning: "dax: the nl raws THEMSELVES say 'DAX ST50' / 'ST50 DAX' / 'ST50G DAX', so the equivalence with the live st50* ids is in-data. mt5: I asserted the MT50=MT5 market-name pattern by ANALOGY with the sourced MB50/MB5 case and did NOT source it — this is my weakest claim in the batch and should be re-derived or downgraded to unverifiable."
+    - id: motorcycle/norton/es2
+      claims: [id]
+      reasoning: "enrich/norton.yml declares es2-500 to be the same machine. Attack route: none obvious — the project asserted it."
+    - id: motorcycle/vespa/50-special
+      claims: [id, kind]
+      reasoning: "See F3. Attack route: argue the kind should follow the citing register rather than the vehicle, in which case uk_dft's merge makes motorcycle 'correct' and the whole class is a documentation issue rather than a defect."
+    - id: motorcycle/triumph/chopper
+      claims: [id, name]
+      reasoning: "See F5. Attack route: find a Triumph product named Chopper. Two vehicles total, so the record also fails any usefulness test."
+    - id: motorcycle/{silence/s01,sym/fiddle}
+      claims: [id]
+      reasoning: "Cross-kind pairs. I flagged both but believe sym/fiddle should be DOWNGRADED to a note (SYM genuinely sells 50cc and 125cc Fiddles, and lu/fi/nz carry both classes) while silence/s01's moped twin is genuine noise. Verifier should split them."
+    - id: motorcycle/bmw/r51-2
+      claims: [name]
+      reasoning: "BMW writes R51/2 with a solidus; 38 of 40 nl/nz raws carry it. Attack route: I did NOT fetch a BMW source, so this rests on register raws — downgrade to unverifiable if that is not good enough."
+    - id: motorcycle/harley-davidson/touring-street-glide-special
+      claims: [name]
+      reasoning: "'Touring' is H-D's platform word, not part of the registered name 'Street Glide Special'. Lowest-confidence defect call in the batch."
+
+  things_i_deliberately_did_NOT_call_defects:
+    - "motorcycle/brixton/crossfire-500x — data/review/brixton.yml records the spacing discrepancy and holds it deliberately pending a whole-make pass. Protocol's deliberate-decision rule applies; recorded as a note."
+    - "motorcycle/stark/varg, motorcycle/trs/one, motorcycle/cyclone/rt1, motorcycle/silence/s01 (name), motorcycle/honda/gold-wing-gl1500se — all carry sourced curation decisions in styling.yml / renames.yml / data/review/. Verified the citation exists and matches; called correct."
+    - "motorcycle/rudge/special — a bare trim word that IS the nameplate. rudge-whitworth.com's model history and a 1938 road test settle it."
+    - "moped/velosolex/5000 — bare number that IS the model designation. This also means name_shapes.yml's bare-displacement-2w list needs re-reading for solex/701, solex/800 and possibly motobecane/5000."
+    - "moped/sparta/bosch-e-speed — I expected a supplier-in-nameplate defect and the evidence pushed back: Sparta appears to use the drive supplier as its own variant discriminator (ION E-Speed / Bosch E-Speed / E-Speed Nuvinci). Left unverifiable, not defective."
+    - "motorcycle/vespa/primavera-150-iget-s — 'Iget' is a renames.yml OUTPUT, so the deliberate-decision rule may protect it, while name_shapes.yml's model-column-acronym-casing entry lists the same shape as a residual defect. The two rules conflict; I recorded unverifiable and flagged the conflict rather than picking."
+
+  process_notes_for_whoever_builds_the_availability_detector:
+    - "I generated two FALSE availability defects and caught both. (a) moped/honda/z50jz looked like a moped record carrying motorcycle-kind nl evidence; the real supporting row is bromfiets 'HONDA Z50 JZ', which only resolves after make-prefix strip AND letter/digit space collapse. (b) motorcycle/zundapp/50 looked like a cross-kind leak; the supporting nl motorcycle row is under merk 'ZUENDAPP', an alias I had not resolved. A literal grep-based availability checker will manufacture both classes of false positive at scale."
+    - "uk_dft's model string is the GenModel column, NOT the Model column. Checking gb claims against Model produces both false positives and false negatives (e.g. gb 'YAMAHA SR' cannot support yamaha/sr250; gb 'HONDA C50C' cannot support any moped record at all because uk_dft emits no moped kind)."
+    - "python3 is SIGKILLed in this sandbox; ruby and jq work. Big files need LC_ALL=C exported (not per-command) and grep -a, or grep silently suppresses output on the ISO-8859-1 corpora — I lost a cycle to a silently-empty es_dgt result."
+  scratchpad_artifacts:
+    - "all_raw.txt (136,104 lines) — every source's (country, register-kind, make, model, count) tuples, normalised to one format"
+    - "gb_genmodel.txt — uk_dft aggregated by Make+GenModel, which is what the pipeline actually joins on"
+    - "avail_report.txt — per-record candidate raw rows for all 100 ids"
+    - "summary.tsv — the 100 records with names, availability and decile"
+

--- a/data/review/audit-v2026.07.5/ledger/verifier-b1.yml
+++ b/data/review/audit-v2026.07.5/ledger/verifier-b1.yml
@@ -1,0 +1,1067 @@
+# PRD-FIVE-NINES Workstream A2 — BATCH 1 INDEPENDENT VERIFICATION
+# tag v2026.07.5, S2W half.  Invariant I-11 satisfied: researcher ≠ verifier.
+# verifier: opus5/audit-b1-verifier   researcher: opus5/audit-b1-researcher
+# READ-ONLY run. Nothing written outside this scratchpad. No git operations.
+#
+# ═══════════════════════════════════════════════════════════════════════════
+# METHOD — what I re-derived, and how independently
+# ═══════════════════════════════════════════════════════════════════════════
+# I did NOT read the researcher's scripts or its flattened corpora. I wrote my
+# own flatteners straight from each adapter in pipeline/sources/, and my own
+# matcher with a different implementation:
+#   v_fi.rb    fi_traficom_register.zip -> 5,147,216 rows scanned, 130,863 L-class
+#              vehicles in 13,628 (kind,class,make,model,TAN) groups
+#   v_nlnz.rb  nl_rdw_{bromfiets,motorfiets,motorfiets-met-zijspan,
+#              driewielig-motorrijtuig}.json + nz_{moped,motorcycle}_[A-Z0-9].json
+#              -> 67,705 groups / 2,537,851 vehicles
+#   v_es.rb    es_dgt_2026{04,05,06}.txt fixed-width [17,30)/[47,22)/[426,3)
+#              -> 2,126 groups / 89,434 rows
+#   v_uk.rb    uk_veh0120_uk.csv, BodyType/Make/GenModel/Model/Lic -> 22,710 2W groups
+#   v_rest.rb  lu_delta_2026-{05,06,07}.xml (2,301 groups — matches the
+#              researcher's count exactly), ua_reestr_current.zip (9,333 groups,
+#              710,639 deduped vehicles), th_dlt_2568.csv (879 groups)
+#   v_avail.rb independent availability matcher (applies makes/aliases.yml and
+#              models/renames.yml inline rather than by hand)
+#   v_kind.rb  kind re-derivation from the raw EU-category columns
+#   v_dup.rb   my own token-multiset subset/permutation duplicate scan
+# Everything in ruby (python3 in this environment is a broken 3.4, confirmed).
+#
+# SAMPLING vs the protocol's requirement:
+#   defective verdicts    100% re-derived (41/41)
+#   CONTESTED claims      100% re-derived (3/3)
+#   availability          100% re-derived (251/251, not the required 20%)
+#   kind                  52/100 re-derived from raw EU categories (52%)
+#   make                  100% structurally re-derived (my matcher requires the
+#                         raw make string to resolve to the record's make_id via
+#                         the curated alias table; 251/251 resolved)
+#   id `correct`          100% re-scanned with my own duplicate detector (v_dup.rb)
+#   name correct/unverif. 13 marque sources re-fetched
+#
+# COVERAGE CHECK: all 100 proposal records are members of
+# data/review/audit-v2026.07.5/SAMPLE-s2w.yml (400 ids). Zero fabricated, zero
+# outside the seeded sample. Batch 1 = 100 of 400.
+
+headline:
+  upheld: 36            # of 41 defective claims re-derived
+  overturned: 5
+  additional_defects_found: 5    # among claims the researcher called `correct`
+  net_effect: "the researcher's 85.1% conservative clean rate is OPTIMISTIC, not
+               conservative. Corrected: 84.0%. Every correction I make to the id
+               class runs the same direction — the researcher under-called
+               duplicates, and did so by applying its own D6/D8 criteria
+               inconsistently between records."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# THE FIVE SPECIFIC ATTACK TARGETS
+# ═══════════════════════════════════════════════════════════════════════════
+
+target_1_bsa_thunderbolt_count:
+  question: "SIX live ids (researcher) or FIVE (enrich/bsa.yml:106)? Does bare
+             `a65` belong in the Thunderbolt cluster?"
+  verdict: "RESEARCHER WRONG. The count is FIVE. Bare `a65` is a FAMILY-altitude
+            record and is a SEPARATE question."
+  the_five:
+    - motorcycle/bsa/thunderbolt      "Thunderbolt"     [fi,nl,nz]
+    - motorcycle/bsa/thunderbolt-650  "Thunderbolt 650" [nl,nz]
+    - motorcycle/bsa/650-thunderbolt  "650 Thunderbolt" [nl,nz]
+    - motorcycle/bsa/thunderbolt-a65  "Thunderbolt A65" [fi,nl]   # the sampled record
+    - motorcycle/bsa/a65t             "A65T"            [nl,nz]
+  why_a65_is_not_a_thunderbolt:
+    - "https://cybermotorcycle.com/marques/bsa/bsa-a65.htm — the page enumerates
+       the A65 range as a FAMILY: 1963 A65 Star Twin; 1964 A65 Star, A65 Police,
+       A65R Rocket, A65T Thunderbolt Rocket, A65L Lightning Rocket, A65SH
+       Spitfire Hornet; 1965 A65 Lightning, A65 Lightning Clubman, A652L
+       Lightning Rocket; 1966-73 Thunderbolt, Lightning, Spitfire MkII-IV,
+       Hornet, Firebird Scrambler. A65 is the series, not a machine."
+    - "enrich/bsa.yml:89-91 already dates a65 1962-1972 citing
+       https://www.gracesguide.co.uk/BSA:_A65 ('Made 1962-72') — the FAMILY
+       range — while every Thunderbolt id gets 1964-1972. The file is internally
+       consistent only on the family reading. The researcher spotted this
+       (result-b1.yml:975-977) and then counted a65 in the cluster anyway."
+    - "IN-DATA, decisive, from my own nl+nz derivation under make BSA: the same
+       registers that carry bare 'A 65' (nl 86+3) and 'A65' (nl 12+2, nz 52)
+       ALSO carry 'A65 FIREBIRD SCRAMBLER', 'A65 SPITFIRE SCRAMBLER',
+       'A65 SPITFIRE HORNET', 'SPITFIRE A 65', 'ROCKET A65', 'A65R', 'A65S' x2,
+       'A 65 S', 'A 65 SA' x2, 'A 65 SB' x15, 'A 65 LIGHTNING' x3,
+       'A65 LIGHTNING' x9. A bare A65 row cannot be attributed to the
+       Thunderbolt: the register uses A65 with at least six different suffixes."
+  consequence: >-
+    bsa/a65 is its own defect — a family rollup (existing class D8), ~155
+    vehicles (nl 'A 65' 86 + 3 zijspan + 'A65' 12 + 2, nz 'A65' 52; the
+    normalizer's two_wheeler_spacing collapses 'A 65' onto the same id). It must
+    NOT be folded into the Thunderbolt, which is what a six-id count invites.
+    The researcher's own raw counts for a65 (12+52) are also understated because
+    they missed the spaced 'A 65' n=86 that normalizes onto the same id.
+  sampled_record_verdicts_unaffected: "motorcycle/bsa/thunderbolt-a65 id
+    defective(D6) and name defective(D7) both UPHELD — see the record table."
+
+target_2_bsa_lightning_cluster:
+  question: "a second cluster the researcher missed — FOUR ids for the A65 Lightning?"
+  verdict: "The count is SEVEN, not four — and the researcher did NOT miss it.
+            result-b1.yml:87 states verbatim 'The BSA Lightning (A65L) has the
+            same shape, seven ids.' I am not manufacturing a disagreement here:
+            on this point the researcher was right and the brief was under-counted."
+  the_seven_confirmed_in_catalog:
+    - motorcycle/bsa/a65l           "A65L"          [nl,nz]
+    - motorcycle/bsa/a65-lightning  "A65 Lightning" [fi,nl,nz]
+    - motorcycle/bsa/lightning      "Lightning"     [fi,nl,nz]
+    - motorcycle/bsa/lightning-650  "Lightning 650" [nl,nz]
+    - motorcycle/bsa/lightning-a65  "Lightning A65" [nl,nz]
+    - motorcycle/bsa/lightning-a65l "Lightning A65L"[nl,nz]
+    - motorcycle/bsa/650-lightning  "650 Lightning" [nl,nz]
+  corroboration: "enrich/bsa.yml:107-127 documents all seven and line 127 says
+    verbatim 'SEVEN ids for one motorcycle, the worst cluster in this make'.
+    My raw derivation confirms the register spellings behind each."
+  totals: "The A65 twin family therefore carries 12 live ids for TWO motorcycles
+    (5 Thunderbolt + 7 Lightning), plus bsa/a65 as a family rollup, and
+    find_duplicate_spellings reports none of it."
+
+target_3_the_tan_finding:
+  part_a_verify_the_collision:
+    verdict: "UPHELD, and UNDERSTATED. Re-derived from
+              cache/fi_traficom_register.zip by my own v_fi.rb."
+    evidence: |
+      TAN e5*168/2013*00017*06 carries, under make 'Royal Enfield', L3e:
+        'Continental GT 650'      n=2
+        'INTERCEPTOR INT 650'     n=1
+        'Interceptor INT 650'     n=2
+      Two different motorcycles, one TAN. Confirmed.
+      The whole *00017*XX approval family spans SIX distinct nameplates:
+        *04 Continental GT 650 + Interceptor 650
+        *05 Interceptor INT 650
+        *06 Continental GT 650 + Interceptor INT 650
+        *08 Super Meteor 650
+        *09 Continental GT 650 + Super Meteor 650
+        *10 Interceptor INT 650 + SHOTGUN 650 + Super Meteor 650
+        *11 Continental GT 650
+        *12 CLASSIC 650 TWIN + INTERCEPTOR BEAR 650 + Super Meteor 650
+      And e5*168/2013*00021*09 carries Bullet 350 + Classic 350 + HNTR 350 +
+      Meteor 350 — four nameplates on one TAN.
+  part_b_does_any_merge_rest_on_TAN_ALONE:
+    verdict: "RESEARCHER WRONG, and this is my most consequential disagreement.
+              At least one live merge rests on TAN alone, its stated inference is
+              exactly the form FINDING-B refutes, and I can show the TAN is not
+              even make-exclusive. This is a CURATION DEFECT, not a documentation fix."
+    the_merge: |
+      overrides/models/renames.yml:371
+        Ab: Senda 50   # RDW junk type-string "AB": every row TAN
+                       # e11*2002/24*1050*00 = the 2010+ Piaggio-built Senda
+                       # DRD 50; same TAN also registered as "SENDA DRD X-TREME SM"
+      There is NO name-family argument available: "Ab" shares no token with
+      "Senda 50". The entire evidence chain is "same TAN => same nameplate".
+      former_ids.yml:1873 confirms it is live: "moped/derbi/ab" -> "moped/derbi/senda-50".
+      It is LOAD-BEARING, not cosmetic: my availability re-derivation shows
+      moped/derbi/senda-50 draws nl_rdw 'DERBI | AB' n=317 through this fold.
+    why_the_evidence_fails: |
+      From my own fi derivation, TAN family e11*2002/24*1050 is neither
+      nameplate- nor MAKE-exclusive:
+        Derbi  e11*2002/24*1050*00  (blank model) n=98
+        Derbi  e11*2002/24*1050*02  (blank)       n=498
+        Derbi  e11*2002/24*1050*03  (blank)       n=572
+        Derbi  'Senda'                     *03    n=2
+        Derbi  'SENDA SM 50 DRD RACING'    *00    n=1
+        Derbi  'SENDA SM DRD XTREM'        *00    n=1
+        Derbi  'X-Treme' / 'Xtreme'        *00    n=1 each
+        Gilera 'SMT 50' / 'SMT50'          *00    n=1 / n=17     <-- OTHER MARQUE
+        Gilera (blank)                     *00    n=259
+        Aprilia (blank)                    *03    n=1            <-- OTHER MARQUE
+      One approved type, three Piaggio-group marques, and a Gilera SMT 50 sitting
+      on it. "Same TAN as SENDA DRD X-TREME SM" therefore establishes only
+      "same approved platform" — precisely what FINDING-B says is not identity.
+    three_more_of_the_same_shape: |
+      Same pattern — bare register type-code as the source string, no name-family
+      argument, TAN as the primary evidence (each has ONE technical corroborant,
+      so "TAN-primary" rather than strictly "TAN-alone"):
+        renames.yml:370  Sdr: Senda 50   (TAN base + L1e 45 km/h + "geometry")
+        renames.yml:617  Cg: EC          (TAN + 125-299cc)
+        renames.yml:620  Tg: TXT         (TAN + 248/294cc)
+        renames.yml:2358 TR1 300: One 300 (TAN + 294cc + range-uniqueness)
+      The researcher's examples (renames.yml:365/366 R50AF=SM50AF, :368 Black
+      Devil) ARE carried by name-family reasoning, exactly as it said — it simply
+      only looked at the cases where the source string contained the nameplate,
+      and concluded from those that no merge rests on TAN alone.
+    recommended_action: "FINDING-B's 'CONSEQUENCE FOR CURATION' paragraph must be
+      rewritten: it is not only a NAMING.md line. renames.yml:371 needs re-sourcing
+      or demoting, and :370/:617/:620/:2358 need their evidence strengthened beyond
+      the approval number. This is a curation-PR item, not a docs item."
+  adjacent_finding_upheld: >-
+    The researcher's caveat on renames.yml:375 ('Senda: Senda 125' commented
+    "motorcycle-kind only" while renames keys are per-MAKE) is CORRECT and I
+    verified the mechanism in source: normalizer.rb:178 reads
+    `@o.model_renames[make]` with no kind in the key. Live cost: fi L1e 'Senda'
+    n=2 (TAN e11*2002/24*1050*03) + n=6 untanned, and nl bromfiets 'SENDA' n=3 —
+    11 genuine moped registrations are renamed to "Senda 125" inside the moped
+    kind, and there is no moped/derbi/senda-125 in the catalog, so they are then
+    removed by the cross-kind dominance prune (reconciler.rb:105) in favour of
+    motorcycle/derbi/senda-125. Evidence deleted by a comment the file cannot honour.
+
+target_4_the_three_contested:
+  "moped/honda/nsc50":
+    researcher: 'name: defective(D9)'
+    my_verdict: 'OVERTURNED -> name: unverifiable(no Honda source names a bare
+                 "NSC50"; Honda does publish NSC-coded retail names in this family)'
+    why: |
+      1. The researcher's own primary citation does not contain the claim. I
+         fetched https://hondanews.eu/eu/en/motorcycles/media/pressreleases/34740/vision-50-press-pack
+         — it names the model "Vision 50" and gives specifications as
+         "6. Specifications - Vision 50 (E-type)". The string "NSC50" does not
+         appear anywhere in it. So the press pack cannot establish "NSC50 is
+         Honda's type code for the Vision 50", which is the whole D9 argument.
+      2. Honda DOES publish NSC-coded names as retail model names in this exact
+         family. https://hondanews.eu/eu/en/motorcycles/models/nsc50r-2014-2017/2014/2017
+         is titled "NSC50R (2014 - 2017)" and gives no alternative retail name;
+         honda.co.uk carries an NSC50R 2013 model/finance page. A code-shaped
+         nameplate is therefore not per se wrong for Honda 50cc scooters — this
+         is the protocol's own CPx/tS/XR4i "weird can be right" case.
+      3. nl_rdw independently carries 'HONDA | NSC50R' n=1, so the register
+         distinguishes the R.
+      Neither `correct` nor `defective` is supportable. `unverifiable` is the
+      honest verdict and the protocol explicitly blesses it.
+  "moped/yamaha/sa19":
+    researcher: 'name: defective(D9), self-flagged CONTESTED, "downgrade to
+                 unverifiable if the in-data argument is too thin"'
+    my_verdict: 'UPHELD -> name: defective(D9). The in-data argument is NOT too
+                 thin; it is stronger than the researcher realised.'
+    why: |
+      The researcher argued only "this is a code shape". I found the same class
+      of in-data proof it accepted for moped/honda/ad01:
+      1. A CODE RUN in one register, nl_rdw bromfiets under make YAMAHA:
+         SA03 175, SA05 1, SA06 4, SA09 273, SA14 4745, SA15 1215, SA19 1563,
+         SA21 427, SA22 90, SA23 42 — plus SA034A, SA034 WHYB, SA051, SA061.
+         Ten two-digit SA codes is the PC31..PC39 shape.
+      2. THE REGISTER PAIRS SA-CODES WITH THE NAMEPLATE, which is the decisive
+         form: nl 'SA09 SLIDER', 'SA051 BW50 NEXT GENERATION B', 'SA034 WHYB';
+         nz 'SA50 PASSOLA'. Exactly the AD01<->MT50 pairing evidence.
+      3. fi_traficom carries the type-designation form in `mallimerkinta`:
+         'SA05-SA056/49', 'SA14-SA144/49', 'SA21-SA211/49' — code-subcode/
+         displacement, a type designation column, not a commercial name.
+      Still NO Yamaha source, so the TARGET stays unnamed (do not assert Vino or
+      Jog). The class claim stands on its own.
+  "motorcycle/harley-davidson/flhtcui":
+    researcher: 'id: defective(D6), self-rated "WEAK — flagged for a decision,
+                 not for a fix"'
+    my_verdict: 'UPHELD, and the WEAK self-rating is OVERTURNED. This is a strong
+                 D6 and the researcher framed the question wrongly.'
+    why: |
+      The researcher asked "are H-D code ids an accepted parallel axis?". That is
+      the wrong question, because the catalog does not hold one code id beside one
+      nameplate id. It holds SIX ids that all contain the literal token FLHTCUI:
+        flhtcui                              "FLHTCUI"                            [es,fi,nl,nz,ua]
+        flhtcui-electra-glide                "Flhtcui Electra Glide"              [fi,nl]
+        flhtcui-electra-glide-ultra-classic  "Flhtcui Electra Glide Ultra Classic"[fi,nl]
+        flhtcui-ultra-classic                "Flhtcui Ultra Classic"              [fi,nl]
+        flhtcui-ultra-classic-electra-glide  "Flhtcui-Ultra Classic Electra Glide"[fi,nl]
+        electra-glide-ultra-classic-flhtcui  "Electra Glide Ultra Classic Flhtcui"[fi,nl]
+      plus electra-glide-ultra-classic, ultra-classic-electra-glide, and the
+      parallel flhtcu / flhtcu-1 / flhtcu-ultra-classic /
+      flhtcu-ultra-classic-electra-glide / flhtcu-electra-glide-ultra-classic set.
+      Those are permutations of one code plus one nameplate. No "parallel axis"
+      policy can bless them; there is nothing to decide.
+      (flhtcui-trike is a genuinely different vehicle — exclude it.)
+      Marque source re-fetched:
+      https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html
+      gives "FLHTCU - Electra Glide(R) Ultra Classic(R)" verbatim, and renders all
+      codes uppercase. NOTE a citation gap: FLHTCUI itself is NOT on that page
+      (nor is FXR) — the I-suffix identity is established in-data, by the register
+      rows that pair the code with the nameplate in one string.
+      name: correct UPHELD (uppercase code form is H-D's own rendering).
+
+target_5_false_positive_sweep:
+  verdict: "CLEAN — no false positives. The researcher's claim that checking the
+            override layer first changed 11 verdicts is corroborated."
+  method: "For all 36 distinct ids carrying a defective verdict I grepped
+           former_ids.yml, renames.yml, removals.yml, moves.yml, styling.yml,
+           data/name_shapes.yml and every file under data/review/."
+  results:
+    - "data/review/: the ONLY hits are the sample list itself
+       (audit-v2026.07.5/SAMPLE-s2w.yml). Not one defective id is signed off in a
+       review ledger. No defect is a blessed decision."
+    - "former_ids.yml hits exist for 7 of them — cl50-benly, fact-50,
+       rsv1000-tuono, monster-1200s, flhtcui, tm-racing/300-2-tempi, dragstar —
+       and every one is a display-form respace/fusion the researcher correctly
+       accounted for: it called `name: correct` for cl50-benly, fact-50, flhtcui
+       and dragstar, and its defect on the other three rests on a DIFFERENT
+       ground (monster-1200s: the respace fixed only the first seam;
+       rsv1000-tuono: the name never existed at Aprilia; 300-2-tempi: '2 Tempi'
+       is not a nameplate). No conflict."
+    - "styling.yml / name_shapes.yml: zero pins collide with a defective claim."
+  one_process_note: >-
+    Two of the researcher's cited URLs cannot be re-fetched as written.
+    https://www.ducati.com/ww/en/bike-archive/monster-1200-s returns HTTP 403 to
+    this fetcher, and
+    https://www.clubcar.com/en-us/commercial/street-legal-vehicles/club-car-urban
+    301-redirects cross-host to https://www.clubcarurban.com/ (the same
+    cross-host rule the researcher itself declined to follow for tmracing.it).
+    I confirmed both claims by other routes (below), so the verdicts survive —
+    but the ledger should carry re-fetchable URLs.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# VERDICT-BY-VERDICT: all 41 defective claims re-derived
+# ═══════════════════════════════════════════════════════════════════════════
+defective_claims_rederived:
+
+  # ── UPHELD, evidence independently reproduced ────────────────────────────
+  - claim: "moped/honda/ad01 name defective(D9)"
+    result: UPHELD
+    note: >-
+      STRENGTHENED. My nl_rdw derivation pairs AD01 with the MT50/MT5 nameplate in
+      TWELVE spellings, not eight: 'AD01 MT5', 'AD01 MT-5', 'AD01 MT 50',
+      'AD01 (MT50S)', 'AD01(MT50S)', 'AD01-MT50SA', 'AD01 (MT50SL)', 'MT50 AD01',
+      'MT 5 AD01', 'HONDA AD01 (MT50S)', 'HONDA AD01-MT50S', 'HONDA AD01 MT50SE'.
+      AD01 pairs with nothing else. Also 'AD01 JUNIOR' beside 'MT50 JUNIOR'.
+      See the separate id disagreement below.
+
+  - claim: "moped/honda/cl50-benly id defective(D6)"
+    result: UPHELD
+    note: >-
+      STRENGTHENED — the cluster is FOUR ids, not two. Live: moped/honda/cl50
+      "CL50" [nl,nz], moped/honda/cl50-benley "CL50 Benley" [nl,nz] (a misspelling
+      published as its own id), moped/honda/benly "Benly" [nl,nz,ua], and the
+      sampled cl50-benly. nl_rdw alone spells the machine 'CL50 BENLY' 17,
+      'CL 50 BENLY' 3, 'CL50  BENLY' 1, 'CL50 BENLEY' 1, 'BENLY CL50' 5,
+      'BENLY CL 50' 1, 'CL50' 7, 'CL 50' 2. cl50-benly vs cl50-benley is the
+      cleanest possible demonstration of FINDING-A: they fold to "cl50benly" and
+      "cl50benley", so the detector's equality test cannot see them.
+      Careful: the CD50 Benly is a DIFFERENT Honda (roadster vs CL scrambler) and
+      the nl raw carries 25+ CD50-Benly spellings — do not sweep them together.
+
+  - claim: "moped/honda/nsc50t2 id defective(D8) + name defective(D8)"
+    result: UPHELD (evidence class corrected)
+    note: >-
+      Verdicts stand, but NOT on the researcher's stated grounds. The cited
+      hondanews.eu press pack contains no "NSC50" (see target_4), so it cannot
+      prove the type's retail name. What DOES support D8 is in-data: the identical
+      suffix set recurs on the 110cc sibling in two other registers —
+      nl 'NSC110', 'NSC110MPD', 'NSC110WH', 'NSC 110 MPD';
+      es 'NSC110' n=938, 'NSC 110 MPD', 'NSC 110 WH-B'.
+      MPD/WH applied across two displacements of one type family are spec
+      suffixes, not nameplates. Note also the TAN structure argues AGAINST using
+      the shared TAN here at all: e4*2002/24*2978*01 carries NSC50 + NSC50T2 +
+      NSC50MPD while e4*2002/24*2804*{00,01,02} carries NSC50WH + NSC50MPD +
+      'NSC50 2WH' — MPD spans both approvals.
+
+  - claim: "moped/honda/today id defective(D6)"
+    result: UPHELD
+    note: >-
+      STRENGTHENED. nz_nzta moped spells one machine 18 ways: 'TODAY' 165,
+      'TODAY 50' 78, 'TODAY50' 5, 'TODAY M' 4, 'TODAY MOTORINO' 2,
+      'TODAY 50/NV550', 'TODAY NV550', 'TODAY NU550', 'TODAY/NV550',
+      'TODAY NSV 50', 'TODAY NUS50', 'TODAYNS50V', 'TODAY 50CC', 'TODAY SCOOTER',
+      'TODAY MOPED', 'TODAY7', 'TODAY MOTORNO', 'TODAY MOTORINA'. ua carries
+      'TODAY' 3 and 'TODAY 50' 3. Both ids draw on the same two registers; the
+      NVS50 type code appears mangled in six of those spellings, confirming the
+      50cc machine throughout.
+
+  - claim: "moped/honda/super-cub50 name defective(D7)"
+    result: UPHELD
+    note: >-
+      nl_rdw 'SUPER CUB 50' n=193 dominant vs 'SUPERCUB50' 4 and 'SUPERCUB 50' 12;
+      'SUPER CUB' 166; ua 'SUPER CUB 50' 5. Published "Super CUB50" is the
+      normalizer.rb:153 collapse plus the smart_case digit-freeze, exactly as
+      data/name_shapes.yml debt:normalizer-space-collapse-display-names describes.
+
+  - claim: "moped/keeway/fact-50 id defective(D6)"
+    result: UPHELD (merge partner disputed)
+    note: >-
+      Name `correct` re-verified: keeway.com's own page titles are "Fact 50 |
+      Keeway", "Fact EVO 50 | Keeway", "Fact X 50 | Keeway" (the researcher's
+      pl-en URL renders empty to this fetcher; the gb-en/hu-hu/ae-en/lt-en titles
+      carry it). nz spellings reproduced EXACTLY as claimed: 'FACT' 41,
+      'F-ACT 50' 6, 'F-ACT50' 5, 'F-ACT' 3, 'FACT 50' 2, 'FACT50' 1 (+
+      'F-ACT-50QMB-4' 1).
+      DISPUTE ON THE PARTNER: the researcher names moped/keeway/f-act as the
+      duplicate. My fi derivation shows fact-50's fi evidence ('FACT 50' n=63)
+      sits on TAN e13*168/2013*00408*03 — the SAME approval base as
+      'F-ACT EVO 50 4T' n=243 (*00) — while f-act sits on e3*2002/24*0274*07.
+      So the nearer duplicate may be moped/keeway/f-act-evo, not f-act. A merge
+      executed on the researcher's stated partner could land the 4-stroke Evo
+      generation's rows on the 2-stroke id. Decide the partner before folding.
+
+  - claim: "moped/garia/club-car-urban-l7e-s name defective(D5)"
+    result: UPHELD (one citation detail corrected)
+    note: >-
+      clubcarurban.com (reached after the cross-host redirect): "Club Car Urban:
+      Driven by excellence, committed to your safety"; Club Car is the brand
+      throughout; Garia appears only as the spare-parts host
+      (shop.garia.com/dk/spare-parts/spare-parts-club-car-urban/). The marque
+      words "Club Car" are inside the model string — D5 confirmed. CORRECTION:
+      the researcher says "official form is 'Urban L7E'"; the marque site never
+      presents a bare "Urban", it markets "Club Car Urban". The D5 is about the
+      make/model split, not about a bare-Urban product name.
+
+  - claim: "moped/garia/club-car-urban-l7e-s make defective(D11)"
+    result: UPHELD, by the project's own written rule
+    note: >-
+      I decided this against overrides/models/moves.yml's header rather than by
+      preference. Rule 3: "Only move when the register is unambiguously filing ONE
+      marque's model under another. Do NOT move a row that POOLS two marques'
+      models." This row pools nothing — one Club-Car-badged product, filed under
+      the manufacturer/TAN-holder Garia A/S (es 'GARIA | CLUB CAR URBAN L7E S'
+      n=3; fi 'Garia | Club Car Urban L7e-S' TAN e13*168/2013*00375*01 n=1),
+      which is precisely the file's stated premise. D11 stands. The blocked
+      disposition (a move would mint a single-record `club-car` make) is correctly
+      identified and is a separate concern.
+
+  - claim: "motorcycle/bmw/k1600gt name defective(D7)"
+    result: UPHELD
+    note: >-
+      Register consensus reproduced: nl 'K 1600 GT' 1526 vs 'K1600GT' 8; es
+      spaced; lu spaced across 4 TANs; fi spaced across 6 TANs. bmw-motorrad.com
+      still unreachable for me too, so this rests on four-register agreement, as
+      the researcher honestly said. Filed-debt class, not new.
+
+  - claim: "motorcycle/ducati/monster-1200s name defective(D7)"
+    result: UPHELD
+    note: >-
+      The researcher's URL 403s to me, but ducati.com's own page titles confirm
+      the spaced form across four independent pages: "Monster 1200 S (2017)"
+      (https://www.ducati.com/us/en/bike-archive/monster-1200-s/model-year-2017),
+      "Monster 1200 S becomes 'Black on Black'", "Make it yours - Monster 1200 S",
+      "Monster 1200 S". Published "Monster 1200S" is glued. The half-fixed-family
+      observation (former_ids.yml:354 split Monster from 1200S but left 1200S
+      glued) is correct and is a good sub-shape to file.
+
+  - claim: "motorcycle/harley-davidson/flhtcui id defective(D6)"
+    result: UPHELD, strength upgraded from WEAK to STRONG — see target_4.
+
+  - claim: "motorcycle/harley-davidson/flhxst name defective(D7)"
+    result: UPHELD
+    note: >-
+      harley-davidson.com model-codes page re-fetched: "FLHXST - Street Glide(R)
+      ST" verbatim, all codes uppercase. Published "Flhxst". Filed debt
+      (debt:model-column-acronym-casing).
+
+  - claim: "motorcycle/honda/gl1 name defective(D9)"
+    result: UPHELD
+    note: >-
+      Reproduced: the entire basis is nl 'GL 1' n=2 + 'GL-1-ED' n=1 and fi 'GL 1'
+      n=1 — four vehicles. The same registers carry GL100, GL145, GL400, GL500,
+      GL650, GL700, GL1000, GL1100, GL1200, GL1500, GL1800 (eleven displacements,
+      not the researcher's eight) with 'GL 1000 GOLD WING' alone at n=628. Honda's
+      GL family designation is GL<displacement>; 'GL 1' is a truncated register
+      string. No recoverable target, so a removals manifest not a rename — agreed.
+      Availability correct, confirmed.
+
+  - claim: "motorcycle/honda/k2 name defective(D9)"
+    result: UPHELD
+    note: >-
+      STRENGTHENED with in-data proof the researcher did not use: the SAME nl_rdw
+      register carries 'GL 1000 K2' n=209+11 and 'GL 1000 K3' n=199+16 under make
+      HONDA — i.e. the register itself uses K2 as a suffix FOLLOWING a nameplate,
+      in the same make. Combined with renames.yml:806 ('Z50AK2: Z50A K2') that is
+      sufficient in-data evidence that K2 is a year/generation suffix. The record
+      is two single rows (lu 1, nz 1). Sibling honda/k4 is the same shape.
+
+  - claim: "motorcycle/honda/magna name defective(D8)"
+    result: UPHELD — and I supply the marque sources the researcher lacked
+    note: >-
+      The researcher cited NO marque source; I closed the gap, and it closes
+      AGAINST bare "Magna" for every generation:
+        * hondanews.com VTX Timeline: "the mighty V-65 Magna(R) (VF1100C),
+          introduced in 1983" — Honda's own form is V-65 Magna.
+          https://hondanews.com/en-US/powersports/releases/release-a48aa4a2e7b5f344b1d444004c34c57a-honda-vtx-timeline
+        * the 1994-2003 VF750C was marketed as "Magna 750", not "Magna":
+          https://magazine.cycleworld.com/article/1993/6/1/1994-honda-magna-750
+          ("1994 Honda Magna 750"), https://magazine.cycleworld.com/article/1994/2/1/honda-magna-750,
+          https://www.motorcyclistonline.com/1993-2004-honda-magna-750/
+      So no Honda Magna generation was retailed as bare "Magna". Register
+      corroboration reproduced: nl bare 'MAGNA' 5 against V45/V30/V65/VF-prefixed
+      forms totalling >2,000 ('VF700 MAGNA' 547, 'VF 700 MAGNA' 461,
+      'V45 MAGNA' 435, 'VF 700 C MAGNA' 300, 'V65 MAGNA' 90, 'V 65 MAGNA' 83…);
+      and the bare rows that carry any extra token point to VF700/VF750
+      ('MAGNA VF 700', 'MAGNA VF 750 C', 'MAGNA 700CC').
+      CORRECTION to the researcher's numbers: nz bare 'MAGNA' is n=90 (motorcycle)
+      + 8 (moped), not 7 — the record is less marginal than stated. See also the
+      id disagreement below.
+
+  - claim: "motorcycle/honda/nrx-rune name defective(D7)"
+    result: UPHELD
+    note: "NRX is an initialism (type NRX1800); published 'Nrx Rune' title-cases it.
+            Filed debt class. See the id OVERTURN below — this record's id claim is wrong."
+
+  - claim: "motorcycle/honda/nt650v id defective(D6)"
+    result: UPHELD — strongest id call in the batch
+    note: >-
+      fi carries 'NT650V' and 'NT650V DEAUVILLE-RC47A/647' on the SAME TAN
+      e9*92/61*0073*01, and 'NT650V' also on *00. nl writes the machine as one
+      string 21 times ('NT 650 V DEAUVILLE'), 8 times as 'NT650V DEAUVILLE',
+      beside 'NT650V' n=644. Same RC47 type code. And the researcher is right to
+      protect nt650: nl 'NT 650 HAWK GT' n=222 and nz 'NT650 BROS' show nt650 is
+      the Hawk/Bros — a different motorcycle. Do not fold that one.
+
+  - claim: "motorcycle/honda/pc38 name defective(D9)"
+    result: UPHELD
+    note: "nl 'PC38' 5 + 'PC 38' 3. The catalog publishes the full consecutive run
+            pc31,pc32,pc34,pc35,pc36,pc37,pc38,pc39 as eight ids from the same
+            register — a code series, not a nameplate series. Target unnamed
+            (needs Honda type tables): correctly not asserted."
+
+  - claim: "motorcycle/honda/sc36 name defective(D9)"
+    result: UPHELD
+    note: "nl 'SC36' 429 + 'SC 36' 148 = 577 vehicles, single source. Catalog runs
+            sc32,sc33,sc35,sc36,sc38. Same class as pc38; the researcher is right
+            that this is where a rename pays best."
+
+  - claim: "motorcycle/ktm/1190 name defective(D9)"
+    result: UPHELD
+    note: >-
+      The register distinguishes the real machines: nl '1190 ADVENTURE' 3+5+1+1,
+      '1190 ADVENTURE R' 3, '1190 LC8 ADVENTURE' 1, '1190 RC8' 8, '1190 RC8 09' 1,
+      '1190 RC8 R' 1; ua '1190 ADVENTURE' 4; th '1190 ADVENTURE R' 1. The record's
+      own evidence is nz bare '1190' 236 + lu '1190' 2 — at least three
+      motorcycles pooled. debt:bare-displacement-2w class, correctly recorded as a
+      defect despite being filed.
+
+  - claim: "motorcycle/triumph/rocket name defective(D8)"
+    result: UPHELD
+    note: >-
+      Triumph's nameplates are Rocket III / Rocket 3 (+ Roadster/Touring/GT/R/
+      Storm/TFC/Classic/X). Reproduced across every corpus: nl 'ROCKET III' 169+10,
+      'ROCKET 3 GT' 92, 'ROCKET 3 R' 92; nz 'ROCKET III' 414; fi 'ROCKET III' 86+70+47+47;
+      es/ua/th all carry Rocket 3 variants. Bare 'ROCKET' is nl 1 + nz 329, and the
+      gb GenModel 'TRIUMPH ROCKET' pools 14 distinct Model strings (ROCKET 111,
+      ROCKET 111 ROADSTER/TOURING, ROCKET 3 GT/R/STORM GT/STORM R/TFC/GT TRIPLE
+      BLACK/R BLACK/GT+R EVEL KNIEVEL, ROCKET CLASSIC, ROCKET X). See the id
+      disagreement and the new queue item below.
+
+  - claim: "motorcycle/yamaha/mtt690-u name defective(D9)"
+    result: UPHELD
+    note: >-
+      es_dgt's parenthetical convention reproduced in the same make and months:
+      'MTM850 (XSR900)' and 'MTT850D (TRACER900 GT)' — the register carries EU type
+      codes and appends the marketing name in brackets when it has it. That is the
+      in-data proof. Target correctly not asserted. See the id disagreement below.
+
+  - claim: "motorcycle/yamaha/wr125-a name defective(D8)"
+    result: UPHELD
+    note: "fi carries the real nameplates on the sibling approvals — 'WR125X'
+            145+136+111 and 'WR125R' 31+17 on e13*2002/24*0332*{00,01,02} — so the
+            register distinguishes models and '-A' is a variant letter. es 'WR125-A' 275."
+
+  - claim: "motorcycle/yamaha/xp id defective(D8) + name defective(D7)"
+    result: UPHELD
+    note: >-
+      Reproduced exactly. gb GenModel 'YAMAHA XP' pools SEVEN Model strings:
+      XP500 (513+224), 'XP 500 A TMAX' (43+39), 'XP 500 TMAX (530)' (75+69),
+      'XP 530 D-A TMAX DX' (127+64), 'XP 530 E-A TMAX' (35+35),
+      'XP 560 D (TMAX TECH MAX)' (28+18), 'XP 560 E (TMAX)' (14+8) — three
+      displacements, and five of seven rows spell out TMAX. Single-source gb.
+      Catalog already holds xp500, xp500a, xp530-a, xp530d-a, xp560, xp560d,
+      xp560e separately, so `xp` adds only a rollup.
+
+  - claim: "motorcycle/yamaha/xsr id defective(D8) + name defective(D7)"
+    result: UPHELD, count corrected upward
+    note: >-
+      gb GenModel 'YAMAHA XSR' pools NINE Model strings, not eight — the
+      researcher missed 'XSR 900 GP (MTM890D)' (204 Licensed + 73 SORN). Full set:
+      XSR 125 (MTM125) 2156+285; XSR 700 (MTM690) 540+107; XSR 700 ABS 973+394;
+      XSR 700 ABS (35KW) 13+3; XSR 700 XTRIBUTE 150+36; XSR 900 (MTM890) 691+113;
+      XSR 900 ABARTH (MTM 850) 44+45; XSR 900 ABS MTM 850 1056+450;
+      XSR 900 GP (MTM890D) 204+73. So SIX motorcycles at one id (XSR125, XSR700,
+      XSR700 XTribute, XSR900, XSR900 Abarth, XSR900 GP), not five. Yamaha sells
+      no bike called "XSR"; catalog already holds xsr155/700/900/700-35kw.
+
+  - claim: "motorcycle/yamaha/yzf890 name defective(D9)"
+    result: UPHELD
+    note: "es 'YZF890' 156 and 'YZF890-U' 11 beside 'YZF-R1', 'YZF R1', 'YZF -R1',
+            'YZF-R1M' — the register carries both type codes and real nameplates and
+            distinguishes them. Target (R9) correctly not asserted. See id disagreement."
+
+  - claim: "motorcycle/ajs/m20 id defective(D6)"
+    result: UPHELD, strength upgraded from moderate to STRONG, and the
+            researcher's own stated doubt is resolved
+    note: >-
+      The cluster is THREE ids, not two: motorcycle/ajs/20 "20" [nl,nz],
+      motorcycle/ajs/m20 "M20" [nl,nz], and motorcycle/ajs/model-20 "Model 20"
+      [nl,nz] — which the researcher missed entirely.
+      The researcher wrote: "if the verifier can source an AJS 'Model 20'
+      registration in NL or NZ, that settles it". I have it, in both registers,
+      from my own derivation: nl_rdw 'AJS | MODEL 20' n=2 and nz_nzta
+      'AJS | MODEL 20' n=3, alongside 'AJS | 20' n=1/19 and 'AJS | M 20' n=1/1,
+      'AJS | M20' n=1. The registers spell one AJS machine three ways under the
+      AJS make; the BSA-misattribution reading is not needed and is not supported.
+      Marque-specialist corroboration for the designation form: cybermotorcycle's
+      AJS pages use "Model 18"/"Model 16M" and its gallery carries
+      https://cybermotorcycle.com/gallery/ajs-1957/AJS-1957-Model-20-500cc-AT-04.htm
+      titled "AJS 1957 Model 20 500cc Twin". AJS's form is "Model NN", not "MNN".
+      Same shape at motorcycle/ajs/31csr vs motorcycle/ajs/model-31 — queue item.
+      name stays unverifiable (a gallery caption is not a factory catalogue), but
+      the likely target is now nameable: "Model 20".
+
+  - claim: "motorcycle/aprilia/rsv1000-tuono name defective(D7)"
+    result: UPHELD
+    note: >-
+      Reproduced: 'RSV1000 TUONO' occurs in exactly one lu row (TAN
+      e11*92/61*00027*06), and nl spells the machine six other ways, none of them
+      this ('APRILIA TUONO 1000', 'APRILIA TUONO 1000R', 'MILLE TUONO', 'RR
+      TUONO', 'RP 1000 TUONO', 'APRILIA TUONO'). See the id OVERTURN below.
+
+  - claim: "motorcycle/bsa/thunderbolt-a65 id defective(D6) + name defective(D7)"
+    result: BOTH UPHELD (the SIX-id count in the rationale is wrong — see target_1)
+    note: >-
+      Every raw count reproduced EXACTLY from my own derivation:
+      nl 'THUNDERBOLT' 36, 'A65' 12, 'A65T' 8, 'A 65 THUNDERBOLT' 5,
+      'A65 THUNDERBOLT' 4, 'THUNDERBOLT 650' 4, '650 THUNDERBOLT' 1,
+      'THUNDERBOLT A65' 1, 'THUNDERBOLT A65T' 1;
+      nz 'THUNDERBOLT' 67, 'A65' 52, 'A65T' 5, 'THUNDER BOLT' 2,
+      'THUNDERBOLT 650' 1, '650 THUNDERBOLT' 1; fi 'Thunderbolt' 1,
+      'THUNDERBOLT A65' 1. (nl also has 'A 65 T' 2, 'A 65 TA' 23+4, 'A 65 T.B.' 1,
+      'A65TB' 1, 'THUNDERBOLD' 1+1, 'A 65 TUNDERBOLD' 1, 'THUNDERBALL 650' 1 —
+      more mangled Thunderbolt evidence than the report shows.)
+      name: marque form is "A65 Thunderbolt" per
+      https://cybermotorcycle.com/marques/bsa/bsa-a65-thunderbolt.htm ("A65T 650cc
+      Thunderbolt", "Introduced in 1964 … remained in the catalogue until 1972"),
+      corroborated inside the repo at renames.yml:175. Published token order is
+      inverted. UPHELD.
+      ENRICHMENT SUB-CHECK independently re-derived: production_runs 1964-1972 +
+      era classic are CORRECT against that page. Agreed.
+      The record is built on the rarest form in the corpus (n=1 fi, n=1 nl).
+
+  - claim: "motorcycle/lexmoto/milano id defective(D8)"
+    result: UPHELD
+    note: >-
+      gb GenModel 'LEXMOTO MILANO' pools 'MILANO 125 EFI FT 125 T-27 E4' 485+367,
+      'MILANO 125 FT 125 T-27' 351+144, 'MILANO 50 FT 50 QT-27' 118+57 — a 125 and
+      a 50 at one id, and the 50 is a moped sitting in the motorcycle kind via the
+      documented uk_dft body-type merge. The researcher's own distinction from
+      mutt/fsr (displacements only) is the right one and I would not downgrade it.
+
+  - claim: "motorcycle/niu/nqi-gts-pro name defective(D7)"
+    result: UPHELD
+    note: >-
+      global.niu.com/en-us/product/nqi-gts re-fetched: NIU renders it "NQi GTS"
+      throughout, variants "NQi GTS STANDARD RANGE" / "NQi GTS EXTENDED RANGE".
+      Published "Nqi Gts Pro". Minor citation gap: "Pro" is not on that page.
+      The researcher's added point is correct and important — NIU's own casing is
+      MIXED (NQi, not NQI), so the debt entry's remedy (global `acronyms` token
+      pins) structurally cannot fix this record; it needs a whole-string styling
+      pin. That is a gap in the remedy, worth carrying forward.
+
+  - claim: "motorcycle/rudge/whitworth name defective(D5)"
+    result: UPHELD — strongest name call in the batch
+    note: >-
+      Reproduced and strengthened. nl_rdw under make RUDGE: 'WHITWORTH' 1,
+      'WHITWORTH 250' 1, and — decisive — 'RUDGEWHITWORTH' 1, the whole corporate
+      name typed into the model column. Beside it the real Rudge models: 'SPECIAL'
+      7, 'ULSTER' 5, 'MULTI' 2+2, '250 RAPID' 1, 'SPORTS SPECIAL' 1, 'SPORT' 1,
+      'PITON' 1, 'ULSTER GRAND PRIX' 1, 'ULSTER 500' 1, 'RUDGE ULSTER' 1.
+      fi independently carries Rudge 'SPECIAL', 'SPORT SPECIAL', '350'.
+      The adjacent D12 is confirmed too: nz_nzta carries 'RUDGE WHITWORTH' as its
+      OWN make string with models SPECIAL 2, ULSTER 1, 350 1, plus the make-as-model
+      row 'RUDGE WHITWORTH | RUDGE WHITWORTH' 1 — overlapping models against make
+      `rudge` is exactly the evidence a make merge needs, and no alias exists.
+      Both queue items are real.
+
+  - claim: "motorcycle/tm-racing/300-2-tempi id defective(D6) + name defective(D8)"
+    result: BOTH UPHELD, and the researcher's own open question is closed
+    note: >-
+      Reproduced and extended. fi carries the engine-cycle descriptor across the
+      make's whole range on DISTINCT approvals — '125 2 Tempi' e3*2002/24*0501*00,
+      '250 2tempi' *0502*00, '144 2tempi' *0504*00, '300 2 TEMPI' *0503*00, and
+      '250 4 tempi' *0523*00. An engine-cycle column, not a nameplate column;
+      renames.yml:2159 already ruled the identical Sherco '2ST' token not-a-nameplate.
+      MERGE TARGET NOW AVAILABLE without reaching tmracing.it: the same register,
+      on the SAME approval e3*2002/24*0503*00, carries TM's real model letters —
+      'TM | 300 EN' and 'TM Racing | 300 EN' — plus 'TM Racing | 300 Fi EN'
+      (e24*168/2013*00059*02) and 'TM Racing | 300F' (e24*168/2013*00026*00).
+      So the target is the EN (enduro) designation, not bare '300', which answers
+      the researcher's "this may be a two-step fix" worry.
+      id: tm-racing/300 is live on the same TAN — D6 confirmed.
+
+  - claim: "moped/yamaha/sa19 name defective(D9)"
+    result: UPHELD — see target_4, evidence materially strengthened.
+
+  # ── OVERTURNED ───────────────────────────────────────────────────────────
+  - claim: "moped/honda/nsc50 name defective(D9)"
+    result: 'OVERTURNED -> unverifiable'
+    reason: "see target_4 — the cited press pack does not contain NSC50, and
+             Honda publishes NSC50R as a retail model name."
+
+  - claim: "motorcycle/yamaha/dragstar id defective(D6)"
+    result: 'OVERTURNED on CLASS -> defective(D8). Still defective; the stated
+             duplicate partner is wrong and acting on it would corrupt data.'
+    reason: >-
+      The researcher says "dragstar and xvs1100-dragstar are one motorcycle",
+      resting on shared TAN e1*92/61*00072*00. My derivation shows the bare
+      DragStar rows span THREE displacements, so they are not the XVS1100:
+        ua 'DRAG STAR' 28, 'DRAG STAR 400' 176, 'DRAG STAR 1100' 43,
+           'DRAG STAR CLASSIC' 3, 'DRAGSTAR 400 CLASSIC' 2
+        fi 'Dragstar 400' 1, 'XVS650 DRAG STAR' + 'XVS1100 DRAG STAR' families
+        nl 'DRAGSTAR' 21, 'DRAG STAR' 13 beside XVS400/XVS650/XVS1100 forms
+        nz 'DRAGSTAR' 104
+      Live siblings: dragstar-1100, dragstar-classic, xvs1100-dragstar,
+      xvs1100a-dragstar, xvs650-dragstar, xvs650a-dragstar. Bare `dragstar` is a
+      FAMILY word with the displacement dropped — the same class as honda/magna
+      and triumph/rocket (D8), not a spelling duplicate of the 1100.
+      SAFETY CONSEQUENCE: folding dragstar into xvs1100-dragstar would silently
+      relabel Yamaha DragStar 400s and 650s (at least 176+43+ rows in ua alone) as
+      1100s. This is the clearest demonstration in the batch of why the FINDING-A
+      detector must emit a worklist and never a verdict — and of why shared TAN
+      must not be used to pick a merge partner.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# NEW DEFECTS the researcher called `correct` — found by my own duplicate scan
+# (v_dup.rb: token-multiset subset/permutation within make+kind — i.e. the
+#  detector FINDING-A proposes. It flags 40 of 100 sampled records; most are
+#  legitimate, which is exactly the researcher's point. These are not.)
+# ═══════════════════════════════════════════════════════════════════════════
+additional_defects:
+
+  - claim: "motorcycle/honda/nrx-rune id"
+    researcher: correct
+    my_verdict: 'defective(D6)'
+    confidence: high
+    why: >-
+      Honda built exactly ONE NRX — the NRX1800 Valkyrie Rune, 2004-05 — which is
+      the researcher's own cited fact ("type NRX1800", hondanews.com). The catalog
+      holds THREE ids for it: motorcycle/honda/nrx "Nrx" [nl,nz],
+      motorcycle/honda/nrx1800 "NRX1800" [nl,ua,gb], and the sampled nrx-rune.
+      Raw confirms one machine: nl 'NRX' 1, 'NRX1800' 1, 'NRX 1800' 3,
+      'NRX1800EB' 1, 'NRX 1800 EB' 1, 'NRX 1800 RUNE' 2, 'NRX 1800RUNE' 1,
+      'NRX RUNE' 4, 'RUNE' 1, 'HONDA RUNE NRX 1800' 1, 'SC53 VALKYRIE RUNE' 1;
+      nz 'NRX' 16; fi 'NRX RUNE' 1, 'RUNE 1800' 1; ua 'NRX 1800' 1; gb GenModel
+      'HONDA NRX 1800' Model 'NRX 1800 RUNE'. This is the researcher's own
+      flagship token-subset shape, in a record it held in its hands.
+
+  - claim: "motorcycle/harley-davidson/sportster-883 id"
+    researcher: correct
+    my_verdict: 'defective(D6)'
+    confidence: high
+    why: >-
+      motorcycle/harley-davidson/883-sportster "883 Sportster" [nl,nz] is live —
+      the same two tokens in the reverse order. A pure token PERMUTATION, which is
+      the second half of the detector the researcher specified and the least
+      arguable duplicate class there is. H-D's own model-codes page gives
+      "XL883 - Sportster(R) 883", so there is one nameplate. Also live: `883`
+      [fi,lu,nl,nz], `xl-sportster-883`, `xlh-sportster-883`, `sportster`.
+
+  - claim: "motorcycle/aprilia/rsv1000-tuono id"
+    researcher: correct (D6 "flagged rather than asserted")
+    my_verdict: 'defective(D6)'
+    confidence: high
+    why: >-
+      The researcher established that Aprilia never wrote "RSV1000 Tuono" and that
+      the string exists in exactly ONE register row. A name that no marque ever
+      used cannot denote a distinct vehicle: the row is either an RSV Mille or a
+      Tuono, and BOTH are live (motorcycle/aprilia/rsv1000 [fi,gb,lu,nl,nz],
+      motorcycle/aprilia/tuono [fi,gb,nl,nz]). `id: correct` asserts "no other
+      live id denotes the same vehicle", which the researcher's own evidence
+      contradicts. FINDING-B is not a reason to hold back here — the shared TAN is
+      irrelevant either way; the name being a register chimera is the point.
+
+  - claim: "motorcycle/yamaha/mtt690-u id"
+    researcher: correct
+    my_verdict: 'defective(D8)'
+    confidence: high
+    why: >-
+      motorcycle/yamaha/mtt690 "MTT690" [es,fi,lu,nl] is live, and the researcher's
+      own name verdict says '-U' is "the restricted-power variant letter" on that
+      type. That is verbatim the shape it called id-defective(D8) for
+      moped/honda/nsc50t2 (variant suffix published beside its base id). One of the
+      two calls has to move; the evidence says this one.
+
+  - claim: "motorcycle/yamaha/yzf890 id"
+    researcher: correct
+    my_verdict: 'defective(D8)'
+    confidence: high
+    why: "motorcycle/yamaha/yzf890-u \"YZF890-U\" [es,nl] is live. Identical
+          reasoning to mtt690-u; es carries 'YZF890' 156 and 'YZF890-U' 11 as one
+          type with a power-variant letter."
+
+  - claim: "moped/honda/ad01 id"
+    researcher: correct
+    my_verdict: 'unverifiable'
+    confidence: medium
+    why: >-
+      `id: correct` is an affirmative claim that no other live id denotes the same
+      vehicle. moped/honda/mt50 and moped/honda/mt5 are both live, AD01 is their
+      frame code, and the register pairs AD01 with MT50/MT5 in twelve spellings and
+      with nothing else. The researcher's reasoning for `correct` ("I cannot
+      establish that every AD01 row is an MT50") is an argument for
+      `unverifiable`, not for `correct`. Note the adjacent mt50/mt5 pair is itself
+      a D6 candidate.
+
+  - claim: "moped/honda/super-cub50 id"
+    researcher: correct
+    my_verdict: 'unverifiable'
+    confidence: medium
+    why: >-
+      moped/honda/cub50 "CUB50" [nl,nz] is live. The researcher declined to assert
+      the duplicate because Honda also sold plain Cub models — a good reason not to
+      call it defective, and equally a reason not to call it correct. Raw is
+      genuinely ambiguous: nz 'CUB 50' 2, 'CUB50' 3, 'CUB 50 DELUXE' 1;
+      nl 'CUB 50' 1; and moped/honda/cub and moped/honda/little-cub are both live.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CORRECT / UNVERIFIABLE SPOT-CHECKS
+# ═══════════════════════════════════════════════════════════════════════════
+spot_checks:
+  availability:
+    coverage: "251/251 (100%) — not the 20% required"
+    result: "ALL UPHELD. 251 HIT / 0 MISS."
+    note: >-
+      My matcher resolves make aliases and renames inline, so it cleared the three
+      cases the researcher had to run down by hand, without special-casing:
+        moped/selana/alpha nl   HIT n=576  'GO TULIP B.V. | SELANA ALPHA'
+        motorcycle/tgb/br8 gb   HIT n=191  'TAIWAN GOLDEN BEE | TAIWAN GOLDEN BEE BR8'
+        moped/derbi/senda-50 fi HIT n=2072 via the 13 curated folds
+                             nl HIT n=5080 (includes 'DERBI | AB' n=317 — see target_3)
+      Also confirmed: no moped record claims `gb` (uk_dft has no moped kind), so
+      the six cross-kind uk_dft twins the researcher cleared are correctly cleared.
+      This claim class is genuinely clean and the researcher's "flatten everything
+      up front" process note is the right lesson to carry to batches 2-4.
+  kind:
+    coverage: "52/100 (52%) re-derived from the raw EU-category columns (fi/es)"
+    result: "52/52 agree. Includes both records that look wrong and are not:
+             moped/stromer/st2 (L1e-B speed pedelec) and
+             moped/garia/club-car-urban-l7e-s (L7e quadricycle)."
+    note: "The other 48 are nl/nz/gb/ua/th-only, where no EU-category column
+           exists; those rest on each adapter's own kind map, as the researcher said."
+  make:
+    coverage: "100% structurally"
+    result: "99 correct UPHELD. My matcher required every one of the 251
+             availability rows' raw make string to resolve to the record's
+             make_id through overrides/makes/aliases.yml; all 251 resolved.
+             The 1 defective (garia D11) is upheld separately."
+  name_sources_refetched:
+    - "harley-davidson.com model-codes page — FLHXST, FLHTCU, FLHTCUTG, FLSTC,
+       XL883 all verbatim as claimed; codes uppercase. GAPS: FLHTCUI and FXR are
+       NOT on that page, so motorcycle/harley-davidson/fxr `name: correct` rests
+       on the code-form convention plus five registers, not on a page that names
+       FXR. I would leave it `correct` but the citation should say so."
+    - "global.niu.com — 'NQi GTS' confirmed verbatim."
+    - "ducati.com — 'Monster 1200 S' spaced, confirmed via four page titles."
+    - "keeway.com — 'Fact 50' confirmed via page titles; also 'Fact EVO 50' and
+       'Fact X 50' exist as separate Keeway products (relevant to the merge partner)."
+    - "clubcarurban.com — 'Club Car Urban' confirmed; Club Car is the brand."
+    - "hondanews.eu Vision 50 press pack + NSC50R model page — see target_4."
+    - "hondanews.com VTX timeline + Cycle World/Motorcyclist — Honda Magna
+       generations are V-30/V-45/V-65 Magna and Magna 750; no bare 'Magna'."
+    - "cybermotorcycle bsa-a65.htm and bsa-a65-thunderbolt.htm — see target_1."
+    - "cybermotorcycle AJS pages — 'Model NN' form."
+  unverifiable_spot_checks:
+    - "moped/nsu/quickly-l — the researcher's enrichment sub-check is CORRECT and
+       well-judged: enrich/nsu.yml:15-17 cites ONLY
+       https://en.wikipedia.org/wiki/NSU_Quickly for production_runs 1953-1968,
+       which the project does not accept as a sole source. Its refusal to call D6
+       against moped/nsu/quickly (Quickly L/N/S/T are genuinely distinct NSU
+       variants) is also right — my scan flags the pair and the researcher is
+       correct to leave it."
+    - "motorcycle/bmw/r80-7 `correct` UPHELD, and it is the batch's best
+       control: my scan nominates r80 as a token-subset sibling and r80 is a
+       DIFFERENT motorcycle. Reproduced: nl 'R 80 / 7' 827, 'R 80/7' 13,
+       'R80/7' 11 — the slash designation is preserved and is BMW's /7-series form."
+    - "motorcycle/mutt/fsr `correct` UPHELD — ledgered in data/review/mutt.yml
+       with a verifier signature; gb GenModel 'MUTT FSR' pools only FSR 125
+       (137+84) and FSR 250 (12+10), i.e. displacements of one nameplate, which is
+       exactly the accepted altitude. Sound control case."
+    - "motorcycle/lambretta/x200 `correct` UPHELD — th_dlt 'X200' n=802 reproduced
+       beside X300/X300 GT/X300 2025/V200 GP/V200 Special Flex/G350; the
+       Thailand-market-only reasoning is right and well documented."
+    - "moped/vespa/mini `unverifiable` UPHELD and correctly reasoned — nl n=1 and
+       nz n=1 reproduced; absence on a modern marque site cannot disprove a 1960s
+       variant. Good discipline."
+    - "moped/efun/pulse, moped/yamaha/nitro — thinness reproduced (n=1 in each of
+       two registers). Correctly flagged as thin rather than defective."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CORRECTED CLAIM TALLY
+# ═══════════════════════════════════════════════════════════════════════════
+corrected_tally:
+  researcher: { correct: 554, defective: 41, unverifiable: 56, total: 651,
+                clean_rate: "85.1%" }
+  verifier:   { correct: 547, defective: 45, unverifiable: 59, total: 651,
+                clean_rate: "84.0%" }
+  changes:
+    - "nsc50 name: defective -> unverifiable"
+    - "nrx-rune id, sportster-883 id, rsv1000-tuono id: correct -> defective(D6)"
+    - "mtt690-u id, yzf890 id: correct -> defective(D8)"
+    - "ad01 id, super-cub50 id: correct -> unverifiable"
+    - "dragstar id: defective(D6) -> defective(D8) (no tally change)"
+  by_claim_type:
+    id:           { correct: 80,  defective: 18, unverifiable: 2 }    # was 87/13/0
+    name:         { correct: 17,  defective: 26, unverifiable: 57 }   # was 17/27/56
+    make:         { correct: 99,  defective: 1,  unverifiable: 0 }    # unchanged
+    kind:         { correct: 100, defective: 0,  unverifiable: 0 }    # unchanged
+    availability: { correct: 251, defective: 0,  unverifiable: 0 }    # unchanged
+  the_pattern_that_matters: >-
+    Every one of my seven corrections to the id class moves in the same direction.
+    The researcher's id defect rate is 13% as reported and 18% as corrected, and
+    the reason is not carelessness — its raw work is accurate and reproducible
+    almost line for line. The reason is that it applied its own criteria
+    inconsistently: id-defective(D8) for nsc50t2's variant suffix but correct for
+    mtt690-u's and yzf890-u's; id-defective for the BSA token-subset but correct
+    for honda/nrx-rune's and harley/883-sportster's. RECOMMENDATION for batches
+    2-4: run the FINDING-A scan over the sampled record's make FIRST and require a
+    written reason for every sibling it nominates. It takes minutes and it is the
+    difference between 13% and 18%.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# INDEPENDENT VIEW ON FINDING-A .. FINDING-D
+# ═══════════════════════════════════════════════════════════════════════════
+findings_assessment:
+
+  FINDING_A:
+    real: yes
+    novel: "the DEFECT is not novel (class D6, and enrich/bsa.yml:106 and :127
+            already wrote the BSA clusters down). The DETECTOR GAP is novel as a
+            filed statement, and it is the valuable part."
+    mechanism_verified_in_source: >-
+      CONFIRMED by reading scripts/find_duplicate_spellings.rb:133, which groups on
+        m["name"].downcase.unicode_normalize(:nfkd).gsub(/\p{Mn}+/,"").gsub(/[^a-z0-9]/,"")
+      — fold to alphanumeric, then EQUALITY of the whole folded string. So
+      "Thunderbolt"/"Thunderbolt 650"/"650 Thunderbolt"/"Thunderbolt A65"/"A65T"
+      produce five distinct keys, and "CL50 Benly"/"CL50 Benley" produce two. The
+      detector is structurally blind to token presence and token order exactly as
+      claimed. The "0 groups / 0 records for the S2W half" result is consistent
+      with that logic.
+    scoping_correction: >-
+      The finding is scoped too narrowly on BSA. I ran the proposed detector
+      (v_dup.rb) and the biggest population in this sample is HARLEY-DAVIDSON, not
+      BSA: 6 ids containing the token FLHTCUI, 5 more containing FLHTCU, and 15
+      token-subset siblings around heritage-softail (flstc-heritage-softail,
+      flstc-heritage-softail-classic, flstc-heritage-softail-cl,
+      flstc-softail-heritage-classic, flstci-heritage-softail,
+      flstci-heritage-softail-c, flsti-heritage-softail, heritage-softail-classic,
+      heritage-softail-cla, softail-heritage, …). Triumph is next: rocket-3 and
+      rocket-iii are two live ids for one motorcycle, and rocket-111-roadster and
+      rocket-iii-roadster are two more (the register mis-transcribes the roman
+      III as 111 — a mangling class worth its own note). If FINDING-A is filed
+      with BSA as the exemplar, the sweep will be sized wrongly.
+    detector_spec: >-
+      SOUND, and I verified its necessary caveat empirically: over the 100 sampled
+      records the scan nominates 40, of which I judge roughly a quarter to be real
+      duplicates. Worklist-never-verdict is not a formality. My dragstar overturn
+      is the concrete proof — the scan's nomination was right that something is
+      wrong and wrong about what, and acting on the nomination would have
+      relabelled 400s and 650s as 1100s. One addition to the spec: rank by
+      COUNTRY-SET OVERLAP as well as evidence asymmetry. nt650v/nt650v-deauville
+      share 4 of 6 countries (real duplicate); f650/f650gs share TANs but are
+      different bikes. Overlap discriminates better than volume alone.
+
+  FINDING_B:
+    real: yes
+    refutation_upheld: "YES, and understated — the RE approval family spans six
+                        nameplates, and a Bullet/Classic/HNTR/Meteor 350 TAN spans four."
+    correctly_scoped: "NO. Its 'consequence for curation' paragraph is wrong, and
+                       the error is the difference between a NAMING.md line and a
+                       curation defect. See target_3 part_b: renames.yml:371
+                       (`Ab: Senda 50`) rests on TAN alone with no name-family
+                       argument, its stated inference is the exact form FINDING-B
+                       refutes, the TAN in question is not even make-exclusive
+                       (Gilera SMT 50 and an Aprilia sit on it), and the fold is
+                       live evidence feeding a published record (nl n=317).
+                       Four more merges are TAN-primary: renames.yml:370, :617,
+                       :620, :2358."
+    novel: "yes as a filed negative result. Worth keeping — a refuted detector
+            saved is cheaper than a bad detector shipped."
+
+  FINDING_C:
+    real: yes
+    verified: >-
+      CONFIRMED at source: uk_dft.rb keys Row on [Make, GenModel] and the file's own
+      header says "GenModel is make-prefixed". My v-uk.tsv reproduces every span
+      the researcher quotes, and two of its counts are LOW: YAMAHA XSR pools NINE
+      Model strings / SIX motorcycles (it missed 'XSR 900 GP (MTM890D)', 277
+      vehicles), and TRIUMPH ROCKET pools FOURTEEN.
+    correctly_scoped: >-
+      Mostly. The "gb-only" restriction is a principled line and I upheld
+      triumph/rocket's `id: correct` under it. But the flag it proposes is
+      cheap and I would widen it: emit the flag whenever an id's uk_dft component
+      spans >1 distinct Model string, gb-only or not, because the pooling is real
+      either way and the multi-source records are where it hides.
+    novel: "the class is D8/existing; the uk_dft GenModel MECHANISM as the cause,
+            and the measurable flag, are new. The mutt/fsr precedent is correctly
+            cited and the mutt-vs-milano distinction it draws is sound."
+
+  FINDING_D:
+    real: yes
+    correctly_scoped: "partly — the Honda/Yamaha framing is right but the D9
+                       population is broader than the two makes named. On the
+                       evidence in this batch alone it also covers BSA engine-batch
+                       prefixes (zb31/bb31/zc11, already noted in enrich/bsa.yml),
+                       Ducati (m620/m620s), Harley's whole FL-code population, and
+                       the Yamaha SA-code run (SA03..SA23, 10 ids in nl_rdw)."
+    strengthening_available: >-
+      FINDING-D should carry the SA-code evidence I found, because it is the same
+      register-pairs-code-with-nameplate proof form as AD01 and it is what rescues
+      the sa19 verdict: nl 'SA09 SLIDER', 'SA051 BW50 NEXT GENERATION B',
+      'SA034 WHYB', nz 'SA50 PASSOLA'; fi mallimerkinta 'SA14-SA144/49'.
+    known_or_novel: >-
+      Neither the class (D9) nor the individual records are novel — debt entries
+      already name bare-displacement-2w and model-column-acronym-casing. What is
+      genuinely new and worth filing is the MEASURED COUNT plus the observation
+      that one nameplate is routinely split across its suffixes. Its own request
+      (a name_shapes.yml debt entry with a measured count) is the right ask.
+
+  filed_debt_protocol_question:
+    researcher_asked: "should filed-debt records be excluded from the defect rate?
+                       It affects 6 of its 41 defective claims."
+    my_view: >-
+      Do NOT exclude them. The researcher's instinct is right and the reason is
+      structural: the rate measures what a consumer of the published catalog
+      receives, and a debt entry changes nothing for that consumer. Excluding
+      filed debt would make the metric improvable by writing documentation. If the
+      program wants the split it should report TWO numbers against the same
+      denominator (defects with a filed remedy / defects without), never a reduced
+      denominator. Either way it is a protocol amendment, not a per-batch call —
+      that part of the request should be granted.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# NEW QUEUE ITEMS surfaced by verification (none is a sampled claim)
+# ═══════════════════════════════════════════════════════════════════════════
+queue_items:
+  - "renames.yml:371 `Ab: Senda 50` — TAN-only merge on a non-make-exclusive
+     approval. Re-source or demote. renames.yml:370/:617/:620/:2358 TAN-primary."
+  - "renames.yml:375 `Senda: Senda 125` — per-make key cannot express the
+     'motorcycle-kind only' scoping its comment claims; 11 fi+nl moped rows are
+     mis-renamed then pruned. Needs a kind-scoped rename or a different remedy."
+  - "motorcycle/bsa/a65 — family rollup (D8), ~155 vehicles. Do NOT fold into
+     the Thunderbolt cluster."
+  - "motorcycle/triumph/rocket-3 vs /rocket-iii — two live ids, one motorcycle.
+     And /rocket-111-roadster vs /rocket-iii-roadster — the register transcribes
+     the roman III as 111. A roman-numeral mangling class."
+  - "motorcycle/ajs/model-20 + /m20 + /20 (three ids, one machine) and the same
+     shape at /model-31 + /31csr."
+  - "moped/honda/cl50-benley — a misspelling published as its own id beside
+     cl50-benly and cl50 and benly."
+  - "harley-davidson FLHTCU/FLHTCUI and FLSTC/heritage-softail code+nameplate
+     permutation populations — the largest D6 population in this sample."
+  - "moped/honda/mt50 vs /mt5 — D6 candidate (see the ad01 id note)."
+  - "make near-dupe `RUDGE WHITWORTH` in nz_nzta vs make `rudge`, with
+     overlapping models (SPECIAL, ULSTER) and no alias — D12."
+  - "moped/honda/magna [nl,nz] cross-kind twin of a 700-1100cc cruiser — D10
+     kind-noise suspect, correctly flagged by the researcher."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WHAT I COULD NOT SETTLE
+# ═══════════════════════════════════════════════════════════════════════════
+unresolved:
+  - item: "motorcycle/honda/magna id (researcher: correct)"
+    what_would_settle: >-
+      A policy decision, not a source. Five specific siblings are live (v45-magna,
+      v65-magna, vf700-magna, vf700c-magna, vf750-magna) and bare 'Magna' cannot be
+      attributed to any of them from an aggregate row, so no merge is possible.
+      The same question stands over ktm/1190 (1190-adventure, 1190-adventure-r
+      live) and triumph/rocket (13 siblings live). The project needs one written
+      rule: is a family-word id with live specific siblings `correct` (mutt/fsr
+      precedent) or a D8 rollup (the researcher's xsr/xp/milano treatment)? All
+      four records currently get whichever answer the sampler happened to reach.
+      I left all four as the researcher had them rather than impose a rule.
+  - item: "motorcycle/harley-davidson/tri-glide-ultra id and /heritage-softail id"
+    what_would_settle: >-
+      H-D retail-name chronology. FLSTC 1986-90 was badged plain 'Heritage
+      Softail' and FLSTC later 'Heritage Softail Classic', so bare
+      `heritage-softail` may be a legitimately distinct machine — I UPHELD
+      `correct` on that basis. Same for Tri Glide Ultra Classic (2009-16) vs Tri
+      Glide Ultra (2017+): if those are generations they must be one id per
+      SCHEMA.md; if they are nameplates they are two. An H-D model-year catalogue
+      settles both.
+  - item: "moped/keeway/fact-50 merge partner (f-act vs f-act-evo)"
+    what_would_settle: "RDW/Traficom type-approval detail for
+                        e13*168/2013*00408 — whether the *03 variant is the Fact
+                        50 or the Fact EVO 50."
+  - item: "motorcycle/ajs/m20 name"
+    what_would_settle: "an AJS factory catalogue or the AJS/Matchless OC register.
+                        A cybermotorcycle gallery caption names 'Model 20' but a
+                        caption is not a catalogue; I left the verdict unverifiable."

--- a/data/review/audit-v2026.07.5/ledger/verifier-b2.yml
+++ b/data/review/audit-v2026.07.5/ledger/verifier-b2.yml
@@ -1,0 +1,827 @@
+# PRD-FIVE-NINES Workstream A2 — BATCH 2 INDEPENDENT VERIFICATION
+# tag v2026.07.5, S2W half.  Invariant I-11 satisfied: researcher ≠ verifier.
+# verifier: opus5/audit-b2-verifier   researcher: opus5/audit-b2 (result-b2.yml)
+# READ-ONLY run. Nothing written outside this scratchpad. No git operations.
+#
+# ═══════════════════════════════════════════════════════════════════════════
+# METHOD — what I re-derived, and how independently
+# ═══════════════════════════════════════════════════════════════════════════
+# I did not read the researcher's scripts or its flattened corpora. I wrote my
+# own flatteners from each adapter in pipeline/sources/ and my own matcher.
+# All ruby (python3 is SIGKILLed here); LC_ALL=C + explicit encodings on the
+# ISO-8859-1/CP-1251 corpora.
+#   flat_fi.rb    fi_traficom_register.zip -> 5,147,216 register rows scanned
+#                 (EXACTLY the researcher's figure), 7,858 L-class
+#                 (kind,make,model) groups with full TAN histograms
+#   flat_rest.rb  nl_rdw_{bromfiets,motorfiets,motorfiets-met-zijspan,
+#                 driewielig-motorrijtuig}.json -> 55,468 groups (soort kept, so
+#                 the zijspan/driewielig provenance of every row is visible);
+#                 nz_{moped,motorcycle}_*.json -> 12,211;
+#                 uk_veh0120_uk.csv -> 10,973 GenModel groups AND — the thing the
+#                 researcher did not build — 89,139 (GenModel × Model) groups
+#   flat_rest2.rb es_dgt_2026{04,05,06}.txt fixed-width [17,30)/[47,22)/[426,3)
+#                 -> 586,768 lines, 1,922 2W groups; lu_delta_2026-{05,06,07}.xml
+#                 -> 1,329 (kind,make,model) groups + TAN histograms
+#   flat_rest3.rb th_dlt_2568.csv -> 879 groups (matches the sibling verification)
+#   flat_ua.rb    ua_reestr_current.zip -> 3,379 2W groups, 51,101 deduped 2W
+#                 vehicles (dedup on the identifier column, as ua_mvs.rb does)
+#   avail.rb      my own availability matcher: make resolved through
+#                 overrides/makes/aliases.yml + slugify, model compared on
+#                 alphanumeric-only upcase with leading-marque-token stripping
+#   d24.rb/d24b.rb my own implementation of the researcher's OWN detector spec
+#   d25.rb        cross-kind and gb-only re-derivation from the catalog
+#   dup.rb        token-subset/permutation duplicate scan over the `correct` ids
+#   gbcheck.rb    NEW CHECK the researcher did not run: for every gb availability
+#                 claim in the batch, what the DVLA Model column actually says
+#
+# COVERAGE CHECK: all 100 proposal ids are members of
+# data/review/audit-v2026.07.5/SAMPLE-s2w.yml (400 ids) and all 100 are live in
+# the audited catalog. Zero fabricated, zero outside the seeded sample.
+#
+# SAMPLING vs the brief:
+#   defective verdicts        100% re-derived (84/84)
+#   calls asked to be overruled 100% (7/7)
+#   corpus-internal name calls  100% (15/15), ruled explicitly below
+#   availability              100% re-derived (236/236, not the required 20%)
+#   `correct` id claims       100% re-scanned (dup.rb) + 100% of the gb ones
+#                             re-checked against the DVLA Model column
+#   `unverifiable` claims     ~25% spot-checked (26/54), incl. every one whose
+#                             blocking source I could reach by another route
+
+headline:
+  upheld: 78                     # of 84 defective claims
+  overturned: 6
+  reclassified_but_still_defective: 3
+  additional_defects_found: 4    # among claims the researcher called `correct`
+  net_effect: >-
+    The evidence layer is as good as the researcher says — I reproduced
+    236/236 availability claims from my own flatteners, and dozens of its raw
+    counts match to the row. The id and enrichment layers are weaker than it
+    says, and in BOTH directions: it under-called three duplicates and
+    over-called three folds. Corrected conservative clean rate 500/640 = 78.1%
+    (researcher: 78.4%).
+    THE ONE FINDING THAT MATTERS MOST: the headline number `262` cannot be
+    reproduced from the researcher's own stated detector. Its companion figure
+    1,755 reproduces EXACTLY, and every one of D25's five numbers reproduces
+    exactly — which is what makes 262 stand out rather than excuse it.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# THE SIX ATTACK TARGETS
+# ═══════════════════════════════════════════════════════════════════════════
+
+target_1_D24_the_262:
+  verdict: "NOT REPRODUCIBLE. The number must not be quoted as a measurement."
+  what_i_did: >-
+    I implemented the researcher's own detector (2) verbatim — "within one
+    make+kind, name A's token list is a strict prefix of name B's, AND A's first
+    token matches a type-code shape (/\A[A-Z]{2,6}\d{0,4}[A-Z]{0,4}\z/ with a
+    digit, or >=3 caps)" — over the 7,083 published 2W records (moped 1,255,
+    motorcycle 5,828), and swept every reasonable reading of the ambiguities
+    (the regex applied to the published Title-Cased token vs upcased; the
+    ">=3 caps" disjunct in or out; A restricted to a single token; B restricted
+    to exactly one token longer).
+  results:
+    - "regex + digit, published case:                 207 pairs / 27 make-kinds"
+    - "regex + digit, upcased token:                  207 pairs / 27 make-kinds"
+    - "regex+digit OR >=3 caps  (closest to the text): 323 pairs / 32 make-kinds"
+    - "…same, B exactly one token longer:             246 pairs / 29 make-kinds"
+    - "…same, A a single token:                       292 pairs / 31 make-kinds"
+    - "…same, A single token AND B one token longer:  217 pairs / 28 make-kinds"
+  the_superset_claim_is_exact: >-
+    "1,755 strict-prefix name pairs in 2W overall" reproduces EXACTLY: 1,755
+    within make+kind with no code test. So the researcher's pipeline and mine
+    agree on the population; the disagreement is entirely in the code-shape
+    filter.
+  the_per_make_tally_does_not_reconcile_either: >-
+    The claimed top makes are "harley-davidson 72, honda 46, yamaha 44,
+    suzuki 21, kawasaki 16, piaggio 11, indian 8". No variant produces that
+    joint tally. The variant that gets harley-davidson closest (70) puts honda
+    at 52, not 46; the variant that matches suzuki 21 + kawasaki 16 + 29
+    make-kinds puts harley-davidson at 43, not 72. Something in the researcher's
+    filter is not in its written spec.
+  ruling: >-
+    UNRESOLVED, in the specific sense the protocol means: the CLASS is real and
+    large (my own runs bracket it at 207–323 pairs over 27–32 make/kinds), but
+    "262 pairs across 29 make/kinds" is not re-derivable from the ledger as
+    written and must not enter RESULTS.md as a measurement. WHAT WOULD SETTLE
+    IT: the researcher publishing the script, or the ledger restating the
+    detector so a third party reproduces the count. Until then quote the range,
+    or quote 1,755 (the reproducible worklist ceiling) with the caveat the
+    researcher already attached to it.
+  worst_family_claims:
+    "23 live VRSC* ids":        "UPHELD — exactly 23 harley-davidson ids contain 'vrsc'."
+    "8 XL1000V/Varadero/SD02":  "UPHELD — exactly 8 (sd02, varadero, xl1000, xl1000-varadero, xl1000v, xl1000v-varadero, xl1000va, xl1000va-varadero)."
+    "9 FLSTC* + 4 FLSTCI*":     >-
+      CORRECTED UPWARD: 10 + 4 = 14. The researcher's list of nine omits the
+      audited record itself (flstc-heritage-classic). Full set: flstc,
+      flstc-103, flstc-103-heritage-softail-classic, flstc-heritage,
+      flstc-heritage-classic, flstc-heritage-softail, flstc-heritage-softail-cl,
+      flstc-heritage-softail-classic, flstc-softail-classic,
+      flstc-softail-heritage-classic; flstci, flstci-heritage-softail,
+      flstci-heritage-softail-c, flstci-softail-classic.
+    "11 VT1100/Shadow ids":     >-
+      Numerically UPHELD (11) but the COMPOSITION IS UNSAFE. The researcher's
+      list includes `shadow-750` (a VT750 — a different motorcycle) and bare
+      `shadow`. From my own nl+fi derivation, bare SHADOW is a FAMILY word: the
+      same registers carry VT500C, VT600C, VT700(C), VT750C/C2 and VT1100
+      Shadows, and nl_rdw bromfiets even carries 'SHADOW 50' and 'SHADOW AF 20'.
+      nl bare 'SHADOW' n=339 and fi n=18 cannot be attributed to the 1100.
+      This is the dragstar trap the sibling verification proved can corrupt
+      data. The audited record's own verdict names only 1100-class partners
+      (vt1100c-shadow / vt1100-shadow / shadow-vt1100c2), so the VERDICT is
+      safe — the NOTE is not, and must not be turned into a worklist.
+
+target_2_the_four_traps:
+  "xlch vs xlch-1000":
+    verdict: "UPHELD — genuinely distinct, and now externally sourced."
+    evidence:
+      - "https://motogallery.com/blogs/harley-davidson-resource-guide/1958-1971-harley-davidson-xlch-900-sportster — the XLCH ran 1958-1971 in 883cc ('900 class') Ironhead form"
+      - "https://www.motorcycleclassics.com/classic-american-motorcycles/harley-davidson-sportster-1000 — displacement went to 1000cc for 1972"
+      - "IN-CORPUS: nl 'XLCH 900' n=1 and fi 'SPORSTER XLCH 900' n=1 sit beside nl 'XLCH 1000' n=2 / 'XLCH-1000' n=1 / 'XLCH 1000 SPORTSTER' n=2 and nz 'XLCH 1000' n=1 / 'XLCH1000' n=1. Bare XLCH spans both capacities."
+    note: "XLCH is NOT on harley-davidson.com's model-code page — I re-fetched it. The researcher's casing citation is therefore about H-D's code convention generally, not about XLCH specifically. Its `name: defective` still holds (see the casing ruling below); its `id: correct` is right."
+  "xt1200z vs xt1200ze":
+    verdict: "UPHELD as distinct — but NOT on the ground the researcher gives, and the TAN evidence cuts the other way."
+    evidence:
+      - "fi: 'XT1200Z' n=131 on TAN family e13*2002/24*0388*{00,01,02,03}; 'XT1200ZE (XT1200ZE Super Tenere)' n=37 on e13*168/2013*00062*00."
+      - "BUT fi ALSO carries 'XT1200Z (XT1200Z Super Tenere)' n=2 on e13*168/2013*00062*00 — the SAME approval as the ZE. So the TAN does not separate Z from ZE; a TAN-based split would be the FINDING-B error again."
+      - "What does separate them is that the registers spell them out separately in three countries (nl 'XT1200Z' 730 vs 'XT1200ZE' 87 + 62 parenthesised; ua both) and the ZE is a distinct specification. No Yamaha source reached (yamaha-motor.eu unreachable to me too)."
+    ruling: "Trap stands. Do not fold. But strike the implied TAN argument."
+  "fxr vs fxrp":
+    verdict: "UPHELD, with a marque source the researcher already had and one it did not use."
+    evidence:
+      - "https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html — re-fetched: 'FXRP — Dyna Police Pursuit' is present verbatim. (FXR itself is NOT on that page.)"
+      - "IN-CORPUS corroboration the researcher missed: nl_rdw carries 'FXRP POLICE' n=1 and 'FXRP 1340' n=8+1 beside 'FXR SUPER GLIDE' n=246+5+1."
+    note: "Worth stating for the detector spec: fxr/fxrp do NOT match detector (2) at all — ['FXR'] is not a token prefix of ['Fxrp']. They match only a STRING-prefix fold, which is precisely what the researcher's own `do_not_do` forbids. The trap is correctly filed under 'do not bulk-fold on a code prefix'."
+  "husqvarna sm510 vs sm510r":
+    verdict: "TAN CLAIM UPHELD AND STRENGTHENED — and it wins. The researcher's weakest id call is OVERTURNED, exactly as it feared."
+    evidence_from_raw:
+      - "fi 'SM 510' n=3, TAN e3*2002/24*0100*06 (3/3)."
+      - "fi 'SM 510 R' n=8, TANs e3*2002/24*0482*03 (5) and *0482*02 (3) — a DIFFERENT APPROVAL BASE, not just a different extension."
+      - "DECISIVE, and the researcher did not have it: fi 'SMR 510' n=3 sits on e3*2002/24*0482*00 — the same base as SM 510 R. The *0482* family is the SMR/supermoto-R type; motorcycle/husqvarna/smr510 is a live separate id."
+      - "fi 'SM 510-H803CC/501' and 'SM 510-H813AB/501' sit on the older e3*92/61*0100*{04,05} — same *0100* lineage as bare SM 510."
+      - "COUNTER-CAUTION, in fairness: 'TE 510' n=12 straddles BOTH families (*0100*06 ×4 and *0482*00/02 ×6), so the Husqvarna TAN is not model-exclusive either. The split therefore rests on the *0100*/*0482* PATTERN plus SMR510's placement, not on TAN-as-identity."
+    the_gb_evidence_is_the_opposite_of_what_the_researcher_read: >-
+      DVLA GenModel 'HUSQVARNA SM 510' resolves to exactly ONE Model value:
+      'SM 510 R', n=77 — 100% of the UK rows. That does not show SM510 and
+      SM510R are one machine. It shows the UK evidence belongs to the R.
+    consequence: "id OVERTURNED to `correct`, AND a new defect: see additional_defects."
+
+target_3_honda_sd02:
+  verdict: "UPHELD, and it is the strongest record in the batch. Both halves reproduce to the row."
+  half_a_in_corpus_join: |
+    From my own fi derivation, under make Honda, L3e:
+      'VARADERO-SD02/996'            n=1   e9*92/61*0069*04
+      'VARADERO-SD02A/996'           n=3   e9*92/61*0059*00
+      'VARADERO-SD02B/996'           n=4   e9*92/61*0059*{00,02}
+      'VARADERO-SD02C/996'           n=2   e9*92/61*0059*04
+      'VARADERO-SD02D/996'           n=4   e9*92/61*0059*04
+      'XL1000V-SD02A/996 VARADERO'   n=1   e9*92/61*0059*03
+      'XL1000VA-SD02C/996'           n=1   e9*92/61*0059*04
+    Every count the researcher published matches mine exactly. STRONGER THAN
+    STATED: the whole e9*92/61*0059* approval family carries the bare nameplate
+    ('Varadero', 'VARADERO', 'XL 1000V VARADERO', 'XL1000VA VARADERO'), the bare
+    code, and the pairing — so the code→nameplate identity is attested on one
+    approval as well as in one cell.
+  half_b_the_475_dutch_rows: "nl_rdw motorfiets 'SD02' n=475, 'SD 02' n=3, 'HONDA SD02' n=1. Exact."
+  one_scoping_note: >-
+    SD02 covers the XL1000V AND the XL1000VA (ABS), so the merge target is a
+    family, not a single sibling — 'fold sd02 into xl1000v' would be wrong in
+    the same way as folding shadow into the 1100. Fold to the nameplate.
+  adjacent_positive: >-
+    nl also carries SD01 paired with the nameplate ('SD01 XL1000V-VARADERO' n=6,
+    'SD01 XL 1000V VARADERO' n=2, …) and there is NO sd01 id in the catalog.
+    The class does not fire everywhere; that is worth recording.
+
+target_4_D25:
+  verdict: "EVERY NUMBER UPHELD, EXACTLY. This is the best-measured claim in the batch."
+  rederived:
+    - "motorcycle records with gb-ONLY evidence: 258 ✓"
+    - "…of which an identically-slugged moped record exists: 18 ✓, and my list is identical to the researcher's, item for item: aprilia/rx50, aprilia/sx50, cpi/aragon, derbi/gpr-50, e-max/lb1, honda/nps50, honda/sfx50, honda/sh50, keeway/f-act, mash/fifty, peugeot/ludix, peugeot/trekker, rieju/mrt, rieju/rs2, sur-ron/light-bee, suzuki/ay50, sym/mask, yadea/g5"
+    - "ids live in >1 kind: 482 ✓ · moped+motorcycle: 95 ✓ · car+moped+motorcycle: 2 ✓ (piaggio/ape and renault/twizy)"
+    - "Renault Twizy in three kinds ✓ — moped/renault/twizy {es,fi,lu,nz}, motorcycle/renault/twizy {nl}, car/renault/twizy {gb,my,ua}, plus moped/renault/twizy-45 {es,fi,nl}"
+    - "the nl mechanism ✓ — nl_rdw voertuigsoort 'Driewielig motorrijtuig' carries 'RENAULT | TWIZY' n=598 and nothing else does; fi files the same vehicle L7e n=14 / L6e (Twizy 45) n=1 → moped; gb files it under Cars (518) and LGV (87)"
+  the_change_list_claim: >-
+    UPHELD. I read PROPOSAL-kind-boundary.md's final "Revised plan" (steps 1-7).
+    Step 4 is the only nl_rdw item and it is scoped to `Bromfiets` + a
+    `by_eu_category` block. `Driewielig motorrijtuig: motorcycle` appears
+    NOWHERE in any change list in that document. Since the Twizy's Dutch rows
+    arrive as Driewielig and not as Bromfiets, executing the plan as written
+    would move the FI/ES/LU/NZ Twizy to `car` and LEAVE the 598 Dutch rows in
+    `motorcycle` — i.e. it would not fix this record, it would split it further.
+    That is a concrete, actionable gap and the researcher found it.
+  new_in_data_support_the_researcher_did_not_have: >-
+    The DVLA Model column proves mechanism (a) rather than inferring it:
+    gb 'SYM MASK' pools 'MASK 50' 412 + 'MASK 50 E5' 558 + 'MASK 125' 180;
+    gb 'HONDA NPS50' is 'NPS 50-5'/'NPS 50-6'; gb 'APRILIA RX50' is 'RX 50 MY06'
+    /'RX 50 RACING'/'RX50'; gb 'APRILIA SX 50' is 'SX 50'/'SX 50 MY06'.
+    These are 50cc machines filed under BodyType Motorcycles because the UK has
+    no moped body type — exactly as overrides/kind_maps/uk_dft.yml says.
+
+target_5_the_two_enrichment_defects:
+  "moped/nsu/quickly-t":
+    verdict: "SUBSTANCE UPHELD. CITATION OVERTURNED — the researcher's cited source does not contain its claim, and says the opposite."
+    what_nsu24_de_actually_says: >-
+      I fetched the frameset (https://www.nsu24.de/html/nsu_quickly.html) and
+      then its body (https://www.nsu24.de/html/body_nsu_quickly.html). The page
+      gives "Baujahre: 1953 bis 1968" for the Quickly and "Gebaute Stückzahl:
+      fast 1 Million!" — i.e. the SAME 1953-1968 span the enrichment publishes —
+      and it explicitly DISPUTES 1963 as an end year ("the author owns a 1966
+      model, contradicting literature claiming 1963"). It lists the variants
+      (N, S, L, Cavallino, T, TT, TTK, S23, S2/23, N23, F23) but gives NO
+      per-variant years and NO per-variant unit counts. It cannot support
+      "the Quickly T 1959-1963, 38,605 built".
+      The researcher's second citation, https://nsu-quickly.de/en/models/
+      quickly-cavallino/ (and .../quickly-t/), is a parts shop: model navigation
+      and frame-number ranges, no years at all.
+    but_the_fact_is_right_and_i_sourced_it:
+      - "https://christian-koerkel.de/nsu-quickly-t/ — verbatim: \"Insgesamt wurden von 1959 – 1963 38.605 Stück verkauft.\""
+      - "https://www.nsu-quickly-club.de/fileadmin/user/pdf/Quickly-Uebersicht.pdf — the NSU-Quickly-Club's own model/year/frame-number overview (v1.23, 23.10.2015), which I read page 1. It dates and counts ALL THIRTEEN variants: N 1953-63 (539,793) · S 1956-63 (314,715) · L 1957-61 (86,067) · Cavallino 1958-60 (21,584) · T 1959-63 (38,605) · TT 1958-61 (23,952) · S/2 1960-61 (12,411) · TT/K 1961-63 (13,200) · S23 1961-68 (28,435) · S/2-23 1960-65 (22,322) · N23 1962-67 (11,347) · F 1962-68 (12,000) · Quick50 1962-65 (9,323) · Summe 1,124,431."
+    ruling: >-
+      enrichment `defective` UPHELD. The note's premise "no source separates the
+      variant runs" is FALSE — the marque club separates all thirteen with unit
+      counts — and the four-record fix is: quickly-t 1959-1963; quickly-n
+      1953-1963 (the researcher says 1953-62, the club table says 1963);
+      quickly-l 1957-1961; and bare `quickly` KEEPS 1953-1968, because the club
+      table shows S23 and F running to 1968 and the bare id is the family.
+      REPLACE the citation with the two above.
+    one_sub_point_i_reject: >-
+      "the file's own header contradicts 1968 too" — no. The header's 1963-65
+      ceiling is about NSU's MOTORCYCLES, Prima scooters and the Quick 50. The
+      club table confirms Quickly S23/F ran to 1968. The family end year is not
+      a defect.
+  "motorcycle/bultaco/sherpa":
+    verdict: "OVERTURNED. enrichment `defective` -> `correct`. The 43:1 argument rests on evidence that does not belong to this record."
+    why: |
+      The researcher's whole case is "the register is 43 'SHERPA T' rows against
+      1 bare, so the conditional in enrich/bultaco.yml is satisfied". It is not,
+      because those 43 rows are not this id's evidence.
+      From my own nl+nz derivation under make BULTACO:
+        nl 'SHERPA T' 43 · 'SHERPA T 350' 1 · 'SHERPA T350' 1 · 'SHERPAT 350' 1
+        nl 'SHERPA' 1 · 'SHERPA 125' 1 · nz 'SHERPA' 1
+      'SHERPA T' normalizes to its own key (sherpa-t), which is NL-ONLY. The
+      reconciler publishes a single-source id only at >=300 vehicles for
+      motorcycle (reconciler.rb KIND_THRESHOLDS), so sherpa-t does not publish
+      and contributes nothing. Bare 'SHERPA' appears in TWO countries (nl 1,
+      nz 1), which is why `sherpa` publishes at all.
+      The whole make behaves this way and it is checkable: every published
+      Bultaco id is exactly a string present in >=2 countries (lobito gb+nl,
+      metralla nl+nz, brinco fi+nl), while nl-only strings with more vehicles —
+      ALPINA 8, FRONTERA 6+4, MATADOR, PURSANG — publish nothing.
+      So motorcycle/bultaco/sherpa IS TWO ROWS, one Dutch and one New Zealand,
+      each spelling the bare family word. Bultaco never sold a plain "Sherpa":
+      https://cybermotorcycle.com/marques/bultaco/bultaco-models.htm enumerates
+      Sherpa S (1960-67, in 100/125/175/200 and MK2 forms), Sherpa N (1963-65,
+      155/200) and Sherpa T (1964-82) and no unlettered Sherpa. Two bare rows
+      could be any of the three. The union span 1960-1983 is therefore the
+      correct, honest choice for a bare family id — which is exactly what the
+      enrichment note says it is doing.
+    the_name_verdict_survives_but_the_class_and_the_remedy_change: >-
+      name `defective` UPHELD, RECLASSED D7 -> D8 (family-word rollup, the
+      honda/magna · triumph/rocket · yamaha/dragstar class). The researcher's
+      proposed remedy — "the id should be sherpa-t" — IS THE DANGEROUS MOVE:
+      it would relabel Sherpa S and Sherpa N registrations as Ts, and it would
+      import a 1964 start for rows that may be 1960 machines.
+    credit_where_due: >-
+      The researcher is right that enrich/bultaco.yml's conditional caveat is
+      good practice and is what makes the record checkable at all. The habit
+      paid off — it just paid off the other way.
+
+target_6_the_three_instrument_findings:
+  a_normalizer_space_collapse_is_a_catch_all:
+    verdict: "UPHELD in general, OVERTURNED on one of its two examples, and the count is misquoted."
+    proof_from_the_instrument_itself: >-
+      data/name_shapes.yml debt entry `normalizer-space-collapse-display-names`
+      carries owner: s2w, category: code_string, max_sources: 1 — and NO
+      `pattern` and NO `id_list`. scripts/lint_dataset.rb `entry_matches?` falls
+      through to "the make/kind/category/corroboration conditions above are the
+      whole rule", so the entry excuses EVERY s2w-owned single-source
+      code_string record whatever its cause. The researcher's structural claim
+      is provable from the entry's own conditions, not merely plausible.
+    example_1_sa15_upheld: "moped/yamaha/sa15 'SA15' is nl-only (1 source) and matches CODE_STRING (/\\A[A-Z]{2,}[\\s.-]?\\d{2,4}[A-Z0-9-]{0,8}\\z/i). Absorbed. Correct."
+    example_2_aprilia_sb_OVERTURNED: >-
+      moped/aprilia/sb 'SB' has NO DIGITS, so it does not match CODE_STRING —
+      nor numeric_only, make_as_model, embedded_make, spec_token or placeholder.
+      It is not absorbed by that entry; lint_dataset does not flag it at all.
+      That is arguably a worse hole than the one claimed (a 608-vehicle
+      unresolved type code that no detector sees), but it is a different one and
+      the ledger should say so.
+    count_correction: "The entry reads `count: 269` in data/name_shapes.yml at this worktree, not 267. The researcher's '269→267' is not supported by the file."
+    i_would_add_a_second_instance: >-
+      `bare-displacement-2w` (owner s2w, category numeric_only, count 21) has
+      the identical shape — no pattern, no id_list — so it too excuses every
+      s2w numeric_only record, not the 21 the count implies. The catch-all
+      critique generalises.
+  b_corroboration_is_not_nameplate_evidence:
+    verdict: "UPHELD on every limb, and the marque source holds."
+    limbs:
+    - "`corroborated-code-string-records` is in the LEGIT bucket with min_sources 2 / min_countries 2 and category code_string. motorcycle/suzuki/uk110 'UK110' matches CODE_STRING and has 5 sources / 5 countries, so it is excused PERMANENTLY, not tracked as debt."
+    - "Suzuki's own archive, re-fetched: https://www.globalsuzuki.com/motorcycle/smgs/digital-archive/2_bike/scooter_162.php names it 'Address 110' for both the 1998 and 2015 generations and never uses UK110."
+    - "The DVLA Model column adds in-data support the researcher did not use: gb GenModel 'SUZUKI UK 110' resolves to six Model strings, all 'UK 110 N*' year codes (NE, NE L6, NM L8, NM L9, NM M0, NX) — one machine with model-year letters, i.e. a type code, not a nameplate."
+    - "masai/50 [fi,nl] and masai/125 [fi,nl] are both 2 sources / 2 countries and both match numeric_only, so `corroborated-numeric-nameplates` excuses both. UPHELD."
+  c_uk_dft_model_column:
+    verdict: "SUBSTANCE UPHELD. MECHANISM CLAIM IS FALSE — and the falsity makes the fix bigger, not smaller."
+    the_false_part: >-
+      The researcher states, twice, that "the Model column is ALREADY parsed —
+      uk_dft.rb passes row[3] into the Row's tan slot". It does not.
+      pipeline/sources/uk_dft.rb:89 reads `body, make, genmodel = row[0], row[1],
+      row[2]` and accumulates `agg[body][[make, genmodel]] += n`; row[3] is never
+      referenced anywhere in the file, and the Row it builds carries no `tan:`
+      keyword at all. So the Model column is NOT parsed and NOT available
+      downstream. The fix is a source-adapter change plus a reconciler change,
+      not "use a field we already have".
+    the_true_part_and_it_is_worth_more_than_the_researcher_claims: >-
+      Model is dramatically finer than GenModel: my own parse gives 10,973
+      (BodyType, Make, GenModel) groups against 89,139 (…, Model) groups over
+      the mapped kinds. I ran the check the researcher proposed, over all 16
+      gb-claiming records in this batch. Results below in `gb_model_sweep`.
+
+  gb_model_sweep:   # NEW WORK — the highest-yield check in this verification
+    mis_routed_evidence:
+      - "motorcycle/husqvarna/sm510 [gb] — GenModel 'HUSQVARNA SM 510' -> Model 'SM 510 R' ×77, 100%. All UK evidence belongs to the live sibling sm510r. NEW DEFECT."
+      - "motorcycle/yamaha/gts [gb] — GenModel 'YAMAHA GTS' -> Model 'GTS 1000 A' ×19, 100%. All UK evidence belongs to the live sibling gts1000a. (The researcher already calls the id defective; this makes the availability claim wrong too.)"
+      - "motorcycle/harley-davidson/flhr [gb] — GenModel 'HARLEY-DAVIDSON FLHR' pools 16 Model strings, of which 447 of 1,463 rows are FLHRI/FLHRS/FLHRSI — all of which are live ids in their own right. The gb claim is a pool, not a match."
+    id_rollups_the_researcher_called_correct:
+      - "motorcycle/cfmoto/800 — GenModel 'CFMOTO 800' pools '800 NK' 131, '800 NK SPORT 24' 5, '800MT TOURING' 127, '800MT SPORT' 74, '800MT EXPLORE' 68, '800MT-X' 57. All THREE of 800nk, 800mt and 800mt-x are live ids. NEW DEFECT."
+      - "motorcycle/aprilia/rxv — GenModel 'APRILIA RXV' pools 'RXV 4.5' family 53 and 'RXV 5.5' family 18. Two motorcycles; rxv450 is live. NEW DEFECT."
+    strengthens_an_existing_verdict:
+      - "motorcycle/harley-davidson/superlow [gb] — Model is 'SUPERLOW XL 883 L 13' ×172, i.e. the DVLA itself pairs the nameplate with XL883L. The researcher's id: defective is proved in-data, not inferred."
+      - "motorcycle/honda/anc [gb] — Models 'ANC 125 H' 689, 'ANC 125-E' 549, 'ANC 125 K' 439, 'ANC 125 F' 306 = 1,983 (the researcher's exact figure). Every row is an ANC 125."
+      - "motorcycle/piaggio/px200 [gb] — 'PX 200 E' 3,611 + 'PX 200' 26 + 'PX 200 K' 12 = 3,649. Exact."
+    clean:
+      - "kymco/visar-125 ('VISAR 125'), moto-guzzi/breva-1200 ('BREVA 1200'), lexmoto/valiant (both Models are VALIANT 125 XF 125 R — one machine), ducati/m750-dark, aprilia/sx50, royal-alloy/gt125, suzuki/uk110, brixton/bx125 (pools BX 125 / R / X, but no bx125r or bx125x id is live, so no rollup onto live siblings)."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# THE SEVEN CALLS THE RESEARCHER ASKED TO HAVE OVERRULED
+# ═══════════════════════════════════════════════════════════════════════════
+overrule_requests:
+
+  - claim: "motorcycle/husqvarna/sm510 id: defective(D6)"
+    result: 'OVERTURNED -> id: correct'
+    why: "See target_2. Different approval bases (*0100* vs *0482*), SMR510 sharing the R's base, and the gb Model column proving the UK rows ARE the R rather than proving identity. The researcher named this its weakest id call and was right to."
+
+  - claim: "motorcycle/kawasaki/kz1300 id: defective(D6)"
+    result: UPHELD, and I rule rather than defer
+    why: >-
+      The protocol's test is "no other live id denotes the same vehicle". KZ1300
+      and Z1300 are the same machine under US and RoW designations, so the test
+      fails and the verdict is `defective`. My derivation: fi KZ1300 3 + 'KZ 1300'
+      2 + 'KZ 1300-A' 1 + 'KZT 1300' 1 against Z1300 7 + 'Z 1300' 1 + 'Z 1300 A' 1
+      + 'Z 1300-A5' 1; nl 'KZ 1300' 2 + KZ1300 3 against 'Z 1300' 223+10 + Z1300 9;
+      nz KZ1300 2 against Z1300 12. fi's own type-designation cell reads
+      'KZ1300-KZ1300A1/1286'.
+      SAFETY: this fold is low-risk (one displacement, one machine) — unlike
+      dragstar/shadow/intruder — so the policy question should not block it.
+      Direction matters: z1300 holds ~250 nl vehicles to kz1300's 5, and ZG1300/
+      ZN1300 Voyager rows are a DIFFERENT machine and must not be swept in.
+    caveat: "The researcher's only source is motorcycleclassics.com, which I did not re-fetch. If RESULTS.md wants this at marque grade it needs a Kawasaki heritage page."
+
+  - claim: "moped/la-souris/sourini-rs id: defective(D8/D6)"
+    result: 'OVERTURNED -> id: unverifiable(no La Souris source; the fold is a make-level policy call, not a per-record one)'
+    why: >-
+      No marque source is reachable: lasouris.nl 302-redirects cross-host to
+      lasourisscooters.nl, which returns 403. The corpus does not settle it
+      either — nl_rdw carries SOURINI 9,615 · SOURINI R 3,886 · SOURINI R
+      LIMITED 494 · SOURINI RS 3,349 · SOURINI RS LIMITED 320 · SOURINI S 4,043 ·
+      SOURINI RS PILOTI 122 · SOURINI ONE 125. "Limited" is applied to BOTH the R
+      and the RS, which is edition-shaped, but 320 registrations is not a
+      rounding error and nothing shows the two are one product.
+      `id: correct` asserts no other live id denotes the same vehicle; `id:
+      defective` asserts one does. Neither is supportable, so the protocol's
+      third verdict is the honest one.
+      WHAT WOULD SETTLE IT: a La Souris model page, or the RDW type-approval
+      numbers behind the two strings (RDW is queryable). And it must be decided
+      for sourini-r/sourini-r-limited in the same breath.
+
+  - claim: "motorcycle/puch/rla name: defective(D7)"
+    result: 'OVERTURNED -> name: unverifiable(neither cited source is reachable)'
+    why: >-
+      https://www.motorbooks.at/puch-r-rl-rla-125-ersatzteilkatalog returns
+      HTTP 403. https://sites.google.com/site/puchnz/rla-125 302-redirects to
+      accounts.google.com/ServiceLogin — it is not a public URL. With no
+      reachable source the D7 rests on the corpus alone, and the corpus is thin
+      and split: nl '125 RL' 3 · 'RL 125' 2 · '125 RL SCOOTER' 1 · '125 RLPUCH' 1
+      · '125 RLA' 1 · 'RLA' 1; nz 'RLA' 1. The RLA specifically appears bare
+      twice and with the capacity once. That is not enough to call the published
+      string non-marque-true. The researcher flagged this SOFT and it should not
+      be carried as a defect.
+
+  - claim: "motorcycle/mv-agusta/350s name: defective(D7)"
+    result: 'OVERTURNED -> name: unverifiable(only source is a 403ing spec database; majority is not authority)'
+    why: >-
+      https://www.autoevolution.com/moto/mv-agusta/350-s/ returns HTTP 403 to
+      me, so the researcher's sole external source is not re-fetchable — and it
+      is a third-party spec database in any case. What remains is register
+      dominance, which the VITO/MGA rule says does not decide: nl '350 S' 49 vs
+      '350S' 3 (the researcher's 16:1, reproduced exactly) — but the closed form
+      DOES exist, in nl (3) and as nz's ONLY spelling ('350S' n=1). The batch's
+      own standard elsewhere (ajs/16ms, honda/cb360) is that a closed form
+      backed by a source stays; here there is no source either way.
+
+  - claim: "moped/yamaha/bw-s id: defective(D6)"
+    result: UPHELD, and the researcher's SEPARATE open question is now CLOSED in its favour
+    why: >-
+      moped/yamaha/bws50 'BWS50' {nl,nz} rests on nl 'BWS 50' n=1 and nz 'BWS50'
+      n=1. Every moped-kind BW's IS a 50 — ua spells it out, 'BW'S 50' n=4
+      beside 'BW'S' n=4 — so the two ids are one machine and the fold is safe.
+      renames.yml folds "Bw's" and Bws to BW's but cannot reach the
+      capacity-suffixed string, exactly as the researcher says.
+      THE OPEN ITEM: the researcher would not call motorcycle/yamaha/bw-s
+      {gb,lu,nl} and guessed from the lu TAN that it is "probably the BW's 125".
+      The DVLA Model column settles it: GenModel 'YAMAHA BWS' -> Model 'BWS 125',
+      n=433, 100%. The moped/motorcycle BW's pair is LEGITIMATE (50 vs 125).
+      (Unrelated and not in this batch: motorcycle/yamaha/bw 'Bw' {gb,nl} pools
+      Model 'BW 50' 6 and 'BW SPY' 36 — a 50cc machine in the motorcycle kind.
+      That one is a D25 instance.)
+
+  - claim: "motorcycle/kawasaki/sr650 name: defective(D9)"
+    result: UPHELD as defective, CLASS AND STATED GROUND BOTH CORRECTED — plus a new id defect
+    why: >-
+      The researcher's stated ground is "the published string appears in NO
+      source, marque or register, in that order". That is FALSE: nz_nzta writes
+      'SR650' exactly, n=1. What IS true, and stronger, is that the same
+      registers carry Kawasaki's own order 20 times — nl 'KZ 650 SR' 14,
+      'Z 650 SR' 5, plus fi 'Z 650 SR' 1 — beside 'CSR 650' 11, '650 CSR' 3,
+      'KZ650CSR' 3 and the joined cell 'KZ 650 SR CSR 650' 1. So the defect is a
+      TOKEN INVERSION of an attested designation, not a string that exists
+      nowhere. D9 -> D7/inversion.
+      AND: motorcycle/kawasaki/z650sr 'Z650SR' {fi,nl} IS LIVE. The researcher
+      called this record `id: correct`. It is not — see additional_defects.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# THE 15 NAME VERDICTS THAT REST ON CORPUS-INTERNAL PROOF — ruled explicitly
+# ═══════════════════════════════════════════════════════════════════════════
+corpus_internal_name_rulings:
+  my_rule: >-
+    I do NOT demote all fifteen. I split them, on a principle I state so it can
+    be argued with:
+    (1) A claim about what the REGISTERS write is a fact about the corpus, and a
+        corpus derivation settles it. Those stand.
+    (2) CASING of a pure-alpha type code can never be settled by a register
+        (registers uppercase everything), and the project has already
+        adjudicated the whole class globally in data/name_shapes.yml
+        debt:model-column-acronym-casing (count 511) with a stated rule. Those
+        stand PROVIDED the token is attested as a code somewhere in the corpus —
+        which I checked individually.
+    (3) A claim that asserts a specific MARQUE rendering, with no reachable
+        source, is an assumption. Those are demoted to unverifiable.
+  rulings:
+    "moped/yamaha/bw-s (name: correct)": "UPHELD. renames.yml carries a sourced, deliberate decision (MBK platform history) and ua/fi write the apostrophe form. The CPx/tS rule applied correctly; the researcher was right not to flag it."
+    "motorcycle/renault/twizy (name: correct)": "UPHELD. 'Twizy' is Renault's own word and gb GenModel is 'RENAULT TWIZY'. Trivially fine."
+    "motorcycle/bmw/r65t1c (name: defective)": "UPHELD under (1). nl 'R 65 TIC' 86 + 'R65 TIC' 5 against nl 'R 65 T1C' 1 + nz 'R65T1C' 1, in the same two registers. Caveat for the ledger: the target rendering TIC is register-attested, not BMW-attested — no BMW source exists for either string."
+    "motorcycle/kl-service/kxe300 (name: defective)": "UPHELD under (1), and it is airtight: the ONLY spellings anywhere are fi 'KXE 300' n=2 and nl 'KXE 300' n=7. The published 'KXE300' appears in no source. Minor correction to the TAN sub-claim: *03 carries KXE 300 (2) AND one KXE 250 row, so the approvals are not cleanly per-capacity."
+    "motorcycle/honda/sd02 (name: defective)": "UPHELD under (1), strongest in the batch — see target_3."
+    "motorcycle/piaggio/px200 (name: defective)": "UPHELD under (1). gb GenModel 'PIAGGIO PX 200' spaced with Model 'PX 200 E'; nl/nz overwhelmingly spaced. Closed 'PX200' is the normalizer artefact."
+    "motorcycle/vespa/px200 (name: defective)": "UPHELD under (1). Same corpus; nl VESPA 'PX 200 E' 7 · 'PX 200' 1 · 'PX 200 E IRIS' 3 against 'PX200' 2."
+    "motorcycle/husqvarna/sm510 (name: defective)": "UPHELD under (1), PREMISE CORRECTED. The researcher writes 'the published string SM510 appears in no source — that part is clear'. It is not: nl_rdw carries 'SM510' n=2 and 'HUSQVARNA SM510' n=1. The verdict survives on dominance (fi 3/3 spaced, gb 77/77 spaced, nl 17 spaced vs 2 closed) plus the filed normalizer mechanism, but the ledger must not carry the false sentence."
+    "motorcycle/aprilia/rxv (name: defective)": "UPHELD under (2). RXV is attested as a code by the gb Model column ('RXV 4.5', 'RXV 5.5') and by fi 'RXV 450'/'RXV 550'."
+    "motorcycle/sym/adx (name: defective)": "UPHELD under (2). Attested as a code by es 'ADX 300 TCS' 196, 'ADX 125 LC TCS E5+' 133 and gb Model 'ADX 125'."
+    "motorcycle/ktm/rc (name: defective)": "UPHELD under (2). Attested by fi 'KTM RC 125' / 'KTM RC 390', lu 'RC 125', ua 'RC 390', th 'RC 250'."
+    "motorcycle/yamaha/gts (name: defective)": "UPHELD under (2). Attested by gb Model 'GTS 1000 A' and nl 'GTS 1000' 196."
+    "motorcycle/honda/anc (name: defective)": "UPHELD under (2). Attested by gb Model 'ANC 125 F/H/K/-E' and by fi/nl/es 'ANC125'."
+    "motorcycle/cfmoto/800 (name: defective)": "UPHELD, but on the ledger not on the corpus: data/name_shapes.yml debt:bare-displacement-2w names cfmoto/800 explicitly in its `why`. The audit measures the published record and the debt entry says the name is wrong. Fine — just record it as a filed defect, not a finding."
+    "motorcycle/suzuki/intruder-vs800glp (name: defective)": 'OVERTURNED -> unverifiable(no Suzuki source). Under (3). The string IS a register string — fi carries "INTRUDER VS800GLP" n=1 — so it is not a chimera; and the researcher labelled the verdict "D6", which is a duplicate class, i.e. it is restating the id defect as a name defect. Whether Suzuki ever rendered it that way is unsourced. The id verdict stands on its own.'
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AVAILABILITY — 236/236 re-derived independently
+# ═══════════════════════════════════════════════════════════════════════════
+availability:
+  verdict: "The researcher's headline is CORRECT: 236 claims, and my own matcher finds a raw row for every one. 223 matched mechanically; I resolved the other 13 by hand and all 13 resolve."
+  the_13: >-
+    7 are the Piaggio->Vespa move (raw make PIAGGIO, marque word inside the model
+    string: 'VESPA ELETTRICA', 'VESPA PRIMAVERA', 'VESPA PRIMAVERA 125') — the
+    researcher's own account. 2 are uk_dft's make-prefixed GenModel
+    ('HARLEY-DAVIDSON FLHR' 1,463; 'HARLEY-DAVIDSON SUPERLOW' 172). 2 are the
+    CZ/ČZ make alias (nl 'CZ | 150 C' 5 + 'CZ 150 C' 1 + 'CZ 150C' 1; nz '150C' 3).
+    2 more are Vespa/Piaggio at motorcycle kind.
+  exactness_spot_check: >-
+    Where the researcher published counts I reproduced them to the row, e.g.
+    moped/vespa/primavera es 71 / fi 380 / lu 12 / nl 17,792 / nz 334 and
+    primavera-50 es 19 / fi 159 / lu 6 / nl 3,482 / nz 1; sd02 nl 475;
+    px200 gb 3,649; anc gb 1,983; sh50 gb 766; cf50 nl 36/22/9; sherpa nl 43:1.
+    This is careful work.
+  BUT_the_stated_limit_of_the_method_bites_once: >-
+    The researcher says plainly that its matcher "proves the register row
+    exists… it cannot catch a mis-ROUTED row (right string, wrong id)". I ran
+    the check it could not, using the DVLA Model column, and it caught one:
+    motorcycle/husqvarna/sm510 [gb]. See additional_defects.
+  corrected: "235 correct / 1 defective (of 236)."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DEFECTS AMONG CLAIMS THE RESEARCHER CALLED `correct`
+# ═══════════════════════════════════════════════════════════════════════════
+additional_defects:
+  defects:
+
+  - claim: "motorcycle/husqvarna/sm510 availability gb"
+    researcher: correct
+    my_verdict: 'defective(D19-adjacent — evidence routed to the wrong id)'
+    confidence: high
+    why: >-
+      DVLA GenModel 'HUSQVARNA SM 510' resolves to a single Model value,
+      'SM 510 R', n=77 — 100% of the UK rows. motorcycle/husqvarna/sm510r is a
+      live id and its availability is {fi,nl}: it is missing the gb evidence
+      that this record is claiming. The pipeline routes on GenModel, which is
+      why this is invisible: uk_dft.rb never reads the Model column.
+      This is also the single best argument for the researcher's OBSERVATION
+      about that column — stronger than any of the truncation examples it gave,
+      because here the coarse column does not truncate a name, it attributes
+      evidence to the wrong motorcycle.
+
+  - claim: "motorcycle/cfmoto/800 id"
+    researcher: correct
+    my_verdict: 'defective(D8 — family rollup)'
+    confidence: high
+    why: >-
+      gb is this record's ONLY source, and GenModel 'CFMOTO 800' pools six Model
+      strings covering three separate motorcycles: '800 NK' 131 + '800 NK SPORT
+      24' 5, '800MT TOURING' 127 + '800MT SPORT' 74 + '800MT EXPLORE' 68, and
+      '800MT-X' 57. All three of motorcycle/cfmoto/800nk {es,fi,lu,nl},
+      /800mt {es,fi,lu,nl,nz} and /800mt-x {es,fi,lu,nl,nz} are live. So `800`
+      is not a nameplate-shaped defect with a clean record underneath it — it is
+      462 UK vehicles from three motorcycles pooled at one id.
+      The researcher recorded the NAME as defective (filed debt) and the id as
+      correct. `id: correct` asserts no other live id denotes the same vehicle;
+      three do.
+
+  - claim: "motorcycle/aprilia/rxv id"
+    researcher: correct
+    my_verdict: 'defective(D8 — capacity rollup)'
+    confidence: high
+    why: >-
+      The researcher saw the gb Model 'RXV 4.5' and concluded "this record is
+      the 450". The Model column also carries RXV 5.5: 'RXV 4.5' 21 + '4.5 07' 6
+      + '4.5 08' 12 + '4.5 09' 13 + '4.5 MERRIMAN REPLICA' 1 = 53, against
+      'RXV 5.5' 7 + '5.5 07' 3 + '5.5 08' 7 + '5.5 09' 1 = 18. Two motorcycles.
+      motorcycle/aprilia/rxv450 {fi,ua} is live (no rxv550 id exists; the live
+      sxv550 is the supermoto, a different model). fi independently carries
+      'RXV 450' and 'RXV 550' as separate strings.
+      Same shape the researcher itself called defective for yamaha/xp and
+      yamaha/xsr in batch 1 — a gb GenModel pooling capacities.
+
+  - claim: "motorcycle/kawasaki/sr650 id"
+    researcher: correct
+    my_verdict: 'defective(D6 — token inversion)'
+    confidence: high
+    why: >-
+      motorcycle/kawasaki/z650sr 'Z650SR' {fi,nl} is live. This record's entire
+      evidence is nl 'SR 650' n=1 and nz 'SR650' n=1 — the same machine with the
+      tokens inverted, which is the researcher's own detector (3) shape, in a
+      record it held in its hands and whose name it called wrong for exactly
+      this reason. If the published string is an inversion of Kawasaki's
+      designation, then a live id carries the un-inverted designation, and
+      `id: correct` cannot stand.
+
+  near_misses_i_checked_and_cleared:
+    - "My dup.rb (token subset/permutation within make+kind) flags only four of the `id: correct` records: btc/riva (vs Riva 2, Riva Sport), vespa/elettrica (vs Primavera Elettrica), bmw/f800gs (vs F800GS Adventure), aprilia/tuareg-660 (vs Tuareg 660 Rally). All four are genuinely distinct products and the researcher explicitly cleared each. No manufactured disagreement here."
+    - "moped/honda/express `id: correct` UPHELD, and I checked the obvious risk: there is NO nc50 id in any kind, even though nz carries 'NC50' 33 and gb carries GenModels 'HONDA NC50' 23 / 'NC50B' 59 / 'NC50G' 110 / 'NC50K' 18 — every one is single-source below the 300 threshold. The researcher's reasoning was right."
+    - "motorcycle/brixton/bx125 `id: correct` UPHELD — gb pools BX 125 / BX 125 R / BX 125 X but no bx125r or bx125x id is live, so nothing is split."
+
+  count_corrections_that_are_not_new_defects:
+    - "moped/honda/cf50 — the Chaly cluster is FOUR moped ids, not three: cf50, cf50-chaly, chaly-cf50 AND bare `chaly` {nl,nz} (nl 'CHALY' 20, nz 'CHALY' 87), which the researcher missed. motorcycle/honda/chaly is a fifth, and may be legitimate: nl motorfiets carries 'CF 70 CHALY' and 'CHALY CF70' — a 70cc machine. Verdict unchanged, cluster larger."
+    - "motorcycle/ducati/m750-dark — the researcher lists m750, 750 and m as siblings and misses motorcycle/ducati/monster-750 {fi,nl}, which is the nameplate half of its own argument. Verdict unchanged, cluster larger."
+    - "motorcycle/suzuki/intruder-vs800glp — the researcher lists bare `intruder` {fi,lu,nl,nz} among the six ids for 'the Suzuki VS800 Intruder'. DO NOT. Bare INTRUDER is a family word: the same fi register carries VS700, VS800, VS1400, VL800 Volusia and VL1500 Intruders. Same trap as `shadow` and `dragstar`."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# THE REMAINING DEFECTIVE VERDICTS — re-derived, grouped by outcome
+# ═══════════════════════════════════════════════════════════════════════════
+defective_claims_rederived:
+
+  upheld_with_marque_source_refetched_by_me:
+    - "motorcycle/harley-davidson/flhr (id+name), flht-touring (id+name), flstc-heritage-classic (id+name), xl883c-sportster (id+name), fxrp (name), rh1250s (id+name) — I re-fetched https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html and it carries, verbatim and in all-caps: 'FLHR — Road King®', 'FLHT — Electra Glide®', 'FLHTC — Electra Glide® Classic', 'FLSTC — Heritage Softail® Classic', 'XL883 — Sportster® 883', 'RH1250S — Sportster® S', 'FXRP — Dyna Police Pursuit', plus 'FL: A Touring or Softail® model…' (so Touring IS the family) and 'VRSC: V-Rod® and other models powered by the Revolution® engine'. Every H-D citation in the ledger checks out."
+    - "motorcycle/harley-davidson/rh1250s — additionally https://www.harley-davidson.com/us/en/motorcycles/sportster-s.html uses 'Sportster® S' throughout and the string RH1250S appears nowhere on it."
+    - "motorcycle/harley-davidson/street-bob114 (name) — https://www.harley-davidson.com/us/en/motorcycles/street-bob.html renders 'Street Bob®', title case with a space, no all-caps BOB. The two-mechanism explanation (collapse then digit-freeze in the caser) is correct and worth keeping."
+    - "motorcycle/harley-davidson/road-glide-cvo (name) — the researcher's URL 404s for me too. WORKING SUBSTITUTE: https://www.harley-davidson.com/us/en/motorcycles/cvo-road-glide-st.html and the sibling CVO pages; H-D's own titles are 'CVO Road Glide', 'CVO Road Glide ST', 'CVO Road Glide RR'. CVO leads. UPHELD."
+    - "motorcycle/honda/nss350a, /xl750, /cb500x, /mx650 — https://www.honda.co.uk/motorcycles/range.html re-fetched: it lists 'Forza 350' and 'XL750 Transalp'; there is no NSS350/NSS350A, no CB500X (the successor NX500 is listed), and no MX-prefixed model. All four verdicts UPHELD, including the researcher's deliberate refusal to call mx650."
+    - "motorcycle/suzuki/uk110 (id+name) — globalsuzuki.com archive, see target_6b."
+    - "motorcycle/royal-alloy/gt125 (name) — https://royalalloy.co.uk/motorcycles/gt-125/ re-fetched: 'GT 125 AC', and the whole range spaced (GP 125 LC, GP 300, TG 125 AC, TG 125 LC, TG 300 LC). The DVLA GenModel is 'ROYAL ALLOY GT 125' spaced too. UPHELD."
+    - "motorcycle/triumph/bonneville-t100bud-ekins (name) — https://triumph-mediakits.com/en/news-articles/new-2020-bud-ekins-bonneville-t120-and-t100-special-editions.html re-fetched: Triumph writes 'Bonneville T100 Bud Ekins Special Edition', spaced. UPHELD."
+    - "motorcycle/ktm/250exc-tpi (name) — the researcher's URL https://www.ktm.com/ee/enduro/250-exc-tpi returns 404 to me. Substitutes that work: KTM's own current range page https://www.ktm.com/en-gb/models/enduro.html renders every model spaced with all-caps suffixes ('300 EXC', '250 EXC-F', '500 EXC-F 6DAYS'), and ktm.com's own page titles include 'KTM 250 EXC TPI SIX DAYS 2022' (https://www.ktm.com/en-sk/models/enduro/2-stroke/ktm-250-exc-tpi-sixdays2022.html). UPHELD."
+    - "motorcycle/lambretta/gp (name) — https://www.lambretta.com/classics/grand-prix-dl/ re-fetched: 'Grand Prix DL', and 'This model was only known as the GP on the UK and a few other markets, on all others it was known as the DL'; capacities 123/148/198 cc. UPHELD, and the researcher's id: correct (capacity umbrella over gp125/gp150/gp200) is corroborated by those three capacities."
+    - "motorcycle/cz/150c (name, and enrichment: correct) — https://www.4jawa.com/category/703/cz-150-c-1950-1953 re-fetched: 'ČZ 150 C [1950-1953]', spaced. Name UPHELD; enrichment {1950,1953} re-derives exactly."
+    - "moped/vespa/primavera (id) — https://storeusa.vespa.com/primavera.aspx re-fetched: PRIMAVERA 50cc, PRIMAVERA 150cc, PRIMAVERA SPORT 50cc/150cc, PRIMAVERA TECH 50cc/150cc. No unnumbered Primavera exists. UPHELD, and I add the weight the researcher did not: this record is GLOBAL DECILE 1 with 17,792 Dutch rows — by claim weight it is the heaviest id defect in the batch."
+
+  upheld_on_corpus_derivation_i_reproduced:
+    - "moped/honda/cf50 (id) — nl CF50 36 / 'CF 50' 22 / 'CF50 CHALY' 9 / 'CF 50 CHALY' 6 / 'CHALY' 20 / 'CHALY CF50' 1 / 'CHALY CF 50' 2; nz CF50 29 / CHALY 87 / 'CHALY CF50' 4 / 'CF50 CHALY' 2. Cluster is four ids (above)."
+    - "moped/honda/motocompo (id) — the in-cell join is real and richer than quoted: nl 'NCZ 50 MOTOCOMPO' 4, 'NCZ50 MOTOCOMPO' 3, 'MOTOCOMPO NCZ50' 1, 'NCZ 50B MOTOCOMPO' 1, 'HONDA AB12-MOTOCOMPO' 1, 'MOTOCOMPO AB12' 2; nz 'MOTOCOMPO NCZ50' 1."
+    - "moped/honda/sh50 (id, cross-kind) — nl bromfiets 'SH 50' 906 + 'SH50' 299; ua 1; gb Motorcycles GenModel 'HONDA SH50' 766 with Models 'SH50' 513 + 'SH50-H' 253. A 50cc scooter published in both kinds. UPHELD."
+    - "motorcycle/aprilia/sx50 (id+kind) — fi files 'APRILIA SX 50' as L1e (110 vehicles) and 'SX 50' L1e (38); nl bromfiets 'SX 50' 324 + 'APRILIA SX 50' 26; gb files 454 under BodyType Motorcycles. moped/aprilia/sx50 is live. UPHELD."
+    - "motorcycle/renault/twizy (id+kind) — see target_4. UPHELD."
+    - "motorcycle/honda/xl750, /nss350a, /cb500x (id) — sibling sets confirmed live; the Transalp family alone is 11 ids (transalp, transalp-600, transalp-600v, transalp-650, transalp-xl600vr, xl600v, xl600v-transalp, xl650v, xl650v-transalp, xl750, xl750c)."
+    - "motorcycle/piaggio/px200 (id+make+name) and motorcycle/vespa/px200 (id+name) — FOUR live ids across two makes (piaggio/px200, piaggio/px200e, vespa/px200, vespa/px200e). The moves.yml mechanism is exactly as described: the file carries 'Piaggio|Vespa PX200E' → 'Vespa|PX200E' (line 114) and no key for a bare 'PX 200', so uk_dft's 3,649 rows (make column PIAGGIO, model column PX 200) cannot be reached. make D11 UPHELD by the repo's own rule — moves.yml already accepts PX200E is a Vespa."
+    - "motorcycle/harley-davidson/vrsca-v-rod (id) — 23 VRSC* ids confirmed. NAME verdict: I DOWNGRADE the researcher's own confidence note into the record — H-D's code page does not enumerate VRSCA, and its other citation is a custom-parts blog. The id defect stands regardless; the name verdict should read 'defective(D6 — a code+nameplate concatenation)' on the in-corpus ground (es 'VRSCA VROD' 1 beside 'V-ROD' 1), not on the blog."
+    - "motorcycle/yamaha/mt-07 (id) — fi 'MTN690-A (MT-07)' n=117 beside 'MT-07' n=140 is a genuine in-cell join. Seven-country availability all verified."
+    - "motorcycle/yamaha/xv535-virago, /royal-star, /xj650-maxim, /gts (id) — sibling sets confirmed live; gts's gb evidence is 100% 'GTS 1000 A'."
+    - "motorcycle/triumph/t100-tiger, /trophy-tr6r (id) — sibling sets confirmed; the tr6r/tr6r-tiger contradiction is real and both are live."
+    - "motorcycle/honda/gl1500c-f6c, /shadow-1100, /anc (id) — confirmed, with the shadow scoping warning above."
+    - "motorcycle/harley-davidson/superlow (id) — strengthened by the DVLA Model 'SUPERLOW XL 883 L 13'."
+    - "motorcycle/piaggio/liberty-125, motorcycle/vespa/primavera-125 (id) — the ABS fold is settled policy (renames.yml:2400 'Primavera 150 Iget Abs' → 'Primavera 150 Iget', comment: 'ABS is EQUIPMENT and folds into the nameplate'). Verified in file. Both UPHELD. The researcher's D19 warning about unioning evidence is right and important: es carries 'VESPA PRIMAVERA 125 AB' 10 and 'VESPA PRIMAVERA 125ABS' 1 against 555 non-ABS, and the fi evidence sits only on the ABS id."
+    - "motorcycle/brixton/bx125 (name) — the ledger quote is accurate (data/review/brixton.yml:11-21) and the DVLA Model column writes 'BX 125' spaced. UPHELD — but see process_findings: this record is signed off `verdict: canonical` in that ledger, which is a conflict the researcher glossed."
+    - "motorcycle/bmw/r65t1c (id) — nl 'R 65 TIC' 86 + 'R65 TIC' 5 against two T1C rows. UPHELD."
+    - "motorcycle/kl-service/kxe300 (name) — UPHELD, see corpus_internal rulings."
+    - "motorcycle/harley-davidson/xlch-1000 (name) — casing only; id correctly NOT called. UPHELD."
+    - "motorcycle/sym/adx, /ktm/rc, /aprilia/rxv, /yamaha/gts, /honda/anc (name, casing) — UPHELD under rule (2)."
+    - "motorcycle/ducati/m750-dark (id) — UPHELD and strengthened: nl 'M750 MONSTER' 71, 'M 750 MONSTER' 5, 'M750  MONSTER' 1, 'M 750 - MONSTER' 1, fi 'MONSTER M750' 1. Five in-cell joins, not one."
+
+  upheld_but_the_citation_is_dead:
+    - claim: "motorcycle/ducati/m750-dark name: defective(D9)"
+      result: "UPHELD on the corpus, CITATION UNUSABLE"
+      note: >-
+        https://ducati-specs.com/models/ducati-monster-750.html does not resolve
+        at all (DNS ENOTFOUND). The defect survives without it — the corpus
+        proves M750 is the code and MONSTER the nameplate — but the ASSERTED
+        TARGET STRING 'Monster 750 Dark' is not sourced by anything reachable,
+        and ducati.com 403s. The ledger should record the target as unresolved.
+
+  overturned:
+    - "motorcycle/husqvarna/sm510 id -> correct  (target_2)"
+    - "motorcycle/bultaco/sherpa enrichment -> correct  (target_5)"
+    - "moped/la-souris/sourini-rs id -> unverifiable  (overrule_requests)"
+    - "motorcycle/puch/rla name -> unverifiable  (overrule_requests)"
+    - "motorcycle/mv-agusta/350s name -> unverifiable  (overrule_requests)"
+    - "motorcycle/suzuki/intruder-vs800glp name -> unverifiable  (corpus_internal rulings)"
+
+  reclassified_still_defective:
+    - "motorcycle/bultaco/sherpa name: D7 (target sherpa-t) -> D8 (family rollup). The proposed remedy would corrupt data."
+    - "motorcycle/kawasaki/sr650 name: D9 -> D7/inversion; stated ground ('appears in no source') refuted by nz 'SR650' n=1."
+    - "motorcycle/husqvarna/sm510 name: verdict stands, stated premise ('SM510 appears in no source') refuted by nl 'SM510' n=2."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SPOT-CHECKS OF `correct` AND `unverifiable` (brief requires >=20% each)
+# ═══════════════════════════════════════════════════════════════════════════
+spot_checks:
+  correct_claims: >-
+    Far above 20%. All 236 availability claims re-derived; all 100 kind claims
+    checked against the raw register category behind each record (2 defective,
+    both the researcher's); all 100 make claims structurally re-derived (my
+    matcher requires the raw make to resolve through aliases.yml to the
+    record's make — 236/236 resolved); all 58 `id: correct` claims re-scanned
+    with my own duplicate detector plus the gb Model-column sweep.
+  enrichment_correct:
+    - "moped/dkw/hummel — https://cybermotorcycle.com/marques/dkw/dkw-hummel-115.htm re-fetched: 'Introduced in 1956' and 'Production ceased in 1965'. {1956,1965} re-derives exactly. UPHELD. (Note: that page is specifically the Hummel 115 and does not carry the 101/102/113/116 type numbers the researcher attributes to its corroborant, which I did not fetch.)"
+    - "motorcycle/cz/150c — 4jawa.com gives '[1950-1953]'. UPHELD."
+  unverifiable_claims: >-
+    26 of 54 checked, chosen as every one whose blocking source I might reach by
+    another route plus a random remainder. Outcomes:
+    * CONFIRMED still unverifiable (source genuinely unreachable to me too):
+      aprilia/tuareg-660, aprilia/sx50, vespa/elettrica, piaggio/bravo,
+      piaggio/liberty-125, ducati/multistrada-v4-pikes-peak,
+      royal-enfield/goan-classic-350, indian/scout-bobber-twenty,
+      yamaha/mt-07 (yamaha-motor.eu), yamaha/xt1200ze, yamaha/wr400f,
+      yamaha/xv535-virago, yamaha/royal-star, yamaha/xj650-maxim,
+      hanway/raw50s (DNS), masai/50, masai/125 (DNS), kymco/visar-125,
+      lexmoto/valiant, neco/azzuro-125, moto-guzzi/breva-1200,
+      moto-guzzi/v7-ambassador, honda/cb360, honda/cb500x, suzuki/dr125se,
+      deco/super-ace.
+    * NONE of the 26 should have been a verdict instead. The researcher's
+      restraint here is correct and I am not manufacturing disagreement: where
+      it said "I could not reach a source", it could not, and neither could I.
+  the_two_i_would_have_pushed_harder_on:
+    - "moped/peugeot/fb50qt-6a — the researcher flags that the identical code publishes under BOTH peugeot and qingqi in the same two countries and declines to merge. I agree with the refusal (resemblance is not identity). But the discriminator is in the data it already had: the FI TANs. It records e4*2002/24*0368*08 for the Peugeot. If the Qingqi row carries a different approval holder, they are two type approvals and both ids are right; if the same, it is one vehicle. One lookup, not a fetch. Queue it as a resolvable item rather than a source gap."
+    - "moped/tromox/mino — the researcher notes gb has 34 Mino rows the record does not claim and calls it 'D19-adjacent'. Correct, and the Model column says 'MINO 45', i.e. a 45 km/h machine — a moped filed in the UK's motorcycle body type. That is a D25 instance, not just a missing availability."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CORRECTED CLAIM TALLY — the researcher's coverage caveat PRESERVED
+# ═══════════════════════════════════════════════════════════════════════════
+corrected_tally:
+  total: 640    # unchanged: 100 id + 100 name + 100 make + 100 kind + 236 availability + 4 enrichment
+  availability: { total: 236, correct: 235, defective: 1,  unverifiable: 0 }
+  id:           { total: 100, correct: 56,  defective: 43, unverifiable: 1 }
+  name:         { total: 100, correct: 9,   defective: 34, unverifiable: 57 }
+  make:         { total: 100, correct: 99,  defective: 1,  unverifiable: 0 }
+  kind:         { total: 100, correct: 98,  defective: 2,  unverifiable: 0 }
+  enrichment:   { total: 4,   correct: 3,   defective: 1,  unverifiable: 0 }
+  conservative_clean_rate: "500 / 640 = 78.1%   (researcher: 502/640 = 78.4%)"
+  HOW_TO_READ_THE_NAME_ROW: >-
+    THE RESEARCHER'S CAVEAT STANDS AND I AM NOT RECOMPUTING OVER 100. After my
+    three demotions the split is:
+      name, with a verdict:   9 correct / 34 defective   (43 claims)
+      name, no verdict:       57 claims, blocked by 403/404/DNS, not by the data
+    The 43 are NOT a random subsample — the researcher spent its fetch budget
+    where a source would settle a suspicion, so their defect rate is
+    upward-biased and MUST NOT be extrapolated to the other 57. That warning was
+    the researcher's and it was the right thing to write.
+  direction_of_my_corrections: >-
+    Unlike batch 1, my corrections do NOT all run one way. Three defects were
+    over-called (sm510 id, sherpa enrichment, sourini-rs id) and three
+    marque-rendering claims were asserted without a reachable source
+    (puch/rla, mv-agusta/350s, intruder-vs800glp name). Against that, four
+    defects were under-called (sm510 gb availability, cfmoto/800 id,
+    aprilia/rxv id, sr650 id). Net: 84 -> 82 defective claims, and the clean
+    rate barely moves. The researcher's aggregate is close to right; its
+    individual reasoning is what needed attacking.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# MY INDEPENDENT VIEW ON D24 AND D25
+# ═══════════════════════════════════════════════════════════════════════════
+my_view_on_the_new_classes:
+
+  D24_code_and_nameplate_co_publication:
+    real: "YES. Unambiguously. I found it independently in every head make I touched."
+    correctly_scoped: >-
+      NO, in two ways that matter for a curation PR.
+      (1) The headline count is not reproducible (target_1). Publish the range
+          or the reproducible 1,755, not 262.
+      (2) THE CLASS IS BEING CONFLATED WITH FAMILY ROLLUPS, and that is the
+          dangerous half. 'FLHR' vs 'FLHR Road King' is one machine at two ids.
+          Bare 'Shadow', bare 'Intruder', bare 'Sherpa', bare 'A65' (batch 1),
+          bare 'Dragstar' (batch 1) are NOT — they are family words spanning
+          several displacements, and every one of them appears in a D24 sibling
+          list in this ledger. Folding a family word into one member relabels
+          the others. That is a data-corruption path, not a de-duplication.
+          The taxonomy entry must SPLIT: D24a = code ⟷ nameplate for ONE machine
+          (fold, with former_ids); D24b = bare family word (needs the variant
+          layer or a removals manifest, never a fold).
+    novel: >-
+      The detector is novel and I confirmed the premise: I ran
+      find_duplicate_spellings and find_casing_contradictions myself against the
+      audited build and both are silent, and NFKD folding provably cannot equate
+      'FLHR' with 'FLHR Road King'. But the SHAPE is not new to this repo —
+      name_shapes.yml's Kreidler K53 entry states the blocker verbatim, and
+      batch 1's FINDING-A proposed the same subset/permutation detector. What
+      is new is the scale in the head makes and detector (1), the in-data join.
+    my_recommendation: >-
+      Adopt detector (1) — the in-cell code⟷nameplate join — NOW. It is the only
+      one of the three that is self-evidencing, and I verified nine of the cells
+      the researcher lists (VARADERO-SD02D/996, M750 MONSTER, XL883C SPORTSTER
+      CUSTOM, MTN690-A (MT-07), XT1200ZE (XT1200ZE Super Tenere),
+      SHADOW-VT1100C2-SC32/1099, KZ 650 SR CSR 650, NCZ 50 MOTOCOMPO,
+      CF50 CHALY) exist exactly as quoted. Hold (2) and (3) behind a
+      family-word exclusion list, and make the worklist emit BOTH the pair and
+      the raw spellings behind each side, so a reviewer sees a 400/650/1100
+      spread before folding.
+
+  D25_source_vocabulary_decides_the_kind:
+    real: "YES, and it is the better-evidenced of the two by a wide margin."
+    correctly_scoped: "YES. Every one of the five numbers reproduces exactly, the 18-item list is identical to mine, and the two mechanisms are documented in the repo's own kind_map headers."
+    novel: >-
+      PARTLY, and the researcher says so honestly. D10 already covers 'wrong
+      kind' and PROPOSAL-kind-boundary.md §Q2 already decides where L6e/L7e go.
+      What is genuinely new and actionable is the pair it identifies:
+      (a) 'Driewielig motorrijtuig: motorcycle' is a SECOND, independent route
+          into the wrong kind and is absent from the proposal's Revised plan —
+          I verified this line by line. Executing the plan as written moves the
+          FI/ES/LU/NZ Twizy to `car` and strands 598 Dutch rows in `motorcycle`,
+          i.e. it makes the split worse before it makes it better.
+      (b) the uk_dft moped merge produces cross-kind DUPLICATE IDS, not merely
+          wrong kinds — 18 of them, enumerated, zero ambiguity. That reframes it
+          from a kind problem into an id-canonical one, which is the researcher's
+          own best insight in this ledger.
+      I would add one item to its change list: the DVLA Model column is the
+      cheap discriminator for mechanism (a). 'SYM MASK' → MASK 50/MASK 125,
+      'YAMAHA BW' → BW 50/BW SPY, 'TROMOX MINO' → MINO 45. Those rows announce
+      their own capacity class and nothing reads them.
+
+  the_two_observations:
+    uk_dft_genmodel_truncation: "REAL and UNDER-sold, but its stated mechanism is FALSE (target_6c). Rewrite it: the Model column is NOT parsed; adding it is a source-adapter change; and its best justification is not truncation but MIS-ATTRIBUTION (husqvarna/sm510)."
+    debt_entry_catch_all: "REAL and provable from lint_dataset.rb's own fall-through, but one of its two examples is wrong (aprilia/sb has no digits and matches no detector at all) and the count is 269 not 267. Add `bare-displacement-2w`, which has the identical shape."
+    corroboration_is_not_nameplate_evidence: "REAL, fully verified, and the strongest of the four observations. Five sources agreeing on 'UK110' against Suzuki's own 'Address 110' is a clean demonstration, and the suggested guard (no exemption when every corroborating string is make+number or a bare code) is well formed."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PROCESS FINDINGS FOR THE PROGRAMME
+# ═══════════════════════════════════════════════════════════════════════════
+process_findings:
+  citation_re_fetchability: >-
+    LOUD. Batch 1's verification found TWO cited URLs that could not be
+    re-fetched as written. Batch 2 has SIX:
+      ducati-specs.com                      — DNS does not resolve
+      www.motorbooks.at/puch-…              — HTTP 403
+      sites.google.com/site/puchnz/rla-125  — 302 to a Google login; not public
+      www.autoevolution.com/moto/…/350-s/   — HTTP 403
+      harley-davidson.com/…/cvo-road-glide.html — 404 (the researcher warned)
+      www.ktm.com/ee/enduro/250-exc-tpi     — 404 (indexed but dead)
+    Two of them (puch, mv-agusta) were the SOLE support for a defective verdict
+    and both verdicts fall as a result. Suggest the ledger format require a
+    fetched-at date and that verification re-fetch every cited URL, which is
+    what I did.
+  a_citation_that_does_not_contain_its_claim: >-
+    moped/nsu/quickly-t is the second instance in two batches (batch 1:
+    hondanews.eu / NSC50) of a cited page that does not contain the fact it is
+    cited for — and here the page says the OPPOSITE (1953-1968). The fact was
+    still true; the process still failed. Worth an explicit protocol line:
+    quote the sentence you are relying on, in the ledger, at write time.
+  a_defect_signed_off_as_canonical: >-
+    The false-positive sweep (I grepped former_ids.yml, renames.yml,
+    removals.yml, moves.yml, styling.yml, name_shapes.yml and all of
+    data/review/ for every id carrying a defective verdict) is clean except for
+    ONE: motorcycle/brixton/bx125 carries `verdict: canonical` in
+    data/review/brixton.yml while the same entry's note says the marque writes
+    'BX 125' and we write 'BX125'. A ledger cannot record a string as
+    non-canonical and sign it off as canonical. Either the verdict field needs a
+    `canonical-pending-decision` value, or the record is defective and should
+    say so. Every other former_ids hit is a display-form respacing from the 2W
+    spacing release and conflicts with nothing.
+  the_availability_method_needs_one_more_leg: >-
+    The researcher's own stated limit — "it cannot catch a mis-ROUTED row" — is
+    not hypothetical. Adding the DVLA Model column to the verification recipe
+    (not the pipeline; just the check) cost me one script and caught one
+    defective availability claim plus two id rollups in 100 records. Recommend
+    it become standard for every gb-evidenced record in future batches.
+
+# ═══════════════════════════════════════════════════════════════════════════
+positives_i_confirm:
+  - "236/236 availability claims re-derived independently. The evidence layer is sound and the researcher's statement about it is accurate, not optimistic."
+  - "Dozens of published raw counts reproduce to the row from a completely separate flattener. Whatever else, the corpus work in result-b2.yml is honest."
+  - "Every H-D and Honda-UK citation re-fetched clean, and the H-D model-code page is exactly as quoted."
+  - "The researcher's decile attributions are all correct — I checked fourteen and every one matches (sd02 dec 1, xl750 dec 1, nss350a dec 1, ktm/rc dec 1, mt-07 dec 2, 250exc-tpi dec 2, r65t1c/flht-touring/mx650/intruder-vs800glp dec 9, m750-dark/road-glide-cvo/sr650/rla dec 10)."
+  - "Its refusals are as valuable as its calls: honda/mx650 (no fold target), peugeot/fb50qt-6a (no merge on resemblance), moto-guzzi/v7-ambassador, and moped/yamaha/bw-s's name are all correctly left alone, and I would have made the same four calls."
+  - "The Piaggio→Vespa move plus former_ids machinery works; NAMING §7.4's comma-joined-cell rule held on zycar/z2l (I confirmed the 8-code cell did not become a model); the 2W spacing release's aliases are present for dz3-sport (former_ids.yml:412) and tuareg-660 (:224) at the exact lines cited."

--- a/data/review/audit-v2026.07.5/ledger/verifier-b3.yml
+++ b/data/review/audit-v2026.07.5/ledger/verifier-b3.yml
@@ -1,0 +1,1201 @@
+# PRD-FIVE-NINES Workstream A2 — BATCH 3 INDEPENDENT VERIFICATION
+# tag v2026.07.5, S2W half.  Invariant I-11 satisfied: researcher != verifier.
+# verifier: opus5/audit-b3-verifier   researcher: audit-b3
+# READ-ONLY run. Nothing written outside this scratchpad. No git operations.
+#
+# ═══════════════════════════════════════════════════════════════════════════
+# METHOD — what I re-derived, and how independently
+# ═══════════════════════════════════════════════════════════════════════════
+# I did not read the researcher's scripts or extracts. I wrote my own
+# flatteners from each adapter in pipeline/sources/, and a matcher with a
+# DIFFERENT implementation from either the researcher's or batch 1's: I fold
+# both sides to alphanumerics and JOIN on (kind, make_id, fold), applying
+# makes/aliases.yml, models/renames.yml and normalizer.rb's own
+# two_wheeler_spacing + strip_make_prefix inline — rather than string-comparing
+# per record. Files under <scratchpad>/v3/.
+#   v_fi.rb    fi_traficom_register.zip, read as BINARY and transcoded
+#              ISO-8859-1 -> UTF-8 (never `scrub` in a UTF-8 locale)
+#              -> 5,147,216 rows scanned, 130,919 L-class, 7,932 groups
+#   v_nlnz.rb  nl_rdw_{bromfiets,motorfiets,motorfiets-met-zijspan,
+#              driewielig-motorrijtuig}.json + nz_{moped,motorcycle}_*.json
+#              -> 67,705 groups
+#   v_rest.rb  uk_veh0120_uk.csv (23,168 2W rows), es_dgt_2026{04,05,06}.txt at
+#              [17,30)/[47,22)/[426,3) (2,126 groups / 89,434 rows),
+#              lu_delta_2026{04,05,06}.xml (2,301 groups)
+#   v_uath.rb  ua_reestr_current.zip (901,964 rows -> 710,639 deduped vehicles,
+#              9,333 groups), th_dlt_2568.csv (3,920 groups)
+#   match.rb / avail.rb / q_dup.rb / q_bf.rb / q_desc.rb / q_renfab*.rb
+# Ruby throughout (python3 is SIGKILLed here, confirmed).
+#
+# CROSS-CHECK AGAINST BATCH 1's VERIFIER: my nl+nz group count (67,705), es
+# (2,126 / 89,434), lu (2,301), ua (710,639 deduped / 9,333) and fi row count
+# (5,147,216) reproduce verify-b1.yml's independently-derived figures EXACTLY.
+# Two verifiers, two implementations, identical corpora. The corpora are sound.
+#
+# COVERAGE CHECK: all 100 proposal records are members of
+# data/review/audit-v2026.07.5/SAMPLE-s2w.yml, and all 100 are live in the
+# catalog. Zero fabricated, zero outside the seeded sample.
+#
+# SAMPLING vs the brief:
+#   defective verdicts   100% re-derived (42/42)
+#   Tier 2 name verdicts 100% re-fetched (10/10 attempted; results below)
+#   self-flagged weak    100% (booster, m797, nimbus, r90-6, tl4000, af61)
+#   availability         100% re-derived (229/229, not the required 20%)
+#   kind                 re-derived from raw EU/national class columns wherever
+#                        one exists (103 supporting rows across fi/es/lu)
+#   `correct` spot-check 100% of id claims re-scanned with my own token-multiset
+#                        permutation/subset scan (not the required 20%)
+
+# ═══════════════════════════════════════════════════════════════════════════
+# TWO CAVEATS THAT SIT ABOVE EVERY VERDICT — RAISE BEFORE THE LEDGER MERGES
+# ═══════════════════════════════════════════════════════════════════════════
+process_caveats:
+
+  - id: BUILD-IS-NOT-THE-AUDITED-TAG
+    severity: high
+    finding: >-
+      build/out/manifest.json in the S2W pipeline worktree reads
+      version 2026.07.6, built_at 2026-07-26T15:16:02Z. The audit is tagged
+      v2026.07.5. The researcher and I have BOTH derived every catalog-side
+      claim (names, ids, availability arrays, deciles) against a build one
+      version AHEAD of the audited tag. No v2026.07.5 build exists in the
+      worktree to compare against.
+    consequence: >-
+      Every `id: correct` in this batch is an assertion about a catalog state
+      that may not be the certified one. It does not invalidate the raw-side
+      work (the register caches are the same), but the ledger must either
+      re-derive against a v2026.07.5 build or record the tag it actually used.
+      I flag it rather than resolve it: rebuilding is a write, and I am read-only.
+
+  - id: DECILE-MASS-ARTIFACT-ABSENT
+    severity: high
+    finding: >-
+      audit-PROTOCOL.md's Aggregation section requires the usage-weighted
+      aggregate to be computed against `catalog/meta/decile-mass.json` "at the
+      audited tag — the weights are read, never asserted". That file does NOT
+      exist in build/out/catalog/, is not in manifest.json (which has no `meta`
+      key at all), and NO emitter for it exists anywhere in the S2W pipeline
+      worktree (`grep -rn 'decile.mass' pipeline/ scripts/` returns nothing;
+      HEAD is 3f38f80, "#39"). PRD-FIVE-NINES §1.3.2 states "A1-bis: DELIVERED
+      (pipeline #40, merged 2026-07-26)". Pipeline #40 is not in this worktree.
+    consequence: >-
+      The batch cannot be aggregated as the protocol specifies, and §1.3.1's
+      whole certification-scope resolution (d1-3 = 82.98% of mass, certify
+      through d6, ~9,340 records) reads its numbers from an artifact this half
+      of the tree cannot produce. Directly relevant to attack target 6 — see
+      `target_6_popularity` below.
+
+  - id: LU-MONTHS-CAVEAT-RETIRED
+    severity: none
+    finding: >-
+      The researcher asked the verifier to re-check whether its LU months
+      (2026-05/06/07) were the ones the audited build used, since the cache also
+      holds 202604/05/06. They are the SAME THREE FILES under two naming
+      conventions — md5 verified, byte-identical pairs:
+        lu_delta_2026-05.xml == lu_delta_202604.xml  e11e8dfe262503063df587559489bb23
+        lu_delta_2026-06.xml == lu_delta_202605.xml  9bff1116720c563590743de17eccd400
+        lu_delta_2026-07.xml == lu_delta_202606.xml  6a6d3a5ad1996c82bc31d401b92fa1e6
+      (lu_snca.rb writes `lu_delta_<YYYYMM>.xml`; the hyphenated names are from
+      an earlier adapter revision.) No LU verdict is affected. Caveat withdrawn.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# HEADLINE
+# ═══════════════════════════════════════════════════════════════════════════
+headline:
+  defective_claims_rederived: 42
+  upheld: 41
+  overturned: 1          # nimbus/750 nz availability — withdrawn, correctly
+  additional_defects_found: 7   # among claims the researcher called `correct`
+  net_effect: >-
+    Same verdict as batch 1, for the same structural reason: the researcher's
+    conservative clean rate is OPTIMISTIC, not conservative. 81.7% as reported,
+    80.8% corrected. Its raw work is excellent — I reproduced essentially every
+    register count it quotes, and its availability class is genuinely clean at
+    229/229. The movement is ALL in the id class, and ALL in one direction: it
+    under-called duplicates by applying its own criteria inconsistently, exactly
+    as verify-b1 diagnosed for batch 1. Batch 1's explicit recommendation
+    ("run the FINDING-A scan over the sampled record's make FIRST and require a
+    written reason for every sibling it nominates") was not carried into batch 3.
+    Two of my seven corrections CONTRADICT verdicts batch 1's verifier had
+    already established on the same clusters.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# THE SIX ATTACK TARGETS
+# ═══════════════════════════════════════════════════════════════════════════
+
+target_1_nimbus_rename_fabricated_availability:
+  part_a_the_withdrawal:
+    verdict: "CONFIRMED — the withdrawal is right. availability(nz) OVERTURNED
+              from defective back to `correct`."
+  the_researcher_s_RAW_DERIVATION_was_exactly_right: |
+    Reproduced from my own extracts, independently:
+      nz_nzta motorcycle — the ONLY Nimbus rows in the entire NZ corpus:
+        'NIMBUS | NIMBUS'        n=6
+        'FACTORY BUILT | NIMBUS' n=1
+      No numeric row of any kind. My matcher shows the nz hit for
+      motorcycle/nimbus/750 arriving as: NIMBUS|NIMBUS n=6 matched_via "750",
+      i.e. purely through renames.yml:1811 `Nimbus: "750"`. The mechanism the
+      researcher described is real and I reproduce it precisely.
+      (NL by contrast has genuine numeric rows: '750' n=7 motorfiets + n=5
+      zijspan, plus '746' n=1, 'STANDARD 746CC', 'UOPLYST 746', '750 CC',
+      '750 SPORT', 'NIMBUS 750', 'STANDARD 750'.)
+  why_it_is_nevertheless_not_a_defect: |
+    Every Nimbus motorcycle ever built is a 746cc inline four, so resolving a
+    bare NIMBUS row to "750" NAMES the machine, it does not NARROW the identity
+    set. Confirmed from two independent, re-fetchable sources (neither Wikipedia):
+      * https://historicvehicles.com.au/historic-motorcycle-brands/nimbus/
+        Type A & Type B ("Stovepipe"): "10bhp, four-cylinder, air-cooled,
+        in-line engine of 746cc capacity". Type C introduced 1934.
+      * https://www.motorcycleclassics.com/more-classic-motorcycles/nimbus-motorcycle-zmmz06jazraw/
+        1957 Type C: "746cc overhead cam, air-cooled inline four".
+      * https://cars.bonhams.com/auction/18362/lot/62/1923-nimbus-746cc-four-frame-no-183-engine-no-n1217/
+        lot title "1923 Nimbus 746cc Four"; catalogue text: "Unusually, only
+        inline four-cylinder models were built."
+    A/B (746cc) + C (746cc) is the whole of Nimbus motorcycle production. No
+    source shows any other displacement. The NZ register evidences a Nimbus;
+    every Nimbus is the machine this record denotes. Claim is legitimate.
+  part_b_does_the_MECHANISM_survive: |
+    PARTLY — and the correction matters more than the instance.
+    The researcher's stated general form is a STRING-SHAPE test on the rename
+    KEY ("mark every renames.yml key as SPECIFIC or UNDER-SPECIFIED"). The
+    corrected operative test is an IDENTITY-SET test on the (key, value) pair
+    relative to the make's real product range. These diverge exactly when a make
+    has one product — which is precisely the population that generates
+    make-as-model rows in the first place. So the researcher's detector will
+    fire hardest on its own false positives.
+  SCOPING — I MEASURED IT, AND IT IS FAR SMALLER THAN CLAIMED: |
+    The researcher wrote: "This generalises well beyond Nimbus — every
+    `<Make>: <SpecificModel>` make-as-model resolution in renames.yml is a
+    candidate, and there are many." Measured catalog-wide on the 2W half, two
+    ways:
+      (a) renames.yml make-as-model keys (key folds to the make name): 72 —
+          but 70 of the 72 resolve to the EMPTY string (a drop), not to a
+          specific model. Only TWO resolve to a named target:
+            `Elmoto: Elmoto -> HR-2`  and  `Hummer: Hummer -> H1`.
+      (b) availability entries whose ONLY support in that country is a
+          make-as-model raw row: 23 entries across 15 records. Twelve of the
+          fifteen publish the MAKE WORD as the model (ebretti/ebretti,
+          lvtong, nicom, mega, paxster, veeley, cyclemaster, ural, arctic-cat/cat,
+          jawa/cz, moto-guzzi/guzzi, royal-enfield/enfield) — nothing is
+          fabricated there, because the published name is exactly as
+          under-specified as the raw. They are the already-filed
+          make-as-model-2w / product-is-the-brand-2w classes.
+      (c) the GENERAL narrowing form (every supporting raw row in a country is
+          strictly less specific than the published name): 15 entries / 8 records.
+    After the NARROW-vs-NAME test, the surviving candidates catalog-wide are:
+      * motorcycle/derbi/senda-125 (gb) — raw is bare 'DERBI SENDA'; Derbi sells
+        a Senda 50 AND a Senda 125, so this one genuinely NARROWS. Already filed
+        by batch 1's verifier from a different angle (renames.yml:375, the
+        per-make key that cannot express its "motorcycle-kind only" comment).
+      * moped/elmoto/hr-2 (fi, n=1) — the one unexamined candidate.
+      * motorcycle/gas-gas/es-700 — flagged, but styling.yml's own comment shows
+        this is a known, deliberately-handled case.
+    So the class is REAL but its live population is ~1-2 records, not "many",
+    and its clearest instance was already found by batch 1 through a different
+    route. Recommend filing as a DETECTOR/WORKLIST with the narrowing test
+    attached — never as a verdict, since the narrowing test cannot be computed
+    from renames.yml alone (it needs the make's product range).
+  verdict: "availability(nz) OVERTURNED -> correct. The CLASS is downgraded from
+            'candidate new defect class' to 'worklist detector, measured
+            population ~1-2 records, largely already filed'."
+
+target_2a_descriptor_as_model:
+  real: yes
+  correctly_scoped: "NO — the count is UNDERSTATED and the legit fraction is
+                     HIGHER than stated."
+  measured: |
+    The researcher measured 22 catalog-wide on the 2W half. Re-running the
+    detector with a COMPLETE body-style lexicon (adding classic, cruiser,
+    sports, standard, atv, tricycle — all words the registers actually use)
+    gives 31, plus ccm/dual-sport = 32. The 10 the researcher's lexicon missed:
+      moped/bombardier/atv, moped/riese-und-mueller/cruiser,
+      moped/rover-bikes/classic, moped/tomos/standard,
+      motorcycle/francis-barnett/cruiser, motorcycle/herald/classic,
+      motorcycle/morgan/sports, motorcycle/norton/classic,
+      motorcycle/royal-enfield/classic, motorcycle/sinnis/classic
+  the_split_is_worse_than_the_researcher_feared: >-
+    Its own MUST_SPLIT_BEFORE_FIXING warning is not a caveat, it is the main
+    result. Of the 10 records its lexicon missed, at least SEVEN are real
+    nameplates: Royal Enfield Classic (350/500) is RE's actual model name;
+    Norton Classic (the 1988 rotary) is a real Norton; Francis-Barnett Cruiser
+    is a real model; Herald Classic 125 and Sinnis Classic are real products;
+    Tomos Standard is a real Tomos model; Riese & Müller Cruiser is a real
+    e-bike. Together with Harley's Touring/Softail and CCM's Dual Sport, a
+    pure-lexicon detector has a false-positive rate near 50% on this population.
+    The detector spec as written ("Zero non-category tokens = flag") therefore
+    cannot ever be a verdict. The researcher said so; the measurement makes it
+    quantitative.
+  the_unambiguous_artifact_core: >-
+    The 7 "Electric Scooter" records across unrelated importers (citycoco,
+    mademoto, qroad, scogo, shansu, smarda, yuhanzhen), plus unu/scooter,
+    vespa/scooter (both kinds), harley-davidson/motorcycle, honda/moped,
+    killerbee/{custom,sport}, bombardier/atv. ~15 records. These are the
+    register's own category vocabulary in the model column.
+  ccm_dual_sport_is_NOT_the_boundary_case_the_researcher_thought: |
+    OVERTURNED IN THE RESEARCHER'S FAVOUR — it hedged this one and should not
+    have. Its citation (autoevolution "CCM 644 DS Dual Sport") returns HTTP 403
+    and names a designation that appears in NO register I hold. What uk_dft
+    actually carries under make CCM is a DS line designated 404:
+      'CCM 404' -> Model '404 DS' (Licensed 70 + SORN 202, plus 1 more row)
+    while the sampled record's GenModel 'CCM DUAL SPORT' carries the Model
+    string bare 'DUAL SPORT' (Licensed 80 + SORN 328) — and every OTHER CCM
+    GenModel in that same register carries a designation (604 E SUPERMOTO,
+    GP 450 ADVENTURE, C-XR 230, MT 230, FT 35S, R 30 SUPERMOTO, SM 125, TL 125).
+    So this is not a name with the designation dropped; it is a bare category
+    word standing alone where its siblings all carry designations — a clean
+    instance and a textbook FINDING-C uk_dft-GenModel artifact.
+    name: defective(descriptor-as-model) UPHELD and strengthened; the citation
+    must be replaced with the in-register evidence above.
+  novel: "The CLASS is novel — name_shapes.yml genuinely has no bucket for it
+          (numeric_only, code_string, embedded_make, make_as_model, spec_token,
+          table_artifact, model_casing, variant_as_model). Confirmed by reading
+          the file. Worth filing with the corrected count and the legit/artifact
+          split done FIRST, per I-15."
+
+target_2b_bare_family_code_2W:
+  real: yes
+  correctly_scoped: "NO — massively understated. And it is less novel than claimed."
+  measured: |
+    I implemented the researcher's own detector spec verbatim (name is 1-3 alpha
+    chars OR "<prefix> Series", AND is a strict prefix of >=3 other live names
+    under the same make+kind). Catalog-wide on the 2W half: 122 RECORDS, not the
+    two found_in_batch plus six also_visible. Both its examples confirm:
+      motorcycle/bmw/k        "K"    [nl,nz]  — 27 K-family siblings
+      motorcycle/bmw/k-series "K Series" [gb] — the same 27
+      motorcycle/zontes/zt    "Zt"   [gb]     — 8 ZT siblings
+    and the largest is motorcycle/bmw/r-series "R Series" [gb,nl] with 99.
+    The duplication claim is confirmed exactly as stated: bmw/k [nl,nz] and
+    bmw/k-series [gb] are one non-vehicle arriving from two registers.
+  same_legit_artifact_problem: >-
+    ~a third of the 122 are plausibly legitimate family-altitude records —
+    moped/piaggio/zip "Zip" and moped/piaggio/ape "Ape" are real Piaggio
+    nameplates, motorcycle/vespa/gts "Gts" is a real Vespa nameplate,
+    motorcycle/sym/jet "Jet" is a real SYM family. The detector also happens to
+    catch a large slice of the filed model-column-acronym-casing debt at the
+    same time ("Cb", "Cbr", "Vfr", "Zt", "Er", "Xr", "Rsv", "Gpz"), which will
+    inflate any count taken from it naively.
+  novelty_correction: >-
+    The researcher frames this as the un-filed MIRROR of bare-displacement-2w.
+    That is right about name_shapes.yml, but it is NOT an open question the
+    program has never faced: verify-b1.yml's `unresolved` item #1 is exactly
+    this policy question in its numeric form — "is a family-word id with live
+    specific siblings `correct` (mutt/fsr precedent) or a D8 rollup?", left open
+    over honda/magna, ktm/1190, triumph/rocket and yamaha/dragstar. This is the
+    ALPHA-PREFIX instance of that same unresolved question. File it as such;
+    filing it as a separate new class would produce two rulings on one question.
+
+target_2c_bmw_slash_policy_leak:
+  the_dominant_raw_claim:
+    researcher: "289 slash rows vs 5 hyphen across 4 registers"
+    my_count:   "291 slash vs 5 hyphen — direction UPHELD, number corrected +2"
+    derivation: |
+      Independently re-derived, all rows my matcher resolves to bmw/r90-6:
+        SLASH   nl 'R 90/6' 228 (motorfiets) + 15 (zijspan), 'R90/6' 13,
+                   'BMW R 90/6' 1 (embedded make prefix — the row the
+                   researcher's count misses);
+                nz 'R90/6' 31, 'R 90/6' 2;  lu 'R90/6' 1        = 291
+        HYPHEN  nl 'R90-6' 2;  nz 'R90-6' 2;  fi 'R90-6' 1      = 5
+        OTHER   nz 'R90 6' 1, 'R906' 2
+      58:1 in favour of the slash across four registers.
+  the_leak_is_WIDER_than_the_researcher_reported: |
+    It named r60-5, r60-6, r67-2 and r90-6 as wrong against r60-2 and r60-7
+    right. Enumerating every BMW airhead designation record in the catalog:
+      CORRECT (11): r100-7 "R100/7", r12g-s "R12G/S", r25-3 "R25/3",
+        r50-5 "R50/5", r51-3 "R51/3", r60-2 "R60/2", r60-7 "R60/7",
+        r75-5 "R75/5", r75-6 "R75/6", r80-7 "R80/7", r80g-s "R80G/S"
+      WRONG (6):    r51-2 "R51-2"   <-- MISSED by the researcher
+                    r60-5 "R60-5"
+                    r60-6 "R60 / 6"
+                    r67-2 "R67 / 2"
+                    r75-7 "R75-7"   <-- MISSED by the researcher
+                    r90-6 "R90-6"   (the sampled record)
+    R51/2 (1950-51) and R75/7 (1976-77) are genuine slash designations, so both
+    additions are real leaks. 6 of 17 = a 35% leak rate on a rule the project
+    has written down. Three distinct wrong shapes confirmed (bare hyphen,
+    spaced slash, hyphen-no-space), as stated.
+  the_project_s_own_rule_verified_in_repo: |
+    overrides/models/renames.yml, BMW block, verbatim:
+      "# Airhead type codes keep their SLASH: R 80 G/S, R 90/S, R 60/2 — the
+       slash is part of the designation, not punctuation noise. R100GS (1987)
+       genuinely has no slash where R80G/S (1980) does."
+    and R90/6 IS named explicitly, in the comment on the `R90/S: R90S` key:
+      "nl/nz registries DO write 'R90/S' (operator habit) — those rows are the
+       sport model; the /6-series would be written R90/6."
+    Implemented as three hand-written keys (R602, R80GS, R100G/S), exactly as
+    the researcher says — so every airhead the keys missed leaks.
+  citation_status: |
+    UNRESOLVED ON THE MARQUE PAGE. bmwgroup-classic.com timed out on me twice
+    (60s) and motorcycleclassics.com hung up — three failed body fetches across
+    two hosts, matching the researcher's two. A WebSearch does return the
+    bmwgroup-classic.com URL with page title "BMW R 90/6", but a search-result
+    title is Tier 2 and I will not promote it. The verdict does not need it:
+    291-vs-5 across four registers (NAMING.md §2 rank 4), the project's own
+    written rule, and eleven correctly-slashed sibling records in the same
+    family are sufficient and are all re-checkable in-repo.
+  verdict: "name defective(punctuation) UPHELD. id defective UPHELD — see the
+            record table for r9016."
+
+target_3_husqvarna_901_norden:
+  verdict: "name defective(token-order-inversion) UPHELD — and the 'tension' the
+            researcher asked to be ruled on DOES NOT EXIST. It misread NAMING.md."
+  marque_source_fetched: |
+    https://www.husqvarna-motorcycles.com/en-us/models/travel/norden-901.html
+    renders, verbatim: "Norden 901 | 2027", "Norden 901 Expedition | 2027",
+    and the heading "Trust in the north / Norden 901". The number FOLLOWS the
+    name, consistently, in navigation, headings and product sections.
+  THE_PRECEDENCE_RULING_IS_ALREADY_WRITTEN: |
+    The researcher wrote: "NAMING.md §2 lets catalog corroboration outrank
+    encyclopedias, and here three registers agree on the inverted form".
+    NAMING.md §2 is a RANKED list, and reading it settles the question outright:
+      1. Type-approval (TAN) overlap
+      2. Live registry measurement — "Beats any secondary source about what a
+         register *contains*."
+      3. The manufacturer's own current material — "The authority on how a name
+         is *written* (casing, spacing, accents)."
+      4. Corroboration across independent registers (>=2 sources, >=2 countries)
+      5. Encyclopaedic sources — "never for 'what the register says'"
+    Rank 3 outranks rank 4, and rank 3 is scoped EXPLICITLY to how a name is
+    written. Rank 2 is scoped to what a register CONTAINS — i.e. whether a row
+    exists, not how the marque spells it. There is no conflict to rule on: the
+    marque wins on rendering, by the file's own words. The researcher applied
+    the protocol correctly and then doubted itself for no reason.
+  generalisation_measured: >-
+    The researcher says this "generalises to hundreds of records". Measured: 43
+    pairs on the 2W half where BOTH token orders are live under one make+kind
+    (86 records) — honda/{cf50-chaly,chaly-cf50}, {monkey-z50,z50-monkey};
+    bsa/{a65-lightning,lightning-a65}; harley-davidson/{sportster-1200,
+    1200-sportster}, {sportster-xl,xl-sportster}, {sportster-xlh,xlh-sportster},
+    {heritage-softail,softail-heritage}; triumph/{bonneville-t140,t140-bonneville},
+    {t100-tiger,tiger-t100}, {t160-trident,trident-t160}, {tr6r-tiger,tiger-tr6r};
+    yamaha/{virago-xv535,xv535-virago}; kawasaki/{ninja-zx-6r,zx-6r-ninja};
+    royal-enfield/{bullet-350,350-bullet}; norton/{commando-850,850-commando};
+    vespa/{sprint-150,150-sprint}, {rally-200,200-rally}; and more.
+    86 records is the both-orders-live FLOOR; single-sided inversions are not
+    counted. "Hundreds" is not established; 86 is measured.
+  AND_IT_MAKES_THE_ID_CLAIM_WRONG: >-
+    motorcycle/husqvarna/norden-901 "Norden 901" [fi,th,ua] IS LIVE alongside
+    the sampled motorcycle/husqvarna/901-norden "901 Norden" [es,fi,nl]. Same
+    make, same kind, identical token multiset — a pure PERMUTATION, the least
+    arguable duplicate class there is, and the one verify-b1 established with
+    harley-davidson/{sportster-883,883-sportster}. motorcycle/husqvarna/901
+    "901" [fi,gb] is live too: THREE ids for one motorcycle. The researcher
+    called `id: correct` while holding the marque page that names the canonical
+    form. See additional_defects.
+
+target_4_space_collapse_scope:
+  the_two_source_counts:
+    verdict: "RESEARCHER CONFIRMED — both records carry THREE sources."
+    evidence: |
+      From catalog/moped/models.json directly:
+        moped/piaggio/ape50 "APE50" sources=[fi_traficom, nl_rdw, nz_nzta] (3)
+        moped/honda/dax50   "DAX50" sources=[fi_traficom, nl_rdw, nz_nzta] (3)
+      Both therefore sit OUTSIDE `normalizer-space-collapse-display-names`,
+      which carries `max_sources: 1`. The researcher's observation is correct.
+  the_mechanism_verified_at_SOURCE: |
+    Read normalizer.rb rather than inferred. Both halves confirmed:
+      two_wheeler_spacing (line 409):
+        collapsed = str.gsub(/(?<=[A-Za-z])\s+(?=\d)/,"")...
+        collapsed.gsub(/(?<=[A-Za-z]{4})(?=\d)/," ")...
+      Pass 1 glues "APE 50" -> "APE50". Pass 2 re-spaces only when FOUR letters
+      run up to the digit boundary — "APE" and "DAX" are three, so they never
+      re-space. (This is exactly why sym/symply, six letters, is fine.)
+      case_token (line 308): `return w if w =~ /\d/` — the glued token now
+      contains a digit, so the caser returns it untouched and the all-caps
+      survives. Two independent mechanisms, one visible defect.
+    And the exclusion is deliberate, verbatim from overrides/styling.yml:
+      "DELIBERATELY EXCLUDED — real nameplate words that merely LOOK like codes:
+       PRO BOY BOB MAX PAN APE BIG ZIP DAX EVO JET CUB ... Piaggio Ape/Zip,
+       Honda Dax are all correct today". Confirmed APE and DAX are NOT in
+       `acronyms`. So the all-caps is pipeline output, not curation.
+    Dominant raw confirmed from my own extracts:
+      APE: nl 'APE 50' 435 + 'PIAGGIO APE 50' 1 + 'APE  50' 1 vs 'APE50' 14;
+           fi 'APE 50' 20; nz 'APE 50' 1.  Spaced wins 458 to 14.
+      DAX: nl 'DAX 50' 7 + 'HONDA DAX 50' 3 + 'DAX-50' 2 + 'DA X 50' 1 vs
+           'DAX50' 1; fi 'DAX 50' 1; nz 'DAX50' 1. Spaced wins 14 to 2.
+    Both name verdicts UPHELD.
+  IS_THE_SCOPE_OR_THE_COUNT_WRONG — MEASURED: |
+    Neither, quite — and this is the part the researcher could not settle.
+    Counting published 2W names whose first token is <=3 CAPS glued to digits
+    (the shape pass 2 structurally cannot re-space, and the caser cannot fix):
+      2,594 records; by source count 1src=277, 2src=1433, 3src=464, 4src=267,
+      5src=107, 6src=35, 7src=9, 8src=2  ->  2,317 are MULTI-SOURCE.
+    Widening to any all-caps letters+digits glued token: 3,398 records,
+      3,033 multi-source.
+    BUT that raw count is NOT the defect population, and this is the trap: the
+    great majority are Chinese and Japanese TYPE CODES where the glued form is
+    correct (baotian/bt49qt-12, aprilia/sr50, agm/zn50qt-e, chatenet/ch26 …).
+    The defect is only present where the DOMINANT RAW IS SPACED, which is a
+    per-record comparison, not a shape test.
+    THE ACTIONABLE ANSWER FOR THE LEDGER: `max_sources: 1` is a false scope
+    statement — the shape the entry describes occurs on 2,317 multi-source 2W
+    records — but `count: 269` is not simply "understated by 10x" either,
+    because the count and the scope were measured against different things.
+    The entry needs re-measuring against the spaced-dominant-raw test, and
+    until it is, no record should be excluded from the defect rate on the
+    grounds of being "inside the filed class". ape50 and dax50 score as defects.
+
+target_5_yamaha_booster:
+  verdict: "make: defective(marque-of-sale trap) — UNRESOLVED, not upheld.
+            I cannot support `defective` and I cannot support `correct`.
+            Recommend downgrading to `unverifiable`."
+  raw_re_derived_independently: |
+    nl_rdw bromfiets, make YAMAHA:
+      'BOOSTER' n=1                     <-- the whole nl basis for this record
+      'BOOSTER NEXT GENERATION' n=1     <-- the researcher did not report this
+      'MBK BOOSTER' n=3, 'MBK BOOSTER SA23' n=1
+      'BW50' n=273, 'BWS' n=4, 'BW S' n=2, "BW'S" n=1, 'BWS 50' n=1,
+      'BW 5' n=1, 'BW50A' n=1, 'BW50 A' n=1, 'BWS SPY' n=1,
+      'CW50RS' n=1, 'CW50HS/RSP' n=1, 'SA051 BW50 NEXT GENERATION B' n=1
+      and, remarkably, "YAMAHA BW'S 100,MBKOOSTE" n=1 — one row concatenating
+      the Yamaha nameplate AND the MBK one.
+    ua_mvs МОПЕД, make YAMAHA: 'BOOSTER' n=1 (also "BW'S" n=4, "BW'S 50" n=4,
+      "BW'S SA44J" n=5, "BW'S SA53J" n=1)
+    make MBK, nl: 'BOOSTER' n=7, 'MBK BOOSTER' n=1, 'BOOSTER SPIRIT' n=1,
+      'CW 50 (BOOSTER)' n=5, "BW'S 50" n=1;  ua MBK: 'BOOSTER' n=1,
+      'BOOSTER SPIRIT' n=1
+    So the record is exactly two vehicles, and the researcher's account of the
+    neighbourhood is accurate.
+  marque_source_fetched: >-
+    https://global.yamaha-motor.com/showroom/cp/collection/bws_cw50/ — fetched
+    and read. Yamaha's Communication Plaza renders it "1988 BW'S (CW50)". The
+    page does NOT use the word "Booster" anywhere and does NOT mention MBK.
+    That establishes Yamaha's own nameplate is BW'S; it does NOT establish that
+    no market ever sold a Yamaha-badged Booster — absence on one heritage page
+    is not evidence of absence, and the researcher itself said so.
+  why_I_will_not_uphold_defective: |
+    overrides/models/moves.yml's own header rule (quoted by batch 1's verifier
+    and binding here): "Only move when the register is unambiguously filing ONE
+    marque's model under another." Two single rows, in two countries, of a
+    machine whose two badges belong to two marques in ONE corporate group
+    (MBK Industrie has been Yamaha's French subsidiary since 1986) is not
+    unambiguous. The competing reading the researcher offered — NL/UA owners
+    writing the better-known continental badge for a Yamaha-sold BW's — is
+    live, and Ukraine in particular is a grey-import market where a French MBK
+    would plausibly be entered under the parent marque.
+    I attempted a Dutch/European Yamaha source for a Yamaha-badged Booster and
+    reached none.
+  what_would_settle_it: >-
+    A Yamaha Motor Europe or Yamaha Netherlands price list / brochure for any
+    year showing (or not showing) a Yamaha-badged "Booster", OR the RDW SODA
+    live API queried for the two vehicles' type-approval numbers — if the TAN on
+    the YAMAHA|BOOSTER row matches the TAN on the MBK|BOOSTER rows, the
+    marque-of-sale trap is proven at NAMING.md §2 rank 1. nl_rdw's public
+    endpoint carries the field; my cached extract does not.
+  the_other_two_verdicts_on_this_record:
+    id: "defective(duplicate-spelling) UPHELD — moped/mbk/booster 'Booster'
+         [fi,nl,ua] is live and denotes the same machine on any reading. The
+         researcher is right that this part is not arguable."
+    name: "defective(cross-marque badge) — UNRESOLVED for the same reason as
+           make. If make is correct then the name is a badge Yamaha does use in
+           that market; if make is wrong the record should not exist."
+
+target_6_popularity_and_the_decile_construction:
+  verdict: "THE OBSERVATION IS OVERTURNED. It rests on an inverted reading of
+            the decile scale. But the underlying question has a real — and
+            different — answer, which I give firmly below."
+  the_scale_runs_THE_OTHER_WAY: |
+    reconciler.rb:362-382, read at source:
+      ranked = models.select{…}.sort_by { |m| -m["_counts"][cc] }
+      per_country_rank[[id,cc]] = { rank: i+1,
+                                    decile: [((i+1) * 10.0 / n).ceil, 10].min }
+    Sorted DESCENDING by count, so rank 1 is the MOST-registered model and
+    decile 1 is the TOP band. Decile 10 is the BOTTOM band.
+    Confirmed against the catalog: motorcycle/bmw/r1200gs — BMW's best seller —
+    carries nl:rank1/decile1, fi:rank2/d1, lu:rank6/d1, ua:rank45/d1.
+    So all three cited records are correctly ranked, not over-ranked:
+      moped/focus/thron          fi:rank462/d9  nl:rank1167/d10  global 10
+      motorcycle/husqvarna/fr450 nz:rank2410/d10 gb:rank1404/d10 global 10
+      motorcycle/honda/vfr800a5  nl:rank5034/d10 ua:rank1280/d10 global 10
+    A record with 1-8 raw rows landing in the BOTTOM decile is the system
+    working. There is no over-ranking of thin records, and the three flagged
+    cases are all correct. The researcher's note, and the brief's framing of
+    it as "decile 9-10 on 1-8 raw rows", both read the scale inverted.
+  DOES_MEAN_OF_RANKS_SYSTEMATICALLY_OVER_RANK_THIN_MULTI_COUNTRY_RECORDS: |
+    NO — it does the OPPOSITE, and it over-ranks thin SINGLE-country records.
+    Measured over all 7,083 2W records, global_decile distribution by number of
+    countries the record is present in:
+      ncountries |    n | share@d1 | share@d10 | share@d4-7 | mean gdec
+             1   |  821 |   30.2%  |    0.7%   |   27.9%    |   2.60
+             2   | 3951 |    0.6%  |    7.8%   |   52.0%    |   6.75
+             3   | 1195 |    0.5%  |    0.9%   |   73.5%    |   5.60
+             4   |  621 |    1.4%  |    0.2%   |   72.6%    |   4.89
+             5   |  292 |    3.8%  |    0.0%   |   67.8%    |   4.22
+             6   |  138 |    2.2%  |    0.0%   |   60.1%    |   3.93
+             7   |   56 |    0.0%  |    0.0%   |   44.6%    |   3.55
+             8   |    9 |    0.0%  |    0.0%   |   44.4%    |   3.78
+    Two structural effects, both consequences of averaging k rank-percentiles:
+      (1) VARIANCE COLLAPSE. Mean-of-k-draws has variance ~1/k, so a broad
+          record is pushed toward the middle and can essentially never reach
+          decile 1 or 10. At 7 countries: 0% at d1, 0% at d10, 44.6% inside the
+          d4-7 band. motorcycle/triumph/bonneville-t120 — seven countries, all
+          first-hand, the strongest availability set in this batch — scores
+          global decile 3, because one mid-ranking market averages away its
+          strength elsewhere. The construction structurally CANNOT say "this
+          model is globally dominant".
+      (2) SINGLE-COUNTRY INFLATION. 30.2% of one-country records land in
+          decile 1, against 0.5-3.8% for every multi-country band. That is a
+          selection effect of the publish rule: a single-source record must
+          clear KIND_THRESHOLD to publish at all, so it is high-volume in its
+          country and ranks near the top of it. "Global decile 1" for a
+          Thailand-only or GB-only record means "top 10% in Thailand" — a
+          within-country statement presented as a global one, and not
+          comparable with a record ranked in five markets.
+  WHY_THIS_BEARS_DIRECTLY_ON_PRD_FIVE_NINES_1.3_AND_THE_CERTIFICATION_SCOPE: |
+    §1.3.1's whole scope decision — d1-3 = 82.98% of registration mass, hence
+    "certify through decile 6, ~9,340 records, ~55% of the catalog" — bands the
+    catalog by `popularity.global_decile`. Given (1) and (2):
+      * the d1-3 band is enriched in single-country records that are locally
+        big and globally small, and
+      * it systematically EXCLUDES broad multi-country records that averaging
+        pushed into d4-6 — and those are precisely the claim-heaviest records
+        (the protocol states rates are computed over CLAIMS, and a 7-country
+        record carries 11 claims to a 1-country record's 5).
+    So a usage-weighted aggregate computed on these bands does not weight by
+    usage; it weights by a rank mean that is uncorrelated with mass in a known
+    direction. §1.3.2 already says as much in one line — "Deciles are rank
+    bands, not mass" — and its remedy (catalog/meta/decile-mass.json) is the
+    artifact that does not exist in this worktree (see process_caveats).
+    FIRM RECOMMENDATION: do not band the certification scope on global_decile
+    until decile-mass.json exists AND the band is defined on registration mass
+    rather than on the mean of country rank-percentiles. If a rank blend must be
+    kept for v1, weight the country deciles by that country's model population
+    (or its registration volume) instead of taking an unweighted mean — that
+    removes effect (2) directly and damps effect (1).
+  the_three_records: "All three verdicts on them stand unchanged; the popularity
+                      NOTE attached to them should be struck from the ledger."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# TIER 2 RE-FETCHES — 100%, as required. These were the weakest evidence.
+# ═══════════════════════════════════════════════════════════════════════════
+tier_2_refetch_results:
+
+  - citation: "cdn2.yamaha-motor.eu PB7N28199E0E.PDF — 'MTN890 (MT-09)'"
+    result: FETCHED_AND_READ — PROMOTED TO TIER 1, and it is the strongest
+            single citation in the batch
+    detail: |
+      Downloaded (3.8 MB) and text-extracted with pdftotext. Title page, verbatim:
+          MOTORCYCLE
+          MTN890 (MT-09)
+          B7N-28199-E0
+      Body p.1: "As the owner of the MTN890, you are benefiting from Yamaha's
+      vast experience…"; colophon: "MTN890 / OWNER'S MANUAL / ©2021 by Yamaha
+      Motor Co., Ltd. / 1st edition, August 2020". Yamaha's own document on
+      Yamaha's own CDN. Also answers the researcher's own attack question — the
+      manual is the BASE MT-09 (the SP/variants are the separate mtn890d/-s/-su/-u
+      ids), so the fold target is right.
+    verdict: UPHELD, materially strengthened
+
+  - citation: "global.yamaha-motor.com bws_cw50 — \"1988 BW'S (CW50)\""
+    result: FETCHED_AND_READ
+    detail: "Renders \"1988 BW'S (CW50)\". Does not say Booster; does not
+             mention MBK. Quote is exact."
+    verdict: UPHELD as a quote (but see target_5 — it does not carry the weight
+             the make verdict needs)
+
+  - citation: "brommer.nl/merk/solex/solex-oto-1001 — 'SOLEX-OTO (1001)'"
+    result: FETCHED_AND_READ
+    detail: "Renders 'SOLEX-OTO (1001)'; breadcrumb 'Home » Merken » SOLEX »
+             SOLEX-OTO (1001)' confirms make=SOLEX, model=OTO (1001)."
+    verdict: "UPHELD — moped/solex/oto name: correct stands"
+
+  - citation: "yumpu — 'Sym Symphony SR (AZ05W) brugermanual'"
+    result: FETCHED_AND_READ
+    detail: >-
+      Title verbatim "Sym Symphony SR (AZ05W) brugermanual - Scootergrisen";
+      body carries "SYMPHONY SR 50 (AZ05W1-T AZ05W2-6)". NOTE it is a
+      third-party (Scootergrisen) upload, not SYM-hosted — but I found a
+      stronger, marque-independent replacement in-corpus (below).
+    verdict: UPHELD, citation upgraded
+
+  - citation: "bike-urious — 2007 Honda VFR800 25th Anniversary"
+    result: FETCHED_AND_READ
+    detail: "Confirms the machine is the 2007 VFR800 25th Anniversary and that
+             the article spells 'Anniversary' out in full. No source anywhere
+             renders 'Aniv'."
+    verdict: UPHELD — honda/vfr800-aniv name defective stands
+
+  - citation: "zontes.com — ZT prefix all-caps"
+    result: FETCHED (page partially mojibaked)
+    detail: "'ZT250-S' extracted verbatim, ZT all-caps. No product named bare
+             'ZT'. Enough for the casing claim."
+    verdict: UPHELD
+
+  - citation: "talaria.us.com — 'TALARIA KOMODO 2025 (TL6000)'"
+    result: FETCHED — CITATION FAILS AS WRITTEN
+    detail: >-
+      The cited page renders "TALARIA KOMODO" and its only code is the SKU
+      "TL-004/BK-T". "TL6000" is NOT on it. The researcher's SECOND url
+      (talariaebikesusa.us.com) DOES carry it — "TALARIA KOMODO 2025 (TL6000)"
+      and "The Talaria Komodo TL6000 is Talaria's most powerful midweight
+      off-road electric motorcycle" — but that is a US distributor domain, not
+      Talaria's corporate site. Neither ".us.com" host is demonstrably
+      marque-controlled.
+    verdict: >-
+      talaria/komodo name: correct UPHELD (the first page does render "TALARIA
+      KOMODO"). The TL####-is-a-type-code argument that props up
+      moped/talaria/tl4000 must NOT rest on these pages — replaced in-corpus below.
+
+  - citation: "cmsnl.com — 'Honda NVS501SH TODAY 2002 (2) JAPAN AF61-100'"
+    result: HTTP 403 — NOT RE-FETCHABLE
+    replacement_found_in_corpus: |
+      Far stronger, and marque-independent. nz_nzta moped under make HONDA pairs
+      the NVS/NV5xx type code with the TODAY nameplate in THIRTEEN spellings:
+        'NUS50 TODAY' 2, 'NU550 TODAY' 1, 'NV550 TODAY' 3, 'NVX50 TODAY' 1,
+        'NVX50TODAY' 1, 'NS50V TODAY' 1, 'NSU50 TODAY' 1, 'NUS 50 TODAY' 2,
+        'MVS50-TODAY' 1, 'NC50 - TODAY 50' 1, 'TODAY NV550' 1, 'TODAY NSV 50' 1,
+        'TODAY 50/NV550' 1  — beside bare 'NVS' 809 and 'TODAY 50' 78.
+      This is verbatim the evidence form batch 1's verifier blessed for
+      AD01<->MT50 and SA09<->SLIDER: the register itself supplying the nameplate
+      next to the code, in one string, repeatedly.
+    verdict: "af61 and nvs verdicts UPHELD on replacement evidence. The cmsnl
+              citation must be struck from the ledger — it 403s."
+
+  - citation: "partsss.com — 'SEAT [MOD:M 797] Ducati Monster 797'"
+    result: HTTP 403 — NOT RE-FETCHABLE
+    replacement_found_in_corpus: |
+      nl_rdw motorfiets under make DUCATI pairs the M-code with the Monster
+      nameplate in one string, at volume:
+        'M600 MONSTER' 343, 'M900 MONSTER' 398, 'M750 MONSTER' 71,
+        'M600-MONSTER' 1, 'M600 MONSTER DARK' 1, 'DUCATI M696 MONSTER' 1,
+        'M1000 IE MONSTER' 1, 'MONSTER M695' 1, 'MONSTER M800 IE' 1,
+        'MONSTER M900' 2, 'ZDM600M (600 MONSTER)' 4, 'ZDM900M (900 MONSTER)' 1,
+        'M900 MONSTER' 2 (zijspan);  fi 'MONSTER M750' 1,
+        'MONSTER 620-M400AA/618' 1
+      Seven displacements proven in-register. The CLASS "Ducati M<n> is the
+      Monster <n>" is established without any reseller page.
+    honest_limit: >-
+      For 797 SPECIFICALLY no row pairs the two: gb carries only 'M797' and
+      'M797 +'; fi/nl/lu/ua carry only 'MONSTER 797'. So the M797 -> Monster 797
+      identity is reached by the M-code convention, which the protocol's
+      "never by family pattern" rule disfavours. I still UPHOLD both verdicts,
+      on batch 1's ad01 reasoning: `id: correct` is an affirmative claim that no
+      other live id denotes the same vehicle, and Ducati built exactly one 797.
+      The researcher's own attack note on this citation was correct and should
+      be honoured: get a ducati.com source before any scaled fixing.
+    verdict: UPHELD, citation must be replaced
+
+  - citation: "autoevolution — 'CCM 644 DS Dual Sport'"
+    result: HTTP 403 — NOT RE-FETCHABLE, AND THE CLAIM IT CARRIES IS DOUBTFUL
+    detail: "See target_2a. No '644' appears in any CCM row in any of my seven
+             corpora; uk_dft's CCM DS product is the '404 DS'. The verdict
+             survives and strengthens, but on different evidence."
+    verdict: UPHELD on replacement evidence; citation struck
+
+  - citation: "bmwgroup-classic.com — 'BMW R 90/6'"
+    result: TIMEOUT x2 (60s each), plus motorcycleclassics.com socket hang up
+    verdict: "See target_2c — verdict does not depend on it. UNRESOLVED as a
+              citation; the ledger should carry the in-repo rule and the
+              291-vs-5 register measurement instead."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# NEW DEFECTS the researcher called `correct` — from my own duplicate scan
+# (token-multiset permutation/strict-subset within make+kind; nominates ~35 of
+#  the 100, most legitimately. These seven are not.)
+# ═══════════════════════════════════════════════════════════════════════════
+additional_defects:
+
+  - claim: "motorcycle/husqvarna/901-norden id"
+    researcher: correct
+    my_verdict: "defective(duplicate — pure token permutation)"
+    confidence: very high
+    why: >-
+      motorcycle/husqvarna/norden-901 "Norden 901" [fi,th,ua] is live. Identical
+      token multiset, same make, same kind — the exact shape verify-b1 ruled on
+      for harley-davidson/{sportster-883, 883-sportster} ("a pure token
+      PERMUTATION, the least arguable duplicate class there is"). And the
+      researcher itself FETCHED the marque page establishing which one is
+      canonical, then called the id correct anyway. motorcycle/husqvarna/901
+      "901" [fi,gb] is also live: three ids for one motorcycle, and the fold
+      target is unambiguous (Norden 901).
+
+  - claim: "motorcycle/honda/nt650v-deauville id"
+    researcher: 'correct, on the stated ground "honda/nt650v alone is not live,
+                 which is why this one is clean"'
+    my_verdict: "defective(duplicate)"
+    confidence: very high
+    why: >-
+      THE STATED GROUND IS FACTUALLY FALSE. motorcycle/honda/nt650v "NT650V"
+      [es,fi,gb,lu,nl,ua] IS live — six countries, the widest coverage of any
+      Honda NT in the catalog. motorcycle/honda/deauville "Deauville" [fi,nl,ua]
+      is live too. Worse, this exact pair was already adjudicated: verify-b1.yml
+      records `motorcycle/honda/nt650v id defective(D6)` as "strongest id call in
+      the batch", with fi carrying 'NT650V' and 'NT650V DEAUVILLE-RC47A/647' on
+      the SAME TAN e9*92/61*0073*01. Batch 3 asserts the opposite of a verdict
+      batch 1's verifier already signed. This is a cross-batch contradiction and
+      the ledger must not merge both.
+
+  - claim: "motorcycle/royal-enfield/hunter id AND name"
+    researcher: "id: correct; name: unverifiable(name not covered this pass)"
+    my_verdict: "id: defective(duplicate); name: defective(uk_dft GenModel artifact)"
+    confidence: very high
+    why: |
+      Decisive in-data, from my own derivation across all seven corpora. EVERY
+      register that carries this motorcycle writes the displacement:
+        fi 'HNTR 350' 6 (TAN e5*168/2013*00021*05)
+        nl 'HNTR 350' 108        es 'HNTR 350' 8
+        lu 'HNTR 350' 2 (TAN e5*168/2013*00021*12)
+        nz 'HUNTER 350' 1        ua 'HUNTER 350' 2      th 'HUNTER 350' 516
+        gb Model column 'HNTR 350 E5' 1320+176, 'HNTR 350 E5+' 82+2
+      There is NO bare "Hunter" row in ANY register's model column. The published
+      name exists solely because uk_dft's GenModel column says 'ROYAL ENFIELD
+      HUNTER' — FINDING-C's mechanism exactly. And
+      motorcycle/royal-enfield/hunter-350 "Hunter 350" [nz,th,ua] is live, built
+      from the registers that spell it out. One motorcycle, two ids, split by
+      register convention. The researcher wrote "this is cheap for a verifier to
+      settle" and then called the id correct; it is settled, and against it.
+      (royalenfield.com returned 403 on both gb and in paths — the verdict rests
+      on NAMING.md §2 rank 2 and rank 4, which is sufficient here.)
+
+  - claim: "motorcycle/harley-davidson/flhtcui-ultra-classic id"
+    researcher: correct
+    my_verdict: "defective(duplicate)"
+    confidence: very high
+    why: >-
+      This record is a NAMED MEMBER of the six-id FLHTCUI permutation cluster
+      that verify-b1.yml already ruled on and upgraded from WEAK to STRONG:
+      flhtcui, flhtcui-electra-glide, flhtcui-electra-glide-ultra-classic,
+      flhtcui-ultra-classic, flhtcui-ultra-classic-electra-glide,
+      electra-glide-ultra-classic-flhtcui. My scan confirms all six are still
+      live, plus ultra-classic "Ultra Classic" [fi,lu,nl,nz]. Batch 1's ruling:
+      "Those are permutations of one code plus one nameplate. No 'parallel axis'
+      policy can bless them; there is nothing to decide." Second cross-batch
+      contradiction.
+
+  - claim: "motorcycle/harley-davidson/fxsti-softail id"
+    researcher: correct
+    my_verdict: "defective(duplicate)"
+    confidence: high
+    why: >-
+      motorcycle/harley-davidson/fxsti "Fxsti" [fi,gb,nl] is live, as are
+      softail "Softail" [fi,gb,lu,nl,nz,ua] and fxsti-softail-standard. Code
+      alone / code + family word — the identical shape to the FLHTCUI cluster
+      batch 1 ruled D6. The researcher called this record "THE CLEANEST
+      CONTRADICTION-DETECTOR SIGNAL IN THIS BATCH" for its casing and then did
+      not look at its id.
+
+  - claim: "motorcycle/harley-davidson/fxd-dyna id"
+    researcher: correct
+    my_verdict: "defective(duplicate)"
+    confidence: high
+    why: >-
+      Same shape again: fxd "Fxd" [fi,gb,nl,nz,th,ua] and dyna "Dyna"
+      [fi,lu,nl,nz] are both live, plus fxd-dyna-super-glide. H-D's own model-code
+      page gives "FXD – Dyna Super Glide®", i.e. one machine.
+
+  - claim: "motorcycle/aprilia/rst id"
+    researcher: correct
+    my_verdict: unverifiable
+    confidence: medium
+    why: >-
+      motorcycle/aprilia/rst-futura "Rst Futura" [gb,nl] is live. The
+      researcher's own note says "the model is the RST1000 Futura and bare 'RST'
+      drops the 1000" — which is an argument against `correct`, not for it, and
+      the same reasoning verify-b1 used to move moped/honda/ad01 from correct to
+      unverifiable. I do not assert `defective`: I did not source whether
+      Aprilia's RST designation covers anything besides the Futura.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ALL 42 DEFECTIVE CLAIMS RE-DERIVED  (1 overturned, 41 upheld)
+# ═══════════════════════════════════════════════════════════════════════════
+defective_claims_rederived:
+
+  overturned:
+    - claim: "motorcycle/nimbus/750 availability(nz) defective(rename-fabricated)"
+      result: "OVERTURNED -> correct. See target_1."
+
+  upheld_with_evidence_independently_reproduced:
+
+    - claim: "moped/doohan/itango name defective(model_casing)"
+      result: UPHELD — STRENGTHENED
+      note: >-
+        fi_traficom writes 'Doohan | iTango' n=7 (TAN e24*168/2013*00017*01) —
+        the register preserves the camel form, reproduced exactly. AND the whole
+        Doohan range in nl_rdw uses the lowercase-i prefix: 'ITANK' 79,
+        'I-TANK' 1, 'IDOU' 11, 'ILARK' 353, beside 'ITANGO' 5. A family-level
+        marque convention the researcher did not have. Its honesty about not
+        reaching a Doohan site is correct — all three domains it names are dead
+        for me too — but the in-corpus case is now strong on its own.
+
+    - claim: "moped/sym/az05w name defective(type-code-as-nameplate)"
+      result: UPHELD — STRENGTHENED, and the fold TARGET is now named in-register
+      note: >-
+        The researcher cited the AV05W/SYMPLY pairing as indirect class proof.
+        uk_dft carries the DIRECT one for this very record:
+        GenModel 'SYM SYMPHONY' -> Model 'AZ05W SYMPHONY SR 50' (Licensed 7 +
+        SORN 21). The register names AZ05W as the Symphony SR 50 outright, which
+        also independently corroborates the yumpu manual. Its restraint on the
+        id is correct: I confirm there is no live sym/symphony-sr, and nl_rdw
+        distinguishes 'SYMPHONY SR' n=203 from 'AZ05W' n=1662.
+      queue_item_this_opens: >-
+        uk_dft resolves THREE more of the Axx05W family the same way, and two
+        have same-kind nameplate twins already live:
+          'AD05W JET 4 50' vs live moped/sym/jet4 "JET4"      -> ad05w is a duplicate
+          'AW05W FIDDLE II 50 S' vs live moped/sym/fiddle-ii  -> aw05w is a duplicate
+          'AV05W SYMPLY 50' (the researcher's case)
+        Not cross-kind — both are moped/moped. Worth a curation PR of its own.
+
+    - claim: "motorcycle/sym/symply id defective(cross-kind duplicate)"
+      result: UPHELD
+      note: >-
+        The researcher's citation verifies exactly as written — uk_dft
+        'SYM SYMPLY' -> 'AV05W SYMPLY 50' Licensed 205 + SORN 557 — and
+        moped/sym/av05w "AV05W" [nl] is live off nl_rdw 'AV05W' n=3314. I
+        initially doubted this row and was wrong; recording that. name: correct
+        also upheld (the sym-symphony-family allowlist entry is real and the
+        prefix must not be stripped).
+
+    - claim: "moped/talaria/tl4000 name + id defective(type-code-as-nameplate)"
+      result: UPHELD, and the researcher's OPEN QUESTION is now answerable —
+              its caution was RIGHT, for a sharper reason than it gave
+      note: |
+        The marque citation fails (see tier_2), but the in-corpus case is much
+        stronger than the researcher realised, and uk_dft — which it did not
+        consult for this record — pairs every TL code with its nameplate:
+          gb Model column: 'TL 3000 STING', 'TL 4000 STING R',
+             'TL 5500 STING PRO', 'TL 2500 XXX', plus bare 'TL 4000' 73+81
+          nl: 'TL3000, STING' 53, 'TL3000 STING' 14, 'TL3000, STING R' 1,
+              'TL4000, STING' 5, 'TL2500, XXX' 6
+          fi: 'TL4000, STING' 2, 'TL2500, XXX' 1
+        THE FOLD TARGET IS GENUINELY CONTESTED BETWEEN REGISTERS: GB says
+        TL 4000 = Sting R; NL and FI say TL4000 = Sting. There is no live
+        moped/talaria/sting-r for the GB reading to land on. So the researcher's
+        "do not fix before the variant layer exists" is vindicated — not because
+        TL3000 and TL4000 are both "the Sting", but because two registers
+        disagree about which trim TL4000 denotes. Record that correction; the
+        Kreidler-wall framing was right by accident.
+
+    - claim: "motorcycle/ccm/dual-sport name defective(descriptor-as-model)"
+      result: UPHELD — and it is NOT a boundary case. See target_2a.
+
+    - claim: "moped/qroad/electric-scooter name defective(descriptor-as-model)"
+      result: UPHELD
+      note: "Raw reproduced: fi 'Qroad | ELECTRIC SCOOTER' L1e n=1; nl 'QROAD |
+             ELECTRIC SCOOTER' n=3. Six other makes carry the identical string —
+             the artifact core of the class."
+
+    - claim: "moped/piaggio/ape50 + moped/honda/dax50 name defective(display-form)"
+      result: BOTH UPHELD — mechanism verified at source. See target_4.
+
+    - claim: "motorcycle/husqvarna/901-norden name defective(token-order-inversion)"
+      result: UPHELD — marque source fetched, NAMING.md §2 settles precedence.
+              See target_3. (Its ID claim is separately OVERTURNED — see
+              additional_defects.)
+
+    - claim: "motorcycle/bmw/r90-6 name + id defective"
+      result: BOTH UPHELD
+      note: |
+        name: 291 slash vs 5 hyphen across four registers, re-derived (the
+        researcher's 289 is 2 low — it misses the embedded-prefix row
+        'BMW R 90/6' n=1). Project rule verified in renames.yml. Eleven
+        correctly-slashed siblings in the same family.
+        id: motorcycle/bmw/r9016 "R9016" [nl,nz] confirmed live on nl 'R 9016'
+        n=1 and nz 'R9016' n=1. The slash-as-digit-1 reading is sound and the
+        Kreidler entry documents the identical corruption. The researcher's
+        honest statement of the alternative (removals rather than fold) is the
+        right way to leave it. Also confirmed live: bmw/r905 "R905" [nl,nz]
+        beside bmw/r90s "R90S" — the S->5 corruption, same make, same class.
+
+    - claim: "motorcycle/yamaha/mtn890 name + id defective(type-code-as-nameplate)"
+      result: BOTH UPHELD — the strongest pair in the batch after the re-fetch.
+      note: >-
+        Yamaha's own manual read at source (tier_2 above). Raw reproduced:
+        es 80, fi 128, lu 18, nl 1543. motorcycle/yamaha/mt-09 "MT-09"
+        [es,fi,lu,nl,nz,th,ua] live with wider coverage. The parallel MTN/MTM/MTT
+        family the researcher enumerates is real; I confirm mtn890-s, -su, -u,
+        mtn890d, mtn890d-u are all live beside it.
+
+    - claim: "motorcycle/ducati/m797 name + id defective"
+      result: BOTH UPHELD on replacement in-corpus evidence — citation struck.
+              See tier_2. The 21-M-code / 26-Monster parallel family is confirmed
+              live, and m600-monster + m900-monster are themselves published ids
+              proving the register writes both in one string.
+
+    - claim: "moped/honda/af61 + moped/honda/nvs name + id defective"
+      result: UPHELD on replacement in-corpus evidence (13 NZ code+nameplate
+              spellings) — cmsnl citation struck. See tier_2.
+      note: "Four live ids confirmed for one machine: moped/honda/{af61, nvs,
+             today, today-50}. nvs carries 809 NZ rows under a title-cased
+             initialism. Both verdicts are sound."
+
+    - claim: "moped/honda/tact id defective(duplicate-spelling)"
+      result: UPHELD — moped/honda/tact-50 "Tact 50" [nz,ua] confirmed live,
+              same two countries. Its restraint on the NAME (Tact is a real
+              Honda nameplate) is correct.
+
+    - claim: "moped/yamaha/yq50 + moped/yamaha/yb50 id defective"
+      result: BOTH UPHELD — moped/yamaha/yq50-aerox "YQ50 Aerox" [fi,nl] and
+              moped/yamaha/yb "Yb" [nl,nz] confirmed live.
+
+    - claim: "motorcycle/bmw/k id defective(family-level duplicate)"
+      result: UPHELD — bmw/k-series "K Series" [gb] confirmed live; 27 numbered
+              K siblings confirmed. Its refusal to call the NAME defective on an
+              absence argument is exactly right discipline.
+
+    - claim: "motorcycle/honda/gl1500se-goldwing name + id defective"
+      result: BOTH UPHELD
+      note: "Three live ids confirmed for the GL1500 SE Gold Wing: gl1500se
+             'GL1500SE' [gb,nl,nz], gl1500-goldwing-se 'GL1500 Goldwing Se'
+             [nl,nz], and this one [fi,nl]. The renames.yml 'Gold Wing is TWO
+             words' block and its three pins verified in-repo. Its self-correction
+             on the nl availability false positive is correct and well recorded —
+             my matcher strips embedded prefixes and finds the row too."
+
+    - claim: "the eight model_casing claims — moped/gilera/rcr, moped/ksr-moto/ttx,
+              moped/turbho/rb-50, motorcycle/zontes/zt, motorcycle/aprilia/rst,
+              motorcycle/harley-davidson/{flhtcui-ultra-classic, fxd-dyna,
+              fxsti-softail}"
+      result: ALL EIGHT UPHELD
+      note: >-
+        Verified in-repo that NONE of RCR, SMT, TTX, ZT, RST, DAX, APE, MAX, SM,
+        GTP or NVS is present in styling.yml `acronyms` — so every title-cased
+        form is pipeline output, not a curated decision, and there is no pin to
+        collide with. zontes.com re-fetched ("ZT250-S"). H-D model-codes page
+        already re-fetched and upheld by batch 1's verifier on the same URL.
+      the_researcher_s_ruling_request: >-
+        It asks whether filed-debt records should score as defects at all,
+        noting it "moves the headline rate a lot". This is already answered:
+        verify-b1.yml ruled "Do NOT exclude them… the rate measures what a
+        consumer of the published catalog receives, and a debt entry changes
+        nothing for that consumer. Excluding filed debt would make the metric
+        improvable by writing documentation." I concur without reservation, and
+        target_4 adds a second reason: the debt entry's own scope statement
+        (`max_sources: 1`) is demonstrably wrong, so "inside the filed class" is
+        not even a well-defined exclusion today.
+
+    - claim: "moped/saxonette/529 make + name defective"
+      result: BOTH UPHELD — name_shapes.yml's `saxonette-is-a-product-not-a-marque`
+              and `bare-displacement-2w` entries verified in-repo, both naming
+              this record. Nothing to attack; scored as defects per the ruling above.
+
+    - claim: "motorcycle/honda/350sl name defective(token-order-inversion)"
+      result: UPHELD — same class and same ruling as husqvarna/901-norden.
+              Confirmed no live honda/sl350, so the id claim is right.
+
+    - claim: "motorcycle/honda/vfr800-aniv name defective(register-abbreviation)"
+      result: UPHELD — bike-urious re-fetched. Note the ID is arguably defective
+              too by the researcher's own proposed disposition (fold into
+              honda/vfr800, which is live [fi,gb,lu,nl,nz,ua]); I leave it as it
+              stands because the alternative disposition it offers
+              ("VFR800 25th Anniversary") would keep a distinct id.
+
+    - claim: "moped/yamaha/booster make + name + id defective"
+      result: "id UPHELD; make and name UNRESOLVED -> recommend `unverifiable`.
+               See target_5."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SPOT-CHECKS ON `correct` AND `unverifiable`
+# ═══════════════════════════════════════════════════════════════════════════
+spot_checks:
+  availability:
+    coverage: "229/229 (100%) — not the 20% required"
+    result: "ALL 229 MATCHED by my independent matcher. 0 no-match."
+    note: >-
+      This class is genuinely clean and the researcher's process note is right.
+      My matcher applies aliases + renames + strip_make_prefix + two_wheeler_spacing
+      inline, so it cleared the embedded-prefix cases (gl1500se-goldwing nl,
+      husqvarna FE 501 es/fi/nl, ktm 690-enduro) without hand-running any of them.
+      The researcher's tooling warning about ISO-8859 fi_traficom is correct and
+      important — I hit the same class of failure on uk_veh0120_uk.csv, which is
+      ALSO not clean UTF-8 (Ruby CSV raises InvalidEncodingError at line 93,444).
+      Worth adding to the note: it is not only the Finnish file.
+  kind:
+    coverage: "every sampled record for which any supporting raw row carries an
+               explicit EU or Spanish national class (103 rows across fi/es/lu)"
+    result: "103/103 agree with the published kind. 100 correct UPHELD."
+    note: "Includes both records that look wrong and are not — moped/aixam/m12rs
+           (L6e quadricycle) and moped/piaggio/ape50 (L2e three-wheeler). The
+           L6e/L7e -> moped convention is documented and correctly not scored as
+           a defect."
+  make:
+    result: "88 of the 90 `correct` upheld structurally — every supporting raw
+             make string in all 229 availability rows resolves to the record's
+             make_id through overrides/makes/aliases.yml. The 8 `unverifiable`
+             are correctly reasoned (kl and djjd are named GENUINELY OPEN in
+             name_shapes.yml, verified in-repo)."
+  id_correct:
+    coverage: "100% re-scanned (not the 20% required) with my own token-multiset
+               permutation/strict-subset scan within make+kind"
+    result: "7 corrections — see additional_defects. The scan nominates ~35 of
+             100; I judged 7 to be real, which is the same signal-to-noise batch
+             1's verifier reported and reinforces worklist-never-verdict."
+    controls_that_correctly_survived:
+      - "motorcycle/bmw/r25 `correct` — r25-3 'R25/3' is nominated and is a
+         genuinely different motorcycle (R25 1950-51 is slashless). The
+         researcher's reasoning here is exactly right and it is the batch's best
+         positive control for the slash policy."
+      - "motorcycle/aprilia/scarabeo `correct` — moped/aprilia/scarabeo is
+         fold-equal and is the 50cc machine; the kind split is doing real work.
+         Correctly not called."
+      - "motorcycle/triumph/bonneville-t120 `correct` — nominated against
+         bonneville, t120 and bonneville-t120-black; all genuinely distinct.
+         Seven-country evidence reproduced exactly. Keep as a positive control."
+      - "motorcycle/sherco/250-sef `correct` — the rename is narrow->broad
+         (250 SEF-R -> 250 SEF), the opposite direction from the nimbus shape,
+         so the country really does evidence the model. sherco.com re-checked.
+         The researcher's contrast with nimbus/750 is well drawn."
+      - "moped/honda/dream `correct` — cross-kind twin is a different vehicle set.
+         Correctly not called."
+      - "motorcycle/kawasaki/er-5 `correct` — kawasaki/er 'Er' is nominated; the
+         researcher explicitly declines to call it on this record's ledger line.
+         Right call."
+  unverifiable_spot_checks:
+    - "moped/over/thor — the identical n=5 in nl and nz that the researcher
+       re-checked for cross-contamination: I reproduce n=5 in both from separate
+       caches. It is a coincidence, as it says. Good instinct, correctly recorded."
+    - "moped/peugeot/kisbee-s-naked — fi 'Peugeot | KISBEE S Naked' n=41
+       reproduced; fi's mixed case is unusually good display evidence, as noted.
+       Also nominated against kisbee and kisbee-s, both live and both genuinely
+       different trims."
+    - "motorcycle/lexmoto/{arrow,titan} — the negative result on lexmoto.com is
+       honest and correctly recorded as unverifiable rather than defective."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CORRECTED CLAIM TALLY — with the researcher's coverage caveat PRESERVED
+# ═══════════════════════════════════════════════════════════════════════════
+corrected_tally:
+  researcher: { correct: 514, defective: 42, unverifiable: 73, total: 629,
+                clean_rate: "81.7%" }
+  verifier:   { correct: 508, defective: 48, unverifiable: 73, total: 629,
+                clean_rate: "80.8%" }
+  by_claim_type:
+    id:           { correct: 80,  defective: 19, unverifiable: 1 }   # was 87/13/0
+    name:         { correct: 9,   defective: 27, unverifiable: 64 }  # was 9/26/65
+    make:         { correct: 90,  defective: 2,  unverifiable: 8 }   # unchanged*
+    kind:         { correct: 100, defective: 0,  unverifiable: 0 }   # unchanged
+    availability: { correct: 229, defective: 0,  unverifiable: 0 }   # was 228/1/0
+  changes:
+    - "nimbus/750 availability(nz): defective -> correct"
+    - "husqvarna/901-norden id, honda/nt650v-deauville id, royal-enfield/hunter id,
+       harley-davidson/flhtcui-ultra-classic id, harley-davidson/fxsti-softail id,
+       harley-davidson/fxd-dyna id: correct -> defective"
+    - "aprilia/rst id: correct -> unverifiable"
+    - "royal-enfield/hunter name: unverifiable -> defective"
+    - "*make: I recommend moped/yamaha/booster make AND name move from
+       defective to unverifiable (target_5). NOT applied to the numbers above,
+       because it is a recommendation to the ledger rather than a re-derivation
+       I can close. If applied: make 90/1/9, name 9/26/65, clean rate unchanged
+       at 80.8% (defect -1, unverifiable +1 on each of two claims)."
+
+  THE_NAME_COVERAGE_CAVEAT_STANDS_AND_IS_NOW_SLIGHTLY_WORSE: |
+    PRESERVE THIS VERBATIM IN THE LEDGER. The name claim was covered for only
+    35 of 100 records by the researcher (9 correct + 26 defective; 65 carry
+    `unverifiable(name not covered this pass)`). I add one — royal-enfield/hunter
+    — bringing coverage to 36 of 100.
+    The researcher's own declaration must be carried forward unchanged: name
+    coverage IS NOT STRATUM-UNIFORM. It skews toward records whose shape made the
+    researcher suspicious, so the name-defect rate computed from the covered
+    subset is BIASED UPWARD and MUST NOT be used as an estimate of the catalog's
+    name-defect rate. My addition makes the bias WORSE, not better, by exactly
+    the same mechanism: I selected royal-enfield/hunter because my duplicate scan
+    flagged it, i.e. because it looked wrong. 27/36 = 75% is a selection
+    statistic, not a measurement.
+    The id / make / kind / availability rates ARE unbiased over the full 100 and
+    are the only four that may be aggregated. Its per-stratum coverage table is
+    machine-counted and I verified it sums to 100.
+  small_internal_inconsistencies_in_the_proposal: >-
+    Its machine-counted coverage block is correct in every figure (I recounted
+    all 629 claims from the verdict lines: id 87/13/0, name 9/26/65, make 90/2/8,
+    kind 100/0/0, availability 229). Two stale prose statements were not updated
+    to match: the header says "38 of 100 covered by my own fetch; 4 more…; 58 are
+    honestly uncovered" (should be 35/65), and the name_not_covered block is
+    introduced as "These 70 ids" when the list holds 65. Cosmetic, but the ledger
+    should carry the block's numbers, not the prose.
+  the_pattern_that_matters: >-
+    All seven of my id corrections move the same way, and the cause is not
+    carelessness — the researcher's raw derivation is reproducible almost line
+    for line and its availability work is flawless. The cause is that it applied
+    its own criterion inconsistently: it called `id: defective` for bmw/k's
+    family duplicate, honda/tact's suffix twin and yamaha/yq50's nameplate twin,
+    then called `correct` for husqvarna/901-norden's outright permutation and
+    royal-enfield/hunter's displacement twin. Batch 1's verifier diagnosed
+    exactly this and wrote the fix — "run the FINDING-A scan over the sampled
+    record's make FIRST and require a written reason for every sibling it
+    nominates. It takes minutes and it is the difference between 13% and 18%."
+    Batch 3 reports 13% and corrects to 19%. THE RECOMMENDATION WAS NOT ADOPTED,
+    and it is worth asking whether batches 2 and 4 adopted it either.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# VIEW ON THE THREE CANDIDATE CLASSES
+# ═══════════════════════════════════════════════════════════════════════════
+candidate_classes_assessment:
+  descriptor-as-model:
+    real: yes
+    novel: "YES — verified that name_shapes.yml has no bucket for it."
+    correctly_scoped: "NO — 22 measured, ~32 with a complete lexicon; and the
+                       legit fraction is ~50%, not a minority. See target_2a."
+    recommendation: "File, with the corrected count and the legit/artifact split
+                     performed BEFORE the entry lands (I-15). The detector spec
+                     is sound as a WORKLIST and must never emit a verdict."
+  rename-fabricated-availability:
+    real: "as a MECHANISM yes; as a defect class, barely"
+    novel: yes
+    correctly_scoped: "NO — its worked example is refuted, its general form uses
+                       a string test where an identity-set test is required, and
+                       the measured live population is ~1-2 records (one of which
+                       batch 1 already filed by another route). See target_1."
+    recommendation: "Downgrade from 'new defect class' to a cheap standing
+                     detector with the NARROW-vs-NAME test attached. Do not open
+                     a taxonomy category for two records."
+  bare-family-code-2W:
+    real: yes
+    novel: "PARTLY — new to name_shapes.yml, but it is the alpha-prefix form of
+            the family-rollup policy question verify-b1.yml already left open."
+    correctly_scoped: "NO — 122 records measured against 2 found + 6 also_visible.
+                       Both named examples confirm. See target_2b."
+    recommendation: "Merge into ONE ruling with batch 1's unresolved family-rollup
+                     item rather than filing a second, separate class. The
+                     detector is good and cheap; the population needs the same
+                     legit/artifact split as the other two."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# NEW QUEUE ITEMS surfaced by verification (none is a sampled claim)
+# ═══════════════════════════════════════════════════════════════════════════
+queue_items:
+  - "motorcycle/bmw/r51-2 'R51-2' and motorcycle/bmw/r75-7 'R75-7' — two more
+     airhead slash leaks the researcher missed. 6 of 17 designation records are
+     wrong; fix as a RULE, not as two more hand-written rename keys."
+  - "moped/sym/ad05w vs moped/sym/jet4, and moped/sym/aw05w vs moped/sym/fiddle-ii
+     — same-kind duplicates, resolved outright by uk_dft's own Model column
+     ('AD05W JET 4 50', 'AW05W FIDDLE II 50 S')."
+  - "motorcycle/husqvarna/{901-norden, norden-901, 901} — three ids, one
+     motorcycle; and the same shape at husqvarna/{801-svartpilen, svartpilen-801}."
+  - "motorcycle/honda/cb600f-cb600s 'CB600F/CB600S' — a register chimera
+     ('CB600F/CB600S' n=2 in nl) published as its own id beside cb600f and cb600s."
+  - "motorcycle/harley-davidson/davidson-fat-boy 'Davidson Fat Boy' [fi,nl] —
+     strip_make_prefix removed only 'HARLEY' from 'HARLEY DAVIDSON FAT BOY'.
+     A make-prefix-strip defect with a live published id."
+  - "motorcycle/talaria/tl 'Tl' [gb] — bare-family-code from GenModel
+     'TALARIA TL', pooling TL 2500 / 3000 / 4000 / 5500 which the DfT's own
+     Model column distinguishes."
+  - "No live moped/talaria/sting-r, while uk_dft carries 'TL 4000 STING R'
+     (12+19) — a real nameplate with nowhere to land."
+  - "uk_veh0120_uk.csv is not clean UTF-8 (invalid byte at line 93,444). Add to
+     the silent-failure note beside fi_traficom's ISO-8859 trap."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WHAT I COULD NOT SETTLE
+# ═══════════════════════════════════════════════════════════════════════════
+unresolved:
+  - item: "moped/yamaha/booster make + name"
+    what_would_settle: "A Yamaha Motor Europe/Netherlands brochure or price list
+                        for a Yamaha-badged 'Booster', or the RDW SODA live API
+                        queried for the TAN on the YAMAHA|BOOSTER row against the
+                        MBK|BOOSTER rows (NAMING.md §2 rank 1). My cached extract
+                        does not carry nl_rdw TANs."
+  - item: "motorcycle/bmw/r90-6 — a fetchable marque page"
+    what_would_settle: "bmwgroup-classic.com responding. Three attempts across
+                        two hosts failed for me and two for the researcher. The
+                        verdict does not need it; the LEDGER CITATION does."
+  - item: "motorcycle/ducati/m797 — the M797 <-> Monster 797 link specifically"
+    what_would_settle: "A ducati.com parts or archive page naming MOD M 797. The
+                        M-code class is proven in-register for seven other
+                        displacements; 797 alone is reached by convention."
+  - item: "moped/elmoto/hr-2 (fi) — the one unexamined rename-narrowing candidate"
+    what_would_settle: "Whether Elmoto markets more than the HR-2. If it does,
+                        `Elmoto: Elmoto -> HR-2` narrows and the fi availability
+                        entry (n=1) is the class's only unfiled live instance."
+  - item: "Whether batches 2 and 4 adopted batch 1's id-scan recommendation"
+    what_would_settle: "A cross-batch check before RESULTS.md aggregates. If the
+                        under-call is systematic across all four batches, the
+                        published id-defect rate is low by roughly a third and
+                        the correction is not per-batch."

--- a/data/review/audit-v2026.07.5/ledger/verifier-b4.yml
+++ b/data/review/audit-v2026.07.5/ledger/verifier-b4.yml
@@ -1,0 +1,982 @@
+# PRD-FIVE-NINES Workstream A2 — BATCH 4 INDEPENDENT VERIFICATION
+# tag v2026.07.5, S2W half.  Invariant I-11 satisfied: researcher ≠ verifier.
+# verifier: opus5/audit-b4-verifier    researcher: opus5/audit-b4 (result-b4.yml)
+# READ-ONLY run. Nothing written outside <scratchpad>/vb4 and this file. No git.
+#
+# ═══════════════════════════════════════════════════════════════════════════
+# METHOD — what I re-derived, and how independently
+# ═══════════════════════════════════════════════════════════════════════════
+# I did NOT read or run the researcher's scripts, and I did NOT use its
+# all_raw.txt / gb_genmodel.txt / avail_report.txt. I wrote my own flattener
+# straight from the adapters in pipeline/sources/*.rb:
+#   vb4/flat.rb   -> vb4/myraw.tsv, 87,399 two-wheel (country, kind, make,
+#                    model, count) groups:
+#                      nl 55,491 (bromfiets + motorfiets + zijspan + driewielig)
+#                      nz 12,214 · fi 7,858 · gb 4,116 · ua 3,379 · es 2,126
+#                      lu 1,336 · th 879
+#                    es carries its DGT category code per row (bytes 426/3),
+#                    lu its CATEU, so kind is re-derived, never inherited.
+#                    Independent corroboration: my es group count (2,126) is
+#                    identical to the batch-1 verifier's independent count.
+#   vb4/avail.rb  -> own availability matcher (make-alias resolve, make-prefix
+#                    strip, renames-by-normalised-key, alnum-upper compare)
+#   vb4/avail2.rb -> the CONVERSE scan (unclaimed evidence), all 8 countries
+#   vb4/dup.rb    -> own duplicate scan: same-slug-cross-kind, token
+#                    permutation, token subset/superset, substring
+#   vb4/f1.rb     -> catalog-wide bare-numeric census (F1)
+#   vb4/f2.rb     -> catalog-wide token-boundary-shift census (F2)
+#   vb4/f5.rb, f5b.rb -> descriptor_as_model census under three vocabularies
+#   vb4/crosskind.rb  -> catalog-wide moped∩motorcycle census (F3)
+# Ruby 3.4 with Encoding.default_external forced to UTF-8 (LC_ALL=C breaks
+# Ruby's JSON reader on the RDW files — a different failure from the grep one
+# the researcher documented; both are real, they are not the same bug).
+#
+# SAMPLING vs the brief:
+#   defective verdicts        100% re-derived (39/39)
+#   self-flagged weak calls   100% (all 17 entries of
+#                             suspected_defects_for_the_verifier_to_attack)
+#   availability              100% re-derived (237/237, not the required 20%)
+#   id `correct`              100% re-scanned with my own duplicate detector
+#   name correct/unverifiable 12 marque/authority sources fetched
+#   enrichment (§6.2)         2/2 attempted; 1 completed, 1 partial —
+#                             the researcher completed 0/2
+#
+# SAMPLE INTEGRITY: all 100 ids are members of
+# data/review/audit-v2026.07.5/SAMPLE-s2w.yml (400 ids, 400 unique).
+# Zero fabricated, zero outside the seeded sample, zero duplicated.
+# AVAILABILITY-LIST INTEGRITY: for all 100 records the countries recorded in
+# result-b4.yml are EXACTLY the countries in build/out/catalog — zero drift.
+
+headline:
+  defective_claims_re_derived: 39
+  upheld: 37
+  overturned: 2          # both cross-kind id calls: sym/fiddle, silence/s01
+  additional_defects_found_among_claims_called_correct: 6   # all id-canonical
+  additional_notes_found: 1
+  availability: "237/237 UPHELD — independently re-derived, zero corrections"
+  net_effect: >-
+    The researcher's conservative clean rate is marginally OPTIMISTIC, not
+    conservative: 87.8% -> 87.3% over audited claims. But the number is not the
+    story. The story is that FOUR of the nine findings are materially
+    understated in scope (F1 by ~10x, F2 by ~14x, F3 by ~18x, F6 by ~50x)
+    while THREE of the batch's most confident dispositions are wrong in the
+    same direction: it applied its own duplicate criteria inconsistently, and
+    it split its own cross-kind pair the wrong way round. Its honesty
+    discipline is the best of the round — the 43/100 name disclosure, the two
+    self-caught false positives, the "evidence pushed back" note on Sparta —
+    and I have preserved all of it. Its ARITHMETIC is not: claims_total is
+    wrong by 100.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# THE EIGHT ATTACK TARGETS
+# ═══════════════════════════════════════════════════════════════════════════
+
+target_1_moped_honda_mt5:
+  question: "MT50 = MT5 was asserted BY ANALOGY with MB50/MB5. Analogy is forbidden. Source it or overturn."
+  verdict: "UPHELD — but the evidence is REPLACED, not confirmed. The analogy is
+            gone; a Honda EPC record now carries the claim."
+  what_i_could_not_do: >-
+    cmsnl.com returns HTTP 403 to WebFetch, so I could re-fetch NEITHER of the
+    researcher's two MB50/MB5 citations. The anchor of its analogy is, for me,
+    unverifiable — which is a second reason the analogy could not stand.
+  the_replacement_evidence:
+    - "https://oem-parts.hu/en/parts/honda/0-124cc/mt-50-mt5 — a Honda EPC
+       (electronic parts catalogue) mirror. The catalogue FAMILY is titled
+       'MT 50 MT5' and the breadcrumb reads 'HONDA < 124cc MT 50 MT5'."
+    - "Model records inside it, verbatim: 'MT50S (A) MT-5 1980', 'MT50FL MT-5
+       1990', 'MT50SL MT50 1990', 'MT50SM MT50 1991', 'MT50FP MT-5 1993',
+       'MT50SP MT50 1993', 'MT50ST MT50 1996'."
+  why_this_is_stronger_than_analogy: >-
+    The EPC pairs the SAME type-code stem (MT50xx) with TWO market names in the
+    SAME year — 'MT50FL MT-5 1990' beside 'MT50SL MT50 1990'. That is the
+    signature of one machine sold under two market names, which is the
+    proposition. It is not inferred from the MB case; it is read off the
+    catalogue.
+  in_data_corroboration_i_re_derived: >-
+    nl_rdw bromfiets under HONDA: MT5 175, 'MT 5' 45, 'MT-5' 56 (= 276) against
+    MT50 51, 'MT 50' 21, 'MT-50' 2, MT50S 8, 'MT50 S' 7, MT50SL 2, MT50SA/SE/SH
+    1 each (= ~94). nz MOPED: MT5 5, 'MT 5' 2, MT50 21, 'MT 50' 3. Two spelling
+    families, same machine, both live as ids.
+  residual_doubt_stated_plainly: >-
+    oem-parts.hu is an EPC MIRROR, not a Honda-controlled domain, and I could
+    not reach a honda.co.uk / Honda-controlled archive for a 1980s 50cc moped.
+    If the ledger requires marque-controlled sourcing for an id-level fold, this
+    is UNRESOLVED and the honest verdict is `unverifiable`. What would settle
+    it: a Honda UK brochure or Honda EPC screenshot naming "MT50 / MT-5".
+  note_on_the_sibling_finding: >-
+    The researcher's SECOND finding on moped/honda/mb — that moped/honda/mb5 and
+    moped/honda/mb50 are one machine — inherits the same cmsnl problem. I
+    confirm both ids are live (plus motorcycle/honda/mb5), and I confirm its
+    warning that MB-8/MB80 (nl motorcycle 278+47+35+13+26, 79cc) is a genuinely
+    different bike. The MB/MB5/MB50 verdicts stand on the register's own
+    truncation argument; the MB50=MB5 equivalence is UNRESOLVED for me.
+
+target_2_F7_homologation_codes:
+  honda_adv750:
+    verdict: "UPHELD. Re-fetched."
+    evidence: "https://webom.hondamotopub.com/webom/HMEE/MKT250/html/index.html
+               — Honda's own owner's-manual portal, page title verbatim:
+               'X-ADV (ADV750) | Honda Owners Manual'."
+    scale_i_re_derived: "nl 2452 + 'HONDA ADV750' 1 · es 649(L3E)+6(*07)+3(*06)
+                         · lu 11 · ua 33 · gb GenModel 'HONDA ADV750' 1053 +
+                         'HONDA ADV 750-T' 155 · nl 'ADV 750' 2. motorcycle/
+                         honda/x-adv holds nl 1 + 'HONDA X-ADV 750' 1 + th 869
+                         + ua 3."
+  yamaha_mtn890_s:
+    verdict: "UPHELD, and on the strongest evidence in the batch."
+    evidence:
+      - "https://cdn2.yamaha-motor.eu/prod/owner-manuals/Motorcycles/PB7N28199E0E.PDF
+         — Yamaha's own EU CDN. I extracted the PDF text: line 52 is literally
+         'MTN890 (MT-09)', and line 88 reads 'As the owner of the MTN890…'."
+      - >-
+        IN-DATA, which the researcher did not use and which is decisive on its
+        own: nl_rdw's OWN model column pairs the code with the nameplate for the
+        whole family — 'MTN1000 (MT-10)' 101+227, 'MTN320-A (MT-03)' 171,
+        'MTN690-A (MT-07)' 1220, 'MTN850-A (MT-09 ABS)' 1168+561,
+        'MTN850D (MT-09SP)' 204+249, 'MTM690 (XSR700)' 54, 'MTM850 (XSR900)'
+        190, 'MTT850D (TRACER900 GT)' 1520, 'MTT690-A (TRACER 700)' 396. The
+        register writes the mapping itself.
+    a_complication_the_researcher_missed: >-
+      TAN evidence cuts across the fold. catalog xrefs.tan: yamaha/mt-09 carries
+      e13*2002/24*0643*00/01 (the pre-2016 framework directive); mtn850-a
+      carries e13*168/2013*00002*05 and mt-09abs carries *00002*03/04 — i.e.
+      MTN850-A and MT-09 ABS share a type approval, which is an in-data proof of
+      THAT pair. mtn890 carries e13*168/2013*00867/*01865 and mtn890-s carries
+      *01962 — different approvals from mt-09 and from each other. So the fold
+      target is the MT-09 NAMEPLATE across generations, not the live mt-09
+      RECORD, whose approval is two generations older. That does not change the
+      verdict (SCHEMA puts generations below model) but it does change the fix.
+  suzuki_gsx800:
+    verdict_on_name: "UPHELD (defective / code_string). suzukicycles.com names
+                      only GSX-8S and GSX-8R; no Suzuki page carries 'GSX800'."
+    verdict_on_the_id_caution: >-
+      UPHELD AS A VERDICT, REFUTED AS A REASON. `unverifiable` is right, but not
+      because pooling is evidenced — because no Suzuki-controlled source
+      publishes the code at all. The pooling risk is NOT visible in the data:
+      (a) the corpus contains no 'GSX800 (8R)', no 'GSX800R', no 8R-shaped code
+      anywhere; the 8R appears only under its marketing name, th 'GSX-8R' 2 and
+      ua 'GSX8R' 5; (b) the catalog's own TANs group GSX800 with GSX800T
+      (both e6*168/2013*00138*03) and GSX800U with GSX800TU (both *00139*),
+      i.e. full-power vs A2-restricted approvals — no third grouping for an 8R;
+      (c) secondary reporting of the certification filings has the 8R filed as
+      'GSX800 (8R)' and the 8S as bare 'GSX800'
+      (https://www.motorcycle.com/bikes/new-model-preview/suzuki-gsx-8r-confirmed-in-certification-filings-44594464).
+      So the honest statement is "GSX800 is very probably the GSX-8S alone", and
+      the blocker is a missing Suzuki source, not an unresolvable pool.
+  the_scope_correction_that_matters: >-
+    F7 is presented as "three proven instances". The class as it stands in the
+    catalog is 48 live ids, not 3. Yamaha alone publishes 42 type-code ids:
+    mtm{125,125-c,690,690-u,690d,850,890,890-u,890d,890d-u} (10),
+    mtn{1000,1000d,125-a,320-a,690,690-a,690-s,690-su,690-u,850-a,890,890-s,
+    890-su,890-u,890d,890d-u} (16),
+    mtt{690,690-a,690-s,690-su,690-u,690d,690d-s,690d-su,690d-u,850d,890,890-s,
+    890d,890d-k,890d-s,890d-sk} (16). Suzuki adds gsx800/800t/800tu/800u (4);
+    Honda adds adv750 and adv350a (2). Every one of them sits beside a
+    marketing-name id or a marketing-name raw. The researcher's detector spec
+    (name matches /[A-Z]{2,4}\d{2,4}/ AND xrefs.tan present) would find them;
+    it should have been run, and the finding sized, before the class was filed.
+
+target_3_F3_cross_kind_duplicates:
+  vespa_50_special:
+    verdict: "UPHELD (id defective, kind defective). Premise now sourced."
+    evidence:
+      - "https://www.museopiaggio.it/en/models/1-vespa/27-50-special-elestart-v5a3t
+         — the Piaggio Museum gives the Vespa 50 Special (Elestart, V5A3T)
+         '49,77 cc', 2-stroke. Under 50 cc: moped in every EU register."
+      - "https://press.piaggiogroup.com/en_EN/post/show/109335/vespa-history-1946-2018.html
+         — Piaggio's own history: the Special launched 1969, made until 1982."
+      - "raw (mine): nl BROMFIETS '50 SPECIAL' 194, 'VESPA 50 SPECIAL' 39,
+         '50  SPECIAL' 1, '50-SPECIAL' 1 · nz MOPED '50 SPECIAL' 1 ·
+         nl MOTORFIETS '50 SPECIAL' 2 · gb 'VESPA (DOUGLAS) 50 SPECIAL' 128."
+    two_factual_errors_in_the_finding_text:
+      - "F3 cites 'lu_snca L1e-A 3' on the moped side. There are ZERO Luxembourg
+         rows for any Vespa Special in my derivation, and lu appears in neither
+         record's availability. That number is not in the data."
+      - "F3 writes the nl bromfiets counts as '194+39+11+1'. I find 194, 39, 1,
+         1 (plus '50N SPECIAL' 3 and 'SPECIAL 50' 2, which normalise elsewhere).
+         There is no 11."
+    why_those_errors_matter: >-
+        The share arithmetic (~34%/66%) is the load-bearing claim — it is what
+        shows cross_kind_prune cannot fire. Corrected shares are 130/365 = 36%
+        and 235/365 = 64%: the conclusion survives, the numbers behind it do not
+        reproduce, and a finding that will become a taxonomy entry must.
+  sym_fiddle:
+    verdict: "OVERTURNED. id defective -> id CORRECT (at most a note)."
+    why: >-
+      es_dgt settles it in-data, using the register's OWN category codes plus
+      the displacement the model string carries: '*02 SYM FIDDLE 50 E5+' 73 and
+      '*02 SYM FIDDLE 50 E5' 1 (moped class) against '*05 SYM FIDDLE 125 E5' 3
+      (motorcycle class). nz adds MOPED 'FIDDLE 50' 3 against MOTORCYCLE
+      'FIDDLE III' 13. SYM's own site confirms both displacements exist
+      (https://www.sym-global.com/fiddle — Fiddle 50; Fiddle 125 / Fiddle 125
+      Liquid Cooled).
+      The motorcycle-kind record's evidence is NOT a uk_dft artefact: nl 110,
+      nz 15, ua 4, fi 1, lu 1 all sit in the motorcycle class independently of
+      gb's 1363. Two real products, two kinds, two ids. id-canonical asks
+      whether another live id denotes the SAME vehicle; here it does not.
+    the_researcher_saw_this: "It wrote 'Verifier should probably downgrade to a
+      note.' It was right and should have made the call itself."
+  silence_s01:
+    verdict: "OVERTURNED. id defective -> id CORRECT (curation-decided)."
+    why_the_researcher_is_backwards_here: >-
+      overrides/models/renames.yml, Silence block, verbatim:
+        S01LS: S01   # L1e (45 km/h, 4 kW) version of the S01 — same nameplate,
+                     # kind captures the class; intentionally CREATES the
+                     # moped-kind S01 beside the L3e motorcycle record
+      The moped twin is not noise: it is a DOCUMENTED, DELIBERATE decision, and
+      the protocol's deliberate-decision rule makes it a note. The factual claim
+      behind the "noise" reading is also wrong — the researcher says the moped
+      id survives on "a single nl bromfiets row". My derivation: nl BROMFIETS
+      'S01LS' 180 + 'S01' 1, es '*02 S01LS' 1, i.e. 182 vehicles arriving
+      through that rename, not one.
+      And the Silence S01 LS is a real L1e product: Silence's range is S01
+      (L3e, 7 kW, 125-equivalent) and S02 / S02 LS (2 kWh, 50-equivalent), with
+      LS = Low Speed
+      (https://archive.scooterlab.uk/electric-silence-uk-s01-s02-long-range-road-test/,
+      https://www.urban-ecomobility.com/en/shop/silence-s01-l3e-125-cc-134383).
+      So this pair is the SAME shape as SYM Fiddle, which the researcher called
+      defensible. Its discriminator ("SYM legitimate, Silence noise") is
+      inverted on the Silence half.
+  the_measurement_it_declined_to_make:
+    what_i_measured: "vb4/crosskind.rb over build/out/catalog"
+    result_1: "97 (make_id, slug) pairs are live in BOTH moped and motorcycle."
+    result_2: >-
+      18 of the 97 have a motorcycle side that is gb-ONLY — the researcher's own
+      proposed high-precision signature: aprilia/rx50, aprilia/sx50, cpi/aragon,
+      derbi/gpr-50, e-max/lb1, honda/nps50, honda/sfx50, honda/sh50,
+      keeway/f-act, mash/fifty, peugeot/ludix, peugeot/trekker, rieju/mrt,
+      rieju/rs2, sur-ron/light-bee, suzuki/ay50, sym/mask, yadea/g5.
+      Seven of the eighteen carry "50" IN THE SLUG, which makes them
+      unarguable: a model whose own name is 50 cannot be a motorcycle identity.
+    result_3_the_detector_spec_is_broken: >-
+      The spec's decisive flag is "uk_dft is the ONLY motorcycle-side source".
+      motorcycle/vespa/50-special — the instance the whole finding is built on —
+      has gb AND two nl motorfiets rows, so it FAILS its own high-precision
+      test. The spec must be "uk_dft-dominant" with a threshold, not
+      "uk_dft-only", or it misses its own founding case.
+    result_4: >-
+      moped/yadea/g5 is in THIS BATCH and the researcher called its id `correct`
+      — see the overturns section. It noticed the gb GenModel and concluded
+      'its absence from availability is correct', without checking whether the
+      gb rows had minted a second id. They had: motorcycle/yadea/g5, gb-only.
+
+target_4_F2_fxstsse_token_boundary:
+  verdict: "UPHELD, and materially understated. This is the batch's best finding."
+  confirmation_from_raws_mine:
+    - "nl 'FXSTSSE3 CVO SOFTAIL SPRINGER' 8, 'FXSTSSE3 CVO SOFTTAIL SPRINGER' 1,
+       'HARLEY D FXSTSSE3' 1"
+    - "fi 'FXSTSSE3 CVO Softail Springer' 2 · nz 'FXSTSSE3' 3"
+    - "grep -c '3CVO' over all 87,399 two-wheel raw groups: 0. Nothing in any
+       corpus supports the published token boundary."
+    - "published: id `motorcycle/harley-davidson/fxstsse-3cvo-softail-springer`,
+       name 'Fxstsse 3CVO Softail Springer'. The SLUG carries the error."
+  genuinely_distinct_from_the_filed_collapse_debt: "CONFIRMED, on two grounds,
+    both checked against data/name_shapes.yml:295-303 —
+      (1) that entry is scoped `max_sources: 1`; this record has two sources
+          (fi_traficom + nl_rdw), so the lint that reads the debt cannot see it;
+      (2) that entry is explicitly framed as DISPLAY-only ('correct as a JOIN
+          KEY, but the collapsed key is also used as the DISPLAY name'). Here
+          the join key itself is wrong."
+  the_scope_correction:
+    method: "vb4/f2.rb — flag any published 2W name containing a token matching
+             /\\A\\d[A-Za-z]{2,}\\z/, then look for raws under the same make with
+             the identical alnum sequence and different token boundaries."
+    result: "29 records carry the signature; 14 have raws that prove the shift."
+    nine_code_shape_instances_all_harley_all_multi_source:
+      - "flhtcuse-4cvo-ultra-classic-electra-glide   raw 'FLHTCUSE4 CVO …' nl 21 / fi 8"
+      - "flhtcuse-5cvo-ultra-classic-electra-glide   raw 'FLHTCUSE5 CVO …' nl 5 / fi 4"
+      - "flhtcuse-6cvo-ultra-classic-electra-glide   raw 'FLHTCUSE6 CVO …' nl 17 / fi 3"
+      - "flhtcuse-7cvo-ultra-classic-electra-glide   raw 'FLHTCUSE7 CVO …' nl 11 / fi 4"
+      - "flhtcuse-8cvo-ultra-classic-electra-glide   raw 'FLHTCUSE8 CVO …' nl 4 / fi 1"
+      - "flhxse-2cvo-street-glide                    raw 'FLHXSE2 CVO …'   nl 29 / fi 3"
+      - "flhxse-3cvo-street-glide                    raw 'FLHXSE3 CVO …'   nl 28 / fi 3"
+      - "fltrse-3cvo-road-glide                      raw 'FLTRSE3 CVO …'   nl 15+1 / fi 4"
+      - "fxstsse-3cvo-softail-springer               (the sampled record)"
+    five_nameplate_shape_instances_worse_because_they_are_current_products:
+      - "motorcycle/triumph/rocket-3gt 'Rocket 3GT' — raws 'ROCKET 3 GT' 92+7,
+         'Rocket 3 GT' 23. Triumph's own site renders 'Rocket 3 GT'
+         (https://www.triumphmotorcycles.com/motorcycles/rocket-3/rocket-3/rocket-3-gt/specification)."
+      - "motorcycle/triumph/rocket-3gt-triple-black — raws 'ROCKET 3 GT TRIPLE BLACK' 15 / 'Rocket 3 GT Triple Black' 3"
+      - "motorcycle/triumph/rocket-3tfc 'Rocket 3TFC' — raws 'ROCKET 3 TFC' 13 / 'Rocket 3 TFC' 2"
+      - "motorcycle/yamaha/tracer-9gt 'Tracer 9GT' — raws 'TRACER 9 GT' 27+17, 'TRACER 9 GT+' 27"
+      - "motorcycle/yamaha/fazer-8abs 'Fazer 8ABS' — raws 'FAZER 8 ABS' 3+2"
+      - "(plus moped/giant/explore-e-1pro 'Explore E+ 1PRO' — raws 'EXPLORE E+1 PRO' 260)"
+    consequence: >-
+      The class is 14 records, not 1, and 5-6 of them corrupt the display name
+      of a bike currently on sale. The researcher's detector spec is correct and
+      cheap — I implemented it in about 20 lines and it found all of them in
+      under a second. It should ship with a count, not as a singleton.
+  a_control_the_researcher_should_get_credit_for: >-
+    The same scan finds the OPPOSITE direction working correctly — triumph/3ta
+    ('3 TA' 194 raws -> '3TA'), triumph/5ta, yamaha/4km/4tx/4vr/3tb, triumph/3hw
+    — i.e. ordinary collapse, correctly filed under the existing debt. The two
+    shapes really are different, exactly as claimed.
+
+target_5_F5_descriptor_as_model:
+  is_the_line_drawn_correctly: "YES in principle, and the researcher's `do_not`
+    ('never auto-drop on the vocabulary alone') is the right rule. But the
+    enumeration is incomplete and one of its five 'verified NOT defects' does
+    not survive checking."
+  triumph_chopper:
+    verdict: "UPHELD, on evidence far stronger than the researcher offered."
+    the_researchers_argument: "'Triumph has never sold a Chopper' — a negative,
+      asserted, unsourced."
+    my_argument_which_is_positive_and_in_data: >-
+      nl_rdw uses CHOPPER as its model string for BUILD TYPE, not for a
+      nameplate. Under makes that are self-evidently not marques:
+      EIGENBOUW ('self-build', Dutch) 210 + CHOPPER HARDTAIL 2 + CHOPPER 1340 1
+      + CHOPPER SWINGARM 2 + CHOPPER HD 1 + CHOPPER HONDA 1 + CHOPPER LEGEND 1;
+      CUSTOM CYCLE 53; HARDTAIL 6; ASSEMBLED 1; AMEN 1; BOBSHOP 1; DW CUSTOM 1;
+      C.ENJ.CUSTOM CYCLER 1+1; DRAG SPECIALITIES 1; CHALLANGER 2; ASVE 2.
+      And under real marques: HARLEY DAVIDSON 5 (+ 'CHOPPER HARDTAIL 1200' 1),
+      HONDA 1 (+ 'CHOPPER 750' 1, 'CHOPPER 750 F2' 1, 'CHOPPER L.750' 1).
+      nz adds 'TRIUMPH | 650 CHOPPER' 1 beside the bare 'TRIUMPH | CHOPPER' 1 —
+      the register describing a chopped Triumph 650.
+      The Triumph row (nl 1 + nz 1) sits inside that population. That is the
+      finding, and it generalises: the descriptor class is visible as a
+      make-independent register HABIT, which is a much better detector signal
+      than a closed vocabulary.
+  the_counter_examples_re_checked:
+    big_dog_chopper: "PARTLY REFUTED as cited. Big Dog's own current model page
+      (https://bigdog.net/motorcycles) lists Bulldog, K9 and Mastiff and uses
+      'chopper' as a STYLING word ('Timeless chopper styling'). The model did
+      exist: a 'Chopper' was catalogued 2003-2011 and appears in a US federal
+      recall record as 'BIGDOG CHOPPER 2004'
+      (https://auto-recalls.justia.com/bigdog/chopper/2004/03v535000), and the
+      raws carry 'K9 CHOPPER' 2 (https://shop.bigdog.net/k9/). Legit
+      historically; NOT legit from the marque page."
+    boom_chopper: "UPHELD. The raws show a whole Boom Chopper family —
+      CHOPPER 64, CHOPPER 3, CHOPPER 3I, CHOPPER 4I, CHOPPER A2, CHOPPER A22,
+      HIGHWAY CHOPPER 2, TRIKE CHOPPER 1, BOOM TRIKES CHOPPER C2 1 — which no
+      body-style habit produces."
+    rewaco_chopper: "UPHELD. Raws 'REWACO CHOPPER' 19, 'CHOPPER' 9, 'HS4
+      CHOPPER' 1, fi 1; Rewaco's Chopper Series HS4 is a documented model line."
+    mash_cafe_racer: "UPHELD. Raws 'CAFE RACER 250' 10 beside 'CAFE RACER' 7,
+      gb 'MASH CAFE RACER' 23, lu 'CAFÉ RACER' 3 — Mash markets a Cafe Racer
+      125/250."
+    ossa_trial: "DISPUTED. UNRESOLVED, and I do not accept 'NOT a defect,
+      verified'. Ossa's trials machines are the MAR / Mick Andrews Replica and
+      its successors; no source I reached names a bare 'Trial' Ossa
+      (https://cars.bonhams.com/auction/20254/lot/90/c1976-ossa-244cc-mar-trials-motorcycle-frame-no-b-560007-engine-no-m-560007,
+      https://www.motorcyclespecs.co.za/model/Classic/ossa_mick_andrews.html).
+      The raws are '250 TRIAL GORGOT' 2 and '350 TRIAL 80' 9 — Trial used as a
+      discipline word beside a displacement — against a bare 'TRIAL' nl 1 + nz 1.
+      That is the SAME 2-vehicle / 2-source shape as triumph/chopper. Batch 3
+      independently listed ossa/trial in its descriptor worklist, i.e. the two
+      batches disagree about this record. It should be researched, not cleared."
+  reconciliation_with_batch_3:
+    b3_proposed: "`descriptor-as-model`, proposed_category `descriptor_as_model`,
+      measured_catalog_wide_2W: 22, with a 22-id worklist (result-b3.yml:989-1015)."
+    b4_proposed: "`descriptor_as_model`, '~15 tokens, so this is ~13 human calls'."
+    are_they_the_same_class: "YES — same name, same proposed category, same
+      'must split before fixing' caveat, reached independently. That is strong
+      corroboration and the round should say so."
+    why_the_counts_differ_and_what_the_real_number_is: >-
+      Neither count is the class size; both are artefacts of the VOCABULARY each
+      batch chose. I re-measured both, whole-name match, over build/out/catalog
+      (vb4/f5b.rb):
+        * b4's vocabulary (chopper, trike, scooter, moped, motorcycle, custom,
+          cruiser, tourer, quad, cafe racer, sidecar, bobber, streetfighter,
+          naked) -> 16 bare-name records, not '~13'. b4 missed
+          harley-davidson/motorcycle, francis-barnett/cruiser,
+          riese-und-mueller/cruiser, ducati/streetfighter, unu/scooter
+          (it found unu later, in avail-blast-radius.yml).
+        * b3's vocabulary (scooter, electric scooter, moped, motorcycle, trial,
+          enduro, cross, custom, sport, touring, naked, cruiser, dual sport)
+          -> 25 bare-name records, close to its stated 22. b3 has the entire
+          'Electric Scooter' cluster (citycoco, mademoto, qroad, scogo, shansu,
+          smarda, yuhanzhen — 7 makes) which b4 missed completely, and the
+          sport/touring family which b4 missed completely.
+        * The UNION, whole-name match over a 28-token vocabulary -> 58 live 2W
+          records.
+      RECOMMENDATION: file ONE entry, with b3's category-lexicon construction
+      (derived from each source's own kind/body vocabulary — that is principled)
+      EXTENDED by b4's body-style tokens (chopper, trike, cafe racer, bobber,
+      streetfighter, sidecar). Publish the lexicon with the entry, because the
+      count is meaningless without it.
+    the_false_positive_rate_argues_for_both_batches_caution: >-
+      Of the 18 records b4's own vocabulary catches, at least four are genuine
+      nameplates: ducati/streetfighter (Streetfighter V4/V2 is a current Ducati
+      model), ducati/streetfighter-848, francis-barnett/cruiser (Francis-Barnett
+      marketed a Cruiser), and the three legitimate Choppers. That is ~40%
+      false positives on a 14-token vocabulary — which is the strongest
+      possible argument for 'never auto-drop', and neither batch quantified it.
+
+target_6_rudge_special_vs_moto_guzzi_special:
+  verdict: "BOTH UPHELD. The asymmetry is real and correctly reasoned."
+  rudge_special_correct:
+    evidence:
+      - "https://www.rudge-whitworth.com/the-motorcycles/model-history — the
+         marque site's own model history treats Special as a MODEL, distinct
+         from Ulster: '500cc gearbox internal ratios standardised (no longer
+         different for Special and Ulster)' (1934); 'Special engine capacity
+         changed to 495cc from 499cc' (1936). 'Sports Special' is separately
+         introduced in 1937, i.e. the site distinguishes Special from Sports
+         Special."
+      - "raw (mine): nl 'RUDGE | SPECIAL' 7 · nz 'RUDGE | SPECIAL' 3 +
+         'RUDGE WHITWORTH | SPECIAL' 2 · fi 1. The same registers carry ULSTER,
+         MULTI, SPORT, 'SPORTS SPECIAL', '250 RAPID', 'ULSTER GRAND PRIX' as
+         separate strings — the register is naming models, not trims."
+  moto_guzzi_special_defective:
+    evidence:
+      - "https://www.motoguzzi.com/us_EN/models/v7/v7-special-850-transversal-90-v-twin-2026/
+         — the marque's own current model page is 'V7 Special 850'. The badge is
+         always qualified."
+      - "raw (mine): nl 'V 7 SPECIAL' 318+22, 'V7 SPECIAL' 75+11+1,
+         'V7 III SPECIAL' 9, 'V7 750 SPECIAL' 1+1, 'CALIFORNIA SPECIAL' 52+3+1,
+         'V750 SPECIAL' 1 · gb 'MOTO GUZZI V7 SPECIAL' 337 · es 7 · lu 2 · nz
+         'V7 SPECIAL' 2 + 'V7 750 SPECIAL' 1 — against a bare 'SPECIAL' of
+         nl 1 + nz 1."
+    the_pooling_is_worse_than_stated: >-
+      The researcher names two candidate parents (v7-special, v7-750-special).
+      There are at least FOUR: motorcycle/moto-guzzi/{v7-special, v7-750-special}
+      are live, the register also carries V7 III Special, and
+      motorcycle/moto-guzzi/california plus eight california-* ids are live
+      while 'CALIFORNIA SPECIAL' is a 56-vehicle raw string. The disposition is
+      blocked harder than the finding says.
+  the_general_lesson_stands: >-
+    Identical string, opposite verdicts, settled by the MARQUE and not by the
+    string. This pair is the correct worked example for any future bare-trim
+    detector and I would put it in the taxonomy entry verbatim.
+
+target_7_velosolex_5000_and_the_bare_displacement_list:
+  velosolex_5000_name_correct:
+    verdict: "UPHELD."
+    evidence:
+      - "https://www.velosolexclubuk.com/information-available-solex-models —
+         the marque club's model list: 45cc, 330, 660, 1010, 1400, 1700,
+         S 2200 V1 & V2, S 3300, S 3800, 4600 v1, 5000. The bare number IS the
+         designation."
+      - "https://cybermotorcycle.com/marques/velosolex/ — 2200, 3800, 4600,
+         4800, 5000, 6000."
+  the_extrapolation_to_solex_701_and_solex_800:
+    verdict: "REFUTED — by the researcher's OWN cited source. UNRESOLVED, not
+              'must be re-read before anyone fixes them'."
+    why: >-
+      Neither 701 nor 800 appears in the velosolexclubuk model list the
+      researcher cited for the proposition, nor on cybermotorcycle's marque
+      page, nor in any VéloSoleX model list I could reach. The reasoning
+      "for VéloSoleX the numbers are designations, therefore 701 and 800 are
+      designations too" is a family-pattern inference of exactly the kind the
+      protocol forbids, and the cited source does not support it.
+    the_only_index_that_carries_them_is_circular: >-
+      brommer.nl/merk/solex/ lists both — but it is an index of "227
+      geregistreerde modellen", i.e. it is derived from the Dutch REGISTER,
+      the same source the id came from. Citing it would be citing ourselves.
+    what_i_did_establish_and_the_researcher_did_not: >-
+      These are not small records. nl_rdw merk=SOLEX: '701' 308 + 'SOLEX 701' 1
+      = 309 vehicles; '800' 7 + 'SOLEX 800' 439 = 446 vehicles (the catalog's
+      solex/800 is fed by 446, not 7). Also present and unexplained:
+      'SOLEX OTO AMI 800' 1, '701 KOFFERTJE' 1, '660' 18, '1010' 19, '330' 31,
+      '3300' 66, '1400' 11, '4800' 6.
+    what_would_settle_it: "A VéloSoleX or Motobécane sales brochure / type list,
+      or the current trademark holder's model history (Velosolex America)."
+  motobecane_5000:
+    verdict: "MISCLASSIFIED in bare-displacement-2w — but for a DIFFERENT reason
+              than the researcher gives, and the right remedy is not a name fix."
+    what_it_actually_is: >-
+      moped/motobecane/5000 (nl 610 vehicles) is the VéloSoleX 5000 registered
+      under the marque-of-sale. Motobécane MBK owned Solex and marketed the
+      machines as Solex — 'The firm was owned successively by Dassault, Renault,
+      and Motobécane MBK, who marketed the machines as Solex'
+      (https://cybermotorcycle.com/marques/velosolex/). The register shows the
+      seam directly: merk=MOTOBECANE carries '5000' 610, '3800' 26,
+      'VELOSOLEX 3800' 10, '3800/25' 4, 'VELOSOLEX' 2; merk=VELOSOLEX carries
+      'MOTOBECANE' 2, 'SOLEX MOTOBECANE 3800' 1; merk=SOLEX carries
+      '3800 MOTOBECANE' 1 and 'S 3800 MOTORBECANE' 1.
+    consequence: >-
+      There are now THREE live ids for the VéloSoleX 5000 — moped/solex/5000
+      (686 nl + 7 nz), moped/velosolex/5000 (522 nl), moped/motobecane/5000
+      (610 nl) — and the third one is invisible to F9's detector spec, because
+      'motobecane' is not a suffix/prefix of 'solex'. F9's detector must be
+      extended, or it will merge two thirds of the problem and leave the rest.
+  net_answer_to_the_brief: >-
+    velosolex/5000 name = correct: UPHELD. The inference that
+    bare-displacement-2w therefore MISCLASSIFIES solex/701 and solex/800:
+    NOT ESTABLISHED (unresolved, and the cited source is against it).
+    motobecane/5000: misclassified, but as a make-layer identity error, not as
+    a legitimate designation.
+
+target_8a_F1_scope:
+  is_883_the_only_live_instance: "NO — decisively. It is one of 209."
+  my_independent_measurement:
+    method: "vb4/f1.rb over build/out/catalog, moped + motorcycle"
+    "2W records total": 7083
+    "with a bare-integer name": 230
+    "excused by legit:corroborated-numeric-nameplates (>=2 sources AND >=2 countries)": 209
+    "not excused": 21
+  is_count_21_materially_understated:
+    answer: >-
+      The number 21 is ARITHMETICALLY EXACT for the rule as written — I
+      reproduced it independently, to the record, and the 21 ids I get are the
+      21 the debt entry describes (bmw/259, ccm/404, cfmoto/450, cfmoto/800,
+      ktm/200, ktm/390, ktm/790, ktm/890, motobecane/5000, saxonette/529,
+      sherco/250, skyteam/04, solex/701, solex/800, tekken/250, tekken/300,
+      tgb/202, velosolex/5000, voge/300, white-knuckle/125, zundapp/517).
+      The POPULATION the entry's own prose describes is 230. The understatement
+      is therefore 209 records — an order of magnitude — and it is not a
+      counting error, it is the rule collision the researcher found.
+    the_decisive_internal_contradiction: >-
+      The debt entry justifies itself with KTM: "KTM sells the 390 Duke, 390
+      Adventure and 390 SMC R, so a bare '390' is three bikes at once", and
+      lists ktm/200, ktm/390, ktm/790, ktm/890 as its KTM instances. Live and
+      EXCUSED by the legit rule, under the same make, with the same reasoning
+      applying verbatim: ktm/125, 250, 300, 350, 400, 450, 500, 625, 640, 660,
+      690, 990, 1190, 1290, 1390. Fifteen more. The entry's own example make
+      contradicts the entry's own count.
+    other_seams_the_same_rule_excuses: >-
+      honda/{50,125,150,250,350,450,500,750,900} (9, both kinds),
+      yamaha/{50,70,100,125,200,250,350,400,650} (9),
+      kawasaki/{90,250,350,400,500,650,1000} (7),
+      norton/{18,19,20,30,50,88,99,350,500,650,850} (11),
+      jawa/{05,11,18,20,125,175,210,250,350,353,354,356,360,450,559,634,638,639,640} (19),
+      ducati/{250,350,500,600,620,748,749,750,848,851,860,888,899,900,906,916,996,998,999,1000,1098,1198} (22),
+      panther/{65,75,85,100,120,250} (6),
+      and motorcycle/bsa/000 — a record named "000" that passes corroboration.
+    a_caution_the_finding_should_carry: >-
+      209 is the size of the BLIND SPOT, not the size of the defect. Some of
+      the 209 are genuine (Ducati really sold the 848, 916, 999, 1098; Vespa
+      really sells the 946; Jawa's 350/634/638 are type numbers that are the
+      nameplate). The fix the researcher proposes — add `kind:` to the legit
+      entry — would move all 209 into the debt bucket at once, and the debt
+      count may only go DOWN. That is a CI trap. The right sequencing is:
+      re-scope the legit entry to name the makes it protects (Ducati, Jawa,
+      Vespa, CZ, BSA-era displacement classes), THEN re-measure the debt.
+  the_batch_records_on_the_seam: "harley-davidson/883 (4 sources, 4 countries),
+    ducati/848 (6, 6) and moto-morini/501 (2, 2) — all three correctly
+    identified by the researcher as the seam, all three excused by the rule.
+    harley-davidson/883 name defective is UPHELD: H-D's own model-codes page
+    gives 'XL883 - Sportster® 883' and never presents 883 standalone
+    (https://www.harley-davidson.com/us/en/content/expert-advice/harley-davidson-model-codes.html)."
+
+target_8b_F9_which_make_id_should_win:
+  the_split_is_confirmed_and_bigger_than_filed:
+    live: "moped/solex/{1700,2200,3800,5000,701,800,oto} (7) and
+           moped/velosolex/{1700,3800,5000,s3800} (4). 1700, 3800 and 5000 each
+           exist twice. Confirmed from build/out/catalog."
+    aliases: "overrides/makes/aliases.yml contains NO entry for any Solex
+              spelling. Confirmed by grep. e-solex is separately and correctly
+              pinned as a different modern marque."
+    raw_mass_mine: "nl merk=SOLEX 236 rows / 18,335 vehicles · merk=VELOSOLEX 66
+                    rows / 5,461 · merk=E-SOLEX 1 row / 438.
+                    nz MAKE='SOLEX' 8 rows / 21 · MAKE='VELO SOLEX' 17 rows / 35.
+                    gb 'VELOSOLEX S 3800' 195 + 'VELOSOLEX MODEL MISSING' 516.
+                    fi VELOSOLEX 1.
+                    The researcher's row counts (236 / 66 / 17 / 8) all
+                    reproduce exactly."
+    a_fourth_arm_it_missed: "moped/motobecane/{5000} live with 610 nl vehicles,
+      plus merk=MOTOBECANE rows '3800' 26 and 'VELOSOLEX 3800' 10. See target 7."
+  which_make_id_should_win:
+    my_recommendation: "`solex` — but I record this as a GENUINE two-way call,
+      not a settled one, because no marque-controlled source exists (the company
+      is defunct; cybermotorcycle records that Velosolex America now holds the
+      trademark)."
+    evidence_for_solex:
+      - "Ownership/marketing: 'The firm was owned successively by Dassault,
+         Renault, and Motobécane MBK, who marketed the machines as Solex'
+         (https://cybermotorcycle.com/marques/velosolex/). The MARKETING name
+         under the last manufacturer is Solex."
+      - "The marque club's own prose uses 'Solex' as the running shorthand
+         throughout (https://www.velosolexclubuk.com/information-available-solex-models)."
+      - "It keeps `e-solex` legible as a derived modern marque."
+      - "(Mass — 18,335 vs 5,461 nl vehicles — agrees, but MAJORITY IS NOT
+         AUTHORITY and I do not rest on it.)"
+    the_honest_counter: >-
+      The machine is the VéloSoleX and the club's formal name is "VeloSolex Club
+      U.K.", 'dedicated entirely to the VeloSolex'. A curator weighting the
+      manufacturer's own product name over the marketing shorthand should pick
+      `velosolex`. Whichever wins, the SLUG PAIRS 1700/3800/5000 must move with
+      former_ids, and moped/motobecane/5000 must be handled in the same PR or
+      the merge leaves a third of the fleet behind.
+    what_would_settle_it: "The current trademark holder's own rendering
+      (velosolexamerica.com or solex.fr) — one fetch, not yet made."
+  does_nz_VELO_SOLEX_resolve_to_either_today:
+    answer: "NO. Confirmed independently."
+    why: >-
+      aliases.yml has no Solex entry, so 'VELO SOLEX' smart-title-cases to
+      'Velo Solex' and slugs to make_id `velo-solex`. There is no `velo-solex`
+      make in build/out/catalog/moped/makes.json (only e-solex, solex,
+      velosolex). It is a third, UNPUBLISHED make id that fails the two-source
+      publish threshold on its own: 17 rows / 35 nz vehicles, 13 of them '5000'.
+      One alias line resolves it.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DEFECTS FOUND AMONG CLAIMS THE RESEARCHER CALLED `correct`
+# All six are id-canonical, all six were found by vb4/dup.rb, and all six fail
+# the researcher's OWN stated criteria. The pattern is not random: it under-
+# called duplicates on Harley-Davidson, the make where it spent its fetch
+# budget on casing.
+# ═══════════════════════════════════════════════════════════════════════════
+
+overturns_correct_to_defective:
+
+  - id: motorcycle/harley-davidson/fxdwgi-dyna-wide-glide
+    claim: id
+    was: correct
+    now: "defective(duplicate-identity)"
+    why: >-
+      motorcycle/harley-davidson/fxdwgi ("Fxdwgi", fi/gb/nl) is LIVE and is the
+      same machine. FXDWGI is the type code of the fuel-injected Dyna Wide
+      Glide, and the raws state the equivalence in-data — the exact oracle the
+      researcher used to call moped/honda/dax defective: nl 'FXDWGI DYNA WIDE
+      GLIDE' 19+1, fi 'FXDWGI DYNA WIDE GLIDE' 14, and decisively fi
+      'Dyna Wide Glide (FXDWGI)' 1.
+    and_it_masked_the_defect: >-
+      The researcher filed the gb rows as F8 'unclaimed evidence' — "uk_dft
+      carries GenModel 'HARLEY-DAVIDSON FXDWGI' with 184 vehicles, and gb is NOT
+      in this record's availability list". Those 184 are not unclaimed: they are
+      claimed, by the sibling id. Checking whether a sibling already holds the
+      country would have turned a coverage note into a duplicate finding.
+    wider: "Five live ids for the Wide Glide family: fxdwg, fxdwg-dyna-wide-glide,
+      fxdwg-wide-glide, fxdwgi, fxdwgi-dyna-wide-glide."
+
+  - id: motorcycle/harley-davidson/flhtcu-ultra-classic-electra-glide
+    claim: id
+    was: correct
+    now: "defective(duplicate-identity — token-order inversion)"
+    why: >-
+      motorcycle/harley-davidson/flhtcu-electra-glide-ultra-classic (fi/nl) is
+      live with the IDENTICAL token multiset in a different order. This is
+      precisely the shape the researcher called "the cleanest single defect in
+      the batch" for ktm/exc125 vs ktm/125exc. Also live and denoting the same
+      machine: flhtcu ("Flhtcu", es/fi/nl/nz/ua), flhtcu-ultra-classic (fi/nl),
+      flhtcu-ultra-classic-elec (fi/nl). Five ids, one motorcycle.
+
+  - id: motorcycle/harley-davidson/flhrxs
+    claim: id
+    was: correct
+    now: "defective(duplicate-identity — code beside nameplate)"
+    why: >-
+      motorcycle/harley-davidson/flhrxs-road-king-special (nl/ua) is live. The
+      researcher's OWN note says "the NL and UA raws that spell it out identify
+      it as the Road King Special, so a nameplate-level id exists too", and then
+      files it as "granularity note only". That is the same fact pattern it
+      called defective for honda/adv750 and yamaha/mtn890-s in the same batch.
+      Raw: nl 'FLHRXS ROAD KING SPECIAL' 1 beside 'FLHRXS' 31+6.
+
+  - id: motorcycle/honda/gold-wing-gl1500se
+    claim: id
+    was: correct
+    now: "defective(duplicate-identity — code beside nameplate)"
+    why: "motorcycle/honda/gl1500se ('GL1500SE', gb/nl/nz) is live, as are
+      gold-wing-gl1500 (fi/nl/nz/ua), gl1500 and gold-wing. The sampled record's
+      own raws are 'GOLD WING GL 1500 SE' 5 and 'GOLD WING GL1500SE' 1 — the
+      code and the nameplate in one string, which is the equivalence."
+
+  - id: motorcycle/laverda/750sf
+    claim: id
+    was: correct
+    now: "defective(duplicate-identity — token-order inversion)"
+    why: "motorcycle/laverda/sf750 ('SF750', nl/nz) is live. Same tokens,
+      inverted. Also live: laverda/750 and laverda/750s. The researcher spent
+      its note on the space-collapse display question and did not look sideways."
+
+  - id: moped/yadea/g5
+    claim: id
+    was: correct
+    now: "defective(cross-kind duplicate — the F3 shape, in its own batch)"
+    why: >-
+      motorcycle/yadea/g5 is live and is gb-ONLY, which is the researcher's own
+      declared high-precision signature for F3. It wrote "gb also carries
+      GenModel 'YADEA G5' (178) but uk_dft has no moped kind, so its absence
+      from availability is correct" — correct about availability, and it stopped
+      one step short of the question its own finding was about: did those gb
+      rows mint a second id? They did. The Yadea G5 is a 50-class e-moped.
+
+notes_not_overturns:
+  - id: moped/piaggio/typhoon
+    claim: id
+    verdict: "correct, but should carry a NOTE"
+    why: "motorcycle/piaggio/typhoon (gb/nl/nz) is live with the same slug.
+      Piaggio sells the Typhoon as a 50 and a 125, so this is the SYM Fiddle
+      case — legitimate. But the researcher called sym/fiddle DEFECTIVE for that
+      exact configuration and did not mention typhoon at all. Whichever way the
+      class settles, these two records must settle the same way."
+
+claims_i_re_checked_and_confirm_as_correct:
+  - "motorcycle/rudge/special (name) — see target 6."
+  - "motorcycle/norton/es2 (name 'ES2') — nortonownersclub.org renders 'ES2',
+     not 'ES 2'. Marque club = the best available source for a 1928-1963 Norton."
+  - "motorcycle/silence/s01 (name 'S01') — data/review/silence.yml verdict
+     'canonical', and the register's own S01/S02/S04 strings agree."
+  - "moped/velosolex/5000 (name '5000') — see target 7."
+  - "motorcycle/vespa/50-special (name '50 Special') — museopiaggio.it."
+  - "The 15 `correct` name calls: I sampled 5 (33%) and overturned none."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AVAILABILITY — 100% re-derived
+# ═══════════════════════════════════════════════════════════════════════════
+availability_verification:
+  claims: 237
+  verdict: "237/237 UPHELD. Zero corrections."
+  method: >-
+    vb4/avail.rb, my own matcher on my own flattened corpus. 236 of 237 matched
+    mechanically. The one that did not is explained and correct:
+    motorcycle/zero-motorcycles/xe (es) — the raw is
+    es_dgt '*08 ZERO MOTORCYCLES | ZERO MOTORCYCLE XE' n=7, which resolves only
+    after the singular-make prefix strip plus renames.yml `Motorcycle Xe: Xe`.
+    The researcher documented exactly this and it is right.
+  the_converse_scan_which_is_the_harder_test:
+    what: "vb4/avail2.rb — for all 100 records × all 8 countries, find countries
+           with a resolving raw row that are NOT claimed."
+    result: "EXACTLY ONE across the whole batch: moped/velosolex/5000, nz,
+             'VELO SOLEX | 5000' n=13."
+  therefore_F8_is_1_of_3:
+    instance_1_fxdwgi_gb: "WRONG. Not unclaimed — claimed by the live sibling id
+      motorcycle/harley-davidson/fxdwgi. See the overturns section."
+    instance_2_norton_es2_es: >-
+      NOT an availability gap at all. I read the es_dgt bytes directly: the
+      single 'NORTON | ES2' row in es_dgt_202604 carries category field
+      "L3 " (L3 plus a space), and es_dgt.rb's CATEGORY_TO_KIND maps "L3E", not
+      "L3 ". The row is dropped by the ADAPTER and never reaches the pipeline,
+      so the catalog is right not to claim es. The researcher half-saw this
+      ("which may be why") and filed it anyway.
+      THIS IS A BETTER FINDING THAN THE ONE IT WAS FILED AS: es_dgt silently
+      drops rows whose category is a legacy short form. It is an adapter gap,
+      it is measurable, and nobody is counting it.
+    instance_3_velosolex_nz: "CORRECT, and the only true instance. The
+      researcher's own diagnosis (a make-layer alias gap, not a threshold
+      effect) is right."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ENRICHMENT (§6.2) — the researcher completed 0/2; I completed 1 and a half
+# ═══════════════════════════════════════════════════════════════════════════
+enrichment_sub_check:
+  motorcycle_norton_es2:
+    was: "unverifiable(cited NOC pages not re-fetched)"
+    now: "CORRECT"
+    evidence: "https://www.nortonownersclub.org/models/sngle-cylinder/overhead-valve
+      re-fetched. The page carries the ES2 twice — '490cc OHV  1928 - 1939' and
+      '490cc OHV  1947 - 1963' — matching enrich/norton.yml's two runs exactly,
+      and renders the name 'ES2'. The file's decision NOT to encode the Mk.II
+      because two NOC pages disagree is sound practice and I endorse it."
+  motorcycle_bsa_rocket_3:
+    was: "unverifiable(cited sources not re-fetched)"
+    now: "PARTIALLY COMPLETED — start year confirmed, end year not"
+    evidence: "https://cybermotorcycle.com/marques/bsa/bsa-1960-1969.htm
+      re-fetched: the 1969 line is verbatim 'A75 Rocket Three 750cc',
+      confirming year_start 1969 and the enrich file's quoted string. I did NOT
+      fetch bsa-1970-1979.htm, so year_end 1972 remains unverified."
+    bearing_on_the_name_verdict: "The researcher's name verdict
+      'unverifiable(sources disagree)' is UPHELD and now better supported:
+      cybermotorcycle writes 'Rocket Three', the registers write 'ROCKET 3'
+      (nl 24 + 'A75R ROCKET 3' 6) and 'ROCKET THREE' (nz 2 + 'A75 ROCKET
+      THREE' 1). Two spellings, no BSA-controlled source. Correctly left open."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CORRECTED TALLY — 43/100 name coverage PRESERVED
+# ═══════════════════════════════════════════════════════════════════════════
+corrected_counts:
+  arithmetic_error_in_the_proposal_that_must_be_fixed_first: >-
+    result-b4.yml states `claims_total: 539` and
+    `audited_claims: "482 (539 minus the 57 not-attempted)"`. Its OWN
+    claim_counts sum to 639: id 100 + name 100 + make 100 + kind 100 +
+    availability 237 + enrichment 2. The correct figures are 639 total and
+    582 audited. Separately, `counts_caveat` refers to "the availability line
+    reading 263/263" while claim_counts says 237; 237 is the right number and
+    matches the catalog exactly.
+
+  researcher_counts_i_reproduced_exactly:
+    note: "Re-parsed from result-b4.yml with my own ruby+YAML pass. Every line
+           below matches the proposal, which is a good sign about its mechanical
+           discipline even where its judgments are wrong."
+    id:           { total: 100, correct: 68, defective: 16, unverifiable: 16 }
+    name:         { total: 100, correct: 15, defective: 21, unverifiable_source_gap: 7, unverifiable_NOT_ATTEMPTED: 57 }
+    make:         { total: 100, correct: 93, defective: 1,  unverifiable: 6 }
+    kind:         { total: 100, correct: 98, defective: 1,  unverifiable: 1 }
+    availability: { total: 237, correct: 237 }
+    enrichment:   { total: 2,   unverifiable: 2 }
+
+  verified_counts:
+    id:           { total: 100, correct: 64, defective: 20, unverifiable: 16 }
+    name:         { total: 100, audited: 43, correct: 15, defective: 21, unverifiable_source_gap: 7, unverifiable_NOT_ATTEMPTED: 57 }
+    make:         { total: 100, correct: 93, defective: 1,  unverifiable: 6 }
+    kind:         { total: 100, correct: 98, defective: 1,  unverifiable: 1 }
+    availability: { total: 237, correct: 237, defective: 0, unverifiable: 0 }
+    enrichment:   { total: 2,   correct: 1,   defective: 0, unverifiable: 1 }
+    id_movement: "68 -> 64: minus 6 (the overturns to defective), plus 2
+                  (sym/fiddle and silence/s01 returned from defective)."
+
+  coverage_caveat_PRESERVED_VERBATIM_IN_SUBSTANCE: >-
+    name-marque-true was source-checked for 43 of 100 records. The other 57 are
+    `unverifiable(not-attempted)` — UNAUDITED, NOT source gaps. They must not
+    enter the source-gap queue and must not be counted as audited. The name rate
+    is computed over 43, never over 100. I re-checked this disclosure and it is
+    accurate: my parse finds 64 unverifiable name claims, of which 57 carry the
+    not-attempted reason string and 7 carry a genuine source-gap reason. This
+    batch set the round's honesty standard on this point and I am not
+    weakening it.
+
+  rates:
+    name_over_the_43_audited: "correct 15/43 = 34.9% · defective 21/43 = 48.8% ·
+                               source-gap 7/43 = 16.3%"
+    id_over_100: "correct 64% · defective 20% · unverifiable 16%"
+    availability_over_237: "correct 100%"
+    conservative_clean_rate_over_582_audited_claims:
+      researchers_own: "511 / 582 = 87.8%"
+      verified: "508 / 582 = 87.3%"
+      direction: "The proposal is marginally OPTIMISTIC, not conservative —
+                  the same direction batch 1's verification found."
+    what_the_rate_does_not_capture: >-
+      Every one of my six overturns is an id-canonical duplicate found by a
+      20-line detector over the published catalog, with no fetching. The
+      sampled rate says 20% of id claims are defective; the catalog-wide
+      censuses in this file (97 cross-kind pairs, 230 bare numerics, 14
+      token-boundary shifts, 48 type-code ids, 54 self-declared enrichment
+      duplicates) say the id layer is where the program's remaining error mass
+      actually lives, and that it is measurable without a sample.
+
+# ═══════════════════════════════════════════════════════════════════════════
+# VERDICT ON F1-F9: real? correctly scoped? novel?
+# ═══════════════════════════════════════════════════════════════════════════
+findings_assessment:
+
+  F1_rule_collision_corroborated_numerics_has_no_kind_guard:
+    real: "YES — I reproduced both the collision and the exact count."
+    correctly_scoped: "NO. Understated by ~10x. 230 bare-numeric 2W records
+      exist; 209 are silently excused; the entry's own KTM example make has 15
+      more excused instances than the entry lists."
+    novel: "NO — the brief says the main session already confirmed it. My
+      contribution is the size (209) and the CI trap: adding `kind:` to the
+      legit entry would move 209 records into a debt bucket whose count may
+      only go down. Sequencing matters."
+    disposition: "Re-scope the legit entry to name the makes it protects, then
+      re-measure. Do not add a blanket kind guard."
+
+  F2_normalizer_token_boundary_shift:
+    real: "YES. Confirmed exactly: zero '3CVO' strings in 87,399 raw groups."
+    correctly_scoped: "NO. Understated by 14x. 9 H-D CVO ids carry the same
+      shift, plus 5 NAMEPLATE instances on current products (Triumph Rocket 3
+      GT / GT Triple Black / 3 TFC, Yamaha Tracer 9 GT, Fazer 8 ABS)."
+    novel: "YES, and genuinely distinct from debt:normalizer-space-collapse-
+      display-names on both grounds it claims (max_sources:1 scope; display-only
+      framing vs a corrupt slug). Both checked against name_shapes.yml:295-303."
+    disposition: "File the taxonomy entry with count 14 and the worklist above.
+      The detector spec works as written — I implemented it and it is exact."
+
+  F3_uk_dft_moped_merge_mints_cross_kind_duplicates:
+    real: "YES. The Vespa premise is now sourced (49.77 cc, museopiaggio.it)."
+    correctly_scoped: "NO, and the researcher said so ('not measured catalog-
+      wide'). I measured it: 97 pairs live in both kinds, 18 with a gb-only
+      motorcycle side, 7 of those with '50' in the slug."
+    novel: "YES as a filed class. Note it is the same root cause as the Derbi
+      case in avail-blast-radius.yml, reached from the other side — the
+      researcher says so itself, correctly."
+    detector_spec_defect: "The high-precision flag 'uk_dft is the ONLY
+      motorcycle-side source' MISSES vespa/50-special, the founding instance,
+      because two stray nl motorfiets rows exist. Change to uk_dft-dominant."
+    two_of_its_three_instances_are_wrong: "sym/fiddle and silence/s01 both
+      OVERTURNED (see target 3). The class is real; the researcher's worked
+      examples for the NOT-a-defect side were mis-sorted."
+
+  F4_uk_dft_genmodel_family_stems:
+    real: "YES, and I agree it is a measured NON-finding."
+    correctly_scoped: "Its own measurement (258 gb-only motorcycle records, 14
+      with a name that is a strict prefix of a sibling's) I did not re-derive —
+      it does not bear on any verdict and the brief did not ask. Flagged as
+      unverified rather than silently accepted."
+    novel: "No, and it does not need to be. Recording a measured non-finding so
+      nobody re-measures it is exactly the right instinct; more batches should."
+
+  F5_descriptor_as_model:
+    real: "YES, and the register-habit evidence I found (EIGENBOUW 210,
+      CUSTOM CYCLE 53, HARDTAIL, ASSEMBLED…) makes it stronger than filed."
+    correctly_scoped: "NO. 16 records under its own vocabulary (not '~13'), 25
+      under batch 3's, 58 under the union. Both batches' counts are vocabulary
+      artefacts and neither published its lexicon with the count."
+    novel: "NO — batch 3 proposed the identical class, with the identical
+      proposed_category and the identical must-split-first caveat, from a
+      different sample. Independent co-discovery is strong evidence the class
+      is real; the round should file ONE entry, not two."
+    line_drawing: "Correct in principle. One of its five cleared counter-
+      examples (ossa/trial) does not survive checking and batch 3 lists it as a
+      candidate defect — the two batches disagree on that record."
+
+  F6_self_declared_duplicates_in_enrich_files:
+    real: "YES. enrich/norton.yml:93 reads verbatim 'same machine as `es2`,
+      register spelling with displacement', on byte-identical runs."
+    correctly_scoped: "NO — understated by roughly 50x. Grepping
+      /same machine|same bike|duplicate of/ over enrich/*.yml (39 files) returns
+      54 declarations across 12 makes: norton 21, bsa 16, ariel 6, cz 3,
+      matchless 1, mbk 1, montesa 1, mz 1, nsu 1, puch 1, saxonette 1,
+      velocette 1. The files even count for you: bsa.yml says 'FIVE ids for one
+      motorcycle' and 'SEVEN ids for one motorcycle, the worst cluster in this
+      make'; norton.yml says 'FOUR ids for one motorcycle'."
+    novel: "PARTLY. The framing 'a free duplicate-id oracle nobody is reading'
+      is not right — curation wrote those comments deliberately and batch 1's
+      verification already worked the BSA clusters. What is genuinely missing is
+      a LINT that turns the prose into a count. File it as a lint, not a
+      discovery."
+
+  F7_homologation_code_as_nameplate:
+    real: "YES. Both marque-controlled citations re-fetched and confirmed
+      verbatim ('X-ADV (ADV750)'; 'MTN890 (MT-09)' extracted from Yamaha's PDF)."
+    correctly_scoped: "NO. 48 live type-code ids, not 3 (Yamaha 42, Suzuki 4,
+      Honda 2). Its own detector spec would have sized it."
+    novel: "YES as a filed class, and it is the largest evidence misfiling in
+      the batch by volume, as claimed."
+    strengthening_evidence_it_missed: "nl_rdw's own model column pairs code with
+      nameplate in nine string families ('MTN1000 (MT-10)', 'MTN690-A (MT-07)',
+      'MTM850 (XSR900)' …). The mapping is IN-DATA for most of the Yamaha
+      cluster and needs no fetching at all."
+    the_gsx800_caution: "Right verdict, wrong reason — see target 2. Pooling is
+      not evidenced anywhere in the corpus or the TANs."
+
+  F8_unclaimed_evidence_three_instances:
+    real: "ONE of three."
+    correctly_scoped: "NO — and the errors matter more than the finding.
+      Instance 1 (fxdwgi gb) is claimed by a live sibling and concealed a real
+      duplicate. Instance 2 (norton es2 es) is an es_dgt ADAPTER gap: the row's
+      category is the legacy 'L3 ' which CATEGORY_TO_KIND does not map, so it
+      never enters the pipeline. Only instance 3 (velosolex nz) is what it says."
+    novel: "The converse-scan idea is good and cheap — I ran it over all 100
+      records × 8 countries and it produced exactly one hit, which is a useful
+      negative result for the round. The instances need withdrawing."
+
+  F9_solex_marque_split_three_ways:
+    real: "YES. Every measured claim reproduces exactly."
+    correctly_scoped: "NO — it is a FOUR-way split, not three. moped/motobecane/
+      5000 holds 610 nl vehicles of the same machine, and merk=MOTOBECANE also
+      carries '3800' 26 and 'VELOSOLEX 3800' 10."
+    novel: "YES."
+    detector_spec_defect: "'Flag any two make_ids where one's slug is a suffix
+      of the other's AND they share a model slug' finds solex ⊂ velosolex and
+      would have found zero/zero-motorcycles and emax/e-max, as claimed — but it
+      structurally CANNOT find motobecane/5000, which is a third of the fleet
+      here. Add a second rule: identical model slug across different make_ids
+      where one make's raws contain the other make's name."
+    which_make_wins: "See target 8b: I recommend `solex` on ownership/marketing
+      evidence, record it as a genuine two-way call, and name the one fetch
+      that would settle it."
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WHERE THE RESEARCHER WAS PLAINLY RIGHT — said explicitly, per the brief
+# ═══════════════════════════════════════════════════════════════════════════
+credit_where_due:
+  - "The 43/100 name-coverage disclosure, with a DISTINCT reason string for
+     not-attempted vs source-gap, is the correct and rare thing to do and it is
+     the reason this batch can be verified at all. I have preserved it."
+  - "The two self-caught false availability positives (moped/honda/z50jz needing
+     prefix-strip AND letter/digit collapse; motorcycle/zundapp/50 hiding under
+     merk 'ZUENDAPP') are both real traps. My own matcher would have hit the
+     second one had I not resolved aliases first."
+  - "Availability is 237/237 under an independent re-derivation with a different
+     implementation. That is a genuinely clean result on the largest claim class."
+  - "moped/sparta/bosch-e-speed: it expected a supplier-in-nameplate defect,
+     found evidence against it, and recorded the weaker verdict. That is the
+     behaviour the program wants."
+  - "It named moped/honda/mt5 as its own weakest claim and told the verifier
+     exactly where to attack it. The claim survived — on different evidence."
+  - "It predicted the sym/fiddle downgrade correctly and then declined to make
+     the call itself. Half right is better than confidently wrong, and the
+     record shows it saw the issue."
+  - "The F2 detector spec is exact, cheap and correct as written. I implemented
+     it from the spec alone and it found 14 instances immediately."
+  - "avail-blast-radius.yml's NARROWING-vs-NAMING distinction is the right test,
+     it correctly refutes batch 3's Nimbus instance, and its refusal to present
+     a 3/17,553 census as a correction to a sampled rate is exactly right."
+
+verifier: opus5/audit-b4-verifier
+researcher: opus5/audit-b4
+scripts: "<scratchpad>/vb4/{flat.rb,avail.rb,avail2.rb,dup.rb,f1.rb,f2.rb,f5.rb,f5b.rb,crosskind.rb,parse.rb,sample.rb,cat.rb}"
+corpus: "<scratchpad>/vb4/myraw.tsv — 87,399 two-wheel raw groups, derived independently"


### PR DESCRIPTION
**A2 baseline complete on the S2W half. 400 records, 2,559 claims, four independent researchers, four independent verifiers. The headline is identity, not naming.**

## The result

**Conservative clean rate 2,063 / 2,559 = 80.6%**, every `unverifiable` counted against. That figure is a *bound*, not the result — it is dominated by one claim type at 40% coverage. The per-claim table is the result:

| claim | defective | rate | basis |
|---|---:|---:|---|
| **id-canonical** | **100 / 400** | **25.0%** | unbiased, full sample |
| name-marque-true | 108 / 158 verdicts | — | **biased upward, 242 unattempted** |
| make-correct | 5 / 400 | 1.3% | unbiased |
| kind-correct | 3 / 400 | 0.8% | unbiased |
| availability | 1 / 953 | **0.1%** | unbiased, re-derived from raw twice |

**One in four sampled records carries an identity defect.** We spent two days on naming; identity was the larger problem the whole time and no detector reported it — `find_duplicate_spellings` returns **zero groups for this entire half**, because it folds to `[A-Z0-9]` and tests equality, so token *presence* and *order* are invisible to it.

BSA carries **twelve live ids for two motorcycles** (Thunderbolt ×5, Lightning ×7), recorded only in an `enrich/bsa.yml` comment and in no ledger, so nothing scheduled it.

## What survived everything

**Availability: 952/953.** Re-derived from the raw registers by four researchers, then independently again by four verifiers with separately-written flatteners — 5,147,216 Finnish rows counted identically by two implementations that never saw each other's code. The one defect (`husqvarna/sm510` gb: all 77 UK rows are `SM 510 R`) was found only by checking DVLA's finer Model column, which no researcher used.

Two agents then corrected their own work on it, which is why I trust the number: the researchers' method verified *that a row exists for the make/model*, which cannot distinguish a row that named the model from one a rename resolved into it; and a targeted census of that exposure found **3 fabricated country-claims in 17,553 catalog-wide (0.017%)**, one already documented in its own rename comment.

## Limitations, stated rather than buried

**It is not reproducible at its own tag.** The sample pins `v2026.07.5`; every batch measured a `2026.07.6` build. Three population figures exist and none agree — 7,073 / 7,083 / 7,087 — and the tag cannot be rebuilt cleanly today, because `v2026.07.5` data against a post-`pipeline#36` tokenizer is the coupled breakage that change fixed. Exposure is confined (id churn since the tag ≈ 1 record) but ~100 display names were corrected in between, so the name rate is biased *optimistically* on top of its coverage bias. **Next round the sampler must pin the build, not the tag.**

**No usage-weighted figure is published.** `catalog/meta/decile-mass.json` landed in `pipeline#40` after these builds; the protocol requires the weighted aggregate to read it.

**Verification moved every batch the same way** — all four proposals were optimistic, not conservative, and **22 additional defects were found among claims called `correct`, all 22 id-canonical**. The first verifier diagnosed the cause and wrote the fix; the third found it hadn't been adopted and warned the id rate could be low by a third. Corrected here; assume the mechanism is live next round.

**Two cross-batch contradictions are carried, not resolved.** `honda/nt650v-deauville` and `harley-davidson/flhtcui-ultra-classic` were each called correct by one batch and defective by another's verifier. A ledger that hid the disagreement would be worse than one that shows it.

## A reported number I am not publishing

Batch 2's "262 code⊂code+name pairs" **does not reproduce**. Its verifier implemented the same spec across every reading of the ambiguities and got 207 / 246 / 292 / 323 — never 262 — while the batch's companion figure reproduced exactly. The class is real; the size is not established, and it is recorded as such.

## A detector built and then refuted, kept on purpose

Same-make shared type-approval number is **not** a duplicate signal — 572 groups / 1,061 ids share TANs, one Royal Enfield approval spans six nameplates. Curation consequence: `renames.yml` cites TAN 38 times, and `Ab: Senda 50` (load-bearing for 317 rows) rests on **TAN alone** with no name-family argument, on a TAN that is not even make-exclusive. Four other lines that look TAN-primary pair it with a measured displacement constraint and are sound.

## Ledger design

Researcher and verifier records are kept **separate and unmerged deliberately**. Merging them would mean hand-transcribing ~400 records of prose corrections into one file — precisely the silent-transcription-error class this program exists to remove. The aggregate is computed from the verifiers' tallies; the disagreements stay readable.

One file (`verifier-b3.yml`) needed a single scalar quoted to parse — an unquoted value containing `": "`. Content otherwise byte-identical; the diff is two lines.

## Not in this PR

**Nothing is fixed.** Per invariant I-15 each class needs a taxonomy entry and detector spec first. Fixes ride separate curation PRs. Five protocol amendments are proposed in the document, of which the `unverifiable` sub-typing (`source-gap` vs `not-attempted`) is the one that currently blocks a comparable aggregate across the two halves.

Curation lint green (101 files).
