### PR TITLE
Gate A2: baseline audit, 4W half — 83.23% claim-level clean, generators identified, protocol v1.1

### DIFF
--- a/DEBT.md
+++ b/DEBT.md
@@ -49,3 +49,17 @@ delete its line in the same PR. S2W's half keeps its own ledger in
 | **G26c Wikidata bulk import** — the next major enrichment program | PRD-QUALITY §14, PRD-PAID §2 | CC0 bulk source; staging + graduation through lint_enrich; conflicts lose to curation. Unbuilt. |
 | G26d fueleconomy.gov per-year-per-trim specs | PRD-PAID §2 | spec'd, unbuilt; feeds catalog-plus |
 | Coverage: 4W enrich sweep beyond the ~30 makes done | pipeline enrich/ (39 files, 506 ids) | continue the swarm pattern (research → verify → land) per marque |
+
+## From the baseline audit (2026-07-26 — see data/review/audit-v2026.07.5/RESULTS.md)
+
+| item | source of record | what resolves it |
+|---|---|---|
+| **Truncation/family stubs** — the largest measured defect generator (setra/s, bmw/z-reihe 7,143 regs, bmw/i, volvo/b, ford/f, scania-vabis/l) | RESULTS §New-1 | detector (single-token id prefixing ≥2 live siblings) + the VARIANT_SUFFIXES/series-collapse normalizer cure above; folds with the disposition pair |
+| tesla/y → model-y retirement (headline; wheelbase-proven) | RESULTS + verify-3 | fold+alias, one PR |
+| Connector-merge detector (oder/ou/slash/space + make axis) | RESULTS §New-2 | extend D13's detector wordlist + make-axis pass |
+| Converter-brand-as-nameplate (D5b) detector | RESULTS §New-3 | one-model-string-under-≥2-chassis-makes scan |
+| TAN hygiene: strip `- (FMVSS)` literals (35 records, fi TAN column) + TAN-overlap caveat in NAMING §2 + a TAN-oracle duplicate detector | RESULTS §New-4 | pipeline fi_traficom fix + NAMING amendment + new detector |
+| Source-forced kind: us_fueleconomy/ca_nrcan hardcode kinds=[:car] with unused class columns | RESULTS §New-5 | pipeline: map the class columns |
+| Typo-split detector (edit-distance-1 in-make siblings) | RESULTS §New-6 | new detector; Spinter/Spriner/Srinter exemplars |
+| Raw-layer fold detector (collisions in raws invisible in published names) | RESULTS §New-7 | detector over observed_variants |
+| NISMO casing family + the 11 title-cased model-name initialisms (Atf/Dt/Sk/…) | verify-2, ledger-4 | per-make passes under the two-halves evidence rule |

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -1,0 +1,49 @@
+# QUALITY — the public dashboard (PRD-FIVE-NINES §8)
+
+*Updated per audit round and per release. Generated context: this file
+states measured numbers with their intervals and the program's honest
+status. It never states more than the measurement supports — the caveats
+are part of the product.*
+
+## Status: INSTRUMENTED · BASELINE MEASURED · FIX PROGRAM DIRECTED
+
+| | |
+|---|---|
+| Program | PRD-FIVE-NINES.md (target: usage-weighted P(defective\|touched) ≤ 1e-5) |
+| Instrument | seeded stratified audit (`scripts/audit_sample.rb`), researcher≠verifier, unverifiable-counts-against |
+| Latest round | **baseline, v2026.07.5, 4W half** — 400 records / 2,624 claims / 4 independent researcher+verifier pairs |
+
+## Measured (baseline round, 2026-07-26)
+
+- **Claim-level clean rate: 83.23%** (defect+unverifiable **16.77%**,
+  95% CI **15.39%–18.25%**). Full breakdown, methods, and every ledger:
+  `data/review/audit-v2026.07.5/RESULTS.md`.
+- **Availability claims ≈99.5% clean** — verified against the registers
+  themselves. Make ~96%, kind ~97%. The defect mass is names and
+  id-canonicality, concentrated in two structural generators (truncation
+  stubs; trim-granularity ids) now being fixed at the generator.
+- **The audit's own error rates, published**: researcher miss rate on
+  spot-checked corrects 7% (CI 2.9–13.9%); defect-verdict confirmation
+  under adversarial re-derivation ~96%; classification labels moved in
+  ~10% of defects (protocol amended — verifiers now confirm class).
+- 2W half: sample pinned (`SAMPLE-s2w.yml`), round pending.
+
+## What we will not claim (verbatim from the PRD)
+
+Not uniform per-record five nines; not correctness of upstream registers
+(availability claims assert what the register said, verified against the
+register); not completeness (coverage is tracked separately and never
+blended into defect rates). The five-nines figure, when published, will be
+a 95% upper bound built from an exhaustively certified head + detector-held
+zeros + a bounded sampled tail — the construction is in PRD-FIVE-NINES §1.3
+and every number in it is recomputable from published artifacts
+(`catalog/meta/decile-mass.json` + the audit ledgers).
+
+## Detector suite (held at zero in CI, every build)
+
+duplicate-spellings · casing-contradictions · corporate-strings ·
+published-name-defects (with recorded verdicts) · curation lint (direction
+wars, chains, shapes) · reachability · id-contract gates 1–7 + publication
+hysteresis · enrich lint (incl. duplicate-insurance sweep). Seven NEW
+classes from the baseline round are entering the taxonomy with detector
+specs (RESULTS.md §New-classes; DEBT.md carries the build list).

--- a/data/review/audit-PROTOCOL.md
+++ b/data/review/audit-PROTOCOL.md
@@ -61,3 +61,17 @@ intervals, per stratum; the usage-weighted aggregate computed against the
 PUBLISHED weights (`catalog/meta/decile-mass.json` at the audited tag — the
 weights are read, never asserted); certified-stratum miss rate reported
 separately (it is the program's own error rate, §5.2).
+
+## v1.1 amendments (from the baseline round's adversarial verification)
+
+1. **Two-route minimum**: `unverifiable` requires TWO distinct failed
+   routes, both named (22/26 baseline unverifiables fell to one more route).
+2. **Pair defects are symmetric, counted once**: the duplicate PAIR is the
+   defect; a `fix_attribution:` line names the record that should retire.
+3. **Verifiers confirm CLASS, not just defectiveness** (44 labels moved in
+   the baseline; remedies differ by class, so labels are load-bearing).
+4. **Evidence hygiene**: every cited id/file/URL in an evidence line must
+   exist — a citation naming a nonexistent artifact voids the line.
+5. **Multi-twin rule**: canonicality checks enumerate ALL live candidate
+   twins in-make before any verdict (the baseline's spot-check misses all
+   compared against exactly one).

--- a/data/review/audit-v2026.07.5/RESULTS.md
+++ b/data/review/audit-v2026.07.5/RESULTS.md
@@ -1,0 +1,122 @@
+# Baseline audit round — 4W half, v2026.07.5 (gate A2, PRD-FIVE-NINES §2)
+
+*Round completed 2026-07-26. Sample: 400 records (seeded stratified draw,
+`SAMPLE-s4w.yml`), 2,624 claims. Four researcher agents (100 records each),
+four INDEPENDENT verifier agents (researcher ≠ verifier; every defective
+verdict re-derived evidence-blind; all unverifiables retried; 25 corrects
+spot-checked per slice). Ledgers + verification files beside this document.
+Unverifiable counts AGAINST the clean rate throughout (conservative bound).*
+
+## The number
+
+**Claim-level clean rate: 83.23%** — 2,184 correct / 412 defective /
+28 unverifiable of 2,624 claims. **Defect+unverifiable rate 16.77%,
+95% CI 15.39%–18.25%** (Wilson). Per slice (verifier-adjusted):
+84.15% · 88.45% · 80.31% · 79.42% — four independent researcher/verifier
+pairs landing in one band is itself evidence the instrument measures
+something real.
+
+| claim type | clean rate | note |
+|---|---|---|
+| availability (1,024 claims) | **≈99.5%** | verified against the registers themselves (streamed full FI/UA/ES pulls, live RDW, all cached artifacts); slice 4's only defect OVERTURNED on re-derivation |
+| kind | ~97% | source-forced-kind class found (below) |
+| make | ~96% | converter/coachbuilder class dominates |
+| name | ~62–75% by slice | the damage: truncation stubs, casing, marque-truth |
+| id-canonical | ~55–65% by slice | the damage: family stubs shadowing siblings, trim-ids, spelling twins outside detector fold-scope |
+
+## What adversarial verification did to the numbers
+
+- **Defect verdicts held: ~96% confirmed** (399 of ~415 reviewed confirmed
+  or reclassified-still-defective; 4 overturned to correct, 5 to
+  unverifiable). The verdicts were right; some evidence lines were not
+  (two citations named things that don't exist — evidence hygiene is now a
+  protocol rule).
+- **Classification did NOT hold: 44 class labels moved** (13/2/13/16 per
+  slice). D6 "duplicate" was a catch-all absorbing what is really D8
+  (trim-of-nameplate) and D5/D11 shapes. **A fix program driven off
+  researcher labels would apply the wrong remedy ~1 time in 9.** RESULTS
+  therefore reports class-as-verified; the taxonomy gets the new classes
+  below and the audit protocol now requires the verifier to confirm CLASS,
+  not just defectiveness.
+- **Researcher miss rate on sampled corrects: 7/100 = 7%** (per-slice 1/25,
+  1/25, 4/25, 1/25; pooled 95% CI ≈ 2.9%–13.9%). The audit's own error
+  rate — published, per §5.2's certified-but-defective discipline. The
+  misses share one shape: comparing against ONE candidate twin when
+  several are live.
+- **22 of 26 unverifiables fell to exactly one more route** (a different
+  domain, another language wiki, a file already on disk). The conservative
+  bound was over-paid. Protocol v1.1: `unverifiable` requires TWO distinct
+  failed routes, named.
+- **One protocol ambiguity moved verdicts**: whether id-canonicality is
+  symmetric (both members of a duplicate pair defective) or lands on the
+  non-canonical member. v1.1: the DEFECT is symmetric (the pair is the
+  defect); the FIX-attribution column names the record that should retire.
+  RESULTS counts pairs once.
+
+## Defective-at-tag, fixed-pending-publish
+
+23 sampled-adjacent ids are defective in the v2026.07.5 artifact and
+already fixed in merged overrides (the release is one curation cycle behind
+its own repo — the pending-publish window, verified against a fresh build:
+all 23 dead there). They are counted DEFECTIVE here — the .5 consumer sees
+them — with the fix status recorded. The next release cures them at zero
+additional cost.
+
+## New defect classes (entering PRD-QUALITY §4 with detector specs — I-15)
+
+1. **Truncation/family stubs** (the single largest generator): a numbered
+   nameplate truncated at its first space or by VARIANT_SUFFIXES/series
+   collapse publishes as a stub that shadows properly-catalogued siblings —
+   `bus/setra/s` (96 raw strings pooled), `car/bmw/z-reihe` (7,143
+   registrations on a register GROUP label), `car/bmw/i`, `bus/volvo/b`,
+   `truck/ford/f` (which swallowed raw "F MAX"), `truck/scania-vabis/l`.
+   Detector: single-token/single-letter ids whose token prefixes ≥2 live
+   sibling ids in-make. The structural cure is the DEBT.md normalizer item.
+2. **Connector-merged dual-market cells**: `JUMPER ODER RELAY`, `ou`, `/`,
+   and bare-space joins — D13 was comma-only. Confirmed on 4 exemplars +
+   the make axis (`Iveco / Igloocar`).
+3. **Converter/coachbuilder brand-or-style as nameplate** (D5b): one model
+   string under ≥2 unrelated chassis makes — `fiat/burstner`,
+   `peugeot/bailey`, `Atego` under five truck makes.
+4. **TAN poisoning**: `xrefs.tan` holds the literal `- (FMVSS)` on 35
+   records across 3 kinds (source: fi_traficom's TAN column); and TAN
+   overlap is NOT duplicate proof (platform sharing, framework
+   generations) — NAMING §2's ranking needs the caveat. Conversely the
+   clean TANs are a free duplicate oracle nothing consumes (it settled
+   fiorino-qubo/qubo and CLEARED kgm/actyon-vs-ssangyong).
+5. **Source-forced kind**: `us_fueleconomy.rb`/`ca_nrcan.rb` hardcode
+   `kinds=[:car]` while shipping an unused class column — Suzuki Equator
+   (a pickup) sits in car. Pipeline fix, one file each.
+6. **Typo-splits invisible to NFKD folding**: `Transit Costum`/`Custom`,
+   live `Spinter`/`Spriner`/`Srinter` beside Sprinter. Detector:
+   edit-distance-1 sibling names in-make.
+7. **Raw-layer folds** the published-name detector cannot see (Scania
+   R142/R142H colliding in raws only).
+
+## The headline record-level findings
+
+`car/tesla/model-y` (decile 1, 13 countries) is shadowed by live
+`car/tesla/y` — and verification made it STRONGER: RDW wheelbase clustering
+positively identifies the bare-Y vehicles as Model Ys (289cm cluster,
+n=55,598). The fix retires `tesla/y`. Head records are not presumed clean —
+which is exactly why D1a certification exists.
+
+## What this means for the five-nines program (the honest read)
+
+The baseline is **not close to the target — as expected for a first honest
+measurement**, and the texture is the good news: ~99.5% of availability
+claims and ~96%+ of make/kind claims are already clean; the defect mass
+concentrates in TWO structural generators (truncation stubs; trim/granularity
+ids) plus casing families — all fixable at the generator, not per-record.
+Sequencing consequence, adopted into the program: **D1a head certification
+becomes fix-then-certify** — the Workstream B duplicate harvests and the
+truncation-stub cure land first, then certification sweeps what remains.
+Usage-weighted computation is deliberately deferred to the next round: this
+round is the baseline that directs the fixes, not the claim.
+
+## Protocol v1.1 amendments (applied to audit-PROTOCOL.md in this PR)
+
+Two-route minimum before `unverifiable` · symmetric pair-defects with
+fix-attribution · verifier confirms CLASS, not just defectiveness ·
+evidence lines must name live artifacts (a cited id/file must exist) ·
+multi-twin rule: canonicality checks enumerate ALL live candidate twins.

--- a/data/review/audit-v2026.07.5/audit-ledger-1.yml
+++ b/data/review/audit-v2026.07.5/audit-ledger-1.yml
@@ -1,0 +1,1162 @@
+# VehiclesDB five-nines baseline audit - gate A2 - RESEARCHER LEDGER
+slice: 1
+researcher: opus-audit-1
+tag: v2026.07.5
+protocol: data/review/audit-PROTOCOL.md
+verifier: null   # MUST be a different agent (I-11: researcher != verifier)
+
+METHOD:
+  corpora_read:
+    - "catalog/{bus,car,van,truck}/models.json + makes.json at tag v2026.07.5 (s4w-data worktree)"
+    - "build/observed_variants.json (45,529 ids) and build/observed_model_names.json"
+    - "overrides/models/{renames,moves,removals,former_ids,drop_patterns}.yml, overrides/styling.yml, overrides/makes/aliases.yml"
+    - "PRD-QUALITY.md §4 defect taxonomy (D1-D23), NAMING.md, DEBT.md, data/review/audit-PROTOCOL.md"
+  registers_queried_directly:
+    - "fi_traficom: streamed all 935 MB of TieliikenneAvoinData_31_03_2026.csv from the cached zip; extracted (ajoneuvoluokka | merkkiSelvakielinen | mallimerkinta | kaupallinenNimi) with counts for every make in this slice -> 103,093 distinct rows. The ajoneuvoluokka column (M1/M2/M3/N1/N2/N3) and the Finnish body codes (CA/CB/CE = bus bodies) let me verify KIND from the register itself."
+    - "ua_mvs: streamed all 306 MB of reestrtz02.07.2026.csv from the cached zip -> (KIND | BRAND | MODEL) counts; note ua writes some marques in Cyrillic (ZAZ = 'ZAZ' in Cyrillic), which a Latin-only filter silently misses - re-grepped for those."
+    - "es_dgt: fixed-width export_mensual_mat_202604/05/06.txt (400 MB); make = cols 18-47, model = cols 48-69 (verified against known rows)."
+    - "nl_rdw: cached nl_rdw_bus.json (1,299 merk/handelsbenaming/n rows) and nl_rdw_personenauto.json (91,910 rows). Using the BUS dataset for bus-kind claims is itself a kind check."
+    - "nz_nzta: all 146 cached shards, split by dataset (bus vs passenger-car-van) - the dataset a row sits in is a kind check."
+    - "uk_dft: veh0120 (38 MB); the BodyType column ('Buses and coaches' vs 'Cars') is a kind check, and GenModel exposes DfT's grouping keys."
+    - "lu_snca: lu_delta_202604/05/06.xml -> (CATEU | LIBMRQ | TYPCOM); ca_nrcan: 6 fuel-consumption CSVs; us_fueleconomy: us_vehicles.csv (make/model/baseModel/VClass - baseModel is an objective altitude signal); my_jpj, th_dlt, ie_cso: full CSVs; de_kba: unzipped de_fz10_202606.xlsx and read xl/sharedStrings.xml in document order (make block -> Modellreihe -> 'ZUSAMMEN' terminator)."
+  decision_rules_i_bound_myself_to:
+    - "name-marque-true = correct only when (a) a marque or encyclopedia URL shows the exact form, OR (b) >=2 INDEPENDENT national registers emit the exact display form (the NAMING.md §2 catalog-corroboration basis). Single-register attestation with no reachable marque source = unverifiable, not correct."
+    - "A suffixed id is judged D8 on the ID claim when the suffix is a trim / engine / drivetrain / body qualifier AND a bare-nameplate sibling is live in the same make+kind; it is judged correct when the marque used the whole string as a distinct product's own name. us_fueleconomy's baseModel column was used as the objective tiebreak where available, and every borderline call says so in its note."
+    - "Cross-KIND twins (bus+van+truck/fiat/ducato) are NOT counted as id-canonical failures: taxonomy D10 requires keeping the other kind's evidence, so the kind namespace is intentional. Only same-kind duplicates score as D6."
+    - "availability = correct means the country's register really has row(s) that this id can rest on, cited verbatim with counts. Where a record's KIND is wrong but the rows exist, the availability claims are still correct and the defect is booked once, against kind."
+    - "Where one root cause breaks several claims (e.g. an ALPINA sold as a BMW breaks id, name and make), each claim is scored separately - that is what claim-level rates are for - and the note says it is one root cause."
+
+SUMMARY:
+  records_audited: 100
+  records_skipped: 0
+  claims_total: 656
+  claims_record_level: 400   # id + name + make + kind
+  claims_availability: 256
+  verdict_counts:
+    correct: 546
+    defective: 95
+    unverifiable: 15
+  clean_rate_conservative: "546/656 = 83.2% (unverifiable counted AGAINST, per protocol)"
+  defects_by_class:
+    D6: 29
+    D9: 17
+    D7: 15
+    D5: 10
+    D8: 10
+    D4: 5
+    D11: 3
+    D10: 2
+    D12: 2
+    D13: 2
+  defects_by_claim:
+    name: 51
+    id: 39
+    make: 3
+    kind: 2
+  defect_list:
+    - "bus/altas-auto/sprinter  id  defective(D12)"
+    - "bus/altas-auto/sprinter  name  defective(D5)"
+    - "bus/altas/sprinter  id  defective(D12)"
+    - "bus/altas/sprinter  name  defective(D5)"
+    - "bus/esref-karoser/sprinter  name  defective(D5)"
+    - "bus/isuzu/f  name  defective(D9)"
+    - "bus/king-long/xmq  name  defective(D7)"
+    - "bus/mazda/e  id  defective(D6)"
+    - "bus/mazda/e  name  defective(D9)"
+    - "bus/mengerler/sprinter  name  defective(D5)"
+    - "bus/mercedes-benz/300  id  defective(D6)"
+    - "bus/mercedes-benz/300  name  defective(D9)"
+    - "bus/mercedes-benz/311  id  defective(D6)"
+    - "bus/mercedes-benz/311  name  defective(D9)"
+    - "bus/mercedes-benz/316  id  defective(D6)"
+    - "bus/mercedes-benz/316  name  defective(D9)"
+    - "bus/mercedes-benz/412-d  id  defective(D6)"
+    - "bus/mercedes-benz/518  id  defective(D6)"
+    - "bus/mercedes-benz/518  name  defective(D9)"
+    - "bus/mercedes-benz/818  id  defective(D6)"
+    - "bus/mercedes-benz/818  name  defective(D9)"
+    - "bus/mercedes-benz/e  name  defective(D9)"
+    - "bus/mercedes-benz/oh  name  defective(D7)"
+    - "bus/mercedes-benz/transfer  id  defective(D6)"
+    - "bus/mercedes-benz/transfer  name  defective(D9)"
+    - "bus/neoplan/316  name  defective(D7)"
+    - "bus/nissan/patrol  kind  defective(D10)"
+    - "bus/scania/bf  name  defective(D7)"
+    - "bus/setra/s  id  defective(D6)"
+    - "bus/setra/s  name  defective(D9)"
+    - "bus/setra/s417  id  defective(D6)"
+    - "bus/setra/s417  name  defective(D7)"
+    - "bus/sprintcar/sprinter  name  defective(D5)"
+    - "bus/temsa/md  name  defective(D7)"
+    - "bus/van-hool/tx  id  defective(D6)"
+    - "bus/van-hool/tx  name  defective(D9)"
+    - "bus/volvo/8900  id  defective(D6)"
+    - "bus/volvo/9700h  id  defective(D6)"
+    - "bus/volvo/b  id  defective(D6)"
+    - "bus/volvo/b  name  defective(D9)"
+    - "bus/volvo/b6  id  defective(D6)"
+    - "bus/wrightbus/gb  name  defective(D7)"
+    - "bus/zhongtong/lck  name  defective(D7)"
+    - "bus/zhongtong/zhongtong  id  defective(D4)"
+    - "bus/zhongtong/zhongtong  name  defective(D4)"
+    - "car/ahorn/van-620  kind  defective(D10)"
+    - "car/aion/hyptec-ht-620-premium  name  defective(D8)"
+    - "car/aion/ut-420-standard  id  defective(D6)"
+    - "car/aion/ut-420-standard  name  defective(D8)"
+    - "car/alpina/bmw-alpina-d5-biturbo-touring  name  defective(D5)"
+    - "car/audi/avant-rs2  name  defective(D7)"
+    - "car/austin/nash  id  defective(D6)"
+    - "car/austin/nash  name  defective(D5)"
+    - "car/bentley/flying-spur-v8  id  defective(D8)"
+    - "car/bmw/activehybrid-7  name  defective(D7)"
+    - "car/bmw/alpina-b6  id  defective(D6)"
+    - "car/bmw/alpina-b6  name  defective(D5)"
+    - "car/bmw/alpina-b6  make  defective(D11)"
+    - "car/bmw/ci  name  defective(D9)"
+    - "car/bmw/i  id  defective(D6)"
+    - "car/bmw/i  name  defective(D9)"
+    - "car/bmw/m-635-csi  name  defective(D7)"
+    - "car/bmw/mini  id  defective(D6)"
+    - "car/bmw/mini  name  defective(D4)"
+    - "car/bmw/mini  make  defective(D11)"
+    - "car/bmw/z-reihe  id  defective(D6)"
+    - "car/bmw/z-reihe  name  defective(D9)"
+    - "car/cadillac/elr  name  defective(D7)"
+    - "car/chery/jaecoo-j8  id  defective(D6)"
+    - "car/chery/jaecoo-j8  name  defective(D5)"
+    - "car/chery/jaecoo-j8  make  defective(D11)"
+    - "car/chevrolet/astro  id  defective(D6)"
+    - "car/chevrolet/aveo-ls  id  defective(D6)"
+    - "car/chevrolet/aveo-ls  name  defective(D8)"
+    - "car/chevrolet/cruze-eco  id  defective(D8)"
+    - "car/chevrolet/lumina-monte-carlo  id  defective(D13)"
+    - "car/chevrolet/lumina-monte-carlo  name  defective(D13)"
+    - "car/chevrolet/sonic-5  id  defective(D8)"
+    - "car/chrysler/gs  name  defective(D9)"
+    - "car/citroen/11bl  id  defective(D6)"
+    - "car/citroen/c  name  defective(D9)"
+    - "car/citroen/gsa-special  id  defective(D8)"
+    - "car/citroen/gsa-special  name  defective(D7)"
+    - "car/citroen/mehari  name  defective(D7)"
+    - "car/cupra/seat-leon  id  defective(D6)"
+    - "car/cupra/seat-leon  name  defective(D5)"
+    - "car/daimler/mkii  name  defective(D7)"
+    - "car/datsun/180b-wagon  id  defective(D8)"
+    - "car/de-soto/soto  id  defective(D4)"
+    - "car/de-soto/soto  name  defective(D4)"
+    - "car/denza/d9-fwd  id  defective(D6)"
+    - "car/denza/d9-fwd  name  defective(D8)"
+    - "car/dodge/polara-880  id  defective(D6)"
+    - "car/dodge/polara-880  name  defective(D8)"
+    - "car/dodge/wc51  id  defective(D6)"
+  unverifiable_list:
+    - "bus/ayats/bravo  name  unverifiable(no Ayats source reachable - ayats.com refused the connection (curl exit 0 bytes); only register attestation is the single string 'BRAVO I R CITY')"
+    - "bus/higer/a30  id  unverifiable(bus/higer/touring holds 'SCANIA TOURING HD' n=99 and 'A80T 6X2: SCANIA TOURING HD'; whether the A30 is the same coach as the Scania Touring HD could not be resolved - en.wikipedia.org/wiki/Scania_Touring returns 404 and higer.com was not reachable)"
+    - "bus/higer/a30  name  unverifiable(single-register attestation only ('SCANIA HIGER A30', nl_rdw n=50); no Higer or Scania source reachable)"
+    - "bus/iveco/dyparro  name  unverifiable(no source reachable identifies 'Dyparro'; en.wikipedia has no article and the string appears in no marque catalogue I could fetch)"
+    - "bus/iveco/dyparro  make  unverifiable(nl_rdw files 4 of the 5 nl rows under merk 'IVECO - DYPETY' - a chassis make hyphenated with a body-builder token. moves.yml's Iveco block routes bodied minicoaches to the BUILDER's make ('Sunrise: null # Ferqui Sunrise ... canonical is ferqui/sunrise', 'Wing: null # Indcar Wing'), which would apply here if the builder could be identified)"
+    - "bus/volvo/8707  id  unverifiable(cannot determine whether '8707' is a distinct product from bus/volvo/8700 - fi emits '8707 RLE' (n=72) and '8700 RLE' (n=23) as separate strings, so it is not a typo, but no Volvo source enumerates 8707)"
+    - "bus/volvo/8707  name  unverifiable(no Volvo source reachable attests '8707'; en.wikipedia.org/wiki/Volvo_8900 lists the predecessors as 8500/8500LE and 8700/8700LE only)"
+    - "car/aion/hyptec-ht-620-premium  make  unverifiable(GAC markets Hyptec as its own brand line (formerly Aion Hyper) but no reachable source settles whether it is a marque separate from Aion; th_dlt files the row under maker 'AION' and the catalog has no hyptec make)"
+    - "car/austin/clifton  id  unverifiable(cannot establish whether 'Clifton' denotes a model, a coachbuilt body on the Austin 12/4, or something else, so overlap with car/austin/metropolitan-style siblings is undecidable)"
+    - "car/austin/clifton  name  unverifiable(en.wikipedia.org/wiki/Austin_12/4 lists the produced bodies as Harley saloon, Ascot saloon, tourer, Eton two-seater tourer, Open Road tourer, cabriolet and estate - 'Clifton' does not appear; no other Austin source reachable)"
+    - "car/bmw/ci  id  unverifiable(the underlying rows are bare trim-suffix strings ('CI CABRIO' nl n=1, 'CI AUTO' gb) that cannot be resolved to a model series, so whether car/bmw/3-series or another live id already denotes them is undecidable)"
+    - "car/chevrolet/universal  availability.nz  unverifiable(the only nz row reachable in the cached NZTA shards is 'CHEVROLET | A D UNIVERSAL' n=1, which does not fold to 'Universal' under any documented rule; the nz claim may rest on a row absent from these shards)"
+    - "car/chrysler/gs  id  unverifiable(the rows are bare trim strings ('GS', 'GS TURBO 2', 'GS TURBO 2 U9') on a 1980s Chrysler G-body; I could not establish which nameplate they denote, so overlap with a live Chrysler id is undecidable)"
+    - "car/citroen/c  id  unverifiable(the record rests on bare-letter rows (nl 'C' n=5, nz 'C' n=1) plus one 'C 5 HP'; Type C, C4, C6 and the modern C-series all fold to the same key, so which vehicle the id denotes - and therefore whether a sibling duplicates it - is undecidable)"
+    - "car/daimler/mkii  id  unverifiable(the id pools 'MKII SALOON' with 'MK II DINGO' (a Daimler Dingo scout car) so it is not clear the id denotes ONE vehicle; DEBT.md files the Daimler/Jaguar Mk split family as open work)"
+
+FLAGGED_LOUDLY:
+  new_defect_classes_found: none
+  rationale: >-
+    Every finding in this slice lands inside PRD-QUALITY §4's existing taxonomy
+    (D4, D5, D6, D7, D8, D9, D10, D12, D13). The one shape I expected to be new
+    - the "family/series stub" id produced by truncating a numbered nameplate at
+    its first space (bus/setra/s pooling 96 S-4nn strings, bus/volvo/b pooling
+    the spaced spellings of 21 live chassis ids, bus/mercedes-benz/e from
+    "MB E 15 RHD", car/citroen/c, car/bmw/i, bus/scania/bf, bus/isuzu/f,
+    bus/mazda/e) - is already covered twice over: D9 for the name half
+    ("registry/type/homologation code as model") and D6/D17 for the id half,
+    with the structural cause already filed in DEBT.md ("VARIANT_SUFFIXES `.*`
+    tails destroy model info", "U7 variant-strip Roman collapse ... unresolvable
+    truncated ids"). I am NOT proposing a new class for it.
+  detector_gaps_worth_a_spec_anyway:
+    - id: "make-as-model surviving prefix-strip"
+      evidence: >-
+        car/de-soto/soto. renames.yml already carries `De Soto: Desoto: null`
+        for exactly this class, but make-prefix stripping turns the raw
+        "DE SOTO" into "SOTO", so the null key never matches and the artifact
+        ships. Same escape applies to any make whose name is >1 token.
+      spec: "flag any model id whose name equals a trailing token-suffix of its own make name after prefix stripping (soto<-De Soto, and check bus/zhongtong/zhongtong which is the un-stripped variant of the same class)."
+    - id: "spacing-only twin across a letter/number boundary"
+      evidence: >-
+        bus/volvo/8900 ('8900 RLE') vs bus/volvo/8900rle ('8900RLE');
+        bus/volvo/9700 ('9700 H') vs bus/volvo/9700h; bus/volvo/b6 ('B6 FA') vs
+        bus/volvo/b6fa; car/bmw/i ('i 8') vs car/bmw/i8; bus/setra/s ('S 417 ...')
+        vs bus/setra/s417. Five independent instances inside one 100-record
+        sample, all in the same shape, all with both spellings present in ONE
+        register (nl_rdw or nz_nzta), which makes them mechanically detectable
+        without any marque research.
+      spec: "NFKD-fold + strip ALL whitespace before the duplicate-spellings comparison, restricted to same make+kind; the existing find_duplicate_spellings appears not to be collapsing the space between a letter group and a digit group."
+    - id: "make string carrying a body-builder token"
+      evidence: "nl_rdw merk 'IVECO - DYPETY' (bus/iveco/dyparro, 4 of 5 nl rows). A D12-shaped make defect that produced a model record under the chassis marque; moves.yml's Iveco block (Ferqui Sunrise, Indcar Wing) is the established remedy but the builder could not be identified from any reachable source."
+      spec: "flag raw make strings containing ' - ' or '/' where one side matches a known chassis marque (also live in this corpus: 'CMS AUTO/MERCEDES-BENZ', 'MAN/NEOPLAN', 'GMC BLUE BIRD', 'CUBY IVECO', 'MERCEDES SPRINTER/BUS FA...', 'MB SPRINTER' as a MAKE)."
+    - id: "converter-make records carrying the donor marque's nameplate"
+      evidence: "six bus-kind makes each own a model called 'Sprinter' (acbus, altas, altas-auto, esref-karoser, mengerler, sprintcar); five are in this slice and all five score D5 on name. The population is small but the pattern is systematic, and altas/altas-auto additionally share a type approval (D12)."
+      spec: "flag any model name that exactly equals a nameplate live under a DIFFERENT make in the same kind, where the raw string also contains the other marque's token ('MB SPRINTER', 'SPRINTER ALTAS')."
+  highest-volume_single_findings:
+    - "car/bmw/z-reihe - 7,143 nl_rdw registrations resting on a German register GROUP LABEL ('Z-Reihe' = 'Z series'), while car/bmw/{z1,z3,z4,z8} are all live. Largest non-nameplate population in the slice."
+    - "car/bmw/mini - 6,572 nz + 55 nl + 2 fi vehicles filed under BMW's model column while the 'mini' make (19 models) covers the same three countries."
+    - "car/bmw/i - 1,319 nz vehicles on a one-letter id that is the spacing twin of car/bmw/i3 and car/bmw/i8."
+    - "bus/setra/s - 96 distinct S-4nn/S-5nn strings across five countries pooled onto the series letter, while bus/setra/s417 and /s431dt are separately live."
+
+"bus/altas-auto/sprinter":
+  verdicts: { id: "defective(D12)", name: "defective(D5)", make: "correct", kind: "correct",
+              availability: { es: "correct", fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'ALTAS AUTO | SPRINTER ALTAS' es_dgt 202604-06 n=2"
+    - "raw: 'Altas Auto | SPRINTER ALTAS Yksikerroksinen (CA) 2ov 1950cm3 A' fi_traficom class=M3 n=8"
+    - "raw: 'ALTAS AUTO | SPRINTER ALTAS' nl_rdw bus n=2 (nl_rdw_bus.json)"
+    - "catalog: bus/altas/sprinter is live with the SAME raw set ('SPRINTER ALTAS','Sprinter ALTAS','Sprinter Altas') and shares TAN e9*2007/46*6386*16 with this record"
+    - "https://en.wikipedia.org/wiki/Van_Hool  # (method) marque-owned badge test applied to converter makes"
+  notes: "id: D12 make near-dupe -> D6 twin. `altas` and `altas-auto` are one Turkish converter: fi_traficom emits BOTH merk 'Altas' and merk 'Altas Auto' against byte-identical mallimerkinta 'SPRINTER ALTAS Yksikerroksinen (CA) ... cm3 A', nl_rdw emits both 'ALTAS' (n=5) and 'ALTAS AUTO' (n=2) with handelsbenaming 'SPRINTER ALTAS', and the two catalog records share type-approval e9*2007/46*6386*16. name: 'Sprinter' is Mercedes-Benz's nameplate carried in the model column of a body-builder row ('SPRINTER ALTAS' / 'MB SPRINTER'); six converter makes in the bus kind (acbus, altas, altas-auto, esref-karoser, mengerler, sprintcar) each carry a model called 'Sprinter'."
+
+"bus/altas/sprinter":
+  verdicts: { id: "defective(D12)", name: "defective(D5)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'Altas | SPRINTER ALTAS Yksikerroksinen (CA) 3ov 2987cm3 A' fi_traficom class=M3 n=16"
+    - "raw: 'ALTAS | SPRINTER ALTAS' nl_rdw bus n=5"
+    - "catalog: bus/altas-auto/sprinter live twin; shared TAN e9*2007/46*6386*16"
+  notes: "Same defect pair as bus/altas-auto/sprinter; this side additionally absorbs the Tourline/Multiline/Businessline body variants ('Sprinter Tourline L' fi n=5, 'SPRINTER TOURLINE L' nl n=1)."
+
+"bus/ayats/bravo":
+  verdicts: { id: "correct", name: "unverifiable(no Ayats source reachable - ayats.com refused the connection (curl exit 0 bytes); only register attestation is the single string 'BRAVO I R CITY')", make: "correct", kind: "correct",
+              availability: { es: "correct", fi: "correct" } }
+  evidence:
+    - "raw: 'AYATS | BRAVO I R CITY' es_dgt n=1"
+    - "raw: 'AYATS | BRAVO I R CITY Kaksikerroksinen (CB) 7698cm3 A' fi_traficom class=M3 n=1"
+  notes: "kind confirmed by the fi body code CB (double-deck bus) - Ayats' Bravo is a double-decker. Only one Ayats record exists in the bus kind, so id-canonicality is trivially clean."
+
+"bus/beulas/glory":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { es: "correct", nl: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Beulas  # 'Glory - top of the range luxury coach, introduced in 2008'; image caption 'Beulas Glory on a Volvo chassis'"
+    - "raw: 'BEULAS | GLORY' es_dgt n=9"
+    - "raw: 'BEULAS | GLORY' nl_rdw bus n=1"
+
+"bus/esref-karoser/sprinter":
+  verdicts: { id: "correct", name: "defective(D5)", make: "correct", kind: "correct",
+              availability: { es: "correct", fi: "correct", nl: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'ESREF KAROSER | SPRINTER' es_dgt n=2"
+    - "raw: 'Esref Karoser | Sprinter Yksikerroksinen (CA) 3ov 1950cm3 A' fi_traficom class=M3 n=2"
+    - "raw: 'ESREF KAROSER | SPRINTER' nl_rdw bus n=1"
+    - "raw: 'ESREF KAROSER | SPRINTER' ua_mvs kind=ABTOBYC n=1"
+  notes: "name: same converter/donor-badge class as the Altas pair. No make near-dupe found for Esref Karoser, so id is clean."
+
+"bus/fiat/ducato":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", gb: "correct", nl: "correct", nz: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Fiat | Ducato Yksikerroksinen (CW) 4ov 2999cm3' fi_traficom class=M2 n=7 (5 distinct M2/M3 rows)"
+    - "raw: 'FIAT | DUCATO 35 STANDARD L3H1' uk_veh0120 BodyType='Buses and coaches'"
+    - "raw: 'FIAT | DUCATO MAXI' nl_rdw bus n=3 (also 'DUCATO' n=1, 'DUCATO 18' n=1)"
+    - "raw: 'FIAT | DUCATO' nz_nzta bus shard n=40"
+    - "raw: 'FIAT | DUCATO' ua_mvs kind=ABTOBYC n=7"
+  notes: "Cross-kind twins van/fiat/ducato and truck/fiat/ducato are by design (taxonomy D10: 'NEVER lose the other kind's evidence'), so they are not counted as id-canonical failures here."
+
+"bus/higer/a30":
+  verdicts: { id: "unverifiable(bus/higer/touring holds 'SCANIA TOURING HD' n=99 and 'A80T 6X2: SCANIA TOURING HD'; whether the A30 is the same coach as the Scania Touring HD could not be resolved - en.wikipedia.org/wiki/Scania_Touring returns 404 and higer.com was not reachable)", name: "unverifiable(single-register attestation only ('SCANIA HIGER A30', nl_rdw n=50); no Higer or Scania source reachable)", make: "correct", kind: "correct",
+              availability: { nl: "correct" } }
+  evidence:
+    - "raw: 'HIGER | SCANIA HIGER A30' nl_rdw bus n=50"
+    - "raw: 'HIGER | SCANIA TOURING HD' nl_rdw bus n=99 and 'HIGER | A80T 6X2: SCANIA TOURING HD' n=1  # the A80T<->Touring HD mapping is explicit in the register; the A30<->Touring mapping is not"
+    - "https://en.wikipedia.org/wiki/Scania_Touring  # 404"
+  notes: "make correct: nl_rdw merk is 'HIGER' (not SCANIA) for all 150 rows, so this is not a marque-of-sale error."
+
+"bus/hyundai/h-1":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { nz: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'HYUNDAI | H1' nz_nzta bus shard n=59"
+    - "raw: 'HYUNDAI | H-1' ua_mvs kind=ABTOBYC n=1 (plus 196 LEGKOVYI / 60 VANTAZHNYI)"
+    - "catalog: former_ids ['bus/hyundai/h1'] - the hyphenated form is a deliberate curation decision, and ua_mvs emits the hyphen verbatim"
+  notes: "ua bus evidence is thin (one ABTOBYC row) but real. Hyundai's own rendering is the hyphenated H-1; ua_mvs is the register that carries the hyphen."
+
+"bus/isuzu/f":
+  verdicts: { id: "correct", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { nz: "correct" } }
+  evidence:
+    - "raw: 'ISUZU | F SERIES' nz_nzta bus shard n=256"
+    - "overrides/models/renames.yml Isuzu block: 'NLR85EXXXB: N-Series  # NLR85 is a CHASSIS code, not a nameplate - Isuzu's light truck line is the N-Series' (https://www.isuzu.co.jp/world/product/elf/)"
+  notes: "name: the register string is 'F SERIES' and Isuzu's own family name is F-Series; the catalog kept only the bare letter 'F'. The project's own Isuzu rename precedent resolves exactly this shape to '<letter>-Series'. Note the inconsistency: the sibling bus/isuzu/series ('Series') was produced from 'N SERIES' by dropping the letter instead of the word."
+
+"bus/isuzu/journey":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { nz: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Anadolu_Isuzu  # Isuzu vehicles template lists Journey, Journey-J, Journey-K, Journey-Q as (past) Isuzu bus models"
+    - "raw: 'ISUZU | JOURNEY' nz_nzta bus shard n=178 (+ 'JOURNEY DELUXE', 'JOURNEY LR312', 'JOURNEY LR312J', 'JOURNEY P-MR112D')"
+
+"bus/isuzu/visigo":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { es: "correct", fi: "correct", nl: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Anadolu_Isuzu  # midibus line: Novo, Novociti, Turquoise, Visigo, Citibus - 'Visigo' spelled exactly so"
+    - "raw: 'ISUZU | VISIGO' es_dgt n=7"
+    - "raw: 'Isuzu | Visigo Yksikerroksinen (CA) 2ov 6700cm3 A' fi_traficom class=M3 n=1"
+    - "raw: 'ISUZU | VISIGO' nl_rdw bus n=1"
+
+"bus/iveco/dyparro":
+  verdicts: { id: "correct", name: "unverifiable(no source reachable identifies 'Dyparro'; en.wikipedia has no article and the string appears in no marque catalogue I could fetch)", make: "unverifiable(nl_rdw files 4 of the 5 nl rows under merk 'IVECO - DYPETY' - a chassis make hyphenated with a body-builder token. moves.yml's Iveco block routes bodied minicoaches to the BUILDER's make ('Sunrise: null # Ferqui Sunrise ... canonical is ferqui/sunrise', 'Wing: null # Indcar Wing'), which would apply here if the builder could be identified)", kind: "correct",
+              availability: { nl: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'IVECO - DYPETY | DYPARRO 90T' nl_rdw bus n=4; 'IVECO | DYPARRO 90T' nl_rdw bus n=1"
+    - "raw: 'IVECO | DYPARRO 90T' ua_mvs kind=ABTOBYC n=3"
+    - "overrides/models/moves.yml Iveco/Irisbus block - body-builder routing precedent"
+  notes: "Flagged for the source-gap queue: the nl merk 'IVECO - DYPETY' is itself a make-string defect (D12 shape) that no detector appears to have caught."
+
+"bus/king-long/xmq":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { es: "correct", nz: "correct", ua: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/King_Long  # 'King Long XMQ6127', 'XMQ6900', 'XMQ6129Y', 'XMQ6112' - XMQ always capitals; no model called 'Xmq'"
+    - "raw: 'KING LONG | XMQ6120C' es_dgt n=1"
+    - "raw: 'KING LONG | XMQ6911' nz_nzta bus n=8 (also XMQ6110, XMQ6130, XMQ6996, XMQ6900)"
+    - "raw: 'KING LONG | XMQ6800Y' ua_mvs kind=ABTOBYC n=1"
+  notes: "name: two defects compounded - the acronym is title-cased ('Xmq') and the model number is gone. Every one of the 7 register strings is 'XMQ' + digits; not one is a bare XMQ."
+
+"bus/ldv/maxus":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { gb: "correct" } }
+  evidence:
+    - "raw: 'LDV | MAXUS 15S 120 MINIBUS' uk_veh0120 BodyType='Buses and coaches' GenModel='LDV MAXUS' (99 model rows under that GenModel)"
+  notes: "name: 'Maxus' is LDV's own nameplate (later a marque in its own right); uk_dft's GenModel is literally 'LDV MAXUS'. No LDV marque site is reachable (defunct), so the citation is the register's own make+model pairing. kind confirmed by the 'MINIBUS' model strings under the bus body type."
+
+"bus/mazda/e":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { gb: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'MAZDA | E2000' and 'MAZDA | E2200 MWB' uk_veh0120 BodyType='Buses and coaches' GenModel='MAZDA E SERIES'"
+    - "raw: 'MAZDA | E 2200' ua_mvs kind=ABTOBYC n=5 (also 'E 2000' LEGKOVYI n=5)"
+    - "catalog: bus/mazda/e2000 ('E2000') is live in the same make+kind; the uk_dft GenModel 'MAZDA E SERIES' feeds both ids"
+  notes: "id: D6 - one GenModel ('MAZDA E SERIES') and one ua family ('E 2000'/'E 2200') are split across bus/mazda/e and bus/mazda/e2000. name: 'E' is a truncated family letter; Mazda's forms are E2000/E2200/E-Series."
+
+"bus/mengerler/sprinter":
+  verdicts: { id: "correct", name: "defective(D5)", make: "correct", kind: "correct",
+              availability: { es: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'MENGERLER | SPRINTER' es_dgt n=1"
+    - "raw: 'MENGERLER | SPRINTER' nl_rdw bus n=1"
+  notes: "Same converter/donor-badge class as the Altas and Esref Karoser records."
+
+"bus/mercedes-benz/300":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { gb: "correct" } }
+  evidence:
+    - "raw: uk_veh0120 GenModel 'MERCEDES 300' under BodyType='Buses and coaches' carries models '308D', '308D LWB', '310 VAN', '311 CDI MWB TRAVELINER', '311 CDI LWB TRAVELINER', '312D LWB' - i.e. exactly the T1/TN minibuses already catalogued as bus/mercedes-benz/308-d, /310, /311, /312-d"
+    - "raw: the SAME GenModel also carries '300 CE AUTO', '300 TE 4MATIC (4WD)', '300 GEL AUTO' - W124 coupe/estate and G-wagen passenger cars"
+  notes: "id: D6 - 'MERCEDES 300' is a uk_dft grouping key, not a nameplate; its bus-body rows are already represented by four live sibling ids. kind is marked correct because the GenModel does contain genuine minibuses (308D, 311 CDI Traveliner). gb availability is correct in the literal sense that the register has 'Buses and coaches' rows under this GenModel; flagged that those rows include passenger cars (a uk_dft body-type contamination worth a source note)."
+
+"bus/mercedes-benz/311":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { fi: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Mercedes-Benz | 311 CDI-9036-3.88T-KASTEN HOCH/403' fi_traficom class=M2 n=3 (4 M2/M3 rows total)"
+    - "raw: 'MERCEDES-BENZ | 311CDI' ua_mvs kind=ABTOBYC n=37; '311 D' ABTOBYC n=11"
+    - "raw: fi_traficom kaupallinenNimi for the very same rows is 'SPRINTER 311 CDI' - the commercial name the register itself supplies"
+    - "catalog: bus/mercedes-benz/sprinter is live and its raw set includes 'SPRINTER 311 CDI', 'SPRINTER 311CDI-3.5T-906635/433'"
+  notes: "id: D6 - the Sprinter 311 CDI is catalogued twice, once as the bare type code and once under the nameplate. name: '311' is a Sprinter tonnage/power type code, not a Mercedes-Benz nameplate; the register's own commercial-name column says 'SPRINTER 311 CDI'."
+
+"bus/mercedes-benz/316":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Mercedes-Benz | 316 CDI-9036-3.5T-KASTEN/355' fi_traficom class=M2 n=3, kaupallinenNimi 'SPRINTER 316 CDI' (10 M2/M3 rows)"
+    - "raw: 'MERCEDES-BENZ | 316 CDI SPRINTER TRANSFER 34 BASIC' nl_rdw bus n=1 (+ '316 CDISPRINTER TRANSFER 34 BASIC' n=1)"
+    - "raw: 'MERCEDES-BENZ | 316' ua_mvs kind=ABTOBYC n=23; '316 CDI' ABTOBYC n=11"
+    - "catalog: bus/mercedes-benz/sprinter live with 'SPRINTER 316', 'SPRINTER 316 CDI', 'SPRINTER 316CDI PROSTYLE'"
+  notes: "Same pair as /311."
+
+"bus/mercedes-benz/412-d":
+  verdicts: { id: "defective(D6)", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Mercedes-Benz | 412D-KA-904463-KASTEN/403' fi_traficom class=M2 n=74"
+    - "raw: 'MERCEDES-BENZ | 412D' ua_mvs kind=ABTOBYC n=22; '412 D' ABTOBYC n=9"
+    - "catalog: bus/mercedes-benz/412 ('412') is live and its raw set is ['412 D', '412 D-904463/403', '412 D-KA']; bus/mercedes-benz/412d-ka-904463-kasten ('412D-Ka-904463-Kasten') is a THIRD live id for the same T2 chassis"
+    - "catalog: former_ids ['bus/mercedes-benz/412d'] - the spaced display form is deliberate curation"
+  notes: "id: D6 with three live ids for the Mercedes-Benz T2 412 D. name accepted: the spaced '412 D' is the marque's T2 badge and is what ua_mvs emits verbatim; the project already rekeyed 412d -> 412-d on purpose."
+
+"bus/mercedes-benz/518":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Mercedes-Benz | 518 Yksikerroksinen (CA) 2ov 2987cm3 A' fi_traficom class=M2 n=1 (5 M2/M3 rows incl. '518 Sprinter Radius', '518 SPRINTER MIX-LINE')"
+    - "raw: 'MERCEDES-BENZ | 518 CDI' nl_rdw bus n=3; '518 CDI SPRINTER' nl_rdw bus n=1"
+    - "raw: 'MERCEDES-BENZ | 518 CDI' ua_mvs kind=ABTOBYC n=2"
+    - "catalog: bus/mercedes-benz/sprinter live; this record's own raw set already contains '518 CDI SPRINTER', '518 SPRINTER MIX-LINE', '518 SPRINTER RADIUS R'"
+
+"bus/mercedes-benz/818":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { fi: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Mercedes-Benz | 818 SUNRIDER Yksikerroksinen (CA) 4249cm3' fi_traficom class=M3 n=2"
+    - "raw: 'MERCEDES-BENZ | 818' ua_mvs kind=ABTOBYC n=1; '818D' ABTOBYC n=1"
+    - "catalog: bus/mercedes-benz/818-d ('818 D') is live with raw '818D Vario Rosero' - the same Vario 818 D chassis"
+  notes: "name: '818' is an Atego/Vario tonnage code; the fi rows that carry it are bodied coaches ('818 SUNRIDER', '818S BELUGA 2', '818D Vario Rosero')."
+
+"bus/mercedes-benz/atego":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct", nz: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Mercedes-Benz | ATEGO 1022L Yksikerroksinen (CA) 4801cm3' fi_traficom class=M3 n=1  # the ONLY bus-class Atego row in fi; the other 628 fi Atego rows are N2/N3 goods vehicles"
+    - "raw: 'MERCEDES-BENZ | ATEGO 1530 TOURING GT' nl_rdw bus n=1"
+    - "raw: 'MERCEDES-BENZ | ATEGO' nz_nzta bus shard n=1"
+    - "raw: 'MERCEDES-BENZ | ATEGO' ua_mvs kind=ABTOBYC n=4; 'ATEGO 1218L' ABTOBYC n=2"
+  notes: "kind correct but thin: every claimed country has at least one genuine bus-class Atego row (bodied coach/minibus on the Atego chassis). Recorded here because the taxonomy names 'Atego in car' as the D10 exemplar - the bus half is evidenced, the car half (car/mercedes-benz/atego, also live) is the one to look at."
+
+"bus/mercedes-benz/e":
+  verdicts: { id: "correct", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { es: "correct", fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'MERCEDES-BENZ | MB E 16/2 RHD' es_dgt n=25 (+ 'MB E 19 UE' n=5, 'MB E 15 RHD' n=5, 'MB E 17 UE' n=3, 'MB E 17 RHD' n=1, 'MB E 15 UE' n=1)"
+    - "raw: 'Mercedes-Benz | MB E 17 UE Yksikerroksinen (CA) 2ov 7698cm3 A' fi_traficom class=M3 n=5 (all 8 MB E rows are M3, body CA)"
+    - "raw: 'MERCEDES-BENZ | MB E 16/2 RHD' nl_rdw bus n=168; 'MB E 17 RHD' n=165; 'MB E 15 RHD' n=67; 'MB E 15 UE' n=34"
+  notes: "name: the register string is 'MB E <rows> RHD|UE' - an EvoBus type code in the same shape as Setra's 'S 4nn HD/UL' (this record and bus/setra/s even share type approval e1*2007/46*1133*07). The catalog kept only the series letter 'E', which is not a Mercedes-Benz bus nameplate. I could not resolve which nameplate E-nn-RHD/UE denotes (Tourismo and Intouro are the plausible candidates; no EvoBus source was fetchable), so the resolution is a source-gap item - but the truncation itself is a defect independent of that."
+
+"bus/mercedes-benz/oh":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nz: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Mercedes-Benz | OH 1628 L-C/480' fi_traficom class=M3 n=1 (+ 'OH 1628L/610' M3, 'OH1625L-LAK' M3, 'OH 1625L-LAK/7200' n=3)"
+    - "raw: 'MERCEDES-BENZ | OH1316' nz_nzta bus shard n=1"
+    - "raw: 'MERCEDES-BENZ | OH 1634L' ua_mvs kind=ABTOBYC n=2"
+    - "https://en.wikipedia.org/wiki/Mercedes-Benz_OH  # 404 - no marque/encyclopedia source reachable for the OH chassis family"
+  notes: "name: three independent registers (fi, nz, ua) spell the prefix in capitals ('OH'); 'Oh' is the title-caser's output, matched by no source at all. The bare token is also a chassis-series prefix (the real designations are OH 1625L / OH 1628 L / OH 1634L), so the display is short of a nameplate as well as mis-cased - D7 is the minimal provable class."
+
+"bus/mercedes-benz/transfer":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'Mercedes-Benz | transfer 45 Yksikerroksinen (CA) 2143cm3' fi_traficom class=M2 n=1"
+    - "raw: 'MERCEDES-BENZ | TRANSFER 45 LL' nl_rdw bus n=3; 'TRANSFER 45' n=1; 'TRANSFER 55' n=1"
+    - "raw: 'MERCEDES-BENZ | TRANSFER 35' nz_nzta bus shard n=3"
+    - "catalog: bus/mercedes-benz/sprinter is live and its raw set contains 'SPRINTER TRANSFER 34', 'SPRINTER TRANSFER 35', 'SPRINTER TRANSFER 45', 'SPRINTER TRANSFER 55' - the same four factory minibuses"
+  notes: "id: D6 - the Sprinter Transfer 34/35/45/55 appear both under the nameplate and under the bare body-line word. name: 'Transfer' is EvoBus's minibus body line within the Sprinter nameplate, not a standalone model."
+
+"bus/mitsubishi-fuso/rosa":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { nz: "correct" } }
+  evidence:
+    - "raw: 'MITSUBISHI FUSO | ROSA' nz_nzta bus shard n=380; 'MITSUBISHI | ROSA' nz bus n=277"
+    - "raw: variants 'ROSA CUSTOM', 'ROSA CUSTOM AWD', 'ROSA SCHOOL AUTO', 'ROSA SCHOOL EURO 6' - trims of one nameplate, correctly folded"
+
+"bus/neoplan/316":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'NEOPLAN | N316 SHD' nl_rdw bus n=1; 'N316/3 UL' n=1; 'N 316 UE' n=1"
+    - "raw: 'Neoplan | 316 SHD-TRANSLINER' fi_traficom class=M3 n=1"
+    - "raw: 'NEOPLAN | 316' ua_mvs kind=ABTOBYC n=2; '316UE' ABTOBYC n=1"
+  notes: "name: Neoplan's designation carries the N prefix (nl_rdw emits 'N316 SHD' and 'N 316 UE'; the coach is the N316 SHD Transliner). The catalog kept the bare number, which collides conceptually with bus/mercedes-benz/316 and with the marque's own N116/N216/N316 series. id marked correct because no OTHER Neoplan id in the bus kind denotes the N316 (siblings 116/216/2216 are different models)."
+
+"bus/nissan/patrol":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "defective(D10)",
+              availability: { gb: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'NISSAN | PATROL GR SGX D' uk_veh0120 BodyType='Buses and coaches' - the same GenModel 'NISSAN PATROL' carries 74 further rows under BodyType='Cars'"
+    - "raw: 'NISSAN | PATROL' nz_nzta bus shard n=1 vs nz_nzta passenger-car-van shard n=2079"
+    - "catalog: car/nissan/patrol and van/nissan/patrol are live"
+  notes: "kind: the Caddymaxi/kind-noise class. The Patrol is an SUV; the bus-kind record rests on one nz bus-shard row and one uk_dft row that the DfT filed under 'Buses and coaches' while placing 2079/74 of the same nameplate under cars. Availability claims are marked correct because the rows do exist - the defect is that they should not have minted a bus-kind record."
+
+"bus/otokar/vectio":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { es: "correct", lu: "correct", nl: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Otokar  # 'a new 9-meter, rear-engined bus called Doruk in Turkey and Vectio in other markets'"
+    - "raw: 'OTOKAR | VECTIO U LE' es_dgt n=4"
+    - "raw: 'OTOKAR | VECTIO 310T' lu_snca CATEU=M3 n=2"
+    - "raw: 'OTOKAR | VECTIO 290T' / 'VECTIO 290 T' / 'VECTIO G 250 U' nl_rdw bus n=1 each"
+  notes: "nl also carries 'VECTIO???T' (n=1) - a mojibake register string folded into this id; noted, not a verdict."
+
+"bus/scania/bf":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'Scania | BF86S59/5880' fi_traficom class=M3 n=2 (also BF11159AS/5890, BF11159/5890, 'BF 8059/5690-69')"
+    - "raw: 'SCANIA | BF-5659-AK' nl_rdw bus n=1"
+  notes: "name: both registers spell the pre-1980 Scania chassis prefix in capitals (BF110/BF111/BF86S); 'Bf' is the title-caser's output and matches no source. As with mercedes-benz/oh the display is also short of a full designation."
+
+"bus/scania/interlink":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { es: "correct", fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'SCANIA | SCANIA INTERLINK' es_dgt n=1"
+    - "raw: 'Scania | Scania Interlink Yksikerroksinen (CA) 2ov 12742cm3 A' fi_traficom class=M3 n=43"
+    - "raw: 'SCANIA | SCANIA INTERLINK' nl_rdw bus n=12"
+    - "three independent registers emit the exact display form 'Interlink' (NAMING.md catalog-corroboration basis)"
+
+"bus/setra/s":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { es: "correct", fi: "correct", lu: "correct", nl: "correct", ua: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Setra  # 'Setra consistently writes the S-prefix with a space before the number (S 415 HD, S 417 HDH, S 431 DT)'; there is no model designated simply 'S'"
+    - "raw: 'SETRA | S 516 HD/2' es_dgt n=13"
+    - "raw: 'Setra | S 417 UL/2 Business Yksikerroksinen (CA) 2ov 7698cm3' fi_traficom class=M3 n=8"
+    - "raw: 'SETRA | S415UL' lu_snca CATEU=M3 n=10"
+    - "raw: 'SETRA | S 415 LE BUSINESS' nl_rdw bus n=169; 'S 431 DT' n=38"
+    - "raw: 'SETRA | S 431DT' ua_mvs kind=ABTOBYC n=22; 'S 417GT-HD' ABTOBYC n=9"
+    - "catalog: bus/setra/s417 ('S417') and bus/setra/s431dt ('S431DT') are live, and THIS record's raw set already contains 'S 417 GT-HD', 'S 417 HDH', 'S 417 UL', 'S 417 UL/2 Business', 'S 431 DT', 'S 431DT'"
+  notes: "id: D6 - the S 417 and S 431 DT are each catalogued twice, once inside this 96-string family stub and once as their own id. name: 'S' is a series letter; Setra's nameplates are S + 3 digits + body code."
+
+"bus/setra/s417":
+  verdicts: { id: "defective(D6)", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Setra  # S-prefix is written WITH a space: 'S 417 HDH', 'S 412 UL'"
+    - "raw: 'SETRA | S 417 UL' nl_rdw bus n=6; 'S 417 GT-HD' n=4; 'S 417 UL/2 BUSINESS' n=1 vs the fused 'S417 UL' n=1"
+    - "raw: 'Setra | S 417 UL/2 Business' fi_traficom class=M3 n=8+2; 'S 417 GT-HD' n=2; fused 'S417 GTHD' n=1"
+    - "catalog: bus/setra/s ('S') holds the same S 417 strings"
+  notes: "name: the register majority AND the marque both use the spaced 'S 417'; the catalog picked the minority fused form (nl 1 vs 11, fi 1 vs 12). Majority is not authority - but here majority and source agree."
+
+"bus/sprintcar/sprinter":
+  verdicts: { id: "correct", name: "defective(D5)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'Sprintcar | MB SPRINTER Yksikerroksinen (CA) 2ov 2987cm3 A' fi_traficom class=M3 n=2 (also M2 and M1 rows)"
+    - "raw: 'SPRINTCAR | MB SPRINTER' nl_rdw bus n=5"
+  notes: "Same converter/donor-badge class. Note that the fi rows for this converter also include M1-class bodies ('MB Sprinter Farmari (AC) 6ov') - the bus-kind claim rests on the M2/M3 rows, which exist."
+
+"bus/temsa/md":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { es: "correct", fi: "correct", gb: "correct", nl: "correct", ua: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Temsa  # 'Temsa MD9', 'Temsa MD9 LE', 'Temsa MD9 ElectriCITY', 'Temsa MD7 Plus' - MD always capitals, no bare 'Md'"
+    - "raw: 'TEMSA | MD9' es_dgt n=3"
+    - "raw: 'Temsa | MD9 Yksikerroksinen (CA) 2ov 6871cm3 A' fi_traficom class=M3 n=4"
+    - "raw: 'TEMSA | MD9 AUTO' uk_veh0120 BodyType='Buses and coaches' GenModel='TEMSA MD9'"
+    - "raw: 'TEMSA | MD9' nl_rdw bus n=11"
+    - "raw: 'TEMSA | MD 9' ua_mvs kind=ABTOBYC n=2"
+
+"bus/toyota/coaster":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { nz: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'TOYOTA | COASTER' nz_nzta bus shard n=344"
+    - "raw: 'TOYOTA | COASTER' ua_mvs kind=ABTOBYC n=2"
+
+"bus/unvi/compa":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'UNVI | COMPA Yksikerroksinen (CA) 2ov 2998cm3 A' fi_traficom class=M3 n=5"
+    - "raw: 'UNVI | COMPA' nl_rdw bus n=1"
+    - "two independent registers emit the exact display form (unvi.es/en/models returned 404 to curl)"
+
+"bus/van-hool/tx":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { gb: "correct", nl: "correct", ua: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Van_Hool  # 'There is no bare TX model listed anywhere... every instance pairs TX with both a numerical identifier and a variant name (TX11 Alicron, TX16 Acron, TX17 Astron, TX15 Astronef, TX17 Altano)'"
+    - "raw: 'VAN HOOL | TX16 ACRON' uk_veh0120 BodyType='Buses and coaches' GenModel='VAN HOOL TX16'"
+    - "raw: 'VAN HOOL | TX17 ACRON' nl_rdw bus n=28; 'TX15 ACRON' n=15; 'TX16 ALICRON' n=11"
+    - "raw: 'VAN HOOL | TX-17 ASTRON' ua_mvs kind=ABTOBYC n=7"
+    - "catalog: bus/van-hool/acron (raw 'VAN HOOL ACRON AUTO'), bus/van-hool/astron (raw 'ASTRON T 818', 'VAN HOOL ASTRON AUTO') and bus/van-hool/t17 (raw 'T17 ACRON', 'T17 ASTRON') are all live and all denote TX-series coaches"
+  notes: "id: D6 - Van Hool's naming is TX<n> + body name, so the bare-body-name ids acron/astron and the T17 pair denote the same coaches this record pools. name: 'TX' is a range letter-pair; styling.yml pins its CASING correctly ('TX: TX') but the altitude is still short of a nameplate."
+
+"bus/volvo/8707":
+  verdicts: { id: "unverifiable(cannot determine whether '8707' is a distinct product from bus/volvo/8700 - fi emits '8707 RLE' (n=72) and '8700 RLE' (n=23) as separate strings, so it is not a typo, but no Volvo source enumerates 8707)", name: "unverifiable(no Volvo source reachable attests '8707'; en.wikipedia.org/wiki/Volvo_8900 lists the predecessors as 8500/8500LE and 8700/8700LE only)", make: "correct", kind: "correct",
+              availability: { fi: "correct" } }
+  evidence:
+    - "raw: 'Volvo | 8707 RLE Yksikerroksinen (CA) 3ov 7146cm3 A' fi_traficom class=M3 n=55 (+ CE-body rows and fused '8707RLE')"
+    - "raw: 'Volvo | 8700 RLE Yksikerroksinen (CA) 3ov 7146cm3 A' fi_traficom class=M3 n=23  # the sibling id's string, distinct"
+    - "https://en.wikipedia.org/wiki/Volvo_8900  # 'The article does not reference Volvo 8900, 8700, 8707' [8xxx predecessors given as 8500/8500LE, 8700/8700LE]"
+  notes: "Single-source (fi only). Filed for the source-gap queue: the 87nn/89nn + 2-digit + RLE shape (8707RLE, 8908RLE, 8900RLE) looks like a Volvo body-model code series that no reachable Volvo page enumerates."
+
+"bus/volvo/8900":
+  verdicts: { id: "defective(D6)", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct", ua: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Volvo_8900  # 'Volvo 8900', 'Volvo 8900LE', 'Volvo 8900 Electric'"
+    - "raw: 'Volvo | 8900 Matalalattiainen yksikerroksinen (CE) 3ov 7698cm3 A' fi_traficom class=M3 n=229"
+    - "raw: 'VOLVO | 8900' nl_rdw bus n=196; '8900 RLE' n=2; and separately 'VOLVO 8900RLE' n=7"
+    - "raw: 'VOLVO | 8900' ua_mvs kind=ABTOBYC n=3"
+    - "catalog: bus/volvo/8900rle ('8900RLE') is live from 'VOLVO 8900RLE'/'Volvo 8900rle' while THIS record's raw set contains '8900 RLE'"
+  notes: "id: D6 - a spacing-only split ('8900 RLE' vs '8900RLE') gives the low-entry 8900 two live ids. bus/volvo/8908rle is a third id in the same shape."
+
+"bus/volvo/9500":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Volvo_9700  # 'Volvo 9500 - stripped down 9700H NG'"
+    - "raw: 'Volvo | 9500 Yksikerroksinen (CA) 2ov 7698cm3 A' fi_traficom class=M3 n=30"
+    - "raw: 'VOLVO | 9500' nl_rdw bus n=18"
+
+"bus/volvo/9700h":
+  verdicts: { id: "defective(D6)", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct", ua: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Volvo_9700  # 'There are three main models in different heights; 9700S (3.42 m), 9700H (3.61 m) and 9700HD (3.73 m)' - 9700H is authentic"
+    - "raw: 'Volvo | 9700H Yksikerroksinen (CA) 2ov 10837cm3 A' fi_traficom class=M3 n=18"
+    - "raw: 'VOLVO | 9700H' nl_rdw bus n=1 AND 'VOLVO | 9700 H' nl_rdw bus n=1 - the same coach, two strings"
+    - "raw: 'VOLVO | 9700H' ua_mvs kind=ABTOBYC n=2"
+    - "catalog: bus/volvo/9700 ('9700') is live and its raw set contains '9700 H', '9700 H 4X2'; bus/volvo/9700hd is a third id while bus/volvo/9700 also holds '9700 HD'"
+  notes: "id: D6 - the 9700 height variants are split across bus/volvo/9700, /9700h and /9700hd purely on spacing."
+
+"bus/volvo/b":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct", nz: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Volvo | B 58-60-S1/6000' fi_traficom class=M3 n=1; 'B 12M 9700S Yksikerroksinen (CA)' M3 n=1; 'B 10 M' n=1"
+    - "raw: 'VOLVO | B7RLE' nl_rdw bus n=30; 'B10M-ART-J71' n=11; 'B12B 4X2 FWS-I' n=7"
+    - "raw: 'VOLVO | B12' nz_nzta bus n=138; 'B7R' n=101; 'B10' n=51; 'B10M' n=33"
+    - "raw: 'VOLVO | B10 M' ua_mvs kind=ABTOBYC n=3; 'B12 B' n=3; 'B10 BLE' n=4"
+    - "catalog: bus/volvo/{b10,b10b,b10m,b10m-55,b10m-60,b11r,b12,b12b,b12ble,b12m,b13r,b58-60,b6,b6fa,b7,b7l,b7r,b7rle,b8r,b9m,b9r} are ALL live; this record's own raw set is the SPACED spelling of exactly those chassis ('B 10 B 4X2 60 N', 'B 10 M', 'B 12 M', 'B 12M', 'B 58', 'B 58-60-S1/6000', 'B 6 F')"
+  notes: "id: D6/D17 on a large scale - a spacing-only split hands 21 live Volvo bus-chassis ids a shadow twin. name: 'B' is a chassis-series letter, not a nameplate."
+
+"bus/volvo/b12ble":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'Volvo | B12BLE-6X2/712+140' fi_traficom class=M3 n=25; 'B12BLE/730' M3 n=4"
+    - "raw: 'VOLVO | B12BLE FWS-IL 6X2' nl_rdw bus n=2"
+    - "B12BLE is a distinct Volvo chassis designation (low-entry 12-litre); b12b and b12m are different chassis, so no D6 twin"
+
+"bus/volvo/b6":
+  verdicts: { id: "defective(D6)", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nz: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Volvo | B6' fi_traficom class=M3 n=1"
+    - "raw: 'VOLVO | B6' nz_nzta bus n=8; 'B6FA' n=5; 'B6 FA' n=1; 'B6 2' n=2"
+    - "raw: 'VOLVO | B6' ua_mvs kind=ABTOBYC n=3"
+    - "catalog: bus/volvo/b6fa ('B6FA') is live while THIS record's raw set contains 'B6 FA' - nz_nzta emits both spellings"
+  notes: "id: D6 - spacing-only split of the B6FA chassis between bus/volvo/b6 and bus/volvo/b6fa."
+
+"bus/wrightbus/gb":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { gb: "correct" } }
+  evidence:
+    - "raw: 'WRIGHTBUS | GB KITE ELECTROLINER' and 'WRIGHTBUS | GB KITE H2 FUEL CELL AUTO', uk_veh0120 BodyType='Buses and coaches' GenModel='WRIGHTBUS GB KITE'"
+    - "compare the same make's other GenModels: 'WRIGHTBUS STREETDECK ULTROLINER', 'WRIGHTBUS GEMINI', 'WRIGHTBUS ELECTROCITY' - all keep the full nameplate"
+  notes: "name: two defects - the model is 'GB Kite' (uk_dft's own GenModel says so) and the surviving token is title-cased from an all-caps acronym. No Wrightbus site fetch was needed: the register supplies the marque's own model string."
+
+"bus/yutong/u12":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Yutong  # 'U12 electric city bus', 'U12DD electric (3-Door and 2-Staircase)', also U11DD and U10 - capital U + number"
+    - "raw: 'Yutong | U12 Matalalattiainen yksikerroksinen (CE) 3ov' fi_traficom class=M3 n=37"
+    - "raw: 'YUTONG | U12' nl_rdw bus n=199"
+
+"bus/zaz/a08b2b-30":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { ua: "correct" } }
+  evidence:
+    - "raw: ua_reestr 02.07.2026: BRAND='ZAZ' (Cyrillic), MODEL='A08B2B-30', KIND='ABTOBYC', PURPOSE='school bus', VIN Y6DA08B2BT0000711, 2025 - 57 rows in the current register"
+    - "the VIN's WMI/VDS segment 'Y6DA08B2B' matches the model string exactly, which is as strong an in-register identity confirmation as this corpus offers"
+  notes: "My Latin-alphabet make filter initially missed this record because ua_mvs writes the marque in Cyrillic; re-grepped the register directly. Nothing wrong with the record."
+
+"bus/zhongtong/lck":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { nz: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Zhongtong_Bus  # 'Zhongtong LCK6103G', 'LCK6129H', 'LCK6126EVG' ... - LCK always uppercase"
+    - "raw: 'ZHONGTONG | LCK' nz_nzta bus shard n=57"
+  notes: "name: acronym title-cased. The register itself supplies only the bare 'LCK' (NZTA truncates), so the model number is unrecoverable from this source - the casing is the fixable half."
+
+"bus/zhongtong/zhongtong":
+  verdicts: { id: "defective(D4)", name: "defective(D4)", make: "correct", kind: "correct",
+              availability: { nz: "correct" } }
+  evidence:
+    - "raw: 'FACTORY BUILT | ZHONGTONG' nz_nzta bus shard n=66; 'FACTORY BUILT | ZHONGTONG BUS' n=8"
+    - "catalog: former_ids ['bus/factory-built/zhongtong'] - the record was moved off the 'FACTORY BUILT' pseudo-make, but the model column still holds the marque name"
+    - "overrides/models/renames.yml precedent: 'Austin: Austin: null # registry rows where the make was written into the model column - not a nameplate'; same for Bentley/Buick/Cadillac/Chrysler/Daimler/Desoto/Isuzu/Iveco"
+  notes: "id+name: D4 make-as-model. The move fixed the make but not the model; bus/zhongtong/lck is the live model id for the same NZ population, and D4's remedy ('drop; if sole model, resolve or debt') applies since it is NOT the sole model."
+
+"car/ahorn/van-620":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "defective(D10)",
+              availability: { lu: "correct", nl: "correct" } }
+  evidence:
+    - "https://www.ahorn-camp.de/en/  # fetched with curl -A Mozilla (HTTP 200); <title>Ahorn Camp motorhomes and campervans</title>; 52 occurrences of 'motorhome', plus Reisemobil/Wohnmobil - Ahorn Camp builds nothing but motorhomes and campervans"
+    - "raw: 'AHORN | VAN 620' lu_snca CATEU=M1 n=2"
+    - "raw: 'AHORN | VAN 620' nl_rdw personenauto n=2"
+    - "catalog: TAN e13*2007/46*1291*12 (a Fiat Ducato-derived base vehicle); car/ahorn/van-620 is the make's ONLY record"
+  notes: "kind: D10 is the taxonomy's own 'campers in car' class. Ahorn is a motorhome manufacturer, so its Van 620 is a coachbuilt camper registered as M1; the record also carries body_types ['hatchback'], which is a separate D16 shape (out of scope for these five claims but worth the detector's attention)."
+
+"car/aion/hyptec-ht-620-premium":
+  verdicts: { id: "correct", name: "defective(D8)", make: "unverifiable(GAC markets Hyptec as its own brand line (formerly Aion Hyper) but no reachable source settles whether it is a marque separate from Aion; th_dlt files the row under maker 'AION' and the catalog has no hyptec make)", kind: "correct",
+              availability: { th: "correct" } }
+  evidence:
+    - "raw: 'AION | HYPTEC HT 620 PREMIUM' th_dlt_2568 type='passenger car not exceeding 7 seats'"
+    - "raw: sibling th rows under the same maker: 'AION | AION UT 420 STANDARD', 'AION | AION UT 500 PREMIUM', 'AION | AION V 602 LUXURY' - '<nnn> <GRADE>' is th_dlt's battery/trim-grade suffix pattern, not part of any nameplate"
+    - "catalog: no 'hyptec' make exists (car/makes.json)"
+  notes: "name: D8 - the nameplate is the Hyptec HT; '620 Premium' is th_dlt's range/trim grade (the same suffix shape appears on UT 420/500 and V 602). The acronym is also title-cased ('Ht'), a D7 rider on the same string."
+
+"car/aion/ut-420-standard":
+  verdicts: { id: "defective(D6)", name: "defective(D8)", make: "correct", kind: "correct",
+              availability: { th: "correct" } }
+  evidence:
+    - "raw: 'AION | AION UT 420 STANDARD' th_dlt_2568, two type rows (private car; tour-service car)"
+    - "catalog: car/aion/ut ('Ut') is live with raw 'AION UT' - the same nameplate"
+    - "raw: 'AION | AION UT 500 PREMIUM' th_dlt - a second grade of the same car, showing '420'/'500' is a grade not a model"
+  notes: "id: D6 against car/aion/ut. name: D8 trim/grade published as model (plus 'Ut' acronym casing)."
+
+"car/alpina/bmw-alpina-d5-biturbo-touring":
+  verdicts: { id: "correct", name: "defective(D5)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'Alpina | BMW ALPINA D5 BITURBO Touring Farmari (AC) 4ov 2993cm3 A' fi_traficom class=M1 n=1"
+    - "raw: 'ALPINA | BMW ALPINA D5 BITURBO TOURING' nl_rdw personenauto n=8; 'BMW ALPINA D5 BITURBO' n=19"
+    - "catalog: 11 of the 15 car/alpina records carry the 'Bmw Alpina ...' prefix while 4 (b3, b3-touring, b7, b7-biturbo-allrad) do not - a half-fixed family"
+    - "NAMING.md:366  # '4W-owned (2 records in 2W vs 9 in 4W - its 4W hits are Alpina's brand-prefix bleed, `Alpina Bmw Alpina B3`)' - the class is already named in the project's own docs"
+  notes: "name: D5 embedded make/brand prefix. The record sits under make 'Alpina' and repeats 'Bmw Alpina' inside the model, so the rendered pair is 'Alpina Bmw Alpina D5 Biturbo Touring'. id correct: no car/alpina/d5 exists."
+
+"car/audi/a8":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { ca: "correct", de: "correct", es: "correct", fi: "correct", gb: "correct", ie: "correct", lu: "correct", my: "correct", nl: "correct", nz: "correct", th: "correct", ua: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'Audi | A8 quattro' ca_nrcan MY1997-2000+ (53 rows)"
+    - "de_kba de_fz10_202606.xlsx xl/sharedStrings.xml: 'AUDI' (idx 92) ... 'A8' (idx 99) ... 'AUDI ZUSAMMEN' (idx 108) - A8 is a Modellreihe inside the AUDI block"
+    - "raw: 'AUDI | A8' es_dgt n=17; 'AUDI A8' n=4"
+    - "raw: 'Audi | A8 Sedan (AA) 4ov 2967cm3 A' fi_traficom class=M1 n=115"
+    - "raw: 'AUDI | A8 2.8 AUTO' uk_veh0120 GenModel='AUDI A8' BodyType='Cars'"
+    - "raw: 'Audi A8' ie_tem20 (Make and Model dimension)"
+    - "raw: 'AUDI | A8' lu_snca CATEU=M1 n=24"
+    - "raw: 'Audi | A8' my_cars type=motokar"
+    - "raw: 'AUDI | A8' nl_rdw personenauto n=1101; 'AUDI A8' n=988"
+    - "raw: 'AUDI | A8' nz_nzta passenger-car shard n=404"
+    - "raw: 'AUDI | A8L 60 TFSIe q Pstg Sline' th_dlt_2568"
+    - "raw: 'AUDI | A8' ua_mvs kind=LEGKOVYI n=641"
+    - "raw: 'Audi | A8' us_fueleconomy y=1997.. baseModel='A8'"
+    - "catalog: former_ids ['car/audi/a-8'] - the spacing twin was already merged"
+  notes: "The claim-heaviest record in the slice (17 claims) and clean on all of them."
+
+"car/audi/avant-rs2":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nz: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Audi_RS2  # 'The official model name ... is Audi RS 2 Avant (also referenced as RS 2 Avant)'; produced March 1994 - July 1995"
+    - "raw: 'Audi | AVANT RS2 QUATTRO /260' fi_traficom class=M1 n=1"
+    - "raw: 'AUDI | AVANT RS2' nz_nzta passenger-car shard n=1"
+  notes: "name: D7 - token order inverted and the space dropped. Audi's own form is 'RS 2 Avant'; both registers happen to carry the inverted fi/nz shape, which is exactly the case the 'majority is not authority' rule covers."
+
+"car/austin/clifton":
+  verdicts: { id: "unverifiable(cannot establish whether 'Clifton' denotes a model, a coachbuilt body on the Austin 12/4, or something else, so overlap with car/austin/metropolitan-style siblings is undecidable)", name: "unverifiable(en.wikipedia.org/wiki/Austin_12/4 lists the produced bodies as Harley saloon, Ascot saloon, tourer, Eton two-seater tourer, Open Road tourer, cabriolet and estate - 'Clifton' does not appear; no other Austin source reachable)", make: "correct", kind: "correct",
+              availability: { nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'AUSTIN | CLIFTON TOURER' nl_rdw personenauto n=1"
+    - "raw: 'AUSTIN | CLIFTON' nz_nzta passenger-car shard n=3; 'AUSTIN | CLIFTON 12/4' n=2"
+    - "https://en.wikipedia.org/wiki/Austin_12/4  # body list, no Clifton"
+  notes: "The nz string 'CLIFTON 12/4' ties Clifton to the Austin 12/4 chassis, which points at a body name rather than a model - but the marque source contradicts the body list, so both id and name are recorded unverifiable rather than guessed. Source-gap item."
+
+"car/austin/nash":
+  verdicts: { id: "defective(D6)", name: "defective(D5)", make: "correct", kind: "correct",
+              availability: { gb: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'AUSTIN | NASH METROPOLITAN' uk_veh0120 GenModel='AUSTIN NASH', BodyType='Cars' (and a second row under 'Light goods vehicles') - the register's own model string names the car"
+    - "raw: 'AUSTIN | NASH' nz_nzta passenger-car shard n=1"
+    - "catalog: car/austin/metropolitan ('Metropolitan') is live (gb-side) AND car/nash/metropolitan ('Metropolitan', fi/nl/nz) is live with raw 'NASH METROPOLITAN'"
+  notes: "id: D6 - the Austin-built Nash Metropolitan has at least three live ids (austin/nash, austin/metropolitan, nash/metropolitan). name: D5 - 'Nash' is a marque badge sitting in Austin's model column; the nameplate is Metropolitan. make left correct: Austin did build the car and uk_dft's make column says AUSTIN."
+
+"car/bentley/flying-spur-v8":
+  verdicts: { id: "defective(D8)", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'Bentley | Flying Spur V8 Sedan (AA) 4ov 3993cm3 A' fi_traficom class=M1 n=1"
+    - "raw: 'BENTLEY | FLYING SPUR V8' nl_rdw personenauto n=31; 'BENTLEY FLYING SPUR V8' n=17; 'FLYING SPUR V8 S' n=11"
+    - "catalog: car/bentley/flying-spur ('Flying Spur') is live with nl n=48"
+  notes: "id: D8 - engine variant published as its own model beside the bare nameplate (taxonomy D8 names 'engine' explicitly). name accepted: 'Flying Spur V8' is Bentley's own designation for the V8 derivative and is what both registers emit."
+
+"car/bmw/activehybrid-7":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'BMW | ActiveHybrid 7 Sedan (AA) 4ov 4395cm3 A' fi_traficom class=M1 n=1 - the register itself supplies BMW's camel-case"
+    - "raw: 'BMW | ActiveHybrid 7' us_fueleconomy y=2012 baseModel='7 Series'; 'ActiveHybrid 7L' y=2012-2014"
+    - "raw: 'BMW | ACTIVEHYBRID 7' nl_rdw personenauto n=23; 'ACTIVEHYBRID 7 L' n=18"
+    - "catalog: the sibling car/bmw/activehybrid-7l already displays 'ActiveHybrid 7L' with correct camel-case - a casing contradiction inside one family, which is the detector shape renames.yml calls 'the seam of half-fixed families'"
+  notes: "name: D7. BMW writes ActiveHybrid; fi_traficom and us_fueleconomy both emit it that way, and the catalog's own 7L twin proves the intended form."
+
+"car/bmw/alpina-b6":
+  verdicts: { id: "defective(D6)", name: "defective(D5)", make: "defective(D11)", kind: "correct",
+              availability: { ca: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'BMW | Alpina B6 xDrive Gran Coupe' ca_nrcan MY2015-2019"
+    - "raw: 'BMW | Alpina B6 xDrive Gran Coupe' us_fueleconomy y=2017-2019, baseModel='6 Series'"
+    - "catalog: car/alpina/b6 is live with raw 'ALPINA B6' - the same car under the marque that builds it"
+    - "catalog: the 'alpina' make exists with 15 records and its own country set (es, fi, lu, nl, nz)"
+  notes: "make: D11 approval/importer trap - BMW of North America imports and warrants the ALPINA B6, so NRCan/EPA put BMW in the make column, exactly the pattern moves.yml exists for. id: D6 against car/alpina/b6. name: D5 brand prefix inside the model. All three verdicts come from one root cause, which is what claim-level scoring is designed to expose."
+
+"car/bmw/ci":
+  verdicts: { id: "unverifiable(the underlying rows are bare trim-suffix strings ('CI CABRIO' nl n=1, 'CI AUTO' gb) that cannot be resolved to a model series, so whether car/bmw/3-series or another live id already denotes them is undecidable)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { gb: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'BMW | CI AUTO' uk_veh0120 GenModel='BMW CI' BodyType='Cars'"
+    - "raw: 'BMW | CI CABRIO' nl_rdw personenauto n=1"
+    - "BMW's Ci suffix is a body+fuel trim marker (318Ci/325Ci/330Ci/630Ci); there is no BMW model named 'Ci'"
+  notes: "name: D9 registry/type fragment as model. Two-country attestation of the STRING does not make it a nameplate - the VITO/MGA rule."
+
+"car/bmw/i":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'BMW | i 8 Coup\u00e9 (AD) 2ov 1499cm3 A' fi_traficom class=M1 n=1; 'BMW | i 3 Sedan (AA) 4ov 647cm3' n=1 - the SPACED register spellings of the i8 and i3"
+    - "raw: 'BMW | I' nz_nzta passenger-car shard n=1319 (nz also has 'I3' n=594, 'I8' n=27, 'I4' n=6, 'IX1' n=2 separately)"
+    - "catalog: car/bmw/i3 ('i3') and car/bmw/i8 ('i8') are live"
+  notes: "id: D6/D17 - a spacing-only split: 'i 8'/'i 3' fold to a bare 'i' id while the fused 'i8'/'i3' get their own. name: D9 - 'i' is BMW's EV sub-brand letter, not a model. The nz side is the volume risk: 1319 NZ vehicles hang on a one-letter id."
+
+"car/bmw/m-635-csi":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'BMW | M635 CSi Coup\u00e9 (AD) 2ov 3450cm3' fi_traficom class=M1 n=3 (+ n=2 at 3453cm3) - the register supplies BMW's own casing"
+    - "raw: 'BMW | M635CSI' nl_rdw personenauto n=6; 'M 635 CSI' n=69; 'M635 CSI' n=4"
+    - "the E24 badge is the closed M635CSi; 'Csi' is the title-caser's output and appears in no register and no marque source"
+  notes: "name: D7. id correct - the sibling car/bmw/m ('M') pools 'BMW M COUPE'/'M Coupe' (the Z3 M Coup\u00e9), not the E24, and there is no car/bmw/m6 record to collide with."
+
+"car/bmw/mini":
+  verdicts: { id: "defective(D6)", name: "defective(D4)", make: "defective(D11)", kind: "correct",
+              availability: { fi: "correct", nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'BMW | MINI Viistoper\u00e4 (AB) 2ov 1598cm3' fi_traficom class=M1 n=1; 'BMW | MINI ONE' n=1"
+    - "raw: 'BMW | MINI ONE' nl_rdw personenauto n=19; 'MINI COOPER' n=18; 'MINI COOPER S' n=11; 'MINI' n=7"
+    - "raw: 'BMW | MINI' nz_nzta passenger-car shard n=6572"
+    - "catalog: the 'mini' make is live with 19 models (1000, Cooper, Clubman, Countryman, Convertible, Aceman, ...) covering fi, nl and nz - the same three countries this record claims"
+    - "catalog: car/mini/cooper's raw set already contains 'MINI COOPER', 'MINI ONE', 'MINI MINI' - i.e. the same register strings"
+  notes: "make: D11 - Mini is a marque with its own make id; BMW is the type-approval holder. name: D4 - 'MINI' in BMW's model column is the marque written into the model field, which renames.yml drops for eight other makes. id: D6 - the car/mini make already denotes these vehicles in all three countries."
+
+"car/bmw/z-reihe":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { es: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'BMW | Z REIHE' nl_rdw personenauto n=7143; 'Z-REIHE' n=4; 'BMW Z REIHE' n=1; and tellingly 'Z REIHE ROADSTER 3.0 I' n=1"
+    - "raw: 'BMW | Z REIHE' es_dgt n=28; 'Z-REIHE' n=1; 'Z REIHE Z4 SDRIVE20I' n=1; 'Z REIHE SEIRE Z' n=1"
+    - "catalog: car/bmw/z1, /z3, /z4 and /z8 are all live"
+  notes: "name: D9 - 'Z-Reihe' is German for 'Z series', a register GROUP label (RDW/DGT use it as the handelsbenaming when the specific Z model is unknown); it is not a BMW nameplate. The register's own 'Z REIHE Z4 SDRIVE20I' row shows the label wrapping a Z4. id: D6 - the four Z-model ids denote the same cars. Volume note: 7143 NL registrations sit on this label, the largest single population on a non-nameplate id in this slice."
+
+"car/bristol/401":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { gb: "correct", nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'BRISTOL | 401' uk_veh0120 GenModel='BRISTOL 401' BodyType='Cars'"
+    - "raw: 'BRISTOL | 401' nl_rdw personenauto n=2"
+    - "raw: 'BRISTOL | 401' nz_nzta passenger-car shard n=7"
+    - "three independent registers emit the exact display form"
+
+"car/bugatti/chiron-pur-sport":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { ca: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'Bugatti | Chiron Pur Sport' ca_nrcan MY2021 - listed as its own model row beside 'Chiron'"
+    - "raw: 'Bugatti | Chiron Pur Sport' us_fueleconomy y=2021, baseModel='Chiron'"
+  notes: "id judged correct: the Pur Sport is a separately homologated, separately bodied 60-unit Bugatti model, and NRCan lists it as its own model row. Recorded honestly that EPA's baseModel field groups it under Chiron, so a verifier applying a strict D8 reading could dissent; the same criterion is what I used to call cruze-eco and sonic-5 defective, and the distinction I drew is 'distinct product' vs 'trim of one product'."
+
+"car/bugatti/divo":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { ca: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'Bugatti | Divo' ca_nrcan MY2020"
+    - "raw: 'Bugatti | Divo' us_fueleconomy y=2020, baseModel='Divo' - EPA treats it as its own base model"
+
+"car/bugatti/mistral":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { ca: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'Bugatti | Mistral' ca_nrcan MY2025"
+    - "raw: 'Bugatti | Mistral' us_fueleconomy y=2025, baseModel='Mistral'"
+
+"car/buick/rainier":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { ca: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'Buick | Rainier' ca_nrcan MY2004; 'Rainier AWD' MY2004-2007"
+    - "raw: 'Buick | Rainier 2WD' / 'Rainier AWD' us_fueleconomy y=2004-2007, baseModel='Rainier'"
+  notes: "The drivetrain suffixes are correctly folded into the nameplate here - the counter-example to car/denza/d9-fwd in the same slice."
+
+"car/byd/han":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", lu: "correct", nl: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'BYD | HAN Sedan (AA) 4ov' fi_traficom class=M1 n=65"
+    - "raw: 'BYD | HAN' lu_snca CATEU=M1 n=3"
+    - "raw: 'BYD | HAN' nl_rdw personenauto n=46"
+    - "raw: 'BYD | HAN' ua_mvs kind=LEGKOVYI n=9"
+
+"car/cadillac/elr":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { ca: "correct", fi: "correct", nl: "correct", ua: "correct", us: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Cadillac_ELR  # 'officially written as Cadillac ELR with ELR in all capital letters'; 2-door coupe, MY2014 and MY2016"
+    - "raw: 'Cadillac | ELR' ca_nrcan MY2014, MY2016; 'ELR (Performance Pkg)' MY2016"
+    - "raw: 'Cadillac | ELR Coup\u00e9 (AD) 2ov 1398cm3 A' fi_traficom class=M1 n=1"
+    - "raw: 'CADILLAC | CADILLAC ELR HYBRID' nl_rdw personenauto n=1"
+    - "raw: 'CADILLAC | ELR' ua_mvs kind=LEGKOVYI n=13"
+    - "raw: 'Cadillac | ELR' us_fueleconomy y=2014-2016, baseModel='ELR'"
+  notes: "name: D7 acronym title-cased. Five registers, five all-caps spellings, and an encyclopedia confirmation - nothing supports 'Elr'."
+
+"car/cadillac/fleetwood-sixty-special":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'Cadillac | Fleetwood Sixty Special Sedan (AA) 4ov 6390cm3 A' fi_traficom class=M1 n=2 (7 rows total)"
+    - "raw: 'CADILLAC | FLEETWOOD SIXTY SPECIAL' nl_rdw personenauto n=15 (+ 'FLEETWOOD SIXTY SPECIAL BROUGHAM' n=1)"
+    - "catalog: car/cadillac/fleetwood ('Fleetwood', nl n=197) is live but denotes the later standalone Fleetwood, a different series"
+  notes: "id judged correct: the Sixty Special is a distinct Cadillac series, not a trim of the Fleetwood."
+
+"car/chery/jaecoo-j8":
+  verdicts: { id: "defective(D6)", name: "defective(D5)", make: "defective(D11)", kind: "correct",
+              availability: { my: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Jaecoo  # models listed as 'J8/8', 'J7/7', 'J6/6 EV', 'J5/5' - the J-prefixed and bare-number names are the SAME vehicles in different markets; Jaecoo 'was created to market SUVs in export markets' as a distinct brand"
+    - "raw: 'Chery | Jaecoo J8' my_cars type=jip (also Jaecoo J5, J6, J7 under maker Chery)"
+    - "catalog: the 'jaecoo' make is live (de, es, gb, lu, nl, nz, th) with car/jaecoo/jaecoo-8 ('Jaecoo 8', es/lu/nl), /jaecoo-7, /jaecoo-6, /jaecoo-5"
+    - "PRD-QUALITY \u00a74 D5 example is literally 'JAECOO5 EV'"
+  notes: "make: D11 - Jaecoo is a recognised marque in this very catalog; my_jpj files it under the parent. id: D6 - car/jaecoo/jaecoo-8 is the same vehicle (J8 == 8), so Malaysian evidence is split off from the European evidence for one car. name: D5 brand prefix. Note the mirror-image defect on the target side: car/jaecoo/jaecoo-8 repeats the marque in its own model string."
+
+"car/chevrolet/astro":
+  verdicts: { id: "defective(D6)", name: "correct", make: "correct", kind: "correct",
+              availability: { ca: "correct", fi: "correct", nl: "correct", nz: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'Chevrolet | Astro Passenger' ca_nrcan MY1996 (43 rows)"
+    - "raw: 'Chevrolet | ASTRO VAN STARCRAFT SL-DM15Z/2820' fi_traficom n=42; 'ASTRO VAN-DM15Z' n=8"
+    - "raw: 'CHEVROLET | ASTRO' nl_rdw personenauto n=49; 'ASTRO VAN' n=13"
+    - "raw: 'CHEVROLET | ASTRO' nz_nzta passenger-car shard n=26"
+    - "raw: 'Chevrolet | Astro 2WD (passenger)' us_fueleconomy y=1985.., baseModel='Astro Passenger'"
+    - "catalog: car/chevrolet/astro-van ('Astro Van') and car/chevrolet/astro-starcraft ('Astro Starcraft') are live - the fi rows 'ASTRO VAN-DM15Z' and 'ASTRO VAN STARCRAFT SL-DM15Z' are the same Astro with a body-conversion suffix"
+  notes: "id: D6 - three live ids for the Chevrolet Astro (bare, +Van, +Starcraft conversion)."
+
+"car/chevrolet/aveo-ls":
+  verdicts: { id: "defective(D6)", name: "defective(D8)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'Chevrolet | AVEO LS Viistoper\u00e4 (AB) 5ov 1498cm3' fi_traficom class=M1 n=1"
+    - "raw: 'CHEVROLET | AVEO LS' nl_rdw personenauto n=1 vs 'CHEVROLET | AVEO' n=7826"
+    - "catalog: car/chevrolet/aveo ('Aveo') is live"
+    - "DEBT.md: 'Chevrolet Lt/Ltz family (9 records, uniformly wrong)' - the same trim-code-as-model family, already filed"
+  notes: "id: D6 (one Aveo at two ids, 1 registration vs 7826). name: D8 - LS is a GM trim code, and the Lt/Ltz debt line says the project already regards this family as wrong."
+
+"car/chevrolet/cruze-eco":
+  verdicts: { id: "defective(D8)", name: "correct", make: "correct", kind: "correct",
+              availability: { ca: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'Chevrolet | Cruze Eco' ca_nrcan MY2011-2013, listed beside 'Cruze' for the same years"
+    - "raw: 'Chevrolet | Cruze Eco' us_fueleconomy y=2011-2013, baseModel='Cruze'"
+    - "catalog: car/chevrolet/cruze ('Cruze') is live"
+  notes: "id: D8 - Eco was a Cruze trim (aero package + taller gearing), and EPA's own baseModel field says 'Cruze'. name accepted: 'Cruze Eco' is how Chevrolet and both North-American sources write the trim."
+
+"car/chevrolet/lumina-monte-carlo":
+  verdicts: { id: "defective(D13)", name: "defective(D13)", make: "correct", kind: "correct",
+              availability: { ca: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'Chevrolet | Lumina/Monte Carlo' us_fueleconomy y=1995, baseModel='Lumina/Monte Carlo'"
+    - "raw: 'Chevrolet | Lumina/Monte Carlo' ca_nrcan MY2000 (ca also lists plain 'Lumina' for 1995-1999)"
+    - "catalog: car/chevrolet/lumina ('Lumina') and car/chevrolet/monte-carlo ('Monte Carlo', raws 'CHEVROLET MONTE CARLO', 'MONTE CARLO COUPE 72-13857/295') are BOTH live"
+  notes: "id+name: D13 merge cell - the source packed two nameplates into one row (the GM10 twins shared a certification family), and the pipeline minted a third id from the slash. name also shows broken casing ('Lumina/monte Carlo'), the same word-boundary bug the caser has after a slash."
+
+"car/chevrolet/malibu-limited":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { ca: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'Chevrolet | Malibu Limited' ca_nrcan MY2016"
+    - "raw: 'Chevrolet | Malibu Limited' us_fueleconomy y=2016"
+    - "GM sold the carry-over eighth-generation car as the MY2016 'Malibu Limited' alongside the new ninth-generation Malibu, so the suffix names a distinct product rather than a trim"
+  notes: "id judged correct on the 'distinct product' side of the rule stated in the header; a verifier reading EPA's baseModel strictly could dissent."
+
+"car/chevrolet/orlando":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { ca: "correct", es: "correct", fi: "correct", gb: "correct", lu: "correct", nl: "correct", nz: "correct", ua: "correct" } }
+  evidence:
+    - "raw: 'Chevrolet | Orlando' ca_nrcan MY2012-2014"
+    - "raw: 'CHEVROLET | ORLANDO' es_dgt n=7"
+    - "raw: 'Chevrolet | ORLANDO Farmari (AC) 4ov 1796cm3' fi_traficom class=M1 n=67"
+    - "raw: 'CHEVROLET | ORLANDO LT' uk_veh0120 GenModel='CHEVROLET ORLANDO' BodyType='Cars'"
+    - "raw: 'CHEVROLET | ORLANDO' lu_snca CATEU=M1 n=5"
+    - "raw: 'CHEVROLET | ORLANDO' nl_rdw personenauto n=471"
+    - "raw: 'CHEVROLET | ORLANDO' nz_nzta passenger-car shard n=3"
+    - "raw: 'CHEVROLET | ORLANDO' ua_mvs kind=LEGKOVYI n=121"
+  notes: "12 claims, all clean - the eight-country trim-free nameplate the protocol says not to write an essay about."
+
+"car/chevrolet/sonic-5":
+  verdicts: { id: "defective(D8)", name: "correct", make: "correct", kind: "correct",
+              availability: { ca: "correct", us: "correct" } }
+  evidence:
+    - "raw: 'Chevrolet | Sonic 5' ca_nrcan MY2012-2014, listed beside 'Sonic'"
+    - "raw: 'Chevrolet | Sonic 5' us_fueleconomy y=2012-2014, baseModel='Sonic'"
+    - "catalog: car/chevrolet/sonic ('Sonic') is live"
+  notes: "id: D8 - '5' is the five-door body designation GM used in Canada, and EPA's baseModel is 'Sonic'. name accepted: 'Sonic 5' is the marque's own market name."
+
+"car/chevrolet/universal":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { nl: "correct", nz: "unverifiable(the only nz row reachable in the cached NZTA shards is 'CHEVROLET | A D UNIVERSAL' n=1, which does not fold to 'Universal' under any documented rule; the nz claim may rest on a row absent from these shards)" } }
+  evidence:
+    - "raw: 'CHEVROLET | UNIVERSAL' nl_rdw personenauto n=4"
+    - "raw: 'CHEVROLET | A D UNIVERSAL' nz_nzta passenger-car shard n=1  # the 1930 Chevrolet Series AD 'Universal'"
+    - "the nz string independently corroborates the nameplate: Chevrolet's 1930 model line was the Series AD Universal"
+  notes: "name accepted on the strength of the nz 'A D UNIVERSAL' string plus the bare nl form. nz availability recorded unverifiable rather than correct because the fold from 'A D UNIVERSAL' to 'Universal' is not something I could demonstrate."
+
+"car/chrysler/gs":
+  verdicts: { id: "unverifiable(the rows are bare trim strings ('GS', 'GS TURBO 2', 'GS TURBO 2 U9') on a 1980s Chrysler G-body; I could not establish which nameplate they denote, so overlap with a live Chrysler id is undecidable)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "raw: 'Chrysler | 2D HATCHBACK GS TURBO 2-BG74A-K/2470' fi_traficom class=M1, kaupallinenNimi 'GS' n=1 and 'GS TURBO' n=1"
+    - "raw: 'CHRYSLER | GS TURBO 2 U9' nl_rdw personenauto n=8; 'GS TURBO 2 K6' n=3; 'GS TURBO 2' n=1; bare 'GS' n=1"
+    - "no Chrysler model named 'GS' exists; 'BG74A' in the fi string is a G-body type code"
+  notes: "name: D9 - registry/type code as model, resolvable only from approval data. Multi-source attestation of the string does not promote it to a nameplate (the VITO/MGA rule). Source-gap item: the fi type code BG74A should identify the car."
+
+"car/citroen/11bl":
+  verdicts: { id: "defective(D6)", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Citro%C3%ABn_Traction_Avant  # 'The 11 was built in two versions, the 11BL (L for L\u00e9g\u00e8re, or light), and the 11B (Normale)' - the fused 11BL is the marque form"
+    - "raw: 'Citroen | 11BL' fi_traficom class=M1 n=1; '11BL SPORT' n=1; '11 BL Sport Sedan (AA) 4ov 1911cm3' n=1"
+    - "raw: 'CITROEN | 11 BL' nl_rdw personenauto n=247; '11BL' n=107; '11' n=75; '11 BL SPORT' n=10"
+    - "catalog: car/citroen/11-legere ('11-Legere', lu+nl) is live - 11BL IS the 11 L\u00e9g\u00e8re; car/citroen/11 ('11') is live and its raw set contains '11 BERLINE LEGERE'; car/citroen/11-bl-sport is a fourth id in the family"
+  notes: "id: D6 - the Traction Avant 11 L\u00e9g\u00e8re has at least three live ids (11bl, 11-legere, and the pooled 11 whose raws include '11 BERLINE LEGERE'). name accepted: the fused 11BL is Citro\u00ebn's own form even though nl's majority string is spaced."
+
+"car/citroen/c":
+  verdicts: { id: "unverifiable(the record rests on bare-letter rows (nl 'C' n=5, nz 'C' n=1) plus one 'C 5 HP'; Type C, C4, C6 and the modern C-series all fold to the same key, so which vehicle the id denotes - and therefore whether a sibling duplicates it - is undecidable)", name: "defective(D9)", make: "correct", kind: "correct",
+              availability: { nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'CITROEN | C' nl_rdw personenauto n=5 (verified by direct grep of nl_rdw_personenauto.json)"
+    - "raw: 'CITROEN | C' nz_nzta passenger-car shard n=1"
+    - "catalog: this record's only observed variant is 'C 5 HP' - i.e. the 1922 Citro\u00ebn Type C 5HP"
+    - "catalog: 50 sibling ids in the same make begin with C (c1, c2, c3, c4, cx, c-crosser, \u00eb-C3 ...)"
+  notes: "name: D9 - a bare letter is not a Citro\u00ebn nameplate; the marque's forms are 'Type C'/'5HP' for the 1922 car and C1..C8/CX for the rest. body_types ['convertible'] is consistent with the Type C torpedo, which is what makes the id plausible but not determinate."
+
+"car/citroen/gsa-special":
+  verdicts: { id: "defective(D8)", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'CITROEN | GSA SPECIAL' nl_rdw personenauto n=42; 'GSA' n=21; 'GS' n=17; 'GSA SPECIAL BREAK' n=5; 'GSA  SPECIAL' n=1"
+    - "raw: 'CITROEN | GSA SPECIAL' nz_nzta passenger-car shard n=1; 'GSA' n=13; 'GS' n=14"
+    - "catalog: car/citroen/gsa ('Gsa', raw 'CITROEN GSA') is live"
+  notes: "id: D8 - Sp\u00e9cial was the base trim of the GSA, and the bare GSA id is live. name: D7 - GSA is an all-caps badge in every one of the 60+ register rows, so 'Gsa Special' is the caser's output; Citro\u00ebn additionally accents the trim ('Sp\u00e9cial'), which I could not fetch a page for and so did not lean on."
+
+"car/citroen/mehari":
+  verdicts: { id: "correct", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { es: "correct", fi: "correct", lu: "correct", nl: "correct", nz: "correct" } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Citro%C3%ABn_M%C3%A9hari  # 'officially spelled Citro\u00ebn M\u00e9hari with an acute accent over the e'; 1968-1988"
+    - "raw: 'CITROEN | MEHARI' es_dgt n=3"
+    - "raw: 'Citroen | Mehari Avoauto (AE) 2ov 602cm3' fi_traficom class=M1 n=1"
+    - "raw: 'CITROEN | MEHARI' lu_snca CATEU=M1 n=2 and CATEU=N1 n=2"
+    - "raw: 'CITROEN | MEHARI' nl_rdw personenauto n=208; 'MEHARI 2+2' n=196"
+    - "raw: 'CITROEN | MEHARI' nz_nzta passenger-car shard n=2"
+    - "build/observed_model_names.json car/citroen/mehari: ['Mehari', 'M\u00e9hari'] - the accented form IS observed in the corpus"
+    - "overrides/styling.yml: 'E-C3: \u00eb-C3  # Citro\u00ebn \u00eb prefix (source strings arrive as E-C3)' - the project restores diacritics rather than folding them away"
+  notes: "name: D7 (accents). The project's own styling policy restores Citro\u00ebn diacritics from ASCII source strings, the corpus already carries 'M\u00e9hari', and the marque spells it with the accent. Cross-kind twin van/citroen/mehari is by design."
+
+"car/cupra/born":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { de: "correct", es: "correct", fi: "correct", gb: "correct", ie: "correct", lu: "correct", nl: "correct", nz: "correct", ua: "correct" } }
+  evidence:
+    - "de_kba de_fz10_202606.xlsx xl/sharedStrings.xml: 'SEAT' (idx 499) ... 'BORN' (idx 502) ... 'SEAT ZUSAMMEN' (idx 509) - Born is a Modellreihe inside the SEAT block, which is exactly what moves.yml routes"
+    - "overrides/models/moves.yml: '\"SEAT|Born\": \"Cupra|Born\"  # Cupra Born, never badged SEAT (https://www.cupraofficial.com/cars/born); 6,785 DE'"
+    - "raw: 'CUPRA | BORN 170 KW 60/63 KWH' es_dgt n=65"
+    - "raw: 'Cupra | BORN 150 KW 58/62 KWH Farmari (AC) 5ov A' fi_traficom class=M1 n=333"
+    - "raw: 'CUPRA | BORN V2 EV' uk_veh0120 GenModel='CUPRA BORN' BodyType='Cars'"
+    - "raw: 'Cupra Born' ie_tem20"
+    - "raw: 'CUPRA | BORN 150 KW 60/63 KWH' lu_snca CATEU=M1 n=38"
+    - "raw: 'CUPRA | BORN' nl_rdw personenauto n=2339 (+ kW/kWh variants totalling 9244)"
+    - "raw: 'CUPRA | BORN' nz_nzta passenger-car shard n=159"
+    - "raw: 'CUPRA | BORN' ua_mvs kind=LEGKOVYI n=19"
+  notes: "13 claims, all clean. The de claim is correct BECAUSE of the documented move, which I re-derived from the KBA workbook rather than taking on trust."
+
+"car/cupra/seat-leon":
+  verdicts: { id: "defective(D6)", name: "defective(D5)", make: "correct", kind: "correct",
+              availability: { es: "correct", lu: "correct" } }
+  evidence:
+    - "raw: 'CUPRA | SEAT LEON SP' es_dgt n=1"
+    - "raw: 'CUPRA | SEAT LEON  SP' lu_snca CATEU=M1 n=2"
+    - "catalog: car/cupra/leon ('Leon') is live and its raw set contains 'LEON SP', 'CUPRA LEON SP', 'CUPRA LEON SPORTSTOURER' - the same car"
+    - "overrides/models/moves.yml: the Cupra block exists precisely because 'NL/NZ registries emit \"SEAT\" + \"CUPRA LEON\"'; here the marque token landed inside the model of a CUPRA-make row and no rename stripped it"
+  notes: "id: D6 - the Cupra Leon has two live ids and its es/lu evidence is split off from the main one. name: D5 - 'Seat Leon' under make Cupra renders as 'Cupra Seat Leon'. make correct: the register's own make column says CUPRA."
+
+"car/daimler/consort":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'DAIMLER | CONSORT SALOON' nl_rdw personenauto n=1"
+    - "raw: 'DAIMLER | CONSORT' nz_nzta passenger-car shard n=19"
+  notes: "Daimler Consort (DB18 successor, 1949-53); two registers, one clean nameplate."
+
+"car/daimler/mkii":
+  verdicts: { id: "unverifiable(the id pools 'MKII SALOON' with 'MK II DINGO' (a Daimler Dingo scout car) so it is not clear the id denotes ONE vehicle; DEBT.md files the Daimler/Jaguar Mk split family as open work)", name: "defective(D7)", make: "correct", kind: "correct",
+              availability: { nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'DAIMLER | MKII' nl_rdw personenauto n=1; 'MK II' n=1; 'MKII SALOON' n=1; 'MK II DINGO' n=1"
+    - "raw: 'DAIMLER | MKII' nz_nzta passenger-car shard n=3"
+    - "overrides/styling.yml acronyms block: 'ALSO EXCLUDED - MK: British usage is \"Mk III\", not \"MK III\"' - the project has already settled that the British form is Mk/MkII, never Mkii"
+    - "overrides/models/renames.yml Austin block: 'Mini Mkii: Mini MkII  # same id already - display fix from the caser's \"Mkii\"' - the identical fix, already applied under another make"
+    - "DEBT.md: 'Jaguar Mk split family (Mki/Mk 1 = one car at two live ids...)' and 'Daimler V8-250 inversion ... five ids for one car'"
+  notes: "name: D7 with an exact in-project precedent ('Mini Mkii: Mini MkII'). id left unverifiable rather than defective because the pooling question (saloon vs Dingo) is a different defect from the split question, and DEBT.md already owns the family."
+
+"car/daimler/super-v8":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'Daimler | SUPER V8 Sedan (AA) 4ov 3990cm3 A' fi_traficom class=M1 n=1"
+    - "raw: 'DAIMLER | DAIMLER SUPER V8' nl_rdw personenauto n=137; 'SUPER V8' n=2"
+    - "raw: 'DAIMLER | SUPER V8' nz_nzta passenger-car shard n=9"
+    - "three registers, exact display form; V8 is kept as a closed token by the Daimler renames block ('V 8: V8')"
+
+"car/datsun/180b-wagon":
+  verdicts: { id: "defective(D8)", name: "correct", make: "correct", kind: "correct",
+              availability: { nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'DATSUN | 180B WAGON' nl_rdw personenauto n=1; '180 B WAGON' n=1; '180 B' n=1"
+    - "raw: 'DATSUN | 180B WAGON' nz_nzta passenger-car shard n=1 vs 'DATSUN | 180B' n=134"
+    - "catalog: car/datsun/180b ('180B') is live"
+  notes: "id: D8 - 'Wagon' is a body style; the 610-series 180B estate belongs on the nameplate. name accepted: '180B Wagon' is the register's own form and matches Datsun's house style (180B, 160J, 280C) that renames.yml documents."
+
+"car/datsun/laurel":
+  verdicts: { id: "correct", name: "correct", make: "correct", kind: "correct",
+              availability: { fi: "correct", gb: "correct", nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'Datsun | 4D LAUREL 2.0-HLJC31VAQ/2670' fi_traficom class=M1, kaupallinenNimi 'LAUREL' n=4"
+    - "raw: 'DATSUN | LAUREL' uk_veh0120 GenModel='DATSUN LAUREL' BodyType='Cars' (+ 'LAUREL SIX', 'LAUREL 2.4 AUTO')"
+    - "raw: 'DATSUN | LAUREL 2400' nl_rdw personenauto n=5; 'LAUREL' n=1"
+    - "raw: 'DATSUN | LAUREL' nz_nzta passenger-car shard n=3"
+  notes: "The fi claim needed a second pass: the fi model column carries a body prefix ('4D LAUREL 2.0-...'), so a naive model-prefix match reports zero. The kaupallinenNimi column resolves it."
+
+"car/de-soto/soto":
+  verdicts: { id: "defective(D4)", name: "defective(D4)", make: "correct", kind: "correct",
+              availability: { fi: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'DE SOTO | 4D HARD TOP/311' fi_traficom class=M1, kaupallinenNimi 'DE SOTO' n=1 - the marque written into the commercial-name column"
+    - "raw: 'DE SOTO | DE SOTO' nz_nzta passenger-car shard n=2"
+    - "catalog: the record's only observed variant is 'DE SOTO'; the make is 'De Soto', so make-prefix stripping removed 'DE ' and left 'SOTO'"
+    - "overrides/models/renames.yml De Soto block: 'Desoto: null  # registry rows where the make was written into the model column (car kind) - not a nameplate'"
+  notes: "id+name: D4. The project already drops this exact shape for De Soto - but the null key is 'Desoto', and make-prefix stripping turned 'DE SOTO' into 'SOTO', which the key never sees. That is a live escape hatch in a curation rule that is otherwise doing its job, and it is worth a detector: any model id whose name is a make-name suffix after prefix stripping."
+
+"car/denza/d9-fwd":
+  verdicts: { id: "defective(D6)", name: "defective(D8)", make: "correct", kind: "correct",
+              availability: { th: "correct" } }
+  evidence:
+    - "raw: 'DENZA | DENZA D9 FWD' th_dlt_2568, two type rows (private car; rental service)"
+    - "catalog: car/denza/d9 ('D9') is live with raw 'DENZA D9 AWD' - the drivetrain twin of the same MPV"
+    - "catalog: car/buick/rainier in this same slice folds 'Rainier AWD'/'Rainier 2WD' into the nameplate, which is the correct handling"
+  notes: "id: D6 - FWD and AWD are drivetrains of one Denza D9; the AWD half sits on the bare id and the FWD half got its own. name: D8 - drivetrain published as model."
+
+"car/dodge/polara-880":
+  verdicts: { id: "defective(D6)", name: "defective(D8)", make: "correct", kind: "correct",
+              availability: { nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'DODGE | POLARA 880' nl_rdw personenauto n=1 vs 'POLARA' n=27 (+ 'DODGE POLARA' n=1, 'polara' n=1)"
+    - "raw: 'DODGE | POLARA 880' nz_nzta passenger-car shard n=2 vs 'POLARA' n=43"
+    - "catalog: car/dodge/polara ('Polara') is live"
+  notes: "id: D6 - 1 nl + 2 nz registrations split off from 27 nl + 43 nz on the bare nameplate. name: D8 - a numeric qualifier appended to the Polara nameplate. Flagged for the verifier: Dodge's Polara and (Custom) 880 were SEPARATE 1962-64 models, so 'Polara 880' may be a register conflation of two nameplates (a D13-shaped reading) rather than a trim - I could not reach a Dodge source to settle it."
+
+"car/dodge/wc51":
+  verdicts: { id: "defective(D6)", name: "correct", make: "correct", kind: "correct",
+              availability: { nl: "correct", nz: "correct" } }
+  evidence:
+    - "raw: 'DODGE | WC 51' nl_rdw personenauto n=66; 'WC51' n=34; 'WC-51' n=6; 'W.C. 51' n=2; 'WC 51 4X4' n=2; bare 'WC' n=5"
+    - "raw: 'DODGE | WC51' nz_nzta passenger-car shard n=1; bare 'WC' n=3"
+    - "catalog: car/dodge/wc ('Wc') is live - the truncated twin, holding the bare 'WC' rows in both countries"
+    - "overrides/models/renames.yml (Alvis/Austin/Bentley/Daimler blocks): 'a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citro\u00ebn C1, Chevrolet C10), so the fused form is canonical'"
+  notes: "id: D6 - car/dodge/wc is the same WC-series vehicle at a truncated id (the U7 'truncated ids' shape DEBT.md files). name accepted under the project's own fused-form convention, even though the US Army designation is hyphenated WC-51 and nl's majority string is spaced. kind accepted: these are historic vehicles that nl_rdw registers as personenauto."
+

--- a/data/review/audit-v2026.07.5/audit-ledger-2.yml
+++ b/data/review/audit-v2026.07.5/audit-ledger-2.yml
@@ -1,0 +1,1649 @@
+# VehiclesDB five-nines baseline audit — gate A2 researcher ledger
+#
+# AUDIT ONLY. Nothing in this file was written into any git repo, and no defect
+# named here was fixed. Every finding is a claim-level verdict with the evidence
+# that produced it. Per PRD-QUALITY invariant I-15 and the audit protocol,
+# new-class findings are FLAGGED with evidence and a detector sketch, never
+# swept.
+#
+# Researcher != verifier (I-11): every verdict below must be re-derived by an
+# independent verifier before this ledger merges.
+
+slice: 2
+researcher: opus-audit-2
+tag: v2026.07.5
+audited_artifact: /Users/javi/GitHub/.vdb-worktrees/s4w-data/catalog/car/models.json (VERSION 2026.07.5, manifest generated_at 2026-07-26T05:28:12Z, file mtime 2026-07-26 06:29:09)
+audited_at: 2026-07-26
+
+sources_reached:
+  nl_rdw: "cache/nl_rdw_personenauto.json + _inrichting.json (91,910 merk|model rows), AND live https://opendata.rdw.nl/resource/m9d7-ebf2.json (CC0) for FAW, GAZ, MCC, MERKUR spot-confirmations"
+  nz_nzta: "cache/nz_passenger-car-van_*.json (17,128 MAKE|MODEL rows) — NOTE this dataset pools cars and vans, so it cannot adjudicate a car-vs-van kind question on its own"
+  fi_traficom: "cache/fi_traficom_register.zip -> TieliikenneAvoinData_31_03_2026.csv, 2,557,593 rows streamed; fields 1/26/27/30 (ajoneuvoluokka, merkkiSelvakielinen, mallimerkinta, kaupallinenNimi)"
+  es_dgt: "cache/es_dgt_202604/05/06.txt, fixed-width (make = cols 18-47, model = cols 48-69); 22,212 distinct make|model pairs. NOTE this is a monthly REGISTRATION FLOW, not a stock register — historic models appear only when re-registered or imported, and several classics in this slice do appear"
+  lu_snca: "cache/lu_delta_202604/05/06.xml (LIBMRQ/TYPCOM), 6,533 distinct pairs"
+  ua_mvs: "cache/ua_reestr_current.zip -> reestrtz02.07.2026.csv (BRAND/MODEL/KIND), 18,234 distinct triples. NOTE the make column is CYRILLIC for post-Soviet marques"
+  uk_dft: "cache/uk_veh0120_uk.csv, 98,704 distinct BodyType|Make|GenModel|Model rows — the BodyType column is what makes GB usable for kind adjudication"
+  ie_cso: "cache/ie_tem20.csv (325 distinct 'Make and Model' strings)"
+  my_jpj: "cache/my_cars_2025.csv + my_cars_2026.csv (748 distinct maker|model|type)"
+  de_kba_fz10: "cache/de_fz10_202606.xlsx -> xl/sharedStrings.xml, reconstructed as 400 Marke|Modellreihe pairs by walking the '<MAKE> ZUSAMMEN' block structure"
+  us_fueleconomy: "cache/us_vehicles.csv, 26,221 distinct make|model|year|VClass rows (VClass is what makes US usable for kind adjudication)"
+  ca_nrcan: "cache/ca_*fuel-consumption-ratings*.csv + BEV/PHEV files, 20,009 distinct Make|Model|Year rows"
+
+method:
+  - "Every one of the 301 availability claims was checked against its own named source, by building a per-source make|model index and classifying each match as EXACT (folded model string equals the catalog name), PREFIX (catalog name is a prefix, i.e. the source adds a drive/body/wheel qualifier) or token-subset."
+  - "id-canonical was checked three ways: (a) all 3,102 sibling records under this slice's 50 makes were pulled and compared by fold key, by first token and by containment; (b) cross-make candidates were pulled explicitly (abarth, daewoo, smart, hongqi, ssangyong, suzuki, mitsubishi); (c) the catalog's own published xrefs.tan approval numbers were compared between candidate pairs — this decided four cases on its own and cleared one."
+  - "kind was checked against the source's own class word where the source has one: uk_dft BodyType, us_fueleconomy VClass, nl_rdw inrichting, ua_mvs KIND, fi_traficom ajoneuvoluokka."
+  - "name was checked against a marque source per record, fetched not assumed. Wikipedia article text and, where reachable, the manufacturer's own site (ford.com only via web.archive.org; EPA's fueleconomy.gov API used to prove which strings are certification artifacts rather than nameplates)."
+  - "The override layer (renames/former_ids/moves/removals/drop/styling) was read for every finding so that already-known defects are reported as known rather than as new."
+SUMMARY:
+  records_audited: 100
+  claims_total: 701          # 100 x (id, name, make, kind) + 301 availability entries
+  verdicts:
+    correct: 619
+    defective: 80
+    unverifiable: 2
+  clean_rate: "88.30%  (619/701; unverifiable counted AGAINST, per protocol)"
+
+  per_claim_type:
+    id:           { total: 100, correct: 59,  defective: 40, unverifiable: 1 }
+    name:         { total: 100, correct: 71,  defective: 29, unverifiable: 0 }
+    make:         { total: 100, correct: 94,  defective: 6,  unverifiable: 0 }
+    kind:         { total: 100, correct: 95,  defective: 5,  unverifiable: 0 }
+    availability: { total: 301, correct: 300, defective: 0,  unverifiable: 1 }
+
+  defects_by_taxonomy_class:   # a defect naming two classes is counted under its first
+    D6  (duplicate spelling, same make+kind):        21
+    D8  (wrong altitude — trim/body/engine as model): 18
+    D7  (non-canonical form — casing/spacing/accent): 16
+    D11 (wrong make — approval holder):                6
+    D10 (wrong kind):                                  5
+    D9  (registry/homologation code as model):         5
+    D5  (embedded make/brand prefix):                  3
+    "cross-make duplicate (no single class fits — see FLAG 1)": 3
+    D13 (temporal/merge cell):                         2
+    D4  (make-as-model):                               1
+
+  headline: >-
+    Availability is the strongest dimension in this slice: 300 of 301
+    country-level claims verified against the named source, with one honest
+    unverifiable and ZERO defects. Every failure is a NAMING or IDENTITY
+    failure. 40 of 100 records share their vehicle with another live id, and
+    that single number carries most of the loss: drop the id dimension and the
+    remaining 601 claims are 93.2% clean (560/601). The id failures are not
+    random — 16 of them are duplicate pairs that the duplicate-spellings detector
+    cannot see BY CONSTRUCTION (FLAG 1), 4 more are cross-make pairs outside its
+    per-make scope, and only ONE was a pair the existing detector should already
+    have caught.
+
+  defect_list:
+    # id-canonical (40)
+    - "car/faw/e-hs9              id   D6 + cross-make   — car/faw/ehs9 AND car/hongqi/e-hs9 are the same car (shared TAN family e13*2018/858*00350)"
+    - "car/faw/ehs9               id   D6                — fold-equal to car/faw/e-hs9; already queued in renames+former_ids"
+    - "car/fiat/500-abarth        id   cross-make        — car/abarth/500 is the same 312-series car"
+    - "car/fiat/eura-mobil-sport  id   D6/D8             — car/fiat/eura-mobil is the same coachbuilder string"
+    - "car/fiat/fiorino-qubo      id   D6                — car/fiat/qubo shares the EXACT TAN extension e3*2001/116*0271*09"
+    - "car/fiat/nuova-500         id   D6                — car/fiat/500-nuova, same words transposed"
+    - "car/fisker/ocean-extreme-one id D13/D6            — a slash-merged two-trim cell; car/fisker/ocean and /ocean-one live"
+    - "car/ford/18                id   D6                — car/ford/model-18"
+    - "car/ford/a-roadster        id   D6/D8             — car/ford/model-a (+ a/a-model/roadster)"
+    - "car/ford/bronco-black-diamond id D8               — trim series; car/ford/bronco live"
+    - "car/ford/e150-van-ffv      id   D8                — car/ford/e150 and /e150-van live"
+    - "car/ford/explorer-tremor   id   D8                — trim; car/ford/explorer live"
+    - "car/ford/galaxie-500-sunliner id D6               — car/ford/galaxie-sunliner"
+    - "car/ford/model-t           id   D6                — car/ford/t (fi row 'T model ... 2896cm3' is the Model T engine)"
+    - "car/ford/mustang-hardtop   id   D8                — body style; car/ford/mustang live"
+    - "car/genesis/gv60-performance id D8                — grade; car/genesis/gv60 live"
+    - "car/geo/tracker-van        id   D6/D8             — car/geo/tracker holds EPA's 'Tracker Convertible' rows"
+    - "car/gm-daewoo/matiz        id   cross-make        — car/daewoo/matiz; identical fi type code 0M11CD/234 under both makes"
+    - "car/hyundai/elantra-wagon  id   D8                — wagon body; car/hyundai/elantra live"
+    - "car/hyundai/pony-gls       id   D8                — trim; car/hyundai/pony live"
+    - "car/hyundai/tucson-ix35    id   D6                — car/hyundai/ix35 shares THREE exact TAN extensions; queued"
+    - "car/jaguar/f-pace-30t      id   D8                — output designation; car/jaguar/f-pace live"
+    - "car/jaguar/f-type-p450     id   D8                — powertrain designation; car/jaguar/f-type live"
+    - "car/jaguar/xj42            id   D6/D9             — collects 'XJ 4.2' displacement strings already held by xj6/xj8"
+    - "car/kia/niro-fe            id   D8                — trim grade; car/kia/niro live"
+    - "car/kia/sedona-sx          id   D8                — trim grade; car/kia/sedona live"
+    - "car/lancia/delta-hf-integrale id D6               — car/lancia/delta-hf-intergrale (a TYPO published as a record) + delta-integrale"
+    - "car/mazda/cx-70-sc         id   D8                — PHEV trim; car/mazda/cx-70 live"
+    - "car/mcc/smart              id   cross-make        — car/smart/{fortwo,city,coupe,cabrio,mcc}; shared approval family e1*98/14*0080"
+    - "car/mg/b-gt                id   D6                — car/mg/mgb-gt is the same MGB GT"
+    - "car/morris/1000-traveller  id   D6                — car/morris/minor-1000-traveller"
+    - "car/morris/mini-cooper     id   D6                — car/morris/cooper"
+    - "car/nissan/maxima-qx       id   D6                — car/nissan/maxima; shared approval family e1*98/14*0136"
+    - "car/nissan/xterra-v6       id   D8                — engine; car/nissan/xterra live"
+    - "car/nissan/z-nismo         id   D8                — grade; car/nissan/z live"
+    - "car/oldsmobile/cutlass-cruiser-wagon id D6/D8     — car/oldsmobile/cutlass-cruiser"
+    - "car/peugeot/604-sl         id   D8                — launch trim; car/peugeot/604 live"
+    - "car/plymouth/valiant-scamp id   D6                — car/plymouth/scamp (disambiguated by engine size, 5190 vs 5211 cc)"
+    - "car/renault/scenic         id   D6                — car/renault/meganescenic is the fused gen-I twin"
+    - "car/saab/9000-turbo        id   D8                — engine designation; car/saab/9000 live"
+    # name-marque-true (29)
+    - "car/dodge/wc52             name D7   — marque/US-Army designation is 'WC-52'"
+    - "car/faw/ehs9               name D7   — Hongqi renders it 'E-HS9'"
+    - "car/faw/hongqi-ehs7        name D5   — marque token 'Hongqi' embedded in the model string (the EHS7 part is CORRECT unhyphenated)"
+    - "car/fiat/eura-mobil-sport  name D5   — 'Eura Mobil' is a motorhome coachbuilder brand, not a Fiat nameplate"
+    - "car/fiat/fiorino-qubo      name D6   — two distinct Fiat nameplates concatenated by the register"
+    - "car/fiat/nuova-500-giardiniera name D7 — Fiat's designation is '500 Giardiniera'; 'Nuova' belongs to the saloon"
+    - "car/fisker/ocean-extreme-one name D13+D7 — merged cell, and 'One' lower-cased"
+    - "car/ford/18                name D7   — Ford's designation is 'Model 18'"
+    - "car/ford/a-roadster        name D8   — 'roadster' is one of the Model A's body styles"
+    - "car/ford/e150-van-ffv      name D9/D7 — EPA certification string; Ford's own name is 'E-150', and FFV is all-caps"
+    - "car/ford/mustang-hardtop   name D8   — 'Hardtop' is a GENERIC Ford body label, not a nameplate or trim"
+    - "car/gaz/2401               name D7   — the marque hyphenates: 'GAZ-24-01'"
+    - "car/geo/tracker-van        name D9   — 'Van' is EPA's class word; Geo called the body a hardtop"
+    - "car/hyundai/tucson-ix35    name D7   — Hyundai's official casing is lowercase 'ix35' (styling.yml says so too)"
+    - "car/jaguar/f-pace-30t      name D7   — Jaguar and BOTH sources render it lowercase '30t'"
+    - "car/jaguar/mark-8          name D7   — Jaguar's designation is Roman: 'Mark VIII'"
+    - "car/jaguar/xj42            name D9   — not a Jaguar nameplate; XJ41/XJ42 were cancelled project codes, and the rows are '4.2' displacements"
+    - "car/kia/sedona-sx          name D7   — both sources render 'SX'"
+    - "car/lamborghini/aventador-countach name D9/D5 — the marque's name is 'Countach LPI 800-4'"
+    - "car/lamborghini/aventador-sian-roadster name D5/D7 — the marque's name is 'Sián Roadster' (acute accent, no Aventador)"
+    - "car/lancia/delta-hf-integrale name D7 — Lancia writes 'Delta HF integrale': HF UP, integrale DOWN — both tokens wrong"
+    - "car/maxus/mifa-9           name D7   — the maker's own site renders 'MIFA 9'"
+    - "car/mazda/cx-70-sc         name D7   — Mazda and both sources render 'SC'"
+    - "car/mcc/smart              name D4/D5 — 'Smart' is the MARQUE sitting in the model column"
+    - "car/mg/b-gt                name D7   — MG's rendering is 'MGB GT'"
+    - "car/morris/1000-traveller  name D7   — Morris's name is 'Minor 1000 Traveller'"
+    - "car/nissan/maxima-qx       name D7   — Nissan Europe renders 'Maxima QX'"
+    - "car/nissan/z-nismo         name D7   — Nissan renders 'Z NISMO'"
+    - "car/oldsmobile/cutlass-cruiser-wagon name D9 — the Cutlass Cruiser IS the wagon; 'Wagon' is redundant"
+    # make-correct (6)
+    - "car/faw/e-hs9              make D11  — the marque is Hongqi; fi_traficom itself files a row under merk=Hongqi"
+    - "car/faw/ehs9               make D11  — same"
+    - "car/faw/hongqi-ehs7        make D11  — same; the hongqi make already exists as a move target"
+    - "car/fiat/500-abarth        make D11  — Abarth for the EU rows (Fiat IS correct for ca/us — remedy is a split, not a merge)"
+    - "car/gm-daewoo/matiz        make D11/D12 — 'GM Daewoo' is the corporate entity; the marque is Daewoo"
+    - "car/mcc/smart              make D11  — MCC is the manufacturing JV; Smart is the marque"
+    # kind-correct (5)
+    - "car/fiat/eura-mobil-sport  kind D10  — BOTH NL rows are inrichting=kampeerwagen, the project's own camper test"
+    - "car/ford/e150-van-ffv      kind D10  — EPA class 'Vans, Cargo Type'"
+    - "car/hummer/h3t             kind D10  — EPA class 'Standard Pickup Trucks 4WD'"
+    - "car/ldv/v80                kind D10  — GB BodyType is 10 LGV / 6 bus / 1 car, and van+bus records already exist"
+    - "car/ram/1500-classic       kind D10  — EPA class 'Standard Pickup Trucks'; truck/ram/1500 already exists"
+
+  unverifiable_list:
+    - "car/mg/magna  availability.nz  — the only NZ evidence is a single row 'MG | MAGNA' n=1, in a register whose MAGNA population is overwhelmingly Mitsubishi (a genuinely unrelated nameplate, en.wikipedia MG_Magna vs Mitsubishi_Magna). A mis-keyed make cannot be excluded from register data alone, and this record has only two sources at n=1 each."
+    - "car/honda/grace  id  — the Grace is the JDM name of the City sedan (en.wikipedia Honda_Grace redirects to Honda City: 'The City is offered and sold as Honda Grace in Japan starting from December 2014'), so car/honda/city may denote the same vehicle. But car/honda/city spans several City generations across five countries, NZTA carries both 'GRACE' (n=1888) and 'CITY' (n=983) with no model-year field, and neither record has an approval number — so unlike car/nissan/maxima-qx (settled by a shared approval family) this overlap cannot be settled from the sources reached. A separate JDM-badge record is also defensible curation (the kgm/ssangyong precedent). Needs a disposition, not a guess."
+
+  # ══════════════════════════════════════════════════════════════════════════
+  # FLAGS — found, not fixed, not extrapolated (invariant I-15)
+  # ══════════════════════════════════════════════════════════════════════════
+
+  FLAG_1_detector_blind_spot_token_difference_duplicates:
+    severity: "highest-value finding in this slice — it explains 21 of the 40 id defects"
+    status: "NOT a new taxonomy class. It is a COVERAGE GAP in D6's detector, which the taxonomy attributes to find_duplicate_spellings.rb."
+    the_gap: >-
+      scripts/find_duplicate_spellings.rb defines a collision in its own header
+      as "two or more records under one make+kind whose names are identical once
+      case and punctuation are removed". That definition is blind, by
+      construction, to three duplicate shapes that are common in this data:
+      (a) pairs differing by a WHOLE TOKEN, (b) pairs differing by token ORDER,
+      (c) pairs differing by a TYPO. It is also per-make, so cross-make pairs
+      are out of scope entirely.
+    measured_in_this_slice_of_100:
+      within_make_token_difference: 14
+      within_make_word_order: 1
+      within_make_typo: 1
+      within_make_fold_equal_ie_ALREADY_DETECTABLE: 1
+      cross_make: 4
+    instances_token_difference:
+      - "car/mg/b-gt 'B GT'  vs  car/mg/mgb-gt 'Mgb GT'      (fold BGT vs MGBGT)"
+      - "car/morris/1000-traveller  vs  car/morris/minor-1000-traveller"
+      - "car/morris/mini-cooper  vs  car/morris/cooper"
+      - "car/ford/18 '18'  vs  car/ford/model-18 'Model 18'"
+      - "car/ford/model-t 'Model T'  vs  car/ford/t 'T'"
+      - "car/ford/a-roadster  vs  car/ford/model-a"
+      - "car/ford/galaxie-500-sunliner  vs  car/ford/galaxie-sunliner"
+      - "car/fiat/fiorino-qubo  vs  car/fiat/qubo"
+      - "car/oldsmobile/cutlass-cruiser-wagon  vs  car/oldsmobile/cutlass-cruiser"
+      - "car/plymouth/valiant-scamp  vs  car/plymouth/scamp"
+      - "car/nissan/maxima-qx  vs  car/nissan/maxima"
+      - "car/geo/tracker-van  vs  car/geo/tracker"
+      - "car/renault/scenic  vs  car/renault/meganescenic  (fused form)"
+      - "car/hyundai/tucson-ix35  vs  car/hyundai/ix35   [ALREADY QUEUED in the override layer]"
+    possible_further_instance_left_open:
+      - "car/honda/grace  vs  car/honda/city — the same market-name shape (Grace is the JDM City sedan), recorded UNVERIFIABLE above because no approval number or model year exists on either side to prove the generational overlap. A token-difference detector would not find this one either, since the two names share no token at all; market-name aliases need the marque dossier, not a string heuristic."
+    instances_word_order:
+      - "car/fiat/nuova-500 'Nuova 500'  vs  car/fiat/500-nuova '500 Nuova'"
+    instances_typo:
+      - "car/lancia/delta-hf-integrale  vs  car/lancia/delta-hf-intergrale ('Intergrale' — a transposition published as its own record)"
+    instances_cross_make:
+      - "car/faw/e-hs9  vs  car/hongqi/e-hs9"
+      - "car/fiat/500-abarth  vs  car/abarth/500"
+      - "car/gm-daewoo/matiz  vs  car/daewoo/matiz"
+      - "car/mcc/smart  vs  car/smart/{fortwo,city,coupe,cabrio,mcc}"
+    proof_that_the_curation_layer_knows_and_still_publishes_both: >-
+      overrides/models/renames.yml, MG block, contains a rename group folding
+      "B G T"/"B.gt"/"B. GT"/"Bgt" into "B GT" with the comment
+      'Bgt: B GT  # register shorthand for the MGB GT', and a few lines away a
+      second group folding "Mgb GT" into "MGB GT". So the project has written
+      down, in the same file, that these are the same car — and still ships two
+      canonical records, because nothing compares the two groups.
+    detector_sketch_proposed_not_built:
+      - "Within make+kind: build a key from the folded name MINUS (i) the make's own tokens and their fusions, and (ii) a small family-word list (Model, Minor, Mini, Nuova...). Compare records on the SORTED token multiset of that key. That catches (a) and (b) in one pass."
+      - "Add an edit-distance-1 comparison on the existing fold key to catch (c) — 'DELTAHFINTERGRALE' vs 'DELTAHFINTEGRALE' is a single transposition."
+      - "Report as CANDIDATES with volumes, exactly as the current script does; the 10.4 skew test then decides the canonical. Note the skew test is INCONCLUSIVE for car/ford/18 (5:2 in NL, 3:3 in NZ), so the marque must decide there."
+    expected_false_positives_to_design_against:
+      - "car/eagle/summit vs car/eagle/summit-wagon — genuinely different vehicles (Mirage vs RVR/Expo LRV). A token-difference detector WILL propose this pair; the disposition is 'not a duplicate'."
+      - "car/kgm/actyon vs car/ssangyong/actyon — same nameplate, different generations across a corporate rename. Cleared here by approval framework (2001/116 vs 2018/858)."
+
+  FLAG_2_xrefs_tan_is_an_unused_duplicate_oracle:
+    severity: "high — it is free, already published, and it discriminates in BOTH directions"
+    finding: >-
+      Four of this slice's duplicate findings were settled by an exact or
+      same-family type-approval number that the catalog ALREADY PUBLISHES in
+      xrefs.tan, with no name heuristic involved at all. The same field also
+      CLEARED a suspected duplicate. Nothing in the detector suite uses it.
+    positives:
+      - "car/fiat/fiorino-qubo e3*2001/116*0271*09  ==  car/fiat/qubo e3*2001/116*0271*09   (exact extension match)"
+      - "car/nissan/maxima-qx e1*98/14*0136*00  vs  car/nissan/maxima e1*98/14*0136*03      (same family)"
+      - "car/gm-daewoo/matiz e4*2001/116*0028*18  vs  car/daewoo/matiz e4*2001/116*0028*15  (same family, cross-make)"
+      - "car/faw/e-hs9 e13*2018/858*00350*00  vs  car/hongqi/e-hs9 e13*2018/858*00350*01    (same family, cross-make)"
+      - "car/hyundai/tucson-ix35 shares THREE exact extensions with car/hyundai/ix35: e11*2007/46*0104*00, e11*2007/46*0192*02, e11*2007/46*0192*03"
+      - "car/mcc/smart's evidence sits in family e1*98/14*0080, shared by car/smart/fortwo (*04,*15,*18,*19,*20,*23), car/smart/city (*07) and car/smart/mcc (*12,*13)"
+    negative_control:
+      - "car/kgm/actyon e6*2018/858*00325*05-09  vs  car/ssangyong/actyon e4*2001/116*0115*00 — DIFFERENT frameworks, correctly NOT a duplicate. An oracle that only ever said 'merge' would be useless; this one says 'don't'."
+    caveat: "TAN coverage is partial (many classic records carry no xrefs at all), so this is a high-precision, low-recall oracle — a complement to name heuristics, not a replacement."
+
+  FLAG_3_uniformly_wrong_casing_is_invisible_to_the_casing_detector:
+    severity: "medium — accounts for 6 of the 16 D7 name defects here"
+    the_gap: >-
+      scripts/find_casing_contradictions.rb states its own question precisely:
+      "does one make spell the same token both ways?" That is a
+      self-contradiction test, so it cannot see a token that a make spells
+      WRONGLY BUT CONSISTENTLY. The catalog-wide alternative
+      (find_published_name_defects.rb) asks "is this token in caps somewhere?",
+      whose output is candidates needing judgement.
+    measured_catalog_wide_16825_published_names:
+      - "HF  — published by exactly one make (lancia) and ONLY as 'Hf'. No make anywhere publishes 'HF'."
+      - "QX  — only nissan, only as 'Qx'."
+      - "MIFA — only maxus, only as 'Mifa'."
+      - "NISMO — only nissan, only as 'Nismo'."
+      - "SX  — published as 'Sx' by datsun, fiat, kia, suzuki, wk-bikes; by NO make as 'SX'."
+      - "SC  — 'Sc' by alvis, bentley, de-soto, jaguar, kawasaki, mazda, porsche, rover, saturn, suzuki; 'SC' only by edwards and lexus (different records), so the mazda CX-70 SC case is not reachable per-make either."
+    note: "This is exactly why the audit fetches the marque instead of asking the catalog. Every one of these was decided from a marque or source rendering, not from internal consistency."
+
+  FLAG_4_release_freshness_the_tagged_catalog_is_older_than_the_tagged_overrides:
+    severity: "medium, and it distorts audit results — it is why an auditor finds defects the maintainers have already fixed"
+    finding: >-
+      At tag v2026.07.5, 23 ids are published in catalog/ AND simultaneously
+      listed as keys in overrides/models/former_ids.yml, i.e. the override layer
+      declares them retired while the shipped catalog still publishes them.
+      Measured by intersecting all 2,474 former_ids keys with all 16,825
+      published ids across the six kinds.
+    checked_and_found_NOT_broken:
+      - "The gate is correctly designed: validate.rb#alias_liveness_failures fails when an alias key is live IN THE BUILD UNDER VALIDATION ('an alias may never name a live id'), so a fresh build catches this. The stale artifact is what escapes it."
+      - "The shipped data is internally consistent: the successors (car/faw/e-hs9, car/hyundai/ix35, car/alfa-romeo/gtv, car/kia/ceed, car/aston-martin/dbx707) carry NO former_ids array in the published catalog, although 622 other car records do. So consumers holding the tag do not see a live-id/alias contradiction — they simply hold a catalog one curation cycle behind."
+    the_actual_gap: "Nothing asserts that the catalog shipped under a tag was BUILT FROM the overrides shipped under that same tag. catalog/car/models.json is stamped 2026-07-26 06:29 while former_ids.yml is 08:12 and renames.yml 15:32."
+    the_23:
+      - "bus/man/lion, bus/man/lions -> bus/man/lion-s"
+      - "car/alfa-romeo/romeo-gtv -> car/alfa-romeo/gtv"
+      - "car/aston-martin/dbx-707 -> car/aston-martin/dbx707"
+      - "car/austin-healey/3000-mk-2, /3000-mk2 -> car/austin-healey/3000-mkii"
+      - "car/chrysler/300c-srt-8 -> car/chrysler/300c-srt8"
+      - "car/datsun/280-zx -> car/datsun/280zx"
+      - "car/faw/ehs9 -> car/faw/e-hs9                                  [IN THIS SLICE]"
+      - "car/hyundai/tucson-ix-35, /tucson-ix35, /tucson-ix35-lm -> car/hyundai/ix35   [tucson-ix35 IS IN THIS SLICE]"
+      - "car/infiniti/ex-35 -> car/infiniti/ex35"
+      - "car/kia/cee-d -> car/kia/ceed"
+      - "car/mazda/r-x-7 -> car/mazda/rx-7"
+      - "car/mercury/cougar-xr7 -> car/mercury/cougar-xr-7"
+      - "car/volkswagen/vw-1-11 -> car/volkswagen/vw1-11"
+      - "motorcycle/moto-guzzi/850le-mans-iii -> motorcycle/moto-guzzi/850-le-mans-iii"
+      - "motorcycle/norton/commando-850mk-iii -> motorcycle/norton/commando-850-mk-iii"
+      - "van/mercedes-benz/639-vito-109, -111, -115, -120 -> van/mercedes-benz/vito"
+    why_it_matters_for_this_programme: >-
+      2 of my 40 id defects are already fixed in curation and merely unbuilt.
+      If RESULTS.md aggregates researcher findings without separating
+      queued-not-shipped from genuinely-open, the measured defect rate will lag
+      the real one by however long the build lag is. Recommend the ledger schema
+      carry a queued_not_shipped boolean, and that the release protocol assert
+      former_ids.keys INTERSECT published_ids == 0 against the tagged dist/
+      artifact rather than against a local build.
+    two_of_the_23_predate_the_2026-07-26_curation_session: "car/alfa-romeo/romeo-gtv and the four van/mercedes-benz/639-vito-* entries are not from the 2026-07-26 singleton-tail batch, so this is not a one-session artifact."
+
+  FLAG_5_camper_leakage_that_names_only_the_coachbuilder:
+    severity: "medium; one instance in this slice, with a measured upper bound"
+    finding: >-
+      car/fiat/eura-mobil-sport is a motorhome published as a car. Both its NL
+      rows carry inrichting=kampeerwagen — the deterministic test NAMING.md 3
+      names for exactly this class, and D10's own example is "campers in car".
+      It evades BOTH existing mechanisms: overrides/makes/drop.yml already drops
+      "EURA MOBIL" but only as a MAKE, and overrides/models/drop_patterns.yml
+      drops base-van nameplates (DUCATO, BOXER, SPRINTER, TRANSIT...) but this
+      model string names only the coachbuilder, so it contains no van nameplate
+      to match.
+    bounded_measurement: >-
+      210 published car-kind records have NL evidence that is 100%
+      inrichting=kampeerwagen (computed over all 24,544 kampeerwagen merk|model
+      rows). CAVEAT, stated so nobody treats this as a fix list: that set
+      contains legitimate cars whose NL rows happen to be camper conversions
+      (volkswagen 'Id. Buzz' is in it at n=104), so 210 is an UPPER BOUND
+      requiring per-record review, not a sweep target.
+    the_unambiguous_sub_shape: "a motorhome brand in the model column under a chassis make — fiat|Dethleffs (55), fiat|Hymer (44), fiat|Adriatik (43), fiat|Burstner (30), fiat|Eura Mobil (28), fiat|Rapido (27), fiat|Trigano FI1 (27), plus the audited fiat/eura-mobil-sport (2)."
+
+  FLAG_6_source_handling_hazards_found_while_auditing:
+    - "ua_mvs writes the MAKE COLUMN IN CYRILLIC for post-Soviet marques. car/gaz/2401's Ukrainian evidence is real ('ГАЗ | 2401 | ЛЕГКОВИЙ' n=3) but a Latin-only make probe returns zero rows for GAZ — and would for VAZ/UAZ/ZAZ/Moskvich too. Any make-matching code touching ua_mvs needs the Cyrillic forms."
+    - "nl_rdw's merk field is NOT uniformly upper-case and the SoQL API is case-sensitive: merk=MERKUR returns [] while merk=Merkur returns the rows. A case-sensitive live probe can silently report a make as absent."
+    - "es_dgt is a monthly REGISTRATION FLOW, not a stock register. Classic-car es claims therefore rest on 2026-Q2 re-registrations/imports. They do check out in this slice (e.g. 'FORD | MUSTANG HARDTOP' is present), but the semantics differ from nl_rdw/nz_nzta and an es absence is much weaker evidence than an nl absence."
+    - "nz_nzta's dataset is 'passenger-car-van' — car and van are NOT separable in it, so it can never adjudicate a car-vs-van kind question. This matters for car/ldv/v80, where NZ is one of only two sources."
+
+  FLAG_7_make_display_casing_D23_observed_but_not_a_record_level_claim:
+    note: "These are make-level defects (remedy: makes/aliases.yml identity pin) surfaced incidentally while auditing records in this slice. Recorded so they are not lost, but they are NOT counted in the claim totals above, which are record-level."
+    observed:
+      - "nio  — ships as 'Nio'; the brand is stylised NIO (https://en.wikipedia.org/wiki/Nio_Inc. — 'stylized as NIO'). Same shape as the already-fixed Ktm/Bsa/Ldv cases."
+      - "mcc  — ships as 'Mcc'; MCC = Micro Compact Car AG."
+      - "gm-daewoo — ships as 'Gm Daewoo'; if the make survives at all it is 'GM Daewoo', but per this audit it should not survive (D12 merge into daewoo)."
+
+  cross_kind_naming_inconsistency_noted:
+    - "car/dodge/wc52 ships as 'WC52' while van/dodge/wc-52 ships as 'Wc-52' for the same vehicle series. Whatever the right rendering is, the catalog currently disagrees with itself across kinds — and 'Wc-52' is additionally a D23-shaped casing defect."
+
+  notes_for_the_verifier:
+    - "Every availability verdict is reproducible from the per-source indexes rebuilt in the scratchpad; the per-claim matched row is recorded in the evidence list for each record."
+    - "Two verdicts deliberately go AGAINST the majority/obvious reading and should get the closest re-derivation: car/kgm/actyon (id correct despite an identically-named ssangyong sibling — decided on approval framework) and car/faw/hongqi-ehs7 (name's EHS7 is correct UNHYPHENATED while car/faw/ehs9's EHS9 is wrong — Hongqi hyphenates its older E-* range and not the 2023+ Tiangong range, so a blanket hyphen fix would break one while fixing the other)."
+    - "One prior hypothesis of mine was REVERSED by the marque source and is flagged in-record: car/mazda/cx-70-sc's 'SC' is a genuine Mazda PHEV trim (mazdausa.com lists 'PHEV SC' and 'PHEV SC Plus'), not the EPA artifact I expected. Any rule written to strip SC as register noise would be wrong."
+    - "car/rover/110 is recorded correct but carries a contamination note: 'ROVER 110' is also the Land Rover Defender 110 wheelbase designation and the NZ row '110 DLS SW TURBO' does not look like a P4 saloon."
+    - "One claim STARTED unverifiable and was resolved by refusing to settle for the encyclopedia: car/hyundai/elantra-wagon's name. en.wikipedia says the second-generation Elantra wagon was marketed as 'Avante Touring'/'Lantra Sportswagon' with no US wagon at all, which contradicted EPA's five model years of 'Elantra Wagon'. Hyundai Motor America's own 1999 site, via the Wayback Machine, settles it — the lineup keywords include 'elantra wagon, Elantra wagon'. Recorded as correct with the residual casing caveat, because a keywords list is weak evidence for capitalisation."
+    - "Fetch-access notes for whoever re-derives this: ford.com, nissanusa.com, hyundai.news, kiamedia.com and lancia.com are unreachable or JS-gated; web.archive.org works via curl but not WebFetch; genesis.com, nio.com, nissan.co.jp, mazdausa.com, jaguarusa.com, maxus.de and renault.co.uk ARE reachable (mazdausa/maxus need curl --compressed, or they return an empty-looking 200)."
+# ── records 1-25 ───────────────────────────────────────────────────────────
+"car/dodge/wc52":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Dodge_WC_series  # 21 occurrences of the hyphenated WC-52; the only unhyphenated WC52 in the page source is an HTML anchor id, not a designation. Primary designation: 'The G-502, WC-51 & WC-52: Truck, Cargo, 3/4-ton, 4x4, Weapons Carrier (T-214)'. WC is a Dodge factory model code, not an acronym"
+    - "raw: 'DODGE | WC 52' n=58, 'WC52' n=19, 'WC-52' n=1, 'W.C. 52' n=4 nl_rdw (live opendata.rdw.nl merk=DODGE)"
+    - "raw: 'DODGE | WC52' n=1 nz_nzta passenger-car-van"
+    - "raw: nl_rdw inrichting for these rows = cabriolet (34+13), terreinvoertuig (6), stationwagen, sedan, MPV — no kampeerwagen"
+  notes: >-
+    name: the hyphenated form is both the marque/US-Army designation and the
+    majority raw spelling; the catalog's own van-kind twin spells it
+    "Wc-52" (van/dodge/wc-52), so the two kinds contradict each other and one
+    of the two is wrong regardless. kind: the vehicle is a 3/4-ton military
+    truck, but both claimed registers file it in their passenger-car datasets
+    and NL's inrichting is overwhelmingly cabriolet, so car is
+    register-faithful; van/dodge/wc-52 and truck/dodge/wc already carry the
+    other kinds (legitimate cross-kind per PRD-QUALITY 10.1). id: sibling
+    car/dodge/wc ("Wc") is an under-specified truncation of the same series —
+    a defect on THAT record, not this one.
+
+"car/eagle/summit":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Eagle | Summit | 1989-1996 | Compact/Subcompact Cars' us_fueleconomy (8 exact rows)"
+    - "raw: 'Eagle | Summit | 1995' ca_nrcan (2 exact rows)"
+    - "https://en.wikipedia.org/wiki/Eagle_Summit  # 'The Summit was a badge engineered version of the Mitsubishi Mirage'; the Wagon 'was a completely different vehicle ... a rebadged Mitsubishi RVR, thus not related to the Mirage-based Summits'"
+  notes: "id: the Summit Wagon is a different vehicle (Mitsubishi Expo LRV vs Mirage), so car/eagle/summit-wagon is not a duplicate."
+
+"car/eagle/summit-wagon":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Eagle | Summit Wagon | 1992-1996 | Midsize-Large Station Wagons' us_fueleconomy (5 exact rows)"
+    - "raw: 'Eagle | Summit Wagon | 1995,1996' ca_nrcan"
+    - "https://en.wikipedia.org/wiki/Eagle_Summit  # 'The somewhat related Eagle Summit Wagon (a compact MPV) was marketed from 1992 through 1996 and was based on the Mitsubishi RVR'"
+    - "https://en.wikipedia.org/wiki/Mitsubishi_RVR  # US market name 'Mitsubishi Expo LRV'; the aka list includes 'Eagle Summit Wagon'"
+
+"car/eagle/vision":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Eagle | Vision | 1993-1997 | Large Cars' us_fueleconomy (5 exact rows)"
+    - "raw: 'Eagle | Vision | 1995' ca_nrcan"
+    - "https://en.wikipedia.org/wiki/Eagle_Vision  # 'The Eagle Vision is a full-sized, front-wheel drive four-door sports sedan produced from 1992 until 1997'"
+
+"car/excalibur/phaeton":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'EXCALIBUR | PHAETON' n=6 + 'EXCALIBUR PHAETON' n=1 + 'PHAETON K6' n=17 nl_rdw"
+    - "raw: 'EXCALIBUR | PHAETON' n=6 nz_nzta"
+    - "raw: nl_rdw inrichting=cabriolet for the PHAETON rows (matches body_types convertible)"
+    - "https://en.wikipedia.org/wiki/Excalibur_(automobile)  # 'a roadster ... was introduced, as well as the four-seater Phaeton model'; captions read 'Series II Phaeton (1972)', 'Series III Phaeton', 'Series IV Phaeton (1982)'"
+
+"car/faw/e-hs9":
+  verdicts: { id: "defective(D6 + cross-make duplicate)", name: correct,
+              make: "defective(D11)", kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Hongqi_E-HS9  # 'Hongqi E-HS9', hyphenated; marque is Hongqi, FAW Group is the parent"
+    - "raw: 'FAW | E-HS9' n=133 and 'FAW | EHS9' n=14 nl_rdw (live opendata.rdw.nl merk=FAW, 2026-07-26)"
+    - "raw: 'M1 | FAW | E-HS9 Farmari (AC) 5ov A' n=11 AND 'M1 | Hongqi | E-HS9 Farmari (AC) 5ov A' n=1 fi_traficom"
+    - "catalog: car/faw/ehs9 (live, fi+nl) and car/hongqi/e-hs9 (live, fi+ua) denote the same vehicle; TAN e13*2018/858*00350*00 here vs *01 on car/hongqi/e-hs9 = one approval family"
+  notes: >-
+    id: three live ids for one vehicle. car/faw/ehs9 is NFKD-fold-equal
+    (EHS9 == E-HS9 after fold) so find_duplicate_spellings should have fired;
+    former_ids.yml already maps car/faw/ehs9 -> car/faw/e-hs9, so the fold is
+    queued but not shipped in this tag. car/hongqi/e-hs9 is the cross-make
+    third copy and is NOT queued. make: fi_traficom itself files one row under
+    merk=Hongqi and renames.yml's FAW block explicitly defers this
+    ("Hongqi-vs-FAW make attribution filed as a moves.yml question, not
+    handled here"), i.e. a known-open D11.
+
+"car/faw/ehs9":
+  verdicts: { id: "defective(D6)", name: "defective(D7)",
+              make: "defective(D11)", kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Hongqi_E-HS9  # 'The Hongqi E-HS9 (Chinese: 红旗E-HS9) is a battery electric full-size luxury crossover SUV' — hyphenated"
+    - "raw: 'FAW | EHS9' n=14 nl_rdw (live) vs 'FAW | E-HS9' n=133 — 9.5x skew, collapse-correct per PRD-QUALITY 10.4"
+    - "raw: 'M1 | FAW | EHS9 Farmari (AC) 5ov' n=1, 'EHS9 Farmari (AC) 4ov A' n=1 fi_traficom"
+    - "overrides: renames.yml FAW: 'EHS9: E-HS9'; former_ids.yml '\"car/faw/ehs9\": \"car/faw/e-hs9\"'"
+  notes: >-
+    QUEUED, NOT SHIPPED — stated precisely because the distinction changes the
+    remediation, not the verdict. The duplicate is real and live in the audited
+    tag. The curation layer already carries the paired fold
+    (renames.yml FAW: EHS9 -> E-HS9) and the migration alias
+    (former_ids.yml car/faw/ehs9 -> car/faw/e-hs9), both authored AFTER the
+    tagged build (catalog/car/models.json 2026-07-26 06:29; former_ids.yml
+    08:12), so it will fold at the next build. Checked and found NOT broken:
+    the published successor car/faw/e-hs9 carries no former_ids array, so the
+    shipped artifact is internally consistent — there is no live-id/alias
+    contradiction in the data consumers hold, and validate.rb's
+    alias_liveness_failures compares against the build under validation, so the
+    gate is correctly designed and will pass. See the RELEASE-FRESHNESS flag in
+    the summary for the catalog-wide measurement of this staleness.
+
+"car/faw/hongqi-ehs7":
+  verdicts: { id: correct, name: "defective(D5)", make: "defective(D11)",
+              kind: correct, availability: { lu: correct, nl: correct } }
+  evidence:
+    - "raw: 'FAW | HONGQI EHS7' n=13 + 'HONGQI EHS7 111 KWH 4WD' n=1 nl_rdw (live opendata.rdw.nl merk=FAW)"
+    - "raw: 'FAW | HONGQI EHS7' lu_snca (lu_delta_2026*.xml LIBMRQ/TYPCOM)"
+    - "https://en.wikipedia.org/wiki/Hongqi_Tiangong_08  # 'The Hongqi Tiangong 08 (Chinese: 红旗天工08) or Hongqi EHS7' — EHS7 with NO hyphen is the marque's own rendering, so the numeric part of this record's name is RIGHT"
+    - "https://en.wikipedia.org/wiki/Hongqi_(marque)  # the lineup mixes conventions on purpose: 'Tiangong 08/EHS7', 'Tiangong 06/EHS5', 'EH7' alongside 'E-HS9' and 'E-QM5' — the older E-* generation is hyphenated, the 2023+ Tiangong generation is not"
+    - "https://en.wikipedia.org/wiki/Hongqi_HS7  # the petrol/PHEV HS7 is a DIFFERENT mid-size SUV; no 'E-HS7' exists, so this is not a mis-hyphenation of that"
+  notes: >-
+    A useful negative result: "EHS7" is NOT a mis-hyphenation. Hongqi
+    deliberately hyphenates its older E-* range (E-HS9, E-QM5) and does NOT
+    hyphenate the 2023+ Tiangong range (EHS7, EHS5, EH7), so a blanket
+    "insert the hyphen" fix would BREAK this record while fixing car/faw/ehs9 —
+    the weird-can-be-right rule, measured. The only name defect here is the
+    embedded marque token 'Hongqi' (D5), the shape moves.yml exists to fix.
+    make: the marque is Hongqi and the catalog already has a hongqi make
+    (car/hongqi/e-hs9), so the move target exists.
+
+"car/fiat/500-abarth":
+  verdicts: { id: "defective(cross-make duplicate)", name: correct,
+              make: "defective(D11)", kind: correct,
+              availability: { ca: correct, es: correct, fi: correct, lu: correct,
+                              nl: correct, ua: correct, us: correct } }
+  evidence:
+    - "raw: 'FIAT | 500 ABARTH' n=1373 nl_rdw — but merk=ABARTH 'handelsbenaming 500' n=190 exists in the same register"
+    - "raw: 'FIAT | 500 ABARTH' and 'FIAT | ABARTH 500' both present in es_dgt 2026-04/05/06 and lu_snca"
+    - "raw: 'Fiat | 500 Abarth | 2013-2019 | Minicompact Cars' us_fueleconomy (8 rows); 'FIAT | 500 Abarth | 2012,2013,2018' ca_nrcan"
+    - "raw: '500 ABARTH Viistopera (AB) 2ov 1368cm3' n=73 fi_traficom; 'FIAT | 500 ABARTH' n=6 ua_mvs"
+    - "catalog: car/abarth/500 live with es,gb,lu,nl,nz,ua"
+    - "https://en.wikipedia.org/wiki/Abarth  # the lineup table renders the pair as 'Abarth 500 / Fiat 500 Abarth (NA)' — (NA) = North America, i.e. one car, two marques by market"
+    - "https://en.wikipedia.org/wiki/Abarth_595  # the European line: 'In 2012 the Abarth range was enlarged with the addition of the 135-160-180 PS Abarth 595'"
+  notes: >-
+    id: car/abarth/500 and this record denote the same 312-series car. make:
+    genuinely mixed — in North America (ca/us) Fiat WAS the marque of sale, so
+    those rows are correctly Fiat; in es/fi/lu/nl/ua the marque is Abarth and
+    the register is filing the type-approval holder (Fiat Group Automobiles).
+    The remedy is therefore a split-and-partial-move, not a plain merge —
+    flagged for curation, deliberately not resolved here. No moves.yml entry
+    exists for Fiat->Abarth today.
+
+"car/fiat/eura-mobil-sport":
+  verdicts: { id: "defective(D6/D8)", name: "defective(D5)", make: correct,
+              kind: "defective(D10)",
+              availability: { es: correct, nl: correct } }
+  evidence:
+    - "raw: 'FIAT | EURA MOBIL SPORT' n=2 nl_rdw, and BOTH rows carry inrichting=kampeerwagen (nl_rdw_personenauto_inrichting)"
+    - "raw: 'FIAT | EURA MOBIL SPORT' es_dgt 2026-04/05/06"
+    - "NAMING.md 3: 'Deterministic test: RDW inrichting=kampeerwagen' is the project's own camper test; PRD-QUALITY D10 lists 'campers in car' as the class"
+    - "overrides/makes/drop.yml line 73: '- EURA MOBIL  # Eura Mobil (DE, Ducato-based motorhomes)' — the make is already dropped from the car kind"
+    - "catalog: car/fiat/eura-mobil ('Eura Mobil', fi+nl) live — same coachbuilder, 28 NL rows, all kampeerwagen"
+    - "https://de.wikipedia.org/wiki/Eura_Mobil  # Eura Mobil is a Reisemobil manufacturer whose 'vehicles at the Sprendlingen location are mainly built on Mercedes and Fiat bases'; 'Ehemalige Modelle von Eura Mobil sind ... die Alkoven-Modelle Sport, Profila A, Activa Style und Terrestra A' — 'Sport' is a EURA MOBIL model, not a Fiat one"
+    - "https://www.euramobil.de/reisemobile/  # the maker's current 11 lines (Activa One, Contura, Eura Mobil Van, Integra, Integra Line, ... Xtura) contain no 'Sport' — a retired Eura Mobil line, consistent with the 2 NL registrations"
+    - "https://en.wikipedia.org/wiki/Fiat_Ducato  # 'The Ducato is the most common motorhome base used in Europe; with around two-thirds of motorhomes using the Ducato base' — why this shape recurs under merk=FIAT"
+  notes: >-
+    A motorhome published as a car. The project already drops EURA MOBIL as a
+    MAKE from the car kind and drops base-van model patterns (DUCATO, BOXER,
+    SPRINTER ...) via drop_patterns.yml — but this row names ONLY the
+    coachbuilder in the model column under merk=FIAT, so it evades both
+    mechanisms. make left correct because Fiat is the chassis maker and the
+    register's make; the honest remedy is the D10 kind-scoped drop, not a move.
+    See the DETECTOR-GAP flag in the summary for the measured size of this shape.
+
+"car/fiat/fiorino-qubo":
+  verdicts: { id: "defective(D6)", name: "defective(D6)", make: correct,
+              kind: correct,
+              availability: { es: correct, fi: correct, nl: correct, ua: correct } }
+  evidence:
+    - "raw: 'FIAT | FIORINO QUBO' n=616 nl_rdw; inrichting = MPV 594 / stationwagen 10 / wheelchair-accessible 12 (no kampeerwagen) — car kind is right"
+    - "raw: 'FIAT | FIORINO QUBO' + 'FIAT FIORINO QUBO' es_dgt; 'FIORINO QUBO Monikayttoajoneuvo (AF)' n=1+1 fi_traficom; 'FIAT | FIORINO QUBO' n=10 ua_mvs"
+    - "catalog: car/fiat/qubo (de,es,fi,gb,lu,nl,ua) shares the EXACT TAN extension e3*2001/116*0271*09 with this record; car/fiat/fiorino shares family 0271"
+    - "https://en.wikipedia.org/wiki/Fiat_Fiorino  # 'Fiat also retails its passenger model as the Fiat Qubo, with the Fiorino name designating the commercial models' — two nameplates, and 'Fiat Fiorino Qubo' appears only as an infobox also-called variant"
+  notes: >-
+    The shared approval extension *09 is direct proof that fiorino-qubo and
+    qubo are one vehicle. "Fiorino Qubo" is a register concatenation of two
+    distinct Fiat nameplates (cargo Fiorino / passenger Qubo) on the 225
+    platform; the fold cannot see it because QUBO != FIORINOQUBO.
+
+"car/fiat/nuova-500":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'FIAT | NUOVA 500' n=897 nl_rdw; 'FIAT | 500 NUOVA' n=7 same register"
+    - "raw: 'FIAT | NUOVA 500' n=1 nz_nzta; 'Nuova 500 Berlina Sedan (AA) 2ov 499cm3' fi_traficom"
+    - "https://en.wikipedia.org/wiki/Fiat_500  # 'Launched as the Nuova (new) 500 in July 1957, as a successor to the 500 Topolino' — 'Nuova 500' is Fiat's own launch name"
+    - "catalog: car/fiat/500-nuova ('500 Nuova', fi+nl+nz) live — the same 1957 Nuova 500 with the two words transposed"
+  notes: >-
+    Word-order duplicate: fold('Nuova 500')='NUOVA500' vs
+    fold('500 Nuova')='500NUOVA', so NFKD-fold equality (D6's detector) is
+    structurally blind to it. 897:7 volume skew makes 'Nuova 500' the correct
+    canonical per the 10.4 skew test.
+
+"car/fiat/nuova-500-giardiniera":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { lu: correct, nl: correct } }
+  evidence:
+    - "raw: 'FIAT | NUOVA 500 GIARDINIERA' n=2 + 'FIAT NUOVA 500 GIARDINIERA' n=1 nl_rdw"
+    - "raw: 'FIAT | NUOVA 500 GIARDINIERA' lu_snca"
+    - "https://en.wikipedia.org/wiki/Fiat_500  # 'Launched as the Nuova (new) 500 in July 1957' AND separately 'the 500 Giardiniera (500 K on some markets) [estate] version of the Fiat 500' — Fiat attaches 'Nuova' to the 500, never to the Giardiniera"
+  notes: >-
+    id: no car/fiat/giardiniera or car/fiat/500-giardiniera exists, so no
+    duplicate; only 'NUOVA 500 D GIARDINIERA' n=1 and
+    '120 NUOVA 500 GIARDINIERA' n=2 remain unfolded nearby. name: the marque's
+    designation is '500 Giardiniera' — the 'Nuova' prefix is carried by the
+    saloon, not the estate, so the published name compounds two Fiat names.
+
+"car/fisker/ocean-extreme-one":
+  verdicts: { id: "defective(D13/D6)", name: "defective(D13 + D7)", make: correct,
+              kind: correct, availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Fisker | Ocean Extreme/One | 2023' ca_nrcan — a slash-merged two-trim cell"
+    - "raw: 'Fisker | Ocean Extreme One | 2023 | Standard Sport Utility Vehicle 4WD' us_fueleconomy"
+    - "raw: ca_nrcan also carries separate 'Ocean Extreme (20\" Wheels)', 'Ocean Ultra', 'Ocean Sport' rows for 2024"
+    - "catalog: car/fisker/ocean ('Ocean') and car/fisker/ocean-one ('Ocean One') both live"
+    - "https://en.wikipedia.org/wiki/Fisker_Ocean  # the trim table headers are verbatim 'One', 'Extreme', 'Ultra', 'Sport' — four trims of one nameplate, and the correct rendering of the launch edition is 'One', capitalised"
+    - "https://en.wikipedia.org/wiki/Fisker_Inc.  # 'a special edition version of the Ocean, called the Ocean One ... 5,000 units sold' — a limited launch edition, i.e. a different product from the Extreme trim"
+  notes: >-
+    The source cell merges two different products (the Extreme trim and the
+    'Ocean One' launch edition) — PRD-QUALITY D13, whose remedy is a
+    source-level COMMA_MERGED-style map, here needed for a slash. On top of
+    that the published display lower-cases the second half ("Extreme/one"),
+    which no marque rendering supports.
+
+"car/ford/18":
+  verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct,
+              kind: correct,
+              availability: { fi: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'M1 | Ford | 18 Avoauto (AE) 2ov 3600cm3' n=1 fi_traficom — 3.6 L = the 1932 flathead V-8, so the row is a genuine Model 18"
+    - "raw: 'FORD | 18' n=5 AND 'FORD | MODEL 18' n=2 nl_rdw; 'FORD | 18' n=3 AND 'FORD | MODEL 18' n=3 nz_nzta"
+    - "catalog: car/ford/model-18 ('Model 18', nl+nz) live"
+    - "https://en.wikipedia.org/wiki/1932_Ford  # 'the Model B, the Model 18, and the Model 40 ... The Model 18 was the first Ford fitted with the flathead V-8' — bare '18' is never Ford's designation"
+  notes: >-
+    Same vehicle under two live ids in one make+kind, invisible to the fold
+    (18 vs MODEL18). Note the skew test is INCONCLUSIVE here (5:2 in NL, 3:3
+    in NZ), so the canonical must be chosen from the marque, not the counts.
+
+"car/ford/a-roadster":
+  verdicts: { id: "defective(D6/D8)", name: "defective(D8)", make: correct,
+              kind: correct,
+              availability: { fi: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'FORD | A ROADSTER' n=21, 'A  ROADSTER' n=2, 'A-ROADSTER' n=2, 'A. ROADSTER' n=2 nl_rdw"
+    - "raw: 'FORD | A ROADSTER' n=3 nz_nzta; 'M1 | Ford | A ROADSTER' n=2 fi_traficom"
+    - "catalog: car/ford/model-a ('Model A', fi+lu+nl+nz), car/ford/a ('A'), car/ford/a-model ('A-Model'), car/ford/roadster ('Roadster') all live"
+    - "https://en.wikipedia.org/wiki/Ford_Model_A_(1927-1931)  # 'The Model A came in a wide variety of styles including coupes ..., roadster coupes (standard and deluxe), convertible cabriolet ... phaetons ..., Tudor sedans' — roadster is lower-case and one of many BODY STYLES; the nameplate is 'Model A'"
+  notes: >-
+    'Roadster' is a Model A body style, and the Model A family is already
+    scattered across at least six live ids (a, a-ford, a-fordor, a-model,
+    a-phaeton, a-sport, a-town, a-tudor, model-a, model-a-fordor,
+    model-a-tudor, roadster). The make-prefix strip has also dropped the word
+    'Model' that Ford's own designation carries.
+
+"car/ford/bronco-black-diamond":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Ford | Bronco Black Diamond 4WD | 2021-2024' ca_nrcan (4 rows) and us_fueleconomy (4 rows, Small Sport Utility Vehicle 4WD)"
+    - "catalog: car/ford/bronco live with ca,es,fi,nl,nz,ua,us; six further Bronco trim ids live (badlands, outer-banks, raptor, sasquatch, wildtrak, xlt)"
+    - "https://web.archive.org/web/20260525103819/https://www.ford.com/suvs/bronco/models/  # Ford's own wording 'Ford Bronco(R) Black Diamond(R) model with optional equipment' — a registered SERIES inside the Bronco line, alongside Big Bend / Outer Banks / Badlands / Raptor / Heritage Edition"
+  notes: "name is Ford's own trim string and correctly cased; the defect is altitude — a trim series published as a model (D8), with the nameplate record already present."
+
+"car/ford/e150-van-ffv":
+  verdicts: { id: "defective(D8)", name: "defective(D9/D7)", make: correct,
+              kind: "defective(D10)",
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Ford | E150 Van FFV | 2011-2014 | Vans, Cargo Type' us_fueleconomy (4 rows); same 4 model-years ca_nrcan"
+    - "catalog: car/ford/e150 ('E150'), car/ford/e150-van ('E150 Van'), car/ford/e150-club-wagon, car/ford/e150-wagon-ffv all live in the car kind"
+    - "https://www.fueleconomy.gov/ws/rest/vehicle/menu/model?year=2011&make=Ford  # EPA is the literal source of the string and returns '<text>E150 Van FFV</text>' — caps FFV, and 'Van' is EPA's own class word"
+    - "https://en.wikipedia.org/wiki/Ford_E-Series  # Ford's own designation is hyphenated: 'the Econoline would be renamed to the E-Series ... This included the E-150, E-250, and E-350'"
+    - "https://en.wikipedia.org/wiki/Flexible-fuel_vehicle  # 'A flexible-fuel vehicle (FFV)' — the initialism is all-caps"
+  notes: >-
+    Three defects on one record. name: the source and Ford render the
+    flex-fuel badge 'FFV' in caps, the catalog ships 'Ffv'. id: FFV is a
+    powertrain descriptor and 'Van' a body descriptor, both below nameplate
+    altitude. kind: the source's own class is 'Vans, Cargo Type' — a full-size
+    cargo van published as a car, and there is no van-kind ford/e150 to hold
+    the evidence, so the D10 remedy must route rather than drop.
+
+"car/ford/explorer-tremor":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Ford | Explorer Tremor AWD | 2026' ca_nrcan and us_fueleconomy (Standard Sport Utility Vehicle 4WD)"
+    - "catalog: car/ford/explorer live with 11 countries; 12 further Explorer trim/drive ids live"
+    - "https://web.archive.org/web/20260724191936/https://www.ford.com/suvs/explorer/  # Ford's own structured data names the 2026 trim 'Ford Explorer(R) Tremor(R)' — a registered trim inside the Explorer line"
+
+"car/ford/flex":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, fi: correct, nl: correct, ua: correct, us: correct } }
+  evidence:
+    - "raw: 'Ford | Flex | 2009-2019' ca_nrcan (11 exact rows); 'Ford | Flex FWD/AWD' us_fueleconomy (22 rows)"
+    - "raw: 'FORD | FLEX' n=24 + 'FORD FLEX' n=3 nl_rdw; 'Flex Monikayttoajoneuvo (AF) 5ov 3500cm3 A' fi_traficom; 'FORD | FLEX' n=50 ua_mvs"
+    - "https://en.wikipedia.org/wiki/Ford_Flex  # 'The Ford Flex is a full-size crossover SUV manufactured and marketed by Ford over a single generation for the 2009-2019 model years'"
+  notes: "us claim rests on PREFIX rows only ('Flex FWD'/'Flex AWD') because EPA never certifies a bare 'Flex'; the nameplate is unambiguous and ca_nrcan carries the bare form."
+
+"car/ford/galaxie-500-sunliner":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: 'FORD | GALAXIE 500 SUNLINER' n=1 nl_rdw"
+    - "raw: 'M1 | Ford | Galaxy 500  2ov 5440cm3 A' with kaupallinenNimi 'Galaxie 500 Sunliner' fi_traficom"
+    - "catalog: car/ford/galaxie-sunliner ('Galaxie Sunliner', fi+nl), car/ford/galaxie-500 ('Galaxie 500', fi+nl), car/ford/sunliner ('Sunliner', nl+nz), car/ford/galaxie ('Galaxie') all live"
+    - "https://en.wikipedia.org/wiki/Ford_Galaxie  # 1962: 'New top-line Galaxie 500 (two-door sedan and hardtop, four-door sedan and hardtop, and Sunliner convertible) models' — Sunliner is the convertible BODY script carried on the Galaxie 500 series"
+    - "https://en.wikipedia.org/wiki/Ford_Sunliner  # lists '1960-1964 Ford Galaxie Sunliner' and no 'Galaxie 500 Sunliner' entry — the documented form is the one car/ford/galaxie-sunliner already publishes"
+  notes: >-
+    name: every token is Ford's own and in Ford's own order (series + body
+    script), so the rendering itself is not wrong; but the DOCUMENTED form is
+    "Galaxie Sunliner", which car/ford/galaxie-sunliner already publishes, and
+    Ford retired its body monikers for generic labels in 1963. The
+    Galaxie/Sunliner family is split across five live ids for one nameplate plus
+    one body style.
+
+"car/ford/galaxy":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { es: correct, fi: correct, gb: correct, nl: correct,
+                              nz: correct, ua: correct } }
+  evidence:
+    - "raw: 'FORD | GALAXY' n=4020 nl_rdw; n=47 nz_nzta; n=208 ua_mvs; 'FORD | GALAXY' es_dgt"
+    - "raw: 'GALAXY Monikayttoajoneuvo (AF) 4ov 1997cm3 A' n=362 fi_traficom"
+    - "raw: uk_dft GenModel 'FORD GALAXY' = 165 model rows, BodyType split 106 Cars / 29 Other / 24 Light goods / 6 Buses — car kind is the plurality and correct"
+    - "https://en.wikipedia.org/wiki/Ford_Galaxy  # 'The Ford Galaxy is a seven-seater car produced by Ford of Europe from June 1995 to April 2023'; the hatnote distinguishes it from the Galaxie"
+  notes: "Distinct from the 1960s Galaxie despite NL rows like 'GALAXY 500'/'GALAXY SKYLINER', which the build routes to car/ford/galaxy-500."
+
+"car/ford/model-t":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'FORD | MODEL T' n=245, 'MODEL ''T''' n=6, 'MODELT' n=2, 'MODEL-T' n=1 nz_nzta; 'FORD | MODEL T' n=27 nl_rdw"
+    - "raw: 'M1 | Ford | Model T Avoauto (AE) 2ov 2896cm3' fi_traficom"
+    - "catalog: car/ford/t ('T', fi+nl+nz) live and denotes the same car — its raw set is 'FORD T | Ford T | T CABRIOLET | T COUPE | T TOURER | T, FORDOR SEDAN | T. COUPE' (observed_variants.json), and fi carries 'T model Avoauto (AE) 4ov 2896cm3' — 2896cc is the Model T engine"
+    - "catalog: car/ford/model ('Model', fi+nl+nz) is a bare truncation of the same family"
+    - "https://en.wikipedia.org/wiki/Ford_Model_T  # 'The Ford Model T is an automobile that was produced by the Ford Motor Company from October 1, 1908, to May 26, 1927'"
+  notes: "name is correct and canonical; the id defect is that car/ford/t (and the truncated car/ford/model) hold Model T evidence under separate ids."
+
+"car/ford/mustang-hardtop":
+  verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+              availability: { es: correct, fi: correct, nl: correct } }
+  evidence:
+    - "raw: 'FORD | MUSTANG HARDTOP' n=21 + 'MUSTANG-HARDTOP' n=1 nl_rdw; 'FORD | MUSTANG HARDTOP' es_dgt"
+    - "raw: 'MUSTANG HARDTOP Sedan (AA) 2ov 4730cm3 A' fi_traficom"
+    - "catalog: car/ford/mustang live with 13 countries; car/ford/mustang-hardtop-grande also live"
+    - "https://en.wikipedia.org/wiki/Ford_Mustang_(first_generation)  # body styles listed as '2-door hardtop, 2-door fastback, 2-door convertible'; first-generation TRIM names were GT, Grande and Mach 1 — never 'Hardtop'"
+    - "https://en.wikipedia.org/wiki/Ford_Galaxie  # Ford's body-label practice: the Club/Town/Victoria monikers 'were retired in 1963, replaced by generic labels, 2-door, 4-door, and Hardtop'"
+  notes: >-
+    Unlike Bronco Black Diamond or Explorer Tremor (registered Ford series
+    names), 'Hardtop' is a GENERIC body label Ford applied across its range, so
+    it is not a marque nameplate rendering at all — hence name is defective as
+    well as the altitude/duplicate problem on id.
+
+"car/ford/sierra":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, gb: correct, lu: correct, nl: correct,
+                              nz: correct, ua: correct } }
+  evidence:
+    - "raw: 'FORD | SIERRA' n=60 + 'FORD SIERRA' n=27 nl_rdw; n=170 nz_nzta; n=352 ua_mvs"
+    - "raw: uk_dft GenModel 'FORD SIERRA' 110 model rows, 92 of them BodyType=Cars"
+    - "raw: 'FORD | SIERRA' and 'FORD (D) | SIERRA' lu_snca; '4D SIERRA 2.0 CLS-DOHC-BFG/260' n=44 fi_traficom"
+    - "https://en.wikipedia.org/wiki/Ford_Sierra  # 'The Ford Sierra is a mid-size/large family car manufactured and marketed by Ford of Europe from 1982-1993'"
+  notes: "lu_snca emits the make as 'FORD (D)' on some rows — a make near-dupe string (D12 shape) on the source side, not a defect in this record."
+# ── records 26-60 ──────────────────────────────────────────────────────────
+"car/gac/gs3":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { my: correct } }
+  evidence:
+    - "raw: 'GAC | GS3 | jip' AND 'GAC Motor | GS3 | jip' my_jpj (my_cars_2025/2026.csv)"
+    - "https://en.wikipedia.org/wiki/GAC_GS3  # 'The Trumpchi GS3 or GAC GS3 is a subcompact crossover SUV produced by GAC Group under the GAC Motor brand globally and the Trumpchi brand in China'"
+    - "https://en.wikipedia.org/wiki/GAC_Motor  # 'GAC Motor Co., Ltd. ... sometimes simply as GAC' — the short form the catalog uses is the accepted export-market one"
+  notes: >-
+    single-source record. my_jpj emits the make as both 'GAC' and 'GAC Motor'
+    (a D12 shape on the source side, already folded to one make here). 'jip' is
+    JPJ's SUV class. Note the Chinese-market badge is Trumpchi, so a future
+    China source would introduce a third spelling of this car.
+
+"car/gaz/2401":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { nl: correct, ua: correct } }
+  evidence:
+    - "raw: 'GAZ | GAZ 2401' n=1 nl_rdw (live opendata.rdw.nl merk=GAZ returns handelsbenaming 'GAZ 2401')"
+    - "raw: 'ГАЗ | 2401 | ЛЕГКОВИЙ' n=3 ua_reestr_current.zip (reestrtz02.07.2026.csv) — the UA register writes the make in Cyrillic, which is why a Latin-'GAZ' scan finds nothing"
+    - "raw: ua also distinguishes 'ГАЗ|24' n=198, 'ГАЗ|2410' n=158, 'ГАЗ|31029', so 2401 is a register-distinguished variant, not noise"
+    - "https://en.wikipedia.org/wiki/GAZ-24  # 'GAZ-24-01 taxi was introduced' (1971), alongside GAZ-24-02/-03/-04/-10 — the marque hyphenates as GAZ-24-XX throughout and no concatenated 'GAZ-2401' form appears"
+  notes: >-
+    name: a genuine GAZ variant published in the register's concatenated form;
+    the marque's rendering is 'GAZ-24-01'. ua verified only after switching the
+    make probe to Cyrillic — worth a source note in the pipeline, since a
+    Latin-only make match silently loses all GAZ/VAZ/UAZ Ukrainian evidence.
+
+"car/genesis/electrified-g80":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Genesis | Electrified G80 | 2023-2026 | Midsize Cars' us_fueleconomy (4 rows); 'Genesis | Electrified G80 | 2023-2025' ca_nrcan"
+    - "overrides/models/moves.yml Genesis block: 'FZ 6.1 HSN 8252 rows read ... G80, GENESIS G80,GENESIS' — confirms Genesis is the marque and Hyundai only the HSN holder"
+    - "https://www.genesis.com/us/en/models.html  # the marque's own model page: 'Electrified G80 AWD (Model #S14E2AEZ)', 'Electrified G80 Charging Plan'"
+    - "https://en.wikipedia.org/wiki/Genesis_G80  # 'The Electrified G80 is the battery electric version of the G80'; overview lists 'Genesis Electrified G80 (EV)' as its own designation"
+  notes: >-
+    A weird-looking name that is right: 'Electrified' reads like a descriptor
+    but is Genesis's own nameplate word (the same family as Electrified GV70),
+    so this is the tS/XR4i/bZ4X case and must not be folded into car/genesis/g80.
+
+"car/genesis/electrified-gv70":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Genesis | Electrified GV70 | 2024,2025 | Small Sport Utility Vehicle 4WD' us_fueleconomy; 'Genesis | Electrified GV70 | 2023-2026' ca_nrcan"
+    - "raw: 2026 US rows are 'Electrified GV70 AWD (19/20 inch Wheels)' — wheel-size suffixes, correctly not published as separate models"
+    - "https://www.genesis.com/us/en/models.html  # the marque's own model page carries 'Genesis Electrified GV70 Prestige AWD'"
+    - "https://en.wikipedia.org/wiki/Genesis_GV70  # 'The Electrified GV70 (or the eGV70) is the battery electric version of the GV70'; note it shares model code JK1 with the ICE GV70"
+    - "overrides/models/moves.yml: '\"Hyundai|GV70\": \"Genesis|GV70\"  # covers the ICE GV70; the EV is catalogued as \"Electrified GV70\"' — the project has already adjudicated this split"
+
+"car/genesis/g80":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, de: correct, gb: correct, my: correct,
+                              nl: correct, nz: correct, us: correct } }
+  evidence:
+    - "raw: 'GENESIS | G80' n=9 nl_rdw, n=8 nz_nzta; 'Genesis | G80 | motokar' my_jpj"
+    - "raw: uk_dft 14 rows, all BodyType=Cars, Make=GENESIS GenModel='GENESIS G80'"
+    - "raw: de_kba_fz10 202606 sharedStrings — 'G80' appears inside the HYUNDAI block (between BAYON and G90), i.e. KBA Marke=HYUNDAI"
+    - "overrides/models/moves.yml: '\"Hyundai|G80\": \"Genesis|G80\"  # 5 DE' — the KBA HSN-8252 attribution is already handled"
+    - "https://en.wikipedia.org/wiki/Genesis_G80  # 'The Genesis G80 is an executive sedan'"
+  notes: >-
+    de availability is correct but indirect: KBA FZ 10.1 has no GENESIS Marke
+    row at all, so the German evidence arrives under Marke=HYUNDAI and is
+    routed by moves.yml. Recording it as correct rather than unverifiable
+    because the routing rule is documented with the FZ 6.1 HSN receipt.
+
+"car/genesis/gv60-performance":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Genesis | GV60 PERFORMANCE | 2023,2024' us_fueleconomy; 'Genesis | GV60 Performance AWD | 2023-2026' ca_nrcan"
+    - "catalog: car/genesis/gv60 ('GV60') live with de,gb,nl,nz,us"
+    - "https://www.genesis.com/us/en/genesis-gv60.html  # Genesis's own grade strings: 'GV60 Standard RWD', 'GV60 Standard AWD', 'GV60 Advanced AWD', 'GV60 Performance AWD' — Performance sits in a Standard/Advanced/Performance ladder"
+  notes: "name is Genesis's own grade string, correctly cased; the defect is altitude — a grade published as a model while car/genesis/gv60 holds the nameplate."
+
+"car/geo/tracker-van":
+  verdicts: { id: "defective(D6/D8)", name: "defective(D9)", make: correct,
+              kind: correct, availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Geo | Tracker Van 2WD/4WD/4x4 | 1992-1997 | Special Purpose Vehicles' us_fueleconomy (7 rows); 'Geo | Tracker Van 4X4 | 1997' ca_nrcan"
+    - "catalog: car/geo/tracker ('Tracker', ca+nl+us) live, and its raw set is 'Tracker 4WD | Tracker Convertible | Tracker Convertible 2WD/4WD/4X4' (observed_variants.json)"
+    - "https://www.fueleconomy.gov/ws/rest/vehicle/menu/model?year=1993&make=Geo  # EPA is the literal source: it returns '<text>Tracker Van 4WD</text>', and the 1997 menu returns 'Tracker Van 2WD', 'Tracker Van 4x4' ALONGSIDE 'Tracker Convertible 2WD/4x4' — EPA's own class words stapled onto the model field"
+    - "https://en.wikipedia.org/wiki/Geo_Tracker  # (redirects to Chevrolet Tracker) 'The Geo Tracker was a mini SUV introduced in late 1988 as a 1989 model'; the enclosed body is 'The two-door hardtop models' — Geo called it a hardtop, never a Van"
+  notes: >-
+    EPA certifies the two Tracker bodies as 'Tracker Convertible' and 'Tracker
+    Van'; the second is a certification/class string, not a Geo nameplate — the
+    same vehicle line as car/geo/tracker. kind stays correct: it is a small
+    SUV, which this catalog places in car.
+
+"car/gm-daewoo/matiz":
+  verdicts: { id: "defective(cross-make duplicate)", name: correct,
+              make: "defective(D11/D12)", kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/GM_Korea  # 'GM Daewoo Auto & Technology' is the corporate entity; the consumer-facing marque on the cars was Daewoo, later rebadged Chevrolet"
+    - "raw: 'GM DAEWOO | MATIZ' n=7 nl_rdw vs 'DAEWOO | MATIZ' n=492 and 'DAEWOO | DAEWOO MATIZ' n=729 in the same register — 174x skew"
+    - "raw: 'M1 | GM Daewoo | 4D MATIZ HATCHBACK 1.0-0M11CD/234' n=48 AND 'M1 | Daewoo | 4D MATIZ HATCHBACK 1.0-0M11CD/234' n=16 fi_traficom — the SAME type code under two makes"
+    - "catalog: car/daewoo/matiz live (fi,gb,lu,nl,nz,ua); TAN e4*2001/116*0028*18 here vs *15 there = one approval family"
+  notes: >-
+    Textbook D12: a corporate string standing in for a marque. The identical
+    fi_traficom type code (0M11CD/234) under both makes is the strongest single
+    piece of evidence. Secondary D23: the make display name ships as
+    'Gm Daewoo' (should be 'GM Daewoo' if the make survives at all).
+
+"car/holden/torana":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nz: correct } }
+  evidence:
+    - "raw: 'HOLDEN | TORANA' n=1008 nz_nzta passenger-car-van"
+    - "https://en.wikipedia.org/wiki/Holden_Torana  # 'The Holden Torana is a mid-size car that was manufactured by Holden from 1967 to 1980'"
+  notes: "single-source record published on the count threshold (car single-source bar is 1000; n=1008 clears it by 8) — worth a threshold tripwire."
+
+"car/honda/cr-z":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, es: correct, fi: correct, gb: correct,
+                              lu: correct, nl: correct, nz: correct, ua: correct, us: correct } }
+  evidence:
+    - "raw: 'HONDA | CR-Z' n=574 nl_rdw, n=1945 nz_nzta, n=19 ua_mvs; 'HONDA | CR-Z' es_dgt and lu_snca"
+    - "raw: 'CR-Z Viistopera (AB) 2ov 1497cm3' n=109 fi_traficom; 'Honda | CR-Z | 2011-2016 | Two Seaters' us_fueleconomy (6 rows); ca_nrcan 2011-2016"
+    - "raw: uk_dft GenModel 'HONDA CR-Z', BodyType Cars"
+    - "https://en.wikipedia.org/wiki/Honda_CR-Z  # 'The Honda CR-Z is a sport compact hybrid electric vehicle manufactured by Honda' — a plain hyphen, all caps"
+  notes: "the hyphenated all-caps rendering is the marque's and is what every register emits; car/honda/cr ('Cr') is a separate truncation defect on that record."
+
+"car/honda/grace":
+  verdicts: { id: "unverifiable(the Grace is the JDM name of the City sedan, so car/honda/city may denote the same vehicle; but car/honda/city spans several City generations across five countries and neither register carries a year or approval number, so the overlap cannot be settled from the sources reached)", name: correct, make: correct, kind: correct,
+              availability: { nz: correct } }
+  evidence:
+    - "raw: 'HONDA | GRACE' n=1888 nz_nzta passenger-car-van"
+    - "raw: the SAME register also carries 'HONDA | CITY' n=983, feeding the live car/honda/city (my,nl,nz,th,ua) — two badges, one register, no year field to separate them"
+    - "https://en.wikipedia.org/wiki/Honda_Grace  # redirects to Honda City: 'The City is offered and sold as Honda Grace in Japan starting from December 2014' — a JDM market name for the GM6 City sedan, 2014-2020"
+  notes: >-
+    Recorded UNVERIFIABLE rather than either stretched verdict, and flagged for
+    the verifier. It is the same market-name shape as car/nissan/maxima-qx (which
+    I DID call defective) and car/hyundai/tucson-ix35 — but there the catalog's
+    own xrefs.tan proved one approval family, and here there are no approval
+    numbers on either record and NZTA carries no model year. A separate JDM-badge
+    record is also defensible curation (the kgm/ssangyong precedent), so this
+    needs a disposition, not a guess. single-source otherwise, clearing the
+    1,000-row car threshold at n=1888.
+
+"car/hudson/hornet":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'HUDSON | HORNET' n=8 nl_rdw, n=7 nz_nzta"
+    - "raw: 'Hornet Sedan (AA) 4ov 5050cm3 A' + 'HUDSON HORNET  4ov 5000cm3 A' fi_traficom"
+    - "https://en.wikipedia.org/wiki/Hudson_Hornet  # 'The Hudson Hornet is a full-size car manufactured by Hudson Motor Car Company of Detroit, Michigan, from 1951 through 1954 model years' — the 5.0 L six matches the fi rows"
+
+"car/hummer/h3t":
+  verdicts: { id: correct, name: correct, make: correct, kind: "defective(D10)",
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Hummer | H3T 4WD | 2009,2010 | Standard Pickup Trucks 4WD' us_fueleconomy — the source's own class is a pickup truck"
+    - "raw: 'Hummer | H3T 4WD | 2010', 'H3T 4X4 | 2009' ca_nrcan"
+    - "catalog: car/hummer/h3 (the SUV) and van/hummer/h3 live; no truck-kind hummer exists"
+    - "https://en.wikipedia.org/wiki/Hummer_H3  # 'The Hummer H3T is a mid-size pickup truck that was available during the 2009 and 2010 model years' — a distinct model, not a trim of the H3"
+    - "https://www.fueleconomy.gov/feg/Find.do?action=sbs&id=29360  # EPA's own page for '2010 Hummer H3T 4WD' gives size class 'Standard Pickup Trucks 4WD'"
+  notes: >-
+    id correct — the H3T is a distinct Hummer model, not a trim of the H3.
+    kind: a pickup in the car kind. Recorded as D10 because the only two
+    sources both class it as a pickup truck, but note this sits inside the open
+    kind-boundary question (PROPOSAL-kind-boundary.md), and there is no
+    truck/hummer to route to, so the D10 remedy here is a route-not-drop.
+
+"car/hyundai/bayon":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { de: correct, es: correct, fi: correct, gb: correct,
+                              ie: correct, lu: correct, nl: correct } }
+  evidence:
+    - "raw: 'HYUNDAI | BAYON' n=4730 nl_rdw; 'HYUNDAI | BAYON' es_dgt, lu_snca; 'Hyundai Bayon' ie_tem20 (ie_cso)"
+    - "raw: 'BAYON Farmari (AC) 5ov 998cm3 A' n=800 fi_traficom; de_kba_fz10 202606 HYUNDAI block contains 'BAYON'"
+    - "raw: uk_dft 6 rows GenModel 'HYUNDAI BAYON', all BodyType=Cars"
+    - "https://en.wikipedia.org/wiki/Hyundai_Bayon  # 'The Hyundai Bayon is a five-door subcompact crossover SUV produced by the South Korean manufacturer Hyundai'"
+  notes: "car/hyundai/bayon-advance/-premium/-ultimate are live GB trim ids — a D8 cluster on those records, not on this one."
+
+"car/hyundai/elantra-wagon":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Hyundai | Elantra Wagon | 1996-2000 | Small Station Wagons' us_fueleconomy (5 rows); ca_nrcan 1997-2000"
+    - "catalog: car/hyundai/elantra live (ca,es,fi,gb,nl,ua,us), plus elantra-gt/-n/-touring/-blue"
+    - "raw: EPA lists BOTH 'Hyundai | Elantra' (Compact Cars) and 'Hyundai | Elantra Wagon' (Small Station Wagons) for every model year 1996-2000 — i.e. the Wagon string is EPA making a BODY distinction it needed, the same shape as its 'Tracker Van'"
+    - "https://en.wikipedia.org/wiki/Hyundai_Elantra  # the second generation's wagon is named 'Avante Touring' (South Korea) and 'Lantra Sportswagon' (Australia); the US 'Elantra Touring' is a LATER, different car (the i30 wagon, 2007+)"
+    - "https://en.wikipedia.org/wiki/Hyundai_Lantra  # the encyclopedia names the 2nd-gen wagon 'Avante Touring' (KR) / 'Lantra Sportswagon' (AU) and gives no North-American wagon name"
+    - "https://web.archive.org/web/19990420185743/http://www.hyundaiusa.com/  # RESOLVED HERE: Hyundai Motor America's OWN 1999 site lists its lineup keywords as 'Accent, elantra, Elantra, sonata, Sonata, elantra wagon, Elantra wagon, tiburon, Tiburon' — Hyundai USA did market an Elantra wagon"
+  notes: >-
+    This one started as unverifiable and was RESOLVED by going to the marque's
+    own archived site rather than settling for the encyclopedia, which says the
+    second-generation wagon was marketed as 'Avante Touring' (KR) and 'Lantra
+    Sportswagon' (AU) and names no US wagon at all. Hyundai Motor America's 1999
+    page proves the US name. Two residual caveats recorded rather than hidden:
+    (a) the marque source is a keywords list, so it is weak on CASING — it
+    writes both 'elantra wagon' and 'Elantra wagon', while EPA writes 'Elantra
+    Wagon'; (b) EPA separately lists a plain 'Elantra' for the same five model
+    years, so 'Wagon' is doing body-distinction work either way. id stays
+    defective: a body variant of the Elantra, with car/hyundai/elantra live.
+
+"car/hyundai/pony-gls":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'HYUNDAI | PONY GLS' n=1 nl_rdw and n=1 nz_nzta"
+    - "catalog: car/hyundai/pony ('Pony') live with fi,gb,nz,ua"
+    - "https://en.wikipedia.org/wiki/Hyundai_Pony  # trim ladders quoted verbatim: '1400: GLS/GL (UK: TL, GL, TLS, GLS)' and '1200: LE/L/GLX/GLS/GL/Standard' — GLS is a trim across generations"
+  notes: >-
+    GLS is Hyundai's trim ladder (GL/GLS), so this is a trim published as a
+    model with the nameplate present. Both sources carry exactly one row each,
+    so this record exists on the 2-source floor with n=2 total — thin even
+    before the altitude problem.
+
+"car/hyundai/tucson-ix35":
+  verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+  evidence:
+    - "raw: 'HYUNDAI | TUCSON,IX35' n=57, 'TUCSON,ix35' n=25, 'TUCSON IX35' n=9 nl_rdw; 'TUCSON IX35' + 'TUCSON, IX35' + 'TUCSON / IX35' es_dgt; six comma/slash/stop variants in lu_snca"
+    - "raw: 'TUCSON ix35 Monikayttoajoneuvo (AF) 5ov 1598cm3 A' fi_traficom — fi_traficom itself writes ix35 in LOWERCASE"
+    - "catalog: car/hyundai/ix35 ('ix35', 7 countries) shares three EXACT TAN extensions with this record: e11*2007/46*0104*00, e11*2007/46*0192*02, e11*2007/46*0192*03"
+    - "catalog: car/hyundai/tucson-ix-35 ('Tucson Ix 35', es+ua) and car/hyundai/tucson-ix35-lm ('Tucson IX35 Lm', es+fi+nl) also live — four ids for one vehicle"
+    - "overrides: renames.yml Hyundai block 'Tucson IX35: ix35  # compound register string, not a nameplate'; former_ids.yml maps tucson-ix35, tucson-ix-35 and tucson-ix35-lm to car/hyundai/ix35"
+    - "overrides/styling.yml line 97-98: 'DELIBERATELY NOT ADDED: IX. Jaguar Mark IX wants caps but Hyundai ix35 is officially LOWERCASE'"
+    - "https://en.wikipedia.org/wiki/Hyundai_Tucson  # infobox 'aka = Hyundai ix35 (2009-2015)' and, for the LM generation, 'aka = Hyundai ix35 / Hyundai Tucson ix'; body text 'The second-generation model was marketed as the Hyundai ix35 in several markets ... before reverting to Tucson'. ix35 and Tucson are ALTERNATIVE MARKET NAMES for one car, and the only combined form Hyundai used was Korea's 'Tucson ix' — never 'Tucson ix35'"
+  notes: >-
+    Same queued-not-shipped shape as car/faw/ehs9 and three-fold: this record
+    plus car/hyundai/tucson-ix-35 and car/hyundai/tucson-ix35-lm are all
+    declared former_ids of car/hyundai/ix35 in the tag's override layer while
+    all three are still published in the tag's catalog. The published
+    car/hyundai/ix35 carries no former_ids array, so the shipped data is
+    self-consistent and the fold is simply one build behind. The name verdict
+    stands on the project's own terms: styling.yml records that the official
+    casing is lowercase 'ix35', and fi_traficom writes it that way.
+
+"car/imperial/custom":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: 'IMPERIAL | CUSTOM' n=2 nl_rdw (+ 'CUSTOM SOUTHAMPTON' n=1)"
+    - "raw: 'M1 | Imperial | CUSTOM Sedan (AA) 4ov 6770cm3 A' n=1 fi_traficom — 6.8 L, consistent with a 1950s-60s Imperial V8"
+    - "https://en.wikipedia.org/wiki/Imperial_(automobile)  # standalone marque confirmed: 'the Imperial, beginning in 1955, would no longer be registered as a Chrysler; but as a separate make'; and 'The previously unnamed standard Imperial model gained the Imperial Custom name this year' (1959)"
+  notes: >-
+    3 registrations total across two sources; make=Imperial is right because
+    Imperial was a standalone Chrysler marque 1955-75. Word order checked and
+    NOT to be reordered: every source renders it 'Imperial Custom', including
+    the 1932 and 1953 Chrysler-era usages; no source renders 'Custom Imperial'.
+
+"car/jaguar/f-pace-30t":
+  verdicts: { id: "defective(D8)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Jaguar | F-PACE 30t | 2020' ca_nrcan and 'Jaguar | F-Pace 30t | 2020 | Small Sport Utility Vehicle 4WD' us_fueleconomy — BOTH sources render the suffix lowercase '30t'"
+    - "catalog: car/jaguar/f-pace live (10 countries); f-pace-25t, f-pace-p340, f-pace-p400, f-pace-s, f-pace-svr also live"
+    - "https://en.wikipedia.org/wiki/Jaguar_F-Pace  # the engine table rows read '30t AWD', '25t/P250 AWD', '20d AWD' — lowercase t, and one of a family of output designations (25t/35t/20d/25d/30d), not a nameplate"
+  notes: "name: the shipped '30T' contradicts both of its own sources, which agree on '30t'. id: an engine/output designation at nameplate altitude."
+
+"car/jaguar/f-type-p450":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Jaguar | F-TYPE P450 Coupe/Convertible [AWD] | 2022-2024' ca_nrcan (12 rows); 'Jaguar | F-Type P450 AWD R-Dynamic Coupe/Convertible' us_fueleconomy (12 rows)"
+    - "catalog: car/jaguar/f-type live (10 countries); f-type-r, f-type-s, f-type-svr, f-type-v8-s also live"
+    - "https://www.jaguarusa.com/all-models/f-type/index.html  # Jaguar's own site: 'with F-TYPE 75 and R75, F-TYPE P450 R-Dynamic comes as RWD' — P450 is a powertrain designation (5.0 supercharged V8, 450 PS) in a P300/P380/P575 family"
+  notes: "P450 is Jaguar's power designation, published as a model while the nameplate record exists (D8)."
+
+"car/jaguar/mark-8":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'JAGUAR | MARK 8' n=1 nl_rdw (+ 'MARK 8 B' n=1); 'JAGUAR | MARK 8' n=2 nz_nzta"
+    - "https://en.wikipedia.org/wiki/Jaguar_Mark_VIII  # 'The Jaguar Mark VIII is a luxury four-door automobile introduced by the Jaguar company of Coventry at the 1956 London Motor Show' — Roman numerals, 1956-58"
+    - "overrides/styling.yml line 97: 'Jaguar Mark IX wants caps' — the project already treats Jaguar Mark designations as Roman-numeral"
+    - "catalog: the jaguar make carries mark, mark-1, mark-2, mark-7, mark-10, mark-11, mark-i, mark-ix, mark-x, mk, mk-7-m, mk-i, mk-ix, mk-x, mk1, mk2, mk4, mk5, mk7, mk9, mk10, mk11, mkii — 23 live ids for the Mark/Mk series"
+  notes: >-
+    id: correct only in the narrow sense that no other live id spells this
+    particular car. The surrounding Mark/Mk cluster is a large unresolved D6
+    field (mark-7/mk7, mark-i/mk-i/mk1, mark-ix/mk-ix/mk9, mark-x/mk-x/mk10 are
+    each two or three ids for one car), and car/jaguar/mark-11 is almost
+    certainly a mis-read Mark II — flagged, not swept.
+
+"car/jaguar/xj42":
+  verdicts: { id: "defective(D6/D9)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: nl_rdw 'JAGUAR | JAGUAR XJ42' n=3 and 'JAGUAR | XJ 4.2' n=2; nz_nzta 'XJ4.2' n=11, 'XJ 4.2' n=5, 'XJ42' n=1, 'XJ4 2' n=1 — the record is dominated by DISPLACEMENT spellings, not by a type code"
+    - "raw: neighbouring nz rows 'XJ4.2C' n=2 / 'XJ42C' n=2 / 'XJ 4.2 AUTO' / 'XJ4.2 SLE' / 'XJ4.2S3' confirm '4.2' is being read as the engine"
+    - "catalog: car/jaguar/xj6 ('XJ6', raw set includes 'XJ 6', 'XJ6 SPORTS 4.0') and car/jaguar/xj8 ('XJ8') live; the 4.2-litre XJ is one of those two"
+    - "https://en.wikipedia.org/wiki/Jaguar_XK_(X100)  # 'XJ41 (coupe) and XJ42 (convertible)' — XJ42 is a PROJECT code"
+    - "https://en.wikipedia.org/wiki/Jaguar_F-Type  # 'The first F-type project at Jaguar was the XJ41/XJ42, begun in 1980 ... The project was canned in March 1990' — nothing was ever badged XJ42, and en.wikipedia has no XJ42 article (the title is a redlink)"
+    - "https://en.wikipedia.org/wiki/Jaguar_XJ40  # 'Model code: XJ40' for the car SOLD as XJ6/Sovereign — confirms the XJnn series are internal codes, not badges"
+  notes: >-
+    'XJ42' is not a Jaguar production nameplate — XJ40 is the internal code of
+    the 1986 XJ6 and XJ41/XJ42 were cancelled project codes. What this record
+    actually collects is 'XJ 4.2' with the decimal point folded out, i.e. an
+    engine-displacement string promoted to a type code. Because '4.2' spans the
+    XJ6 4.2 and the XJ8 4.2, the record is also under-specified, which is why
+    the id verdict is a duplicate AND a code-as-model finding.
+# ── records 48-82 ──────────────────────────────────────────────────────────
+"car/jeep/cherokee":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, es: correct, fi: correct, gb: correct,
+                              lu: correct, my: correct, nl: correct, nz: correct,
+                              ua: correct, us: correct } }
+  evidence:
+    - "raw: 'JEEP | CHEROKEE' n=1990 nl_rdw, n=2891 nz_nzta, n=2546 ua_mvs; 'JEEP | CHEROKEE' es_dgt, lu_snca; 'Jeep | Cherokee | jip' my_jpj"
+    - "raw: '5D CHEROKEE WAGON 2.4-LN81-4X4/265' n=125 fi_traficom; 'Jeep | Cherokee | 1996-2022' ca_nrcan (14 exact rows)"
+    - "raw: uk_dft GenModel 'JEEP CHEROKEE' 90 rows, 62 BodyType=Cars"
+    - "raw: us_fueleconomy carries only drive-qualified rows ('Cherokee 2WD/4WD', 74 PREFIX rows) — no bare 'Cherokee', which is EPA's convention"
+    - "https://en.wikipedia.org/wiki/Jeep_Cherokee  # 'The Jeep Cherokee is a line of sport utility vehicles (SUV) manufactured and marketed by Jeep over six generations' (1974-2012, 2014-2023, 2026-) — a nameplate, and the Grand Cherokee is correctly a separate line"
+  notes: "id: car/jeep/g-cherokee ('G. Cherokee', gb+nl) is a truncated Grand Cherokee — a defect on that record. The Grand Cherokee family is correctly separate."
+
+"car/kgm/actyon":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { de: correct, lu: correct, nl: correct } }
+  evidence:
+    - "raw: 'KGM | ACTYON' de_kba_fz10 202606 (sharedStrings KGM block: ACTYON, KORANDO, REXTON, TIVOLI, TORRES)"
+    - "raw: 'KG Mobility | ACTYON' lu_snca; 'KG MOBILITY | KG MOBILITY ACTYON' n=15 nl_rdw"
+    - "catalog: car/ssangyong/actyon carries TAN e4*2001/116*0115*00 (2001/116 framework = pre-2009 approval, the C100 Actyon 2005-11); THIS record carries e6*2018/858*00325*05/*06/*08/*09 (2018/858 framework = the 2024 KGM Actyon)"
+    - "https://en.wikipedia.org/wiki/KGM_Actyon  # 'The KGM Actyon is a mid-size crossover SUV produced by KG Mobility since 2024'"
+    - "https://en.wikipedia.org/wiki/SsangYong_Actyon  # the hatnote 'For the 2024 vehicle produced by KG Mobility, see KGM Actyon' and 'In 2024, SsangYong under the new name KG Mobility reused the Actyon nameplate for the KGM Actyon, an SUV based on the KGM Torres' — two vehicles, one nameplate, confirmed independently of the approval evidence"
+  notes: >-
+    A deliberate NOT-a-duplicate call. car/ssangyong/actyon and car/kgm/actyon
+    share a nameplate across a corporate rename but the approval frameworks
+    place them a generation apart, so two records are right. NOTE the sibling
+    pairs kgm/korando+ssangyong/korando, kgm/rexton+ssangyong/rexton,
+    kgm/tivoli+ssangyong/tivoli, kgm/torres+ssangyong/torres are the OPPOSITE
+    case (nameplates that simply continued through the rename) and look like a
+    four-record D12 field — flagged, outside this slice.
+
+"car/kia/niro-fe":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Kia | Niro FE | 2018-2026 | Small Station Wagons / Small Sport Utility Vehicle 2WD' us_fueleconomy (10 exact rows); same 10 model-years ca_nrcan"
+    - "catalog: car/kia/niro live with 12 countries; niro-ev, niro-ex, niro-touring also live"
+    - "https://en.wikipedia.org/wiki/Kia_Niro  # the first-generation specification table lists the trim ladder verbatim as 'FE, LX, EX, Touring' — FE is a Kia trim grade, correctly cased in the catalog"
+    - "https://www.fueleconomy.gov/feg/bymake/Kia2017.shtml  # EPA lists 'Niro', 'Niro FE' and 'Niro Touring' as separate entries — the classic register-artifact shape that mints trim records"
+  notes: >-
+    name correct (FE is Kia's own trim code, and both sources render it in
+    caps); what FE abbreviates is not stated by any source I reached, which does
+    not affect the rendering. id defective: a trim grade published as a model
+    with the nameplate record live in 12 countries — and note car/kia/niro-ex
+    and /niro-touring are two more rungs of the SAME ladder published as models.
+
+"car/kia/picanto":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { de: correct, es: correct, fi: correct, gb: correct,
+                              ie: correct, lu: correct, nl: correct, nz: correct, ua: correct } }
+  evidence:
+    - "raw: 'KIA | PICANTO' n=168573 nl_rdw, n=3394 nz_nzta, n=306 ua_mvs; 'KIA | PICANTO' es_dgt, lu_snca; 'Kia Picanto' ie_cso; de_kba_fz10 KIA block contains 'PICANTO'"
+    - "raw: 'Picanto Monikayttoajoneuvo (AF) 5ov 998cm3' n=1513 fi_traficom"
+    - "raw: uk_dft GenModel 'KIA PICANTO' 78 rows, 77 BodyType=Cars"
+    - "https://en.wikipedia.org/wiki/Kia_Picanto  # 'The Kia Picanto is a city car that has been produced by the South Korean car manufacturer, Kia, since 2003'"
+  notes: "car/kia/picanto-morning / -sa / -gpl are live comma-cell residues ('PICANTO, MORNING' = the Korean Morning name) — a D13 field on those records."
+
+"car/kia/sedona-sx":
+  verdicts: { id: "defective(D8)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Kia | Sedona SX | 2015-2018 | Minivan - 2WD' us_fueleconomy (4 rows); 'Kia | Sedona SX | 2015-2018' ca_nrcan — BOTH sources render 'SX' in caps"
+    - "catalog: car/kia/sedona live (ca,fi,gb,nl,nz,ua,us); car/kia/sedona-sxl ('Sedona Sxl') live with the same mis-casing"
+    - "https://en.wikipedia.org/wiki/Kia_Carnival  # 'In 2015, Kia expanded the trim levels to L, LX, EX, SX and Limited' — SX is a trim, rendered in caps"
+    - "https://www.fueleconomy.gov/feg/bymake/Kia2016.shtml  # EPA lists 'Sedona', 'Sedona SX', 'Sedona SXL', all caps"
+  notes: "name: shipped 'Sx' contradicts both sources. id: SX is a Kia trim grade with the nameplate record present."
+
+"car/kia/soul-ev":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, fi: correct, ua: correct } }
+  evidence:
+    - "raw: 'Kia | Soul EV | 2015-2019' ca_nrcan (5 exact rows, plus battery-size variants 'Soul EV (120/180 Ah)')"
+    - "raw: 'Soul EV Viistopera (AB) 5ov' fi_traficom; 'KIA | SOUL EV' n=48 ua_mvs"
+    - "catalog: car/kia/soul live separately (10 countries)"
+    - "https://en.wikipedia.org/wiki/Kia_Soul_EV  # 'The Kia Soul EV, also known as Kia e-Soul, is a battery electric subcompact crossover SUV manufactured by Kia' — its own nameplate, not a trim of the Soul"
+  notes: >-
+    Kept as correct rather than D8: the Soul EV was marketed as its own
+    nameplate, and the EV token is pinned as an acronym in styling.yml for
+    exactly the Kia EV family. Note for a future pass, not a defect here: Europe
+    badged the same car 'e-Soul' and EPA rendered it 'Soul Electric', so two
+    more spellings of this vehicle exist in the wild.
+
+"car/lada/111":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: 'LADA-VAZ | LADA 111' n=3 nl_rdw"
+    - "raw: 'M1 | Lada | 111   4ov 1596cm3' n=1 fi_traficom"
+    - "https://en.wikipedia.org/wiki/Lada_110  # 'The Lada 111 or VAZ-2111 is AvtoVAZ's front wheel drive car with a station wagon bodystyle' — 'Lada 111' is the marque's own rendering"
+  notes: >-
+    nl emits the make as 'LADA-VAZ' (a corporate/marque compound, D12 shape on
+    the source side) but the record is under the lada make, which is right.
+    Siblings car/lada/1117 and /1119 are Kalina type codes, a different family,
+    so no duplicate.
+
+"car/lamborghini/aventador-countach":
+  verdicts: { id: correct, name: "defective(D9/D5)", make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Lamborghini | Aventador Countach | 2022 | Two Seaters' us_fueleconomy and ca_nrcan — a single 2022 model year"
+    - "catalog: car/lamborghini/countach live (gb,nl,nz,us) — the 1974-90 car, a DIFFERENT vehicle, so this record is not a duplicate"
+    - "catalog: car/lamborghini/aventador live; EPA groups the LPI 800-4 under the Aventador platform for certification"
+    - "https://en.wikipedia.org/wiki/Lamborghini_Countach_LPI_800-4  # 'The Lamborghini Countach LPI 800-4 is a limited-production mid-engine hybrid-electric sports car'; the hatnote separates it from 'the original 1974-1990 model' — the marque's name carries no 'Aventador'"
+  notes: >-
+    id correct (nothing else denotes the 2022 car) but the published name is an
+    EPA certification concatenation: the marque's name carries no 'Aventador'
+    prefix. This is the same shape as aventador-sian-roadster below.
+
+"car/lamborghini/aventador-s-roadster":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Lamborghini | Aventador S Roadster | 2018 | Two Seaters' us_fueleconomy and ca_nrcan"
+    - "catalog: car/lamborghini/aventador, /aventador-s, /aventador-roadster all live"
+    - "https://en.wikipedia.org/wiki/Lamborghini_Aventador  # section heading 'Aventador S Roadster (2017-2021)' — a genuine Lamborghini model name, unlike the Sian/Countach derivatives which the same article files separately under 'Limited production derivatives'"
+  notes: "one of the few Aventador-prefixed EPA strings that IS the marque's own name — the contrast with aventador-countach and aventador-sian-roadster is what makes those two defects rather than a blanket rule."
+
+"car/lamborghini/aventador-sian-roadster":
+  verdicts: { id: correct, name: "defective(D5/D7)", make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Lamborghini | Aventador Sian Roadster | 2020,2021 | Two Seaters' us_fueleconomy and ca_nrcan"
+    - "catalog: car/lamborghini/aventador-sian ('Aventador Sian', ca+us) live for the coupe; no car/lamborghini/sian exists"
+    - "https://en.wikipedia.org/wiki/Lamborghini_Sián  # 'The Lamborghini Sian FKP 37 is a limited production mid-engine hybrid sports car'; 'In July 2020, Lamborghini unveiled the convertible roadster version of the Sian FKP 37 simply called the Sian Roadster' — with the acute accent throughout and no Aventador prefix"
+  notes: "'Aventador' is EPA's platform prefix and the marque's name carries an acute accent on the a (Sián Roadster); the catalog already honours accents elsewhere (styling.yml pins ë-C3/ë-C4)."
+
+"car/lancia/delta-hf-integrale":
+  verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: 'LANCIA | DELTA HF INTEGRALE' n=124 nl_rdw (+ 'LANCIA DELTA HF INTEGRALE' n=2, 'DELTA HF INTEGRALE 16V' n=85, 'DELTA HF INTEGRALE E2' n=36, 'DELTA HF INTEGRALE U9' n=13)"
+    - "raw: 'DELTA HF INTEGRALE Viistopera (AB) 4ov 1995cm3' n=2 fi_traficom; also 'Delta HF Integrale Evo', 'Delta HF Integrale 8v' with HF in caps"
+    - "catalog: car/lancia/delta-hf-intergrale ('Delta Hf Intergrale', fi+nl) — a MISSPELLING ('Intergrale') published as its own record; car/lancia/delta-integrale ('Delta Integrale', nl+nz) and car/lancia/delta-hf ('Delta Hf', fi+nl+nz) also live"
+    - "https://en.wikipedia.org/wiki/Lancia_Delta  # section headings are 'Delta HF integrale \"8V\"', 'Delta HF integrale 16v', 'Delta HF integrale \"Evoluzione\"' and the prose reads 'the Lancia Delta HF integrale' — HF UPPERCASE and integrale LOWERCASE, so BOTH tokens of the shipped 'Delta Hf Integrale' are wrong"
+  notes: >-
+    name: two errors in one string. HF is an initialism and every raw row in
+    both sources capitalises it, while Lancia renders the second word
+    LOWERCASE ("integrale") — so 'Delta Hf Integrale' matches neither the
+    sources nor the marque, and is pure title-caser output. id: four live ids
+    for the Delta HF integrale, one of them a transposition typo
+    ("Intergrale") — the typo is fold-distinct, so D6's detector cannot see it
+    either.
+
+"car/lancia/ypsilon":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { es: correct, fi: correct, lu: correct, nl: correct, ua: correct } }
+  evidence:
+    - "raw: 'LANCIA | YPSILON' n=2261 + 'LANCIA YPSILON' n=1796 nl_rdw; 'LANCIA | YPSILON' es_dgt, lu_snca; n=25 ua_mvs"
+    - "raw: '2D YPSILON HATCHBACK 95 1.4-843AXC1B06/239' n=7 fi_traficom"
+    - "https://en.wikipedia.org/wiki/Lancia_Ypsilon  # 'The Lancia Ypsilon is a supermini car manufactured and marketed by Lancia, currently in its fourth generation'"
+
+"car/ldv/v80":
+  verdicts: { id: correct, name: correct, make: correct, kind: "defective(D10)",
+              availability: { gb: correct, nz: correct } }
+  evidence:
+    - "raw: uk_dft GenModel 'LDV V80' = 21 model rows; BodyType split is 10 Light goods vehicles / 6 Buses and coaches / 3 Other vehicles / 1 Heavy goods vehicles / 1 Cars"
+    - "raw: 'LDV | V80' n=25 nz_nzta — but the NZTA dataset is 'passenger-car-van', i.e. car and van are not separable in it"
+    - "catalog: van/ldv/v80 (gb,nl) and bus/ldv/v80 (gb,nz) already exist for the same nameplate"
+    - "https://en.wikipedia.org/wiki/Maxus_V80  # 'The Maxus V80 is exported to English speaking countries under the LDV brand'; bodies are van, 'Minibus (passenger van) version providing 10, 12, 15 or 17 seats' and chassis cab — no car body exists"
+    - "https://en.wikipedia.org/wiki/LDV_V80  # redirects to LDV Maxus: 'The LDV Maxus is a light commercial van model'"
+  notes: >-
+    The car-kind record rests on exactly one GB 'Cars' row plus an NZ dataset
+    that cannot distinguish car from van. The V80 is a light commercial
+    van/minibus and both other kinds already hold it, so this is registry
+    kind-noise of the same vehicle — the caddymaxi class named in D10 and in
+    former_ids.yml's own comment.
+
+"car/lloyd/arabella":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: 'LLOYD | ARABELLA' n=2 nl_rdw"
+    - "raw: 'M1 | Lloyd | Arabella Sedan (AA) 2ov 897cm3' n=1 fi_traficom — 897 cc matches the Arabella"
+    - "https://en.wikipedia.org/wiki/Lloyd_Arabella  # 'The Lloyd Arabella was a passenger car produced by the Borgward Group in West Germany between 1959 and 1961'"
+  notes: "the same car was marketed as the BORGWARD Arabella from 1961-63, so a borgward/arabella record would be a legitimate second marque pair rather than a duplicate — noted so a future dedupe pass does not collapse them."
+
+"car/lucid/air-sapphire":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Lucid | Air Sapphire AWD | 2024-2026 | Large Cars' us_fueleconomy (3 rows); 'Lucid | Air Sapphire AWD | 2024,2025' ca_nrcan"
+    - "catalog: car/lucid/air, /air-pure, /air-touring, /air-dream-p live"
+    - "https://en.wikipedia.org/wiki/Lucid_Air  # quotes Lucid's own release title: 'Lucid Announces Final Production Specifications for the Lucid Air Sapphire'"
+  notes: "both sources carry only the AWD-suffixed form; the drive suffix is correctly stripped. Lucid's own press rendering is 'Lucid Air Sapphire', so 'Air Sapphire' under make lucid is exact."
+
+"car/maserati/430":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, gb: correct, nl: correct, nz: correct, us: correct } }
+  evidence:
+    - "raw: 'MASERATI | 430' n=8 nl_rdw (+ '430 U9' n=19, '430 4V E2' n=3), n=4 nz_nzta"
+    - "raw: uk_dft 'Cars | MASERATI | MASERATI 430 | 430' and '430 AUTO'"
+    - "raw: '4D SEDAN 430-332B28A-AUTOMATIC/2600' fi_traficom; 'Maserati | 430 | 1989-1991 | Subcompact Cars' us_fueleconomy"
+    - "https://en.wikipedia.org/wiki/Maserati_Biturbo  # 'In 1986, Maserati launched the high-performance version of the Biturbo saloon called the 430' — a genuine Biturbo-family nameplate"
+  notes: "bare numerals are legitimate in the car kind only when they are the marque's designation; NAMING.md 7.2 — here five independent registers plus the marque history agree on '430'."
+
+"car/maxus/mifa-9":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: 'MAXUS | MAXUS MIFA 9' n=2 + 'MAXUS | MIFA 9' n=1 nl_rdw — the register writes MIFA in caps"
+    - "raw: 'M1 | Maxus | MAXUS MIFA 9 Monikayttoajoneuvo (AF) 5ov' n=5 fi_traficom — also caps"
+    - "https://www.maxus.de/de  # the maker's own embedded model records read '\"label\":\"MIFA 9\"' with model codes 'MIFA9' — all-caps MIFA is the marque's rendering"
+  notes: >-
+    MIFA is an acronym; the maker's own site and both registers capitalise it,
+    and the shipped 'Mifa 9' is title-caser output. NOTE for whoever fixes it:
+    en.wikipedia files this car as 'Maxus G90' and mixes 'Mifa 9'/'MIFA 9', so
+    Wikipedia is NOT the casing authority here — maxus.de is.
+
+"car/mazda/cx-70-sc":
+  verdicts: { id: "defective(D8)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Mazda | CX-70 SC 4WD | 2026 | Standard Sport Utility Vehicle 4WD' us_fueleconomy; 'Mazda | CX-70 SC PHEV 4WD | 2026' ca_nrcan — both render 'SC' in caps"
+    - "catalog: car/mazda/cx-70 ('CX-70', ca+nl+ua+us) live"
+    - "https://www.mazdausa.com/vehicles/cx-70-phev  # Mazda's OWN trim selector lists 'PHEV SC' and 'PHEV SC Plus', with copy '2026 Mazda CX-70 PHEV SC Polymetal Gray' — SC is a real Mazda trim, NOT a certification artifact"
+    - "https://www.fueleconomy.gov/ws/rest/vehicle/50266  # the EPA record behind the string: model 'CX-70 SC 4WD', atvType 'Plug-in Hybrid', phevBlended true — it resolves to the PHEV SC trim (2025 used 'CX-70 4WD PHEV' instead)"
+    - "https://www.mazdausa.com/vehicles/cx-70  # the ICE trims are '3.3 Turbo Preferred/Premium/Premium Plus', '3.3 Turbo S Premium/Premium Plus' — the nameplate is 'CX-70'"
+  notes: >-
+    HYPOTHESIS REVERSED, recorded because it matters for the fix: I expected 'SC'
+    to be an EPA certification artifact and it is not — it is a genuine Mazda
+    PHEV trim name, sourced from mazdausa.com. So the D9 (code-as-model) reading
+    is WRONG here and any rule written to strip 'SC' as register noise would be
+    wrong too. What remains is exactly two defects: the casing ('Sc' contradicts
+    Mazda and both sources, which write 'SC') and the altitude (a trim published
+    as a model while car/mazda/cx-70 holds the nameplate).
+
+"car/mcc/smart":
+  verdicts: { id: "defective(cross-make duplicate)", name: "defective(D4/D5)",
+              make: "defective(D11)", kind: correct,
+              availability: { gb: correct, nz: correct } }
+  evidence:
+    - "raw: uk_dft Make='MCC' GenModel='MCC SMART' 35 rows, 29 of them BodyType=Cars, Model strings 'SMART PASSION AUTO (LHD)', 'SMART CROSSBLADE AUTO', 'SMART PASSION CDI SEMI-AUTO' — the marque sits in the model column"
+    - "raw: 'MCC | SMART COUPE' n=44, 'MCC | SMART K' n=32, 'MCC | SMART CABRIO' n=3, 'MCC | SMART FORTWO' n=1 nz_nzta — no bare 'SMART' row exists in either source"
+    - "catalog: car/smart/fortwo, /city, /coupe, /cabrio and car/smart/mcc (raw form 'Smart MCC') all live; smart/fortwo, smart/city and smart/mcc share the approval family e1*98/14*0080 (*04/*15/*18/*19/*20/*23 vs *07 vs *12/*13)"
+    - "NAMING.md: 'builder in the make column, marque in the model column — the marque wins; needs a cross-make move'"
+    - "https://en.wikipedia.org/wiki/Smart_(marque)  # Smart is 'a Swiss born-German automotive marque established in 1994'; MCC was 'a joint venture between SMH ... and Daimler-Benz', a wholly owned Daimler subsidiary from 1998. The actual first model names: 'The original being the City Coupe that would be renamed the ForTwo'"
+  notes: >-
+    The mirror image of car/smart/mcc: one register puts the builder (MCC =
+    Micro Compact Car AG) in the make column and the marque in the model
+    column, the other does the reverse, and the catalog published both. The
+    shared 98/14*0080 approval family is direct proof that all of these are the
+    W450 fortwo/City-Coupe. availability recorded correct because both registers
+    genuinely evidence these vehicles; the defect is entirely in
+    id/name/make. Secondary D23: the make display ships as 'Mcc' (should be
+    'MCC' if the make survives at all).
+
+"car/mercedes-benz/280-te":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'MERCEDES-BENZ | 280 TE' n=91 (+ '280TE' n=2) nl_rdw; '280 TE' n=4 + '280TE' n=4 nz_nzta"
+    - "raw: '280 TE Farmari (AC) 5ov 2799cm3 A' fi_traficom"
+    - "https://en.wikipedia.org/wiki/Mercedes-Benz_W123  # technical-data row '280 TE | 123.093 | 5/78-8/78'; 'T for Tourismus und Transport (estate/station wagon)'"
+  notes: "genuine W123 estate designation with the space before the suffix; the spaced form is dominant 91:2 in NL, so the canonical is right."
+
+"car/mercedes-benz/300-gd":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'MERCEDES-BENZ | 300 GD' n=187 + '300GD' n=80 nl_rdw; '300 GD' n=1 nz_nzta"
+    - "raw: '3D GELANDEWAGEN 300GD-460.3-4X4/2400' n=7 with kaupallinenNimi '300 GD' fi_traficom"
+    - "catalog: van/mercedes-benz/300-gd also live — the W460 was homologated M1 and N1, so this cross-kind pair is legitimate (PRD-QUALITY 10.1)"
+    - "https://en.wikipedia.org/wiki/Mercedes-Benz_G-Class  # engine table '300 GD | 1979-1991 | I5 (OM 617.931, OM 617.932)', present in W460 and continuing into W461; D denotes diesel"
+
+"car/mercedes-benz/300-te":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct, nz: correct, us: correct } }
+  evidence:
+    - "raw: 'MERCEDES-BENZ | 300 TE' n=71 + '300TE' n=4 nl_rdw; '300TE' n=22 + '300 TE' n=5 nz_nzta"
+    - "raw: 'Mercedes-Benz | 300TE | 1988-1993 | Midsize-Large Station Wagons' us_fueleconomy (6 rows)"
+    - "raw: '5D KOMBI 300TE-AUTOMATIC-124090/280' fi_traficom"
+    - "https://en.wikipedia.org/wiki/Mercedes-Benz_W124  # specification row '124.090 | 300 TE | 3.0 L M103.983 I6 | 11.1985-10.1992' (the estate is the S124); note one prose list in the same article compresses it to '300TE' without the space, but the spec tables and Mercedes' convention use the space"
+  notes: "NL prefers the spaced form (71:4) while NZ and the US prefer the fused one — a case-pair/spacing skew that disagrees BY SOURCE; the spaced form is the marque's."
+
+"car/merkur/scorpio":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nl: correct, us: correct } }
+  evidence:
+    - "raw: live opendata.rdw.nl merk=Merkur -> [{'merk':'Merkur','handelsbenaming':'SCORPIO','count_kenteken':'1'},{'...':'XR4TI','count_kenteken':'2'}] (queried 2026-07-26)"
+    - "raw: 'Merkur | Scorpio | 1988,1989 | Midsize Cars' us_fueleconomy"
+    - "raw: nl_rdw inrichting for the row = sedan (matches body_types)"
+    - "https://en.wikipedia.org/wiki/Merkur_Scorpio  # 'The Merkur Scorpio is a mid-size luxury car produced by Ford of Europe and sold in North America as the flagship of the Ford Motor Company's new Merkur brand'"
+  notes: >-
+    nl rests on a single registration. Note the RDW make string is mixed-case
+    'Merkur' where almost every other RDW merk is upper-case, so a
+    case-sensitive make probe against the live API misses it entirely — a
+    source-handling hazard, not a record defect.
+
+"car/mg/b-gt":
+  verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'MG | B GT' n=211, 'B-GT' n=12, 'B G T' n=3, 'B.GT' n=3, 'MG B-GT' n=1 nl_rdw; 'BGT' n=440, 'B GT' n=98, 'B-GT' n=3 nz_nzta; 'B GT Coupe (AD) 2ov 1798cm3' fi_traficom"
+    - "catalog: car/mg/mgb-gt ('Mgb GT', fi+lu+nl+nz) live with raw set 'MG MGB GT | MGB GT COUPE | MGB-GT COUPE'; car/mg/mgb ('MGB') also live"
+    - "overrides/renames.yml MG block: 'Bgt: B GT   # register shorthand for the MGB GT' — the project's own comment identifies these as the same car"
+    - "overrides/styling.yml line 60: 'MGB: MGB  # same closed-token rule (en.wikipedia MG_MGB)'"
+    - "https://en.wikipedia.org/wiki/MG_MGB  # 'later variants include the MGB GT three-door 2+2 coupe (1965-1980)'; 'The fixed-roof MGB GT was introduced in October 1965' and 'Relatively few components differed' from the roadster — same vehicle family, and the marque's rendering is 'MGB GT'"
+  notes: >-
+    The clearest instance of the detector gap flagged in the summary:
+    fold('B GT')='BGT' and fold('Mgb GT')='MGBGT' are unequal, so
+    find_duplicate_spellings is structurally silent, and the curation layer
+    maintains BOTH as canonicals (a rename block folding B G T/B.gt/Bgt into
+    'B GT' sits a few lines from one folding Mgb GT into 'MGB GT'). The marque's
+    rendering is 'MGB GT' and the project already pins MGB as a closed token.
+
+"car/mg/magna":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: "unverifiable(single register row under make MG; NZ carries a large Mitsubishi Magna fleet, so a mis-keyed make cannot be excluded from register data alone)" } }
+  evidence:
+    - "raw: 'MG | MG MAGNA' n=1 nl_rdw — the row names the marque explicitly, so the attribution is safe"
+    - "raw: 'MG | MAGNA' n=1 nz_nzta — one row, no marque token, in a register where MAGNA is overwhelmingly a Mitsubishi nameplate"
+    - "https://en.wikipedia.org/wiki/MG_Magna  # 'The MG F-type (also known as the MG Magna) is a six-cylinder-engined car that was produced by MG from October 1931 to 1932', with the L-type Magna 1933-34 — a genuine MG nameplate"
+    - "https://en.wikipedia.org/wiki/Mitsubishi_Magna  # 'produced over three generations between 1985 and 2005 by Mitsubishi Motors Australia Limited' — an unrelated nameplate sharing the word, which is exactly why the single NZ row cannot be attributed"
+  notes: >-
+    Recorded honestly as unverifiable rather than stretched: the record's second
+    source is a single ambiguous row, and with only two sources at n=1 each the
+    whole record hangs on it.
+
+"car/morris/1000-traveller":
+  verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'MORRIS | 1000 TRAVELLER' n=14 nl_rdw, n=3 nz_nzta"
+    - "catalog: car/morris/minor-1000-traveller ('Minor 1000 Traveller', nl+nz) live — the same car; car/morris/minor ('Minor') folds 'MINOR ESTATE TRAVELER' and 'MINOR SALOON 1000'; car/morris/1000 ('1000') also live"
+    - "https://en.wikipedia.org/wiki/Morris_Minor  # image caption 'Morris Minor 1000 Traveller'; series heading 'Minor 1000'; 'An estate version of the Morris Minor was introduced in 1952, known as the Morris Traveller' — 'Minor' is load-bearing and '1000 Traveller' alone is not a Morris name"
+  notes: >-
+    Another token-difference duplicate invisible to the fold (1000TRAVELLER vs
+    MINOR1000TRAVELLER). Morris's designation carries the 'Minor' that the
+    make-prefix logic had no reason to keep. Secondary altitude point: the
+    Traveller is the ESTATE BODY of the Minor 1000, so even the correctly-named
+    car/morris/minor-1000-traveller sits below nameplate altitude.
+
+"car/morris/mini-cooper":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'MORRIS | MINI COOPER' n=12 nl_rdw, n=30 nz_nzta (+ 'MINI COOPER S' n=9/n=11 on the separate car/morris/mini-cooper-s record)"
+    - "catalog: car/morris/cooper ('Cooper', nl+nz) live — a Morris 'Cooper' is the Mini Cooper, so the two ids denote one car; car/morris/mini also live"
+    - "https://en.wikipedia.org/wiki/Mini  # 'The Austin Mini Cooper and Morris Mini Cooper debuted in September 1961' — UNHYPHENATED, which is what the catalog ships"
+  notes: >-
+    name correct, and deliberately so: I went looking for a hyphenated period
+    rendering ('Morris Mini-Cooper') and could not substantiate one from any
+    marque-controlled source, so it is not asserted. The only 'Mini-Cooper'
+    occurrence found was an en.wikipedia redirect note, which is an editorial
+    artifact, not marque evidence.
+
+"car/nash/ambassador":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'NASH | AMBASSADOR' n=2 nl_rdw, n=8 nz_nzta"
+    - "https://en.wikipedia.org/wiki/Nash_Ambassador  # 'The Nash Ambassador is a full-size automobile produced by Nash Motors from 1927 until 1957'"
+  notes: "car/nash/ambassador-six and -super are live sub-series ids (D8 shape on those records)."
+
+"car/nash/metropolitan":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'NASH | METROPOLITAN' n=10 (+ 'METRO POLITAN' n=1, 'NASH METROPOLITAN' n=1) nl_rdw; n=28 nz_nzta"
+    - "raw: 'Metropolitan Coupe (AD) 2ov 1489cm3' fi_traficom"
+    - "https://en.wikipedia.org/wiki/Nash_Metropolitan  # 'The Nash Metropolitan is an American automobile marketed from 1953 until 1962, manufactured in England'"
+
+"car/nio/et7":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: 'NIO | ET7' n=295 nl_rdw"
+    - "raw: 'M1 | NIO | ET7 Sedan (AA) 4ov' n=2 + '4ov A' n=1 fi_traficom"
+    - "https://www.nio.com/  # the marque's own site: title 'NIO - Home', 'NIO Brand and Products', 'NIO House', and the model asset 'ET7.svg' alt='ET7' linking to /et7"
+    - "https://en.wikipedia.org/wiki/Nio_Inc.  # 'Nio Inc. (... stylized as NIO)' — note Wikipedia TITLES it 'Nio ET7', but the manufacturer's own site is unambiguously all-caps"
+  notes: >-
+    Record-level claims all correct. MAKE-LEVEL flag (not a defect of this
+    record): the make display name ships as 'Nio' while the brand is stylised
+    NIO in all capitals — PRD-QUALITY D23, whose remedy is a
+    makes/aliases.yml identity pin. Same shape as the already-fixed Ktm/Bsa/Ldv
+    cases.
+
+"car/nissan/axxess":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Nissan | Axxess | 1990-1992 | Special Purpose Vehicle 2WD / Special Purpose Vehicles' us_fueleconomy (3 exact rows, + 3 'Axxess AWD')"
+    - "raw: 'Nissan | Axxess | 1995' ca_nrcan"
+    - "https://en.wikipedia.org/wiki/Nissan_Axxess  # redirects to Nissan Prairie; 'Axxess' (double X) is the North-American name of the second-generation model"
+
+"car/nissan/maxima-qx":
+  verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: '4D MAXIMA QX SEDAN 3.0 AUTOMATIC-CCUA33/275' n=483 fi_traficom (15 exact rows, all caps QX)"
+    - "raw: 'NISSAN | NISSAN MAXIMA QX' n=116 + 'MAXIMA QX' n=1 nl_rdw"
+    - "catalog: car/nissan/maxima ('Maxima', 8 countries) carries TAN e1*98/14*0136*03 while this record carries e1*98/14*0136*00 — one approval family, i.e. the same A32/A33 car under its European name"
+    - "https://en.wikipedia.org/wiki/Nissan_Maxima  # A32 infobox 'aka = ... Nissan Maxima QX (EU) | Nissan QX (UK)'; body 'This generation was also sold as the Maxima QX in Europe'; A33 infobox 'aka = Nissan Cefiro (A33B) / Nissan Maxima QX (Europe)' — caps QX, generations A32 (1994-99) and A33 (1999-2003)"
+  notes: >-
+    name: QX is an initialism and both sources capitalise it; 'Qx' is
+    title-caser output. id: the shared 98/14*0136 approval family is the proof
+    — 'Maxima QX' was the European market name of the car car/nissan/maxima
+    already publishes.
+
+"car/nissan/micra":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, de: correct, es: correct, fi: correct,
+                              gb: correct, ie: correct, lu: correct, nl: correct,
+                              nz: correct, ua: correct } }
+  evidence:
+    - "raw: 'NISSAN | NISSAN MICRA' n=46501 + 'MICRA' n=200 nl_rdw; n=3007 nz_nzta; n=822 ua_mvs; 'NISSAN MICRA' es_dgt, lu_snca; 'Nissan Micra' ie_cso; de_kba_fz10 NISSAN block contains 'MICRA'"
+    - "raw: 'NISSAN MICRA Monikayttoajoneuvo (AF) 4ov 1198cm3' n=3598 fi_traficom; 'Nissan | Micra | 2015-2019' ca_nrcan"
+    - "raw: uk_dft GenModel 'NISSAN MICRA' 225 rows, 201 BodyType=Cars"
+    - "https://en.wikipedia.org/wiki/Nissan_Micra  # 'The Nissan Micra, also known as the Nissan March, is a supermini car'"
+
+"car/nissan/xterra-v6":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Nissan | Xterra V6 | 2000' ca_nrcan (+ 'Xterra V6 4X4' 2000-2004); 'Nissan | Xterra V6 2WD/4WD | 2000-2004 | Sport Utility Vehicle' us_fueleconomy (10 rows)"
+    - "catalog: car/nissan/xterra ('Xterra', ca+fi+nl+nz+ua+us) live"
+    - "https://en.wikipedia.org/wiki/Nissan_Xterra  # 'The base XE featured a 143 hp KA24DE I4' with an optional '170-horsepower 3.3 L VG33E SOHC V6 engine' — trims were XE/SE/SE S/C, so V6 is the engine and never a nameplate"
+    - "https://www.fueleconomy.gov/feg/bymake/Nissan2001.shtml  # EPA carries 'Xterra 2WD', 'Xterra V6 2WD', 'Xterra V6 4WD' side by side — the engine is being used to split certification entries"
+  notes: "V6 is an engine descriptor; NAMING.md treats engine size as a car-kind spec that gets collapsed (the 'Leaf 40KWH -> Leaf' precedent). kind correct — EPA classes it SUV."
+
+"car/nissan/z-nismo":
+  verdicts: { id: "defective(D8)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Nissan | Z NISMO | 2024,2025 | Two Seaters' us_fueleconomy — caps NISMO; ca_nrcan has 'Z NISMO' 2024,2025 and 'Z Nismo' 2026 (the source itself is inconsistent, majority caps)"
+    - "catalog: car/nissan/z ('Z', ca+nl+nz+ua+us) live"
+    - "https://www.nissan.co.jp/Z/  # Nissan's own Japanese site: alt text 'FAIRLADY Z NISMO', pricing line 'フェアレディZ NISMO', and a GRADE-RANKING table row 'NISMO' — all-caps, and listed as a grade alongside the other Z grades"
+  notes: >-
+    NISMO is Nissan Motorsport's initialism and the dominant source rendering is
+    all-caps (4 of 6 rows). Recorded as D7 on name and D8 on id (a grade of the
+    Z with the nameplate record present) — the CVO/GSX precedent in
+    styling.yml's acronym list is the same shape.
+# ── records 83-100 ─────────────────────────────────────────────────────────
+"car/oldsmobile/cutlass-cruiser-wagon":
+  verdicts: { id: "defective(D6/D8)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Oldsmobile | Cutlass Cruiser Wagon | 1984,1985 | Midsize (-Large) Station Wagons' us_fueleconomy; 'Oldsmobile | Cutlass Cruiser Wagon | 1995' ca_nrcan"
+    - "catalog: car/oldsmobile/cutlass-cruiser ('Cutlass Cruiser', fi+nl+us) live"
+    - "https://en.wikipedia.org/wiki/Oldsmobile_Cutlass  # 'a flat-top station wagon called the Cutlass Cruiser'; the sub-series are 'Cutlass Cruiser and Cutlass Cruiser Brougham station wagons' — Oldsmobile's suffixes are Brougham/LS, never 'Wagon'"
+  notes: >-
+    The Cutlass Cruiser IS Oldsmobile's station wagon, so the trailing 'Wagon'
+    is a redundant EPA class word, and the un-suffixed nameplate record already
+    exists with the same US source. Ten further Cutlass ids are live
+    (cutlas, cutlass, cutlass-4-4-2, brougham, calais, ciera, s,
+    salon-brougham, supreme, supreme-brougham) — a wider D6/D8 field.
+
+"car/opel/manta-400":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, lu: correct, nl: correct } }
+  evidence:
+    - "raw: 'OPEL | MANTA 400' n=4 nl_rdw; 'OPEL | MANTA 400' lu_snca"
+    - "raw: 'M1 | Opel | Manta 400 Sedan (AA) 2ov 2393cm3' n=1 fi_traficom — 2.4 L matches the Group B homologation car"
+    - "https://en.wikipedia.org/wiki/Opel_Manta  # 'The Manta 400 was produced in a total of 245 specimens following the homologation regulations by FISA' — a Group B homologation model, not a trim"
+  notes: "the 400 is a homologation model in its own right, not a trim, so id stays correct alongside car/opel/manta."
+
+"car/opel/olympia":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, gb: correct, nl: correct } }
+  evidence:
+    - "raw: 'OPEL | OLYMPIA' n=190 (+ 'OPEL OLYMPIA' n=1) nl_rdw"
+    - "raw: uk_dft 'Cars | OPEL | OPEL OLYMPIA | OLYMPIA' and 'Light goods vehicles | ... | OLYMPIA'"
+    - "raw: 'Olympia Sedan (AA) 2ov 1477cm3' fi_traficom"
+    - "https://en.wikipedia.org/wiki/Opel_Olympia  # 'The Opel Olympia is a compact car by German automaker Opel ... from 1935 to 1940, and after World War II continued from 1947 to 1953'"
+  notes: "distinct from the Olympia Rekord, which the catalog holds separately (olympia-record, olympia-rekord, olympia-rekord-1700, olympia-rekord-r3, rekord-olympia — themselves a D6 field)."
+
+"car/panther/lima":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'PANTHER | LIMA' n=3 nl_rdw (+ 'LIMA MK1', 'LIMA SERIE II', 'LIMA 2300 SPORTSCAR'), n=3 nz_nzta"
+    - "raw: nl_rdw inrichting=cabriolet, matching body_types convertible"
+    - "https://en.wikipedia.org/wiki/Panther_Lima  # 'The Panther Lima is a retro-styled roadster built in the 1970s built by Panther Westwinds'"
+
+"car/perodua/myvi":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { gb: correct, my: correct } }
+  evidence:
+    - "raw: uk_dft GenModel 'PERODUA MYVI' — 'Cars | MYVI EZI AUTO', 'Cars | MYVI SXI', 'Light goods vehicles | MYVI EZI AUTO'"
+    - "raw: 'Perodua | Myvi | motokar' my_jpj"
+    - "https://en.wikipedia.org/wiki/Perodua_Myvi  # 'The Perodua Myvi is a subcompact car/supermini (B-segment) produced by the Malaysian manufacturer Perodua since 2005'"
+
+"car/peugeot/107":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { es: correct, fi: correct, gb: correct, lu: correct,
+                              nl: correct, nz: correct, ua: correct } }
+  evidence:
+    - "raw: 'PEUGEOT | PEUGEOT 107' n=102197 + '107' n=205 nl_rdw; n=7 nz_nzta; n=232 ua_mvs; 'PEUGEOT | 107' es_dgt and lu_snca"
+    - "raw: 'PEUGEOT 107 Viistopera (AB) 4ov 998cm3' n=273 fi_traficom"
+    - "raw: uk_dft GenModel 'PEUGEOT 107' 24 rows, 21 BodyType=Cars"
+    - "https://en.wikipedia.org/wiki/Peugeot_107  # 'The Peugeot 107 is a city car produced by French automaker Peugeot, launched in June 2005, and produced until 2014'"
+  notes: "car/peugeot/107-1-0i ('107 1.0I', es+nl) is a live engine-string sibling — D8/D9 on that record."
+
+"car/peugeot/604-sl":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'PEUGEOT | 604 SL' n=1 + '604SL' n=1 nl_rdw (+ '604 SL A37', '604 SL AUTOMATIQUE'); 'PEUGEOT | 604 SL' n=1 nz_nzta"
+    - "catalog: car/peugeot/604 ('604', fi+gb+nl+nz+us) live; car/peugeot/604-sti and /604-d-turbo also live"
+    - "https://en.wikipedia.org/wiki/Peugeot_604  # 'It was originally available in a single specification, as the 604 SL' — SL is the launch trim, with TI/STi/GTi/D Turbo/Grand Comfort as siblings; the nameplate is 604"
+  notes: "SL is a 604 trim level; the nameplate record exists in five countries. Total evidence here is 2 registrations."
+
+"car/peugeot/bipper":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { es: correct, gb: correct, lu: correct, nl: correct, ua: correct } }
+  evidence:
+    - "raw: 'PEUGEOT | PEUGEOT BIPPER' n=641 + 'BIPPER' n=1 nl_rdw; 'PEUGEOT | BIPPER' es_dgt and lu_snca"
+    - "raw: 'PEUGEOT | BIPPER | ЛЕГКОВИЙ' n=65 AND '| ВАНТАЖНИЙ' n=42 ua_mvs — the UA register itself splits it between passenger and goods"
+    - "raw: uk_dft GenModel 'PEUGEOT BIPPER' 23 rows, 11 BodyType=Cars vs 10 Light goods — and the Cars rows are 'BIPPER TEPEE ...' (the M1 passenger version)"
+    - "catalog: van/peugeot/bipper live for the N1 side"
+    - "https://en.wikipedia.org/wiki/Fiat_Fiorino  # 'Citroen Nemo and Peugeot Bipper share the same architecture and bodywork under a joint venture arrangement' — the Bipper is the Peugeot-marque 225-platform vehicle, so make and name are the marque's own"
+  notes: >-
+    kind kept correct, unlike car/ldv/v80: the Bipper Tepee is a genuine M1
+    passenger variant, the GB plurality is Cars, and the van kind holds the
+    commercial half — a legitimate cross-kind pair rather than leakage.
+
+"car/plymouth/laser":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nl: correct, ua: correct, us: correct } }
+  evidence:
+    - "raw: 'PLYMOUTH | LASER' n=1 nl_rdw (+ 'LASER U9' n=2, 'LASER RS TWIN CAM 16 VALVE' n=1); 'PLYMOUTH | LASER' n=1 ua_mvs"
+    - "raw: 'Plymouth | Laser | 1990-1994 | Subcompact Cars' us_fueleconomy (5 rows)"
+    - "https://en.wikipedia.org/wiki/Plymouth_Laser  # 'The Plymouth Laser is a two-door 2+2 sports coupe sold by Plymouth from 1989 until 1994'"
+
+"car/plymouth/neon":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, ua: correct, us: correct } }
+  evidence:
+    - "raw: 'Plymouth | Neon | 1995-2000 | Compact Cars' us_fueleconomy (7 rows); 'Plymouth | Neon | 1995-1998' + 'Neon #' ca_nrcan"
+    - "raw: 'PLYMOUTH | NEON' n=7 ua_mvs"
+    - "https://en.wikipedia.org/wiki/Plymouth_Neon  # 'In the United States and Canada, it was sold as either a Dodge or a Plymouth' — the Plymouth badge ran 1995-2001, matching the source years"
+
+"car/plymouth/valiant-scamp":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: 'PLYMOUTH | VALIANT SCAMP' n=11 nl_rdw (+ 'VALIANT SCAMP OF VALIANT BROUGHAM' n=2)"
+    - "raw: 'M1 | Plymouth | Valiant Scamp  2ov 5211cm3 A' n=1 fi_traficom"
+    - "catalog: car/plymouth/scamp ('Scamp', fi+nl+nz, raw 'PLYMOUTH SCAMP') and car/plymouth/valiant ('Valiant', fi+nl+nz) both live"
+    - "https://en.wikipedia.org/wiki/Plymouth_Valiant  # 'Beginning in 1971, a badge-engineered version of the 111 in wheelbase Dodge Dart Swinger called the Valiant Scamp was offered'"
+    - "raw: DISAMBIGUATED BY ENGINE SIZE. en.wikipedia.org/wiki/Plymouth_Scamp lists TWO unrelated Scamps (the 1971-76 A-body coupe and a 1983 Horizon-based coupe utility), so a bare 'Scamp' id is ambiguous in principle. Measured: fi_traficom's car/plymouth/scamp row is 'SCAMP Coupe (AD) 2ov 5190cm3 A' and its car/plymouth/valiant-scamp row is 'Valiant Scamp 2ov 5211cm3 A' — both the 318 V8 A-body, and the 1983 car was a 1.7/2.2 four. The two ids therefore do denote one vehicle."
+  notes: >-
+    name: 'Valiant Scamp' is the marque's own 1971 badge, so the rendering is
+    correct. id: the same A-body car is also published as car/plymouth/scamp —
+    a token-difference duplicate invisible to the fold. The ambiguity that a
+    bare 'Scamp' could be the 1983 coupe utility was resolved from the register
+    itself (5190 cc), not assumed away.
+
+"car/ram/1500-classic":
+  verdicts: { id: correct, name: correct, make: correct, kind: "defective(D10)",
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Ram | 1500 Classic 2WD/4WD | 2020-2024 | Standard Pickup Trucks' us_fueleconomy (12 rows) — the source's own class is a pickup truck"
+    - "raw: 'Ram | 1500 Classic | 2019-2024' ca_nrcan (6 exact rows, + FFV/4X4 variants)"
+    - "catalog: truck/ram/1500 (fi,nl) and van/ram/1500 (es,fi,lu,nl) already exist, alongside car/ram/1500"
+    - "https://en.wikipedia.org/wiki/Ram_Pickup  # the 4th-generation infobox 'also called' reads 'Ram 1500 Classic (2019-2024)' — Ram's own name for the previous-generation truck sold alongside the DT"
+    - "https://www.fueleconomy.gov/feg/Find.do?action=sbs&id=47606  # EPA's page for '2024 Ram 1500 Classic 2WD' gives size class 'Standard Pickup Trucks 2WD'"
+  notes: >-
+    id and name correct — '1500 Classic' is Ram's own name for the DS-generation
+    truck sold alongside the DT. kind: a full-size pickup in the car kind, with
+    a truck-kind sibling already present to route to. Same open-boundary caveat
+    as car/hummer/h3t.
+
+"car/renault/4-gtl":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { es: correct, fi: correct, lu: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'RENAULT | 4 GTL' n=627 + '4GTL' n=153 + 'RENAULT 4 GTL' n=3 nl_rdw; '4GTL' n=1 nz_nzta"
+    - "raw: 'RENAULT | RENAULT 4 GTL' es_dgt; 'RENAULT | RENAULT R4 GTL' lu_snca; 'R 4 GTL Farmari (AC) 5ov 1108cm3' fi_traficom"
+    - "https://en.wikipedia.org/wiki/Renault_4  # 'In 1978, the R4 GTL arrived. It had the 1108 cc engine from the Renault 6 TL' — 1108 cc matches the fi row exactly, and GTL is a VERSION of the Renault 4"
+  notes: >-
+    Latent D8: GTL is a Renault 4 version designation, but NO bare car/renault/4
+    record exists, so folding would have to mint one — and 'GTL' is how five
+    registers name these cars. Recorded correct with the altitude noted rather
+    than called a defect, since there is no duplicate id and the string is the
+    marque's own version name.
+
+"car/renault/scenic":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { de: correct, es: correct, fi: correct, gb: correct,
+                              ie: correct, lu: correct, nl: correct, nz: correct, ua: correct } }
+  evidence:
+    - "raw: 'RENAULT | SCENIC' n=12353 nl_rdw; n=106 nz_nzta; n=1306 ua_mvs; 'RENAULT | SCENIC' es_dgt and lu_snca; 'Renault Scenic' ie_cso; de_kba_fz10 RENAULT block contains 'SCENIC'"
+    - "raw: 'SCENIC Viistopera (AB) 4ov 1461cm3 A' n=119 fi_traficom; uk_dft GenModel 'RENAULT SCENIC' 241 rows, 221 BodyType=Cars"
+    - "raw: this record's own observed variants include 'MEGANE SCENIC', 'MEGANE SCENIC II', 'GRAND SCENIC', 'SCENIC E-TECH ELECTRIC' — four generations plus the Megane-prefixed first generation"
+    - "catalog: car/renault/meganescenic ('Meganescenic', es+nl) live — a fused-form id for the same nameplate's first generation"
+    - "https://www.renault.co.uk/  # the marque's CURRENT rendering carries no accent: page markup reads 'SCENIC E-TECH ELECTRIC', 'Scenic E-Tech 100% electric', 'SCENIC', slug scenic-e-tech-100-electric"
+    - "https://en.wikipedia.org/wiki/Renault_Scénic  # the HISTORIC rendering was accented, deliberately: 'Renault decided to add an acute accent to the production model name (Megane Scenic), in order to assert its European identity'; gen I launched as the 'Megane Scenic' in November 1996"
+  notes: >-
+    name recorded correct because the shipped ASCII display is exactly the
+    marque's current rendering (renault.co.uk, verified). But the finding under
+    it is a SCOPE problem, not a casing one: Renault badged generations I-IV
+    'Scenic' WITH an acute accent and the 2024 E-Tech car WITHOUT it, and this
+    single record spans both (its own raw set runs from 'MEGANE SCENIC' to
+    'SCENIC E-TECH ELECTRIC'). No single display string can be marque-true for
+    the whole span, so the honest remedy is a split, which is an id decision.
+    id is already defective for car/renault/meganescenic, the fused gen-I twin.
+
+"car/riley/1300":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'RILEY | 1300' n=1 nl_rdw; 'RILEY | 1300' n=2 nz_nzta (+ '1300KESTRALL' n=1 — a mis-spelled Kestrel)"
+    - "https://en.wikipedia.org/wiki/Riley_1300  # redirects to BMC ADO16; produced 1968-69, 'initially marketed as the Riley Kestrel before the Kestrel name was dropped in October 1968'"
+  notes: >-
+    3 registrations total. The neighbouring '1300KESTRALL' row is the register
+    remembering the pre-October-1968 'Riley Kestrel 1300' name for the same car;
+    'Riley 1300' is the correct post-1968 marque rendering, so the record is
+    right and the Kestrell row is an unfolded variant of it.
+
+"car/rover/110":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'ROVER | 110' n=16 nl_rdw (+ '110 SALOON' n=1, 'ROVER 110 ROADSTER' n=1); n=39 nz_nzta (+ '110 MARK 1', '110 DLS SW TURBO')"
+    - "https://en.wikipedia.org/wiki/Rover_P4  # 'The final members of the series were the 95 and 110' (1962-64) — 'Rover 110' is a genuine P4 designation"
+    - "https://en.wikipedia.org/wiki/Rover_P5  # cross-checked: the P5 is only ever 'Rover 3 Litre'/'3.5 Litre'/'3-1/2 Litre', so a P5 attribution would be a platform error"
+  notes: >-
+    name correct (P4 110, 1962-64). NOTE a contamination risk the audit should
+    record rather than resolve: 'ROVER 110' is also the Land Rover Defender 110
+    wheelbase designation, and the nz row '110 DLS SW TURBO' does not look like
+    a P4 saloon. The record is evidenced, but the two sources may be pooling P4
+    110s with Defender 110s, which body_types=sedan would then be wrong for.
+
+"car/rover/2300":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'ROVER | 2300' n=2 nl_rdw (+ '2300S' n=11, '2300 S' n=4); 'ROVER | 2300' n=1 nz_nzta (+ '2300 AUTO', '2300S', '2300 S')"
+    - "catalog: car/rover/2300-s ('2300 S', nl+nz) live for the S trim"
+    - "https://en.wikipedia.org/wiki/Rover_SD1  # 'The models produced ... were usually named according to their engine size', list includes verbatim 'Rover 2300', 'Rover 2300 S', 'Rover 2300 SE', 'Rover 2300 Vanden Plas'"
+  notes: "the bare 2300 has 3 registrations while its own S trim record has 17 — the trim record is the volume, which is a D8 inversion worth a curation look. Note Rover named SD1s by engine size, so bare '2300' is a legitimate marque designation here, unlike a bare number in most makes (NAMING.md 7.2)."
+
+"car/saab/9000-turbo":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, fi: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: 'SAAB | 9000 TURBO' n=4 nl_rdw (+ '9000 TURBO 16V' n=4, '9000 TURBO 16 2.3 U9' n=1, '9000TURBO1' n=1); n=3 nz_nzta"
+    - "raw: 'Saab | 9000 Turbo | 1997,1998' ca_nrcan; '5D COMBI SEDAN 9000 TURBO-LM/2670' fi_traficom"
+    - "catalog: car/saab/9000 ('9000', 8 countries) live; car/saab/9000-turbo-16v, /9000-aero, /9000-cd, /9000-cde, /9000-cs, /9000-cse also live"
+    - "https://en.wikipedia.org/wiki/Saab_9000  # the factory designation was longer: 'This original model called Saab 9000 Turbo 16 was a five-door hatchback', with 'Saab 9000 Turbo 16 S' and 'Turbo 16 SP' siblings; the formal trim letters are CC/CD/CS/Aero and Turbo is the engine designation appended to them"
+  notes: >-
+    Turbo is a 9000 engine/variant designation and the nameplate record carries
+    eight countries; the 9000 family is currently split across eight live ids,
+    of which Aero/CD/CS/CSE are genuine Saab model designations and 'Turbo' /
+    'Turbo 16V' are powertrain descriptors.

--- a/data/review/audit-v2026.07.5/audit-ledger-3.yml
+++ b/data/review/audit-v2026.07.5/audit-ledger-3.yml
@@ -1,0 +1,1322 @@
+# Five-nines baseline audit (PRD-FIVE-NINES gate A2) — results ledger
+slice: 3
+researcher: opus-audit-3
+verifier: null
+status: awaiting_verification
+tag: v2026.07.5
+audited_catalog: /Users/javi/GitHub/.vdb-worktrees/s4w-data/catalog/{car,truck}/models.json  # VERSION 2026.07.5, built 2026-07-26T05:28:12Z
+audited_at: 2026-07-26
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DECISION RULES USED (stated so the verifier can re-derive, and disagree
+# cleanly). All five are literal readings of the protocol; where a reading was
+# genuinely open I took the narrower one and said so in the record's note.
+#
+# R1  id-canonical = defective ONLY when a SPECIFIC live id can be named that
+#     denotes the same vehicle (spelling twin, code→nameplate resolution, or a
+#     nameplate id whose own raw strings include this id's strings). Where a
+#     candidate exists but the identification cannot be closed from reachable
+#     sources → unverifiable, never defective.
+# R2  Where the record is a trim/engine/body/generation of a live nameplate id
+#     (NAMING §1: "one record covers a nameplate's trims, engines and bodies"),
+#     the defect is recorded on `id` as D8 — not on `name`, if the display form
+#     itself is what the marque/source writes.
+# R3  name-marque-true is judged against the marque's own material where
+#     reachable (rank 3); where the marque page 403s/404s I fell back to the
+#     record's own cited source's rendering (EPA/NRCan/KBA are catalogues, not
+#     uppercase registers, so they DO carry casing) and said which rank I used.
+#     Registers that uppercase everything (RDW/FI/ES/UA/NZ/DVLA) are never
+#     treated as casing authority — only as authority on what strings exist.
+# R4  availability = correct when the named register holds ≥1 row that the
+#     pipeline's fold maps to THIS id's referent — even where the id's NAME is
+#     a code or fragment (that defect lands on name/id, not on the country).
+#     availability = defective only where the rows plainly denote a DIFFERENT,
+#     separately-identified nameplate (2 cases in this slice: suzuki/wagon,
+#     ford/ranger nl).
+# R5  kind is judged against the legal category the source itself carries
+#     (§2.3 — the kind axis is settled): FI ajoneuvoluokka, RDW voertuigsoort +
+#     europese_voertuigcategorie (live), ES EUCAT, DVLA BodyType. N2/N3 → truck.
+#
+# EVIDENCE PROVENANCE (all read-only; captures kept in this scratchpad)
+#   nl  LIVE SoQL group-by on RDW m9d7-ebf2 (CC0), queried 2026-07-26 —
+#       merk × handelsbenaming × europese_voertuigcategorie × inrichting counts.
+#   fi  cache/fi_traficom_register.zip → TieliikenneAvoinData_31_03_2026.csv,
+#       935 MB streamed; effective model = kaupallinenNimi else mallimerkinta
+#       (matches pipeline/sources/fi_traficom.rb), class from ajoneuvoluokka.
+#   es  cache/es_dgt_2026{04,05,06}.txt, fixed-width [17,30)/[47,22)/[426,3).
+#   gb  cache/uk_veh0120_uk.csv (BodyType,Make,GenModel,Model,…) — note the
+#       pipeline reads GenModel; the finer Model column is decisive evidence
+#       several times below.
+#   nz  cache/nz_passenger-car-van_<LETTER>.json (ArcGIS group-by; car kind only).
+#   ua  cache/ua_reestr_current.zip (BRAND/MODEL/KIND; VIN column never read).
+#   my/th/ie/de/ca/us  respective cached files; de via pipeline XlsxLite sheet4.
+# ─────────────────────────────────────────────────────────────────────────────
+
+summary:
+  records_audited: 100
+  claims_total: 645          # 100×4 + 245 availability entries
+  verdicts:
+    correct: 517
+    defective: 119
+    unverifiable: 9
+  clean_rate_claims: 0.8016  # 517/645; unverifiable counts AGAINST (conservative bound)
+  by_claim_type:
+    id:            { correct: 40,  defective: 58, unverifiable: 2 }
+    name:          { correct: 42,  defective: 52, unverifiable: 6 }
+    make:          { correct: 97,  defective: 2,  unverifiable: 1 }
+    kind:          { correct: 96,  defective: 4,  unverifiable: 0 }
+    availability:  { correct: 242, defective: 3,  unverifiable: 0 }
+  records_with_zero_defects: 27      # of 100 (73 records carry at least one defective claim)
+  defect_classes_seen:               # one primary class per defective claim; sums to 119
+    D1:  10   # parser/fold artifact — fabricated or truncated display name
+    D5:   1   # brand in the model column (prefix-strip over-reach: 'Chevy Van' → 'Van')
+    D6:  33   # duplicate spelling / same vehicle under a second live id
+    D7:  13   # non-canonical casing/spacing vs the marque's rendering
+    D8:  21   # wrong altitude — trim/engine/body/generation published as a model
+    D9:  27   # registry/type/homologation code as a model
+    D10:  4   # wrong kind
+    D11:  1   # wrong make — approval/plate holder (saxas→mercedes-benz)
+    D12:  1   # make split / corporate string as marque (renault vs renault-trucks)
+    NEW-1: 8  # see new_classes below — NOT in PRD-QUALITY §4
+  defect_list:                     # every defective claim, per record
+    - "car/scion/xd: name=defective(D7)"
+    - "car/skoda/enyaq-85x: id=defective(D8)"
+    - "car/skoda/octavia-a5: id=defective(D8); name=defective(D8)"
+    - "car/subaru/brz-ts: id=defective(D8); name=defective(D7)"
+    - "car/suzuki/equator: kind=defective(D10)"
+    - "car/suzuki/sc: name=defective(D9)"
+    - "car/suzuki/sidekick-sport: id=defective(D8)"
+    - "car/suzuki/wagon: id=defective(D6); name=defective(D6); avail.nl=defective(D6); avail.ua=defective(D6)"
+    - "car/tesla/model-y: id=defective(D6)"
+    - "car/toyota/camry-wagon: id=defective(D8)"
+    - "car/triumph/tr2: id=defective(D6)"
+    - "car/triumph/tr4a: id=defective(D6)"
+    - "car/vauxhall/viva-deluxe: id=defective(D8); name=defective(D8)"
+    - "car/volkswagen/211: name=defective(D9)"
+    - "car/volkswagen/baja: id=defective(NEW-1); name=defective(NEW-1)"
+    - "car/volkswagen/bestel-0: id=defective(D6); name=defective(D1)"
+    - "car/volkswagen/caravelle-syncro: id=defective(D8)"
+    - "car/volkswagen/id-buzz: id=defective(D8); name=defective(D7)"
+    - "car/volkswagen/van: id=defective(D9); name=defective(D9)"
+    - "car/volvo/850-wagon: id=defective(D8)"
+    - "car/volvo/c303: id=defective(D6)"
+    - "car/volvo/ec40-twin: id=defective(D8)"
+    - "car/volvo/p-54405-a: id=defective(D9); name=defective(D9)"
+    - "car/volvo/xc40-b4: id=defective(D8)"
+    - "car/volvo/xc60-d5: id=defective(D8)"
+    - "truck/all-wheel-drive/tl: name=defective(D7)"
+    - "truck/bucher/citycat: id=defective(D6); name=defective(D7)"
+    - "truck/chevrolet/20-starcraft-3-9t-fg25f: id=defective(D6); name=defective(D1)"
+    - "truck/chevrolet/cheyenne: id=defective(D8)"
+    - "truck/chevrolet/k: id=defective(D6); name=defective(D9)"
+    - "truck/chevrolet/pick-up: id=defective(D9); name=defective(D9)"
+    - "truck/chevrolet/van: id=defective(D6); name=defective(D5)"
+    - "truck/daf/fancf: id=defective(D6); name=defective(D9)"
+    - "truck/daf/fas: id=defective(D9); name=defective(D9)"
+    - "truck/daf/ftg: id=defective(D9); name=defective(D9)"
+    - "truck/daf/v1600dd: name=defective(D9)"
+    - "truck/de-soto/sc: name=defective(D9)"
+    - "truck/fiat/burstner: id=defective(NEW-1); name=defective(NEW-1); kind=defective(D10)"
+    - "truck/fiat/swift: id=defective(NEW-1); name=defective(NEW-1); kind=defective(D10)"
+    - "truck/ford/350: id=defective(D6); name=defective(D1)"
+    - "truck/ford/f-max: name=defective(D7)"
+    - "truck/ford/f250xlt: id=defective(D6); name=defective(D7)"
+    - "truck/ford/ranger: avail.nl=defective(D6)"
+    - "truck/fordson/wot: name=defective(D7)"
+    - "truck/gmc/cckw: name=defective(D7)"
+    - "truck/isuzu/nqr: name=defective(D7)"
+    - "truck/iveco/260s: id=defective(D6); name=defective(D9)"
+    - "truck/iveco/40c17d: id=defective(D6); name=defective(D8)"
+    - "truck/iveco/60c16: id=defective(D8); name=defective(D8)"
+    - "truck/iveco/80el: id=defective(D8); name=defective(D9)"
+    - "truck/liebherr/lg: name=defective(D7)"
+    - "truck/liebherr/utm: id=defective(D9); name=defective(D7)"
+    - "truck/man/12: id=defective(D6); name=defective(D1)"
+    - "truck/man/18ml: name=defective(D9)"
+    - "truck/man/8-150-f: id=defective(D8); name=defective(D6)"
+    - "truck/man/h39: id=defective(D9); name=defective(D9)"
+    - "truck/man/hn: name=defective(D1)"
+    - "truck/mercedes-benz/1223-l: id=defective(D6); name=defective(D8)"
+    - "truck/mercedes-benz/290: id=defective(D6); name=defective(D1)"
+    - "truck/mercedes-benz/312d-ka-903462-kasten: id=defective(D9); name=defective(D9)"
+    - "truck/mercedes-benz/609-d: id=defective(D6)"
+    - "truck/mercedes-benz/609d-ka: id=defective(D6); name=defective(D9)"
+    - "truck/mercedes-benz/816-d: id=defective(D6)"
+    - "truck/mercedes-benz/918-l: id=defective(D6)"
+    - "truck/mercedes-benz/967pkx2: id=defective(D9); name=defective(D9)"
+    - "truck/mercedes-benz/l508dg: id=defective(D6); name=defective(D7)"
+    - "truck/mercedes-benz/la: id=defective(D6); name=defective(D1)"
+    - "truck/peugeot/bailey: id=defective(NEW-1); name=defective(NEW-1); kind=defective(D10)"
+    - "truck/renault/d14: id=defective(D6); make=defective(D12)"
+    - "truck/saxas-nutzfahrzeuge-werdau/atego: id=defective(D6); make=defective(D11)"
+    - "truck/scania/143m: id=defective(D6); name=defective(D1)"
+    - "truck/scania/460: id=defective(D1); name=defective(D1)"
+    - "truck/scania/p230: id=defective(D6)"
+  new_defect_classes_flagged: [NEW-1, NEW-2, NEW-3]   # see new_classes: below
+  stratum_note: >-
+    This slice is heavily long-tail: 64 of 100 records are trucks, and truck
+    ids are dominated by register type-codes and axle/chassis designations —
+    which is why D6/D9/D8 carry the mass. The two head-mass records in the
+    slice (car/tesla/model-y decile 1, car/volkswagen/id-buzz decile 5) are
+    BOTH defective, so the low clean rate is not purely a tail effect.
+  evidence_class_note: >-
+    Every `ca` and `us` availability claim is marked correct on the strength of
+    the exact cached artifact the pipeline reads (ca_*.csv, us_vehicles.csv):
+    the (make, model) row is present. Both sources are model-year CATALOGUES
+    with `evidence: approval` and no counts — honest labelling in the schema —
+    so "the register evidences this model" is satisfied by certification, not
+    by vehicles in use. Flagged once here rather than as 8 per-record
+    unverifiables (an earlier draft of this ledger did the latter and was
+    internally inconsistent with the three car/saturn records).
+  heaviest_finding: >-
+    car/tesla/model-y (global decile 1, 13 countries) is NOT id-canonical:
+    car/tesla/y ("Y", es+nl, 3 vehicles) is a live truncation of the same
+    nameplate. A head record failing the canonicality test is the single
+    most consequential result in this slice.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# NEW DEFECT CLASSES — flagged LOUDLY, not fixed, not extrapolated (I-15).
+# None of the three is covered by PRD-QUALITY §4 as written.
+# ─────────────────────────────────────────────────────────────────────────────
+new_classes:
+
+  NEW-1:
+    name: converter/coachbuilder brand or conversion STYLE published as a
+          nameplate of the chassis marque
+    why_not_existing_class: >-
+      D5 is "embedded make/brand PREFIX" whose remedy is rename-or-move to that
+      brand's own make; here the model column carries a third party whose
+      correct target is often a NON-marque that drop.yml already removes per
+      kind (G7/G18), so "move" would resurrect exactly what the drop deletes.
+      D10 (wrong kind) is a frequent companion but not the same defect: the kind
+      can be right while the model still is not a nameplate. D11 is the mirror
+      image (third party in the MAKE column) and IS covered.
+    instances_in_slice_3:
+      - "truck/fiat/burstner — gb GenModel 'FIAT BURSTNER', Model 'BURSTNER ARGOS A 747-2 G' (Bürstner = motorhome converter; `burstner` is dropped as a make in car but lives as a Fiat model in truck)"
+      - "truck/fiat/swift — gb 'FIAT SWIFT' / 'SWIFT KONTIKI 649', 'SWIFT EDGE 466 S-A' (Swift Group, UK motorhomes)"
+      - "truck/peugeot/bailey — gb 'PEUGEOT BAILEY AUTOGRAPH' / 'BAILEY AUTOGRAPH IV 79-4I A' (Bailey of Bristol)"
+      - "car/volkswagen/baja — nl_rdw 'BAJA' 2, 'KEVER BAJA' 2, 'BAJA BUGG' 1, 'BAJA REPLICA' 1 (an aftermarket Beetle conversion STYLE; RDW's own string says REPLICA)"
+      - "truck/chevrolet/20-starcraft-3-9t-fg25f + the live sibling truck/chevrolet/starcraft (Starcraft = US van converter)"
+      - "truck/scania/metago + truck/mercedes-benz/metago — 'METAGO PRO' carried as the model under TWO unrelated chassis marques in es (2026-04..06), lu and nl; identity unresolvable (see that record)"
+    systemic_scale_signal: >-
+      truck/fiat alone publishes EIGHT converter brands as models (adria,
+      benimar, burstner, carthago, dethleffs, hymer, mobilvetta, rapido, roller,
+      swift); truck/ford has bailey/benimar/chausson/swift; truck/peugeot has
+      bailey/theault; truck/renault has theault. NOT swept, NOT extrapolated —
+      counted here only to size the class.
+    detector_spec_proposal: >-
+      (a) model-string token ∈ the union of makes/drop.yml + known coachbuilder
+      list, scoped per kind; (b) cheap independent signal with no list at all:
+      the SAME model string appearing under ≥2 unrelated chassis makes in one
+      kind (fires on metago, burstner, swift, bailey, atego-under-bodybuilders).
+
+  NEW-2:
+    name: TAN overlap is NOT a duplicate proof — and xrefs.tan can be poisoned
+    why_it_matters: >-
+      NAMING.md §2 ranks a shared EU whole-vehicle type-approval number as
+      "the strongest duplicate proof available". In this slice it produces
+      false positives in three different ways AND carries a junk key that would
+      make any TAN-equality detector fire on nonsense. Anything built on
+      TAN-equality needs guards BEFORE it is trusted.
+    evidence:
+      - "PLATFORM SHARING: car/tesla/model-y shares 11 TANs with car/tesla/model-3 (e4*2007/46*1293*19/21/27…). Tesla approved both under one base WVTA; fi_traficom shows MODEL Y under *21/*25/*26 and MODEL 3 under *06/*15/*19 — the extensions differ per model, so the catalog's per-id TAN SETS overlapping is a build-side attribution artifact, not two spellings of one car."
+      - "CROSS-KIND, LEGITIMATE: truck/land-rover/defender and car/land-rover/defender share e5*2007/46*0092*10 — one approval spans the M1G and N2G Defender variants. Correct data, would read as a duplicate."
+      - "CROSS-NAMEPLATE LEAK: car/skoda/enyaq-85x shares e8*2007/46*0416*22 with car/skoda/elroq AND car/skoda/elroq-85x. Enyaq and Elroq are different nameplates on different approvals — that TAN is attached to at least one record that cannot own it."
+      - "POISONED KEY: truck/ford/f-150 carries the literal string '- (FMVSS)' in xrefs.tan, shared with 33 records across 4 kinds (audi/tts, bmw/x3, harley-davidson/road-king, zero-motorcycles/sr-f…). A non-TAN placeholder is being stored in the TAN field."
+    detector_spec_proposal: >-
+      Reject non-conforming TAN strings at ingest (shape `e<n>*<dir>*<num>*<ext>`
+      or a national format) and never store a placeholder; when comparing, match
+      on base approval + extension AND require the same kind + same make before
+      a duplicate is even proposed. Where TAN-equality is the ONLY evidence, it
+      is a shortlist, not a verdict (the §2.1 "structural corroboration is a
+      triage filter, not proof" rule applies here too).
+
+  NEW-3:
+    name: source-forced kind — a source that declares one kind makes every
+          record it feeds that kind, with no kind_map to correct it
+    evidence:
+      - "pipeline/sources/us_fueleconomy.rb and ca_nrcan.rb both declare `kinds = [:car]` and emit Row(kind: :car) unconditionally. There is no overrides/kind_maps entry for either source (only de_kba_fz10, nl_rdw, uk_dft exist)."
+      - "car/suzuki/equator is therefore in `car` while it is a pickup truck: us_vehicles.csv VClass = 'Small Pickup Trucks 2WD'/'4WD'; ca 'Vehicle class' = 'Pickup truck: Small'. Its badge-engineered twin truck/nissan/titan sits in `truck`."
+      - "Both sources ship a free, unused class column (VClass / 'Vehicle class') that would resolve it."
+    why_not_plain_D10: >-
+      D10 exists and this IS a wrong kind, but D10's detector list is
+      "kind_maps + segment joins (FZ 11.1) + kampeerwagen test" — none of which
+      has any hook into a source that hardcodes its kind. The class needs the
+      sub-case named or the fix will be looked for in the wrong layer.
+    scope_note: NOT extrapolated — one instance measured in this slice.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# UNVERIFIABLE REGISTER (counts against the clean rate; feeds the source-gap queue)
+# ─────────────────────────────────────────────────────────────────────────────
+unverifiable_register:
+  - "car/volkswagen/211 (id) — the VW 211-series order code cannot be resolved to a specific live id from reachable sources; en.wikipedia Volkswagen_Type_2 does not list VW's numeric order codes and vw.com press archive is not reachable. NAMING §7.5 (resolve, never guess)."
+  - "car/volkswagen/caravelle-syncro (name) — VW's own rendering of the drivetrain badge is lowercase 'syncro' in period material; no VW-owned page reachable to cite, and every register uppercases. Spacing/casing left open."
+  - "truck/scania/metago (id, name, make) — 'Metago Pro' identity unresolved: metago.eu and metago.nl do not resolve (curl exit 0 bytes), WebSearch is dead. Strong NEW-1 signature (same model string under Scania AND Mercedes-Benz) but unproven."
+  - "truck/scania/p230, p280, p380 (name) — the marque's exact rendering (space or no space: 'P 280' vs 'P280') is undecidable from here: scania.com product pages 404/JS-render, and both forms are live in nl_rdw ('P280' n=284 and 'P 280 B 4X2' n=25). The cab-letter+power token itself is verified present."
+  - "truck/renault/d14 (name) — renault-trucks.com/en/trucks/renault-trucks-d returned HTTP 502; register forms split 'D 14' (nl, n=2) and 'D14' (nl n=1, es n=1)."
+  - "truck/mercedes-benz/1726, 2538 (name) — accepted as correct BUT flagged: no raw in ANY register carries the series token (SK/NG/Actros) for these two, so 'the marque's own rendering' cannot be confirmed to be the bare 4-digit type number. Recorded correct on the R3 fallback, not on marque evidence. (Counted correct, listed here for the source-gap queue.)"
+  - "NOT counted as unverifiable, recorded for the source-gap queue: every ca/us claim rests on a model-year CATALOGUE (evidence: approval), not a fleet register — see summary.evidence_class_note. Presence is confirmed per row in the cached artifact the pipeline reads; currency is not a property these two sources have."
+  - "NOT counted, recorded for the queue: scania.com, daf.com/en/trucks, buchermunicipal.com product pages, skoda-auto.com/models/range/enyaq, suzuki.co.nz/cars/fronx and media.volvocars.com all returned 403/404/502 to this session. Where the marque page 404d I could still read the site chrome/nav (Bucher CityCat, Mecalac Revotruck, Ford Trucks F-MAX, Suzuki Fronx, DAF XB/XD/XF/XG) and those verdicts are cited to that capture; Scania and Volvo Cars yielded nothing and are the two real marque-source gaps from this slice."
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RECORDS
+# ─────────────────────────────────────────────────────────────────────────────
+
+"car/saturn/aura":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Saturn | Aura' + 'Aura Hybrid' us_fueleconomy (us_vehicles.csv, MY2007-2010, VClass 'Midsize Cars')"
+    - "raw: 'Saturn | Aura' + 'Aura Hybrid' ca_nrcan (class 'Mid-size')"
+    - "catalog sibling sweep, car/saturn (16 ids): no other id denotes the Aura"
+  notes: "Both sources are catalogues carrying casing, so 'Aura' is rank-3-equivalent evidence for a defunct marque (R3)."
+
+"car/saturn/l300":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Saturn | L300' us_fueleconomy MY2001-2005 (VClass 'Midsize Cars'); ca_nrcan 'L300' ('Mid-size')"
+    - "catalog sibling sweep: l100-200='L100/200' and l200='L200' are the 4-cyl L-Series ids; L300 is the V6 — no id denotes the same vehicle"
+  notes: >-
+    Flagged not-defective but adjacent: the L-Series nameplate has no
+    family-level id, so l100-200 / l200 / l300 are three trim-level ids with no
+    parent (and l100-200 vs l200 duplicate EACH OTHER — outside this slice).
+
+"car/saturn/relay":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Saturn | Relay AWD' / 'Relay FWD' us_fueleconomy MY2005-2007 (VClass 'Minivan - 4WD'/'2WD')"
+    - "raw: 'Saturn | Relay' (bare) ca_nrcan, class 'Minivan' — the nameplate form is the marque's"
+  notes: "Minivan = M1 → kind car is correct on R5."
+
+"car/scion/xd":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { ca: correct, ua: correct, us: correct } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Scion_xD  # renders the nameplate 'Scion xD' throughout — lowercase x, uppercase D"
+    - "raw: 'Scion | xD' us_fueleconomy MY2008-2014 (the record's OWN cited source writes xD)"
+    - "raw: 'Scion | xD' ca_nrcan (class 'Subcompact') — second catalogue, same casing"
+    - "raw: 'SCION | XD' ua_mvs n=2 ЛЕГКОВИЙ (register uppercases everything — not casing authority, R3)"
+  notes: >-
+    The make's own convention is lowercase-initial across the range and the
+    catalog already gets iq='iQ' right, so this is internally inconsistent too
+    (xa='Xa', xb='Xb', tc='Tc', ia='Ia', im='Im' are the same D7 shape, outside
+    this slice). id: the JDM twin car/toyota/ist is a different marque record
+    (marque-of-sale, the Cupra/SEAT precedent) — not a duplicate.
+
+"car/skoda/enyaq-85x":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { es: correct, fi: correct, lu: correct, nl: correct, ua: correct } }
+  evidence:
+    - "TAN overlap (NAMING §2 rank 1): all THREE of this id's TANs — e8*2007/46*0416*13, *16, *22 — are also carried by car/skoda/enyaq. Same approved vehicle; 85X is the AWD/battery variant of the Enyaq nameplate."
+    - "https://en.wikipedia.org/wiki/%C5%A0koda_Enyaq  # renders the AWD variants '80X'/'85X' with capital X (rank-5 source: skoda-auto.com/models/range/enyaq 404s, skoda-storyboard 404s)"
+    - "raw: 'SKODA | ENYAQ 85X' es_dgt 202604-06 n=10 (M1); fi_traficom 'ENYAQ 85X' n=1021 TAN e8*2007/46*0416*16/*18; lu_snca 'ENYAQ 85X' n=10 (M1); nl_rdw live 'ENYAQ 85X' n=12 (M1); ua_mvs 'ENYAQ 85X' n=1"
+  notes: >-
+    Same-class siblings enyaq-50 and enyaq-80x are live too (systemic, not
+    swept). See NEW-2: TAN *22 also appears under car/skoda/elroq and
+    elroq-85x, which no TAN-equality merge should ever act on.
+
+"car/skoda/octavia-a5":
+  verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+              availability: { ua: correct } }
+  evidence:
+    - "raw: 'SKODA | OCTAVIA A5' ua_mvs n=1965 (+ 'OCTAVIA A5 COMBI' 131, 'OCTAVIA A5 RS' 15), all ЛЕГКОВИЙ"
+    - "catalog: car/skoda/octavia (name 'Octavia') is live and carries the nameplate; octavia-a7 is the same-class sibling"
+  notes_extra: "A5 is Škoda's internal platform/generation code (Typ 1Z, marketed as Octavia II) used by the Ukrainian trade; it is not a marketed nameplate."
+  notes: "Single-source record; the generation split exists only because UA writes the platform code."
+
+"car/srt/viper":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'SRT | Viper' us_fueleconomy — ONLY MY2013 and MY2014 exist under make SRT"
+    - "raw: 'SRT | Viper' / 'Viper Coupe' / 'Viper GTS' / 'Viper GTS Coupe' ca_nrcan (class 'Two-seater')"
+    - "catalog: car/dodge/viper is live with ca,es,lu,nl,nz,us — different model years, different marque of sale"
+  notes: >-
+    Deliberately NOT called a duplicate: SRT was the marque of sale for MY2013-14
+    only (the Cupra-under-SEAT precedent in NAMING §1 resolves in favour of the
+    marque). ca marked unverifiable because the 2013/2014 NRCan rows come from
+    the archived 1995-2014 file, not a register current at the audited tag.
+
+"car/subaru/brz-ts":
+  verdicts: { id: "defective(D8)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Subaru_BRZ  # 'BRZ tS' — lowercase t, uppercase S ('tS' = tuned by STI); base nameplate 'BRZ'"
+    - "raw: 'Subaru | BRZ tS' us_fueleconomy MY2018 + MY2020 (the record's own cited source writes BRZ tS)"
+    - "raw: 'Subaru | BRZ tS' ca_nrcan (class 'Minicompact')"
+    - "catalog: car/subaru/brz (name 'Brz', 10 countries) is live — tS is a special edition of it"
+  notes: >-
+    This is the protocol's own 'weird can be right' example and the dataset has
+    it wrong in BOTH directions: the acronym is title-cased AND the marque's
+    lowercase-t styling is lost. car/subaru/brz itself is 'Brz' (same D7 shape,
+    outside this slice).
+
+"car/subaru/trezia":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct, ua: correct } }
+  evidence:
+    - "raw: 'SUBARU | SUBARU TREZIA' nl_rdw live n=691 (M1, hatchback/MPV) + 'TREZIA' n=1"
+    - "raw: 'SUBARU | TREZIA' nz_nzta n=227 (PASSENGER CAR/VAN); ua_mvs n=5 ЛЕГКОВИЙ"
+    - "catalog sibling sweep car/subaru (82 ids): nothing else denotes the Trezia (the Toyota Ractis twin sits under car/toyota/ractis — a different marque of sale)"
+  notes: "A rebadge sold as a Subaru in Europe — make is the marque of sale and is right."
+
+"car/suzuki/equator":
+  verdicts: { id: correct, name: correct, make: correct, kind: "defective(D10)",
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Suzuki | Equator 2WD' / 'Equator 4WD' us_fueleconomy, VClass = 'Small Pickup Trucks 2WD' / 'Small Pickup Trucks 4WD'"
+    - "raw: 'Suzuki | Equator' / 'Equator 4X4' / 'Equator V6 4X4' ca_nrcan, Vehicle class = 'Pickup truck: Small'"
+    - "pipeline/sources/us_fueleconomy.rb:36 `def kinds = %i[car]` and ca_nrcan.rb:30 identical — no kind_map exists for either source"
+    - "catalog: truck/nissan/titan (the Frontier/Titan family this is badge-engineered from) is in kind truck"
+  notes: "See NEW-3. body_types ['hatchback'] is also wrong (D16) — not one of the five claims, recorded for the curation queue."
+
+"car/suzuki/fronx":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { my: correct, nz: correct } }
+  evidence:
+    - "https://www.suzuki.co.nz/cars/fronx  # HTTP 404 page, but the site chrome/nav renders 'Fronx' ×7 vs 'FRONX' ×2 (the caps form is the stylised wordmark) — capture: captures/suzuki_nz.html"
+    - "raw: 'Suzuki | Fronx' my_jpj n=22 (2025+2026 files, type motokar)"
+    - "raw: 'SUZUKI | FRONX' nz_nzta n=1446 (PASSENGER CAR/VAN)"
+
+"car/suzuki/sc":
+  verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+              availability: { gb: correct, nz: correct } }
+  evidence:
+    - "raw: gb uk_dft BodyType 'Cars', Make 'SUZUKI', GenModel 'SUZUKI SC', Model 'SC 100 GX' — 26 Licensed + 67 SORN. The finer Model column names the actual nameplate."
+    - "raw: 'SUZUKI | SC100' nz_nzta n=20, 'SC 100' n=1, 'SC100CXG' n=1, and 'SC' n=3"
+    - "catalog: no car/suzuki/sc100 id exists — the SC100 spellings are single-source in nz (22 < the 1000 car threshold) so only the truncated two-source spelling 'SC' got published"
+  notes: >-
+    Precise mechanism worth keeping: DVLA's GenModel is itself truncated
+    ('SUZUKI SC'), it corroborated the nz 'SC' rows, and the informative
+    spelling stayed in the candidate queue. The vehicle is the Suzuki SC100
+    (Cervo/'Whizzkid'). id verdict is correct only on the literal R1 test — no
+    LIVE id duplicates it.
+
+"car/suzuki/sidekick-sport":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Suzuki | Sidekick Sport 4WD' (MY1996-1998), 'Sidekick Sport 2WD' (1997), 'Sidekick Sport RWD' (1998) us_fueleconomy, VClass 'Special Purpose Vehicle'"
+    - "raw: 'Suzuki | Sidekick Sport' ca_nrcan ('Sport utility vehicle')"
+    - "catalog: car/suzuki/sidekick (ca,nl,nz,ua,us) is live and its own raws include 'Sidekick 4X4', 'SIDEKICK CABRIO JX'"
+  notes: "Sport is a trim/equipment level of the Sidekick nameplate (NAMING §1). Name form itself matches both catalogues."
+
+"car/suzuki/wagon":
+  verdicts: { id: "defective(D6)", name: "defective(D6)", make: correct, kind: correct,
+              availability: { nl: "defective(D6)", ua: "defective(D6)" } }
+  evidence:
+    - "raw: nl_rdw live SUZUKI 'WAGON' n=1 (M1, hatchback) against 'WAGON R' n=10736 across 4 inrichtingen — one row versus ten thousand"
+    - "raw: ua_mvs 'SUZUKI | WAGON' n=5 and 'SUZUKI | WAGON R' n=12 in the same file"
+    - "catalog: car/suzuki/wagon-r ('Wagon R', 7 countries) is live; its own raws are 'SUZUKI WAGON R', 'SUZUKI WAGON R+', 'SUZUKI WAGON-R'"
+    - "marque: Suzuki has never marketed a model called 'Wagon' — the nameplate is Wagon R (and the sibling id 'Every Wagon' shows 'Wagon' is a suffix word here)"
+  notes: >-
+    Both availability claims are marked defective under R4: the rows exist but
+    plainly denote Wagon R. A verifier preferring the 'string is present'
+    reading would flip these two to correct and the record would still be
+    defective on id+name — the class does not change.
+
+"car/tesla/model-y":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, de: correct, es: correct, fi: correct, gb: correct,
+                              ie: correct, lu: correct, my: correct, nl: correct, nz: correct,
+                              th: correct, ua: correct, us: correct } }
+  evidence:
+    - "DUPLICATE: catalog car/tesla/y is LIVE (name 'Y', es+nl, global_decile 8). Its raws are the bare register string: nl_rdw live merk TESLA handelsbenaming 'Y' n=2 (M1) and es_dgt 'TESLA|Y|M1' n=1. Tesla has no model named 'Y' — these three vehicles are Model Ys."
+    - "raw: de de_kba_fz10 202606 sheet4 row 461 'MODEL Y' 6023; nl_rdw live 'MODEL Y' 55581+693+…; gb uk_dft GenModel 'TESLA MODEL Y' (MODEL Y LONG RANGE AWD 66824 …); nz_nzta 'MODEL Y' 12171; ua_mvs 'MODEL Y' 4401; es_dgt 'MODEL Y' 1586; th_dlt 'MODEL Y LONG RANGE' 1755 + 'Model Y Rear-Wheel Drive' 1621 + 'MODEL Y PERFORMANCE' 83 (passenger ≤7); my_jpj 'Model Y' 5401; lu_snca 'MODEL Y' 446 (M1); fi_traficom 'MODEL Y' (M1, TAN e4*2007/46*1293*21/*25/*26); ie_cso 'Tesla Model Y'; ca_nrcan 'Model Y AWD' etc.; us_fueleconomy 'Model Y Long Range AWD' etc."
+    - "https://en.wikipedia.org/wiki/Volkswagen_ID._Buzz — n/a for this record (see id-buzz); name form 'Model Y' is the marque's and is corroborated by the two catalogues (ca_nrcan/us_fueleconomy) which carry casing"
+  notes: >-
+    THE heaviest finding of the slice: a decile-1, 13-country head record is not
+    id-canonical. Also see NEW-2 — this record shares 11 TANs with
+    car/tesla/model-3, which is NOT a duplicate signal.
+
+"car/toyota/camry-wagon":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Toyota | Camry Wagon' us_fueleconomy MY1994-1996, VClass 'Midsize-Large Station Wagons' / 'Small Station Wagons'"
+    - "raw: 'Toyota | Camry Wagon' ca_nrcan ('Station wagon: Mid-size')"
+    - "catalog: car/toyota/camry (12 countries) is live — the wagon is a BODY of the Camry nameplate (NAMING §1)"
+  notes: "Name form is what both catalogues write; the defect is altitude only (R2)."
+
+"car/toyota/celsior":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, gb: correct, my: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: fi_traficom kaupallinenNimi 'CELSIOR' n=19 across 5 displacement rows (M1, 4292/4300/4290/3968 cm3 sedans) incl. 'CELSIOR 430 C-Type', 'CELSIOR 400C F Package'"
+    - "raw: gb uk_dft 'Cars,TOYOTA,TOYOTA CELSIOR,CELSIOR AUTO' 14 Licensed + 3 SORN (+1 other-fuel)"
+    - "raw: nl_rdw live 'CELSIOR' n=7 (M1 sedan); nz_nzta 'CELSIOR' n=427; my_jpj 'Toyota|Celsior' n=1"
+    - "catalog sibling sweep car/toyota (257 ids): the LS400 twin is car/lexus/ls — different marque of sale, not a duplicate"
+
+"car/toyota/cressida":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, gb: correct, nl: correct, nz: correct, us: correct } }
+  evidence:
+    - "raw: fi_traficom '4D CRESSIDA-RX30L-EKDW/2640' → kaupallinenNimi 'CRESSIDA' (M1), 12+ rows incl. GL TURBO D and STW bodies"
+    - "raw: nl_rdw live 'CRESSIDA' n=8 + 27 further CRESSIDA * spellings (62 vehicles); nz_nzta 'CRESSIDA' n=364"
+    - "raw: gb uk_dft 'Cars,TOYOTA,TOYOTA CRESSIDA,CRESSIDA DX DIESEL' Licensed 1; us_fueleconomy 'Toyota | Cressida' MY1984-1992"
+  notes: "gb is thin (1 vehicle) but present and multi-source overall."
+
+"car/triumph/tr2":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { fi: correct, gb: correct, lu: correct, nl: correct, nz: correct } }
+  evidence:
+    - "DUPLICATE: catalog car/triumph/tr (name 'Tr') is live and its observed raws are ROMAN-numeral spellings of the same cars — ['TR CONVERTIBLE','TR II','TR III','TR III A','TR III CABRIOLET','TR- CONVERTIBLE']. 'TR II' is a TR2 (a D17 case-/form-split feeding a truncation id)."
+    - "raw: nl_rdw live 'TR2' n=25, 'TR 2' n=20, 'TR-2' n=1, 'TR.2' n=1, 'TR2 CABRIOLET' n=1 (M1 cabriolet); fi_traficom 'TR2 SPORT/2240', 'TR2' (M1 Avoauto), 'TR 2 / 2240', 'SPORT CAR TR-2/2235'"
+    - "raw: gb uk_dft 'Cars,TRIUMPH,TRIUMPH TR2,TR2' 414 Licensed + 85 SORN; nz_nzta 'TR2' 46 + 'TR 2' 3 + 'TR2 SPORTS' 1; lu_snca 'TRIUMPH|TR2|M1' n=2"
+  notes: "Name 'TR2' is the marque's own form (Triumph TR2, 1953-55) and the dataset's TR-series ids are consistently correct on casing."
+
+"car/triumph/tr4a":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "DUPLICATE: catalog car/triumph/tr4a-irs (name 'TR4A Irs', fi+nl) is live. The TR4A WAS the IRS car — nl_rdw carries 'TR4A' n=41 and 'TR4A IRS'/'TR4 A IRS'/'TR 4 A IRS'/'TR4A-IRS' n=17 as spellings of one model; the split is D6 (and 'Irs' is a D7 acronym title-case on top)."
+    - "raw: nl_rdw live TRIUMPH 'TR4A' n=31+10, 'TR 4 A' n=58, 'TR 4A' n=14, 'TR4 A' n=8 (M1 cabriolet); nz_nzta 'TR4A' n=15"
+    - "car/triumph/tr (see tr2) is a third overlapping identifier for the TR family"
+
+"car/uaz/469":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct, ua: correct } }
+  evidence:
+    - "raw: ua_mvs 'УАЗ | 469' n=21 ЛЕГКОВИЙ (and '469Б' n=48, '469A' n=5 — genuinely distinct UAZ type designations, not spellings)"
+    - "raw: nl_rdw live UAZ '469' n=5 (M1 cabriolet/stationwagen); fi_traficom '469  4ov 2445cm3' → '469' (M1G) and '469B' (M1G)"
+    - "catalog: car/uaz/469b ('469B') is the civilian non-portal-axle variant — a real UAZ designation, so NOT a duplicate spelling"
+  notes: "Numeric type designation IS the marque's nameplate convention for UAZ (§7.2 kind-dependent numeric legitimacy)."
+
+"car/vauxhall/viva-deluxe":
+  verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+              availability: { fi: correct, nz: correct } }
+  evidence:
+    - "raw: fi_traficom '2D VIVA DELUXE 9D11DD/2460', '2D VIVA DELUXE 933110/2430', '2D VIVA DELUXE 90-933110/2430', '2D VIVA DELUXE 93311/2430' (M1/MUU) — DELUXE always follows the VIVA nameplate plus a body/type code"
+    - "raw: nz_nzta VAUXHALL 'VIVA DELUXE' n=9 against 'VIVA' n=329"
+    - "catalog: car/vauxhall/viva ('Viva', fi/gb/nl/nz) is live AND already absorbs de-luxe strings — its own raws include 'VIVA ESTATE CAR DELUXE 933159/2430'"
+  notes: >-
+    De Luxe is Vauxhall's trim level (written 'De Luxe' as two words in period
+    material), so the name is wrong twice over — but the load-bearing defect is
+    altitude: the same trim string is already inside the nameplate id.
+
+"car/volkswagen/211":
+  verdicts: { id: "unverifiable(211-series order code unresolved; see unverifiable_register)",
+              name: "defective(D9)", make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: nl_rdw live VOLKSWAGEN '211' n=7 (M1: MPV 3, stationwagen 3, kampeerwagen 1) alongside '211011' n=6, '211031' n=5, '211211' n=2, '211311' n=1, '211011 KAMPEERAUTO' n=6, '211 KASTENWAGEN' n=1, '211 PANEL' n=1 — a 6-digit VW order-code family, and the bare form only ever appears with a body word attached"
+    - "raw: nz_nzta VOLKSWAGEN '211' n=1"
+    - "catalog: consecutive numeric siblings 112,113,114,118,204,211,221,224,241,251,253 under one make — NAMING §2.1's presumptive shared-string/type-code family"
+    - "https://en.wikipedia.org/wiki/Volkswagen_Type_2  # does NOT list VW's numeric order codes — the resolution NAMING §7.5 demands is not available from reachable sources"
+  notes: >-
+    Candidate overlapping live ids exist (volkswagen/t2 'T2 KOMBI', type-2,
+    kastenwagen 'VOLKSWAGEN KASTENWAGEN', kasten, bestel) but the code cannot be
+    pinned to one generation, so id is unverifiable under R1 rather than
+    defective. kind: all rows are M1 → car is right even where inrichting is
+    kampeerwagen.
+
+"car/volkswagen/baja":
+  verdicts: { id: "defective(NEW-1)", name: "defective(NEW-1)", make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: nl_rdw live VOLKSWAGEN 'BAJA' n=2 (M1 sedan + 'Niet geregistreerd'), 'KEVER BAJA' n=2, 'BAJA BUGG' n=1, 'BAJA REPLICA' n=1 — 'kever' is Dutch for Beetle and the register itself says REPLICA"
+    - "raw: nz_nzta VOLKSWAGEN 'BAJA' n=6"
+    - "catalog: car/volkswagen/beetle is live; the same aftermarket-style cluster also holds beach-buggy, dune-buggy, bug, super-beetle"
+  notes: >-
+    A Baja Bug is an owner/aftermarket conversion STYLE of the Beetle, never a
+    Volkswagen model. Not D8 (no manufacturer trim/body), not D5 (no brand
+    prefix), not D3 (not a placeholder) → NEW-1. Availability is correct on R4:
+    the vehicles are real and are registered as Volkswagens.
+
+"car/volkswagen/bestel-0":
+  verdicts: { id: "defective(D6)", name: "defective(D1)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live VOLKSWAGEN 'BESTEL 0,8 D 50 KW' n=50, 'BESTEL 0,7 D 50 KW' n=11, 'BESTEL 0,8 50 KW KAT D' n=11, 'BESTEL 0,8 D 45 KW' n=9 … 139 distinct BESTEL* spellings / 617 vehicles, ALL inrichting kampeerwagen, all M1"
+    - "raw: fi_traficom 'Bestel 0,8 D 50KW' etc. (the record's observed_variants carry 16 such strings)"
+    - "DUPLICATE: catalog car/volkswagen/bestel (name 'Bestel', nl+nz) is live and its own raws are the SAME string family with integer payloads — 'BESTEL 44 KW', 'BESTEL 57 KW', 'BESTEL  TDI 75 KW'. The only thing separating the two ids is whether the payload figure has a decimal comma."
+    - "'bestel' is Dutch for a delivery/panel van (a body description, not a nameplate); the display name 'Bestel 0' is a fold artifact — NO register anywhere writes 'Bestel 0', they write 'BESTEL 0,8'"
+  notes: "kind car is legally right (M1) even though every row is a camper conversion."
+
+"car/volkswagen/caravelle-syncro":
+  verdicts: { id: "defective(D8)", name: "unverifiable(marque rendering of 'syncro' uncitable; see unverifiable_register)",
+              make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live VOLKSWAGEN 22 distinct 'CARAVELLE…SYNCRO' spellings / 32 vehicles — 'CARAVELLE 57KW SYNCRO' n=6, 'CARAVELLE SYNCRO' n=4, 'CARAVELLE SYNCRO TD 51 KW' n=5, 'CARAVELLE GL SYNCRO', 'CARAVELLE C, SYNCRO' … (M1)"
+    - "raw: fi_traficom TAN e1*96/79*0067*04 on the record; the fi row set is the T3/T4 Caravelle syncro"
+    - "catalog: car/volkswagen/caravelle ('Caravelle', 7 countries) is live — syncro is VW's four-wheel-drive DRIVETRAIN badge, i.e. an engine/driveline variant of the nameplate (NAMING §1)"
+  notes: "Same class as multivan-syncro / passat-syncro / vw 'syncro' ids (systemic, not swept)."
+
+"car/volkswagen/id-buzz":
+  verdicts: { id: "defective(D8)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { de: correct, gb: correct, lu: correct, my: correct, nl: correct,
+                              nz: correct, th: correct, ua: correct, us: correct } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Volkswagen_ID._Buzz  # the marque's form is 'ID. Buzz' — 'ID.' with a period, capital I and D, throughout"
+    - "raw: us_fueleconomy 'Volkswagen | ID. Buzz' and 'ID. Buzz 4motion' (MY2025) — a catalogue that preserves casing, and it writes ID."
+    - "raw: de de_kba_fz10 202606 sheet4 row 499 'ID. BUZZ' 1077; nl_rdw live 'ID. BUZZ PRO 150 KW' n=965 + 34 further ID.BUZZ spellings (2041 vehicles); gb uk_dft GenModel 'VOLKSWAGEN ID BUZZ' (ID BUZZ STYLE 3648 …); lu_snca 'ID.BUZZ 150 KW' 13; th_dlt 'ID BUZZ' 10; ua_mvs 'ID.BUZZ' 2 ЛЕГКОВИЙ; my_jpj 'ID.Buzz' 2; nz_nzta present"
+    - "catalog internal inconsistency: id-3='ID.3', id-4='ID.4', id-5, id-6, id-7 are all correctly cased — only the Buzz ids are 'Id.'"
+    - "DUPLICATE/ALTITUDE: car/volkswagen/id-buzz-pro is live and shares BOTH of this record's TANs (e1*2018/858*00164*01 and *04); id-buzz-gtx-kr, id-buzz-gtx-lr, id-buzz-pro-kr, id-buzz-pro-lr, id-buzz-pro-4motion, id-buzz-pure-kr are the same trim-as-model class"
+  notes: >-
+    Seven trim-level Id. Buzz ids sit beside the nameplate id; the TAN identity
+    with id-buzz-pro is the rank-1 proof for this one. Name defect is the same
+    D7 across all eight.
+
+"car/volkswagen/van":
+  verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { nl: correct, nz: correct } }
+  evidence:
+    - "raw: nl_rdw live VOLKSWAGEN 'VAN' n=1 (M1, inrichting kampeerwagen) — one vehicle; the 24 other VAN* spellings under VW are all 'VANAGON…' (a real nameplate, live as car/volkswagen/vanagon)"
+    - "raw: nz_nzta VOLKSWAGEN 'VAN' n=7 and 'VAN BUS' n=1"
+    - "marque: Volkswagen has no model named 'Van'; the generic body word is the register's fallback description"
+  notes: >-
+    Same generic-body-word class as car/volkswagen/kasten, kastenwagen, combi,
+    kleinbus, camper, cabrio, automatic, business, urban, special (systemic,
+    not swept). Availability correct on R4 — the vehicles are VW vans.
+
+"car/volvo/480":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, gb: correct, nl: correct, nz: correct } }
+  evidence:
+    - "raw: nl_rdw live VOLVO 36 '480*' spellings / 752 vehicles — '480 ES 2.0 I' n=143, '480 ES' n=107, '480 TURBO U9' n=93, bare '480' n=6 (M1 hatchback)"
+    - "raw: fi_traficom '2D SEDAN 480 ES-E-143E/2500' → '480' (M1) n=11; nz_nzta '480' 4 + '480ES' 6 + '480 ES' 2; gb uk_dft GenModel 'VOLVO 480' 744"
+    - "catalog: siblings 480-es and 480-turbo are trim-level ids of THIS nameplate (D8 against them, not against this record — this id IS the nameplate)"
+  notes: "Numeric nameplate is Volvo's own convention for the era (§7.2)."
+
+"car/volvo/850-wagon":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Volvo | 850 Wagon' us_fueleconomy MY1994-1996 (VClass station wagon)"
+    - "raw: ca_nrcan '850 GLT Wagon', '850 AWD Wagon', '850 2-valve Wagon', '850 4-valve Wagon' ('Station wagon: Mid-size')"
+    - "catalog: car/volvo/850 (9 countries) is live — the estate is a BODY of the 850 nameplate"
+
+"car/volvo/c303":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "DUPLICATE: catalog car/volvo/c303-4x4-1-v (name 'C303-4X4-1-V', fi+nl) is live and its raw is 'VOLVO C303-4X4-1-V' — the SAME register string form that also feeds this id ('C303 4X4-1-V', 'VOLVO C 303 4X4 1V' are in this record's own variants). One vehicle, two ids, split on punctuation."
+    - "raw: nl_rdw live VOLVO 24 'C303*' spellings / 54 vehicles — 'C303 4X4 1V' n=12, 'C303' n=10, 'C 303' n=5, 'VOLVO C303 4X4 1V' n=10 (M1)"
+    - "raw: fi_traficom 'C303-4X4-1-V' (M1G), 'C303 4X4 1V' (M1G), 'C303 4X4' (M1G), 'C 303 4X4 1v' (M1)"
+  notes: >-
+    kind car is correct on R5 (FI M1G, RDW Personenauto) even though the C303
+    Laplander is a military off-roader. body_types hatchback+wagon is wrong
+    (D16) — noted for the curation queue, not one of the five claims.
+
+"car/volvo/ec40-twin":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Volvo | EC40 Twin' us_fueleconomy MY2025 + MY2026, beside bare 'EC40'"
+    - "raw: ca_nrcan 'Volvo | EC40 Twin' and 'EC40' ('Sport utility vehicle: Small')"
+    - "catalog: car/volvo/ec40 ('EC40', 9 countries) is live — Twin (twin-motor AWD) is a powertrain variant"
+  notes: >-
+    Name accepted on the R3 fallback: volvocars.com and media.volvocars.com both
+    return HTTP 403 to this session, so the marque's own form (probably
+    'EC40 Twin Motor') could not be cited; the two government catalogues both
+    write exactly 'EC40 Twin'. Same treatment applied to xc40-b4 and xc60-d5.
+
+"car/volvo/p-54405-a":
+  verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom 'VOLVO P 54405 A Sedan (AA) 2ov 1580cm3' ×2 (M1) — a two-door sedan with the 1583 cc B16, i.e. a PV544"
+    - "raw: nl_rdw live VOLVO 'P54405 A' n=41, 'P 54405 A' n=9, 'P54405A' n=2, 'P54405' n=2, 'P 54405A' n=1 (M1 sedan, 55 vehicles)"
+    - "catalog: car/volvo/pv544 ('PV544', 4 countries, raws 'PV 544'/'VOLVO PV544') and car/volvo/p544 ('P544', raw 'P 544') are BOTH live — the nameplate is published twice already; sibling code-ids p-544-04-a ('VOLVO P 544 04 A') and p54403a ('VOLVO P54403A') prove this is a type-code FAMILY, not a nameplate"
+    - "https://en.wikipedia.org/wiki/Volvo_PV444/544  # does not document factory type numbers — the exact 544-05 variant stays unresolved (D9 remedy: 'resolve via raw + approval data; else debt')"
+  notes: >-
+    The class does not depend on resolving the variant: five live ids
+    (pv544, p544, p-544-04-a, p54403a, p-54405-a) denote one nameplate.
+
+"car/volvo/xc40-b4":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { ca: correct, us: correct } }
+  evidence:
+    - "raw: 'Volvo | XC40 B4' us_fueleconomy MY2023 + MY2026; ca_nrcan 'XC40 B4 AWD' ('Sport utility vehicle: Small') — matches the record's own variant 'XC40 B4 AWD'"
+    - "catalog: car/volvo/xc40 (13 countries) is live; xc40-b5, xc40-t2, xc40-t4, xc40-recharge, xc40-recharge-twin are the same engine-badge-as-model class"
+  notes: "B4 is Volvo's mild-hybrid engine badge — an engine variant of the nameplate (NAMING §1). Name form is Volvo's own badge and both catalogues write it."
+
+"car/volvo/xc60-d5":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { es: correct, nl: correct } }
+  evidence:
+    - "raw: es_dgt 202604-06 'VOLVO|XC60 D5 AWD R|M1G' n=1 (the record's own variant string)"
+    - "raw: nl_rdw live VOLVO 'XC60 D5 AWD' n=2 (M1 stationwagen) + 'XC60 D5' n=1 (M1 MPV)"
+    - "catalog: car/volvo/xc60 (14 countries) is live; xc60-b5, xc60-b6, xc60-2-0t, xc60-fwd are the same class"
+  notes: "Three vehicles in nl, one in es — a thin engine-variant id beside a 14-country nameplate."
+
+"car/zeekr/009":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { my: correct, nz: correct, th: correct, ua: correct } }
+  evidence:
+    - "https://www.zeekrglobal.com/models  # the marque lists 'ZEEKR 009' (brand wordmark in caps + bare model number) — capture: captures/zeekr.html"
+    - "raw: my_jpj 'Zeekr | 009' n=1244 (window_van 1234 / jip 7 / MPV 3); th_dlt 'ZEEKR 009' n=1904 (passenger ≤7); nz_nzta '009' n=21; ua_mvs 'ZEEKR|009' n=19 ЛЕГКОВИЙ"
+    - "catalog sibling sweep car/zeekr (001, 009, 7GT, X): no overlap"
+  notes: "kind car is right (M1 MPV) despite MY's 'window_van' type string — my_jpj declares kinds=[:car] and ignores the type column (see NEW-3 for where that bites)."
+
+"truck/all-wheel-drive/tl":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { gb: correct } }
+  evidence:
+    - "raw: gb uk_dft BodyType 'Heavy goods vehicles', Make 'ALL WHEEL DRIVE', GenModel 'ALL WHEEL DRIVE TL 8-14' 137, 'TL 17-18' 9, 'TL 13-16' 9, 'TL 10-14' 6, 'TL 9-14' 2, 'TL 12-16' 2, 'TL 20-18' 2, 'TL 7-14' 1, 'TL 21-16' 1 (HGV rows exist under 5 body types; the truck kind is properly evidenced)"
+    - "https://en.wikipedia.org/wiki/Bedford_TL  # 'TL' in capitals; production restarted 1988 under AWD, also-called 'AWD TL'; AWD's later designations '17-18'/'17-27' match DVLA's 'TL 17-18'"
+  notes: >-
+    make judged CORRECT: 'All Wheel Drive' is the right marque ENTITY (All Wheel
+    Drive Ltd, the post-1987 Bedford truck business). Flagged for the make-name
+    canonicality queue rather than as a defect on this claim: the trucks were
+    badged 'AWD', so the display make is the expanded corporate string
+    (D12-family, cf. D23 for the mirror case). A verifier who reads
+    'make-correct' as including the marque's rendering should flip this to
+    defective(D12) — the evidence is the same.
+
+"truck/bucher/citycat":
+  verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { es: correct, fi: correct, nl: correct } }
+  evidence:
+    - "https://www.buchermunicipal.com  # the marque writes 'CityCat' in prose — 'CityCat VR17a', 'CityCat VR17', 'CityCat WR50', 'CityCat VR50 80 kW' (9 CityCat vs 8 'Citycat', the latter only inside image filenames) — capture: captures/bucher2.html"
+    - "DUPLICATE: catalog truck/bucher/city (name 'City', fi+lu) is live and its raws are 'CITY CAT 5006' and 'CITY-CAT' — the same product with a space/hyphen. nl_rdw live confirms both spellings under one make: 'CITYCAT 5006' N2 n=22 and 'CITY CAT 5006' n=2 (+ 'CITY CAT 5000' N2 n=2 under BUCHER-GUYER)."
+    - "raw: es_dgt 202604 'BUCHER|CITYCAT VR50|N2' n=1 (the other 11 VR50 + 11 V20 rows carry the Spanish national category MAA, which is unmapped → the truck kind rests on the one N2 row); fi_traficom 'CityCat VR50' N2 n=1 TAN e1*2018/858*00484*01; nl_rdw live 'CITYCAT 5006' N2 Bedrijfsauto n=22, 'CITYCAT VR50' N2 n=14"
+  notes: >-
+    A compact street sweeper: most register rows are special-machine categories
+    (RDW 'Mobiele machine'/'Motorrijtuig met beperkte snelheid', ES MAA) and only
+    a minority are N2 — the truck kind is correct per R5 but rests on a thin
+    slice of the make's fleet. Worth a kind-boundary note for municipal machines.
+
+"truck/chevrolet/20-starcraft-3-9t-fg25f":
+  verdicts: { id: "defective(D6)", name: "defective(D1)", make: correct, kind: correct,
+              availability: { fi: correct } }
+  evidence:
+    - "raw: fi_traficom 'CHEVY VAN 20-STARCRAFT-3.9T-FG25F/343' N2 n=593 (+ n=19 without /343) — the register string is <nameplate> <series>-<converter>-<GVW>-<FI type code>/<wheelbase>; the id keeps everything EXCEPT the nameplate"
+    - "DUPLICATES: truck/chevrolet/20-3-9t-fg25f (raw 'CHEVY VAN 20-3.9T-FG25F/343', fi) — the same vehicle without the converter token; truck/chevrolet/starcraft (raws 'Chevy Van Starcraft', 'STARCRAFT G30 6,2L DIESEL', fi+nl); truck/chevrolet/van (raws 'CHEVROLET CHEVY VAN', 'CHEVY VAN'). Four live ids for the Chevy Van 20."
+    - "nl_rdw live corroborates the same string family: 'CHEVY VAN 20 STARCRAFT' N1 n=65+23, 'CHEVY VAN STARCRAFT' N1 n=62, 'STARCRAFT G30 6,2L DIESEL' N2 n=1"
+  notes: "Also a NEW-1 instance (Starcraft = US van converter). D1 chosen for the name because no register writes this display string."
+
+"truck/chevrolet/cheyenne":
+  verdicts: { id: "defective(D8)", name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live CHEVROLET N2 'CHEYENNE' n=3, 'CHEYENNE 20' n=4, 'CHEYENNE 3500' n=1, 'CHEYENNE 20 PICK-UP' n=1, 'C20 CHEYENNE' n=1 (+127 vehicles in N1); fi_traficom 'Cheyenne LTZ' N2G n=3, 'Cheyenne C 20' N2, 'CHEYENNE 3500 PICK-UP' N2, 'K2500 Cheyenne' N2G, '2500 CHEYENNE-3.9T-GK24F/334' N2"
+    - "ALTITUDE: Cheyenne is a C/K-series TRIM in the US rows and the trim strings are already inside other live ids — truck/chevrolet/k2500 carries 'K2500 Cheyenne' and truck/chevrolet/c20 carries 'C20 CHEYENNE'"
+  notes: >-
+    Deliberately NOT called a phantom: 'Cheyenne' IS a marketed nameplate in
+    Mexico (the local Silverado) and fi's 'Cheyenne High Country'/'Cheyenne LTZ'
+    rows are exactly those. The record therefore conflates a Mexican nameplate
+    with a US trim level; the defect recorded is the altitude split, and the
+    name form is the marque's either way.
+
+"truck/chevrolet/k":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live CHEVROLET N2 'K30 PICK UP 4X4' n=6, 'K 2500' n=5, 'K2500' n=2, 'K 20 SILVERADO CAMPER SPECIAL' n=1 (+375 vehicles in N1); fi_traficom 'K2500' N2G n=6, 'K2500HD SILVERADO' N2G n=5, 'K2500 SUBURBAN' N2G n=3"
+    - "DUPLICATES: truck/chevrolet/k2500 (raws 'K2500 Cheyenne','K2500 HD SILVERADO','K2500 SUBURBAN'), k2500hd, k3500 are all live — the bare 'K' id holds the same vehicles' other spellings ('K 2500','K 3500','K 30')"
+    - "marque: 'K' is GM's 4WD CHASSIS code (C = 2WD, K = 4WD) inside the C/K series designation, not a model name"
+  notes: "The 'K 2500 SUBURBAN' rows are an SUV in the truck kind — kind noise, not scored here."
+
+"truck/chevrolet/pick-up":
+  verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live CHEVROLET N2 'PICK UP' n=1, 'C30 PICK-UP' n=1, 'PICKUP 2500 EXT.CABTD 4X4' n=1, 'PICKUP 2500 EXT CABTD 4X4' n=1, 'K30 PICK UP 4X4' n=6 (+1357 in N1); fi_traficom '2500 FLEETSIDE PICKUP-3.9T-GK24F-4X4/334' N2 n=24, '1500 FLEETSIDE PICKUP-3.6T-EK19S-4X4/359' N2 n=25"
+    - "marque: 'Pick Up' is a body descriptor; Chevrolet's nameplates for these are C/K, Silverado, Cheyenne — all live as separate ids (c20, c3500, k2500, k3500, silverado, cheyenne, 1500, 2500, 3500)"
+    - "catalog: the same make also publishes 'Pick' (truck/chevrolet/pick) — a second fragment of the same word"
+  notes: "The record carries former_ids, i.e. something was renamed INTO this generic form — worth the curation queue's attention."
+
+"truck/chevrolet/van":
+  verdicts: { id: "defective(D6)", name: "defective(D5)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: this id's own observed_variants are exactly ['CHEVROLET CHEVY VAN', 'CHEVY VAN'] — the nameplate IS 'Chevy Van'; the prefix strip removed 'CHEVY' (a Chevrolet make alias) and fabricated the generic 'Van'"
+    - "raw: nl_rdw live CHEVROLET N2 'CHEVY VAN 30' n=20, 'CHEVY VAN' n=9, 'CHEVY VAN 30 KAMPEERAUTO' n=3 (+1682 in N1: 'CHEVY VAN' n=217, 'CHEVY VAN 20' n=317); fi_traficom 'CHEVY VAN 20-3.9T-FG25F/343' N2 n=154, 'CHEVY VAN 30-GG35Y/318' N2 n=17"
+    - "DUPLICATES: truck/chevrolet/starcraft, 20-3-9t-fg25f, 20-starcraft-3-9t-fg25f are all fed by 'CHEVY VAN …' strings too"
+  notes: >-
+    D5 with the arrow reversed: the strip is correct for 'CHEVROLET CHEVY VAN'
+    but wrong for 'CHEVY VAN', where CHEVY is part of the nameplate. The
+    remedy is a scoped exception, not a rename.
+
+"truck/citroen/jumper":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live CITROEN N2 'JUMPER' n=22, 'CITROEN JUMPER' n=4, 'E.JUMPER' n=5, 'JUMPER TURBO D' n=1 (35 vehicles; the bulk of the Jumper fleet is N1 → the van kind, which is correct and separate)"
+    - "raw: fi_traficom 'JUMPER' N2 n=174, 'Jumper' N2 n=86, 'JUMPER FOURGON 2.8HDI-ZCPMNC/370' N2 n=105 …"
+    - "marque: Jumper is Citroën's own nameplate for the Ducato-platform van (Relay in the UK) — no sibling id overlaps"
+  notes: "Heavy-variant Jumpers really are N2; the truck-kind record is legitimate."
+
+"truck/daf/fancf":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { es: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live DAF N3 'FAN CF85' n=121, 'FAN CF75' n=117, 'FAN CF ELECTRIC' n=43, 'FAN CF' n=35 (116 groups / 789 vehicles) — the register writes FAN and CF as SEPARATE tokens; 'FANCF85.360T' (this id's raw) is the squashed minority form"
+    - "raw: es_dgt 202604-06 'DAF|FANCF85|N3' n=1, and in the same three months 'DAF|FAN CF75|N3', 'DAF|CF460 FAN|N3', 'DAF|XF 480 FAN|N3', 'DAF|XD 450 FAN|N3' — FAN attaches to XF/XD/CF alike, i.e. it is the 6x2 axle configuration, not a model"
+    - "DUPLICATES: truck/daf/fan (raws 'DAF FAN CF85','DAF FAN XF105'), truck/daf/cf, truck/daf/xf, truck/daf/fascf are all live for the same vehicles"
+    - "https://www.daf.com/en/trucks  # 404 page, but the marque's own nav lists the model range as XB / XD / XF / XG (+XFC/XDC electrics) — no 'FANCF'"
+  notes: "24 axle-code ids exist under truck/daf (fa, fad, fag, fak, falf, fam, fan, fancf, far, fas, fascf, fat, fatcf, fatxf, fax, ft, ftg, ftgxf, ftm, ftp, ftr, fts, ftt, ftxf) — sized, not swept."
+
+"truck/daf/fas":
+  verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { es: correct, fi: correct, gb: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live DAF N3 'CF 410 FAS' n=98, 'FAS XF105' n=90, 'FAS CF85' n=88, 'CF 450 FAS' n=55, 'XF 480 FAS' n=40 (193 groups / 1001 vehicles) — FAS appears on BOTH sides of the nameplate, never alone as a product"
+    - "raw: gb uk_dft HGV Make 'DAF TRUCKS' GenModel 'DAF TRUCKS FAS' 494, 'FAS 75CF' 30, 'FAS 85CF' 10, 'FAS 95XF' 29 (+ Make 'DAF' 'DAF FAS 2100'/'DAF FAS 2500', and LEYLAND DAF rows under its own make)"
+    - "raw: fi_traficom 'XF 530 FAS' N3 n=35, 'XF 510 FAS' n=6, 'CF85.360FAS' n=2; es_dgt 'FAS CF 85' N3, 'FASCF85.410T' N3, 'CF 440 FAS' N3"
+    - "DUPLICATES: truck/daf/xf's own raws include 'DAF XF 480 FAS' — the identical string form feeds both ids; truck/daf/fascf is a third"
+  notes: "FAS = 6x2 rigid axle configuration in DAF's type designation. The nameplates (XF/CF/XG/XD/LF) are all live ids already."
+
+"truck/daf/ftg":
+  verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct, gb: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live DAF N3 'XF 480 FTG' n=1110, 'XG 480 FTG' n=603, 'XF 460 FTG' n=404, 'XF 530 FTG' n=282, 'FTG XF105' n=152 (76 groups / 3796 vehicles) — the dominant form is <nameplate> <power> FTG"
+    - "raw: gb uk_dft HGV 'DAF TRUCKS FTG XF' 930, 'FTG CF' 813, 'FTG 95XF' 130, 'FTG 85CF' 44; fi_traficom 'XF 530 FTG' N3 TAN e4*2007/46*0002*24, 'XG+ 480 FTG' N3"
+    - "DUPLICATES: truck/daf/ftgxf ('Ftgxf') and truck/daf/xf / xg are live for the same vehicles"
+  notes: "Same class as fas/fancf; 3796 NL vehicles makes this the largest-volume D9 in the slice."
+
+"truck/daf/v1600dd":
+  verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live DAF N3 'V1600DD358' n=4, 'V1600BB358' n=5, 'V1600 BB 358' n=2, '_V1600 DT 358' n=1 (35 groups / 41 vehicles) — V1600 is the series and BB/DD/DT are chassis/body codes, so the id keeps a code suffix and drops nothing else"
+    - "raw: fi_traficom 'V1600DD' N3 n=1 (this record's raw 'V1600DD 358')"
+    - "catalog: no other live DAF id denotes this vehicle (no v1600 / 1600 id exists) → id correct on R1"
+  notes: >-
+    Name is a chassis/type code (DAF's 1960s-70s range was marketed as the
+    1600/2000/2600 series). The register's own sibling codes V1600BB/DT are
+    NOT published, so this id also under-covers its own family.
+
+"truck/de-soto/sc":
+  verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom make 'DE SOTO' mallimerkinta 'SC3-HA6-171/4340-56' N2 n=1 — the FI pattern is <model>-<body>-<wheelbase inches>/<mm-year>, i.e. SC3 body HA6, 171in wheelbase, 1956"
+    - "raw: nl_rdw live 'DE SOTO' N2 'SC-HA-171' n=1 (plus '105 AL', 'S 64 L', 'SLD 800-192' — the same code-string shape across this make's 5 truck rows)"
+    - "catalog: truck/de-soto has exactly one model id → id correct on R1"
+  notes: >-
+    Two vehicles worldwide. De Soto's export trucks were Dodge-derived and
+    carried these series/body codes; 'Sc' as a display name is the leading
+    fragment of one. D9's remedy is 'resolve via raw + approval data; else
+    debt' — nothing reachable resolves it.
+
+"truck/fiat/burstner":
+  verdicts: { id: "defective(NEW-1)", name: "defective(NEW-1)", make: correct, kind: "defective(D10)",
+              availability: { gb: correct } }
+  evidence:
+    - "raw: gb uk_dft BodyType 'Heavy goods vehicles', Make 'FIAT', GenModel 'FIAT BURSTNER', Model 'BURSTNER ARGOS A 747-2 G' 8+3, 'BURSTNER ARGOS A747-2 AUTO' 8, 'BURSTNER BREVIO T601' … — every Model string is a Bürstner motorhome model on a Fiat Ducato chassis"
+    - "catalog: 'burstner' is in overrides/makes/drop.yml as a make (motorhome coachbuilder) yet survives here as a Fiat MODEL — the G18 kind-scoping gap in a new shape"
+    - "kind: a motorhome's EU category is M1 (special purpose, SA bodywork) regardless of mass; DVLA's HGV BodyType is a taxation class (private HGV >3.5t), so the uk_dft kind_map HGV→truck imports it as a truck (same mechanism as G7's Atego-in-car, opposite direction)"
+  notes: "Availability correct on R4 — the vehicles exist and are registered with FIAT in the make column."
+
+"truck/fiat/swift":
+  verdicts: { id: "defective(NEW-1)", name: "defective(NEW-1)", make: correct, kind: "defective(D10)",
+              availability: { gb: correct } }
+  evidence:
+    - "raw: gb uk_dft HGV Make 'FIAT' GenModel 'FIAT SWIFT EDGE' Model 'SWIFT EDGE 466 S-A' 4, 'FIAT SWIFT CARRERA' / 'SWIFT CARRERA 244 AUTO' 1; the same GenModel family also appears under BodyType Cars ('SWIFT KONTIKI 649', 'SWIFT BESSACARR 560 LOUNGE S-A') and Buses ('SWIFT BOLERO 724FB S-A')"
+    - "marque: Swift Group is a British motorhome/caravan manufacturer; Fiat has no 'Swift' model (Suzuki does — a cross-make collision hazard: car/suzuki/swift is live)"
+    - "catalog: truck/ford/swift is live too — the SAME converter brand under a second chassis marque, which is NEW-1's cheap detector signal"
+  notes: "Kind defective for the same reason as fiat/burstner."
+
+"truck/ford/350":
+  verdicts: { id: "defective(D6)", name: "defective(D1)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: this id's own variants are ['350 ECOLINE', '350 ECONOLINE'] — the nameplate is Econoline/E-350 and the id keeps only the series number"
+    - "DUPLICATES: truck/ford/econoline (raws 'ECONOLINE 350', 'ECONOLINE 350 CLUBWAGON XLT', 'ECONOLINE E 350') and truck/ford/e-350 (raws 'E-350 ECONOLINE', 'E-350 ECOLINE') are BOTH live — three ids, one vehicle, differing only in token order"
+    - "raw: nl_rdw live FORD N2 'ECONOLINE 350' n=4, '350 ECONOLINE' n=2, 'ECONOLINE' n=2, 'ECONOLINE E350' n=1; fi_traficom 'ECONOLINE E350-HA61D-SUPER CLUB/351' N2"
+    - "marque: Ford's forms are 'E-350'/'Econoline'; no register writes a bare '350' as a Ford product name"
+  notes: "The fi rows this id was built from also include Transit 350L strings in the same register — a second conflation risk (truck/ford/transit is live)."
+
+"truck/ford/f-150":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom 'F150' N2G n=92, 'F-150' N2G n=84, 'F 150' N2G n=13, 'F-150 RAPTOR' n=12, 'F-150 XLT' n=9"
+    - "raw: nl_rdw live FORD N2 'F-150 LIGHTNING' n=3, 'FORD F-150' n=3, 'FORD F150 XLT' n=3, 'FORD F150 LARIAT' n=3, 'F 150' n=3 (26 groups / 40 vehicles; the bulk is N1)"
+    - "marque: 'F-150' with the hyphen is Ford's own form and is the register's dominant form too"
+    - "catalog: siblings f-250/f-350/f-450/f-600 are distinct models; no id duplicates the F-150"
+  notes: >-
+    NEW-2 instance: this record's xrefs.tan contains the literal placeholder
+    '- (FMVSS)', shared with 33 unrelated records across car/truck/motorcycle.
+    Not scored against the five claims, flagged as detector poison.
+
+"truck/ford/f-max":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { es: correct, lu: correct, nl: correct } }
+  evidence:
+    - "https://www.fordtrucks.com.tr/en  # Ford Trucks' own site renders it 'F-MAX' — 75 occurrences of 'F-MAX' (page title/nav/prose: 'F-MAX tractor, road and construction…'), 0 of 'F-Max' — capture: captures/ford_max.html"
+    - "raw: es_dgt 202604-06 'FORD|F-MAX|N3' n=32; lu_snca 'FORD|F-MAX|N3' n=3; nl_rdw TAN e9*2007/46*0089*38/*39 on the record"
+    - "catalog: no sibling denotes the F-MAX (f-line, f-600, f700 are other products)"
+  notes: >-
+    A 'weird can be right' case in reverse — the marque's rendering IS the
+    all-caps one (it is the Turkish-built heavy tractor brand's wordmark used in
+    running text on their own product pages), and the catalog title-cased it.
+
+"truck/ford/f250xlt":
+  verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live FORD N2 'F250 XLT' n=5, 'F 250 XLT' n=2, 'F250XLT' n=1, 'F 250 XLT LARIAT' n=1 — the glued form is a 1-vehicle minority spelling of a spaced form"
+    - "raw: fi_traficom 'F250 XLT SUPER DUTY' N2G n=21 (and 'F250' N2G n=129, 'F 250' n=37, 'F-250' n=16)"
+    - "DUPLICATE: truck/ford/f-250 is live (raws 'F-250 4X4', 'F-250 LARIAT SUPER DUTY', 'F-250 RANGER XLT') — XLT is a Ford trim level, so this is both a spelling twin and an altitude error"
+    - "marque: Ford writes 'F-250' + trim as separate tokens ('F-250 XLT')"
+  notes: "D7 recorded for the name (glued tokens, missing hyphen); D8 also applies to the trim — one class per finding, altitude noted here."
+
+"truck/ford/ranger":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: "defective(D6)" } }
+  evidence:
+    - "raw fi (GOOD): fi_traficom 'Ranger' N2G n=1113, 'Ranger Raptor' n=43, 'Ranger Wildtrak' n=19, 'Ranger Tremor' n=5 — genuine Ranger pickups over 3.5t"
+    - "raw nl (BAD): every N2/N3 RANGER row in nl_rdw is an F-series with the 1970s-80s 'Ranger' TRIM — 'F250 RANGER' n=2, 'F-250 RANGER XLT' n=2, 'F250 RANGER XLT' n=2, 'F350 RANGER XLT' n=2, 'F350 RANGER' n=1, 'RANGER XCT F250' n=1 (22 vehicles). The Ranger NAMEPLATE's own NL rows are N1 (5712 vehicles) → the van kind. truck/ford/f-250's own raws include 'F-250 RANGER XLT', i.e. the same vehicles are already there."
+    - "this id's own observed_variants confirm the misattribution: 'RANGER F 250', 'RANGER F250', 'RANGER XCT F250'"
+  notes: >-
+    The only availability defect in the slice that is NOT a phantom-model
+    knock-on: nl's truck-kind rows evidence the F-250, not the Ranger. Under R4
+    this is defective; the fi claim stands on its own.
+
+"truck/fordson/wot":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/Fordson_WOT  # 'WOT' all caps ('War Office type/truck'); a FAMILY covering WOT1, WOT2, WOT3, WOT6, WOT8"
+    - "raw: fi_traficom 'WOT SUSSEX' N2 n=1; nl_rdw live FORDSON N2 'WOT 6' n=1 (the make's other N2 rows are 'BB 18 F' and '-')"
+    - "catalog: truck/fordson has one model id → id correct on R1"
+  notes: >-
+    Casing is the scored defect. Altitude is arguable in both directions (the
+    id covers WOT 6 and 'WOT SUSSEX' with 1 vehicle each) and is left as a note
+    rather than stretched into a second verdict.
+
+"truck/gmc/cckw":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "https://en.wikipedia.org/wiki/GMC_CCKW  # 'CCKW' all caps, and the letters are a code (C=1941 design, C=conventional cab, K=all-wheel drive, W=dual rear axles); 352/353 are the two wheelbases"
+    - "raw: nl_rdw live 'G.M.C.' N2 'CCKW 353' n=83 across spellings, 'CCKW353' n=20, 'CCKW 353-VAB' n=20 (103 groups / 310 vehicles); fi_traficom 'CCKW353' N2G, 'CCKW 353' N2, 'CCKW-353-6X6/3570+1140' N2"
+    - "catalog: truck/gmc has no other id for this vehicle"
+  notes: >-
+    Textbook D23-shaped defect on a MODEL name (single Titlecase token, ≤4
+    chars, ≤1 vowel) — the same shortlist rule that finds 'Ktm' finds 'Cckw',
+    and here the marque evidence confirms it.
+
+"truck/isuzu/nqr":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, gb: correct, nl: correct } }
+  evidence:
+    - "raw: gb uk_dft HGV Make 'ISUZU TRUCKS' GenModel 'ISUZU TRUCKS NQR' Model 'NQR 70' 298 Licensed + 1008 SORN — Isuzu Truck UK's own model designation, all caps"
+    - "raw: nl_rdw live ISUZU N2 'NQR' n=3, 'NQR70G-5L' n=1, 'NQR 70 L 5LX' n=1, 'NQR70LL' n=1, 'NQR70PL' n=1; fi_traficom 'NQR-NQR70LL-7.5T/336' N2, 'NQR 70' N2"
+    - "catalog: truck/isuzu has no overlapping id"
+  notes: "NQR is Isuzu's N-series cab/GVW code and is written in capitals by every source including the marque's UK arm (GenModel is DVLA's copy of the manufacturer's own designation)."
+
+"truck/iveco/260s":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { es: correct, fi: correct, nl: correct } }
+  evidence:
+    - "DUPLICATE: truck/iveco/260 (name '260', fi+nl) is live and its OWN raws include '260 S' and '260 S/P' — the identical strings that feed this id ('260S/P', '260S/PS')"
+    - "raw: nl_rdw live IVECO N3 '260S/P' n=1, '260S/PS' n=3, '260 S/P' n=1 (8 vehicles on the leading-260S form; the make's other 374 N3 vehicles are Stralis/Trakker forms like 'AD260SY/PS', 'AS260SY/FS')"
+    - "raw: es_dgt 'IVECO|MAGIRUS 260S/E4|N3' n=1 (this record's own variant); fi_traficom '260S' N3 n=16"
+    - "marque: Iveco's product names are EuroTech/EuroTrakker/Stralis/Trakker/S-Way (all live ids); 260S is the GVW+chassis code inside e.g. 'AS260S'"
+  notes: "133 numeric/code ids under truck/iveco — the largest code-as-model cluster in the slice's makes."
+
+"truck/iveco/40c17d":
+  verdicts: { id: "defective(D6)", name: "defective(D8)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "DUPLICATE: truck/iveco/40c17 is live with the raw '40C17 EURO V HD EEV' — this id's raws are '40C17D EURO V HD EEV', '40C17D/T EURO V HD EEV', '40C17D 345', '40C17D 375'. Same vehicle, one letter apart."
+    - "raw: nl_rdw live IVECO N2 '40C17D EURO V HD EEV' n=5, '40C17D/T EURO V HD EEV' n=2, '40C17D' n=1 (and bare '40C17' N2 n=465); fi_traficom '40C17D 375' N2 n=2, '40C17D 345' N2 n=1 (bare '40C17' N2 n=10+)"
+    - "ALTITUDE: truck/iveco/daily is live (raws 'DAILY 35C15', 'DAILY 40/35C', 'DAILY 40.10 WD') — 40C17 is a Daily variant designation; Iveco's own form is 'Daily 40C17'"
+  notes: "The catalog publishes ~40 Daily variant codes as models (35C.., 40C.., 50C.., 65C.., 70C..) beside the Daily nameplate id."
+
+"truck/iveco/60c16":
+  verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom '60C16' N2 n=1 TAN e3*2007/46*0115*18 (the record's own TAN); nl_rdw live IVECO '60C16' N2 n=1"
+    - "ALTITUDE: truck/iveco/daily is live; 60C16 is the 6-tonne/160hp Daily variant and Iveco writes it 'Daily 60C16' — the sibling id 60c15 is the same class"
+    - "catalog: no exact spelling twin → the defect is altitude, not duplication"
+  notes: "Two vehicles total. Global decile 9."
+
+"truck/iveco/80el":
+  verdicts: { id: "defective(D8)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live IVECO N2 '80EL' n=48 across 13 groups; fi_traficom '80EL' N2 n=1 TAN e3*2007/46*0202* (note the truncated TAN in the record's xrefs — trailing '*' with no extension)"
+    - "ALTITUDE: truck/iveco/eurocargo is live (raws 'EUROCARGO 75E15', 'EUROCARGO 100E22'…) and truck/iveco/80e18 / 80e are live siblings — 80E.. is the EuroCargo GVW+power code"
+    - "marque: Iveco's form is 'EuroCargo 80E18'; '80EL' matches no Iveco product name (the 'L' is a chassis/wheelbase letter)"
+  notes: "Both defects are on the same underlying fact; D8 recorded for the id (nameplate exists), D9 for the name (code, and not even a well-formed one)."
+
+"truck/land-rover/defender":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, gb: correct } }
+  evidence:
+    - "raw: fi_traficom Land Rover N2G rows exist — 'DEFENDER 130' n=3 (one carrying TAN E5*2007/46*0092*09), 'DEFENDER 130 PICKUP CREW CAB 2.5TD5-LDKH5-4X4/323' n=1, 'DEFENDER 110' N2G n=1 (74 N2G vehicles in total, against 6291 M1G and 1181 N1G)"
+    - "raw: gb uk_dft Make 'LAND ROVER' GenModel 'LAND ROVER DEFENDER' under BodyType 'Heavy goods vehicles' = 161 vehicles (Cars 73860, LGV 121110 — the truck slice is small but real)"
+    - "marque: 'Defender' is Land Rover's own nameplate; no sibling id in the truck kind overlaps"
+  notes: >-
+    The shared TAN with car/land-rover/defender (e5*2007/46*0092*10) is
+    CORRECT data — one approval spans M1G and N2G variants — and is logged as a
+    NEW-2 false-positive case for any TAN-equality duplicate detector.
+
+"truck/liebherr/lg":
+  verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live LIEBHERR N3 'LG 1750' n=45, 'LG 1550' n=3, 'LG 1800-1.0' n=3 — the marque's lattice-boom crane series, always capitals"
+    - "raw: fi_traficom 'LIEBHERR LG 1150' N3 n=1, 'LG1750' N3G n=1"
+    - "catalog: truck/liebherr's other ids (ltm, ltc, mk) are different crane families → id correct on R1"
+  notes: >-
+    Family-prefix altitude (the products are LG 1550/1750/1800) is arguable but
+    the LG series is genuinely marketed as a series; only the casing is scored.
+
+"truck/liebherr/utm":
+  verdicts: { id: "defective(D9)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "DUPLICATE/RESOLUTION: truck/liebherr/ltm's OWN raws include 'LTM 1030-2-UTM 625' — the UTM number is a sub-code INSIDE the LTM mobile-crane designation (the carrier/undercarriage type). fi_traficom shows the same nesting: 'LTM 1055/1UTM735-6X6' n=2, 'LTM1200UTM565-12X8', 'LTM1200-1-UTM755-10X4', 'LTM 1500 UTM 680'."
+    - "raw: nl_rdw live LIEBHERR N3 'UTM 625' n=4, 'UTM 630' n=3, 'UTM 532' n=3, 'UTM 530' n=2, 'UTM 555'/'UTM 655'… (11 groups / 19 vehicles); fi_traficom 'UTM845' N3, 'UTM 645' N3"
+    - "marque: Liebherr markets no product named UTM (its mobile-crane families are LTM/LTF/LTC/LG/LR/MK) — so the display form has no marque rendering to match; the registers write it in capitals"
+  notes: >-
+    id defective because the same machines are already under truck/liebherr/ltm
+    (proved by the nested string), name defective on casing only; the altitude
+    question ('is UTM a nameplate at all?') is answered NO but the fix belongs
+    with the LTM records.
+
+"truck/man/12":
+  verdicts: { id: "defective(D6)", name: "defective(D1)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live MAN N2/N3 '12 LL' n=9, '12.192 FL/BL-V' n=7, '12.192 F-V' n=3, '12.192 F' n=2 (47 groups / 67 vehicles); fi_traficom '12.224 LL/458' n=6, '12.224 LL/368' n=5, '12.220 BL/328' n=5, '12.225 LLC/458' n=3"
+    - "DUPLICATE: truck/man/12-170f (name '12.170F', raw '12.170F/3800') is live — the same '12.<power>' designation family"
+    - "marque: MAN's form is '<tonnes>.<power><cab code>' (12.192, 12.224); a bare '12' is the tonnage prefix only and is written by no register as a product"
+  notes: "This id's own variants ('12. 192 FL-FL-B-12,8T', '12. 225 LL /458') show the fold splitting at the decimal point."
+
+"truck/man/18ml":
+  verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live MAN N3 '18 ML' n=12 across groups, '18 MLL' n=3, '18 MLT' n=2 (13 groups / 24 vehicles) — the register writes the tonnage and the cab code as separate tokens"
+    - "raw: fi_traficom '18ML' N3 n=1"
+    - "marque: MAN's designation is '<tonnes>.<power> <cab>' (e.g. 18.360 ML); '18ML' drops the power figure and glues the rest — the nameplate-level ids (f2000/tga/tgx) exist separately"
+    - "catalog: no exact spelling twin under truck/man → id correct on R1"
+
+"truck/man/8-150-f":
+  verdicts: { id: "defective(D8)", name: "defective(D6)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom 'TGL 8.150' N2 n=9, 'TGL 8.150/3050 4X2 BL' n=4, 'TGL/8.150 4X2 BL' n=1, 'TGL 8.150-BL' n=1 — the nameplate token TGL is present in the majority of FI rows; bare '8.150 BB/425' n=2, '8.150 4X2 BB 7.49/395' n=2"
+    - "raw: nl_rdw live MAN N2 'TGL 8.150 4X2 BB' n=2, 'TGL 8.150 4X2 BL' n=2, '8.150FAE 4X4' n=1, \"8.150'F\" n=1, '8.150 FAE 4X4' n=1"
+    - "ALTITUDE: truck/man/tgl (name 'TGL') is live and is the nameplate these rows belong to"
+    - "SPELLING TWIN inside the id: observed_model_names for this id are [\"8.150'F\", '8.150-F'] — an apostrophe/hyphen pair (D6/D17 shape) collapsed into one display form"
+  notes: "D8 on the id (TGL exists), D6 on the name (two spellings, one id, and the chosen form is the register's rarer one)."
+
+"truck/man/h39":
+  verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "RESOLUTION: fi_traficom's row is 'H39 TGA 41.440 8x4 BB' N3 — the code H39 PRECEDES the commercial name (TGA 41.440), i.e. it is a type/chassis code, and truck/man/tga is live with 'MAN TGA 35.480 8X6H BB/2505'-style raws"
+    - "raw: nl_rdw live MAN N3 bare 'H39' n=14 across 5 groups (so the string does stand alone in NL, but the FI row identifies what it denotes)"
+    - "catalog: siblings h=H, h25, h36, h39 form a code family; h36 has no observed variants at all"
+  notes: "Same class as h25/h36 (not swept). The vehicle is an MAN TGA."
+
+"truck/man/hn":
+  verdicts: { id: correct, name: "defective(D1)", make: correct, kind: correct,
+              availability: { es: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live MAN N3 'HN 19 FT' n=1, 'HN 19 F' n=1, 'HN26 FNLC' n=1; es_dgt 202604-06 'MAN|HN 19 F|N3' n=1"
+    - "the display name drops the tonnage that every register row carries (19 / 26) — no source writes a bare 'HN'"
+    - "catalog: no spelling twin under truck/man → id correct on R1"
+  notes: >-
+    'HN' is a MAN chassis/cab code prefix; with 4 vehicles across two registers
+    and no reachable MAN type list, the honest classification is the truncation
+    (D1), not a resolution.
+
+"truck/man/l2000":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live MAN N2 'L 2000' n=14 across groups, 'L2000' n=9+ (52 groups / 71 vehicles); fi_traficom 'L2000' N2 n=7, 'L2000 8.153 BB/4250', 'L2000 8 185 LC', 'LE 180C-L2000-4X2/3950'"
+    - "marque: L2000 is MAN's own series name (the L2000/M2000/F2000 generation) — a genuine nameplate at the right altitude"
+    - "catalog: truck/man/le and /l are separate fragments but neither is this series' spelling twin"
+  notes: "Spacing varies in the registers ('L 2000' vs 'L2000'); MAN's own material used 'L2000', which is what is published."
+
+"truck/mecalac/revotruck":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { gb: correct, lu: correct } }
+  evidence:
+    - "https://www.mecalac.com/en/  # the marque's own nav and product pages: 'Revotruck-Series', 'Revotruck 6', 'Revotruck 9', /en/machine/revotruck9.html — capital R only, NOT 'RevoTruck' — capture: captures/mecalac_root.html"
+    - "raw: gb uk_dft HGV Make 'MECALAC' GenModel 'MECALAC REVOTRUCK9'; lu_snca 'MECALAC|REVOTRUCK 6T|N2' n=2"
+    - "catalog: truck/mecalac's other ids (mdx, ta) are different product families"
+  notes: >-
+    An assumption-trap that came out CORRECT: 'Revotruck' looks like a
+    camel-case product name that the caser would have flattened, and the
+    marque's own rendering is exactly what is published. Verified, not assumed.
+
+"truck/mercedes-benz/1223-l":
+  verdicts: { id: "defective(D6)", name: "defective(D8)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "DUPLICATE: truck/mercedes-benz/1223 (name '1223', fi+nl) is live and its OWN raws are '1223 L', '1223 L-97025/476', '1223 L-97025/416', '1223 L-97025/536' — the identical strings that feed this id"
+    - "raw: nl_rdw live MERCEDES-BENZ N2 '1223 L' n=3, '1223' n=2, '1223L' n=2, '1223L ATEGO' n=1; fi_traficom '1223 L-97025/476' N2 n=17, '1223 L-97025/416' n=15, 'ATEGO 1223L' n=9, 'Atego 1223' n=6, 'ATEGO 1223' n=5"
+    - "ALTITUDE: the register itself names the nameplate — 'ATEGO 1223L' — and truck/mercedes-benz/atego is live; 'L' is MAN… (MB's) wheelbase/configuration suffix, so 1223 and 1223 L are one vehicle"
+  notes: "Same pattern across the whole MB numeric block (1117 L/1117, 1218 L/1218, 1222 L/1222, 1224 L/1224 …) — sized, not swept."
+
+"truck/mercedes-benz/1726":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, lu: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom '1726 AK-JAV-4X4' N3 n=3, '1726/4500' N3 n=2, '1726/5200' N3 n=1, '1726-LAV/420' N3 n=1, '1726' N3 n=1, '1726 Paloauto 4x4' N3G n=1 (TAN MER13451114 on the record)"
+    - "raw: nl_rdw live MERCEDES-BENZ '1726 LS' N3 n=3; lu_snca 'MERCEDES|1726|N3' n=1"
+    - "marque: the 4-digit type number IS Mercedes-Benz's own model designation for heavy trucks of this era (tonnes+power), and NO raw in any register carries a series token for these rows — so there is nothing to fold into"
+    - "catalog: no '1726 L'-style spelling twin exists under truck/mercedes-benz → id correct on R1"
+  notes: >-
+    Listed in unverifiable_register as a caveat: the name verdict rests on the
+    R3 fallback (register-only evidence class), not on Mercedes material.
+
+"truck/mercedes-benz/2538":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom '2538K-6X4/385+135' N3, '2538-NT-6X2/450+136' N3, '2538' N3, '2538 K-6X4' N3, '2538 DNA-6X2/385+136' N3 (5 vehicles); nl_rdw live '2538 6 X4' N3 n=1"
+    - "marque: same convention as 1726 — no series token in any raw; the suffixes K/NT/DNA are body/axle codes"
+    - "catalog: no '2538 L' twin → id correct on R1"
+  notes: "Same R3-fallback caveat as 1726."
+
+"truck/mercedes-benz/290":
+  verdicts: { id: "defective(D6)", name: "defective(D1)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: NO register writes a bare '290' for this make — nl_rdw live has '290GD' n=3, '290 GD 4X4 3120' n=1, '290 GD' n=1 in N2 (plus 42 vehicles in N1: '290 GD' n=23, '290 GD TURBODIESEL' n=7, '290 GD STATIONWAGEN KORT/LANG'), and fi_traficom has '290 GD' N2G n=1. The display name is a fold artifact."
+    - "DUPLICATE: truck/mercedes-benz/g (name 'G', fi+gb+nl) is live with raws 'G 280 CDI', 'G 300 CDI', 'G 350 D', 'G 500', 'MERCEDES G CLASS' — the 290 GD is a G-Class (W461/W463) and belongs to that nameplate"
+  notes: "GD = the naturally-aspirated diesel G-Wagen designation; dropping it leaves a number that denotes nothing."
+
+"truck/mercedes-benz/312d-ka-903462-kasten":
+  verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct } }
+  evidence:
+    - "raw: fi_traficom '312D-KA-903462-KASTEN/355' N2 n=182, '312D-KA-903462-KASTEN HOCHDACH/355' n=13 — the string is <type>D-<body>-<chassis type number>-<body word>/<wheelbase>. 903.xxx is the Mercedes-Benz SPRINTER (T1N) chassis type series; KA/KASTEN = panel van."
+    - "DUPLICATES: truck/mercedes-benz/312d-ka-903463-kasten (the adjacent chassis number) AND truck/mercedes-benz/312 (raws '312 D-9034-3.55T-KASTEN/355', '312 CDI-9036-3.50T-KASTEN/403', '312 D') AND truck/mercedes-benz/sprinter (raws 'MERCEDES SPRINTER', 'MERCEDES-BENZ SPRINTER 417 CDI AUTO') are all live"
+    - "raw: nl_rdw live corroborates the family — '312 D-9034-…' style strings sit under truck/mercedes-benz/312"
+  notes: >-
+    Four live ids for one vehicle (the Sprinter 312 D panel van), and the
+    published display name is the longest, least human form of the four.
+
+"truck/mercedes-benz/609-d":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "DUPLICATES: THREE live ids for the T2 609 D — truck/mercedes-benz/609 (raws '609 D', '609 D - I', '609 D - III', '609 D KA'), this id, and truck/mercedes-benz/609d-ka. nl_rdw live shows the spellings interleaved under one make: '609 D' N2 n=83, '609 D-III' N1 n=66, '609D' N2 n=29, '609D-KA' N2 n=13, '609 D-KA' n=4."
+    - "raw: fi_traficom '609D' N2 n=22, '609 D/3700' n=16, '609 D-KA-KASTEN/4250' n=12, '609 D/4250' n=9, '609 D' n=5"
+    - "marque: '609 D' (type number + D for Diesel) is Mercedes-Benz's own designation for the T2/Vario-predecessor — the name form is right"
+  notes: "The defect is purely the three-way split; the display form of THIS id is the best of the three."
+
+"truck/mercedes-benz/609d-ka":
+  verdicts: { id: "defective(D6)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom '609D-KA-KASTEN' N2 n=15, '609D-KA-KASTEN/3700' n=13, '609 D-KA-KASTEN/4250' n=12, '609D-KA-KASTEN/4250' n=6; nl_rdw live '609D-KA' N2 n=13, '609 D-KA' N2 n=4, '609 D KA' N1/N2 n=2"
+    - "DUPLICATE: truck/mercedes-benz/609-d and /609 (above) hold the same vehicle; 'KA'/'KASTEN' is the panel-van BODY code (Kastenwagen), not part of the model designation"
+  notes: "Name defective as a body-code fragment glued to the type number; id defective as the third spelling of one vehicle."
+
+"truck/mercedes-benz/816-d":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { es: correct, fi: correct, nl: correct } }
+  evidence:
+    - "DUPLICATE: truck/mercedes-benz/816 is live and its OWN raws are '816 D', '816 D VARIO', '816 ATEGO', '816 L', '816 4x2', '816 DA-KA' — this id's strings are inside that id already; truck/mercedes-benz/816-l is a third"
+    - "raw: fi_traficom '816D' N2 n=24, 'ATEGO 816' n=20, 'Atego 816' n=16, '816' n=9, '816-7.49T-97001/422' n=4; nl_rdw live '816 D' N2 n=3, '816 D VARIO' N2 n=2, '816 ATEGO' N2 n=1; es_dgt 'MERCEDES-BENZ|816D|N2' n=1 + 'MERCEDES BENZ|816D' n=2"
+    - "cross-nameplate ambiguity worth recording: the same type number was used on the T2 (pre-1996) and the Vario (post-1996) — 'ATEGO 816' and '816 D VARIO' rows show TWO live nameplate ids (atego, vario) claiming these vehicles"
+  notes: "Name '816 D' is MB's own form; the defect is the split (816 / 816-d / 816-l) plus unresolved nameplate attribution."
+
+"truck/mercedes-benz/918-l":
+  verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "DUPLICATE: truck/mercedes-benz/918 is live with raws '918 L', '918 L  ATEGO', '918 L ATEGO 3', '918 L-97023/422', '918 ATECO 970.23/362' — the same strings"
+    - "raw: fi_traficom 'Atego 918L' N2 n=12, '918L-97023/422' n=10, '918 L-97023/422' n=7, 'Atego 918' n=4"
+    - "ALTITUDE: the register names the nameplate (Atego) in the majority of FI rows and truck/mercedes-benz/atego is live"
+  notes: "Also note the '918 ATECO' misspelling under the sibling id (a D6/D7 pair of its own)."
+
+"truck/mercedes-benz/967pkx2":
+  verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+              availability: { es: correct, nl: correct } }
+  evidence:
+    - "RESOLUTION: nl_rdw live returns, under MERCEDES-BENZ N2, BOTH '967PKX2' n=1 AND 'ATEGO 967.000…' n=1 — the 967.xxx type-number series IS the Atego, and truck/mercedes-benz/atego is live"
+    - "raw: es_dgt 202606 'MERCEDES-BENZ|967PKX2|N2' n=1"
+    - "catalog: sibling code-ids 963-0-a ('963-0-A'), 963-4-a, 3553 are the same class (MB internal type numbers published as models)"
+  notes: "Two vehicles. Global decile 10 (the thinnest possible), and the string is a factory chassis code with a variant suffix."
+
+"truck/mercedes-benz/l508dg":
+  verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "DUPLICATES: FOUR live ids for the L 508 D — truck/mercedes-benz/l-508 (raws 'L508 D(G)/3500', 'L508 DG KASTEN', 'L508 DG MA'), /l508d (raws 'L508D KASTEN', 'MERCEDES BENZ L508D'), /508-d, /508 — plus this one"
+    - "raw: nl_rdw live MERCEDES-BENZ N2 'L 508 DG' n=120, 'L508DG' n=52, 'L 508 D' n=34, 'L508DG/35' n=22, 'L508 DG' n=9 (+550 vehicles in N1 with the same spellings) — the register's DOMINANT form is spaced 'L 508 DG', not the glued published form"
+    - "raw: fi_traficom 'L508 D(G)/3500' N2 n=9, 'L508DG-KASTEN/3500' n=7, 'L508 DG-KASTEN' n=3"
+    - "marque: Mercedes-Benz wrote these as 'L 508 D' (spaced, series letter + type number + fuel letter)"
+  notes: "D7 for the glued form, D6 for the four-way split; the 'G' suffix is a chassis/driveline letter."
+
+"truck/mercedes-benz/la":
+  verdicts: { id: "defective(D6)", name: "defective(D1)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: this id conflates SEVEN distinct nameplates — nl_rdw live N2/N3 'LA 1113 B MA' n=3, 'LA 3500' n=2, 'LA 1113 B' n=2, 'LA 710 KR' n=1, 'LA 1513' n=1, 'LA 311/42' n=1 …; fi_traficom 'LA321-4X4/4200', 'LA 312/42', 'LA 312/4200', 'LA 321' N2G, 'LA 321-4X4/4299-59'"
+    - "DUPLICATES: truck/mercedes-benz/l-312 ('L 312'), /l-321 ('L 321', raw 'L-321/4200-58'), /l-322, /l-3500 are live — LA differs from L only by the A (Allrad/4x4) suffix, so the same vehicles are split across ids by drivetrain letter"
+    - "marque: 'LA' is Mercedes-Benz's series PREFIX (L = Lastwagen, A = Allrad); no vehicle is named 'LA'"
+  notes: "26 raw strings folded into a two-letter prefix — the widest single conflation in the slice."
+
+"truck/mercedes-benz/vario":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live MERCEDES-BENZ N2 'VARIO' n=33, 'MERCEDES VARIO' n=12, '815 D VARIO' n=3, '816 D VARIO' n=2, '816D VARIO' n=2 (58 vehicles); fi_traficom 'VARIO' N2 n=11, 'Vario' n=9+3 (one carrying TAN e1*2007/46*1035*00, the record's own)"
+    - "marque: Vario is Mercedes-Benz's own nameplate for the 1996-2013 T2 successor — correct altitude and rendering"
+    - "catalog: no spelling twin (the numeric ids 814-d/815-d/816-d overlap in REFERENT, which is recorded against those records, not this one)"
+  notes: >-
+    Kept as correct deliberately: this is the nameplate id the numeric
+    type-number ids should fold into, so calling it defective would invert the
+    fix direction.
+
+"truck/nissan/titan":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom 'Titan XD Platinum Reserve 4X4' N2G n=5, 'Titan XD' N2G n=4, 'Titan XD SL 4X4' n=2, 'Titan XD Pro-4X 4X4' n=2, 'Titan XD' N2 n=1; nl_rdw live NISSAN 'TITAN' N2 n=2 (+74 vehicles in N1)"
+    - "marque: Titan is Nissan's own nameplate; XD is the heavy-duty variant (correctly folded into the nameplate here — the opposite of what happened to F250XLT)"
+    - "catalog: truck/nissan has no overlapping id"
+  notes: "A clean record; cited as the counter-example for car/suzuki/equator's kind (NEW-3) — the same class of vehicle, correctly in truck."
+
+"truck/peugeot/bailey":
+  verdicts: { id: "defective(NEW-1)", name: "defective(NEW-1)", make: correct, kind: "defective(D10)",
+              availability: { gb: correct } }
+  evidence:
+    - "raw: gb uk_dft HGV Make 'PEUGEOT' GenModel 'PEUGEOT BAILEY AUTOGRAPH' Model 'BAILEY AUTOGRAPH IV 79-4I A' 20, 'IV 81-5 AUTO' 19, 'IV 79-4T AUTO' 12, 'IV 72-2 AUTO' 5 (+ BodyType Cars GenModel 'PEUGEOT BAILEY' / 'BAILEY APPROACH AUTOGRAPH 625' 8)"
+    - "marque: Bailey of Bristol is a British caravan/motorhome manufacturer; Peugeot has no 'Bailey' model — the Boxer is the chassis (truck/peugeot/boxer is live)"
+    - "kind: motorhomes are M1 special-purpose regardless of mass (same reasoning as truck/fiat/burstner)"
+  notes: "Third instance of one converter brand under a third chassis marque (Fiat, Ford, Peugeot all carry 'Bailey' or 'Swift')."
+
+"truck/ram/2500":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom '2500' N2G n=19, 'RAM 2500' N2G n=5, '2500 Laramie Crew Cab 4X4' n=3, '2500  Power Wagon 4X4' n=3; nl_rdw live RAM N2 '2500' n=8, 'RAM 2500' n=7, 'RAM 2500 POWER WAGON' n=3, '2500 LARAMIE' n=3 (32 vehicles)"
+    - "marque: Ram's own model name is 'Ram 2500' — with the make in the make column, '2500' is the correct model form (the sibling truck/dodge/ram holds the pre-2010 badge, a legitimate marque split)"
+    - "catalog: truck/ram has no spelling twin for 2500"
+  notes: "The trim strings (Laramie, Power Wagon, Tradesman, Longhorn, Rebel) are correctly folded into the nameplate here."
+
+"truck/renault-trucks/maxity":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { gb: correct, nl: correct } }
+  evidence:
+    - "raw: gb uk_dft HGV Make 'RENAULT TRUCKS' GenModel 'RENAULT TRUCKS MAXITY' Model 'MAXITY 110.35 LWB' 1, 'MAXITY 130.35/5 LWB' 1 (plus LGV rows, correctly a different kind)"
+    - "raw: nl_rdw live merk 'RENAULT TRUCKS' 'MAXITY' N2 n=1"
+    - "marque: Maxity is Renault Trucks' own nameplate (the 2.5-4.5t range) and the make is the correct distinct legal manufacturer (G21 explicitly affirms Renault Trucks as a real marque)"
+  notes: >-
+    Internal inconsistency worth flagging next to truck/renault/d14: this record
+    is correctly under renault-trucks while d14 — also a Renault Trucks product
+    — sits under renault.
+
+"truck/renault/d14":
+  verdicts: { id: "defective(D6)", name: "unverifiable(marque page 502; see unverifiable_register)",
+              make: "defective(D12)", kind: correct,
+              availability: { es: correct, fi: correct, nl: correct } }
+  evidence:
+    - "raw: es_dgt 202604-06 'RENAULT|D14 MED P4X2 280 E6|N3' n=1; fi_traficom 'D14' N3 n=2; nl_rdw live merk RENAULT 'D 14' N3 n=2, 'D14' N3 n=1"
+    - "DUPLICATE + MAKE: truck/renault-trucks/d (name 'D', es+gb+nl) is live with raws 'D 280', 'D WIDE', 'RENAULT TRUCKS D SERIES' — the same Renault Trucks D-series product line. The D 14 is a 14-tonne D-series."
+    - "make: the marque of sale and type-approval holder for the D-series is Renault Trucks (a distinct legal manufacturer per G21), and the dataset publishes BOTH makes; the register writing 'RENAULT' is the registrant, not the marque (NAMING §1)"
+    - "https://www.renault-trucks.com/en/trucks/renault-trucks-d  # HTTP 502 — the marque's own rendering ('D 14' vs 'D14') could not be captured"
+  notes: >-
+    The clean statement of the split: truck/renault holds d12, d14, d280,
+    d-wide, kerax, magnum, midlum, premium, maxity, t460 while
+    truck/renault-trucks holds c, d, maxity, t — two makes, one marque, with
+    'maxity' and the D-series duplicated across both.
+
+"truck/saxas-nutzfahrzeuge-werdau/atego":
+  verdicts: { id: "defective(D6)", name: correct, make: "defective(D11)", kind: correct,
+              availability: { es: correct, fi: correct, nl: correct } }
+  evidence:
+    - "raw: es_dgt 202606 MARCA_ITV 'SAXAS NUTZFAHRZEUGE WERDAU' MODELO_ITV 'ATEGO - MKD 61-M-E' N2 n=1; fi_traficom merkkiSelvakielinen 'Saxas Nutzfahrzeuge Werdau' kaupallinenNimi 'Atego' N2 n=1 TAN e1*2007/46*1366*10; nl_rdw live merk 'SAXAS NUTZFAHR WRDAU GMBH' handelsbenaming 'ATEGO' N2 n=1"
+    - "make: SAXAS Nutzfahrzeuge Werdau GmbH is a German BODY builder — nl_rdw shows its own products are trailers/bodies (merk SAXAS: 'AKD 41-3.5-DZ' O2, 'AKD 74-18' O4, 'AKW 66-18-Z' O4, 'MPB61-M'). The vehicle here is a Mercedes-Benz Atego with a SAXAS body; ES DGT's MARCA_ITV is the plate/approval holder, which for bodied trucks is the bodybuilder. NAMING §1's table covers exactly this ('the marque wins; needs a cross-make move')."
+    - "scale of the same mechanism in one ES month: 'ATEGO' appears as the MODELO_ITV under makes SUBIELA (20), COLD CAR (3), JUNGE FAHRZEUGBAU GMBH (2), THERMOEUROP (1), PUJOL (1) as well as MERCEDES-BENZ (11)"
+    - "DUPLICATE: truck/mercedes-benz/atego is live (es,fi,lu,nl) with raws 'ATEGO 1224', 'ATEGO 1017 L' …"
+    - "make near-dupe: truck/saxas ('Saxas') AND truck/saxas-nutzfahrzeuge-werdau are BOTH live makes (D12 on top), and observed_raw_makes shows five canonical spellings of this one company"
+  notes: >-
+    Name 'Atego' is correct — as Mercedes-Benz's rendering. That is the tell:
+    the model column holds the right nameplate under the wrong make.
+
+"truck/scania-vabis/l51":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom make 'Scania Vabis' 'L51' N2 n=3 (Avolavakuorma-auto + Umpikorinen bodies, 6229-6230 cm3) and 'L5146/4600' N2 n=1; nl_rdw live merk 'SCANIA-VABIS' 'L51 50 110' N2 n=1, 'L5146110' N2 n=1"
+    - "marque: Scania-Vabis's own type designation was 'L51' (L = Lastbil, 51 = series) — the register form and the published form agree"
+    - "catalog: truck/scania-vabis (8 ids) has no spelling twin for L51"
+  notes: >-
+    The make 'Scania Vabis' vs the raw 'SCANIA-VABIS' is a spelling matter that
+    slugifies to the same make_id; not scored.
+
+"truck/scania-vabis/l71":
+  verdicts: { id: correct, name: correct, make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: fi_traficom make 'SCANIA-VABIS' mallimerkinta 'L71' N2 n=1 (the make string is all-caps in this row, which is why a case-sensitive pass initially missed it — recorded so the verifier does not repeat the error); nl_rdw live 'SCANIA-VABIS' 'L71' N3 n=1 and 'L7134' N3 n=1"
+    - "marque: same L-series designation convention as L51; siblings L56/L76 exist in the same registers and are NOT published (thin)"
+  notes: "Two vehicles worldwide, one per register; both verified individually."
+
+"truck/scania/143m":
+  verdicts: { id: "defective(D6)", name: "defective(D1)", make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live SCANIA N3 'R143 M 4X2 AS 65115 E' n=63, 'R143 M 6X2/4 AS 75188 E' n=30, 'R143 M 4X2 AS 75115 E' n=13, 'R 143 M 4X2 AS 75115 E' n=12, 'T143 M 4X2 AS 65115 E' n=9, bare '143M' n=11 (135 groups / 307 vehicles) — the CAB letter (R/T/P) is part of Scania's designation and the published form drops it"
+    - "raw: fi_traficom 'R143ML-6X2L' N3, 'R 143MA-6X2/4L' N3, 'R 143M' N3, '143M' N3 (4 vehicles)"
+    - "DUPLICATE: truck/scania/143 (name '143') is live with raws '143 M', '143 MA', '143 MA 4X2', '143 H' — the same vehicles; r143, r143h, r143hl, t143h are further live ids of the same 3-series"
+  notes: "D1 for the name because '143M' without a cab letter denotes no single Scania; D6 for the id against /143."
+
+"truck/scania/460":
+  verdicts: { id: "defective(D1)", name: "defective(D1)", make: correct, kind: correct,
+              availability: { es: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live SCANIA bare '460' N3 n=2; es_dgt 202604-06 'SCANIA|460|N3' n=1 — three vehicles, and in the SAME es file 'SCANIA|R460|N3' n=423"
+    - "marque: 460 is the POWER RATING; Scania's model name is cab letter + power (R 460, P 460, G 460, S 460) and all four are live ids (r460 es+fi+lu+nl, p460 es+fi+nl, g460, s460)"
+    - "id: the bare number cannot be resolved to one of the four cab series, so it denotes no single vehicle — recorded as D1 (fold/registry truncation) rather than D6, since no ONE live id can be named (R1)"
+  notes: "Sibling bare-power ids 480 and 500 are the same class under this make."
+
+"truck/scania/metago":
+  verdicts: { id: "unverifiable('Metago Pro' identity unresolved)",
+              name: "unverifiable(no marque material reachable)",
+              make: "unverifiable(chassis marque vs converter brand undecided)",
+              kind: correct,
+              availability: { es: correct, lu: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live merk SCANIA 'METAGO PRO' N3 n=16; lu_snca 'SCANIA|METAGO PRO|N3' n=7; es_dgt 202604-06 'SCANIA|METAGO PRO|N3' n=2"
+    - "CROSS-MAKE SIGNATURE: the same model string is carried under a second, unrelated chassis marque — es_dgt 'MERCEDES BENZ|METAGO PRO|N3' n=2 — and truck/mercedes-benz/metago is live (es,fi,nl) with raws ['METAGO PRO','Metago pro']"
+    - "https://www.metago.eu and https://metago.nl  # neither host resolves (curl: 0 bytes, exit 000); WebSearch unavailable this session"
+    - "catalog: Scania's own product families (P/R/G/S series) are all live; 'Metago' matches no Scania product name known to this session"
+  notes: >-
+    Recorded as unverifiable rather than defective on purpose: the NEW-1
+    signature is strong (one model string under two chassis marques, N3 in three
+    registers) but unproven, and 'majority is not authority'. Highest-value item
+    in the source-gap queue from this slice — one reachable page about
+    'Metago Pro' resolves three records (this, mercedes-benz/metago, and the
+    NEW-1 detector's cross-make rule).
+
+"truck/scania/p230":
+  verdicts: { id: "defective(D6)", name: "unverifiable(marque spacing; see unverifiable_register)",
+              make: correct, kind: correct,
+              availability: { fi: correct, nl: correct } }
+  evidence:
+    - "DUPLICATE: truck/scania/p230db4x2mna (name 'P230DB4X2MNA', fi+nl) is live — and THIS id's own raws already include 'P230 DB4X2MNA', 'P230 DB 4X2 MNA'. Same vehicle, one with the chassis code glued into the id."
+    - "raw: nl_rdw live SCANIA N3 'P 230 B 4X2' n=141 across groups, 'P 230 DB4X2MNA' n=14, bare 'P230' n=10 (78 groups / 312 vehicles); fi_traficom 'P230' N3 n=24, 'P230 4X2' n=2, 'Scania P230' n=1"
+    - "name: the register carries BOTH 'P230' and 'P 230 B 4X2'; scania.com product pages 404/JS-render, so the marque's own spacing is uncited"
+  notes: "The cab-letter+power token itself is verified; only the space is open."
+
+"truck/scania/p280":
+  verdicts: { id: correct, name: "unverifiable(marque spacing; see unverifiable_register)",
+              make: correct, kind: correct,
+              availability: { es: correct, fi: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live SCANIA N3 'P280' n=532 across four groups, 'P 280 B 6X2/4' n=26, 'P 280 B 4X2' n=25 (70 groups / 855 vehicles); fi_traficom 'P280' N3 n=59 (one row carrying the record's TAN e4*2007/46*0031*10) + 'P280 4X2' n=3; es_dgt 'SCANIA|P280|N3' n=9"
+    - "catalog: no chassis-code twin for p280 (unlike p230) → id correct on R1"
+  notes: "Here the register's dominant form IS the glued 'P280', which is what is published."
+
+"truck/scania/p380":
+  verdicts: { id: correct, name: "unverifiable(marque spacing; see unverifiable_register)",
+              make: correct, kind: correct,
+              availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+  evidence:
+    - "raw: nl_rdw live SCANIA N3 'P 380 A 4X2' n=11, 'P 380 B 6X2*4' n=10, 'P 380 B 6X2' n=7, 'P 380 B 8X4*4' n=6 (69 groups / 128 vehicles); fi_traficom 'P380' N3 n=34, 'P380 6X2' n=21, 'SCANIA P380 6X2' n=3; es_dgt 'SCANIA|P380|N3' n=1 + 'P380CB8X4MHZ' + 'P 380 B 8X4/*6'; lu_snca 'SCANIA|P380|N3' n=2"
+    - "catalog: no chassis-code twin for p380 → id correct on R1"
+  notes: "Record carries TAN 'U/52368' — a national-format approval, noted for the NEW-2 TAN-shape work."

--- a/data/review/audit-v2026.07.5/audit-ledger-4.yml
+++ b/data/review/audit-v2026.07.5/audit-ledger-4.yml
@@ -1,0 +1,741 @@
+# VehiclesDB five-nines baseline audit — gate A2, slice 4
+# AUDIT ONLY. Nothing in this file was written into any git repo; no fix was applied.
+slice: 4
+researcher: opus-audit-4
+tag: v2026.07.5              # catalog/ + VERSION at /Users/javi/GitHub/.vdb-worktrees/s4w-data (VERSION=2026.07.5, manifest.json version 2026.07.5)
+verifier: null
+status: awaiting_verification
+
+conventions:                  # stated so the verifier can re-derive identically
+  id_scope: >-
+    id-canonical is judged WITHIN the published kind-scoped id space (kind is part of every id).
+    Same-nameplate twins in ANOTHER kind under the same make (car/van/truck/bus) are NOT counted as
+    per-record id defects — they are the owner-decided kind-axis debt (PROPOSAL-kind-boundary.md,
+    DECISION Q1 "derive kind from the EU category" + Q3 "not yet implementable"). The slice-wide
+    count of those twins is reported once in the summary instead.
+  kind_rule: >-
+    kind-correct is judged against the PUBLISHED derivation rule (register legal category:
+    NL Bedrijfsauto N1 -> van, N2/N3 -> truck; FI/ES/LU N1/N1G -> van, N2/N3 -> truck;
+    UK BodyType LGV -> van, HGV -> truck; overrides/kind_maps/*.yml). A marketing-category
+    mismatch (a Suburban or Land Cruiser registered N1) is therefore NOT a kind defect; it is
+    noted per record.
+  availability_test: >-
+    "the country's register really evidences this model" = at least one row in that country's
+    cached register pull, under a make string that resolves to this make, in the kind-appropriate
+    legal category, whose raw model string plausibly folds to this record's name. Verified by
+    per-country extracts (see sources) — every one of the 222 availability claims was checked
+    against a matched row set, not by analogy.
+  name_evidence: >-
+    Marque rendering fetched where reachable (URLs cited per record). Where the marque is defunct
+    or its site did not serve content to curl, and the published form MATCHES the register's own
+    dominant form, the verdict is `correct` with evidence_class register-only (PRD-QUALITY §5.2).
+    Where the published form differs from every observed spelling AND from every reachable marque
+    source, the verdict is defective. Where the marque rendering is genuinely undetermined
+    (site JS-only/404, market renderings conflict), the verdict is unverifiable.
+  sources_used:
+    - "catalog: /Users/javi/GitHub/.vdb-worktrees/s4w-data/catalog/{truck,van}/models.json (+ all six kinds for twin/sibling scans)"
+    - "raw corpus: build/observed_variants.json (token-loss feed), build/observed_model_names.json"
+    - "register extracts built for this audit (scratchpad/s4-{fi,es,uk,lu,th,nl}-raw.txt) from cache/fi_traficom_register.zip, cache/es_dgt_2026{04,05,06}.txt, cache/uk_veh0120_uk.csv, cache/lu_delta_2026{04,05,06}.xml, cache/th_dlt_2568.csv, cache/nl_rdw_{bedrijfsauto_europese_voertuigcategorie,personenauto,bus}.json"
+    - "de_kba_fz10: cache/de_fz10_202606.xlsx (xl/sharedStrings.xml) + overrides/kind_maps/de_kba_fz10.yml by_model"
+    - "curation layer: overrides/models/{renames,former_ids,removals,drop_patterns,moves}.yml, overrides/makes/aliases.yml"
+
+summary:
+  records_audited: 100
+  claims_total: 622           # 100 records x 4 (id/name/make/kind) + 222 availability entries
+  verdicts:                   # counted from the records block below, not asserted
+    correct: 494
+    defective: 109
+    unverifiable: 19
+  claim_clean_rate: "494/622 = 79.4% (conservative: unverifiable counts against)"
+  per_claim_class:
+    id:           { correct: 49,  defective: 47, unverifiable: 4 }
+    name:         { correct: 30,  defective: 56, unverifiable: 14 }
+    make:         { correct: 94,  defective: 5,  unverifiable: 1 }
+    kind:         { correct: 100, defective: 0,  unverifiable: 0 }
+    availability: { correct: 221, defective: 1,  unverifiable: 0 }
+  record_level: "records with all claims correct: 23 of 100"
+  stratum_note: >-
+    This slice is tail-heavy (72 of the 100 records are single- or two-country; global_decile 1-3
+    on 35 of them). The defect mass is entirely in NAME (56/100) and ID (47/100); MAKE is 94%
+    clean and KIND is 100% clean under the published derivation rule. Do NOT extrapolate this
+    rate to the head strata — and note the inverse-coverage effect PRD-QUALITY §5.2 warns about:
+    the records that could not be checked against a marque are the same ones nobody can catch.
+
+  defects_by_class:          # <id>[<claim>]; a verdict naming two classes appears under both
+    D8_wrong_altitude_trim_body_engine (42 claims):
+      - "van/chevrolet/3100-pick-up[name], van/chevrolet/astro-van[name], van/dodge/ram-van-2-8crd-aut-van[name], van/fiat/doblo-standard[name]"
+      - "van/ford/f-150-xlt[id,name], van/gmc/sierra-at4[id,name], van/iveco/daily-35s13v[id,name], van/man/tge-multicab[id,name]"
+      - "van/mercedes-benz/108-d[id,name], van/mercedes-benz/213[id,name], van/mercedes-benz/315[id,name], van/mercedes-benz/516-cdi[name]"
+      - "van/opel/combo-van-y1-7dtl[id,name], van/peugeot/expert-2[id,name], van/peugeot/expert-2-0hdi[id,name], van/peugeot/partner-120-l1-1-6hdif[id,name]"
+      - "van/ram/1500-laramie[id,name], van/renault/kangoo-express-z-e[id], van/vauxhall/astra[name], van/volkswagen/caddy-sdi[id,name]"
+      - "van/volkswagen/crafter-aut[id,name], van/volkswagen/id-buzz-cargo-modified-partition-wall[id,name], van/volkswagen/touran-van[id,name]"
+      - "van/volkswagen/transporter-sn-double-cab[id,name], van/volvo/940-hearse[name]"
+    D7_non_canonical_form (20 claims):
+      - "truck/sisu/cm[name], truck/spierings/sk[name], truck/tadano-faun/atf[name], truck/terberg/dt[name], truck/volvo/fll[name], truck/volvo/fmd[name], truck/wacker-neuson/dw[name]"
+      - "van/citroen/ak[name], van/dodge/w-250[name], van/ford/f-150-xlt[name], van/ford/transit-costum[name] (COSTUM typo), van/hyundai/iload[name] (iLoad)"
+      - "van/kawasaki/kaf[name], van/man/tge-multicab[name] (TGE), van/maxus/e-deliver-9[name] (eDeliver 9), van/mercedes-benz/x[name] (X-Class)"
+      - "van/renault/kangoo-express-z-e[name] (Z.E.), van/saxas-nutzfahrzeuge-werdau/mkd-43-l[name] (MKD), van/ssangyong/actyon-sport[name] (Actyon Sports), van/volkswagen/caddy-sdi[name] (SDI)"
+    D6_duplicate_spelling_same_make_kind (19 claims, all [id]):
+      - "truck/scania/r142 (+142, +r142h), truck/scania/r164 (+r164ga, r164gb, r164gb6x4nz), truck/spierings/sk (+truck/spierings/at)"
+      - "van/chevrolet/3100-pick-up (+3100), van/chevrolet/astro-van (+astro), van/citroen/jumper-oder-relay (+jumper), van/dodge/ram-van-2-8crd-aut-van (+ram-van)"
+      - "van/fiat/doblo-standard (+doblo), van/ford/transit-costum (+transit-custom), van/iveco/35s14-multitel (+35s14), van/mercedes-benz/300-gd (+300-gd-2400-van)"
+      - "van/mercedes-benz/516-cdi (+516), van/mitsubishi/montero (+pajero-montero), van/opel/combo (+combo-van, +combo-cargo, +combo-c-van)"
+      - "van/saxas-nutzfahrzeuge-werdau/mkd-43-l (+mkd-43-l-n, +mkd-43-l-u), van/stx/master-horsebox (+master), van/vauxhall/astra (+astravan)"
+      - "van/volkswagen/kombiwagen (+kombiwagen-23-2400), van/volkswagen/transport (+transporter)"
+    D9_registry_type_code_as_model (16 claims):
+      - "truck/spierings/sk[name], truck/volvo/fll[id,name], truck/volvo/fmd[id,name]"
+      - "van/iveco/35s11v[id,name], van/iveco/35s14-multitel[name], van/iveco/35s18[id,name]"
+      - "van/mercedes-benz/906-ba-35[id,name], van/mercedes-benz/l[id], van/teijo/24[name], van/volkswagen/7j0[id,name]"
+    D11_wrong_make_chassis_make_trap (5 claims):
+      - "van/ford/swift[make], van/iveco/35s14-multitel[make], van/mercedes-benz/westfalia[make], van/renault/theault[id,make]"
+    D3_placeholder_or_fragment_name (3 claims):
+      - "van/mercedes-benz/l[name] (bare series letter spanning L 206…L 608), van/volkswagen/transport[name] (truncated Transporter), van/volkswagen/kombiwagen[name] (body word)"
+    taxonomy_gap_no_D_number (3 claims):
+      - "van/ford/swift[name], van/mercedes-benz/westfalia[name], van/renault/theault[name] — third-party CONVERTER company name published as a nameplate; find_corporate_strings.rb exists (§20.3) but §4 has no class number for it"
+    D13_merge_cell (2 claims):
+      - "van/volkswagen/transporter-caravelle[id,name]"
+    D4_make_as_model (1):   "van/iveco-igloocar/igloocar[name]"
+    D12_make_corporate_string (1): "van/iveco-igloocar/igloocar[make]"
+    D18_alias_names_a_live_id (1): "van/mercedes-benz/vito[id] — see scale_and_new_findings"
+    D10_wrong_kind_evidence (1):   "van/fiat/strada[availability:gb] — the only gb LGV rows are a SORN Strada Abarth MK3 hatchback"
+    new_class_candidate (1): "van/citroen/jumper-oder-relay[name] — CONNECTOR-merged dual-market cell"
+
+  unverifiable:              # 19 claims, verbatim reasons
+    - "truck/scania/p460 [id] — sibling truck/scania/460 is a bare power rating; overlap with the P-cab 460 can be neither confirmed nor excluded from its 2 NL rows"
+    - "truck/scania/p460 [name] — Scania's rendering not captured (scania.com and scania.co.uk served 404/JS-only to curl); register forms uniformly fused"
+    - "truck/scania/r580 [name] — same source gap"
+    - "truck/scania/s530 [name] — same source gap"
+    - "truck/steyr/586 [name] — de.wikipedia 'Steyr 586' does not exist and no marque page is reachable; the verdict would rest on register forms alone"
+    - "truck/volvo/f610 [name] — en.wikipedia Volvo F4/F6/F7 is a 3-sentence stub and does not render F610 (the live F612/F613/F614/F616 family is why this is not defective)"
+    - "van/ameline/master [name] — converter make carrying Renault's nameplate; no Ameline page reached, so `correct` would overstate"
+    - "van/dfsk/ec75 [name] — no DFSK/Seres marque page reached; register forms uniform 'EC75' + catalog family EC31/EC35/C31/C35"
+    - "van/edward-davies/ranger [name] — same shape (Ford's nameplate under the converter make)"
+    - "van/fiat/280 [id] — cannot resolve whether 280 is a Fiat numeric nameplate (238/241/242 family) or the Ducato Type-280 chassis code; van/fiat/ducato is live"
+    - "van/fiat/280 [name] — same reason (en.wikipedia Fiat Ducato never uses 'Type 280')"
+    - "van/ford/fiesta-van [name] — Ford did market a 'Fiesta Van' commercial variant but no marque page was captured; the FI commercial-name column collapses these rows to 'FIESTA'"
+    - "van/goupil/g4l [id] — goupil-ev.com lists G2/G4/G4+/G6; whether G4L is a discontinued model or a register variant of G4 is undetermined"
+    - "van/goupil/g4l [name] — same"
+    - "van/mercedes-benz/300-gd [name] — no reachable Mercedes source for the W460 '300 GD' badge this pass (corpus 'GELÄNDEWAGEN 300GD-460.3-4X4' corroborates the designation)"
+    - "van/saxas-nutzfahrzeuge-werdau/mkd-43-l [make] — the register spellings are corporate forms ('SAXAS NUTZFAHR. WERDAU AG'); whether the marque's short form (SAXAS) should be the make id needs the marque page, which was not reached"
+    - "van/ssangyong/actyon-sport [id] — the nl 'ACTYON SPORTS …' raws (10 units) are the same pickup; whether they land on van/ssangyong/actyon or are dropped cannot be determined from the published artifacts"
+    - "van/toyota/lite-ace [name] — marque renderings conflict by market (en.wikipedia titles it 'LiteAce'; uk_dft 'LITE ACE'/'LITE-ACE'; observed_model_names carries both 'Lite Ace' and 'Lite-Ace')"
+    - "van/volkswagen/caddy-life [name] — VW marketed 'Caddy Life' as the passenger version, but no marque page was captured this pass"
+  register_only_correct:     # NOT unverifiable — defunct/long-tail marque, published form == the register's own form (PRD-QUALITY §5.2)
+    - "van/ldv/cub[name], van/leyland-daf/200[name], van/stx/master-horsebox[name], van/nilsson/v70-ambulance[name], truck/scania/r94[name]"
+  source_gap_queue:          # what would close the unverifiables
+    - "scania.com / scania.co.uk: no server-rendered model text (404 or JS-only). Needed for the P/R/S power-designation rendering (4 claims)."
+    - "tadano.com, wackerneuson.com, spieringskranen.nl, maxusmotors.co.uk, mercedes-benz.co.uk: same class of failure this pass (JS-only, 404, or connection refused to curl)."
+    - "No page exists for: Steyr 586 (de.wikipedia), Kawasaki Mule (en.wikipedia), Ameline, Edward Davies, STX, Teijo, Saxas."
+    - "en.wikipedia Volvo F4/F6/F7 is a stub — the F6 designation table (F609…F616) is uncited anywhere reachable."
+
+  scale_and_new_findings:
+    - id: "GATE MISS — former_ids alias names a LIVE id (23 occurrences catalog-wide at v2026.07.5)"
+      severity: blocking
+      class: D18
+      evidence: >-
+        overrides/models/former_ids.yml HARD RULE 1 ("An old id may appear here ONLY if it no
+        longer exists in the build") is violated by 23 of 2474 aliases. Reproduce: load
+        former_ids.yml, load all six catalog/*/models.json, intersect the alias KEYS with the live
+        ids. In my slice this lands on van/mercedes-benz/vito, whose four declared former ids
+        van/mercedes-benz/639-vito-{109,111,115,120} are all still published (fi+lu+nl, es+nl, nl,
+        nl). Full list of the other 19: car/aston-martin/dbx-707, car/austin-healey/3000-mk-2,
+        car/austin-healey/3000-mk2, car/chrysler/300c-srt-8, car/datsun/280-zx, car/faw/ehs9,
+        car/hyundai/tucson-ix-35, car/hyundai/tucson-ix35, car/hyundai/tucson-ix35-lm,
+        car/infiniti/ex-35, car/kia/cee-d, car/mazda/r-x-7, car/mercury/cougar-xr7,
+        car/volkswagen/vw-1-11, bus/man/lions, bus/man/lion,
+        motorcycle/moto-guzzi/850le-mans-iii, motorcycle/norton/commando-850mk-iii,
+        car/alfa-romeo/romeo-gtv.
+      why_it_matters: >-
+        This is exactly the failure §20.2 (the disposition PAIR rule) says an alias-without-fold
+        produces: consumers are told a LIVE id is an alias of a different record. It is also a
+        detector gap — validate.rb/lint_dataset are supposed to assert this and did not fire on
+        the shipped tag. NOT FIXED HERE (audit finds, never sweeps).
+    - id: "NEW DEFECT CLASS CANDIDATE — connector-merged dual-market cell"
+      severity: taxonomy
+      evidence: >-
+        Raw register strings that carry TWO market nameplates joined by a WORD, not a comma:
+        es_dgt/fi_traficom/nl_rdw all serve "JUMPER ODER RELAY" (nl bedrijfsauto N1 x20,
+        personenauto x26; es 9 units; fi 3 units). Siblings prove it is systemic, not one row:
+        van/citroen/jumper-ou-relay, van/citroen/jumpy-oder-dispatch,
+        van/volkswagen/transporter-caravelle ("TRANSPORTER /CARAVELLE", "TRANSPORTER,CARAVELLE,BUS"),
+        van/volkswagen/transporter-ww-caravelle, van/ford/transit-connect-tourneo-connect.
+      why_D13_does_not_cover_it: >-
+        §4 D13 is "temporal merge cell" with example "GLK, GLC" and detector "comma-cell warn in
+        source". A comma detector cannot see "ODER"/"OU"/"WW."/"/" connectors, and the German/French
+        connector words are type-approval designation artifacts (both market names on one approval),
+        not a temporal KBA merge. Needs its own entry + detector spec (connector wordlist:
+        oder|ou|or|and|/|&|ww.) BEFORE any scaled fixing (invariant I-15).
+    - id: "SCALE — model-name initialisms title-cased by smart_case (11 of 100 records in this slice)"
+      severity: high
+      class: D7
+      evidence: >-
+        Atf, Dt, Dw, Sk, Cm, Fll, Fmd, Kaf, Ak, Sdi (in "Caddy Sdi"), Tge (in "Tge Multicab"),
+        plus Z.e (in "Kangoo Express Z.e") and Iload. In every case the register corpus is
+        uniformly upper-case (ATF 100G-4 / DT183LE / DW30 / SK599-AT5 / CM16M / FLL 42R /
+        FMD13 / KAF1000EKF / AK 350 / CADDY SDI 51 KW / TGE MULTICAB), so the Titlecase display
+        comes from the normalizer, not from any source.
+      relation_to_D23: >-
+        D23 covers acronym MAKE names and its own note says smart_case consults stylings/acronyms
+        "curated for MODEL names" — i.e. model initialisms are supposed to be pinned and these are
+        not. Same mechanism, different surface; scale here (>1 in 10 tail records) suggests a
+        model-acronym pin sweep is worth costing.
+    - id: "SCALE — cross-kind nameplate twins (kind-axis debt already owner-decided)"
+      severity: informational
+      evidence: >-
+        26 of the 100 sampled records have a same-nameplate twin under the same make in another
+        kind (e.g. car+truck+van Suburban / H2 / Land Cruiser / Escort / Strada / Astra / Dyna /
+        Montero / Sierra / Ram 1500 / 207 D / 213 / 315 / Combo / Touran / Kombiwagen / 940).
+        Reported once here, not charged per record, per the conventions block.
+    - id: "OBSERVATION — the bodybuilder-as-make policy is applied inconsistently"
+      severity: medium
+      evidence: >-
+        renames.yml (Iveco Sunrise -> ferqui, Iveco Wing -> indcar, Scania Irizar -> irizar) sets
+        the precedent that the BODY builder is the make. The slice contains it applied
+        (ameline, stx, nilsson, teijo, edward-davies, saxas…, theault as a make) AND not applied
+        (van/renault/theault, van/mercedes-benz/westfalia, van/ford/swift,
+        van/iveco/35s14-multitel), plus one fused-make hybrid (van/iveco-igloocar/igloocar).
+        theault is the sharpest case: the make exists and the chassis-marque duplicate is still
+        published alongside it.
+
+records:
+
+  "truck/scania/p460":
+    verdicts: { id: "unverifiable(sibling truck/scania/460 is a bare power rating; overlap unresolvable)", name: "unverifiable(scania.com/scania.co.uk 404/JS-only to curl; no marque rendering captured)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: 'SCANIA | P460' es_dgt N3 202604/05/06 (11+9+2 units)", "raw: 'Scania | P460' fi_traficom N3 x7", "raw: 'SCANIA | P460' nl_rdw bedrijfsauto N3 x32", "https://en.wikipedia.org/wiki/Scania_PRT-range  # P-series exists as a cab range; the power-suffix rendering is not shown"]
+    notes: "Register forms are uniformly fused P460 in all three countries. truck/scania/460 {es+nl} holds 2 NL rows whose model string is the bare '460'."
+
+  "truck/scania/r142":
+    verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["catalog: truck/scania/142 [142] {fi+nl} and truck/scania/r142h [R142H] {fi+nl} are live — same truck (H = cab code, 142 = engine denotation)", "https://en.wikipedia.org/wiki/Scania_3-series  # marque-era rendering is fused ('Scania R143')", "raw: 'R142 HL', 'R142 H 6X2 46', 'R142HL-46-6X2' fi_traficom N3; 'R142' nl_rdw N3 x4"]
+
+  "truck/scania/r164":
+    verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["catalog: truck/scania/r164ga, r164gb, r164gb6x4nz all live {fi+nl} — GA/GB/NZ are chassis/axle codes of the same R164", "raw: 65 distinct R164 forms in observed_variants (R164 GA 4X2 NA 580 …)", "https://en.wikipedia.org/wiki/Scania_3-series  # fused era rendering"]
+
+  "truck/scania/r580":
+    verdicts: { id: correct, name: "unverifiable(no Scania rendering captured — site 404/JS-only)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["raw: 'SCANIA | R580' es_dgt N3 x7, lu_snca N3 x8, nl_rdw N3 (27 forms incl. 'R-SERIE,R580'), fi_traficom N3 x106", "xrefs.tan e4*2007/46*0046*12 etc. present on the record"]
+
+  "truck/scania/r94":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'R 94 LB 4X2 NB 300' fi_traficom N3 x1; 'R94 DB 4X2 NB230', 'R94 LB4X2NA 300' nl_rdw N3", "https://en.wikipedia.org/wiki/Scania_3-series  # fused R143 rendering for the same era"]
+    notes: "Both spaced (FI) and fused (NL) forms are observed; the fused published form matches the encyclopedia rendering of the sibling designation. Thin evidence (2 units total) but real."
+
+  "truck/scania/s530":
+    verdicts: { id: correct, name: "unverifiable(no Scania rendering captured — site 404/JS-only)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: 'SCANIA | S530' es_dgt N3 202604 x1; 'S530' fi_traficom N3 x3; 'S530' nl_rdw bedrijfsauto N3 x550", "xrefs.tan e4*2018/858*00100*10"]
+
+  "truck/sisu/cm":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { fi: correct } }
+    evidence: ["raw: 'CM16M K-AKK-8x4/345+140+137' fi_traficom N3G x29 (+117 further CM13M/CM16M forms) — corpus is uniformly upper-case 'CM'", "https://de.wikipedia.org/wiki/Sisu_Auto  # Sisu model list (E12M, DK12M/DK16M…) does not carry a bare CM"]
+    notes: "Casing is the assertable defect. Secondary (not charged): 'CM' is a family prefix — the corpus designations are CM13M/CM16M with engine size, so the record also sits above the marque's own model altitude."
+
+  "truck/sisu/e12m":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct } }
+    evidence: ["https://de.wikipedia.org/wiki/Sisu_Auto  # model list contains 'E12M 2005'", "raw: 234 E12M forms, fi_traficom N3 (E12M K-AKK-8X2/325+140+130 x23 …)"]
+
+  "truck/spierings/sk":
+    verdicts: { id: "defective(D6)", name: "defective(D7+D9)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["catalog: truck/spierings/at [At] {fi+nl} is live — 'At' and 'Sk' are the two halves of one designation ('SK1265-AT6')", "raw: 'SK1265-AT6' nl_rdw N3 x161, 'SK 597-AT4' x143, 'SK599-AT5' x6; 'SK498-AT4' fi_traficom N3 x1; 'SK1265-AT5' es_dgt N3G x1", "https://www.spieringskranen.nl  # not served to curl (no content) — the model-number evidence is the register's own strings"]
+
+  "truck/steyr/586":
+    verdicts: { id: correct, name: "unverifiable(no marque/encyclopedia rendering reachable — de.wikipedia 'Steyr 586' missing)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: '586/4200' fi_traficom N2 x1; '586 AQZ', '586' nl_rdw bedrijfsauto N2", "catalog: sibling truck/steyr/680 {fi+nl} — a coherent Steyr numeric family"]
+
+  "truck/tadano-faun/atf":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'ATF 100G-4' nl_rdw N3 x8, 'ATF130G-5' x12, 'ATF 220G-5 (FA067)' fi_traficom N3G — corpus uniformly 'ATF' upper-case", "https://www.tadano.com/products/all-terrain-cranes/  # served, but model text is JS-rendered (no ATF strings in HTML)"]
+    notes: "Secondary (not charged): ATF is the all-terrain family prefix; the marque's models are ATF <capacity>G-<axles>."
+
+  "truck/terberg/dt":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft HGV 'TERBERG | TERBERG DT183 | DT183LE' Licensed 506 + SORN 95", "https://www.terbergspecialvehicles.com/  # current families rendered YT201/YT203, RT, TT — all upper-case"]
+    notes: "The register's own Model column is DT183LE; the published 'Dt' is both title-cased and truncated to the family letters."
+
+  "truck/toyota/dyna":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Toyota_Dyna  # nameplate 'Dyna'", "raw: 'DYNA BU85L-MDDHTW' fi_traficom N2 x10 (+25 further N2 forms); 'DYNA BU 85 L-MDDHTW 3', 'DYNA' nl_rdw bedrijfsauto N2"]
+    notes: "Cross-kind twins van/toyota/dyna (+dyna-100/-150) and car/toyota/dyna exist; the truck record's own evidence is N2-only, which is the correct side of the N1/N2 split."
+
+  "truck/volta-trucks/zero":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Volta_Trucks  # 'Volta Trucks launched the Volta Zero, an all-electric 16-tonne vehicle'", "raw: uk_dft HGV 'VOLTA TRUCKS ZERO | ZERO 16T EXTENDED RANGE' Licensed 0 + SORN 3; 'VOLTA ZERO' nl_rdw N3 x2"]
+    notes: "gb evidence is SORN-only (3 units) — registered fleet, per uk_dft's Licensed+SORN convention."
+
+  "truck/volvo/f610":
+    verdicts: { id: correct, name: "unverifiable(en.wikipedia Volvo F4/F6/F7 is a stub and does not render F610)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'F610' fi_traficom N2 x9 + 'F610-1-V/3850' N2 x3; 'F610' nl_rdw bedrijfsauto N2 x1", "catalog corroboration: truck/volvo/f612, f613, f614, f616 all live {fi+nl} — a coherent F6-series designation family (NAMING.md §2)"]
+
+  "truck/volvo/fll":
+    verdicts: { id: "defective(D9)", name: "defective(D9+D7)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: 'FL-FLL42 RD-4X2/4700' fi_traficom N2 x4 — the register string itself names the FL chassis; 'FLL 42' nl_rdw N2 x172; 'FLL 42' es_dgt N2 x3", "catalog: truck/volvo/fl [FL] {es+fi+gb+lu+nl} is the marque nameplate (https://en.wikipedia.org/wiki/Volvo_FL); FLL sits beside a whole cluster of code fragments (Flc, Flh, Fhd, Fmfh)"]
+
+  "truck/volvo/fmd":
+    verdicts: { id: "defective(D9)", name: "defective(D9+D7)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: 'FMD13-FM84RB-VTA5411-10x4/200+230+137+133' fi_traficom N3 — the string carries the FM chassis code; 'FMD6244A8' es_dgt N3 x1; 'FMD42T' nl_rdw N3 x1", "catalog: truck/volvo/fm [FM] live (https://en.wikipedia.org/wiki/Volvo_FM  'FM stands for Forward control Medium height cab')"]
+    notes: "No exact 'FMD' row exists in any register: every raw is FMD11/FMD13/FMD42T/FMD6244A8. The published name is a stem, and the vehicles are Volvo FMs."
+
+  "truck/wacker-neuson/dw":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft HGV 'WACKER NEUSON | WACKER NEUSON DW | DW30' Licensed 496 + SORN 193, DW20 17+8, DW100 7+14", "https://en.wikipedia.org/wiki/Wacker_Neuson  # marque; product pages 404 to curl"]
+    notes: "The register's Model column carries the real designations (DW15/DW20/DW30/DW100); the published 'Dw' is the title-cased family prefix. Cf. sibling truck/wacker-neuson/dv."
+
+  "van/ameline/master":
+    verdicts: { id: correct, name: "unverifiable(no Ameline marque page reached; the string is Renault's nameplate carried under the converter make)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct } }
+    evidence: ["raw: 'AMELINE | MASTER' es_dgt N1 x8 (202604+202606); 'AMELINE | MASTER' fi_traficom N1 x2", "xrefs.tan e2*2007/46*0051*44 — Renault Master's approval family (the type-approval-holder trap: the approval is Renault's, the register make is the bodybuilder)", "precedent: overrides/models/renames.yml Iveco 'Sunrise: null' / 'Wing: null' + Scania 'Irizar: null' — the bodybuilder IS the make"]
+
+  "van/byd/etp3":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/BYD_M3  # 'also marketed as the BYD ETP3 in Europe'", "raw: 'BYD | ETP3' fi_traficom N1 x62; nl_rdw bedrijfsauto N1 x207", "xrefs.tan e9*KS07/46*6757*01"]
+
+  "van/chevrolet/3100-pick-up":
+    verdicts: { id: "defective(D6)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["catalog: van/chevrolet/3100 [3100] {fi+lu+nl} live, plus van/pick-up-3100 and van/panel-3100 — same Advance-Design ½-ton", "https://en.wikipedia.org/wiki/Chevrolet_Advance_Design  # '3100 on ½ ton, 3600 on ¾ ton, 3800 on 1 ton' — 3100 is the model number; pick-up is the body", "raw: '3100 PICK UP' nl_rdw N1 x51, '3100 PICKUP' x12, '3100 PICK-UP' x11; fi_traficom N1 9 forms"]
+    notes: "former_ids van/chevrolet/3100-pickup is correctly dead (checked against all six catalogs)."
+
+  "van/chevrolet/astro-van":
+    verdicts: { id: "defective(D6)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["catalog: van/chevrolet/astro [Astro] {fi+nl} live (also car/astro, car/astro-van)", "https://en.wikipedia.org/wiki/Chevrolet_Astro  # 'the Astro was marketed in multiple configurations, including passenger van and cargo van' — Astro is the nameplate, van is the configuration", "raw: 'ASTRO VAN' nl_rdw N1 x22, 'ASTROVAN' x1; 'ASTRO VAN STARCRAFT SL-DM15Z/2820' fi_traficom N1 x42"]
+
+  "van/chevrolet/k10":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Chevrolet_C/K  # 'C denoted two-wheel drive, K denoted four-wheel drive' — K10 is the marque designation", "raw: 'K10' nl_rdw N1 x12, 'K10 PICK-UP', 'K10 CHEYENNE SUPER'; 'K10' fi_traficom N1G x1"]
+    notes: "car/chevrolet/k10 is the cross-kind twin (kind-axis debt, counted once in the summary)."
+
+  "van/chevrolet/suburban":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Chevrolet_Suburban  # nameplate", "raw: 'SUBURBAN' nl_rdw bedrijfsauto N1 x55, 'CHEVROLET SUBURBAN' x7; 'Suburban', 'SUBURBAN-FK16C-4X4/3280' fi_traficom N1G/N1"]
+    notes: "Marketing category is SUV, legal category on these rows is N1/N1G (grey-plate commercial conversions) — kind is correct under the published EU-category rule. car/ and truck/ twins exist."
+
+  "van/citroen/ak":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { lu: correct, nl: correct } }
+    evidence: ["raw: 'AK 350' nl_rdw N1 x10, 'AK 250' x4, 'AK-B', '2CV AK 400' — 11 forms, all upper-case; 'AK' lu_snca N1 x2", "https://en.wikipedia.org/wiki/Citro%C3%ABn_H_Van  # H-type derivatives are designated by upper-case type letters (HW…HZ, HP)"]
+    notes: "Sibling van/citroen/ak400 [AK400] is a genuine payload variant, so no duplicate is charged. The defect is the title-cased display of a type designation."
+
+  "van/citroen/jumper-oder-relay":
+    verdicts: { id: "defective(D6)", name: "defective(NEW-CLASS CANDIDATE: connector-merged dual-market cell; D13 covers comma cells only)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: 'JUMPER ODER RELAY' nl_rdw bedrijfsauto N1 x20 (+personenauto x26), es_dgt N1 x9, fi_traficom N1 x3", "catalog: van/citroen/jumper [Jumper] {es+fi+lu+nl} live; siblings van/citroen/jumper-ou-relay and van/citroen/jumpy-oder-dispatch show the same connector pattern", "https://en.wikipedia.org/wiki/Citro%C3%ABn_Jumpy  # Citroën's market names are Jumper/Relay (UK) — never a compound"]
+
+  "van/daihatsu/midget":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Daihatsu_Midget  # nameplate", "raw: uk_dft LGV 'DAIHATSU MIDGET | MIDGET II CARGO AUTO' 1+3; 'MIDGET II' nl_rdw N1 x3"]
+
+  "van/dfsk/ec75":
+    verdicts: { id: correct, name: "unverifiable(no DFSK/Seres marque page reached; register-only + catalog family)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: 'DFSK | EC75' es_dgt N1 x7, fi_traficom N1 x2, nl_rdw N1 x1", "catalog family: van/dfsk/ec31, ec35, c31, c32, c35 — coherent DFSK EC/C naming", "https://en.wikipedia.org/wiki/Seres_Auto_(Hubei)  # DFSK brand identity (microvans/commercial), model list not enumerated"]
+
+  "van/dodge/ram-van-2-8crd-aut-van":
+    verdicts: { id: "defective(D6)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["catalog: van/dodge/ram-van [Ram Van] {fi+nl} live", "https://en.wikipedia.org/wiki/Dodge_Ram_Van  # nameplate is Ram Van; 2.8 CRD is the engine and 'Aut.' the transmission", "raw: 'RAM VAN 2.8CRD AUT. VAN' nl_rdw N1 x36; 'RAM VAN 2.8CRD AUT.VAN' fi_traficom N1 x1"]
+
+  "van/dodge/w-250":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Dodge_D_series  # marque renders the series fused ('D100/W100 … redesignated as D150/W150')", "raw: 'W250' nl_rdw N1 x2 + N2 x1, 'DODGE W250' x1, 'W 250' x1; 'W 250-JM23Z-PICKUP-4X4/378' fi_traficom N1", "precedent: renames.yml — 'a short letter prefix glued to digits IS the nameplate for this make … the fused form is canonical'"]
+
+  "van/edward-davies/ranger":
+    verdicts: { id: correct, name: "unverifiable(converter make carrying Ford's nameplate; no Edward Davies page reached)", make: correct, kind: correct,
+                availability: { lu: correct, nl: correct } }
+    evidence: ["raw: 'EDWARD DAVIES | RANGER' lu_snca N1 x6, nl_rdw N1 x5 + 'RANGER MS-RT' x1", "xrefs.tan e5*2007/46*1171*09/10 (Ford Ranger approval family)", "precedent: bodybuilder-as-make (renames.yml Iveco Sunrise/Wing)"]
+
+  "van/fiat/280":
+    verdicts: { id: "unverifiable(cannot resolve whether 280 is a Fiat numeric nameplate or the Ducato Type-280 chassis code; van/fiat/ducato is live)", name: "unverifiable(same)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: '280' nl_rdw bedrijfsauto N1 x1178, '280 MAXI', '280 KAMPEERWAGEN' x23, '280 L' x19, '280MA4', '280EH7' (146 matched N1 rows)", "https://en.wikipedia.org/wiki/Fiat_Ducato  # article never uses 'Type 280' (platform codes given are X250/X290), so the chassis-code reading cannot be confirmed from it", "catalog: car/fiat/280 {es+fi+nl} also live"]
+    notes: "Single-source (nl) and camper-heavy raws point at a Ducato-generation chassis code, but Fiat also names commercial models numerically (238/241/242) — an honest ceiling, not a verdict."
+
+  "van/fiat/doblo-standard":
+    verdicts: { id: "defective(D6)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["catalog: van/fiat/doblo [Doblo] {de+es+fi+gb+lu+nl} live; siblings van/fiat/doblo-primo, van/fiat/scudo-standard show the trim-word pattern", "raw: uk_dft LGV 'FIAT DOBLO STANDARD | DOBLO STANDARD L1' 266+3, 'DOBLO STANDARD L2' 317+7 — 'Standard' is the UK spec level, L1/L2 the body length"]
+
+  "van/fiat/strada":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, gb: "defective(D10)", nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Fiat_Strada  # 'a coupé utility produced … since 1998' — the pickup nameplate", "raw: 'FIAT STRADA 1.7 TD' nl_rdw N1 x10, 'FIAT STRADA 1.2' x8 (15 N1 rows, 131 units); 'Strada' fi_traficom N1 x4", "raw: uk_dft LGV rows are ONLY 'STRADA ABARTH MK3' SORN 1, 'STRADA 70 CL BIANCA' 0, 'STRADA SAN REMO' 0 — i.e. the 1980s hatchback, mis-bodytyped"]
+    notes: "gb availability is charged as a defect: the gb register evidences the Fiat Strada HATCHBACK (uk_dft's documented BodyType misclassification), not the coupé-utility this van record denotes. All 34 other gb Strada rows sit under BodyType=Cars."
+
+  "van/ford/escort":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Ford_Escort_(Europe)  # nameplate; 'the panel van version ending production in 2002'", "raw: 'ESCORT 1.8D-75 VAN' fi_traficom N1 x10 (17 N1 rows); 'ESCORT 75 VAN 1.8D' nl_rdw N1 x25, 'ESCORT 1300 KOERIER' x15; uk_dft LGV 'FORD ESCORT' 216 rows / 9,767 units"]
+
+  "van/ford/f-150-xlt":
+    verdicts: { id: "defective(D8)", name: "defective(D8+D7)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["catalog: van/ford/f-150 [F-150] {es+fi+gb+lu+nl} live; siblings van/ford/f150-xlt-lariat, van/ford/f-250-xlt", "raw: 'F 150 XLT' nl_rdw N1 x18, 'F-150 XLT 4X4'; 'F-150 XLT' fi_traficom N2G x8; 'F150 XLT' es_dgt N1 x1 — XLT is Ford's trim level, and the marque writes it upper-case", "former_ids van/ford/f150-xlt is correctly dead"]
+
+  "van/ford/fiesta-van":
+    verdicts: { id: correct, name: "unverifiable(Ford did market a 'Fiesta Van' commercial variant but no marque page was captured)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'FIESTA VAN 1.3I-JC3/249' fi_traficom N1 x216 (commercial-name column collapses to 'FIESTA'); 'FIESTA VAN 1.6 D' nl_rdw N1 x8, 'FIESTA VAN' x1", "https://en.wikipedia.org/wiki/Ford_Fiesta  # mentions a van body from Mk1 on, without the 'Fiesta Van' badge string"]
+    notes: "No bare van/ford/fiesta exists, so no duplicate is charged."
+
+  "van/ford/swift":
+    verdicts: { id: correct, name: "defective(third-party converter company as nameplate — taxonomy gap, no D-number in §4)", make: "defective(D11)", kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft 'FORD | FORD SWIFT | SWIFT TREKKER 584 AUTO / SWIFT VOYAGER 505 / SWIFT TREKKER X' — Swift Group motorhomes on Ford chassis; LGV 57 rows / 2,898 units + HGV rows", "https://en.wikipedia.org/wiki/Westfalia-Werke  # (analogous converter case) ", "precedent: renames.yml Iveco 'Sunrise: null' -> ferqui/sunrise, 'Wing: null' -> indcar/wing — converter is the marque"]
+    notes: "No `swift` make exists in any kind, so the fix is a curation call (move vs drop), not an audit call. Kind: LGV/HGV rows are motorhomes — correct under the legal-category rule, and the kampeerwagen class is a known kind-noise area."
+
+  "van/ford/transit-costum":
+    verdicts: { id: "defective(D6)", name: "defective(D7)", make: correct, kind: correct,
+                availability: { es: correct, nl: correct } }
+    evidence: ["catalog: van/ford/transit-custom [Transit Custom] {de+es+fi+gb+lu+nl} live — 'Costum' is a register misspelling of the same nameplate", "raw: 'TRANSIT COSTUM' es_dgt N1 x1 (202606); 'TRANSIT COSTUM' nl_rdw bedrijfsauto N1 x2 + 'TRANSIT COSTUM VAN' x1 (+personenauto x1)", "https://en.wikipedia.org/wiki/Ford_Transit_Custom  # marque nameplate is Transit Custom"]
+    notes: "Two registers repeat the same typo, so corroboration does not clear it (the 'majority is not authority' rule). Both matched rows are genuine N1 registrations, hence availability correct."
+
+  "van/freight-rover/sherpa":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Freight_Rover  # 'its sole product was the Sherpa family of light panel vans'", "raw: uk_dft LGV 'FREIGHT ROVER SHERPA' 84 rows / 459 units (SHERPA 200/230/250 CB…)"]
+    notes: "evidence_class register-only for the name is not needed — the marque article renders 'Sherpa'."
+
+  "van/gmc/sierra-at4":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { lu: correct, nl: correct } }
+    evidence: ["https://www.gmc.com/trucks/sierra/1500  # AT4 and AT4X are Sierra 1500 TRIM levels (alongside Denali) — 26 AT4 / 15 AT4X mentions on the model page", "catalog: van/gmc/sierra [Sierra] {fi+nl} and van/gmc/sierra-1500 live", "raw: 'GMC | SIERRA AT4' lu_snca N1G x1, nl_rdw N1 x3"]
+
+  "van/goupil/g4l":
+    verdicts: { id: "unverifiable(overlap with van/goupil/g4 undetermined)", name: "unverifiable(G4L is not in the marque's listed range)", make: correct, kind: correct,
+                availability: { es: correct, nl: correct } }
+    evidence: ["https://www.goupil-ev.com/en/models/  # model menu: 'G2 G4 G4+ G6' — no G4L", "raw: 'GOUPIL | G4L' es_dgt N1 x27, nl_rdw bedrijfsauto N1 x184", "catalog: van/goupil/g4 [G4] {es+fi+nl} live"]
+
+  "van/goupil/g6":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.goupil-ev.com/en/models/  # 'G6' is a listed model", "raw: 'GOUPIL | G6' fi_traficom N1 x1, nl_rdw N1 x187", "xrefs.tan e8*KS07/46*0003*00"]
+
+  "van/great-wall/steed":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Great_Wall_Wingle  # 'It was also made available in Italy, with the model name Steed' — Steed is Great Wall's export nameplate", "raw: uk_dft LGV 'GREAT WALL STEED | STEED SE TD 4X4' 398, 'STEED S TD 4X4' 335+171, 'STEED CHROME TD 4X4' 18+12"]
+
+  "van/hummer/h2":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Hummer_H2  # nameplate; 'H2 SUT' pickup variant", "raw: 'H2' nl_rdw bedrijfsauto N1 x16 + 'HUMMER H2' x13 + 'HUMMER H2 SUT' x2; uk_dft LGV 'HUMMER H2' 7 rows / 20 units"]
+    notes: "car/ and truck/ H2 twins exist (kind-axis debt)."
+
+  "van/hyundai/iload":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Hyundai_Starex  # 'marketed as the Hyundai iLoad in both Australia and the United Kingdom' — marque form is iLoad", "raw: uk_dft LGV 'HYUNDAI ILOAD | ILOAD COMFORT CRDI 136 DC' etc., 28 rows"]
+
+  "van/iveco-igloocar/igloocar":
+    verdicts: { id: correct, name: "defective(D4)", make: "defective(D12)", kind: correct,
+                availability: { lu: correct, nl: correct } }
+    evidence: ["raw: make strings are 'IVECO/IGLOOCAR' (nl_rdw N1 x37 + N2 x7) and 'IVECO / IGLOOCAR' (lu_snca N1 x1) — a fused chassis+bodybuilder register string kept as the make id", "raw: the model string is 'IGLOOCAR' — i.e. the make's own second token published as the nameplate", "precedent: renames.yml Iveco 'Sunrise: null' -> ferqui, 'Wing: null' -> indcar (bodybuilder is the make, and it is its own make id)"]
+    notes: "Both defects are the same underlying row shape: the pipeline kept the fused make and then had nothing left for the model. Disposition (make alias igloocar + model = the Daily nameplate) is a curation call."
+
+  "van/iveco/35s11v":
+    verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["catalog: van/iveco/35s11 [35S11] {es+fi+nl} live — 'V' is the body/version letter of the same Daily 35S11", "https://en.wikipedia.org/wiki/Iveco_Daily  # the nameplate is Daily; 35S11 is the GVW/power code", "raw: '35S11V-3.55T-VAN/395' fi_traficom N2/N1; '35S11V' nl_rdw N1 x19, '35S 35S11V EURO 3' x12"]
+
+  "van/iveco/35s14-multitel":
+    verdicts: { id: "defective(D6)", name: "defective(D9)", make: "defective(D11)", kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: nl_rdw make strings are 'IVECO - MULTITEL' (N1 x150+42) and 'IVECO - MULTITEL PAGLIERO' (N1 x7+1) — Multitel Pagliero is the aerial-platform bodybuilder", "catalog: van/iveco/35s14 [35S14] {es+fi+lu+nl} live, plus 35s14-veko/35s14e/35s14g/35s14h/35s14n/35s14v — one chassis code split nine ways", "raw: '35S14 - MULTITEL' es_dgt N1 x3, fi_traficom N1 x1"]
+
+  "van/iveco/35s18":
+    verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["catalog: van/iveco/35s18v and van/iveco/daily-35s18 live — the same Daily 35S18", "raw: '35S18' es_dgt N1 x69, fi_traficom N1 x87, lu_snca N1 x4, nl_rdw N1 x1754 (+bodybuilder make variants IVECO/AGB-PROJECT, IVECO/BLYSS, IVECO/POLMAR…)", "https://en.wikipedia.org/wiki/Iveco_Daily  # nameplate"]
+    notes: "former_ids truck/iveco/35s18 is correctly dead. The record is real and well-evidenced; the defect is altitude (chassis code above the Daily nameplate)."
+
+  "van/iveco/daily-35s13v":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["catalog: van/iveco/daily [Daily] {de+es+fi+gb+lu+nl} live; siblings daily-35s12/35s12v/35s14/35s14-a8/35s16-a8/35s18 — the payload+version codes are published as separate nameplates", "raw: 'DAILY 35S13V' nl_rdw N1 x6 + 'DAILY 35S13V, 5-TRIN' x1; 'Daily 35S13V' fi_traficom N1/N2", "renames.yml Iveco already folds '35S13' -> '35 S 13' — the same string is handled two different ways"]
+
+  "van/kawasaki/kaf":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft LGV 'KAWASAKI-KL | KAWASAKI KAF | KAF1000EMFNN / KAF1000EKF / KAF1000BMFNN' — 64 LGV rows / 1,145 units, corpus uniformly upper-case", "en.wikipedia has no 'Kawasaki Mule' article to cite (checked: missing), so the Mule-nameplate altitude claim is left as a note, not a verdict"]
+    notes: "Secondary (not charged): KAF#### is Kawasaki's type code for the Mule utility vehicle family."
+
+  "van/ldv/200-series":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft LGV 'LDV | LDV 200 SERIES' 23 rows / 1,701 units (Model column '200 SERIES 2.2T', '200 PILOT DIESEL')", "https://en.wikipedia.org/wiki/LDV_Pilot  # LDV's Sherpa-derived van lineage (marque defunct — evidence_class register-only)", "catalog: sibling van/ldv/400-series uses the same form"]
+    notes: "Same vehicle family as van/freight-rover/sherpa and van/leyland-daf/200 under successive marques-of-sale — not charged as a duplicate."
+
+  "van/ldv/cub":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft LGV 'LDV | LDV CUB | CUB DIESEL' 37+2 units (also Cars/Buses rows — kind takes the LGV side)", "evidence_class: register-only (LDV defunct; published form == the register's own form)"]
+
+  "van/leyland-daf/200":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["raw: uk_dft LGV 'LEYLAND DAF | LEYLAND DAF 200' 18 rows / 313 units", "https://en.wikipedia.org/wiki/Leyland_DAF  # marque (defunct 1993) — evidence_class register-only"]
+    notes: "The register's Model column says '200 SERIES' and the LDV sibling is published as '200 Series'; the pipeline reads GenModel ('LEYLAND DAF 200'), so the published form is faithful to its own source. Flagged as an internal inconsistency, not charged."
+
+  "van/man/tge-multicab":
+    verdicts: { id: "defective(D8)", name: "defective(D7+D8)", make: correct, kind: correct,
+                availability: { es: correct, lu: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Volkswagen_Crafter  # 'A version of the Crafter is also sold by MAN Truck & Bus as the MAN TGE' — upper-case TGE", "catalog: van/man/tge [Tge] {de+es+fi+gb+lu+nl} live; siblings van/volkswagen/crafter-multicab, van/citroen/jumper-multicab show 'Multicab' as a conversion word", "raw: 'TGE MULTICAB' es_dgt N1 x17, lu_snca N1 x1, nl_rdw N1 x1"]
+
+  "van/maxus/e-deliver-9":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Maxus_V90  # 'an all-electric version known as the eDeliver 9' — marque form has no hyphen and a lower-case e", "raw: 'MAXUS eDELIVER 9' fi_traficom N1 x71 and nl_rdw N1 x3; 'MAXUS EDELIVER 9' nl_rdw N1 x502, 'EDELIVER 9' x49", "catalog: siblings van/maxus/edeliver-5 and edeliver-7 use the fused form — the family is split across two conventions"]
+    notes: "former_ids van/maxus/edeliver-9 is correctly dead."
+
+  "van/mercedes-benz/108-d":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: '108D-638064-KASTEN/300' fi_traficom N1 x114 and '638 VITO 108D' nl_rdw N1 x1, '4D VITO 108D-638164/300' fi_traficom M1 — 638 is the Vito W638 chassis: this is the Vito 108 D engine variant", "catalog: van/mercedes-benz/vito live; van/mercedes-benz/108 [108] also live", "https://en.wikipedia.org/wiki/Mercedes-Benz_Vito  # the Vito nameplate; 108 CDI/108 D are output variants"]
+    notes: "former_ids van/mercedes-benz/108d is correctly dead."
+
+  "van/mercedes-benz/207-d":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Mercedes-Benz_TN  # 'The TN/T1 van model series included 207 D, 208, 307 D and 308' — spaced, upper-case D, exactly as published", "raw: '207 D-III' nl_rdw N1 x7, '207 D-VI' x5, '207 D III', '207 .D.' — 36 N1 rows"]
+
+  "van/mercedes-benz/213":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["raw: 'SPRINTER 213 CDI' fi_traficom N1 x22, '906 KA 30 SPRINTER 213CDI' nl_rdw N1 x242, '902.6 213CDI' x40 — the Sprinter nameplate is present in the register's own strings", "catalog: van/mercedes-benz/sprinter {de+es+fi+gb+lu+nl+th} live; car/213 and car/213-cdi also live", "https://en.wikipedia.org/wiki/Mercedes-Benz_Sprinter  # 213 CDI = GVW/output code within the Sprinter range"]
+
+  "van/mercedes-benz/300-gd":
+    verdicts: { id: "defective(D6)", name: "unverifiable(no reachable Mercedes source for the W460 badge this pass)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["catalog: van/mercedes-benz/300-gd-2400-van [300 GD 2400 Van] {fi+nl} live — the same vehicle with the wheelbase/body tokens", "raw: '3D GELÄNDEWAGEN 300GD-460.3-4X4/2400' fi_traficom N1G/N1 (460.3 = W460 chassis); '300 GD LANG' nl_rdw N1 x21, '300 GD 2400' x3, '300 GD /BM460.322'", "former_ids van/mercedes-benz/300gd is correctly dead"]
+
+  "van/mercedes-benz/315":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, lu: correct, nl: correct } }
+    evidence: ["raw: '906 KA 35 SPRINTER 315CDI' nl_rdw N1 x552, 'SPRINTER 315 CDI' fi_traficom N1 (97 rows), 'SPRINTER 315 CDI' es_dgt N1, '906 KA 35 SPRINTER 315' es_dgt M1", "catalog: van/mercedes-benz/315-cdi and van/mercedes-benz/906-ka-35-sprinter-315cdi are BOTH live alongside this record", "https://en.wikipedia.org/wiki/Mercedes-Benz_Sprinter"]
+
+  "van/mercedes-benz/516-cdi":
+    verdicts: { id: "defective(D6)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { es: correct, nl: correct } }
+    evidence: ["catalog: van/mercedes-benz/516 [516] {fi+nl}, truck/mercedes-benz/516-cdi and truck/mercedes-benz/516 all live", "raw: 'SPRINTER 516 CDI' es_dgt N2 x1, '516CDI' es_dgt N1 x1; '516 CDI' nl_rdw N1 x41, '516 CDI (906.153)' x8, '516CDI-S' x19 — Sprinter 516 CDI", "https://en.wikipedia.org/wiki/Mercedes-Benz_Sprinter"]
+
+  "van/mercedes-benz/906-ba-35":
+    verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'SPRINTER 906BA35' nl_rdw N1 x1, '906BA35' x2, '906.BA35', '906BA35 - STEEL-TRUCK'; 'MERCEDES-BENZ 906 BA35' fi_traficom N1 — 906 is the Sprinter W906 chassis, BA-35 the body/GVW code", "catalog: van/906, van/906-ka-30, van/906-ka-35, truck/906-ba-50, bus/906, car/906 all live — one chassis code, six records", "former_ids van/mercedes-benz/906-ba35 + 906ba35 are correctly dead"]
+
+  "van/mercedes-benz/l":
+    verdicts: { id: "defective(D9)", name: "defective(D3)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw (this id's own folded strings): 'L 206 D', 'L 306 D', 'L 406 DG', 'L 407 D-II', 'L 508 DG', 'L 608 D', 'L 319', 'L 1500' — 120 forms spanning at least seven distinct models collapsed onto one bare letter", "raw: fi_traficom N1 'L407D/3500', 'L407 DG/2950', 'L207', 'L 319'; nl_rdw N1 'L 1500', 'L 206 AR'", "catalog: truck/mercedes-benz/l, car/mercedes-benz/l, bus/mercedes-benz/l all live too; truck/l-407, truck/l-508, truck/l-608 exist as the resolved forms"]
+
+  "van/mercedes-benz/v-class":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, lu: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Mercedes-Benz_Vito  # 'it is known as the Vito Traveliner, V-Class or Viano' — V-Class is the marque's English rendering", "raw: 'V-KLASSE' nl_rdw N1 x5988, lu_snca N1 x2; 'V-Klasse' fi_traficom N1/N1G (76 rows); uk_dft LGV 'MERCEDES V CLASS' 40 rows / 225 units"]
+    notes: "van/viano, van/eqv and car/v-class are market-name/kind siblings of the same vehicle — marque-legitimate names, so no duplicate charged."
+
+  "van/mercedes-benz/vito":
+    verdicts: { id: "defective(D18)", name: correct, make: correct, kind: correct,
+                availability: { de: correct, es: correct, fi: correct, gb: correct, lu: correct, nl: correct, th: correct } }
+    evidence: ["overrides/models/former_ids.yml declares van/mercedes-benz/639-vito-{109,111,115,120} as former ids of this record, but all four are LIVE in catalog/van/models.json (fi+lu+nl, es+nl, nl, nl) — HARD RULE 1 violation, and they denote the same vehicle", "https://en.wikipedia.org/wiki/Mercedes-Benz_Vito  # nameplate 'Vito'", "raw: 'VITO' es_dgt N1 x517 + 'VITO TOURER' M1; fi_traficom N1/N1G 1,529 rows; uk_dft LGV 668 rows; lu_snca N1 x27; nl_rdw N1 '639 VITO 109 CDI' x3679 (184 rows); th_dlt 'VITO 116 CDI VAN EXTRA LO' รถยนต์บรรทุกส่วนบุคคล x1", "de: cache/de_fz10_202606.xlsx xl/sharedStrings.xml contains 'VITO' + overrides/kind_maps/de_kba_fz10.yml 'VITO: van  # 2,194'"]
+    notes: "th availability is a single unit in the van-mapped DLT class (the other 152 TH Vito units sit in the >7-seat passenger class, which maps to car) — thin but real."
+
+  "van/mercedes-benz/westfalia":
+    verdicts: { id: correct, name: "defective(third-party converter company as nameplate — taxonomy gap, no D-number in §4)", make: "defective(D11)", kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Westfalia-Werke  # 'a manufacturer of automotive camping equipment … best known for Volkswagen Westfalia Campers' — a converter, not a Mercedes nameplate", "raw: uk_dft LGV 'MERCEDES WESTFALIA | WESTFALIA JULES VERNES AUTO' 23+2, 'WESTFALIA JULES VERNES' 16+2; 'WESTFALIA JAMES COOK' nl_rdw N1 x2", "precedent: renames.yml Iveco Sunrise/Wing, Scania Irizar"]
+    notes: "No `westfalia` make exists in any kind. The vehicles are James Cook / Jules Verne campers on Sprinter/Vito bases."
+
+  "van/mercedes-benz/x":
+    verdicts: { id: correct, name: "defective(D7)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, gb: correct, lu: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Mercedes-Benz_X-Class  # 'The Mercedes-Benz X-Class (W470)' — the nameplate is X-Class; a bare 'X' appears in no marque source", "raw: 'X-KLASSE' nl_rdw N1 x320, lu_snca N1G x6; 'X-Klasse' fi_traficom N1G (185 rows); 'CLASE X' es_dgt N1G x4; uk_dft LGV 'MERCEDES X CLASS' 14 rows / 3,921 units", "xrefs.tan e9*2007/46*6531*00…08 (W470 approval family)"]
+    notes: "A bare single-letter id is also a magnet: nl_rdw rows like '208 D-X' (x79) and '410 D-XI' (x120) share the token; whichever ids they land on, the display form here should be X-Class."
+
+  "van/mitsubishi/montero":
+    verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+                availability: { fi: correct, gb: correct } }
+    evidence: ["catalog: van/mitsubishi/pajero-montero [Pajero Montero] {fi+nl} live — and the FI raws feeding it are literally 'PAJERO MONTERO' / 'PAJERO/MONTERO' / 'Pajero, Montero'", "https://en.wikipedia.org/wiki/Mitsubishi_Pajero  # 'Mitsubishi marketed the SUV as the Montero in North America, Spain, and Latin America' — Montero is a marque name", "raw: 'PAJERO MONTERO' fi_traficom N1G x3 + N1 x2 (17 OK-category rows); uk_dft LGV 'MITSUBISHI MONTERO | MONTERO LWB AUTO' SORN 1"]
+    notes: "gb rests on a single SORN LGV unit (a Pajero LWB commercial) — thin but a real register row."
+
+  "van/mitsubishi/triton":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { th: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Mitsubishi_Triton  # nameplate (L200 in most export markets, Triton in Thailand)", "raw: th_dlt 'MITSUBISHI | TRITON' in รถยนต์บรรทุกส่วนบุคคล (the van-mapped personal-pickup class) x4,273"]
+
+  "van/nilsson/v70-ambulance":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["https://www.nilsson.se/en/  # Nilsson Special Vehicles builds Volvo-based ambulances/hearses (current range XC90/V90) — converter-as-make", "raw: 'NILSSON V70 AMBULANCE' fi_traficom N1 x1 and nl_rdw bedrijfsauto N1 x1 (+5 personenauto units)", "evidence_class: register-only for the model string (published form == register form minus the make prefix)"]
+    notes: "Thin (1 unit per country) but both rows are in the van-mapped category. Sibling nilsson records (car/hearse-3d, car/volvo-s80-hearse, car/s80, car/volvo-s-80) show the same base-nameplate-plus-body pattern — and their own duplicate pair (s80 vs volvo-s-80) is outside this slice."
+
+  "van/opel/combo":
+    verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+                availability: { de: correct, es: correct, fi: correct, gb: correct, lu: correct, nl: correct } }
+    evidence: ["catalog: van/opel/combo-van {es+fi+lu+nl}, van/opel/combo-cargo {es+fi+lu+nl}, van/opel/combo-c-van, van/opel/combo-van-cng all live and denote the same panel van", "https://en.wikipedia.org/wiki/Opel_Combo  # 'The Opel Combo is a panel van and leisure activity vehicle' — Combo is the nameplate", "raw: 'COMBO' lu_snca N1 x176, 'COMBO EDITION N1 100 C' es_dgt N1 x510, 'Combo' fi_traficom N1 x461, nl_rdw N1 (145 rows), uk_dft LGV 'OPEL COMBO'; de: sharedStrings 'COMBO' + kind_maps 'COMBO: van  # 497'"]
+    notes: "Disposition is a curation call: Opel itself markets 'Combo Cargo' and 'Combo Life' as distinct names, so the fold set is Combo/Combo Van/Combo C-Van/Combo-Van-Cng, not necessarily Cargo/Life."
+
+  "van/opel/combo-van-y1-7dtl":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'COMBO-C-VAN Y1.7DTL' nl_rdw bedrijfsauto N1 x439 (+ 'COMBO-C-VAN Y1.7DTH' x131, '…DTL AC' x38) — Y17DTL is the GM engine code, C the generation", "catalog: van/opel/combo, van/opel/combo-van, van/opel/combo-c-van live; siblings combo-van-z13dtj-dpf(-ac) are the same shape"]
+
+  "van/opel/olympia":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { gb: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Opel_Olympia  # nameplate", "raw: 'OLYMPIA' nl_rdw bedrijfsauto N1 x6, 'OLYMPIA BESTEL' x2, 'OLYMPIA VAN' x1, 'OLYMPIA CAR-A-VAN' x1; uk_dft LGV 'OPEL OLYMPIA | OLYMPIA' 1"]
+    notes: "car/opel/olympia is the cross-kind twin; the van record's rows are the delivery/bestel variants."
+
+  "van/peugeot/expert-2":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: the feeding strings are engine strings truncated at the decimal comma — 'EXPERT 2,0 HDI' nl_rdw N1, 'EXPERT 2, 0 HDI 128 HK L2H2', 'Peugeot Expert 2,0 Hdi' fi_traficom N1", "catalog: van/peugeot/expert [Expert] {de+es+fi+gb+lu+nl} AND van/peugeot/expert-2-0hdi are both live — three ids for one nameplate", "https://en.wikipedia.org/wiki/Citro%C3%ABn_Jumpy  # the Peugeot Expert nameplate (shared platform article)"]
+
+  "van/peugeot/expert-2-0hdi":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'EXPERT 2.0HDI-BYRHXB-FOURGON/282' fi_traficom N1 x55 (commercial name column collapses to 'EXPERT'); 'EXPERT 2.0HDI' nl_rdw N1 x2, 'EXPERT 2,0HDI' x1", "catalog: van/peugeot/expert live; van/peugeot/expert-2 live"]
+
+  "van/peugeot/partner-120-l1-1-6hdif":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'PARTNER 120 L1 1.6HDIF 66KW - 2PL' nl_rdw N1 x656 and '… - 3PL' x184 — payload class (120), body length (L1), engine (1.6 HDi), power and seat count", "catalog: van/peugeot/partner [Partner] {es+fi+gb+lu+nl} live; siblings partner-170c-1-6hdi / -1-9d / -2-0hdi are the same shape"]
+
+  "van/ram/1500-laramie":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Ram_pickup  # Laramie is a Ram trim level, 1500 the model line", "catalog: van/ram/1500 [1500] {es+fi+lu+nl} live; siblings 1500-limited/-rebel/-sport/-trx/-rho are the same shape", "raw: '1500 LARAMIE' nl_rdw N1 x11, 'RAM 1500  LARAMIE' x6, 'RAM 1500 LARAMIE 4X4' x3, 'DODGE RAM 1500 LARAMIE' x1"]
+
+  "van/renault/alaskan":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { es: correct, lu: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Nissan_Navara  # the Renault-badged D23 is the Renault Alaskan (nameplate 'Alaskan')", "raw: 'ALASKAN' es_dgt N1G x4, lu_snca N1G x3, nl_rdw bedrijfsauto N1 x19", "xrefs.tan e9*2007/46*6515*00"]
+
+  "van/renault/kangoo-express-z-e":
+    verdicts: { id: "defective(D8)", name: "defective(D7)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Renault_Kangoo  # 'the electric variant, the Renault Kangoo Z.E.' — the marque form is Z.E. (both letters capitalised, trailing stop)", "catalog: van/renault/kangoo and van/renault/kangoo-express are both live — Express is the van body name and Z.E. the powertrain badge", "raw: 'KANGOO EXPRESS Z.E.' nl_rdw N1 x1134, 'KANGOO EXPRESS Z.E' x610, es_dgt N1 x3, fi_traficom N1 x110"]
+
+  "van/renault/theault":
+    verdicts: { id: "defective(D11)", name: "defective(third-party converter company as nameplate — taxonomy gap, no D-number in §4)", make: "defective(D11)", kind: correct,
+                availability: { fi: correct, gb: correct, lu: correct, nl: correct } }
+    evidence: ["catalog: the make `theault` EXISTS in van kind with van/theault/proteo {fi+lu+nl} and van/theault/first-eo {fi+nl} — this record duplicates the bodybuilder under the chassis marque; van/renault/master-theault, van/renault/theault-proteo and truck/renault/theault are live too", "https://www.theault.com/en/  # the company renders itself THEAULT/Theault and builds on the Renault Master (4 'Master' mentions on the page)", "raw: 'THEAULT' nl_rdw N1 x48, 'THEAULT PROTEO' x10; fi_traficom N2 'THEAULT'; uk_dft LGV 'RENAULT THEAULT | THEAULT PROTEO SWITCH' 22; lu_snca N1 x3"]
+
+  "van/saxas-nutzfahrzeuge-werdau/mkd-43-l":
+    verdicts: { id: "defective(D6)", name: "defective(D7)", make: "unverifiable(register spellings are corporate forms; marque short form unconfirmed)", kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["catalog: van/…/mkd-43-l-n [Mkd 43 L N] {es+fi} and van/…/mkd-43-l-u [Mkd 43 L U] {fi+nl} live — the same MKD 43-L with the N/U body-code suffix (plus truck/…/mkd)", "raw: 'MKD 43 - L - U' nl_rdw N1 x35+1, 'MKD 43 - L - N' x7, 'MKD 43-L' x1; fi_traficom N1 'MKD 43 - L - N' x13, 'MKD 43-L' x4 — corpus is uniformly 'MKD'", "raw make spellings: 'SAXAS NUTZFAHR. WERDAU AG', 'SAXAS NUTZFAHR WRDAU GMBH' (nl_rdw), 'Saxas Nutzfahrzeuge Werdau' (fi_traficom)"]
+
+  "van/ssangyong/actyon-sport":
+    verdicts: { id: "unverifiable(the nl 'ACTYON SPORTS …' raws are the same pickup; their published id cannot be determined from the artifacts)", name: "defective(D7)", make: correct, kind: correct,
+                availability: { es: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/SsangYong_Actyon  # 'available either as an SUV (Actyon) or as a pick-up truck (Actyon Sports)' — the marque form is plural", "raw: 'ACTYON SPORT' es_dgt N1 x1 and 'SSANGYONG ACTYON SPORT' nl_rdw N1 x1; separately 'ACTYON SPORTS A200 XDI 4WD' nl_rdw N1 x7 + 'ACTYON SPORTS' x1 + '… 2WD' x1 + '… 4WD AUT.' x1", "catalog: van/ssangyong/actyon [Actyon] {lu+nl} live (the SUV)"]
+
+  "van/stx/master-horsebox":
+    verdicts: { id: "defective(D6)", name: correct, make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["catalog: van/stx/master [Master] {es+fi+nl} live — the same STX-bodied Renault Master (cf. the identical pair van/stx/movano and van/stx/movano-horsebox)", "raw: 'MASTER HORSEBOX' nl_rdw N1 x516 + N2 x1, es_dgt N1 x4, fi_traficom N1/N2 x8 — published form == register form (evidence_class register-only)", "xrefs.tan e7*2007/46*0022*02/13"]
+
+  "van/teijo/24":
+    verdicts: { id: correct, name: "defective(D9)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'AVOLAVA-24-01/2420' fi_traficom N1 x5 (avolava = Finnish flatbed body) and '24 AVOLAVA' nl_rdw N1 x1 — the published '24' is a numeric fragment of the body designation", "raw: bare '24' exists too (fi_traficom N1 x1, nl_rdw N1 x1), which is why availability is correct while the name is not"]
+
+  "van/toyota/land-cruiser":
+    verdicts: { id: correct, name: correct, make: correct, kind: correct,
+                availability: { es: correct, fi: correct, gb: correct, lu: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Toyota_Land_Cruiser  # nameplate (also spelt LandCruiser)", "raw: nl_rdw N1 'TOYOTA LAND CRUISER VAN' x793, 'TOYOTA LAND CRUISER (150 SERIES)' x743 (524 N1 rows); fi_traficom N1G x184+166+157…; uk_dft LGV 99 rows / 3,351 units; es_dgt N1/N1G x5; lu_snca N1/N1G x6", "aliases ランドクルーザー + Landcruiser and former_ids van/toyota/landcruiser (correctly dead)"]
+    notes: "es and lu evidence is thin (5 and 6 units in the van-mapped categories; most of their Land Cruiser volume is M1G = car) but present. Generation ids (90/120/150 series) are marque sub-series, not duplicates."
+
+  "van/toyota/lite-ace":
+    verdicts: { id: correct, name: "unverifiable(marque renderings conflict by market)", make: correct, kind: correct,
+                availability: { fi: correct, gb: correct, nl: correct } }
+    evidence: ["https://en.wikipedia.org/wiki/Toyota_LiteAce  # the article renders it fused, 'LiteAce'", "raw: uk_dft LGV/Cars 'TOYOTA LITE ACE | LITE-ACE / LITEACE'; nl_rdw N1 'LITE ACE 1.5 COMMERCIAL' x14, 'LITE ACE 2.0 COMM. D' x9; fi_traficom N1 'LITEACE KM36LV-JRSW-VAN/2100' x25", "observed_model_names carries both 'Lite Ace' and 'Lite-Ace' for this id"]
+
+  "van/vauxhall/astra":
+    verdicts: { id: "defective(D6)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { gb: correct } }
+    evidence: ["catalog: van/vauxhall/astravan [Astravan] {gb} is live and denotes the same LGV Astra vans", "https://en.wikipedia.org/wiki/Vauxhall_Astra  # 'There was also a van version which was badged as the Bedford Astra Van' … later 'the coupe, convertible and Astravan models continued into 2006' — the van's marque name is Astravan", "raw: uk_dft LGV 'VAUXHALL ASTRA' 288 rows / 28,068 units (plus 2,009 Cars rows under the same GenModel)"]
+
+  "van/volkswagen/7j0":
+    verdicts: { id: "defective(D9)", name: "defective(D9)", make: correct, kind: correct,
+                availability: { es: correct, nl: correct } }
+    evidence: ["raw: '7J0' is the ENTIRE model string in both registers — nl_rdw bedrijfsauto N1 x54 (+personenauto x1), es_dgt N1 x1; no other token accompanies it in any row", "shape: 3-character alphanumeric VW type/parts-family code, matching no VW nameplate (NAMING.md §2.1 treats bare code-shaped strings as suspects)"]
+    notes: "Resolution is blocked: the corpus offers no disambiguating token, so the honest disposition is debt, not a guess at the nameplate."
+
+  "van/volkswagen/caddy-life":
+    verdicts: { id: correct, name: "unverifiable(VW marketed 'Caddy Life' but no marque page captured)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'CADDY LIFE' nl_rdw bedrijfsauto N1 x39 (and personenauto x1697 — the passenger version), 'CADDY,-LIFE' N1 x3; fi_traficom 'CADDY LIFE' N1 x61 + M1 x84, 'CADDY KOMBI LIFE 1.6-2K/268' M1 x119", "https://en.wikipedia.org/wiki/Volkswagen_Caddy  # Caddy generations/derivatives; the 'Life' passenger-version name is not rendered in the article"]
+    notes: "The van record's own evidence is the N1 slice (39 nl + 61 fi units); the mass of Caddy Life registrations is M1, which is why the car-kind twin also exists."
+
+  "van/volkswagen/caddy-sdi":
+    verdicts: { id: "defective(D8)", name: "defective(D7+D8)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: 'CADDY SDI 51 KW BESTEL' nl_rdw N1 x6451, 'CADDY SDI 47 KW' x797; es_dgt N1 'CADDY SDI 51 KW BESTEL'; fi_traficom N1 'CADDY SDI' — SDI is VW's engine badge (upper-case), 'bestel' the Dutch body word", "catalog: van/volkswagen/caddy [Caddy] {de+es+fi+gb+lu+nl} live", "https://en.wikipedia.org/wiki/Volkswagen_Caddy  # nameplate"]
+
+  "van/volkswagen/crafter-aut":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'CRAFTER AUT' nl_rdw N1 x9, 'VW CRAFTER AUT' x1; 'VW CRAFTER AUT' fi_traficom N1 x1 — 'Aut' is the transmission token", "catalog: van/volkswagen/crafter live AND van/volkswagen/vw-crafter-aut live (the same string with the make prefix kept)", "https://en.wikipedia.org/wiki/Volkswagen_Crafter  # nameplate"]
+
+  "van/volkswagen/id-buzz-cargo-modified-partition-wall":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'ID. BUZZ CARGO MODIFIED PARTITION WALL' nl_rdw bedrijfsauto N1 x6996 (+personenauto x14) — an RDW body-modification phrase, not a nameplate", "catalog: van/volkswagen/id-buzz-cargo [Id. Buzz Cargo] {fi+lu+nl} live; the identical shape is already known for the Caddy (drop_patterns.yml: 'RDW even has CADDY MODIFIED PARTITION WALL (25,250 rows measured)') and van/volkswagen/caddy-modified-partition-wall is live too", "https://en.wikipedia.org/wiki/Volkswagen_ID._Buzz  # 'a cargo van as the ID. Buzz Cargo'"]
+
+  "van/volkswagen/kombiwagen":
+    verdicts: { id: "defective(D6)", name: "defective(D3)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: 'KOMBIWAGEN 1600-23/2400' fi_traficom N1 x8, 'KOMBIWAGEN 23/2400' N1 x3 (23 = the T2 Transporter type number); 'KOMBIWAGEN' nl_rdw N1 x1, 'KOMBIWAGEN 23/2400' x1", "catalog: van/volkswagen/kombiwagen-23-2400 live (the same string unfolded), van/volkswagen/kombi-2 live, car/volkswagen/kombiwagen live", "https://en.wikipedia.org/wiki/Volkswagen_Transporter  # the vehicle is a Type 2 / Transporter Kombi; 'Kombiwagen' is a body word"]
+
+  "van/volkswagen/touran-van":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'TOURAN VAN 1.6 TDI 77 KW' nl_rdw N1 x5, 'TOURAN VAN 1,6 TDI' x3, 'TOURAN VAN TDI 103 KW' … (22 N1 rows) — 'Van' is the RDW N1-conversion marker on the Touran MPV", "catalog: car/volkswagen/touran {de+es+fi+gb+lu+my+nl+nz+ua} live", "https://en.wikipedia.org/wiki/Volkswagen_Touran  # the nameplate is Touran (a compact MPV)"]
+    notes: "kind is correct under the legal-category rule (these really are N1 van conversions), which is exactly why the nameplate should be Touran with a body/kind distinction rather than a 'Touran Van' record."
+
+  "van/volkswagen/transport":
+    verdicts: { id: "defective(D6)", name: "defective(D3)", make: correct, kind: correct,
+                availability: { es: correct, fi: correct, nl: correct } }
+    evidence: ["raw: the id's own rows are truncations — 'TRANSPORT' fi_traficom N1 x2 (one row's mallimerkinta is 'TRANSPORTER 2.5TDI-70X0C-2-Z15-KOMBI/332' with commercial name 'TRANSPORT'), 'TRANSPORT 7JD-AXC2D' / 'TRANSPORT. KASSEVOGN 1,9TDI' / 'TRANSPORT.KASSEVOGN 2,5 TD AUT' nl_rdw N1, 'VOLKSWAGEN TRANSPORT' es_dgt N1", "catalog: van/volkswagen/transporter [Transporter] {de+es+fi+gb+lu+nl} live with 12,670-unit FI rows and 58,728-unit NL rows", "https://en.wikipedia.org/wiki/Volkswagen_Transporter  # nameplate"]
+
+  "van/volkswagen/transporter-caravelle":
+    verdicts: { id: "defective(D13)", name: "defective(D13)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: merge cells — 'TRANSPORTER /CARAVELLE' nl_rdw N1 x1, 'TRANSPORTER.CARAVELLE' x1, 'TRANSPORTER, CARAVELLE' / 'TRANSPORTER,CARAVELLE,BUS' (personenauto); fi_traficom N1 'TRANSPORTER CARAVELLE 2.5TDI-7HC-KOMBI-S/300' x42 (commercial name 'TRANSPORTER')", "catalog: van/volkswagen/transporter, van/volkswagen/caravelle AND van/volkswagen/transporter-ww-caravelle all live", "observed_model_names for this id: ['Transporter /caravelle', 'Transporter Caravelle', 'Transporter.caravelle']"]
+    notes: "Two marque names (panel van + passenger version) in one cell; D13's comma detector sees the ',' variants but not the '/' and '.' ones — see the connector-merge new-class candidate."
+
+  "van/volkswagen/transporter-sn-double-cab":
+    verdicts: { id: "defective(D8)", name: "defective(D8)", make: correct, kind: correct,
+                availability: { nl: correct } }
+    evidence: ["raw: 'TRANSPORTER SN DOUBLE CAB' nl_rdw bedrijfsauto N1 x1356 and '… 75 EDITION' x180 — cab/body spec tokens", "catalog: van/volkswagen/transporter live, plus van/volkswagen/transporter-double-cab and van/volkswagen/transporter-dc — three ids for the double-cab Transporter", "https://en.wikipedia.org/wiki/Volkswagen_Transporter  # 'a gamut of variants including … chassis cab and pickup trucks'"]
+
+  "van/volvo/940-hearse":
+    verdicts: { id: correct, name: "defective(D8)", make: correct, kind: correct,
+                availability: { fi: correct, nl: correct } }
+    evidence: ["raw: '940 HEARSE' fi_traficom N1 x1 with vehicle class 'Ruumisauto (SD)' = hearse body; nl_rdw bedrijfsauto N1 x1 (+personenauto x3)", "https://en.wikipedia.org/wiki/Volvo_900_Series  # the nameplate is 940; hearse is a body type (the catalog has a body_types layer for exactly this)", "catalog: car/volvo/940 and its trim siblings (940 GL/GLE/Polar/Turbo) live"]
+    notes: "Converter-built hearses are elsewhere published under the converter make (nilsson/…-hearse); here the register attributes to VOLVO, so the make verdict follows the register."

--- a/data/review/audit-v2026.07.5/audit-verify-1.yml
+++ b/data/review/audit-v2026.07.5/audit-verify-1.yml
@@ -1,0 +1,1160 @@
+# VehiclesDB five-nines baseline audit — gate A2 — INDEPENDENT VERIFIER LEDGER
+slice: 1
+verifier: opus-verify-1
+researcher: opus-audit-1
+tag: v2026.07.5
+date: 2026-07-26
+protocol: data/review/audit-PROTOCOL.md
+status: COMPLETE — 95/95 defective claims re-derived, 15/15 unverifiables retried, 25 records spot-checked.
+
+METHOD:
+  independence:
+    - "Every defective claim was re-derived from the catalog, the raw corpora and the cached registers BEFORE that record's evidence line in the researcher's ledger was read. I read their evidence only afterwards, to compare — and in five places that comparison changed MY verdict, which is recorded below with the correction shown, not silently."
+  sources_i_read_myself:
+    - "catalog/{bus,car}/models.json + makes.json at v2026.07.5 (s4w-data worktree, clean at d9b2cb7)"
+    - "build/observed_variants.json (raw register strings per id) and build/observed_model_names.json"
+    - "cache/us_vehicles.csv — make|model|baseModel|VClass|year. baseModel is the objective altitude signal the researcher bound themselves to; I used it as an independent check ON them"
+    - "cache/uk_veh0120_uk.csv — BodyType|Make|GenModel|Model, read directly to test the uk_dft grouping-key claims"
+    - "cache/nl_rdw_bus.json and nl_rdw_personenauto.json — merk/handelsbenaming/n rows, grepped verbatim"
+    - "PRD-QUALITY.md §4 taxonomy D1–D23; overrides/models/moves.yml header (the marque-of-sale / approval-holder rules)"
+    - "marque + encyclopedia fetches: en.wikipedia.org, scania.com, ahorn-camp.de, dyparro.com, nationalmotormuseum.org.uk, truck1.eu, ayats.es (via search index)"
+  rules_binding_me:
+    - "fetch-never-assume — where no source was reachable I record unverifiable; I never resolve by analogy"
+    - "majority-is-not-authority — register counts inform, marque sources decide"
+    - "skipped-beats-assumed — nothing below is confirmed on the strength of the researcher having said it"
+    - "I fixed nothing and wrote nothing into any git repo."
+  five_places_i_corrected_myself:
+    - "bus/mercedes-benz/300#id — I first overturned to unverifiable; their uk_dft evidence was better than mine and I verified it independently. Reverted to CONFIRMED."
+    - "car/chery/jaecoo-j8#id — I first overturned because no twin exists inside car/chery; they cited a twin in the separate `jaecoo` MAKE, which I verified is live. Reverted to CONFIRMED."
+    - "car/dodge/wc51#id — I first overturned to correct; they cited car/dodge/wc, which I verified is live. Reverted to CONFIRMED."
+    - "car/austin/nash#id — my evidence was thin (truncated sibling listing); theirs named two live twins, both verified. Evidence upgraded, verdict unchanged."
+    - "car/bmw/alpina-b6#id — I overturned, then read their evidence, then checked it: their cited twin DOES NOT EXIST. Overturn stands and is strengthened."
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PART 1 — ALL 95 DEFECTIVE CLAIMS, RE-DERIVED
+# ══════════════════════════════════════════════════════════════════════════════
+
+"bus/altas-auto/sprinter#id":
+  researcher: defective(D12)
+  verifier: CONFIRMED
+  evidence:
+    - "catalog: bus/altas/sprinter and bus/altas-auto/sprinter are BOTH live in kind=bus"
+    - "observed_variants: overlapping raw set — 'SPRINTER ALTAS', 'Sprinter ALTAS', 'Sprinter Altas' appear under BOTH ids"
+    - "catalog xrefs: altas-auto/sprinter tan=[e9*2007/46*6386*15, e9*2007/46*6386*16]; altas/sprinter tan=[…, e9*2007/46*6386*16] — a SHARED type-approval number. Two ids on one TAN is dispositive."
+    - "makes.json: 'altas' (bus; fi,nl) and 'altas-auto' (bus; es,fi,nl) — 'altas' is a strict token-prefix of 'altas-auto', which is D12's containment scan"
+    - "class is right, not merely defensible: the duplication is ACROSS make ids, and D12's remedy is 'make alias merge, with model-overlap evidence' — exactly this"
+
+"bus/altas/sprinter#id":
+  researcher: defective(D12)
+  verifier: CONFIRMED
+  evidence: ["the other half of the same D12 pair; same shared-TAN and overlapping-raw evidence"]
+
+"bus/altas-auto/sprinter#name":
+  researcher: defective(D5)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Sprinter' is Mercedes-Benz's nameplate; bus/mercedes-benz/sprinter is live in the same kind with 180+ raw spellings"
+    - "raw 'SPRINTER ALTAS' — the converter's token is the SUFFIX; the register is naming a Mercedes chassis bodied by Altas, and the display name kept the donor nameplate"
+    - "Altas's OWN product names are in the corpus and were discarded: bus/altas-auto/novus 'ALTAS NOVUS', bus/altas/multiline 'MULTILINE L', bus/altas-auto/tge 'TGE ALTAS Intercity', and under this very make-pair 'Sprinter Tourline L' / 'Sprinter Businessline L' / 'Sprinter Multiline L'"
+    - "systematic: six bus makes each own a model called 'Sprinter' (acbus, altas, altas-auto, esref-karoser, mengerler, sprintcar); none of them builds a vehicle called Sprinter"
+    - "class boundary noted: D5's detector is a PREFIX test and the brand token here was stripped rather than left in place. D5's own remedy line ('if cross-make badge → move') is the pathway that fits. Not overturned; flagged in JUDGMENT_RULES."
+
+"bus/altas/sprinter#name":
+  researcher: defective(D5)
+  verifier: CONFIRMED
+  evidence: ["as above; this side additionally absorbs 'Sprinter Tourline L', 'SPRINTER TOURLINE L', 'Sprinter Businessline L', 'Sprinter Multiline L' — the builder's real product names, present in the raw, discarded in favour of the donor nameplate"]
+
+"bus/esref-karoser/sprinter#name":
+  researcher: defective(D5)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Sprinter', make esref-karoser (Turkish bodybuilder), avail es/fi/nl/ua"
+    - "observed_variants has NO entry for this id ⇒ the raw string is the bare word 'Sprinter': the register put the donor chassis nameplate in the model column with no builder product name at all"
+    - "id=correct is right: no second esref-karoser model and no make near-dupe (makes.json checked for containment on 'esref' and 'karoser')"
+
+"bus/mengerler/sprinter#name":
+  researcher: defective(D5)
+  verifier: CONFIRMED
+  evidence: ["name 'Sprinter' under make 'Mengerler' (Turkey, Mercedes-Benz distributor/bodybuilder), avail es/nl; observed_variants empty ⇒ bare 'Sprinter'; same class as Altas/Esref"]
+
+"bus/sprintcar/sprinter#name":
+  researcher: defective(D5)
+  verifier: CONFIRMED
+  evidence:
+    - "raw = ['MB SPRINTER', 'MB Sprinter'] — the raw literally carries the donor marque token 'MB' as a PREFIX, so D5's prefix detector fires on the string exactly as written"
+    - "the cleanest D5 of the six-converter family"
+
+"bus/isuzu/f#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'F'; the only raw is 'F SERIES' (nz_nzta, single source)"
+    - "sibling bus/isuzu/series name='Series' raw ['N SERIES','N SERIES 100P'] — the SAME truncation artifact on the N-series, proving the pipeline splits '<letter> SERIES' into a letter stub and a 'Series' stub"
+    - "no marque renders a bus range as the bare letter 'F'"
+    - "D9's detector ('code-string shape + single-source') fires on both halves. D7 (form of 'F-Series') is the reasonable alternative — flagged, not flipped."
+
+"bus/mazda/e#id":
+  researcher: defective(D6)
+  verifier: RECLASSIFIED(D9)
+  evidence:
+    - "bus/mazda/e (name 'E', raw ['E 2200','MAZDA E SERIES']) and bus/mazda/e2000 (name 'E2000') are both live"
+    - "the E2000 IS an E-series member, so the stub pools a vehicle e2000 already denotes ⇒ id-canonical genuinely fails; the DEFECT verdict stands"
+    - "but D6 is 'duplicate SPELLING' (detector find_duplicate_spellings, example '280 Se' vs '280SE'). No NFKD/whitespace fold makes 'E' equal 'E2000' — the D6 detector cannot fire. The artifact is a family stub from 'MAZDA E SERIES', which is D9 and is what the researcher themselves booked for this record's NAME."
+
+"bus/mazda/e#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence: ["'E' derived from 'MAZDA E SERIES' / 'E 2200'; Mazda's renderings are E2000 / E2200 / E-Series. Bare letter, code-shaped ⇒ D9"]
+
+"bus/mercedes-benz/300#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "MY FIRST VERDICT WAS WRONG AND I AM RECORDING THE CORRECTION. Working from the catalog alone I could name no live twin (the near neighbours are '303' and '0303', different digits) and I overturned to unverifiable. Their evidence pointed at the underlying uk_dft file, so I went there myself."
+    - "cache/uk_veh0120_uk.csv, verbatim rows: 'Buses and coaches,MERCEDES,MERCEDES 300,308D,…' / '…,308D LWB,…' / '…,310 VAN,…' / '…,311 CDI LWB TRAVELINER,…' / '…,311 CDI MWB TRAVELINER,…' / '…,312D LWB,…' / '…,307D VAN,…'"
+    - "bus/mercedes-benz/308-d, /310, /311, /312-d are ALL live. 'MERCEDES 300' is a DfT GenModel grouping key whose bus rows are already denoted by four live sibling ids ⇒ id-canonical fails on named twins. D6 CONFIRMED."
+    - "I also verified their contamination note independently: the same GenModel carries '300 CE AUTO', '300 TE 4MATIC (4WD)', '300 GEL AUTO' under BodyType='Buses and coaches' — W124 coupé/estate and G-wagen passenger cars filed as buses. That is a real uk_dft source defect and their kind=correct call is generous to the record."
+
+"bus/mercedes-benz/300#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence: ["'300' is a DfT grouping key, not a Mercedes bus nameplate; the coach families are O 302/303/305/404/405/530, all separately live as bus/mercedes-benz/o. Code-shaped + single-source ⇒ D9"]
+
+"bus/mercedes-benz/311#id":
+  researcher: defective(D6)
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "raw ['311 CDI','311 CDI-9036-3.88T-KASTEN HOCH/403','311 CDI-9036-3.88T/403','311 D']"
+    - "bus/mercedes-benz/sprinter is live and its raw set contains 'SPRINTER 311 CDI' and 'SPRINTER 311CDI-3.5T-906635/433' — the same vehicles under the nameplate. id-canonical fails; defect stands."
+    - "but 311 is a tonnage/engine designation of a live bare nameplate — the researcher's OWN D8 rule verbatim ('the suffix is a trim / engine / drivetrain / body qualifier AND a bare-nameplate sibling is live'). They applied D8 at car/bentley/flying-spur-v8 and car/chevrolet/cruze-eco and D6 here. D6 cannot fire: no fold makes '311' equal 'Sprinter'."
+
+"bus/mercedes-benz/316#id":
+  researcher: defective(D6)
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "raw includes '316 CDI SPRINTER TRANSFER 34 BASIC' and '316 CDISPRINTER TRANSFER 34 BASIC' — the raw itself names the nameplate AND the product line; bus/mercedes-benz/sprinter and /transfer are both live"
+    - "same reasoning as #311 — a tonnage/engine designation of a live bare nameplate ⇒ D8, not D6"
+
+"bus/mercedes-benz/518#id":
+  researcher: defective(D6)
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "raw includes '518 CDI SPRINTER', '518 SPRINTER MIX-LINE', '518 SPRINTER RADIUS R', 'MB 518 CDI TREND SITCAR/435'; bus/mercedes-benz/sprinter's raw contains 'SPRINTER 518 CDI', 'SPRINTER 518CDI', 'SPRINTER 518 CDI-906657'"
+    - "id-canonical fails; class is D8 (engine/tonnage variant of a live nameplate)"
+
+"bus/mercedes-benz/818#id":
+  researcher: defective(D6)
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "bus/mercedes-benz/818 raw ['818 SUNRIDER'] and /818-d raw ['818D Vario Rosero'] are both live; bus/mercedes-benz/vario is live with raw 'VARIO 818 D','VARIO O818 D','Vario O818D Rosero'"
+    - "three live ids for the Vario 818 D. Defect stands and is severe."
+    - "class: 818 vs 818 D IS a D6-shaped spelling pair, but the load-bearing duplication is against the live NAMEPLATE id `vario`, which is D8. Recorded as D8; a D6 reading of the 818/818-d pair alone is also defensible."
+
+"bus/mercedes-benz/412-d#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "THREE live ids for one T1 412 D: '412' (raw '412 D','412 D-904463/403','412 D-KA'), '412-d' (raw '412D/402.5/185 SPRINTER'), '412d-ka-904463-kasten' (raw '412D-KA-904463-KASTEN/403')"
+    - "'412 D-KA' vs '412D-KA-…' is a literal spelling duplicate after whitespace/hyphen folding — textbook D6"
+
+"bus/mercedes-benz/311#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence: ["'311' is a Mercedes tonnage/engine code, never a standalone nameplate; the marque form is 'Sprinter 311 CDI'"]
+
+"bus/mercedes-benz/316#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence: ["as #311; raw '316 CDI SPRINTER TRANSFER 34 BASIC' shows the marque form is 'Sprinter Transfer 34'"]
+
+"bus/mercedes-benz/518#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence: ["as #311; raw '518 CDI SPRINTER' / '518 SPRINTER RADIUS R' shows the marque form is 'Sprinter 518 CDI'"]
+
+"bus/mercedes-benz/818#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence: ["'818' rests on raw '818 SUNRIDER'; the marque form is 'Vario 818 D' (bus/mercedes-benz/vario raw 'VARIO 818 D'). Bare tonnage code ⇒ D9"]
+
+"bus/mercedes-benz/e#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence:
+    - "raw = ['MB E 12 UE','MB E 15 RHD','MB E 15 UE','MB E 16 RHD','MB E 16/2 RHD','MB E 17 RHD','MB E 17 UE','MB E 19 UE'] — every string is 'MB E <length> <steering code>', a fleet/type designation"
+    - "the single letter 'E' is the residue after stripping the make token 'MB'; no Mercedes source renders a coach as 'E'"
+
+"bus/mercedes-benz/transfer#id":
+  researcher: defective(D6)
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "bus/mercedes-benz/transfer raw ['TRANSFER 35','TRANSFER 45','TRANSFER 45 LL','TRANSFER 55','transfer 45']; /sprinter raw contains 'SPRINTER TRANSFER 34/35/45/55'; /316 raw contains '316 CDI SPRINTER TRANSFER 34 BASIC'; /515 raw contains '515 Transfer 45'"
+    - "four live ids denote the Sprinter Transfer ⇒ id-canonical fails"
+    - "class: 'Transfer' is a body/product-line qualifier on the live nameplate 'Sprinter' ⇒ D8. D6 cannot fire."
+
+"bus/mercedes-benz/transfer#name":
+  researcher: defective(D9)
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "'Transfer' is not a registry or homologation CODE — it is a real Mercedes-Benz product-line word ('Sprinter Transfer 45'). D9's 'code-string shape' detector does not fire on an English word."
+    - "the defect is a sub-nameplate qualifier published at model altitude ⇒ D8. Claim stays defective."
+
+"bus/mercedes-benz/oh#name":
+  researcher: defective(D7)
+  verifier: RECLASSIFIED(D9)
+  evidence:
+    - "name 'Oh'; raw ['OH 1627 L-LAK/520','OH 1628 L-C/480','OH 1628L/610','OH 1634L','OH1625L-LAK']"
+    - "'OH' is Mercedes-Benz do Brasil's chassis-family code, always carried with a number (OH 1628 L). 'Oh' title-cases a two-letter code, so D7 does fire — but fixing the casing leaves a bare family code as a model name, which is D9's definition, and the researcher used D9 for the structurally identical bus/mercedes-benz/e."
+    - "reclassified for consistency with the slice's own treatment of family-code stubs; defective either way"
+
+"bus/neoplan/316#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "name '316'; raw ['316 SHD-TRANSLINER','N 316','N 316 SHD TRANSLINER/580','N 316 UE'] — three of four raw strings carry the 'N' prefix"
+    - "siblings bus/neoplan/{116,216,2216} have the identical shape (raw 'N 116','N 216','N 2216 SHD TOURLINER') — the whole numeric family lost its 'N'"
+    - "Neoplan's designation is 'N 316 SHD Transliner' ⇒ '316' is a non-canonical rendering ⇒ D7"
+
+"bus/nissan/patrol#kind":
+  researcher: defective(D10)
+  verifier: CONFIRMED
+  evidence:
+    - "bus/nissan/patrol: name 'Patrol', raw ['NISSAN PATROL'], avail gb + nz"
+    - "the Nissan Patrol is a 4x4 station wagon / SUV with no M2/M3 bus variant; the make's other bus siblings (Civilian, Urvan, Caravan, NV) are genuine minibuses — Patrol is the outlier"
+    - "D10 confirmed; remedy is a kind_map route, never a drop"
+
+"bus/scania/bf#name":
+  researcher: defective(D7)
+  verifier: RECLASSIFIED(D9)
+  evidence:
+    - "name 'Bf'; raw ['BF 110','BF-5659-AK','BF111 59/5890','BF111-59A/5890','BF11159A/5890','BF111S-59AS/5890','BF86S59/5880','Scania BF11159A']"
+    - "'BF' is a Scania chassis type code, always numbered. Title-casing to 'Bf' is a D7 wart, but the substantive defect is a bare type-code prefix standing in as a model — D9 — and the slice books the identical shape (bus/isuzu/f, bus/mazda/e, bus/mercedes-benz/e) as D9"
+    - "researcher booked bus/scania/bf as D7 and bus/isuzu/f as D9: same shape, two classes"
+
+"bus/setra/s#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "bus/setra/s pools 96 distinct raw strings from 'S 120 A' to 'S 531 DT' across five countries and carries 24 distinct type approvals in xrefs"
+    - "bus/setra/s417 (raw 'S417 GTHD','S417 UL') and bus/setra/s431dt are separately live"
+    - "s's own raw set contains 'S 417 GT-HD','S 417 HDH','S 417 UL','S 417 UL/2 BUSINESS','S 431 DT','S 431DT' — the SAME vehicles s417 and s431dt denote, differing only by the space between letter and digits"
+    - "D6 exactly. The single strongest id defect in the slice."
+
+"bus/setra/s#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence: ["the bare series letter 'S' as a display name, pooling 96 distinct model strings; Setra's forms are 'S 415 HDH', 'S 517 HD' ⇒ D9"]
+
+"bus/setra/s417#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence: ["the other half of the pair: 'S417 GTHD' (id s417) vs 'S 417 GT-HD' (id s) — identical after whitespace/hyphen fold, same make+kind"]
+
+"bus/setra/s417#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'S417'; every register spelling outside this id writes it spaced — 'S 417 GT-HD','S 417 HDH','S 417 UL','SETRA S 411 HD','SETRA S 415 HDH','SETRA S 416 GT-HD'"
+    - "Setra's convention is 'S 417 HDH' ⇒ 'S417' is non-canonical ⇒ D7, established on corpus evidence alone"
+
+"bus/king-long/xmq#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Xmq'; observed_variants EMPTY; avail es/nz/ua; the make's only model"
+    - "'XMQ' is King Long's model-code prefix (XMQ6127, XMQ6900) — an acronym; 'Xmq' is a title-cased acronym, which no source renders"
+    - "D7 confirmed. A D9 reading (bare code prefix at model altitude) is equally available — flagged."
+
+"bus/temsa/md#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Md'; raw ['MD 7','MD 9','MD 9C','MD C9','MD7 PLUS','TEMSA MD9'] — every raw string upper-cases it"
+    - "sibling bus/temsa/hd carries the identical defect ('Hd' vs raw 'TEMSA HD12 AUTO'), so this is systematic acronym title-casing, not a one-off"
+    - "D7 confirmed; D9 is the alternative reading (bare family code pooling MD7/MD9/MD9C)"
+
+"bus/van-hool/tx#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "bus/van-hool/tx raw includes 'TX-17 ACRON','TX17 ACRON','TX17 ASTRON','TX 18 ACRON','TX15 ACRON'; bus/van-hool/t17 is live with raw ['T17 ACRON','T17 ASTRON']; /acron, /astron, /t, /t915 are live too"
+    - "'TX17 ACRON' and 'T17 ACRON' denote one coach family, and bus/van-hool/acron ('VAN HOOL ACRON AUTO') denotes it a third time under the body name ⇒ D6"
+
+"bus/van-hool/tx#name":
+  researcher: defective(D9)
+  verifier: RECLASSIFIED(D7)
+  evidence:
+    - "the name 'TX' is correctly upper-cased and TX IS Van Hool's own range prefix ('TX16 Astron', 'TX17 Acron', 'TX21 Altano')"
+    - "so it is not a registry/homologation code (D9's definition) — it is a genuine marque range designator with the model number stripped. Closest fit is D7 ('does not match the marque's rendering, which always carries the number'); D8 is the reasonable alternative. Claim stays defective."
+
+"bus/volvo/8900#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "bus/volvo/8900 (raw '8900 B6SC','8900 B7RLE','8900 B8R','8900 LE','8900 R','8900 RLE') and bus/volvo/8900rle (raw 'VOLVO 8900RLE','Volvo 8900rle') are both live"
+    - "'8900 RLE' vs '8900RLE' is a pure whitespace-only duplicate — the canonical D6 shape and the exact case the taxonomy's '280 Se' vs '280SE' example describes"
+
+"bus/volvo/9700h#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "bus/volvo/9700h (raw '9700H B13R','Volvo 9700H'), /9700hd ('Volvo 9700HD') and /9700 (raw contains '9700 H','9700 H 4X2','9700 HD','9700 HD 6X2') are all live"
+    - "'9700 H' vs '9700H' and '9700 HD' vs '9700HD' are whitespace-only ⇒ D6"
+
+"bus/volvo/b#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "raw ['B 10 B 4X2 60 N','B 10 M','B 10 M-70','B 10 M-A','B 12 M','B 12M','B 12M 9700S','B 58','B 58-60-S1/6000','B 5860','B 6 F','B 619','B 75508']"
+    - "each has a live unspaced twin: /b10b, /b10m, /b12m, /b58-60, /b6 (raw 'B6 FA'), /b6fa. 'B 10 M' vs 'B10M', 'B 12M' vs 'B12M', 'B 58-60-S1/6000' vs 'B58-60/6000', 'B 6 F' vs 'B6 FA' ⇒ D6, high severity across 21 live chassis ids"
+
+"bus/volvo/b#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence: ["bare chassis-series letter 'B' pooling 13 distinct chassis strings; Volvo's renderings are B10M, B12B, B7RLE ⇒ D9"]
+
+"bus/volvo/b6#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence: ["bus/volvo/b6 (raw 'B6 2','B6 FA') and bus/volvo/b6fa are both live; 'B6 FA' vs 'B6FA' is whitespace-only ⇒ D6"]
+
+"bus/wrightbus/gb#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Gb'; the ONLY raw is 'WRIGHTBUS GB KITE' (uk_dft, single source)"
+    - "the make token was stripped AND the product word 'KITE' was dropped, leaving a two-letter code title-cased to 'Gb'"
+    - "siblings /gemini, /streetdeck, /streetlite, /nb keep their product words — 'Gb' is the outlier"
+    - "defective on both casing and truncation. D7 confirmed; D9 is the alternative."
+
+"bus/zhongtong/lck#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Lck'; observed_variants EMPTY; nz only"
+    - "'LCK' is Zhongtong's chassis/VIN model-code prefix (LCK6127H, LCK6100); no source renders it 'Lck'"
+    - "title-cased acronym ⇒ D7, the model-name analogue of D23"
+
+"bus/zhongtong/zhongtong#id":
+  researcher: defective(D4)
+  verifier: CONFIRMED
+  evidence:
+    - "the model slug EQUALS its own make id; name 'Zhongtong' equals make name 'Zhongtong'; raw ['ZHONGTONG BUS']"
+    - "D4's detector is literally name==make. It fires."
+    - "the make has only two models (lck, zhongtong) and 'ZHONGTONG BUS' is a make-level string, so this id denotes the same population as any other Zhongtong record"
+
+"bus/zhongtong/zhongtong#name":
+  researcher: defective(D4)
+  verifier: CONFIRMED
+  evidence: ["name == make name; D4 detector fires directly"]
+
+# ── CAR ────────────────────────────────────────────────────────────────────────
+
+"car/ahorn/van-620#kind":
+  researcher: defective(D10)
+  verifier: CONFIRMED
+  evidence:
+    - "the make's ONLY model; name 'Van 620'; avail lu + nl; tan e13*2007/46*1291*12"
+    - "MARQUE SOURCE: https://ahorn-camp.de/…/campervans/modelle-2023/van-620/ — Ahorn Camp's own site lists 'VAN 620' under 'Campervans / Reisemobile und Kastenwagen'. Independent test reports (promobil.de 'Campingbus-Test: Ahorn Camp Van 620', autobild.de 'Wohnmobil-Test: Ahorn Van 620') describe a campervan on a Renault Master chassis with kitchen, shower and toilet."
+    - "D10's example set names 'campers in car' and the 'kampeerwagen test' explicitly; the model NAME itself contains the word 'Van'"
+    - "D10 confirmed; remedy is a kind_map route, never a drop"
+
+"car/aion/ut-420-standard#id":
+  researcher: defective(D6)
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "car/aion/ut (raw 'AION UT') and car/aion/ut-420-standard (raw 'AION UT 420 STANDARD') are both live"
+    - "'420 Standard' is a range-and-trim designation on the nameplate 'UT'; the bare-nameplate sibling is live ⇒ the researcher's own D8 rule"
+    - "D6 cannot fire. Siblings car/aion/v ('AION V') vs /v-602-luxury ('AION V 602 LUXURY') show the same th_dlt trim-in-model artifact."
+
+"car/aion/ut-420-standard#name":
+  researcher: defective(D8)
+  verifier: CONFIRMED
+  evidence: ["a range+trim qualifier at model altitude with car/aion/ut live ⇒ D8 exactly as booked"]
+
+"car/aion/hyptec-ht-620-premium#name":
+  researcher: defective(D8)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Hyptec Ht 620 Premium'; single source th_dlt"
+    - "'620 Premium' is a range/trim designation on the nameplate 'HT' ⇒ D8; the acronym 'Ht' is a further D7-shaped wart"
+    - "corroborated by paultan.org's launch coverage, which renders the product 'GAC Aion Hyptec HT' with '83.3 kWh, 620 km' as SPECIFICATIONS, not as part of the name"
+
+"car/alpina/bmw-alpina-d5-biturbo-touring#name":
+  researcher: defective(D5)
+  verifier: CONFIRMED
+  evidence:
+    - "make='alpina'; name 'Bmw Alpina D5 Biturbo Touring' repeats BOTH the parent marque token and its own make name before the model designation — D5's prefix test fires twice, and D4 (name==make) fires on the 'Alpina' token"
+    - "the same make holds bare, well-formed siblings car/alpina/b3, /b7, /b3-touring, proving the prefix is not the catalog's convention"
+    - "ten of the make's fifteen models carry the same 'Bmw Alpina …' prefix — systematic"
+
+"car/audi/avant-rs2#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "car/audi/avant-rs2 name 'Avant RS2', raw ['AVANT RS2 QUATTRO /260']; car/audi/rs2 is SEPARATELY live with raw ['AUDI RS2','RS2 AVANT','RS2 AVANT 6 SPEED']"
+    - "Audi's designation is 'RS 2 Avant' — the body word FOLLOWS the model designation; 'Avant RS2' is a register word-order inversion"
+    - "corroborated inside the corpus: the sibling id's raw 'RS2 AVANT' has the correct order, and car/audi/avant-s6 shows the same inversion on a second record"
+    - "SEE MISSED_DEFECTS: the researcher scored this record's ID claim correct, but car/audi/rs2 is live and denotes the same car"
+
+"car/austin/nash#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "raw ['AUSTIN NASH'], avail gb + nz"
+    - "VERIFIED TWINS (my first pass could not name them; I checked the catalog directly after reading their evidence): car/austin/metropolitan is LIVE (name 'Metropolitan', nl/nz) and car/nash/metropolitan is LIVE (name 'Metropolitan', fi/nl/nz, raw 'NASH METROPOLITAN','METROPOLITAN CONVERTIBLE','METROPOLITAN IV')"
+    - "the Austin-built Nash Metropolitan therefore has THREE live ids. D6 confirmed on named twins."
+
+"car/austin/nash#name":
+  researcher: defective(D5)
+  verifier: CONFIRMED
+  evidence: ["display name 'Nash' under make 'Austin' — a different marque's name as Austin's model name; raw 'AUSTIN NASH' is make token + foreign marque token, with the actual nameplate (Metropolitan) absent. D5 cross-make badge."]
+
+"car/bentley/flying-spur-v8#id":
+  researcher: defective(D8)
+  verifier: CONFIRMED
+  evidence:
+    - "car/bentley/flying-spur is live; so are flying-spur-v8, -w12, -s, -speed, -azure, -mulliner, -mulliner-w12"
+    - "'V8' is an ENGINE qualifier on a live bare nameplate — the researcher's own D8 rule applied correctly"
+    - "corroborated in the same make: continental-gt-v8 and continental-gt-v8-s alongside continental-gt"
+    - "this is the benchmark entry against which their other altitude calls should be judged"
+
+"car/bmw/activehybrid-7#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "catalog name 'Activehybrid 7'; BMW's rendering is 'ActiveHybrid 7'"
+    - "INTERNAL PROOF: sibling car/bmw/activehybrid-7l is stored in this very catalog as 'ActiveHybrid 7L' — correctly cased — while -3, -5, -7 and -x6 are title-cased. One make, two conventions."
+    - "REGISTER PROOF: cache/us_vehicles.csv rows read make=BMW, model='ActiveHybrid 7' / 'ActiveHybrid 7L' / 'ActiveHybrid 5' / 'ActiveHybrid 3' — the source carries the camel-case form the catalog lost"
+
+"car/bmw/alpina-b6#name":
+  researcher: defective(D5)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Alpina B6' under make 'bmw' — another marque's brand token embedded in the model name; D5's prefix test fires"
+    - "car/bmw also holds alpina, alpina-b3, alpina-b5, alpina-b7, alpina-b8-gran, alpina-roadster-s, alpina-xb7 — seven more of the same shape"
+
+"car/bmw/alpina-b6#make":
+  researcher: defective(D11)
+  verifier: CONFIRMED
+  evidence:
+    - "a live car/alpina make exists with 15 models, so the catalog already recognises ALPINA as a marque — and this record sits under bmw anyway"
+    - "ALPINA Burkard Bovensiepen GmbH is a type-approval-holding manufacturer in its own right, which is D11's test"
+    - "REGISTER CONTEXT (does not overturn): us_vehicles.csv files it as make='BMW', model='Alpina B6 xDrive Gran Coupe', baseModel='6 Series' — the marque-of-sale trap moves.yml warns about. Per 'majority is not authority' the register's make column does not settle the marque."
+
+"car/bmw/alpina-b6#id":
+  researcher: defective(D6)
+  verifier: OVERTURNED(unverifiable)
+  evidence:
+    - "THE RESEARCHER'S CITED EVIDENCE IS FACTUALLY FALSE. Their line reads: 'catalog: car/alpina/b6 is live with raw ALPINA B6'. It is not live."
+    - "I enumerated alpina's model ids straight from catalog/car/models.json: b3-touring, b3, b7-biturbo-allrad, b7, bmw-alpina-b3-3, bmw-alpina-b3-biturbo, bmw-alpina-b3-gt, bmw-alpina-b3-touring, bmw-alpina-b5-touring, bmw-alpina-d3-biturbo-touring-allrad, bmw-alpina-d3-biturbo, bmw-alpina-d3, bmw-alpina-d5-biturbo-touring, bmw-alpina-roadster-s, bmw-alpina-xd3-biturbo. FIFTEEN ids, no b6."
+    - "a grep for every id containing 'b6' across the whole car catalog returns: aston-martin/db6, bmw/alpina-b6, fiat/b644, fiat/b654, volvo/s90-b6, volvo/xc60-b6, volvo/xc90-b6. The only ALPINA B6 in the catalog is the record under audit."
+    - "no second live id denoting this vehicle can be named ⇒ D6 is not demonstrated. The make defect (D11) is real and separately booked; the id may well become non-canonical once the D11 move happens, but that is a consequence of the fix, not present evidence."
+    - "OVERTURNED to unverifiable — which still counts AGAINST the clean rate, so this does not flatter the slice."
+
+"car/bmw/ci#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Ci'; raw ['BMW CI','CI CABRIO'] (gb + nl)"
+    - "'Ci' is BMW's coupé/injection body-and-engine SUFFIX (318Ci, 320Ci, 325Ci, 330Ci, 645Ci, 840Ci) — never a standalone model. car/bmw/3-series' raw set contains '318 CI COUPE','320 CI CONVERTIBLE','325 CI CABRIO','330 CI COUPE'; car/bmw/6-series' contains '645 CI CABRIO','650 CI CABRIO'; car/bmw/8-series' contains '840 CI AUTO','850 CI E2'"
+    - "a bare trim/body suffix as a model ⇒ D9 fires (2-char code). D8 is the reasonable alternative."
+
+"car/bmw/i#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "car/bmw/i (name 'I', raw ['BMW i'], fi + nz, tan e1*2007/46*1213*03) is live alongside /i3, /i4, /i5, /i7, /i8, /ix, /ix1, /ix2, /ix3"
+    - "car/bmw/i3's raw set contains 'I 3' and 'i 3' — the SPACED spelling. A one-letter 'i' id and a spaced 'I 3' sibling string is the whitespace-fold duplicate D6 describes."
+
+"car/bmw/i#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence: ["'I' is BMW's sub-brand letter (BMW i), not a model; every real model is i3/i4/i5/i7/i8/iX ⇒ bare brand letter at model altitude"]
+
+"car/bmw/m-635-csi#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "catalog name 'M 635 Csi'; the only raw is 'BMW M 635 CSI'. BMW's rendering is 'M635CSi' — unspaced, camel 'CSi'. The catalog form has both wrong spacing and wrong suffix casing."
+    - "corroborated in the corpus: car/bmw/6-series raw contains 'BMW M635 CSI', 'M635 CS I', '635 CSi A' — the unspaced marque form is present in the registers"
+
+"car/bmw/mini#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "car/bmw holds mini, mini-cooper, mini-one AND one ('One', raw 'ONE CABRIO'), cooper, cooper-s, clubman-cooper, john-cooper-works — while a separate `mini` MAKE exists covering the same countries"
+    - "the same vehicles are denoted by car/bmw/mini* ids and by the mini make's ids ⇒ id-canonical fails"
+    - "class note: the cross-MAKE half is D12/D11 territory, but mini vs mini-cooper vs cooper INSIDE one make is a genuine same-make duplicate set, so D6 does fire"
+
+"car/bmw/mini#name":
+  researcher: defective(D4)
+  verifier: CONFIRMED
+  evidence:
+    - "'Mini' is a MARQUE (MINI, a BMW Group brand) published as a BMW model name; the catalog's own `mini` make (19 models) proves it is a make-level string in this dataset"
+    - "D4's literal detector is name==make and the make here is 'BMW', so the strict detector does not fire — but this is the make-as-model shape D4 exists for, with the make being a different one. D5 (cross-make badge) is the boundary alternative. Flagged, not flipped."
+
+"car/bmw/mini#make":
+  researcher: defective(D11)
+  verifier: CONFIRMED
+  evidence: ["MINI is a marque of the BMW Group with its own type approvals and its own live make in this catalog; filing MINI vehicles under make=bmw is the D11 shape (register put the group / approval holder in the make column)"]
+
+"car/bmw/z-reihe#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "car/bmw/z-reihe (name 'Z-Reihe', es + nl, observed_variants EMPTY) is live alongside /z1, /z3, /z4, /z8 — and /m-z-reihe (raw 'M Z REIHE, M ROADSTER-') too"
+    - "'Z-Reihe' is German for 'Z series' — a GROUP LABEL that necessarily denotes the same vehicles as z1/z3/z4/z8 ⇒ id-canonical fails"
+
+"car/bmw/z-reihe#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence: ["'Z-Reihe' is a register grouping key in German, not a BMW model name in any language of sale ⇒ D9"]
+
+"car/cadillac/elr#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "catalog name 'Elr'; the only raw is 'CADILLAC ELR HYBRID'"
+    - "REGISTER PROOF: us_vehicles.csv carries make=Cadillac, model='ELR' (2014, 2015, 2016) and 'ELR Sport' (2016), baseModel='ELR' — upper case in the source"
+    - "title-cased acronym ⇒ D7. Siblings /cts ('Cts') and /sts ('Sts') carry the same wart — systematic."
+
+"car/chery/jaecoo-j8#name":
+  researcher: defective(D5)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Jaecoo J8' under make 'chery'; JAECOO is a separate marque and the brand token is embedded in the model name ⇒ D5"
+    - "siblings jaecoo-j5, jaecoo-j7, omoda-5, omoda-9, jetour-x70, icaur-03, icaur-v23 show FIVE Chery-group brands carried as model-name prefixes"
+    - "PRD-QUALITY §4's D5 example is literally 'JAECOO5 EV'"
+
+"car/chery/jaecoo-j8#make":
+  researcher: defective(D11)
+  verifier: CONFIRMED
+  evidence: ["JAECOO is retailed as its own marque and is a live make in this catalog; my_jpj files it under the parent Chery — the D11 shape moves.yml documents for Cupra-under-SEAT and Genesis-under-Hyundai"]
+
+"car/chery/jaecoo-j8#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "MY FIRST VERDICT WAS WRONG AND I AM RECORDING THE CORRECTION. I enumerated the 16 models under car/chery, found no J8 twin there, and overturned to unverifiable. I had looked in the wrong namespace."
+    - "VERIFIED: car/jaecoo/jaecoo-8 is LIVE — name 'Jaecoo 8', avail es/lu/nl. The `jaecoo` make holds jaecoo-5, jaecoo-6, jaecoo-7, jaecoo-8."
+    - "the J8 and the '8' are the same vehicle under two market naming conventions, so Malaysian evidence is split off from European evidence for one car ⇒ id-canonical fails. D6 CONFIRMED."
+
+"car/chevrolet/astro#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "car/chevrolet/astro (raw 'ASTRO AWD','Astro AWD (cargo)','Astro AWD (passenger)','CHEVROLET ASTRO') and /astro-van (raw 'ASTRO VAN 4WD','Astro Van AWD','CHEVROLET ASTRO VAN','CHEVROLET ASTRO VAN 4WD') are both live; /astro-starcraft is a third"
+    - "us_vehicles.csv gives baseModel='Astro Cargo' / 'Astro Passenger' for these rows — the source distinguishes cargo from passenger, NOT 'Astro' from 'Astro Van', so 'Astro Van' is a duplicate spelling of one nameplate ⇒ D6"
+
+"car/chevrolet/aveo-ls#id":
+  researcher: defective(D6)
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "car/chevrolet/aveo (raw 'AVEO,1.2 4D','CHEVROLET AVEO'), /aveo-5 and /aveo-ls (raw EMPTY) are all live; /kalos (the Aveo's European name) is live too"
+    - "'LS' is a Chevrolet trim (LS/LT/LTZ) and the bare nameplate is live ⇒ the researcher's own D8 rule verbatim. D6 cannot fire."
+
+"car/chevrolet/aveo-ls#name":
+  researcher: defective(D8)
+  verifier: CONFIRMED
+  evidence: ["a trim level at model altitude with car/chevrolet/aveo live ⇒ D8 exactly as booked"]
+
+"car/chevrolet/cruze-eco#id":
+  researcher: defective(D8)
+  verifier: CONFIRMED
+  evidence:
+    - "OBJECTIVE TIEBREAK, verified myself: us_vehicles.csv reads model='Cruze Eco', baseModel='Cruze' for MY2011–2015 (also 'Cruze Limited'→'Cruze', 'Cruze Premier'→'Cruze', 'Cruze Hatchback'→'Cruze')"
+    - "car/chevrolet/cruze is live; cruze-eco, cruze-limited, cruze-limited-eco, cruze-lt, cruze-premier are five live trim siblings ⇒ D8"
+    - "this entry is the internal benchmark showing the researcher DID know the D8 rule, which is why the D6-labelled aveo-ls / ut-420-standard / denza-d9-fwd entries are reclassifications rather than overturns"
+
+"car/chevrolet/lumina-monte-carlo#id":
+  researcher: defective(D13)
+  verifier: CONFIRMED
+  evidence:
+    - "catalog name is literally 'Lumina/monte Carlo' — a slash-joined two-nameplate cell"
+    - "us_vehicles.csv confirms the artifact at source: model='Lumina/Monte Carlo', baseModel='Lumina/Monte Carlo', alongside separate model='Lumina', baseModel='Lumina' rows"
+    - "car/chevrolet/lumina, /monte-carlo (raw 'CHEVROLET MONTE CARLO') and /monte-carlo-ss are all separately live; the Lumina and Monte Carlo are distinct nameplates (the Lumina coupé was renamed Monte Carlo for 1995)"
+    - "D13 is 'temporal merge cell' with remedy 'source-level COMMA_MERGED map'; a slash-merged cell is the same artifact with a different separator"
+
+"car/chevrolet/lumina-monte-carlo#name":
+  researcher: defective(D13)
+  verifier: CONFIRMED
+  evidence: ["'Lumina/monte Carlo' is not any marque's rendering of anything — a merged source cell plus a casing wart ('monte')"]
+
+"car/chevrolet/sonic-5#id":
+  researcher: defective(D8)
+  verifier: CONFIRMED
+  evidence:
+    - "OBJECTIVE TIEBREAK, verified myself: us_vehicles.csv reads model='Sonic 5', baseModel='Sonic' and model='Sonic 5 RS', baseModel='Sonic'"
+    - "car/chevrolet/sonic, /sonic-5, /sonic-lt are all live ⇒ D8 by the declared rule"
+
+"car/chrysler/gs#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED (contested)
+  evidence:
+    - "car/chrysler/gs: name 'GS', observed_variants EMPTY, fi + nl. nl_rdw rows verified verbatim: {'merk':'CHRYSLER','handelsbenaming':'GS','n':'1'}, 'GS TURBO 2' n=1, 'GS TURBO 2 K6' n=3, 'GS TURBO 2 U9' n=8 (K6/U9 are RDW internal suffixes seen across many makes)"
+    - "the make's 89 siblings are nameplates (300, Concorde, Neon, Voyager, Le Baron); a bare two-letter code is the outlier ⇒ D9"
+    - "CONTESTED, and I record it honestly: while resolving the ID claim I found third-party sources (car.info 'Chrysler Daytona Shelby/GS Turbo II 1987–1991'; chrysler-club.net 'Chrysler Laser / Daytona / GS') indicating the European marque-of-sale name really did use 'GS'. Under the CPx/tS/XR4i rule ('weird can be right') a period Chrysler Europe brochure could flip this to correct. The preponderance is still that the nameplate is Daytona and GS is the trim, so I confirm — but a curator should not treat this as settled."
+
+"car/citroen/11bl#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "car/citroen holds 11, 11-bl-sport, 11-legere, 11b, 11bl, 11c, 15, 15-six, 15cv AND traction — ten live ids for the Traction Avant range"
+    - "car/citroen/11's raw is ['11 BERLINE','11 BERLINE LEGERE','11 CABRIOLET','11-B'] and /traction's raw contains 'TRACTION AVANT 11 BL','TRACTION AVANT 11 B','TRACTION AVANT 11 SIE BL'"
+    - "'11 BL', '11-Legere' (= 11 BL, Berline Légère) and '11bl' are three live ids for ONE car; '11b' vs '11-B' is a second whitespace/hyphen duplicate ⇒ D6"
+
+"car/citroen/c#name":
+  researcher: defective(D9)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'C', raw ['C 5 HP'], nl + nz"
+    - "the bare letter pools the 1922 Type C (5 HP) with anything else registered as a bare C, while /c1…/c8 are all live with raw sets containing the spaced spellings 'C 1' and 'C 2'"
+    - "Citroën's forms are 'Type C', '5 HP', 'C3' — never a bare 'C' ⇒ D9"
+
+"car/citroen/gsa-special#id":
+  researcher: defective(D8)
+  verifier: CONFIRMED
+  evidence:
+    - "car/citroen/gsa (raw 'CITROEN GSA') is live, as are gsa-break, gsa-club, gsa-pallas, gsa-special, plus the whole GS set (gs, gs-1220, gs-break, gs-club, gs-pallas, gs-special, gs1220-club)"
+    - "'Spécial' is a Citroën trim level (Spécial / Club / Pallas / X) ⇒ trim at model altitude with the bare nameplate live = D8"
+
+"car/citroen/gsa-special#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Gsa Special' — two form errors: 'Gsa' title-cases the acronym GSA, and 'Special' drops the acute in Citroën's 'Spécial'"
+    - "INTERNAL PROOF: the sibling car/citroen/gs-special is stored as 'GS Special' with the acronym upper-cased, while every gsa-* sibling is 'Gsa …'. One make, two conventions."
+
+"car/citroen/mehari#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "catalog name 'Mehari', but observed_model_names for this id records BOTH 'Mehari' AND 'Méhari' — the accented form is present in the corpus and was dropped"
+    - "Citroën's rendering is 'Méhari'; the taxonomy's D7 example set lists accents explicitly. Established on corpus evidence alone."
+
+"car/cupra/seat-leon#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "car/cupra/leon (raw 'CUPRA LEON','CUPRA LEON SP','CUPRA LEON E-HYBRID…') and car/cupra/seat-leon (raw 'SEAT LEON SP','SEAT LEON  SP') are BOTH live under make cupra"
+    - "'CUPRA LEON SP' and 'SEAT LEON SP' are one car written by two registers with different marque tokens; strip the marque token and both fold to 'Leon SP' ⇒ D6"
+
+"car/cupra/seat-leon#name":
+  researcher: defective(D5)
+  verifier: CONFIRMED
+  evidence:
+    - "name 'Seat Leon' under make 'cupra' — a foreign marque token prefixed to the nameplate; D5's prefix test fires literally"
+    - "moves.yml's header documents this exact register behaviour ('NL/NZ registries emit \"SEAT\" + \"CUPRA LEON\"/\"CUPRA ATECA\"') and states the remedy is a routing rule, with the marque token never surviving into the name"
+
+"car/daimler/mkii#name":
+  researcher: defective(D7)
+  verifier: CONFIRMED
+  evidence:
+    - "catalog name 'Mkii' — the Roman numeral II collapsed to lower-case 'ii'; the only raw is 'MKII SALOON'"
+    - "sibling car/daimler/mk2 (name 'MK2') is separately live — one make, two renderings of one designation"
+    - "no marque renders it 'Mkii'. DEBT.md's 'U7 variant-strip Roman collapse' is the known structural cause."
+
+"car/datsun/180b-wagon#id":
+  researcher: defective(D8)
+  verifier: CONFIRMED
+  evidence:
+    - "car/datsun/180b (raw '180B COUPE S') is live and /180b-wagon (raw EMPTY) is its sibling; /bluebird and /bluebird-1200 are live too"
+    - "'Wagon' is a BODY qualifier on a live bare nameplate ⇒ D8"
+    - "the same make repeats the pattern: 120y-wagon vs 120-y, 1600-de-luxe vs 1600, 260z-2-2 vs 260-z"
+
+"car/de-soto/soto#id":
+  researcher: defective(D4)
+  verifier: CONFIRMED
+  evidence:
+    - "make id 'de-soto' (name 'De Soto'); model slug 'soto', name 'Soto', raw ['DE SOTO'] — the raw string IS the bare make name, and the model name is what survived make-prefix stripping of a two-token make"
+    - "the make's other 15 models are real nameplates (Adventurer, Airflow, Firedome, Fireflite, Firesweep, Diplomat, Powerflite) — 'Soto' is the outlier, and /powerflite's raw 'DESOTO POWERFLITE' shows the same make written unspaced"
+    - "their detector-gap diagnosis (renames.yml carries 'De Soto: Desoto: null' but prefix-stripping produces 'SOTO', so the null key never matches) is correct and is the most valuable structural finding in the ledger"
+
+"car/de-soto/soto#name":
+  researcher: defective(D4)
+  verifier: CONFIRMED
+  evidence: ["name 'Soto' is a token-suffix of its own make name 'De Soto'; D4's name==make detector fires once the two-token make is accounted for"]
+
+"car/denza/d9-fwd#id":
+  researcher: defective(D6)
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "car/denza holds exactly three models: b8, d9 (raw 'DENZA D9 AWD') and d9-fwd (raw 'DENZA D9 FWD')"
+    - "'FWD'/'AWD' are DRIVETRAIN qualifiers of one nameplate — the researcher's own D8 rule names drivetrain explicitly, and the bare-nameplate sibling is live"
+    - "the asymmetry makes it unambiguous: the AWD variant was folded INTO car/denza/d9 while the FWD variant got its own id. D6 cannot fire."
+
+"car/denza/d9-fwd#name":
+  researcher: defective(D8)
+  verifier: CONFIRMED
+  evidence: ["'D9 Fwd' publishes a drivetrain qualifier at model altitude (and title-cases the acronym FWD) while car/denza/d9 already absorbs 'DENZA D9 AWD' ⇒ D8 as booked"]
+
+"car/dodge/polara-880#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "car/dodge holds polara (raw 'DODGE POLARA','POLARA ESTATE','Polara Convertible'), polara-500 (raw 'POLARA 500 CONVERTIBLE'), polara-880 (raw EMPTY), custom-880 and custom"
+    - "the Dodge 880 / Custom 880 was a SEPARATE 1962–65 nameplate from the Polara, so 'Polara 880' collides with TWO live siblings ⇒ id-canonical fails"
+    - "class: the merge shape is closer to D13 than D6, and the researcher flagged that reading for the verifier themselves. With observed_variants EMPTY I cannot show the source cell, so I do not reclassify on speculation."
+
+"car/dodge/polara-880#name":
+  researcher: defective(D8)
+  verifier: CONFIRMED
+  evidence: ["Dodge sold the Polara, the Polara 500 and the (Custom) 880 as distinct lines; 'Polara 880' is not a Dodge rendering. D8 vs D13 flagged in JUDGMENT_RULES."]
+
+"car/dodge/wc51#id":
+  researcher: defective(D6)
+  verifier: CONFIRMED
+  evidence:
+    - "MY FIRST VERDICT WAS WRONG AND I AM RECORDING THE CORRECTION. I checked wc51 against wc52/wc56/wc57 — which ARE legitimately distinct vehicles (WC51 = ¾-ton weapons carrier without winch, WC52 = with winch, WC56 = command reconnaissance car) — and overturned to correct. I overlooked the stub."
+    - "VERIFIED: car/dodge/wc is LIVE — name 'Wc', avail nl + nz, observed_variants EMPTY (i.e. the raw string is the bare 'WC'). A bare-prefix stub that pools the whole WC series therefore denotes, among others, the WC51 ⇒ id-canonical fails as the protocol words it. D6 CONFIRMED."
+    - "METHODOLOGICAL NOTE worth carrying into the fix queue: the defective record here is car/dodge/wc, not car/dodge/wc51. wc51 is the CANONICAL id and is being penalised for the existence of a truncated neighbour. Booking the claim against the sampled record is correct per §2's wording, but a curator reading the ledger could easily 'fix' the wrong id."
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PART 2 — ALL 15 UNVERIFIABLE CLAIMS, ONE ALTERNATIVE ROUTE EACH
+# ══════════════════════════════════════════════════════════════════════════════
+
+"bus/ayats/bravo#name":
+  researcher: "unverifiable(no Ayats source reachable — ayats.com refused the connection)"
+  verifier: RESOLVED → correct
+  route_tried: "the researcher tried ayats.com. I tried the encyclopedia and the marque's ACTUAL domain, which is ayats.es, not ayats.com."
+  evidence:
+    - "https://en.wikipedia.org/wiki/Ayats_Bravo — a dedicated article: 'The Ayats Bravo is a range of coaches manufactured by Ayats… There are four variants, the Bravo 1, Bravo 2, Bravo 3, and Bravo City'"
+    - "https://ayats.es/en/ayats-en — Carrocerías Ayats SA's own live site (the .com the researcher tried is not the marque's domain)"
+    - "the register string 'BRAVO I R CITY' maps onto 'Bravo 1' + 'City'; the display name 'Bravo' is the marque's own range name ⇒ rule (a) satisfied"
+    - "FINDING FOR THE SOURCE-GAP QUEUE: this unverifiable was caused by a wrong domain guess, not by an unreachable marque. Worth a note in the queue so the same miss is not repeated."
+
+"bus/higer/a30#id":
+  researcher: "unverifiable(whether the A30 is the same coach as the Scania Touring HD could not be resolved)"
+  verifier: RESOLVED → correct
+  route_tried: "the researcher tried en.wikipedia.org/wiki/Scania_Touring (404) and higer.com. I went to the cached nl_rdw bus file and read the rows verbatim."
+  evidence:
+    - "cache/nl_rdw_bus.json, verbatim: {'merk':'HIGER','handelsbenaming':'A80T 6X2: SCANIA TOURING HD','n':'1'}; {'merk':'HIGER','handelsbenaming':'SCANIA HIGER A30','n':'50'}; {'merk':'HIGER','handelsbenaming':'SCANIA TOURING HB','n':'1'}; {'merk':'HIGER','handelsbenaming':'SCANIA TOURING HD','n':'99'}"
+    - "the register BINDS the Touring to the A80T body in its own row text. The A30 is therefore a different Higer body from the one bus/higer/touring denotes."
+    - "no other live id denotes the A30: bus/higer has exactly two models (a30, touring), and no scania/a30 exists (I enumerated bus/scania's 30 models)"
+    - "id-canonical is CORRECT."
+
+"bus/higer/a30#name":
+  researcher: "unverifiable(single-register attestation only; no Higer or Scania source reachable)"
+  verifier: RESOLVED → correct
+  route_tried: "the researcher tried higer.com. I searched scania.com, which is the co-marque and was reachable."
+  evidence:
+    - "MARQUE SOURCE: scania.com hosts a spec sheet 'SCA0363SchoolBusesSpecSheet_HigerA30_SAU2016-7-A30_4x2_WEB.pdf' — Scania's own document names the product 'Higer A30'"
+    - "corroborated by a manufacturer user manual indexed as 'Scania Higer A30 User Manual'"
+    - "'A30' is the marque's own rendering ⇒ rule (a) satisfied, name is CORRECT"
+
+"bus/iveco/dyparro#name":
+  researcher: "unverifiable(no source reachable identifies 'Dyparro')"
+  verifier: RESOLVED → correct
+  route_tried: "the researcher searched en.wikipedia and marque catalogues. I searched for the string itself and found the builder's own site."
+  evidence:
+    - "BUILDER SOURCE: https://dyparro.com/Iveco-chassis-offer/ — page titled 'DYPETY - DYPARRO 90T'. The builder is DYPETY and DYPARRO is its product range."
+    - "corroborated by dealer listings that carry both tokens: truckscout24.com 'Iveco Dypety Dyparro 90T ( Rapido, 818 )', autoline 'IVECO Dypety Dyparro 90T'"
+    - "the display name 'Dyparro' is the builder's own product name ⇒ name is CORRECT (minor altitude note: the full designation is 'Dyparro 90T' and the raw carries the 90T, so a D8-shaped reading exists, but the range name itself is marque-true)"
+
+"bus/iveco/dyparro#make":
+  researcher: "unverifiable(nl_rdw files 4 of 5 rows under merk 'IVECO - DYPETY'… moves.yml routes bodied minicoaches to the BUILDER's make, which would apply here if the builder could be identified)"
+  verifier: RESOLVED → defective(D11)
+  route_tried: "same route — the builder the researcher could not identify is named on its own website."
+  evidence:
+    - "cache/nl_rdw_bus.json, verbatim: {'merk':'IVECO','handelsbenaming':'DYPARRO 90T','n':'1'} and {'merk':'IVECO - DYPETY','handelsbenaming':'DYPARRO 90T','n':'4'} — 4 of 5 nl rows name the builder"
+    - "the builder is DYPETY (dyparro.com, 'DYPETY - DYPARRO 90T'); the vehicle is a DYPETY Dyparro body on an Iveco 70C17 chassis"
+    - "the researcher's OWN stated condition is now met: moves.yml's Iveco block routes bodied minicoaches to the builder ('Sunrise: null # Ferqui Sunrise … canonical is ferqui/sunrise', 'Wing: null # Indcar Wing'). By the project's established convention this record belongs to a dypety make, not to iveco."
+    - "D11 (wrong make; remedy is a moves.yml route) — the condition the researcher set for converting this to a defect is satisfied."
+
+"bus/volvo/8707#id":
+  researcher: "unverifiable(cannot determine whether '8707' is a distinct product from bus/volvo/8700)"
+  verifier: RESOLVED → defective(D8)
+  route_tried: "the researcher looked for a Volvo source enumerating 8707. I looked for a source that EQUATES the two designations."
+  evidence:
+    - "https://www.truck1.eu/buses/suburban-buses/volvo-8707-rle-8700-b7r-le-a2541356.html — listing title, verbatim: 'Volvo 8707 RLE // 8700 B7R LE'. One vehicle, both designations, written as equivalents."
+    - "https://en.wikipedia.org/wiki/Volvo_8700 — 'The 8700LE was available on B7RLE and B12BLE'. So an 8700 on a B7RLE chassis is exactly what '8707 RLE' describes; the '07' encodes the B7R."
+    - "the catalog's own sibling bus/volvo/8908rle ('8908RLE 6x2') is the same encoding one family up: 8900 body + B8R chassis"
+    - "bus/volvo/8700 is live with raw '8700 RLE' ⇒ another live id denotes the same vehicle. Class D8: a chassis qualifier fused into the number, published at model altitude with the bare nameplate live."
+    - "EVIDENCE TIER, stated honestly: the equating source is a used-bus dealer listing plus an encyclopedia, not a Volvo document. Strong enough to resolve, not strong enough to call airtight."
+
+"bus/volvo/8707#name":
+  researcher: "unverifiable(no Volvo source reachable attests '8707')"
+  verifier: RESOLVED → defective(D9)
+  route_tried: "en.wikipedia.org/wiki/Volvo_8700 (the researcher went to the Volvo_8900 page)"
+  evidence:
+    - "https://en.wikipedia.org/wiki/Volvo_8700 enumerates the range exhaustively: 'Volvo 8700 (medium floor)', 'Volvo 8700LE (low-entry)', 'Volvo 8700LEA (articulated low-entry)'. Fetched and checked specifically: the page does not contain the string '8707' anywhere."
+    - "a display name absent from the marque's own enumerated range, arising from a register composite of body number + chassis number ⇒ D9 (registry/type code as model)"
+
+"car/aion/hyptec-ht-620-premium#make":
+  researcher: "unverifiable(GAC markets Hyptec as its own brand line but no reachable source settles whether it is a marque separate from Aion)"
+  verifier: RESOLVED → correct
+  route_tried: "en.wikipedia.org/wiki/Hyptec plus trade press (marklines.com, gasgoo, paultan.org)"
+  evidence:
+    - "https://en.wikipedia.org/wiki/Hyptec — HYPTEC is GAC Aion's luxury SUB-BRAND, rebranded from 'Hyper' in August 2024"
+    - "in December 2025 GAC Group merged the Hyptec and Aion business units into a single unified business unit"
+    - "the market rendering of the product is 'GAC Aion Hyptec HT' (paultan.org, marklines.com 'GAC Aion's HYPTEC HT electric SUV officially launched in Thailand'), i.e. Aion is the marque and Hyptec the line"
+    - "th_dlt filing the row under maker 'AION' therefore matches the marque of sale ⇒ make is CORRECT. This resolves in the researcher's favour."
+
+"car/austin/clifton#id":
+  researcher: "unverifiable(cannot establish whether 'Clifton' denotes a model, a coachbuilt body, or something else, so overlap is undecidable)"
+  verifier: RESOLVED → defective(D6)
+  route_tried: "the researcher went to Wikipedia for the body list. I went to the catalog's own sibling set — the referent question is answered by a record the catalog already holds."
+  evidence:
+    - "car/austin/clifton (name 'Clifton', raw ['CLIFTON TOURER']) is live — AND car/austin/12-4-clifton is LIVE with name '12/4 Clifton' and raw ['12/4 CLIFTON TOURER']"
+    - "the two raw strings are the same string with and without the type prefix. That is a duplicate spelling in the strictest sense."
+    - "the make repeats it twice more: car/austin/ascot (raw 'ASCOT SALOON'), /12-4-ascot (name '12 / 4 Ascot', raw '12-4 ASCOT SALOON') and /ascot-12-4 (name 'Ascot 12/4') — THREE live ids for one body style, one of them carrying stray spaces"
+    - "id-canonical fails on a named live twin ⇒ defective(D6)"
+
+"car/austin/clifton#name":
+  researcher: "unverifiable(en.wikipedia.org/wiki/Austin_12/4 lists the produced bodies as Harley, Ascot, tourer, Eton, Open Road, cabriolet and estate — 'Clifton' does not appear)"
+  verifier: RESOLVED → correct
+  route_tried: "I re-fetched the researcher's page and reproduced their negative result exactly (Harley, Ascot, Eton, Open Road only — no Clifton). Then I went to a different source class: a museum collection record."
+  evidence:
+    - "https://nationalmotormuseum.org.uk/collections/vehicles/austin-twelve-clifton/ — the vehicle record is TITLED 'Austin Twelve Clifton' and reads: 'Available with a variety of saloon and tourer bodies, including the Clifton five-seater tourer seen here'"
+    - "corroborated by iconicauctioneers.com ('1930 Austin Heavy Twelve-Four Clifton Open Road Tourer') and by the catalog's own car/austin/12-4-clifton"
+    - "'Clifton' is Austin's own word for this product ⇒ the display name is marque-true. Name is CORRECT."
+    - "ALTERNATIVE READING, flagged not applied: because the museum frames Clifton as a BODY on the Austin Twelve — and car/austin/12 is live — a D8 altitude reading is available. I book one defect on this record (the id twin), not two."
+
+"car/bmw/ci#id":
+  researcher: "unverifiable(the underlying rows are bare trim-suffix strings that cannot be resolved to a model series, so whether another live id already denotes them is undecidable)"
+  verifier: RESOLVED → defective(D8)
+  route_tried: "closed-world enumeration of the candidate parents inside car/bmw — the referent need not be pinned to a single series if EVERY candidate parent is live."
+  evidence:
+    - "BMW's 'Ci' suffix was used on exactly three ranges: the 3 Series (318Ci…330Ci), the 6 Series (645Ci, 650Ci) and the 8 Series (840Ci, 850Ci)"
+    - "all three parents are LIVE and I verified each carries the Ci strings in its own raw set: car/bmw/3-series contains '318 CI COUPE','320 CI CONVERTIBLE','325 CI CABRIO','330 CI COUPE'; car/bmw/6-series contains '645 CI CABRIO','650 CI CABRIO'; car/bmw/8-series contains '840 CI AUT. E2','840 CI AUTO','850 CI A COUPE','850 CI E2'"
+    - "whichever range the 'CI CABRIO' / 'BMW CI' rows belong to, a live id already denotes them ⇒ id-canonical fails under every reading. This is enumeration, not analogy: the candidate set is closed and each member was checked."
+    - "class D8: a body/engine suffix at model altitude with live bare nameplates"
+
+"car/chevrolet/universal#availability.nz":
+  researcher: "unverifiable(the only nz row reachable is 'CHEVROLET | A D UNIVERSAL' n=1, which does not fold to 'Universal' under any documented rule)"
+  verifier: UPHELD — remains unverifiable
+  route_tried: "observed_variants for the id, plus a sibling scan of all 285 car/chevrolet models for a Series-AD-shaped neighbour"
+  evidence:
+    - "observed_variants has NO entry for car/chevrolet/universal at all, so the catalog carries no raw spelling for this id in either country — I cannot reproduce the nz row from the corpus side either"
+    - "the make holds /independence, /national, /confederate (other Chevrolet series names) but no 'series-ad' id that could absorb an 'A D UNIVERSAL' row"
+    - "I found no route the researcher had not already taken. Their unverifiable stands and correctly counts against the clean rate."
+
+"car/chrysler/gs#id":
+  researcher: "unverifiable(the rows are bare trim strings on a 1980s Chrysler G-body; I could not establish which nameplate they denote, so overlap with a live Chrysler id is undecidable)"
+  verifier: RESOLVED → correct
+  route_tried: "targeted search on the exact register string 'GS Turbo II' rather than on the bare 'GS'"
+  evidence:
+    - "car.info lists the vehicle as 'Chrysler Daytona Shelby/GS Turbo II 177ps, (1987 - 1991)'; automobile-catalog carries '1988 Chrysler GTS Shelby 2.2L Turbo Intercooler … for Europe export'; chrysler-club.net groups the family as 'Chrysler Laser / Daytona / GS'. The referent is the European-market Chrysler version of the Dodge Daytona Shelby Z — the blocker the researcher stated is removed."
+    - "with the referent established I checked for a live twin: car/chrysler has 89 models including /laser and /le-baron but NO /daytona. No live car/chrysler id denotes this vehicle."
+    - "car/dodge/daytona is live, but that is the SAME car under its US marque of sale, which the project's own marque-of-sale convention (moves.yml header) treats as a legitimately separate record"
+    - "id-canonical is CORRECT."
+
+"car/citroen/c#id":
+  researcher: "unverifiable(the record rests on bare-letter rows plus one 'C 5 HP'; Type C, C4, C6 and the modern C-series all fold to the same key, so which vehicle the id denotes — and therefore whether a sibling duplicates it — is undecidable)"
+  verifier: RESOLVED → defective(D6)
+  route_tried: "same closed-world enumeration: every candidate referent has a live sibling, so the overlap question resolves without pinning the referent."
+  evidence:
+    - "the id's only raw string is 'C 5 HP' — the Citroën Type C / 5 CV — and car/citroen/5-cv is LIVE (name '5 Cv', nl + nz). That alone is a named twin for the record's only attested raw string."
+    - "for the bare-'C' rows the enumeration closes too: car/citroen/{c1,c2,c3,c4,c5,c6,c8} are all live, and c1's raw contains 'C 1' while c2's contains 'C 2' — the spaced spellings that a bare 'C' key would collide with"
+    - "under every candidate reading a live sibling denotes the vehicle ⇒ id-canonical fails. D6."
+
+"car/daimler/mkii#id":
+  researcher: "unverifiable(the id pools 'MKII SALOON' with 'MK II DINGO' so it is not clear the id denotes ONE vehicle; DEBT.md files the Daimler/Jaguar Mk split family as open work)"
+  verifier: RESOLVED → defective(D6)
+  route_tried: "closed-world enumeration over the two referents the researcher himself named."
+  evidence:
+    - "if the id denotes the Mk II saloon: car/daimler/mk2 is LIVE (name 'MK2', nl + nz). 'Mkii' and 'MK2' are two renderings of 'Mark II' — a D6 spelling pair under NFKD + Roman-numeral folding."
+    - "if the id pools the Dingo Mk II scout car: car/daimler/dingo is LIVE. (car/daimler/century-mk2 and /ferret are live as well.)"
+    - "both of the researcher's own candidate referents already have a live id ⇒ id-canonical fails either way. D6."
+    - "caveat recorded: car/daimler/mk2's observed_variants is empty, so its referent rests on the name string alone. The verdict does not depend on that leg, because the Dingo leg closes the enumeration independently."
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PART 3 — SPOT-CHECK OF `correct` VERDICTS
+# ══════════════════════════════════════════════════════════════════════════════
+# Sampling (deterministic and reproducible): select every record whose ledger
+# verdicts carry BOTH id:correct AND name:correct → 33 records; sort by id; take
+# index floor(i*33/25) for i in 0..24 → 25 records; re-derive the id and name
+# claim of each → 50 claims. Script: vfy/parse2.rb in the scratchpad.
+
+spot_check_sample: [bus/beulas/glory, bus/fiat/ducato, bus/hyundai/h-1, bus/isuzu/journey,
+  bus/ldv/maxus, bus/mercedes-benz/atego, bus/mitsubishi-fuso/rosa, bus/otokar/vectio,
+  bus/scania/interlink, bus/toyota/coaster, bus/volvo/9500, bus/volvo/b12ble, bus/yutong/u12,
+  car/ahorn/van-620, car/audi/a8, car/bristol/401, car/bugatti/divo, car/bugatti/mistral,
+  car/buick/rainier, car/cadillac/fleetwood-sixty-special, car/chevrolet/malibu-limited,
+  car/chevrolet/orlando, car/cupra/born, car/daimler/consort, car/daimler/super-v8]
+
+"car/cadillac/fleetwood-sixty-special#id":
+  researcher: correct
+  verifier: MISS — should be defective(D6)
+  evidence:
+    - "FOUR live ids in car/cadillac denote the Cadillac Sixty Special, all verified live: fleetwood-sixty-special ('Fleetwood Sixty Special'), fleetwood-60-special ('Fleetwood 60 Special', fi/nl, raw 'FLEETWOOD 60 SPECIAL SEDAN','FLEETWOOD 60 SPECIAL SEDAN 1958','Fleetwood 60 Special Sedan'), fleetwood-60s ('Fleetwood 60S') and sixty-special ('Sixty Special', fi/nl)"
+    - "'Fleetwood Sixty Special' vs 'Fleetwood 60 Special' is a word/digit spelling pair of ONE nameplate, same make+kind, and both carry fi+nl availability — the same two registers, so this is not two markets naming one car differently"
+    - "the researcher's note reads 'id judged correct: the Sixty Special is a distinct Cadillac series, not a trim of the Fleetwood'. That answers a different question — they compared only against car/cadillac/fleetwood and never enumerated the other three."
+    - "the make repeats the pattern: fleetwood-brougham vs fleetwood-broughan (a typo twin), fleetwood-75 vs fleetwood-seventy-five, sixty-two vs series-62 vs 62-series vs 62"
+    - "GENUINE MISS: a defective id claim scored correct."
+
+"car/cadillac/fleetwood-sixty-special#name":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence: ["'Fleetwood Sixty Special' is a real Cadillac model name and the fi raw 'Fleetwood Sixty Special Sedan (AA) 4ov 6390cm3 A' and nl raw 'FLEETWOOD SIXTY SPECIAL' both carry it. Name is correct; only the id claim fails."]
+
+"car/chevrolet/malibu-limited#id":
+  researcher: correct
+  verifier: CONTESTED — flagged, not flipped
+  evidence:
+    - "car/chevrolet/malibu is live, as are malibu-classic, malibu-limited, malibu-maxx and a bare /classic"
+    - "OBJECTIVE TIEBREAK, checked myself: us_vehicles.csv reads model='Malibu Limited', baseModel='Malibu' (alongside 'Malibu Hybrid'→'Malibu', 'Malibu eAssist'→'Malibu', 'Malibu Maxx'→'Malibu'). By the researcher's OWN declared tiebreak this flips to defective(D8)."
+    - "against that: 'Malibu Limited' was GM's official model-year designation for the 2016 carry-over eighth-generation car sold alongside the all-new ninth-generation Malibu — a distinct catalogued product, which is the 'distinct product' side of their stated rule"
+    - "the researcher anticipated this exact dissent in their own note ('a verifier reading EPA's baseModel strictly could dissent'), which is good practice and is why I flag rather than flip"
+    - "NOT counted in the miss rate."
+
+"car/daimler/super-v8#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence:
+    - "I checked the tempting neighbours: car/daimler/super-8 ('Super 8', raw 'DAIMLER SUPER 8') and /super-eight ('Super Eight') are a D6 pair WITH EACH OTHER, but they denote the X350-era Daimler Super Eight — a different car from the X308-era Super V8 this id carries (raw 'DAIMLER SUPER V8')"
+    - "car/daimler/super-v8 has no twin. Correct as scored. (The super-8/super-eight pair is a defect in records outside this slice.)"
+
+"car/bristol/401#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence: ["raw ['BRISTOL 401']; siblings 400,402,403,405,406,407,408,409,410,411 each carry exactly one raw string of the same shape — a cleanly enumerated numeric range with no spelling twins"]
+
+"car/audi/a8#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence: ["80+ raw variants across 13 countries; the only near-neighbour is car/audi/s8, a genuinely distinct model. The spaced spellings 'A 8','A 8 QUATTRO','A 8 LIMOUSINE' are absorbed INTO a8 rather than forming a twin — the correct outcome and the exact opposite of the volvo/b and setra/s failures."]
+
+"bus/volvo/9500#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence: ["raw ['Volvo 9500'] — one spelling. The neighbours 8900/8900rle and 9700/9700h/9700hd are defective pairs among themselves (booked elsewhere in this slice) but neither collides with 9500."]
+
+"bus/volvo/b12ble#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence: ["raw ['B12BLE 4X2 8700LE','B12BLE 4x2','B12BLE 6x2','B12BLE FWS-IL 6X2','B12BLE/730']; b12, b12b, b12m are distinct Volvo chassis. No 'B12 BLE' whitespace twin exists as its own id."]
+
+"bus/scania/interlink#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence: ["11 spellings of one product all absorbed into ONE id ('SCANIA INTERLINK','Scania Interlink, 3-axle','INTERLINK 3-AXLE','SCANIA INTERLINK, 3AXEL'…). No twin. The folding behaving correctly."]
+
+"bus/otokar/vectio#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence: ["raw ['VECTIO 290 T','VECTIO 290T','VECTIO 310T','VECTIO G 250 U','VECTIO U LE'] all under one id — note '290 T' vs '290T' folded together correctly here, the same fold that FAILED for setra/s417"]
+
+"bus/mitsubishi-fuso/rosa#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence: ["five trim strings ('ROSA CUSTOM','ROSA CUSTOM AUTO','ROSA CUSTOM AWD','ROSA SCHOOL AUTO','ROSA SCHOOL EURO 6') correctly folded into one nameplate id; sibling canter is a different product"]
+
+"bus/mercedes-benz/atego#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence: ["raw ['ATEGO 1022L','ATEGO 1217','ATEGO 1218L','ATEGO 1530 TOURING GT'] folded into one nameplate; no 'atego-<number>' twin exists. Notably this is the SAME make whose 300/311/316/412-d/518/818 numeric ids failed — the failure is confined to code-stub ids, not to the make."]
+
+"bus/isuzu/journey#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence: ["raw ['JOURNEY DELUXE','JOURNEY LR312','JOURNEY LR312J','JOURNEY P-MR112D'] under one id; sibling turquoise is a different Isuzu product"]
+
+"bus/fiat/ducato#id":
+  researcher: correct
+  verifier: CONFIRMED
+  evidence:
+    - "14 spellings ('DUCATO 18','DUCATO MAXI','FIAT DUCATO 35','DUCATO MINIBUS'…) all folded into ONE bus-kind id; no ducato twin under bus/fiat"
+    - "the cross-KIND twins (van/fiat/ducato, truck/fiat/ducato) are excluded by the researcher's declared rule and by D10's 'NEVER lose the other kind's evidence'. I applied the identical rule."
+
+"bus/ldv/maxus#id":       {researcher: correct, verifier: CONFIRMED, evidence: ["raw ['LDV MAXUS'], the make's only model, no twin"]}
+"bus/beulas/glory#id":    {researcher: correct, verifier: CONFIRMED, evidence: ["bus/beulas has exactly two models (glory, jewel), both real Beulas coaches, no twin"]}
+"bus/hyundai/h-1#id":     {researcher: correct, verifier: CONFIRMED, evidence: ["the make's ONLY bus model; observed_variants empty; no twin possible"]}
+"bus/toyota/coaster#id":  {researcher: correct, verifier: CONFIRMED, evidence: ["bus/toyota holds coaster and hiace — two distinct Toyota products"]}
+"bus/yutong/u12#id":      {researcher: correct, verifier: CONFIRMED, evidence: ["bus/yutong holds u11dd, u12, u13l, u15, u18 — a correctly enumerated U-series with NO bare-'u' stub, plus ic and zk. Contrast bus/setra/s, where the bare series letter did get an id."]}
+"car/chevrolet/orlando#id": {researcher: correct, verifier: CONFIRMED, evidence: ["raw ['CHEVROLET ORLANDO'] across 8 countries, one spelling, no twin among 285 siblings"]}
+"car/cupra/born#id":      {researcher: correct, verifier: CONFIRMED, evidence: ["14 power/battery strings ('BORN 150 KW 58/62 KWH','BORN 240 KW 79/84 KWH','CUPRA BORN'…) ALL folded into one nameplate id — the direct contrast with car/cupra/seat-leon, where the marque-token spelling got its own id"]}
+"car/daimler/consort#id": {researcher: correct, verifier: CONFIRMED, evidence: ["raw ['CONSORT SALOON']; siblings db18 and light-15 are the related but distinct DB18 / Light Fifteen"]}
+"car/bugatti/divo#id":    {researcher: correct, verifier: CONFIRMED, evidence: ["us_vehicles.csv: make=Bugatti, model='Divo', baseModel='Divo' — the register's own altitude signal says Divo IS the base model, not a Chiron trim"]}
+"car/bugatti/mistral#id": {researcher: correct, verifier: CONFIRMED, evidence: ["us_vehicles.csv: model='Mistral', baseModel='Mistral' — base model per the register; no twin"]}
+"car/buick/rainier#id":   {researcher: correct, verifier: CONFIRMED, evidence: ["us_vehicles.csv: model='Rainier AWD'/'Rainier 2WD', baseModel='Rainier'. The drivetrain token was correctly stripped rather than promoted to an id — the opposite of the denza/d9-fwd failure."]}
+"car/ahorn/van-620#id":   {researcher: correct, verifier: CONFIRMED, evidence: ["the make's only model; no twin possible. (Its KIND claim is separately and correctly booked defective — see PART 1.)"]}
+
+spot_check_name_claims:
+  method: "all 25 name claims re-derived; the 21 not itemised above resolved to CONFIRMED on marque-name evidence with no dissent worth an entry"
+  confirmed_on_marque_or_register_evidence:
+    - "car/ahorn/van-620 'Van 620' — ahorn-camp.de's own model page renders 'VAN 620'"
+    - "car/bugatti/divo 'Divo', car/bugatti/mistral 'Mistral', car/buick/rainier 'Rainier' — us_vehicles.csv model/baseModel columns carry the exact forms"
+    - "bus/scania/interlink 'Interlink', bus/otokar/vectio 'Vectio', bus/mitsubishi-fuso/rosa 'Rosa', bus/isuzu/journey 'Journey', bus/toyota/coaster 'Coaster', bus/ldv/maxus 'Maxus', bus/beulas/glory 'Glory', bus/mercedes-benz/atego 'Atego', bus/fiat/ducato 'Ducato', bus/hyundai/h-1 'H-1', bus/yutong/u12 'U12', bus/volvo/9500 '9500', bus/volvo/b12ble 'B12BLE' — each is the marque's own product name, and each appears verbatim in the id's own raw set (or, for h-1/u12/coaster/glory, is the bare canonical form with no competing spelling in the corpus)"
+    - "car/audi/a8 'A8', car/bristol/401 '401', car/chevrolet/orlando 'Orlando', car/cupra/born 'Born', car/daimler/consort 'Consort', car/daimler/super-v8 'Super V8', car/cadillac/fleetwood-sixty-special 'Fleetwood Sixty Special'"
+  misses_found: 0
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PART 4 — THE RESEARCHER'S SELF-DECLARED JUDGMENT RULES, AUDITED
+# ══════════════════════════════════════════════════════════════════════════════
+
+JUDGMENT_RULES:
+  - rule: "D8-on-id when the suffix is a trim / engine / drivetrain / body qualifier AND a bare-nameplate sibling is live"
+    applied_consistently: NO
+    finding: >-
+      The rule is sound and explicitly declared, but it was applied to some records
+      and D6 used for structurally identical ones. D8 was used at
+      car/bentley/flying-spur-v8, car/chevrolet/cruze-eco, car/chevrolet/sonic-5,
+      car/datsun/180b-wagon, car/citroen/gsa-special. D6 was used for the same shape
+      at car/chevrolet/aveo-ls (trim), car/aion/ut-420-standard (trim),
+      car/denza/d9-fwd (drivetrain) and bus/mercedes-benz/{311,316,518,818,transfer}
+      (engine / tonnage / body). I reclassified those eight to D8.
+      No claim-level verdict changes — only the class mix. That still matters,
+      because §4's remedy column differs per class: D6's remedy is "merge to
+      canonical", D8's is "fold into nameplate, record as a variant". Executing a
+      D8 as a D6 merge would DESTROY the trim / engine / drivetrain distinction
+      (Aveo LS, Cruze Eco, D9 FWD, Sprinter 311/316/518). This is the single most
+      consequential finding of the verification pass, and it is a CLASSIFICATION
+      finding, not a rate finding.
+    would_flip_under_alternative_reading: "no verdict flips; only classes"
+  - rule: "us_fueleconomy baseModel as the objective altitude tiebreak 'where available'"
+    applied_consistently: NO
+    finding: >-
+      I checked the column myself. It gives baseModel='7 Series' for BMW
+      ActiveHybrid 7, '6 Series' for the Alpina B6, and 'Malibu' for the Malibu
+      Limited. The researcher scored car/bmw/activehybrid-7#id and
+      car/chevrolet/malibu-limited#id as CORRECT and car/bmw/alpina-b6#id as D6 —
+      i.e. the declared tiebreak was available in all three cases and consulted in
+      none of them, and in two of the three it points the other way. Neither
+      reading is unreasonable (ActiveHybrid 7 and Malibu Limited were both
+      marketed as models), and to their credit the malibu-limited note anticipates
+      the dissent in writing. FLAGGED, NOT FLIPPED — I leave all three as scored.
+  - rule: "name-marque-true = correct only with (a) a marque/encyclopedia URL showing the exact form, or (b) ≥2 INDEPENDENT registers emitting the exact display form; single-register attestation with no reachable marque source = unverifiable"
+    applied_consistently: MOSTLY-YES
+    finding: >-
+      A strict, well-chosen rule, and the reason the slice carries 15
+      unverifiables rather than a flattering zero. I tested it against the
+      single-source records and found it honoured in the conservative direction
+      (bus/isuzu/f nz-only, bus/wrightbus/gb gb-only, bus/zhongtong/lck nz-only
+      were all scored defective, not correct). Two asymmetries: (i) the same
+      evidentiary strictness is NOT applied to the ID claim — several D6 id
+      verdicts assert a duplicate without naming the colliding live id, which is
+      what my alpina-b6 overturn corrects; (ii) the rule made them stop at the
+      first unreachable source. Seven of the 15 unverifiables fell to ONE
+      alternative route each: a different domain (ayats.es not ayats.com), a
+      co-marque's site (scania.com for the Higer A30), the builder's own site
+      (dyparro.com), a museum record (Austin Clifton), a different Wikipedia page
+      (Volvo_8700 not Volvo_8900), a cached register file already on disk (Higer),
+      or an enumeration over the catalog itself (Austin Clifton, Citroën C,
+      Daimler Mk II, BMW Ci). The rule is right; the search was one step short.
+  - rule: "cross-KIND twins are NOT id-canonicality failures (D10 requires keeping the other kind's evidence)"
+    applied_consistently: YES
+    finding: >-
+      Correct, principled, and consistent with D10's remedy column. I applied the
+      identical rule and it changed no verdict of mine. bus/fiat/ducato's
+      id=correct is right.
+  - rule: "one root cause breaking several claims is scored per-claim"
+    applied_consistently: YES-BUT
+    finding: >-
+      Right in principle — that is what claim-level rates are for — and applied
+      evenly across car/bmw/mini, car/chery/jaecoo-j8 and the altas pair. The BUT:
+      where the id claim's only support IS the make claim's evidence, scoring id
+      defective too is not per-claim scoring, it is double-counting. car/bmw/alpina-b6
+      is exactly that case, and there the supporting id evidence turned out not to
+      exist at all.
+  - rule: "availability = correct where the register really has rows, even if the record's KIND is wrong (defect booked once, against kind)"
+    applied_consistently: YES
+    finding: >-
+      Sound and matches §5's wording. Applied consistently at bus/nissan/patrol and
+      car/ahorn/van-620. No change. Their bus/mercedes-benz/300 note goes further
+      and flags that the gb rows include passenger cars — a uk_dft body-type
+      contamination I verified verbatim, and a good catch that belongs in the
+      source-gap queue rather than in this record's verdicts.
+
+MISSED_DEFECTS_FOUND_BY_VERIFIER:
+  - id: "car/cadillac/fleetwood-sixty-special#id"
+    class: D6
+    how_found: "the 25-record deterministic spot-check"
+    detail: "four live ids for the Cadillac Sixty Special; the researcher compared only against car/cadillac/fleetwood. COUNTED in the miss rate."
+  - id: "car/audi/avant-rs2#id"
+    class: D6
+    how_found: "incidentally, while re-deriving that record's NAME claim"
+    detail: "car/audi/rs2 is live (gb/nl/nz) with raw 'AUDI RS2','RS2 AVANT','RS2 AVANT 6 SPEED' — the same car as car/audi/avant-rs2 (raw 'AVANT RS2 QUATTRO /260'). The researcher scored the id correct. NOT counted in the miss rate, because the sample was drawn deterministically and this record falls outside it — but it is the second confirmed correct-scored duplicate, and it says the true miss rate is not a one-off."
+  - id: "car/daimler/super-8 / car/daimler/super-eight"
+    class: D6
+    how_found: "while clearing car/daimler/super-v8 in the spot-check"
+    detail: "'Super 8' (raw 'DAIMLER SUPER 8') and 'Super Eight' are a digit/word twin for one car. NOT counted — both records are outside slice 1. Reported so the pair is not lost."
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SUMMARY
+# ══════════════════════════════════════════════════════════════════════════════
+
+SUMMARY:
+  defects_reviewed: 95           # every claim in the researcher's defect_list
+  defects_confirmed: 81
+  defects_reclassified: 13
+  defects_overturned_to_correct: 0
+  defects_overturned_to_unverifiable: 1   # car/bmw/alpina-b6#id — cited twin does not exist
+  reclassification_detail:
+    D6_to_D8: [bus/mercedes-benz/311#id, bus/mercedes-benz/316#id, bus/mercedes-benz/518#id,
+               bus/mercedes-benz/818#id, bus/mercedes-benz/transfer#id, car/aion/ut-420-standard#id,
+               car/chevrolet/aveo-ls#id, car/denza/d9-fwd#id]
+    D6_to_D9: [bus/mazda/e#id]
+    D9_to_D8: [bus/mercedes-benz/transfer#name]
+    D7_to_D9: [bus/mercedes-benz/oh#name, bus/scania/bf#name]
+    D9_to_D7: [bus/van-hool/tx#name]
+
+  unverifiables_reviewed: 15
+  unverifiables_resolved: 14
+  unverifiables_upheld: 1        # car/chevrolet/universal#availability.nz
+  resolved_to_defective: 7
+    # car/austin/clifton#id D6 · bus/volvo/8707#id D8 · bus/volvo/8707#name D9
+    # · bus/iveco/dyparro#make D11 · car/bmw/ci#id D8 · car/citroen/c#id D6
+    # · car/daimler/mkii#id D6
+  resolved_to_correct: 7
+    # bus/ayats/bravo#name · bus/higer/a30#id · bus/higer/a30#name
+    # · bus/iveco/dyparro#name · car/aion/hyptec-ht-620-premium#make
+    # · car/austin/clifton#name · car/chrysler/gs#id
+
+  corrects_spot_checked: "25 records / 50 claims (id + name each), deterministically sampled"
+  misses_found: 1                # car/cadillac/fleetwood-sixty-special#id
+  contested_not_scored_as_miss: 1  # car/chevrolet/malibu-limited#id
+  spot_check_miss_rate: "1/50 claims = 2.0%  (1/25 records = 4.0%)"
+
+  adjusted_per_claim_tallies_for_the_slice:
+    researcher: {correct: 546, defective: 95, unverifiable: 15, total: 656}
+    verifier_deltas:
+      - "−1 defective, +1 unverifiable   car/bmw/alpina-b6#id overturned"
+      - "−7 unverifiable, +7 defective   seven unverifiables resolved to defects"
+      - "−7 unverifiable, +7 correct     seven unverifiables resolved to correct"
+      - "−1 correct, +1 defective        the spot-check miss"
+    verifier_adjusted: {correct: 552, defective: 102, unverifiable: 2, total: 656}
+    clean_rate_conservative: "552/656 = 84.1%  (researcher reported 546/656 = 83.2%)"
+    why_it_moved_up: >-
+      Not because the data is better than they said — the defect count went UP,
+      from 95 to 102. It moved because 14 of the 15 unverifiables were resolvable
+      with one more fetch each, and unverifiables count against the clean rate.
+      The conservative bound was being paid on evidence that existed and had not
+      been found.
+    caveat: >-
+      84.1% is an UPPER bound and should be read as one. The spot-check found a
+      defective id scored correct in a 25-record sample, and a second (car/audi/
+      avant-rs2#id) turned up incidentally outside it. Both are the same shape —
+      a live duplicate the researcher did not enumerate — which is the failure
+      mode their method is structurally weakest against, since the id check has
+      no evidentiary rule as strict as the one they wrote for names.
+    class_histogram:
+      researcher: {D6: 29, D9: 17, D7: 15, D5: 10, D8: 10, D4: 5, D11: 3, D10: 2, D12: 2, D13: 2}
+      verifier:   {D6: 23, D8: 21, D9: 19, D7: 14, D5: 10, D4: 5, D11: 4, D10: 2, D12: 2, D13: 2}
+      note: "verifier column includes the 7 defects promoted from unverifiable and the 1 spot-check miss (102 total)"
+
+  verdict_on_the_ledger: >-
+    Substantially sound and unusually well evidenced. Raw strings are quoted with
+    counts, single-register attestation is refused, the unverifiable bucket is used
+    honestly rather than as a dumping ground, and two of the borderline calls
+    (car/chevrolet/malibu-limited, car/dodge/polara-880) are flagged FOR the
+    verifier in the ledger itself — which is exactly the behaviour I-11 is meant
+    to produce. Four weaknesses, in descending order of consequence:
+    (1) D6 is used as a catch-all for any id-canonicality failure, including eight
+    altitude failures whose §4 remedy is different and destructive if mis-executed;
+    (2) three id verdicts assert a duplicate without naming the colliding live id,
+    and in one of those the named twin does not exist in the catalog at all
+    (car/alpina/b6);
+    (3) at least two genuine duplicate families were scored clean (Cadillac
+    Fleetwood Sixty Special, Audi RS2/Avant RS2), both the same shape;
+    (4) the unverifiable bucket was closed one search step early — 14 of 15 fell
+    to a single alternative route, several of them to a file already on disk.
+    None of this moves the headline rate materially. All four are worth acting on
+    before the ledger merges, and (1) and (2) should be fixed in the ledger itself
+    rather than downstream.
+
+PROCESS_NOTES:
+  - "Three evidence-gathering subagents were dispatched for marque renderings and had not reported when the verification closed. Every verdict above stands on evidence I gathered and cite directly — corpus, cached register files, or a URL I fetched myself. Nothing here is pending on those agents."
+  - "I re-fetched one of the researcher's own negative results (en.wikipedia.org/wiki/Austin_12/4) and reproduced it exactly before going to a different source class. Their negative was honest."
+  - "Five of my own first-pass verdicts were wrong and were corrected after reading their evidence and checking it independently. All five corrections are recorded in place rather than quietly amended, because a verifier who only ever finds the other side's errors is not verifying."

--- a/data/review/audit-v2026.07.5/audit-verify-2.yml
+++ b/data/review/audit-v2026.07.5/audit-verify-2.yml
@@ -1,0 +1,682 @@
+# VehiclesDB five-nines baseline audit — slice 2 INDEPENDENT VERIFICATION
+#
+# I-11 verifier pass. I am NOT the researcher. My job was to try to OVERTURN the
+# ledger's verdicts, not to confirm them. Nothing here was written into any git
+# repo; nothing was fixed. Every verdict below was re-derived from the catalog,
+# the raw corpora, the cached register pulls and fetched marque sources BEFORE
+# the ledger's own evidence line for that claim was read.
+
+slice: 2
+verifier: opus-verify-2
+researcher: opus-audit-2
+researcher_ledger: /private/tmp/claude-501/-Users-javi-GitHub-vehiclesdb/e02d1805-5b56-4163-8a22-0bb948dcf773/scratchpad/audit-ledger-2.yml
+tag: v2026.07.5
+date: 2026-07-26
+
+# ─────────────────────────────────────────────────────────────────────────────
+# WHAT I REBUILT FROM SCRATCH (nothing below is taken from the ledger)
+# ─────────────────────────────────────────────────────────────────────────────
+independent_apparatus:
+  catalog: >-
+    catalog/{car,van,truck,bus,moped,motorcycle}/models.json at VERSION
+    2026.07.5 flattened to 16,825 rows of (id, name, kind, make, body_types,
+    availability, xrefs.tan). Slice-2 = 100 records carrying 301 availability
+    entries => 701 claims. Both totals reproduce the ledger's exactly.
+  sources_rebuilt:
+    nl_rdw: "cache/nl_rdw_personenauto.json -> 91,910 merk|model rows; _inrichting.json -> 113,062 merk|model|inrichting rows (both counts match the ledger's)"
+    nz_nzta: "cache/nz_passenger-car-van_*.json (36 shards) -> 17,128 MAKE|MODEL rows (matches)"
+    uk_dft: "cache/uk_veh0120_uk.csv -> 215,825 BodyType|Make|GenModel|Model|Fuel|Status rows (ISO-8859-1; UTF-8 read fails at line 93,445)"
+    lu_snca: "cache/lu_delta_2026{04,05,06}.xml -> 22,664 distinct LIBMRQ|TYPCOM|PVRNUM triples"
+    es_dgt: "cache/es_dgt_2026{04,05,06}.txt fixed-width cols 18-47 / 48-69 -> 22,212 distinct make|model pairs (matches the ledger exactly)"
+    fi_traficom: "cache/fi_traficom_register.zip -> TieliikenneAvoinData_31_03_2026.csv streamed, fields 1/26/27/30/32 -> 495,927 distinct (class, merkki, mallimerkinta, kaupallinenNimi, tyyppihyvaksyntanro) tuples"
+    us_fueleconomy: "cache/us_vehicles.csv via CSV, fields make/model/VClass/year/baseModel/atvType"
+    ca_nrcan: "cache/ca_*.csv incl. BEV/PHEV files"
+    fresh_build: "/Users/javi/GitHub/.vdb-worktrees/s4w-pipeline-schema/build/out/catalog/ (built 2026-07-26 16:03) -> 16,823 rows + former_ids"
+  marque_fetches_made:
+    - "https://en.wikipedia.org/wiki/Hongqi_EHS7 (redirects to 'Hongqi Tiangong 08')"
+    - "https://en.wikipedia.org/wiki/Hongqi_E-HS9"
+    - "https://en.wikipedia.org/wiki/Mazda_CX-70"
+    - "https://www.mazdausa.com/vehicles/cx-70  # decisive on SC"
+    - "https://news.mazdausa.com/2025-10-07-2026-Mazda-CX-70-Pricing-and-Packaging (via search index)"
+    - "https://en.wikipedia.org/wiki/Lamborghini_Countach_LPI_800-4"
+    - "https://en.wikipedia.org/wiki/Lamborghini_Sián"
+    - "https://en.wikipedia.org/wiki/Lancia_Delta"
+    - "https://en.wikipedia.org/wiki/Dodge_WC_series"
+    - "https://en.wikipedia.org/wiki/GAZ-24"
+    - "https://en.wikipedia.org/wiki/Jaguar_Mark_VIII"
+    - "https://en.wikipedia.org/wiki/MG_MGB"
+    - "https://en.wikipedia.org/wiki/Hyundai_ix35 (redirects to Hyundai Tucson)"
+    - "https://en.wikipedia.org/wiki/Ford_Model_18 (redirects to 1932 Ford)"
+    - "https://en.wikipedia.org/wiki/Nissan_Maxima"
+    - "https://en.wikipedia.org/wiki/Fiat_500  # Giardiniera"
+    - "https://en.wikipedia.org/wiki/Ford_E-Series"
+    - "https://en.wikipedia.org/wiki/Fiat_Fiorino  # decisive AGAINST one ledger verdict"
+    - "https://en.wikipedia.org/wiki/Morris_Minor"
+    - "https://en.wikipedia.org/wiki/Eagle_Summit  # spot-check"
+    - "https://en.wikipedia.org/wiki/Lucid_Air    # spot-check"
+    - "https://en.wikipedia.org/wiki/Nissan_Z_(RZ34)"
+    - "https://www.nissanusa.com/vehicles/sports-cars/z.html via curl -A Mozilla/5.0  # NISMO casing count"
+    - "https://www.euramobil.de/en/"
+  fetches_that_failed: >-
+    nissanusa.com/vehicles/sports-cars/z-nismo.html (403 to WebFetch; recovered
+    by curl on the /z.html page), usa.nissannews.com (empty body),
+    nissan-global.com press release (404), saicmaxus.com/en/products/mifa9
+    (404), maxusmotors.eu / maxus.nl / maxusmotors.co.uk / maxus-automotive.com
+    / ldvautomotive.com.au (404 or empty). NO Maxus marque page was reached —
+    see the maxus/mifa-9 entry for how that changes the evidence basis.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# THE TWO COUNTER-INTUITIVE CALLS THE LEDGER ASKED ME TO ATTACK HARDEST
+# ─────────────────────────────────────────────────────────────────────────────
+counter_intuitive_calls:
+
+  "faw: EHS7-unhyphenated-correct vs ehs9-wrong":
+    researcher: "Hongqi hyphenates the older E-* range, not Tiangong: 'E-HS9' is right, 'EHS7' is right, 'EHS9' is wrong"
+    verifier: CONFIRMED
+    evidence:
+      - "en.wikipedia.org/wiki/Hongqi_EHS7 redirects to article titled 'Hongqi Tiangong 08'; lead: 'The Hongqi Tiangong 08 (红旗天工08) or Hongqi EHS7' — UNhyphenated, and its sibling is 'Hongqi EH7', also unhyphenated. Cited source in that article: 'Hongqi EH7 and EHS7 open pre-sales in Europe'."
+      - "en.wikipedia.org/wiki/Hongqi_E-HS9 lead: 'The Hongqi E-HS9 (红旗E-HS9) is a battery electric full-size luxury crossover SUV produced by ... Hongqi, a subsidiary of FAW Group' — HYPHENATED. So the two ranges genuinely differ, exactly as the ledger says."
+      - "Register corroboration I derived myself: fi_traficom carries merkki=FAW 'E-HS9' (n=12 across 4 rows) AND merkki=FAW 'EHS9' (n=2) AND merkki=Hongqi 'E-HS9' (n=1). nl_rdw carries FAW|E-HS9 n=133 vs FAW|EHS9 n=14 — the hyphenated form is 10x the unhyphenated one under the same make."
+      - "lu_snca: 'FAW | HONGQI EHS7 | e13*2018/858*00829*00' — the EHS7 rows are unhyphenated in a register that preserves case, and carry the marque token in the model column."
+    verifier_note: >-
+      This is a good call and it survives attack. The trap it avoids is exactly
+      the one the protocol names (the CPx/tS/XR4i rule): a naive
+      "hyphenate-the-family" sweep would corrupt EHS7. I also confirm the
+      ledger's decision NOT to flag hongqi-ehs7's id: there is no
+      car/hongqi/ehs7 in the catalog, so it has no live twin.
+
+  "mazda: SC is a genuine PHEV trim":
+    researcher: "Mazda and both sources render 'SC'; the id is D8 because SC is a PHEV trim of the CX-70"
+    verifier: CONFIRMED
+    evidence:
+      - "mazdausa.com/vehicles/cx-70 renders the PHEV variant 'Mazda CX-70 PHEV SC Plus' (asset name my26-cx70-phev-sc-plus-rhodiumwhite-animatedms.png, plus a 'CX-70 PHEV SC Plus' build link) — the MARQUE'S OWN SITE, all-caps SC."
+      - "SC expands to 'Select Choice': the 2026 CX-70 PHEV is offered in Select Choice (SC) and Select Choice Plus (SC Plus) trims (2026 Mazda CX-70 Pricing and Packaging, news.mazdausa.com, 2025-10-07; corroborated by Edmunds' 2026 CX-70 PHEV page)."
+      - "us_fueleconomy: 'CX-70 SC 4WD', VClass 'Standard Sport Utility Vehicle 4WD', year 2026, atvType 'Plug-in Hybrid', eng_dscr 'SIDI; PHEV'. It is the ONLY string containing SC under make=Mazda in the whole EPA file."
+      - "ca_nrcan PHEV file carries BOTH 'CX-70 PHEV 4WD' (2026) and 'CX-70 SC PHEV 4WD' (2026) — two distinct 2026 PHEV entries, so SC discriminates within the PHEV line rather than naming it."
+    verifier_note: >-
+      WIKIPEDIA REFUTES THIS AND IS WRONG. en.wikipedia.org/wiki/Mazda_CX-70
+      lists Preferred / Premium / Premium Plus / Premium Sport / GT / Azami /
+      Signature and contains no 'SC' anywhere. Had I stopped at the
+      encyclopedia I would have overturned the ledger and been wrong. This is a
+      clean instance of the protocol's "majority is not authority" rule and of
+      "fetch, never assume" paying out: only the marque's own site settles it.
+      Both the name verdict (D7, Sc -> SC) and the id verdict (D8, trim) stand.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RELEASE-FRESHNESS CATEGORY
+# ─────────────────────────────────────────────────────────────────────────────
+freshness_check:
+  researcher_claim: "23 ids are simultaneously live in catalog/ and present as keys in overrides/models/former_ids.yml at tag v2026.07.5; 2 of the 40 id defects are already fixed in curation and merely unbuilt"
+  verifier: CONFIRMED
+  evidence:
+    - "Independent computation: 2,474 distinct kind/make/slug keys in overrides/models/former_ids.yml; intersected against the 16,825 live catalog ids => EXACTLY 23. Number reproduces."
+    - "Cause reproduced from mtimes: catalog/car/models.json 2026-07-26 06:29:09 (manifest generated_at 05:28:12Z) but overrides/models/renames.yml 15:32:23 and former_ids.yml 08:12:34 — the tagged overrides are strictly NEWER than the tagged catalog artifact."
+    - "Slice-2 members of the 23: car/faw/ehs9 and car/hyundai/tucson-ix35. Exactly 2, matching the ledger."
+    - "Fresh-build cross-check: s4w-pipeline-schema/build/out/catalog holds 16,823 records — exactly 2 fewer — and both slice-2 members are ABSENT from it. car/faw/ehs9 now appears in former_ids on car/faw/e-hs9; car/hyundai/tucson-ix35 appears in former_ids on car/hyundai/ix35 alongside tucson-ix-35 and tucson-ix35-lm."
+    - "Curation intent independently located: overrides/models/renames.yml lines 821-829 fold 'Tucson IX35', 'Tucson / IX35', 'Tucson . IX35', 'TUCSON/IX35', 'Tucson Ix 35' and 'Tucson IX35 Lm' into ix35, citing en.wikipedia.org/wiki/Hyundai_Tucson."
+  verifier_addition:
+    - "The ledger UNDER-counts by one partial: car/fisker/ocean-extreme-one's name is 'Ocean Extreme/One' in the fresh build vs 'Ocean Extreme/one' published. The D7 half of that name defect is already cured pending publish; the D13 merged-cell half is NOT (car/fisker/ocean and car/fisker/ocean-one are both still live in the fresh build). This is the only name-level freshness delta in the whole slice — I diffed all 100 slice names published-vs-fresh and it is the sole difference."
+  caveat_i_could_not_close: >-
+    The fresh build sits in a different worktree (s4w-pipeline-schema), so I
+    cannot prove it was built against THIS data worktree's override tree. The
+    fisker casing change shows it picked up at least the 2026-07-26 renames, and
+    the two disappearances match former_ids exactly, so the inference is strong
+    but not airtight.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PER-CLAIM VERDICTS — the 80 defects
+# ─────────────────────────────────────────────────────────────────────────────
+reviewed_claims:
+
+  # ── id-canonical (40 claims) ──────────────────────────────────────────────
+  "car/faw/e-hs9#id":
+    researcher: "defective(D6 + cross-make)"
+    verifier: CONFIRMED
+    evidence:
+      - "fi_traficom files type-approval e13*2018/858*00350*01 under merkki=FAW ('E-HS9 Farmari (AC) 5ov A', n=5) AND under merkki=Hongqi ('E-HS9 Farmari (AC) 5ov A', n=1) — the SAME approval extension under two makes in one register. Decisive."
+      - "Catalog: car/faw/e-hs9 tan e13*2018/858*00350*00, car/hongqi/e-hs9 tan e13*2018/858*00350*01 — same base approval 00350."
+      - "car/faw/ehs9 folds to the same key (EHS9 == E-HS9 after punctuation fold)."
+  "car/faw/ehs9#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["fold-equal to car/faw/e-hs9", "absent from the 2026-07-26 16:03 fresh build; present as a former_id on car/faw/e-hs9", "nl_rdw FAW|EHS9 n=14 vs FAW|E-HS9 n=133 in the same case-preserving register"]
+  "car/fiat/500-abarth#id":
+    researcher: "defective(cross-make — car/abarth/500 is the same 312-series car)"
+    verifier: RECLASSIFIED(D6 within-make, token-order — the cross-make leg is NOT supported)
+    evidence:
+      - "The ledger misses the tighter twin: car/fiat/abarth-500 ('Abarth 500', es/fi/lu/nl/nz) shares FOUR EXACT tan extensions with car/fiat/500-abarth — e3*2007/46*0064*33, *43, *52, *70. That is a same-make, token-order duplicate and it is the strongest identity evidence in the record."
+      - "The cited cross-make twin fails the ledger's own approval test: car/abarth/500 carries only e3*2018/858*00001*10 and *14 — the 2018/858-era (500e) family — and *14 is shared with car/fiat/500, NOT with car/fiat/500-abarth (which is entirely 2001/116*0261 + 2007/46*0064, the 2008-2016 car). On approval evidence these are different generations."
+      - "fi_traficom has NO make 'Abarth' at all; it files '500 ABARTH' under merkki=Fiat with e3*2001/116*0261*07 and e3*2007/46*0064*26/*33 — the exact tans on car/fiat/500-abarth."
+    verdict_effect: "still defective — the class and the cited twin change, the verdict does not."
+  "car/fiat/eura-mobil-sport#id":
+    researcher: "defective(D6/D8)"
+    verifier: CONFIRMED
+    evidence: ["car/fiat/eura-mobil live (fi+nl)", "nl_rdw under FIAT: 'EURA MOBIL' n=28, 'EURAMOBIL' n=6, 'EURA MOBIL SPORT' n=2, plus 12 further EURA MOBIL <code> strings — one coachbuilder, many spellings"]
+  "car/fiat/fiorino-qubo#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/fiat/fiorino-qubo tan e3*2001/116*0271*09; car/fiat/qubo tan list contains e3*2001/116*0271*09 — an EXACT extension match, not merely a shared family"]
+  "car/fiat/nuova-500#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/fiat/500-nuova ('500 Nuova', fi/nl/nz) live; same tokens transposed, same make+kind"]
+  "car/fisker/ocean-extreme-one#id":
+    researcher: "defective(D13/D6)"
+    verifier: CONFIRMED
+    evidence: ["car/fisker/ocean (de/fi/gb/nl/ua) and car/fisker/ocean-one (fi/ua) both live", "the published name 'Ocean Extreme/one' is a slash-merged two-trim cell; both halves already have their own live id"]
+  "car/ford/18#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/ford/model-18 ('Model 18', nl/nz) live; both are body-type convertible"]
+  "car/ford/a-roadster#id":
+    researcher: "defective(D6/D8)"
+    verifier: CONFIRMED
+    evidence: ["car/ford/model-a, car/ford/a, car/ford/a-model all live; roadster is one of the Model A body styles, which the catalog also carries as a-tudor / a-fordor / a-phaeton / a-town / a-sport"]
+  "car/ford/bronco-black-diamond#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/ford/bronco live (7 countries); Black Diamond is a trim series, sitting in the catalog beside badlands/outer-banks/sasquatch/wildtrak/xlt — the same D8 family"]
+  "car/ford/e150-van-ffv#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/ford/e150 and car/ford/e150-van both live", "us_fueleconomy baseModel for 'E150 Van FFV' is literally 'E150 Van' with atvType=FFV — EPA itself declares it a fuel-variant of the E150 Van"]
+  "car/ford/explorer-tremor#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/ford/explorer live (11 countries); Tremor is a trim, beside timberline/limited/xlt/xls/sport in the same catalog"]
+  "car/ford/galaxie-500-sunliner#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/ford/galaxie-sunliner (fi+nl, convertible) live — identical vehicle, one token difference; car/ford/galaxie and galaxie-500 also live"]
+  "car/ford/model-t#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/ford/t ('T', fi/nl/nz, convertible) live; the catalog also carries the parallel families model-t-{runabout,speedster,touring,tudor} and t-{roadster,runabout,touring,tudor} — the same car twice"]
+  "car/ford/mustang-hardtop#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/ford/mustang live (13 countries); hardtop is a body style, and the catalog also has mustang-hardtop-grande"]
+  "car/genesis/gv60-performance#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/genesis/gv60 live (de/gb/nl/nz/us); Performance is a grade of the GV60"]
+  "car/geo/tracker-van#id":
+    researcher: "defective(D6/D8)"
+    verifier: CONFIRMED
+    evidence: ["car/geo/tracker live", "us_fueleconomy gives baseModel='Tracker' for every 'Tracker Van 2WD/4WD/4x4' row, alongside 'Tracker Convertible' and 'Tracker Hardtop 4WD' — one vehicle, EPA body words"]
+  "car/gm-daewoo/matiz#id":
+    researcher: "defective(cross-make — car/daewoo/matiz)"
+    verifier: CONFIRMED
+    evidence:
+      - "fi_traficom carries the IDENTICAL type string '4D MATIZ HATCHBACK 1.0-0M11CD/234' under merkki='GM Daewoo' (n=30 + n=18 with e4*2001/116*0028*18) AND under merkki='Daewoo' (n=16). Same type code, two makes."
+      - "Catalog: car/gm-daewoo/matiz tan e4*2001/116*0028*18, car/daewoo/matiz tan e4*2001/116*0028*15 — same base approval 0028."
+      - "Systemic, not isolated: car/gm-daewoo/{kalos,lacetti} duplicate car/daewoo/{kalos,lacetti} the same way. That is a make-level D12, worth flagging beyond this record."
+  "car/hyundai/elantra-wagon#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/hyundai/elantra live (7 countries); wagon is a body, and car/hyundai/elantra-touring (the US name for the same estate) is also live"]
+  "car/hyundai/pony-gls#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/hyundai/pony live (fi/gb/nz/ua); GLS is a trim grade"]
+  "car/hyundai/tucson-ix35#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/hyundai/ix35 live (7 countries)", "already curated: renames.yml folds 'Tucson IX35' -> ix35; absent from the fresh build; present as a former_id on car/hyundai/ix35"]
+  "car/jaguar/f-pace-30t#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/jaguar/f-pace live (10 countries); '30t' is an output designation — us_fueleconomy baseModel for 'F-Pace 30t' is 'F-Pace', and the same catalog carries f-pace-25t/p340/p400/s/svr"]
+  "car/jaguar/f-type-p450#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/jaguar/f-type live (10 countries); P450 is a powertrain output designation"]
+  "car/jaguar/xj42#id":
+    researcher: "defective(D6/D9)"
+    verifier: RECLASSIFIED(D9 primary, not D6)
+    evidence:
+      - "nz_nzta under JAGUAR: 'XJ4.2' n=11, 'XJ 4.2' n=5, 'XJ 4.2 AUTO' n=1, 'XJ4 2' n=1, 'XJ4.2 SLE' n=1, 'XJ4.2S3' n=1 — AND 'XJ42' n=1, 'XJ42C' n=2, 'XJ402C' n=1 beside 'XJ4.2C' n=2. The unpunctuated forms are fusions of the punctuated displacement, pair for pair."
+      - "nl_rdw under JAGUAR: 'JAGUAR XJ42' n=3 (also carrying the make token), against 207x 'XJ6-4.2', 268x 'XJ6 4.2 SERIES III', 143x 'XJ 6 4.2 L SERIES 2 AUTOMATIC' etc. The 4.2 is a displacement across the whole XJ population."
+      - "So the record is a homologation/displacement string, not a nameplate: D9 is the primary class and the D6 twin is car/jaguar/xj (and xj6/xj8/xj12), not a spelling pair."
+    verdict_effect: "still defective; class order should be D9 first."
+  "car/kia/niro-fe#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/kia/niro live (12 countries); FE is the base trim grade, and car/kia/niro-{ev,ex,touring} sit beside it"]
+  "car/kia/sedona-sx#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/kia/sedona live (7 countries)", "us_fueleconomy baseModel for 'Sedona SX' and 'Sedona SXL' is 'Sedona' — EPA itself declares them trims"]
+  "car/lancia/delta-hf-integrale#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/lancia/delta-hf-intergrale ('Delta Hf Intergrale' — a TYPO published as a live record, fi+nl) and car/lancia/delta-integrale (nl+nz) both live, alongside delta-hf, delta-hf-turbo, delta-hf-integrale-16v"]
+  "car/mazda/cx-70-sc#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/mazda/cx-70 live (ca/nl/ua/us); SC = Select Choice, a 2026 CX-70 PHEV trim per mazdausa.com — see the counter-intuitive block above", "us_fueleconomy baseModel for 'CX-70 SC 4WD' is 'CX-70'"]
+  "car/mcc/smart#id":
+    researcher: "defective(cross-make; 'shared approval family e1*98/14*0080')"
+    verifier: CONFIRMED — but the cited evidence does not exist on the published record
+    evidence:
+      - "car/mcc/smart carries NO xrefs.tan at all in catalog v2026.07.5 (its only sources are uk_dft and nz_nzta, neither of which supplies approval numbers to this record). The ledger's 'shared approval family e1*98/14*0080' cannot be read off the audited artifact — I could not reproduce it. Flagging as an over-claimed evidence line."
+      - "The verdict nevertheless stands on stronger, reproducible evidence: nz_nzta files MCC|'SMART COUPE' n=44, MCC|'SMART K' n=32, MCC|'SMART CABRIO' n=3, MCC|'SMART FORTWO' n=1 — and car/smart/{coupe,cabrio,fortwo} are all live. uk_dft files Make=MCC, GenModel='MCC SMART', Model='SMART PASSION S-TOUCH 16 A' / 'SMART PULSE ...'."
+      - "The catalog additionally carries car/smart/mcc ('Mcc') and car/smart/mcc-smart ('Mcc Smart') — the same JV string already exists on the smart side, twice."
+  "car/mg/b-gt#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/mg/mgb-gt ('Mgb GT') live", "nz_nzta under MG: 'BGT' n=440, 'MGB GT' n=105, 'B GT' n=98, 'MGBGT' n=51, 'CGT' n=10 — four spellings of one car, and the catalog also has b-gt-v8 vs mgb-gt-v8"]
+  "car/morris/1000-traveller#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/morris/minor-1000-traveller and car/morris/minor-traveller both live, same make+kind, same body_types (hatchback;wagon)"]
+  "car/morris/mini-cooper#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/morris/cooper live (nl+nz); the parallel pair car/morris/mini-cooper-s vs car/morris/cooper-s is also both-live, so it is a systematic token-difference split"]
+  "car/nissan/maxima-qx#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence:
+      - "car/nissan/maxima live (8 countries) with tan e1*98/14*0136*03; car/nissan/maxima-qx tan e1*98/14*0136*00 — same base approval 0136, so the same EU type."
+      - "en.wikipedia.org/wiki/Nissan_Maxima: the A32 'was also sold as the Maxima QX in Europe', and the A33B is listed as 'Nissan Maxima QX (Europe)' — a market suffix on the same nameplate, not a different nameplate."
+      - "Contrast test I ran deliberately: the catalog DOES keep genuinely different market NAMEPLATES apart (car/nissan/cefiro alongside car/nissan/maxima). 'Maxima QX' is not a different nameplate, so the ledger's discrimination here is principled."
+  "car/nissan/xterra-v6#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/nissan/xterra live (6 countries); V6 is an engine designation"]
+  "car/nissan/z-nismo#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/nissan/z live (5 countries)", "en.wikipedia.org/wiki/Nissan_Z_(RZ34) treats the Z Nismo as a performance grade alongside Sport and Performance, not a separate model", "the same catalog carries gt-r-nismo, juke-nismo, sentra-nismo — an entire D8 family"]
+  "car/oldsmobile/cutlass-cruiser-wagon#id":
+    researcher: "defective(D6/D8)"
+    verifier: CONFIRMED
+    evidence: ["car/oldsmobile/cutlass-cruiser live", "us_fueleconomy gives baseModel='Cutlass Cruiser' for BOTH strings, and shows EPA itself switching from 'Cutlass Cruiser Wagon' (1984-85) to 'Cutlass Cruiser' (1986-95) for the same car"]
+  "car/peugeot/604-sl#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/peugeot/604 live (fi/gb/nl/nz/us); SL is the launch trim, beside 604-sti and 604-d-turbo in the same catalog"]
+  "car/plymouth/valiant-scamp#id":
+    researcher: "defective(D6)"
+    verifier: CONFIRMED
+    evidence: ["car/plymouth/scamp live (fi/nl/nz) and car/plymouth/valiant live; the Scamp is the Valiant Scamp — one car, two live ids, plus valiant-100/duster/signet in the same family"]
+  "car/renault/scenic#id":
+    researcher: "defective(D6 — car/renault/meganescenic is the fused gen-I twin)"
+    verifier: CONFIRMED — with an attribution objection
+    evidence:
+      - "car/renault/meganescenic ('Meganescenic', es+nl, no tan) is live; it is a fused register spelling of the Megane Scenic, i.e. phase-1 Scenic. Two live ids do denote that vehicle, so the claim as written fails."
+      - "OBJECTION worth recording: the DEFECTIVE record is meganescenic, not scenic. car/renault/scenic is the canonical nameplate with 9 countries and 25 tan extensions; meganescenic has 2 countries and none. Booking the id defect against the canonical record (rather than against the fused twin, which was not sampled) is technically consistent with the protocol's symmetric wording but inflates the id-defect count with a record whose own name and id are correct. Same pattern applies to car/fiat/nuova-500, car/ford/18, car/ford/model-t and car/morris/1000-traveller. Recommend the RESULTS.md aggregation report 'id-canonical pair defects' separately from 'this record is the wrong one'."
+  "car/saab/9000-turbo#id":
+    researcher: "defective(D8)"
+    verifier: CONFIRMED
+    evidence: ["car/saab/9000 live (8 countries); Turbo is an engine designation, and the catalog also carries 9000-turbo-16v, 9000-aero, 9000-cd/cs/cse/cde"]
+
+  # ── name-marque-true (29 claims) ──────────────────────────────────────────
+  "car/dodge/wc52#name":
+    researcher: "defective(D7 — 'WC-52')"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/Dodge_WC_series: 'the WC-51 / WC-52 Weapons Carrier'; 'The G-502, WC-51 & WC-52: Truck, Cargo, 3/4-ton, 4x4, Weapons Carrier' — hyphenated throughout the G-numbered ordnance designations"]
+  "car/faw/ehs9#name":
+    researcher: "defective(D7 — 'E-HS9')"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/Hongqi_E-HS9 lead renders 'Hongqi E-HS9' hyphenated", "nl_rdw E-HS9 n=133 vs EHS9 n=14 under the same make in a case-preserving register", "already cured in the fresh build (ehs9 folded into e-hs9)"]
+  "car/faw/hongqi-ehs7#name":
+    researcher: "defective(D5 — marque token embedded; the EHS7 part is CORRECT unhyphenated)"
+    verifier: CONFIRMED
+    evidence: ["nl_rdw 'FAW | HONGQI EHS7' n=13 and 'HONGQI EHS7 111 KWH 4WD' n=1; lu_snca 'FAW | HONGQI EHS7 | e13*2018/858*00829*00' — the marque name is inside the model column", "the EHS7 half is right: see the counter-intuitive block"]
+  "car/fiat/eura-mobil-sport#name":
+    researcher: "defective(D5 — 'Eura Mobil' is a motorhome coachbuilder brand)"
+    verifier: CONFIRMED
+    evidence: ["euramobil.de/en/: 'Premium motorhomes made in Germany', 'over six decades' in Sprendlingen; model ranges Van, Activa One, Contura, Profila RS/T/T Freestyle/T MB, Integra, Integra Line, Integra Line GT, Xtura — an independent motorhome builder, not a Fiat nameplate", "note: 'Sport' is NOT in Eura Mobil's current range, so the whole string is a converter brand plus an unattested line"]
+  "car/fiat/fiorino-qubo#name":
+    researcher: "defective(D6 — two distinct Fiat nameplates concatenated by the register)"
+    verifier: OVERTURNED(correct)
+    evidence:
+      - "en.wikipedia.org/wiki/Fiat_Fiorino lists 'Fiat Fiorino Qubo' among the third-generation (Type 225) model's own alternate names — the string is an attested Fiat designation, NOT something the register concatenated."
+      - "Same article: Fiat 'retails its passenger model as the Fiat Qubo', and in Turkey the passenger version was sold as 'Fiorino Panorama' — i.e. Fiat itself used compound Fiorino-plus-suffix passenger names in several markets."
+      - "Applying the protocol's own CPx/tS/XR4i rule (weird can be right) and 'fetch, never assume', the display name matches a marque rendering and the name claim should read correct."
+    verdict_effect: "The record still fails id-canonical (exact shared tan extension e3*2001/116*0271*09 with car/fiat/qubo). Only the NAME verdict flips."
+  "car/fiat/nuova-500-giardiniera#name":
+    researcher: "defective(D7 — Fiat's designation is '500 Giardiniera')"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/Fiat_500: 'The 500 Giardiniera (500 K on some markets) estate version of the Fiat 500 is the longest running model'; and 'Launched as the Nuova (new) 500 in July 1957' — 'Nuova' names the SALOON, so 'Nuova 500 Giardiniera' mixes two designations", "consistency check: the ledger correctly leaves car/fiat/nuova-500's NAME alone, because 'Nuova 500' is Fiat's own name for the 1957 saloon"]
+  "car/fisker/ocean-extreme-one#name":
+    researcher: "defective(D13+D7)"
+    verifier: CONFIRMED
+    evidence: ["the published string 'Ocean Extreme/one' is a slash-merged two-trim cell", "the D7 half is already cured pending publish: the fresh build renders 'Ocean Extreme/One'; the D13 half is not"]
+  "car/ford/18#name":
+    researcher: "defective(D7 — 'Model 18')"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/Ford_Model_18 redirects to '1932 Ford': 'three models ... the Model B, the Model 18, and the Model 40'; the article uses 'Model 18' consistently, never bare '18'"]
+  "car/ford/a-roadster#name":
+    researcher: "defective(D8 — 'roadster' is a Model A body style)"
+    verifier: CONFIRMED
+    evidence: ["Model A body styles in the catalog's own Ford set: a-tudor, a-fordor, a-phaeton, a-town, a-sport, a-roadster, plus model-a-tudor / model-a-fordor — the register is emitting body styles, not nameplates"]
+  "car/ford/e150-van-ffv#name":
+    researcher: "defective(D9/D7 — Ford's name is 'E-150'; FFV is all-caps)"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/Ford_E-Series: 'For 1999, the Econoline would be renamed to the E-Series ... This included the E-150, E-250, and E-350' — hyphenated throughout", "us_fueleconomy renders the string 'E150 Van FFV' with FFV all-caps; the catalog's 'Ffv' is a title-casing artifact"]
+  "car/ford/mustang-hardtop#name":
+    researcher: "defective(D8 — 'Hardtop' is a generic Ford body label)"
+    verifier: CONFIRMED
+    evidence: ["the catalog's own Ford set carries galaxie-500-hardtop and mustang-hardtop-grande — 'Hardtop' recurs across unrelated nameplates, which is the signature of a body word, not a trim"]
+  "car/gaz/2401#name":
+    researcher: "defective(D7 — 'GAZ-24-01')"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/GAZ-24: 'GAZ-24-01 taxi', 'GAZ-24-02 four-door station wagon', 'GAZ-24-10', 'GAZ-24-24' — the marque's format is GAZ-24-XX with both hyphens; the fused '2401' appears in no marque rendering"]
+  "car/geo/tracker-van#name":
+    researcher: "defective(D9 — 'Van' is EPA's class word)"
+    verifier: CONFIRMED
+    evidence: ["us_fueleconomy carries 'Tracker Van 2WD/4WD/4x4' beside 'Tracker Convertible 2WD/4WD/4x4' and 'Tracker Hardtop 4WD', all with baseModel='Tracker' and VClass='Special Purpose Vehicles' — the three words are EPA body descriptors applied to one nameplate"]
+  "car/hyundai/tucson-ix35#name":
+    researcher: "defective(D7 — lowercase 'ix35')"
+    verifier: CONFIRMED (class understated — see note)
+    evidence:
+      - "en.wikipedia.org/wiki/Hyundai_ix35 redirects to Hyundai Tucson: 'the Hyundai Tucson name was changed to Hyundai ix35' — lowercase i and x throughout. Hyundai's only compound was the Korean 'Tucson ix', never 'Tucson ix35'."
+      - "overrides/styling.yml line 97 already reasons about exactly this ('DELIBERATELY NOT ADDED: IX. Jaguar Mark IX wants caps but Hyundai ix35 is ...')."
+      - "NOTE: the project's own curation is stronger than D7 — renames.yml calls 'Tucson IX35' a 'compound register string, not a nameplate' and folds it to ix35. So the name defect is a fold (D6), not a casing fix; the remedy differs."
+  "car/jaguar/f-pace-30t#name":
+    researcher: "defective(D7 — lowercase '30t')"
+    verifier: CONFIRMED
+    evidence: ["us_fueleconomy: 'F-Pace 30t'; ca_nrcan: 'F-PACE 30t' — both sources lowercase the t, and NRCan's neighbours '20d', '25t', '35t' do the same. The catalog's '30T' matches neither."]
+  "car/jaguar/mark-8#name":
+    researcher: "defective(D7 — 'Mark VIII')"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/Jaguar_Mark_VIII: 'The Jaguar Mark VIII is a luxury four-door automobile introduced by the Jaguar company of Coventry at the 1956 London Motor Show'; siblings rendered Mark VII M, Mark IX, Mark X — Roman throughout", "the catalog is internally split on this: mark-1/2/7/8/10/11 (Arabic) coexist with mark-i/ix/x (Roman)"]
+  "car/jaguar/xj42#name":
+    researcher: "defective(D9 — not a Jaguar nameplate; the rows are 4.2 displacements)"
+    verifier: CONFIRMED
+    evidence: ["see the xj42 id entry: nz_nzta pairs XJ42/XJ4.2 and XJ42C/XJ4.2C, nl_rdw shows 'JAGUAR XJ42' n=3 against ~800 punctuated 'XJ6 4.2' rows. XJ42 was a cancelled Jaguar project code and is not a sold nameplate."]
+  "car/kia/sedona-sx#name":
+    researcher: "defective(D7 — 'SX')"
+    verifier: CONFIRMED
+    evidence: ["us_fueleconomy renders 'Sedona SX' and 'Sedona SXL' all-caps (2015-2018); the catalog's 'Sedona Sx' matches no source"]
+  "car/lamborghini/aventador-countach#name":
+    researcher: "defective(D9/D5 — the marque's name is 'Countach LPI 800-4')"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/Lamborghini_Countach_LPI_800-4: 'The Lamborghini Countach LPI 800-4 is a limited-production mid-engine hybrid-electric sports car produced by ... Lamborghini'. 'Aventador' is NOT part of the name — the car shares underpinnings with the Sian FKP 37, and car/lamborghini/countach already exists as its own live record."]
+  "car/lamborghini/aventador-sian-roadster#name":
+    researcher: "defective(D5/D7 — 'Sián Roadster')"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/Lamborghini_Sián: 'In July 2020, Lamborghini unveiled the convertible roadster version of the Sián FKP 37 simply called the Sián Roadster' — acute accent preserved, no Aventador token"]
+  "car/lancia/delta-hf-integrale#name":
+    researcher: "defective(D7 — 'Delta HF integrale': HF up, integrale down)"
+    verifier: CONFIRMED on the HF token; the 'integrale' half is weaker than stated
+    evidence:
+      - "en.wikipedia.org/wiki/Lancia_Delta uses 'Delta HF integrale' with lowercase i in running text ('the Lancia Delta HF integrale incorporated some of the features of the Delta HF 4WD into a road car') but capital I in section headers — the source is INCONSISTENT on that token."
+      - "HF is unambiguous: it is an initialism (High Fidelity) and no source renders it 'Hf'. The catalog's 'Delta Hf Integrale' is wrong on HF regardless of how integrale is settled."
+      - "Recommend the fix ride with an archive-grade Lancia citation for the integrale token specifically, not a Wikipedia body-text preference."
+  "car/maxus/mifa-9#name":
+    researcher: "defective(D7 — the maker's own site renders 'MIFA 9')"
+    verifier: CONFIRMED — but on a DIFFERENT evidence basis than the ledger claims
+    evidence:
+      - "I could NOT reach any Maxus/LDV marque page: saicmaxus.com/en/products/mifa9 404, maxusmotors.eu / maxus.nl / maxusmotors.co.uk / maxus-automotive.com / ldvautomotive.com.au all 404 or empty. The ledger's cited basis ('the maker's own site') is not reproducible from here."
+      - "Both of the record's OWN sources render it all-caps: nl_rdw 'MAXUS | MIFA 9' n=1 and 'MAXUS | MAXUS MIFA 9' n=2; fi_traficom 'Maxus | MAXUS MIFA 9 | e4*2018/858*00108*00' n=5."
+      - "That is probative here because nl_rdw preserves case — the same file carries 'EQ forfour', 'EQ fortwo cabrio' and 'EQ fortwo coupe' in mixed case beside their upper-case twins. An all-caps MIFA in a case-preserving register is a signal, not an artifact."
+      - "en.wikipedia.org/wiki/Maxus_Mifa_9 redirects to 'Maxus G90' and is itself inconsistent (Mifa 9 / MIFA 9), so the encyclopedia does not settle it."
+  "car/mazda/cx-70-sc#name":
+    researcher: "defective(D7 — 'SC')"
+    verifier: CONFIRMED
+    evidence: ["see the counter-intuitive block: mazdausa.com renders 'CX-70 PHEV SC Plus'; SC = Select Choice; us_fueleconomy 'CX-70 SC 4WD' and ca_nrcan 'CX-70 SC PHEV 4WD' both all-caps"]
+  "car/mcc/smart#name":
+    researcher: "defective(D4/D5 — 'Smart' is the MARQUE in the model column)"
+    verifier: CONFIRMED
+    evidence: ["uk_dft: Make='MCC', GenModel='MCC SMART', Model='SMART PASSION S-TOUCH 16 A' — the marque word is the model column's whole content", "nz_nzta MCC|'SMART COUPE', 'SMART K', 'SMART CABRIO', 'SMART FORTWO'", "the catalog's own make list has 'smart' as a live marque with 24 models"]
+  "car/mg/b-gt#name":
+    researcher: "defective(D7 — 'MGB GT')"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/MG_MGB: 'the MGB GT three-door 2+2 coupé', 'the fixed-roof MGB GT was introduced in October 1965' — MGB GT with a space, and 'B GT' without the MG prefix appears nowhere as a model name"]
+  "car/morris/1000-traveller#name":
+    researcher: "defective(D7 — 'Minor 1000 Traveller')"
+    verifier: "CONFIRMED — class quibble, this is a missing NAMEPLATE token, not casing/spacing/accents"
+    evidence: ["en.wikipedia.org/wiki/Morris_Minor: the estate is the 'Morris Traveller' / 'Morris Minor 1000 Traveller'; '1000 Traveller' without the Minor prefix is not used as a product name — the 1000 is the engine designation and only appears bound to Minor"]
+  "car/nissan/maxima-qx#name":
+    researcher: "defective(D7 — 'Maxima QX')"
+    verifier: CONFIRMED
+    evidence: ["en.wikipedia.org/wiki/Nissan_Maxima renders 'Maxima QX' all-caps for both the A32 and A33B European cars; the catalog's 'Maxima Qx' matches nothing"]
+  "car/nissan/z-nismo#name":
+    researcher: "defective(D7 — 'Z NISMO')"
+    verifier: CONFIRMED
+    evidence:
+      - "nissanusa.com/vehicles/sports-cars/z.html fetched via curl -A Mozilla/5.0: 'NISMO' all-caps occurs 38 times, 'Nismo' 8 times, in contexts like 'NISMO aerodynamic', 'NISMO Recaro', 'NISMO RAYS' — the marque's own page favours all-caps 4.75:1."
+      - "NISMO is an initialism (NISsan MOtorsport), which is why it upper-cases."
+      - "CAVEAT the ledger should carry: this is a FAMILY-wide styling defect, not a one-off. The catalog renders all four as 'Nismo' (gt-r-nismo, juke-nismo, sentra-nismo, z-nismo) and overrides/styling.yml has no NISMO pin at all. Fixing one record would leave the family half-fixed, which is exactly the seam the renames.yml Alfa Romeo block warns about."
+  "car/oldsmobile/cutlass-cruiser-wagon#name":
+    researcher: "defective(D9 — the Cutlass Cruiser IS the wagon)"
+    verifier: CONFIRMED
+    evidence: ["us_fueleconomy VClass for every Cutlass Cruiser row is 'Midsize(-Large) Station Wagons', and EPA drops the redundant 'Wagon' token itself from 1986 onward while keeping baseModel='Cutlass Cruiser' for both spellings"]
+
+  # ── make-correct (6 claims) ───────────────────────────────────────────────
+  "car/faw/e-hs9#make":
+    researcher: "defective(D11 — the marque is Hongqi)"
+    verifier: CONFIRMED
+    evidence: ["fi_traficom itself files merkki='Hongqi' with 'E-HS9' and approval e13*2018/858*00350*01 — the same extension it also files under merkki='FAW'. The register demonstrates the marque split on its own.", "en.wikipedia.org/wiki/Hongqi_E-HS9: produced by 'Hongqi, a subsidiary of FAW Group' — FAW is the group, Hongqi the marque", "car/hongqi/ already exists as a live make in the catalog"]
+  "car/faw/ehs9#make":
+    researcher: "defective(D11)"
+    verifier: CONFIRMED
+    evidence: ["same as above; the record is the same vehicle under a fused spelling"]
+  "car/faw/hongqi-ehs7#make":
+    researcher: "defective(D11)"
+    verifier: CONFIRMED
+    evidence: ["nl_rdw and lu_snca both write the marque token HONGQI into the model column under make FAW — the classic approval-holder-in-the-make-column shape moves.yml exists for"]
+  "car/fiat/500-abarth#make":
+    researcher: "defective(D11 — Abarth for the EU rows; Fiat IS correct for ca/us; remedy is a split)"
+    verifier: CONFIRMED
+    evidence:
+      - "us_fueleconomy files it under make='Fiat' as '500 Abarth', VClass 'Minicompact Cars', 2012-2016 — the North American marque-of-sale genuinely is Fiat."
+      - "es_dgt carries BOTH make=ABARTH rows and make=FIAT rows with models 'ABARTH 500', '500C ABARTH', 'FIAT 500 ABARTH' — the same register splits the marque."
+      - "fi_traficom has NO make 'Abarth' whatsoever and files '500 ABARTH' under merkki=Fiat."
+      - "So the record pools two marques' rows; the ledger's 'split, not merge' framing is the right remedy and matches moves.yml's own warning against moving pooled rows."
+  "car/gm-daewoo/matiz#make":
+    researcher: "defective(D11/D12 — 'GM Daewoo' is the corporate entity)"
+    verifier: CONFIRMED
+    evidence: ["fi_traficom carries merkki='GM Daewoo', merkki='Daewoo' and merkki='Chevrolet' all bearing the identical type code '4D MATIZ HATCHBACK 1.0-0M11CD/234'", "GM Daewoo Auto & Technology was the corporate entity; the marque on the car was Daewoo (then Chevrolet)", "make-level scope: car/gm-daewoo has exactly 3 models (matiz, kalos, lacetti) and ALL THREE duplicate a car/daewoo record — this is a whole-make D12, which the ledger's per-record framing understates"]
+  "car/mcc/smart#make":
+    researcher: "defective(D11 — MCC is the manufacturing JV; Smart is the marque)"
+    verifier: CONFIRMED
+    evidence: ["uk_dft's own GenModel is 'MCC SMART' — the register knows the marque and puts it in the model column", "nz_nzta MCC rows are all 'SMART <variant>'", "car/smart is a live make with 24 models covering exactly these variants (coupe, cabrio, fortwo, city, mcc, mcc-smart)"]
+
+  # ── kind-correct (5 claims) ───────────────────────────────────────────────
+  "car/fiat/eura-mobil-sport#kind":
+    researcher: "defective(D10 — both NL rows are inrichting=kampeerwagen)"
+    verifier: CONFIRMED
+    evidence: ["nl_rdw_personenauto_inrichting: FIAT|'EURA MOBIL SPORT'|kampeerwagen|n=2 — and there is no second inrichting value for that string. Every one of the 16 FIAT EURA* strings in that file is kampeerwagen except one 'Niet geregistreerd'."]
+  "car/ford/e150-van-ffv#kind":
+    researcher: "defective(D10 — EPA class 'Vans, Cargo Type')"
+    verifier: CONFIRMED
+    evidence: ["us_fueleconomy VClass = 'Vans, Cargo Type' for all four rows (2011-2014)"]
+  "car/hummer/h3t#kind":
+    researcher: "defective(D10 — EPA 'Standard Pickup Trucks 4WD')"
+    verifier: CONFIRMED
+    evidence: ["us_fueleconomy: 'H3T 4WD' VClass='Standard Pickup Trucks 4WD' (2009, 2010, 2010 FFV) — and the sibling 'H3 4WD' is 'Sport Utility Vehicle - 4WD', so EPA distinguishes them deliberately", "truck/hummer/{h1,h2} already exist, so the truck kind is populated for this make"]
+  "car/ldv/v80#kind":
+    researcher: "defective(D10 — GB BodyType is mostly LGV/bus)"
+    verifier: CONFIRMED
+    evidence: ["uk_dft BodyType for LDV V80: 20 'Light goods vehicles' rows (largest: V80 L2H1 C/C TD, 826 licensed), 8 'Buses and coaches' rows, 3 'Other vehicles' rows, 1 'Heavy goods vehicles' row and only 2 'Cars' rows (V80 L2H3 P/V TD, 1 licensed + 1 SORN)", "van/ldv/v80 and bus/ldv/v80 are BOTH already live, so the car record adds a third kind for a vehicle GB overwhelmingly registers as a van"]
+  "car/ram/1500-classic#kind":
+    researcher: "defective(D10 — EPA 'Standard Pickup Trucks')"
+    verifier: CONFIRMED
+    evidence: ["us_fueleconomy: every '1500 Classic 2WD/4WD' row (2019-2024) is VClass 'Standard Pickup Trucks 2WD/4WD'", "truck/ram/1500 and van/ram/1500 already exist"]
+
+  # ── unverifiables retried (2 claims) ──────────────────────────────────────
+  "car/mg/magna#availability.nz":
+    researcher: 'unverifiable("MG | MAGNA" n=1 in a register whose MAGNA population is overwhelmingly Mitsubishi)'
+    verifier: CONFIRMED — unverifiable stands, but with materially stronger corroboration than the ledger records
+    alternative_route_tried: "profile the NZ MG population for period plausibility, and check whether any OTHER register evidences the MG Magna as a nameplate at all"
+    evidence:
+      - "nz_nzta MG rows include a substantial pre-war/classic tail: MGA n=49 + 'MG A' n=60, MIDGET n=326, TC n=33, MAGNETTE n=40, J2 n=9, VA n=9, 'MG 1100' n=40. NZTA demonstrably carries 1930s MGs at single-digit counts, so a single MG Magna (F/L-type, 1931-1936, a direct contemporary of the J2 and VA) is period-coherent rather than anomalous."
+      - "nl_rdw independently evidences the MG Magna nameplate 13 distinct ways under make MG: 'F1 MAGNA', 'F2 MAGNA', 'F2 MAGNA JARVIS', 'F3 MAGNA', 'F TYPE MAGNA', 'F-TYPE MAGNA SALONETTE', 'L MAGNA', 'L2 MAGNA', 'L MAGNA CONTINENTAL COUPE', 'MAGNA F2 CABRIOLET', 'MG-F MAGNA', 'MG MAGNA', 'MAGNA'. The nameplate is real and the SLICE RECORD'S NL LEG IS SOLID."
+      - "Against resolution: NZTA files MITSUBISHI|MAGNA n=189 correctly, so the register is not systematically mis-keying Magna; but a single mis-key out of 190 is exactly the failure mode that cannot be excluded from register data alone, and I found no NZ-side second source."
+    verdict: "stays unverifiable, leaning correct. Per 'skipped-beats-assumed' I decline to resolve it on plausibility. Recommended source-gap queue entry: a NZ marque-club or historic-vehicle register lookup, which is the only route that would settle it."
+  "car/honda/grace#id":
+    researcher: 'unverifiable("the Grace is the JDM name of the City sedan ... needs a disposition, not a guess")'
+    verifier: OVERTURNED(correct)
+    alternative_route_tried: "test the catalog's PUBLISHED convention for market-badge twins, rather than re-litigating whether Grace == City"
+    evidence:
+      - "The catalog systematically keeps market-badge twins as SEPARATE live ids, and does so with OVERLAPPING availability in the very same country: car/toyota/vitz (fi,gb,my,nl,nz,ua) alongside car/toyota/yaris (14 countries incl. nz); car/nissan/cefiro (fi,my,nz,ua) alongside car/nissan/maxima (8 countries incl. nz); car/honda/fit (10 countries incl. nz) alongside car/honda/jazz (11 countries incl. nz). All three pairs are the same vehicle under a JDM and an export badge, both live, both claiming NZ."
+      - "car/toyota/aqua (nz) and car/mazda/demio (nz) are further JDM-badge records in the same shape."
+      - "DECISIONS.md states the intent directly: 'Availability is evidence, not marketing history ... NZ's JDM grey imports are the canonical counterexample, and they are a feature: those models exist on real roads.'"
+      - "Against the alternative reading: unlike car/nissan/maxima-qx (settled by a shared e1*98/14*0136 approval family), there is NO shared approval, NO shared source row and NO shared register string tying grace to city — nz_nzta files GRACE n=1888 and CITY n=983 as wholly separate strings, and nl_rdw carries CITY n=2 with no GRACE at all."
+      - "So on the project's own published convention, a JDM badge with its own register evidence IS a canonical id. car/honda/grace#id reads correct."
+    residual_risk: >-
+      This resolves a convention question, not a vehicle-identity question. If the
+      project ever rules that market badges must fold, grace/city, vitz/yaris,
+      cefiro/maxima and fit/jazz all fall together — a ~5-pair decision, not a
+      1-record one. Worth a DECISIONS.md line either way.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SPOT-CHECK OF 'correct' VERDICTS
+# ─────────────────────────────────────────────────────────────────────────────
+spot_check:
+  selection_rule: >-
+    Deterministic and reproducible. Extract every distinct record id named
+    anywhere in the ledger's defect_list or unverifiable_list (67 distinct
+    lines, but only 56 distinct record ids once the same record's id/name/make/
+    kind lines are deduplicated); subtract those from the 100 slice ids, leaving
+    44 records whose every claim the ledger scored correct. Sort ascending, then
+    take index floor(i*44/25)+1 for i=0..24 -> 25 records. Re-derive id + name
+    for each = 50 claims.
+  records:
+    - car/eagle/summit-wagon
+    - car/eagle/vision
+    - car/ford/flex
+    - car/ford/sierra
+    - car/genesis/electrified-g80
+    - car/genesis/electrified-gv70
+    - car/holden/torana
+    - car/hudson/hornet
+    - car/imperial/custom
+    - car/jeep/cherokee
+    - car/kia/soul-ev
+    - car/lamborghini/aventador-s-roadster
+    - car/lloyd/arabella
+    - car/lucid/air-sapphire
+    - car/mercedes-benz/280-te
+    - car/mercedes-benz/300-te
+    - car/nash/ambassador
+    - car/nash/metropolitan
+    - car/nissan/axxess
+    - car/opel/manta-400
+    - car/panther/lima
+    - car/perodua/myvi
+    - car/peugeot/bipper
+    - car/plymouth/neon
+    - car/riley/1300
+  method: >-
+    For id I ran an independent twin detector over the whole 16,825-row catalog:
+    per (make, kind) group, flag any sibling whose name is fold-equal, a token
+    subset in either direction, or a token permutation. That is deliberately
+    LOOSER than find_duplicate_spellings.rb, so it over-fires on base nameplates
+    (a base name is a token subset of all its trims); each hit was then judged
+    on whether the sibling denotes the SAME vehicle. For name I checked the
+    marque rendering, fetching where the answer was not already established.
+  misses_found: 1
+  miss:
+    "car/lucid/air-sapphire#id":
+      researcher: correct
+      verifier: "defective(D8) — MISS"
+      evidence:
+        - "car/lucid/air is live (de, es, nl, ua), as are car/lucid/air-pure, air-touring and air-dream-p."
+        - "en.wikipedia.org/wiki/Lucid_Air lists Sapphire in the Air trim table alongside Pure, Touring, Grand Touring and Dream Edition, and describes it as a high-performance variant WITHIN the Air lineup, not a separate model."
+        - "This is the identical shape the ledger itself calls D8 elsewhere in this slice: car/kia/niro-fe (trim grade), car/genesis/gv60-performance (grade), car/nissan/z-nismo (grade), car/jaguar/f-type-p450. Lucid's own marketing line ('the world's first luxury electric super-sports sedan') is no stronger than NISMO's, which the ledger did not accept."
+      verdict: "id should read defective(D8). The NAME 'Air Sapphire' is correct — it is Lucid's own string."
+  near_miss_that_survived_scrutiny:
+    "car/eagle/summit-wagon":
+      note: >-
+        This one LOOKS like the same D8 body-variant trap as
+        car/hyundai/elantra-wagon and car/daewoo/nubira-wagon, and I expected a
+        second miss here. It is not. en.wikipedia.org/wiki/Eagle_Summit: 'The
+        Summit Wagon joined the line, and it was a completely different vehicle
+        featuring a high roofline and sliding rear side door. This crossover
+        design was actually a rebadged Mitsubishi RVR, thus not related to the
+        Mirage-based Summits.' Different vehicle, different platform, and
+        'Summit Wagon' is Eagle's own designation. The researcher's correct
+        verdict is right and non-obvious — good discrimination.
+  other_records_examined_and_upheld:
+    - "car/genesis/electrified-g80 / electrified-gv70 — 'Electrified <model>' is Genesis's own model name for the BEVs, not a grade; upheld (and consistent with the ledger flagging gv60-performance, which IS a grade)"
+    - "car/kia/soul-ev — 'Soul EV' is Kia's own BEV model name; the ledger likewise leaves car/kia/niro-ev alone. Upheld."
+    - "car/lamborghini/aventador-s-roadster — a genuine Lamborghini model name, in contrast to the two Aventador-prefixed strings the ledger DID flag. Upheld; this is the sharpest discrimination in the whole ledger."
+    - "car/mercedes-benz/280-te and 300-te — genuine W123/S124 estate designations; base records relative to 300-te-24 and 300-te-4-matic. Upheld."
+    - "car/ford/sierra, car/jeep/cherokee, car/ford/flex, car/nash/ambassador, car/nash/metropolitan, car/opel/manta-400 — all base nameplates whose only twin-detector hits are their own trim records. Upheld (and this is the correct altitude: the trim record is the defect, not the base)."
+    - "car/imperial/custom — 'Custom' is an Imperial series name (Imperial Custom / Crown / LeBaron), all three live and all three marque designations. Upheld."
+    - "car/riley/1300 — 'Riley 1300' is the marque's own post-1967 ADO16 name; car/riley/kestrel is the earlier name and a separate real record. Upheld."
+    - "car/eagle/vision, car/holden/torana, car/hudson/hornet, car/lloyd/arabella, car/nissan/axxess, car/panther/lima, car/perodua/myvi, car/peugeot/bipper, car/plymouth/neon — no twin, marque-true name. Upheld."
+  miss_rate:
+    claims_rederived: 50
+    misses: 1
+    rate_per_claim: "2.0% (1/50); 95% Clopper-Pearson interval approx [0.05%, 10.6%]"
+    rate_per_record: "4.0% (1/25)"
+  what_the_miss_rate_implies: >-
+    One miss in 50 spot-checked claims is not evidence of a sloppy ledger — the
+    interval is wide and the near-miss above shows the researcher resisting the
+    obvious wrong answer on a harder case. But it does mean the slice's clean
+    rate is an UPPER bound: applied naively to the 619 claims the ledger scored
+    correct, a 2% miss rate would imply on the order of a dozen further defects,
+    with a 95% interval spanning roughly 0 to 65. RESULTS.md should carry the
+    verifier miss rate as its own line (it is the program's own error rate,
+    PRD-FIVE-NINES §5.2), not fold it into the headline.
+
+# ─────────────────────────────────────────────────────────────────────────────
+SUMMARY:
+  defects_reviewed: 80
+  defects_confirmed: 77
+  defects_overturned: 1          # car/fiat/fiorino-qubo#name -> correct
+  defects_reclassified: 2        # car/fiat/500-abarth#id (cross-make -> D6 within-make);
+                                 # car/jaguar/xj42#id (D6/D9 -> D9 primary)
+                                 # both remain DEFECTIVE; only the class/twin changes
+  unverifiables_reviewed: 2
+  unverifiables_resolved: 1      # car/honda/grace#id -> correct
+  unverifiables_upheld: 1        # car/mg/magna#availability.nz (stays unverifiable, leaning correct)
+  corrects_spot_checked: 25 records / 50 claims
+  misses_found: 1                # car/lucid/air-sapphire#id -> defective(D8)
+
+  evidence_lines_i_could_not_reproduce:
+    - "car/mcc/smart#id — ledger cites 'shared approval family e1*98/14*0080'; the published record carries NO xrefs.tan at all. Verdict stands on other evidence, but the line should be corrected before merge."
+    - "car/maxus/mifa-9#name — ledger cites 'the maker's own site'; five Maxus/LDV URLs 404 or returned empty for me. Verdict stands on the record's own case-preserving registers, but the citation should be replaced with something reachable."
+    - "car/fiat/500-abarth#id — ledger's cross-make identity claim is contradicted by the approval numbers on the two records (different regulatory eras). The within-make twin car/fiat/abarth-500 shares four exact tan extensions and is not mentioned anywhere in the ledger."
+
+  adjusted_tallies:
+    claims_total: 701
+    correct: 620          # 619 +1 (fiorino-qubo name) +1 (grace id) -1 (air-sapphire id)
+    defective: 80         # 80 -1 (fiorino-qubo name) +1 (air-sapphire id)
+    unverifiable: 1       # 2 -1 (grace id resolved)
+    clean_rate: "88.45% (620/701; unverifiable counted AGAINST, per protocol) — vs the ledger's 88.30%"
+    per_claim_type:
+      id:           { total: 100, correct: 59, defective: 41, unverifiable: 0 }
+      name:         { total: 100, correct: 72, defective: 28, unverifiable: 0 }
+      make:         { total: 100, correct: 94, defective: 6,  unverifiable: 0 }
+      kind:         { total: 100, correct: 95, defective: 5,  unverifiable: 0 }
+      availability: { total: 301, correct: 300, defective: 0, unverifiable: 1 }
+    taxonomy_shifts:
+      - "D6 loses car/fiat/fiorino-qubo#name and car/jaguar/xj42#id; gains car/fiat/500-abarth#id. Net -1."
+      - "D8 gains car/lucid/air-sapphire#id. Net +1."
+      - "D9 gains car/jaguar/xj42#id as primary class. Net +1."
+      - "The ledger's ad-hoc 'cross-make duplicate' class held four id entries (car/faw/e-hs9, car/fiat/500-abarth, car/gm-daewoo/matiz, car/mcc/smart). Removing 500-abarth leaves three. FLAG 1's measured breakdown should therefore read cross_make: 3 and within_make_token_difference: 15, not 4 and 14 — the blind spot the flag identifies gets slightly LARGER, not smaller."
+
+  verifier_assessment: >-
+    The ledger holds up under adversarial re-derivation. 77 of 80 defect
+    verdicts confirmed outright, 2 more confirmed-as-defective with a corrected
+    class, exactly 1 overturned. The two calls flagged for my closest attention
+    both survive, and the Mazda SC call in particular is a case where the
+    encyclopedia would have led me to overturn it wrongly — the ledger's insistence
+    on the marque's own site is what makes it right. The 23-id freshness number
+    reproduces exactly and the fresh build corroborates the disposition of both
+    slice-2 members.
+
+    Three things should change before merge: the two unreproducible evidence
+    citations (mcc/smart, maxus/mifa-9), the fiat/500-abarth cross-make claim
+    (which the approval data contradicts), and the fiorino-qubo name verdict
+    (Fiat did use that compound). Two things should be reported rather than
+    fixed: the id-defect count is inflated by booking pair defects against the
+    CANONICAL half of the pair (scenic, nuova-500, ford/18, model-t,
+    1000-traveller), and the z-nismo casing defect is one member of an
+    untouched four-record NISMO family with no styling pin — fixing it alone
+    would create exactly the half-fixed seam the project's own detectors read as
+    a signal.
+
+  rules_observed:
+    fetch_never_assume: "every name verdict rests on a fetched source or the record's own source strings; where I could not fetch (Maxus), I said so and named the substitute basis"
+    majority_is_not_authority: "the Mazda SC call is decided by mazdausa.com against Wikipedia; the MG Magna call is NOT decided by the 189-vs-1 count"
+    skipped_beats_assumed: "car/mg/magna#availability.nz left unverifiable despite strong circumstantial support"
+    nothing_fixed: "no repo file was written or modified by this verification"

--- a/data/review/audit-v2026.07.5/audit-verify-3.yml
+++ b/data/review/audit-v2026.07.5/audit-verify-3.yml
@@ -1,0 +1,1237 @@
+# Five-nines baseline audit (PRD-FIVE-NINES gate A2) — INDEPENDENT VERIFICATION
+# I-11: researcher ≠ verifier. Every defective verdict below was re-derived from
+# primary sources BEFORE the researcher's evidence line was read.
+slice: 3
+verifier: opus-verify-3
+researcher_reviewed: opus-audit-3
+date: 2026-07-26
+status: COMPLETE
+verdict_on_the_ledger: >-
+  The ledger's headline finding stands and its aggregate number is sound
+  (clean rate 0.8016 → 0.8031 adjusted). But 20 of its 119 defect verdicts are
+  wrong in verdict (7) or in class (13), 7 of its 9 unverifiables were
+  resolvable with one more route, and 4 of 25 sampled `correct` verdicts are
+  misses. Merge the number; re-point the lines. Details in SUMMARY.
+
+evidence_base_built_by_verifier:
+  - "catalog v2026.07.5: /Users/javi/GitHub/.vdb-worktrees/s4w-data/catalog/{car,truck,van,bus,moped,motorcycle}/models.json (all six kinds loaded — sibling and cross-kind sweeps are mine, not copied)"
+  - "raw corpora: build/observed_variants.json, build/observed_model_names.json"
+  - "fi: own single-pass aggregate of cache/fi_traficom_register.zip → (ajoneuvoluokka, merkkiSelvakielinen, kaupallinenNimi|mallimerkinta, count, tyyppihyvaksyntanro): 5,147,216 register rows → 278,147 distinct triples"
+  - "es: own fixed-width read of cache/es_dgt_2026{04,05,06}.txt at [17,30)/[47,22)/[426,3)"
+  - "nl: LIVE SoQL against https://opendata.rdw.nl/resource/m9d7-ebf2.json (queried 2026-07-26), incl. per-row wielbasis/massa fields the researcher did not use"
+  - "ua: own single-pass aggregate of cache/ua_reestr_current.zip → (KIND, BRAND, MODEL, count): 901,963 operation rows → 18,067 distinct triples (the per-vehicle identifier column was never read)"
+  - "es: own aggregate es_agg.tsv → (EU category, MARCA, MODELO, count): 24,802 distinct triples over the three cached months"
+  - "gb: cache/uk_veh0120_uk.csv (BodyType,Make,GenModel,Model,…) — read at the finer Model column, which the pipeline does not use"
+  - "marque fetches (curl -A Mozilla/5.0 / WebFetch): mecalac.com, fordtrucks.com.tr, ford-trucks.eu, scania.com/uk, renault-trucks.co.uk, kaessbohrer.com, daf.com, saxas.biz, buchermunicipal.com, liebherr.com, landrover.com, ramtrucks.com, subaru.com, vw.com, zeekrlife.com, mercedes-benz-trucks.com, pressroom.toyota.com, static.oneweb.mercedes-benz.com (Vario W670 owner's manual), en/de.wikipedia.org where rank 3 was unreachable — every rank stated per claim"
+  - "an automated availability re-derivation of my own (v3/availcheck.rb) over all 245 availability entries, machine-checkable against fi/ua/gb/es"
+  - "METHOD: 119 defective claims + 9 unverifiables + 25 spot-checks were re-derived across five parallel evidence-blind workstreams that were forbidden to open the researcher's ledger; I adjudicated every disagreement myself and overrode four of them (PART 8)."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 1 — THE HEADLINE FINDING, RE-DERIVED HARDEST
+# ═════════════════════════════════════════════════════════════════════════════
+
+"car/tesla/model-y#id":
+  researcher: "defective(D6) — car/tesla/y is a live truncation of the same nameplate"
+  verifier: CONFIRMED
+  verifier_did_not_rely_on: "the researcher's counts; every number below is my own query"
+  evidence:
+    - "catalog: car/tesla/y IS live at the audited tag — {id: tesla/y, name: 'Y', kind: car, body_types: [hatchback], availability: [es/es_dgt registration, nl/nl_rdw registration], popularity.global_decile 8}. No alias/former_id/deprecation marker on it. So the id-canonical test ('no OTHER LIVE id denotes the same vehicle') has a live counterparty to fail against."
+    - "LIVE nl_rdw 2026-07-26, merk=TESLA & handelsbenaming=Y → EXACTLY 2 rows: kenteken GDT64B (DET 2024-06-26, massa 1959, wielbasis 289, M1, Personenauto) and GJX24J (DET 2023-08-25, massa 1884, wielbasis 289, M1)."
+    - "PHYSICAL DISCRIMINATOR (my own test, not in the researcher's ledger): live RDW group-by merk=TESLA on (handelsbenaming, wielbasis) — MODEL Y wb=289 n=55,598; MODEL 3 wb=288 n=65,990; MODEL S wb=296 n=5,469; MODEL X wb=297 n=3,715. Both bare-'Y' rows are wb=289. The wheelbase separates Model Y from every other Tesla in the same register, and it lands on Model Y exactly (2,890 mm). Kerb masses 1,884/1,959 kg sit inside the Model Y RWD/LR band and below Model S/X."
+    - "es_dgt 2026-04..06, own fixed-width read: TESLA|Y|M1 = 1 row (against TESLA|MODEL Y|M1 = 1,586). Tesla's ES M1 line in the same three months is MODEL 3 / MODEL Y / MODEL S / MODEL X only — a bare 'Y' M1 under merk TESLA has no other referent in that marque's line-up."
+    - "So car/tesla/y = 3 vehicles (2 nl + 1 es), and the NL pair is positively identified as Model Y on register-carried dimensions, not by resemblance."
+  could_the_bare_Y_be_something_else:
+    considered: "Tesla Semi (N3), Cybertruck (bare 'Y' unlikely, and Cybertruck is not EU-approved), Roadster, a coachbuilt one-off, or a non-Tesla 'Y' misfiled under merk TESLA."
+    ruled_out_by: "voertuigsoort=Personenauto + europese_voertuigcategorie=M1 kills Semi/Cybertruck; wielbasis 289 ≠ Roadster (RDW Tesla Roadster rows are cabriolet, and the M1 wb clusters at 288/296/297/289 by model). No Tesla product other than Model Y has a 2,890 mm wheelbase."
+    residual_doubt: "none material. The only unfalsifiable residue is that RDW's wielbasis is self-reported per plate; two independent plates agreeing to the cm, plus the ES row, plus Tesla's 4-product M1 line-up, closes it."
+  verdict_note: >-
+    The defect is real and it is on the id axis, but note WHICH record is
+    wrong: the protocol's check is symmetric ("no other live id denotes the
+    same vehicle"), so car/tesla/model-y fails it while being the CORRECT
+    canonical form. A reader of the ledger could mistake this for "Model Y is
+    misnamed". The fix lands on car/tesla/y (fold + alias), not on model-y.
+    I record the claim CONFIRMED, with that framing correction.
+  head_mass_note: "car/tesla/model-y is global_decile 1 with 13 countries — the researcher's 'a head record fails canonicality' framing survives verification."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 2 — THE TWO MARQUE OVERTURNS, RE-FETCHED
+# ═════════════════════════════════════════════════════════════════════════════
+
+"truck/mecalac/revotruck#name":
+  researcher: "correct (published 'Revotruck' is the marque's own rendering)"
+  verifier: CONFIRMED
+  evidence:
+    - "https://mecalac.com/en/products/revotruck/ (HTTP 200, fetched 2026-07-26, curl -A Mozilla/5.0): nav + breadcrumb + og image alt all render 'Revotruck-Series'."
+    - "https://mecalac.com/en/machine/revotruck6.html (HTTP 200): <title>Mecalac Revotruck 6 - Revotruck-Series</title>; 39 occurrences of the exact token 'Revotruck' in body copy, 0 occurrences of 'REVOTRUCK' or 'RevoTruck' outside lowercase URL slugs."
+    - "raw corroboration (not authority on casing): observed variants 'MECALAC REVOTRUCK9', 'REVOTRUCK 6T'; register strings uppercase everything, so they neither support nor contradict."
+  note: >-
+    Worth stating because it is the trap this check exists for: the raw
+    registers only ever shout REVOTRUCK, and the model is sold as
+    'Revotruck 6'/'Revotruck 9'. The published bare 'Revotruck' is the series
+    name at nameplate altitude — right form AND right altitude.
+
+"truck/ford/f-max#name":
+  researcher: "defective(D7) — Ford Trucks writes F-MAX, catalog publishes 'F-Max'"
+  verifier: CONFIRMED
+  evidence:
+    - "https://www.fordtrucks.com.tr/en (HTTP 200, fetched 2026-07-26): 75 occurrences of the exact string 'F-MAX'; zero of 'F-Max'. Menu entries render 'F-MAX', 'F-MAX L', 'F-MAX LL' (href /en/tractor-series/fmax, /fmax-l, /fmax-ll); meta description: 'Turkey's leading heavy truck brand. F-MAX tractor…'."
+    - "https://www.ford-trucks.eu/ → redirects to ford-trucks.pl (HTTP 200): 63 occurrences of 'F-MAX', same rendering on a second Ford Trucks national site."
+    - "catalog: truck/ford/f-max name='F-Max', avail es+lu+nl, tan e9*2007/46*0089*38/*39 (a genuine EU WVTA, so the record itself is sound — only the casing is not the marque's)."
+  make_axis_considered_and_rejected: >-
+    I tested whether this should ALSO carry a D12 (make split) by parity with
+    the researcher's truck/renault/d14 → renault-trucks finding, since the
+    marque here is 'Ford Trucks' (Ford Otosan) and the catalog has a separate
+    renault-trucks make. Rejected: Ford Trucks is a sub-brand of Ford, the
+    vehicles carry the Ford blue oval, and the type approval is issued under
+    e9*…*0089 to Ford Otosan as a Ford. Renault Trucks is a separately-owned
+    marque (Volvo Group). Not a defect; recorded so the asymmetry is on record.
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 3 — THE THREE NEW-CLASS EXEMPLARS
+# ═════════════════════════════════════════════════════════════════════════════
+
+"NEW-3 (source-forced kind) — us_fueleconomy.rb / ca_nrcan.rb hardcode kinds=[:car]":
+  researcher: "both sources declare kinds=[:car] and emit Row(kind: :car) unconditionally; no kind_map exists for either"
+  verifier: CONFIRMED
+  evidence:
+    - "pipeline/sources/us_fueleconomy.rb: `def kinds = %i[car]` and, in rows(_kind), `Row.new(source: key, country: country, kind: :car, …)` — the kind argument is discarded (`_kind`) and :car is a literal."
+    - "pipeline/sources/ca_nrcan.rb: identical shape — `def kinds = %i[car]`, `Row.new(…, kind: :car, …)` with `rows(_kind)`."
+    - "overrides/kind_maps/ contains exactly three files: de_kba_fz10.yml, nl_rdw.yml, uk_dft.yml. There is no us_fueleconomy.yml or ca_nrcan.yml, so no correction layer can reach these rows."
+    - "the unused free class column is real: cache/us_vehicles.csv column 63 is VClass; Suzuki Equator rows read VClass='Small Pickup Trucks 2WD' (make='Suzuki', model='Equator 2WD', baseModel='Equator', MY2009). ca_nrcan's parser reads only Make/Model and never touches the 'Vehicle class' column."
+  consequence_claim_car_suzuki_equator_kind: CONFIRMED (see that record below)
+
+"truck/ford/f-150#xrefs.tan — the '- (FMVSS)' literal (NEW-2 poisoned key)":
+  researcher: "literal string '- (FMVSS)' in xrefs.tan, shared with 33 records across 4 kinds"
+  verifier: "CONFIRMED(with correction to the numbers)"
+  evidence:
+    - "own sweep of all six kind files for the literal '- (FMVSS)' in xrefs.tan: 35 records carry it — 22 car, 10 motorcycle, 3 truck. That is 34 OTHER records besides truck/ford/f-150, across THREE kinds, not 33 across four. Exemplars match the researcher's (audi/tts, bmw/x3, harley-davidson/road-king, zero-motorcycles/sr-f-zf14-4-premium) plus chevrolet/silverado, dodge/ram, jeep/wrangler, toyota/camry, fisker/ocean-one."
+    - "PROVENANCE (the researcher did not name it): the string comes from fi_traficom's `tyyppihyvaksyntanro` column — my FI aggregate carries '- (FMVSS)' as the TAN for 74 distinct (class, make, model) triples, e.g. 'N2G|AMG Hummer|H2', 'M1|Audi|A4 allroad quattro'. It is Traficom's placeholder for a vehicle admitted on US FMVSS rather than an EU WVTA. It is not in the LU, UK or NL caches (0 hits each), so fi_traficom is the sole ingest path."
+    - "so the defect is exactly as characterised: a non-TAN placeholder is being stored in the TAN field, and any TAN-equality duplicate detector would fire across 35 unrelated records in 3 kinds."
+  note: "the correction is arithmetic only; the class and its severity stand."
+
+# (Part 4: NEW-1 converter-brand exemplar, remaining defective claims,
+#  unverifiables, and the 25 correct spot-checks follow — see below.)
+
+"NEW-1 (converter/coachbuilder brand or conversion STYLE as a nameplate) — exemplars re-derived":
+  researcher: "8 defective claims (id+name on truck/fiat/burstner, truck/fiat/swift, truck/peugeot/bailey, car/volkswagen/baja) + a proposed new class"
+  verifier: "CONFIRMED as a real, repeating defect — with a taxonomy caveat and a materially STRONGER evidence base than the ledger carries"
+  evidence:
+    - "gb VEH0120 (own awk over cache/uk_veh0120_uk.csv): Make=FIAT, GenModel='FIAT BURSTNER', Model column = 'BURSTNER ARGOS A 747-2 G' (8+3), 'BURSTNER ARGOS A747-2 AUTO' (8), 'BURSTNER DELFIN T680G HARMONY' (3), 'BURSTNER DELFIN T727G/T736' … — the model column carries Bürstner's own motorhome nameplates, never a Fiat one."
+    - "gb: Make=PEUGEOT, GenModel='PEUGEOT BAILEY', Model='BAILEY APPROACH A-GRAPH 79-4T' (114+10), 'BAILEY APPROACH AUTOGRAPH 68-2', 'BAILEY ADVANCE 76-4' — Bailey of Bristol."
+    - "gb: Make=FIAT, GenModel='FIAT SWIFT', Model='SWIFT KONTIKI 649', 'SWIFT BESSACARR 560 LOUNGE S-A', 'SWIFT BOLERO 724FB S-A' — Swift Group. Note the same GenModel appears under THREE BodyTypes (Cars, Buses and coaches, Heavy goods vehicles), which is itself the kind-noise fingerprint."
+    - "the remedy really is blocked: overrides/makes/drop.yml drops BURSTNER, BÜRSTNER and SWIFT (and ~40 more coachbuilders) as MAKES for kind car, and NIESMANN+BISCHOFF / HYMER / MOBILVETTA for kind truck. So 'move it to its own marque' would resurrect exactly what the drop layer deletes. That is the researcher's central argument and it holds on inspection of the file."
+    - "SCALE — larger than the ledger says: the string 'Burstner' is published as a MODEL under FOUR different chassis makes across three kinds — car/citroen/burstner [es,nl], car/fiat/burstner [fi,nl], car/mercedes-benz/burstner [fi,nl], truck/fiat/burstner [gb], van/fiat/burstner [gb,nl]. 'Swift' likewise: car/fiat/swift, truck/fiat/swift, truck/ford/swift, van/fiat/swift, van/ford/swift. 'Bailey': truck/ford/bailey, truck/peugeot/bailey, van/ford/bailey, van/peugeot/bailey."
+    - "car/volkswagen/baja re-derived at row level: LIVE nl_rdw 2026-07-26, merk=VOLKSWAGEN AND handelsbenaming LIKE '%BAJA%' → 'BAJA' 2 (sedan + Niet geregistreerd), 'KEVER BAJA' 2 (coupe + sedan), 'BAJA BUGG' 1, 'BAJA REPLICA' 1 — all Personenauto M1. 'KEVER' is Dutch for Beetle and RDW's own string says REPLICA: this is the aftermarket Baja Bug conversion STYLE, not a VW nameplate."
+    - "and the nz half of that record is REAL (I checked, because a bogus availability would have been a second defect): cache/nz_passenger-car-van_V.json carries {MAKE: VOLKSWAGEN, MODEL: BAJA, n: 6}."
+  taxonomy_caveat_the_verifier_records: >-
+    The DEFECT is confirmed in every instance. Whether it needs a new class
+    number is thinner than the ledger implies: PRD-QUALITY §4's D5 is
+    "embedded make/BRAND prefix … remedy rename; if cross-make badge → move",
+    which covers the detector (a third-party brand occupying the model column)
+    and even contemplates the move remedy. The researcher's case for newness
+    rests on the REMEDY being blocked (the move target is a dropped make, so
+    the fix is a per-kind drop, not a move) rather than on the detector being
+    different. That is a legitimate basis for a sub-class, and the proposed
+    list-free detector (same model string under ≥2 unrelated chassis makes in
+    one kind) is genuinely new and fires on all four exemplars — but I would
+    file it as D5b, not as a class unrelated to D5. Recorded as dissent, not
+    as an overturn.
+  kind_claims_on_the_three_gb_records: CONFIRMED (D10)
+  kind_evidence:
+    - "kind is a LEGAL axis: PROPOSAL-kind-boundary.md DECISION (2026-07-25) Q1 — 'derive kind from the EU category; treat the register's own vehicle-type word as a hint, never as truth'. GB VEH0120's BodyType is exactly such an administrative word, and overrides/kind_maps/uk_dft.yml maps 'Heavy goods vehicles' → truck mechanically."
+    - "a motor caravan with ≤8 passenger seats is M1 SA at ANY mass — the same document cites Germany's Pkw table legitimately carrying 'motorhomes up to 26 t (SA/Wohnmobil, 71,575 units)'. So Bürstner Argos / Bailey Autograph / Swift Kon-tiki rows are M1, and kind=truck is wrong."
+    - "CONFLICT I am obliged to flag: NAMING.md §3 says the opposite in writing — 'Heavy trucks appear in German passenger-car tables … motorhomes on Actros/Arocs/FH chassis. Drop from car; they are correct in truck.' The 2026-07-25 decision post-dates it and is explicit, so I follow the decision — but the two documents disagree and a fixer will hit that."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 5 — THE UNVERIFIABLE REGISTER, RETRIED (one honest alternative route each)
+# ═════════════════════════════════════════════════════════════════════════════
+
+"truck/scania/metago#id + #name + #make":
+  researcher: "unverifiable(id, name, make) — 'Metago Pro' identity unresolved; metago.eu/.nl do not resolve, WebSearch dead"
+  verifier: "RESOLVED — 3 unverifiables closed; #id and #name become defective(NEW-1/D5-shape), #make becomes correct"
+  alternative_route_taken: >-
+    Instead of hunting a 'Metago' company, I asked the register which MAKES
+    carry the string — a cross-make live RDW group-by. That names the owner
+    immediately.
+  evidence:
+    - "LIVE nl_rdw 2026-07-26, $where=starts_with(handelsbenaming,'METAGO') grouped by merk: KAESSBOHRER 'METAGO PRO' Aanhangwagen O4 n=15 + Middenasaanhangwagen O4 n=6; KASSBOHRER TRANSPORT TECH 'METAGO PRO'/'METAGO-PRO'/'METAGOPRO' O4 n=11+27+15+2+1; KAESSBOHRER TRANSPORT TEC N3 n=17. The PRODUCT is a Kässbohrer Transport Technik car-transporter (O4 trailer/centre-axle trailer)."
+    - "the chassis makes that also carry it are exactly the NEW-1 fingerprint: MERCEDES-BENZ N3 n=58, SCANIA N3 n=16, VOLVO N3 n=10, DAF N3 n=1, and one literal 'SCANIA/KASSBOHRER TRANSPO' N3 n=1 — the tractor of a car-transporter combination, with the bodybuilder's product name in the model column."
+    - "marque corroboration: https://kaessbohrer.com/en (HTTP 200) links its own product page href='https://kaessbohrer.com/en/vehicle/metago-pro'; the target itself 404s (site restructure), so I cite the live link, not a page I could not read."
+    - "es_dgt 2026-04..06, own read: 'MERCEDES BENZ | METAGO PRO | N3' 2 and 'SCANIA | METAGO PRO | N3' 2 — the same shape in a second country."
+    - "the catalog carries THREE of these, not the two the ledger names: truck/mercedes-benz/metago [es,fi,nl], truck/scania/metago [es,lu,nl], truck/volvo/metago [fi,nl] — all named 'Metago'. There is no kaessbohrer/kassbohrer make in any kind."
+  verdicts:
+    id: "defective — 'Metago' is not a Scania nameplate; the id is a bodybuilder product string (same NEW-1/D5 shape as burstner/swift/bailey). Note this is NOT a duplicate-of-a-live-id defect: the three metago records denote three different chassis, so D6 would be wrong."
+    name: "defective — same reason; the marque's own rendering is Kässbohrer's 'METAGO PRO', and it is Kässbohrer's, not Scania's."
+    make: "CORRECT — I overturn the researcher's unverifiable here. The 16 NL rows are N3 Bedrijfsauto registered under merk SCANIA: they ARE Scania tractors. The third party sits in the MODEL column, so the make axis is not the defective one (contrast D11, where the third party is in the make column)."
+
+"truck/renault/d14#name":
+  researcher: "unverifiable(name) — renault-trucks.com/en/trucks/renault-trucks-d returned HTTP 502; register forms split 'D 14' (nl n=2) and 'D14' (nl n=1, es n=1)"
+  verifier: "RESOLVED — the published closed form 'D14' IS the marque's own rendering → the name claim is CORRECT"
+  alternative_route_taken: "the .com host really is 502 (I reproduced it); I went to the marque's NATIONAL sites instead."
+  evidence:
+    - "https://www.renault-trucks.com/en/trucks/renault-trucks-d → HTTP 502 (reproduced 2026-07-26): the researcher's blocker is real."
+    - "https://www.renault-trucks.co.uk/press-release/renault-trucks-d14-little-green-truck-set-to-unlock-tighter-access-for-rubis-in-channel-islands-fuel-operation → HTTP 200, <title>Renault Trucks D14 'little green truck' set to unlock tighter access for Rubis in Channel Islands fuel operation | Renault Trucks UK</title>. Body copy: 'the D14 4x2 rigid has been engineered specifica…', 'D14 and D16 chassis give us that flexibilit…', 'a D14 rigid designed to reach the most restri…'. Rank 3, the marque's own press release."
+    - "counter-evidence I looked for and found: the same site also writes 'Renault Trucks D 19 T X-Load' (spaced) and 'D Wide'. So Renault Trucks uses BOTH forms; the closed 'D14' is attested for exactly this model, which is all the claim needs."
+  note: "this cuts against the researcher's own #make=defective(D12) verdict being wrong — the press release is published BY Renault Trucks, which is evidence FOR the make split. That claim was assigned to my truck-batch verifier."
+
+"truck/scania/p230#name (and p280, p380 — same question)":
+  researcher: "unverifiable(name) — scania.com 404s/JS-renders; both 'P280' and 'P 280 B 4X2' live in nl_rdw"
+  verifier: "PARTIALLY RESOLVED — one rank-3 instance of Scania's own convention found; it favours the SPACED form, so the published closed forms are non-canonical (D7). Recorded with the thinness stated."
+  alternative_route_taken: "the researcher tried scania.com product pages; I tried the national market sites and read the CMS image metadata, which survives JS rendering."
+  evidence:
+    - "reproduced the blocker: scania.com/group/en/home/products-and-services/trucks/our-range.html → 404; scania.co.uk/trucks → 404; scania.nl/trucks → 404. The P-series page (https://www.scania.com/uk/en/home/products/trucks/p-series.html) is HTTP 200 but carries NO power designations in the served HTML (JS)."
+    - "https://www.scania.com/uk/en/home/products/trucks.html HTTP 200: the page's own itemprop='name' image captions read 'P-series', 'R-series', 'G-series', 'S-series', 'Low-entry cab trucks L-series' and — the decisive one — 'Scania R 410 LBG 4x2 Highline, general cargo transport'. Scania's own CMS writes cab-letter SPACE power-figure."
+    - "so 'P 230' / 'P 280' / 'P 380' is the marque form and the catalog's 'P230' / 'P280' / 'P380' is not."
+  honesty_note: >-
+    This rests on ONE scania.com asset caption ('R 410'), for a different cab
+    letter than any of the three records. I could not get a second independent
+    Scania instance (series pages JS-render; the newsroom index served no
+    article text). A reviewer who wants two instances before renaming three
+    live ids is entitled to leave these unverifiable; I record the resolution
+    as DIRECTIONAL and would not sweep on it alone.
+
+"car/volkswagen/caravelle-syncro#name":
+  researcher: "unverifiable(name) — VW's rendering of the drivetrain badge is lowercase 'syncro' in period material; no VW-owned page reachable"
+  verifier: "CONFIRMED UNVERIFIABLE — my independent route failed too"
+  alternative_route_taken: "volkswagen-newsroom.com search (HTTP 200 but JS-rendered: the only 5 'syncro' hits in the served HTML are the query echoed back in hreflang/locale-switcher links); volkswagen-classic.de/en/models → redirects to a newsroom hub with 0 hits; volkswagen-classic-parts.com/en/vehicles/t3 → 404; vwn-presse.de → 200 but a 2.3 KB shell; volkswagen-newsroom.com/en/volkswagen-commercial-vehicles-3701 → 404."
+  evidence:
+    - "no VW-owned page rendering the badge could be read, so the capital-S 'Caravelle Syncro' is neither confirmed nor refuted. Recorded as unverifiable per skipped-beats-assumed; feeds the source-gap queue."
+
+"car/volkswagen/211#id":
+  researcher: "unverifiable(id) — the VW 211-series order code cannot be resolved to a specific live id; en.wikipedia Volkswagen_Type_2 does not list VW's numeric order codes"
+  verifier: "CONFIRMED UNVERIFIABLE for the id axis — but I closed WHAT the vehicle is, which the ledger did not"
+  alternative_route_taken: "row-level live RDW instead of encyclopaedia lookup: I pulled every NL row and read the physical columns."
+  evidence:
+    - "LIVE nl_rdw 2026-07-26, merk=VOLKSWAGEN AND handelsbenaming='211' → 15 rows: 8 Bedrijfsauto N1 'gesloten opbouw', 3 Personenauto M1 MPV, 3 Personenauto M1 stationwagen, 1 Personenauto M1 kampeerwagen."
+    - "the seven Personenauto rows (the ones that put this record in kind=car) are DET 1956-08-23, 1960-06-30, 1963-02-28, 1964-06-30, 1965-10-20, 1966-02-28, 1975-06-30; wielbasis 240/241 cm; massa 950–1,127 kg; 3–9 seats. Wheelbase 2,400 mm + that date span + those masses identify the VW Type 2 Transporter (T1 to 1967, T2 from 1968) beyond reasonable doubt — six of the seven are T1-era."
+    - "WHY IT STILL DOES NOT CLOSE: the catalog has no live Type 2 / Transporter / Beetle-style nameplate id in kind car to name as the canonical target — the family is scattered across car/volkswagen/t2 [lu,my,nl] (2nd generation only, so it covers just the 1975 row), plus combi, micro-bus, kleinbus, kleinbuss, kombiwagen, bestel, bestel-0. Naming any single one as 'the same vehicle' would be the resolve-by-resemblance that NAMING §7.5 forbids."
+  note: "the ledger's separate #name=defective(D9) on this record is independently supported by the above: '211' is a factory order code for the Type 2, not a nameplate."
+
+"ca/us availability claims (flagged by the researcher as a class, not counted as unverifiable)":
+  verifier: "AGREE with the researcher's handling, and I checked the schema label myself"
+  evidence:
+    - "pipeline/sources/us_fueleconomy.rb and ca_nrcan.rb both declare `def evidence = :approval` and emit `count: nil`. The catalog records carry `evidence: approval` accordingly (e.g. car/tesla/model-y ca/us entries). So 'the register evidences this model' is satisfied by certification, and the schema is not overclaiming. Counting these correct rather than unverifiable is defensible BECAUSE the label is honest."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 6 — LEDGER ARITHMETIC (verified independently, not taken on trust)
+# ═════════════════════════════════════════════════════════════════════════════
+ledger_arithmetic_check:
+  slice_records: "100 — all 100 slice ids resolve to a live record in the audited catalog (0 missing)"
+  availability_entries: "245 — my own count over the catalog's availability arrays for those 100 records. Matches the ledger."
+  claims_total: "645 = 100×4 + 245 ✓"
+  verdict_sums: "correct 517 + defective 119 + unverifiable 9 = 645 ✓; per-axis sums: id 40+58+2=100 ✓, name 42+52+6=100 ✓, make 97+2+1=100 ✓, kind 96+4+0=100 ✓, availability 242+3+0=245 ✓"
+  defect_list_vs_summary: "the enumerated defect_list contains exactly 119 defective claims over 73 records, and its per-class tally (D1 10, D5 1, D6 33, D7 13, D8 21, D9 27, D10 4, D11 1, D12 1, NEW-1 8) reproduces summary.defect_classes_seen exactly ✓"
+  note: "the ledger is internally consistent; no bookkeeping defect found."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 7 — NEW-2's OTHER THREE CLAIMS, AND CLAIMS I RE-DERIVED PERSONALLY
+# (these are my own derivations; where a batch verifier disagreed, mine governs
+#  and the disagreement is recorded)
+# ═════════════════════════════════════════════════════════════════════════════
+
+"NEW-2 evidence line 1 — PLATFORM SHARING (tesla model-y vs model-3)":
+  researcher: "model-y shares 11 TANs with model-3; fi shows MODEL Y under *21/*25/*26 and MODEL 3 under *06/*15/*19"
+  verifier: CONFIRMED
+  evidence:
+    - "own set intersection over the catalog: car/tesla/model-y has 25 TANs, car/tesla/model-3 has 25, and |intersection| = 11 exactly — e4*2007/46*1293*{19,21,27,28,30,33,34,37,44,51,52}."
+    - "my FI aggregate attributes the extensions PER MODEL: 'M1|Tesla|Model Y' n=15,271 → e4*2007/46*1293*19; 'M1|Tesla|MODEL Y' n=34 → *19; 'Model Y Long Range Dual Motor' → *21; 'model y' → *25; 'M1|Tesla|Model 3' n=14,236 → *00; 'MODEL 3' n=83 → *06; 'Tesla Model 3' → *02. So the BASE approval e4*2007/46*1293 is shared and the EXTENSIONS are model-specific."
+    - "which sharpens the researcher's point: extension *19 is attributed to Model Y by FI, so model-3 carrying *19 in the catalog is a build-side mis-attribution, and a TAN-equality merge would fold the #1 and #2 selling EVs in Europe into one record."
+
+"NEW-2 evidence line 2 — CROSS-KIND legitimate (land-rover/defender)":
+  verifier: CONFIRMED
+  evidence:
+    - "truck/land-rover/defender tans = ['E5*2007/46*0092*09','e5*2007/46*0092*10']; car/land-rover/defender carries 25 tans including 'e5*2007/46*0092*10' → intersection is exactly e5*2007/46*0092*10. One approval spanning the M1G and N2G Defender; correct data that reads as a duplicate."
+
+"NEW-2 evidence line 3 — CROSS-NAMEPLATE LEAK (skoda enyaq/elroq)":
+  verifier: "CONFIRMED, and WORSE than reported"
+  evidence:
+    - "car/skoda/enyaq-85x tans = *13,*16,*22 (all three also on car/skoda/enyaq — which is what makes its own D8 verdict stand)."
+    - "car/skoda/elroq tans = *17,*18,*19,*20,*21,*22,*23 and car/skoda/enyaq carries *19,*21,*22,*23 — so Enyaq and Elroq share FOUR full TAN strings, not the one the ledger names. Two different nameplates cannot both own e8*2007/46*0416*{19,21,22,23}."
+
+"truck/ford/ranger#availability.nl":
+  researcher: "defective(D6)"
+  verifier: CONFIRMED
+  evidence:
+    - "LIVE nl_rdw 2026-07-26, merk=FORD, handelsbenaming LIKE '%RANGER%', restricted to the TRUCK categories N2/N3 → 13 distinct strings, and 11 of them are F-series: 'F250 RANGER' 3, 'F250 RANGER XLT' 3, 'F350 RANGER XLT' 3, 'F-250 RANGER XLT' 2, 'F350 RANGER' 2, 'F250 RANGER XL' 1, 'F 250 RANGER XLT' 1, 'F250 SUPERCAB RANGER XLT' 1, 'F350 RANGER LARIAT' 1, 'RANGER F250' 1, 'RANGER F 250' 1, 'RANGER XCT F250' 1. Only 'RANGER XLT' (n=2) is unqualified."
+    - "'Ranger' was Ford's US TRIM name on F-series pickups, which is what these rows are; the actual Ranger pickup sits in NL at N1 (5,143 rows) and M1 (20) — i.e. in the VAN/CAR kinds, not truck."
+    - "and the correct target id is live: truck/ford/f-250 [fi,nl]. So NL's truck-kind rows evidence a different, separately-identified nameplate."
+
+"truck/scania/460#id + #name":
+  researcher: "defective(D1) on both — parser artifact"
+  verifier: "RECLASSIFIED(D8) on both — the defect is real, the CLASS is wrong"
+  evidence:
+    - "the string is NOT a parser fabrication: bare '460' is register-attested in TWO countries — es_dgt 2026-04..06 'SCANIA | 460 | N3' n=1, and LIVE nl_rdw merk=SCANIA handelsbenaming='460' n=2. NAMING §2.1/§7.1 scope the parser-suspect rule to a bare integer that is SINGLE-SOURCE; this is the two-source case the canon explicitly warns not to treat as a parser artifact."
+    - "row-level resolution (live RDW, both NL plates): row 1 is voertuigsoort Bedrijfsauto, N3, opleggertrekker, GVW 18,600 kg, DET 1997-03-14, and carries type='T 144 LA 4X2 NA 460' — a Scania 4-series 144 with a T cab at 460 hp. Row 2 (DET 2001-01-24, N3, wb 355) carries no type string."
+    - "so a SPECIFIC live id denotes the same vehicle: truck/scania/144 [fi,nl] is live. The published '460' is a bare ENGINE POWER figure severed from its type designation — PRD-QUALITY §4 D8 ('wrong altitude — trim/edition/body/ENGINE published as model'), with a D6-style merge remedy."
+    - "the four cab-series siblings that make '460' ambiguous are all live too: scania/r460 (nl 1,951 / es 423), scania/s460 (nl 1,208), scania/g460 (nl 131), scania/p460 (nl 32 / es 22)."
+  why_it_matters: "D1's remedy is 'fix the parser; records HEAL, never delete'. Chasing a parser bug here would find nothing, because the register really does carry '460'."
+
+"car/triumph/tr2#id":
+  researcher: "defective(D6)"
+  verifier: "CONFIRMED — and I can name the mechanism the ledger does not"
+  evidence:
+    - "the duplicate id is car/triumph/tr (name 'Tr', nl+nz). Its observed_variants are ['TR CONVERTIBLE','TR II','TR III','TR III A','TR III CABRIOLET','TR- CONVERTIBLE'] — 'TR II' IS a TR2."
+    - "the mechanism is the roman-numeral collapse NAMING §6 mandates for the car kind ('Car-kind roman numerals still collapse — VARIANT_SUFFIXES strips them'): 'TR II' → 'TR'. So car/triumph/tr is a fold artifact that swallows TR2 AND TR3 AND TR3A."
+    - "bonus finding, outside this slice: car/triumph/tr is therefore a THREE-nameplate merge, which is a worse defect than the one being audited."
+
+"car/skoda/octavia-a5#id + #name":
+  researcher: "defective(D8) on both"
+  verifier: CONFIRMED
+  evidence:
+    - "my UA aggregate (own pass over cache/ua_reestr_current.zip): ЛЕГКОВИЙ|SKODA|OCTAVIA 16,506 operations; OCTAVIA A5 1,965; OCTAVIA TOUR 1,217; OCTAVIA A7 1,097; OCTAVIA COMBI 330; OCTAVIA A8 147; OCTAVIA A5 COMBI 131; OCTAVIA A5 RS 15."
+    - "car/skoda/octavia is live in NINE countries incl. ua — so the nameplate id exists and A5 (Typ 1Z, marketed Octavia II) is a generation code beneath it. Generation-as-model = D8."
+    - "asymmetry noted for the queue, not audited here: UA writes OCTAVIA A8 147 times and no car/skoda/octavia-a8 id exists, while A5 and A7 both do."
+
+"truck/chevrolet/van#name (the slice's only D5)":
+  researcher: "defective(D5) — prefix-strip over-reach, 'Chevy Van' → 'Van'"
+  verifier: CONFIRMED
+  evidence:
+    - "observed_variants for truck/chevrolet/van are exactly ['CHEVROLET CHEVY VAN','CHEVY VAN'] — every raw string carries the nameplate 'CHEVY VAN'; the published 'Van' exists in no source row."
+    - "'Chevy Van' is a real Chevrolet nameplate, so stripping 'CHEVY' as a make alias destroyed the name rather than cleaning it. The catalog proves it knows better elsewhere: car/chevrolet/chevy-van [fi,nl], van/chevrolet/chevy-van [fi,nl], car/chevrolet/chevy-van-20/-30/-g20 are all live with the prefix intact."
+
+"truck/saxas-nutzfahrzeuge-werdau/atego#make + #id":
+  researcher: "make=defective(D11); id=defective(D6)"
+  verifier: "CONFIRMED both — with a mirror-image finding the ledger misses"
+  evidence:
+    - "my FI aggregate carries the row verbatim: 'N2 | Saxas Nutzfahrzeuge Werdau | Atego | 1 | e1*2007/46*1366*10' — the body builder is in the MAKE column and Mercedes-Benz's nameplate is in the model column. Classic D11."
+    - "MIRROR IMAGE, same base approval: truck/mercedes-benz/mkd (name 'Mkd') carries TAN e1*2007/46*1366*06 — the SAME base WVTA e1*2007/46*1366 with the roles swapped, i.e. the chassis marque in the make column and SAXAS's own body designation ('MKD') in the model column. es_dgt confirms MKD is Saxas's: 'SAXAS | MKD 61-M-E | N2' 2, 'MKD 1-M' 1, 'MKD 61 - M - E' 1, 'MKD 61-3-E' 1, 'MKD 71 - M - E' 1. So this one approval produced a D11 on one side and a NEW-1/D5 on the other."
+    - "id duplicate named: truck/mercedes-benz/atego [es,fi,lu,nl] is live and denotes an Atego. D6 stands."
+    - "SCALE the ledger does not state: 'Atego' is published under FIVE makes in the truck kind — mercedes-benz, junge-fahrzeugbau-gmbh, junge-fahrzeugbau, monza, saxas-nutzfahrzeuge-werdau — plus bus/mercedes-benz/atego and car/mercedes-benz/atego. The researcher's own NEW-1 detector proposal (same model string under ≥2 unrelated makes in one kind) fires on it, which is a point in that detector's favour."
+    - "adjacent D12 not flagged by the researcher: the makes `saxas-nutzfahrzeuge-werdau` (3 truck + 3 van records) and `saxas` (truck/saxas/mkd, es+lu) are both live — a corporate-string make near-dupe. Outside this record's four claims, so not scored; queued."
+
+"the DAF cluster (fas / ftg / fancf / v1600dd) — verifier's own marque evidence":
+  note: >-
+    Recorded here because the batch verifier's lines for these records should be
+    read against it, and because the ledger cites only a site-chrome capture.
+  evidence:
+    - "https://www.daf.com/en (HTTP 200, fetched 2026-07-26) — the marque's own range renders 'DAF XB', 'DAF XD', 'DAF XF', 'DAF XG', 'DAF XDC', 'DAF XFC', 'DAF XB E', 'DAF XD E'. The strings FA / FAS / FAN / FT / FTG appear NOWHERE on it. (daf.com/en/trucks/daf-xf and daf.co.uk/…/new-generation-daf-xf both 404 — the researcher's blocker is real; the /en landing page is the reachable substitute.)"
+    - "so FAS/FTG/FAN/FANCF are DAF chassis-and-axle configuration codes, not nameplates — D9 on the NAME axis is right for all of them."
+    - "the id axis then splits, and the researcher split it correctly, which is worth saying: truck/daf/fancf's raws are FANCF75.360U / FANCF85.360T / FANCF85.410T / FANCF85.460T / FANCF85.510T — ALL are CF, so a single live id (truck/daf/cf) denotes them → D6. Whereas truck/daf/fas's raws mix nameplates ('FAS CF 85', 'FAS XF 105', 'FAS XF105', 'FAS 2103 DHTD 352', 'FAS 2600 DK 360') and truck/daf/ftg's likewise ('FTG CF85', 'FTG XF105', 'FTG105.410T') — no single live id covers them, so D9 rather than D6 is the honest call. That asymmetry in the ledger is deliberate and correct."
+    - "systemic scale (mine, for the queue): the make carries TWENTY-FOUR such ids in truck alone — fa, fad, fag, fak, falf, fam, fan, fancf, far, fas, fascf, fat, fatcf, fatxf, fax, ft, ftg, ftgxf, ftm, ftp, ftr, fts, ftt, ftxf — beside the real nameplates cf, lf, xb, xd, xdc, xf, xfc, xg."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 8 — A PROTOCOL AMBIGUITY THAT MOVES FOUR VERDICTS (including the headline)
+# ═════════════════════════════════════════════════════════════════════════════
+id_canonical_reading:
+  the_question: >-
+    Protocol §1 reads "id-canonical — no other live id denotes the same
+    vehicle". When two live ids denote one vehicle, does the claim fail on
+    BOTH records (literal, symmetric) or only on the non-canonical member?
+  literal_symmetric_reading: >-
+    Both fail. This is what the ledger applies, and it is what makes the
+    headline finding work: car/tesla/model-y is the CORRECT form of the name
+    and still fails, because car/tesla/y exists. The protocol's own suggested
+    check — "the duplicate-spellings detector should be silent" — is a
+    property of the PAIR, so it fires on both members. I adopt this reading
+    and score every id claim under it.
+  the_other_reading: >-
+    A parent nameplate is not made non-canonical by its own trim children
+    (D8's remedy is "fold into nameplate", i.e. the defect is ON the child),
+    and the canonical spelling is not made non-canonical by a truncation
+    (D6's remedy is "merge to canonical"). Under this reading four claims in
+    this slice flip to correct: car/triumph/tr2, car/triumph/tr4a,
+    car/volvo/c303, car/volkswagen/id-buzz — and, for consistency,
+    car/tesla/model-y would flip too, taking the slice's headline with it.
+  why_it_matters_here: >-
+    An independent re-derivation I commissioned reached OVERTURNED(correct) on
+    exactly those four by applying the second reading, having found that each
+    of those records already carries `former_ids` (i.e. the catalog itself
+    treats them as the merge TARGET). That is a strong signal — but it cannot
+    be applied to the trims and left unapplied to Tesla. I therefore score all
+    of them defective under the literal reading, and record the alternative
+    tally in the SUMMARY so the ledger can choose ONE and apply it uniformly.
+  verifier_recommendation: >-
+    Keep the literal reading for MEASUREMENT (a duplicate pair is one defect
+    visible from two sides, and the clean-rate must see it), but make every
+    ledger line name WHICH member the fix lands on. Four of this slice's id
+    lines currently point the fixer at the wrong record.
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 9 — CAR-KIND DEFECT CLAIMS (32 claims re-derived independently)
+# ═════════════════════════════════════════════════════════════════════════════
+
+"car/scion/xd#name":
+  researcher: "defective(D7)"
+  verifier: CONFIRMED
+  evidence:
+    - "rank 3 unavailable and said so: scion.com HTTP 200 → redirects to toyota.com (brand retired); pressroom.toyota.com/vehicle/2015-scion-xd/ HTTP 403. Fell back to rank 5: en.wikipedia.org/wiki/Scion_xD renders 'Scion xD' — lowercase x, capital D."
+    - "the record's OWN source writes it: cache/us_vehicles.csv model='xD', baseModel='xD', VClass 'Subcompact Cars', 14 rows. The catalog publishes 'XD'."
+    - "not a schema limit: the sibling car/scion/iq publishes 'iQ' correctly."
+
+"car/skoda/enyaq-85x#id":
+  researcher: "defective(D8)"
+  verifier: CONFIRMED
+  evidence:
+    - "rank-1 TAN: all three of enyaq-85x's TANs (e8*2007/46*0416*13, *16, *22) are also carried by car/skoda/enyaq — verified by my own set intersection over the catalog."
+    - "es_dgt 2026-04..06: 'ENYAQ 85' 161, 'ENYAQ 85X' 10, 'ENYAQ 60' 7, 'ENYAQ 50' 1 — 85X is one battery/drive spelling inside the Enyaq block."
+    - "named live parent: car/skoda/enyaq covers all five of enyaq-85x's countries."
+
+"car/skoda/octavia-a5#id + #name":
+  researcher: "defective(D8) on both"
+  verifier: CONFIRMED (independently corroborated by me — see Part 7)
+
+"car/subaru/brz-ts#id + #name":
+  researcher: "id=defective(D8); name=defective(D7)"
+  verifier: CONFIRMED both
+  evidence:
+    - "cache/us_vehicles.csv: model='BRZ tS' baseModel='BRZ' (2 rows) beside model='BRZ' baseModel='BRZ' (26 rows) — the source's own parent field names the nameplate."
+    - "rank 3: https://www.subaru.com/vehicles/brz HTTP 200 renders 'BRZ tS' as a trim inside the BRZ page; zero occurrences of 'Brz'. Catalog publishes 'Brz Ts' — casing destroyed downstream of a source that had it right."
+    - "named live parent: car/subaru/brz (10 countries incl. ca+us)."
+
+"car/suzuki/sc#name":
+  researcher: "defective(D9)"
+  verifier: CONFIRMED
+  evidence:
+    - "uk_veh0120: GenModel='SUZUKI SC' but the finer Model column reads 'SC 100 GX' — the pipeline reads the coarser column."
+    - "nz_passenger-car-van_S.json: SUZUKI 'SC100' 20, 'SC 100' 1, 'SC100CXG' 1, 'SC' 3 — the bare 'SC' is a 3-row truncation of an SC100 population."
+    - "rank 5 en.wikipedia.org/wiki/Suzuki_Cervo: export designation SC100, UK trims CX/CX-G/GX — matches the UK Model string exactly."
+    - "D6 was tested and rejected: no live suzuki/sc100 exists to merge into, so the honest class is D9 (resolve-or-debt), resolution target SC100."
+
+"car/suzuki/sidekick-sport#id":
+  researcher: "defective(D8)"
+  verifier: CONFIRMED
+  evidence:
+    - "cache/us_vehicles.csv: 'Sidekick Sport 4WD/2WD/RWD' all carry baseModel='Sidekick', beside 12 other Sidekick rows with the same baseModel."
+    - "named live parent: car/suzuki/sidekick [ca,nl,nz,ua,us] covers both of sidekick-sport's countries."
+
+"car/suzuki/wagon#id":
+  researcher: "defective(D6)"
+  verifier: OVERTURNED(unverifiable)
+  evidence:
+    - "the nl evidence is ONE vehicle: LIVE RDW merk=SUZUKI handelsbenaming='WAGON' n=1 (kenteken 01GLL9, 1298 cc, wielbasis 238, massa 885, hatchback, DET 2001-02-06) against 'WAGON R' n=10,737."
+    - "the spec cell refutes the assumed twin: RDW merk=SUZUKI AND cilinderinhoud=1298 AND wielbasis=238 returns BALENO 1.3 n=45, SAMURAI n=21, WAGON n=1, WAGON R n=1 — while the Wagon R population's own modal shape is 1298/236 (n=6,649) and 1328/236 (n=3,412). Wheelbase 238 is not the Wagon R shape."
+    - "so car/suzuki/wagon-r cannot be NAMED as the twin without the resolve-by-resemblance NAMING §7.5 forbids. Routes tried: RDW exact match, RDW spec-cell join, ua aggregate, suzuki.co.uk (JS shell)."
+
+"car/suzuki/wagon#name":
+  researcher: "defective(D6)"
+  verifier: RECLASSIFIED(D3)
+  evidence:
+    - "the D6 detector cannot fire: 'WAGON' and 'WAGON R' do not NFKD-fold to one another and are distinct strings in both registers (nl 1 vs 10,737; ua 5 vs 12)."
+    - "Suzuki markets no nameplate 'Wagon' (suzuki.co.uk HTTP 200, zero 'Wagon' strings — JS shell, so no rank-3 support either way)."
+    - "a bare body word with an unresolved referent is D3's placeholder shape, whose remedy is rename-if-identifiable-else-debt, not merge-to-canonical."
+
+"car/suzuki/wagon#availability.nl + #availability.ua":
+  researcher: "defective(D6) on both"
+  verifier: "OVERTURNED(correct) on both"
+  evidence:
+    - "nl: the register holds a row spelled exactly as this record — LIVE RDW kenteken 01GLL9, Personenauto, M1, DET 2001-02-06."
+    - "ua: my UA aggregate has 'ЛЕГКОВИЙ|SUZUKI|WAGON|5' as a row distinct from 'ЛЕГКОВИЙ|SUZUKI|WAGON R|12' — the register itself keeps them apart."
+    - "protocol R4: a wrong NAME is not an availability defect; availability fails only where the rows plainly denote a DIFFERENT, separately-identified nameplate. Since the twin identification itself did not close (above), that condition is not met."
+  consequence: "this removes 2 of the slice's 3 availability defects."
+
+"car/toyota/camry-wagon#id":
+  researcher: "defective(D8)"
+  verifier: CONFIRMED
+  evidence:
+    - "cache/us_vehicles.csv: model='Camry Wagon' baseModel='Camry' (VClass 'Midsize-Large Station Wagons' 10 + 'Small Station Wagons' 12); 24 other Camry strings share baseModel='Camry'."
+    - "named live parent: car/toyota/camry (12 countries incl. ca+us)."
+
+"car/triumph/tr2#id":
+  researcher: "defective(D6)"
+  verifier: "CONFIRMED (under the literal reading — see Part 8; my re-deriver reached OVERTURNED(correct) under the other reading)"
+  evidence:
+    - "the live id that denotes this vehicle is car/triumph/tr (name 'Tr', nl+nz): its observed raws are ['TR CONVERTIBLE','TR II','TR III','TR III A','TR III CABRIOLET','TR- CONVERTIBLE'] — 'TR II' IS a TR2."
+    - "mechanism: NAMING §6's car-kind roman-numeral collapse (VARIANT_SUFFIXES) turns 'TR II' into 'TR'."
+    - "counter-evidence that decides WHERE the fix goes: car/triumph/tr2 carries former_ids ['car/triumph/tr-2'] and has already absorbed 'TR 2','TR2 CABRIOLET','TR2 SPORTS','TRIUMPH TR2'; nz has TR2 46 / TR 2 3 / TR2 SPORTS 1, fi has three more — this record is the catalog's own merge target."
+    - "so the defect is real and the LEDGER LINE POINTS AT THE WRONG RECORD: car/triumph/tr is a three-nameplate bucket (TR2+TR3+TR3A) and is where the fix belongs."
+
+"car/triumph/tr4a#id":
+  researcher: "defective(D6)"
+  verifier: "CONFIRMED (literal reading), fix belongs elsewhere"
+  evidence:
+    - "live counterpart: car/triumph/tr4a-irs ('TR4A Irs', fi+nl) — IRS was standard on the TR4A, so it is not a model."
+    - "car/triumph/tr4a already carries former_ids ['car/triumph/tr-4a','car/triumph/tr4-a'] and folded five raws."
+    - "SECOND, UNADJUDICATED DEFECT FOUND: car/triumph/tr4 has folded the raw 'TR4-A' into itself — a TR4A row sitting inside the TR4 record, i.e. a false merge across two different models (D17 shape)."
+
+"car/vauxhall/viva-deluxe#id + #name":
+  researcher: "defective(D8) on both"
+  verifier: CONFIRMED both
+  evidence:
+    - "the register writes the trim ladder explicitly: fi_agg 'VIVA HA DE LUXE 2D SEDAN' 1 (HA = the generation, De Luxe = the equipment level), plus '2D VIVA DELUXE 933110/2430' ×3, 'VIVA DELUXE' 2, against 'VIVA' 8 / 'Viva' 5."
+    - "nz: VAUXHALL 'VIVA' 329 vs 'VIVA DELUXE' 9 (also VIVA GT 6, VIVA 1300, VIVA ESTATE)."
+    - "rank 5 en.wikipedia.org/wiki/Vauxhall_Viva: HA launched 'in Standard and Deluxe versions'; HB offered 'base, deluxe and SL trims'."
+    - "named live parent: car/vauxhall/viva [fi,gb,nl,nz] covers both of viva-deluxe's countries."
+
+"car/volkswagen/211#name":
+  researcher: "defective(D9)"
+  verifier: CONFIRMED
+  evidence:
+    - "re-derived from the live register rather than the build, because NAMING §7.1 makes a bare integer a PARSER suspect first: RDW live carries '211' in handelsbenaming across 15 vehicles, and nz carries VOLKSWAGEN '211' n=1 — two-source, so NOT an xlsx index leak. The §7.1 test is applied and cleared."
+    - "what the rows are (my own row-level pull): DET 1955-1979, wielbasis 239-243 cm, cilinderinhoud 1200/1493/1584/1594/1641 — the air-cooled Type 2 Transporter envelope."
+    - "so '211' is a VW factory order/type number, not a nameplate → D9."
+
+"car/volkswagen/bestel-0#id":
+  researcher: "defective(D6)"
+  verifier: CONFIRMED
+  evidence:
+    - "named live twin: car/volkswagen/bestel ('Bestel', nl+nz) whose raws are 'BESTEL 44 KW','BESTEL 57 KW','BESTEL V.D. 1,0 D 50 KW','BESTEL TDI 75 KW SYNCRO' — the same RDW string family as bestel-0's 'BESTEL 0,8 D 50 KW'."
+    - "LIVE RDW: handelsbenaming='BESTEL' n=56; the 'BESTEL 0,x …' family n≈900. One string family split by a decimal."
+  fixer_warning: "volkswagen/bestel carries [nl,nz] and bestel-0 carries [fi,nl] — a naive merge deletes the Finnish evidence (fi_agg: 'M1|Volkswagen|Bestel 0,8 D 50KW|1'). NAMING §2's availability subset check applies."
+
+"car/volkswagen/bestel-0#name":
+  researcher: "defective(D1)"
+  verifier: CONFIRMED
+  evidence:
+    - "LIVE RDW starts_with(handelsbenaming,'BESTEL 0') → 45 distinct strings, every one of the form 'BESTEL 0,7 D 50 KW' / 'BESTEL 0,8 TDI 65 KW' / 'BESTEL 0,9 D 57 KW SYNCRO'. NOT ONE row is spelled 'BESTEL 0'."
+    - "fi_agg: 'M1|Volkswagen|Bestel 0,8 D 50KW|1' — comma decimal there too."
+    - "the published 'Bestel 0' is the integer part of a payload figure in tonnes, cut at the comma. That is D1's fabricated name, earned by re-parse rather than by shape."
+
+"car/volkswagen/caravelle-syncro#id":
+  researcher: "defective(D8)"
+  verifier: CONFIRMED
+  evidence:
+    - "rank-1 TAN: caravelle-syncro = e1*96/79*0067*04; car/volkswagen/caravelle = e1*96/79*0067*05 — same base approval, differing extension. The same base is also on van/volkswagen/caravelle and van/volkswagen/transporter-syncro."
+    - "fi shows Syncro as a drivetrain qualifier ON the Caravelle: '3D CARAVELLE C SYNCRO-9-D-255-299-4X4/2460' 10+4, '3D CARAVELLE GL SYNCRO…' 2, beside '3D CARAVELLE CL-9-DIESEL-255/2460'."
+    - "named live parent: car/volkswagen/caravelle (7 countries incl. fi+nl)."
+
+"car/volkswagen/id-buzz#id":
+  researcher: "defective(D8)"
+  verifier: "CONFIRMED (literal reading) — but the D8 CLASS is wrong for this record"
+  evidence:
+    - "the TAN direction is the opposite of a wrong-altitude record: id-buzz holds e1*2018/858*00164*01 and *04, and it is car/volkswagen/id-buzz-PRO that shares *01/*04. The trims hang off this id."
+    - "it is the broadest record in its family: 9 countries vs 4-6 for each trim; https://www.vw.com/en/models/id-buzz.html HTTP 200 renders 'ID. Buzz' 146× as a model in its own right."
+    - "the live ids that make it non-canonical are its own CHILDREN — id-buzz-pro, id-buzz-pro-kr, id-buzz-pro-lr, id-buzz-gtx-kr, id-buzz-gtx-lr, id-buzz-pure-kr, id-buzz-pro-4motion — every one of which is a trim/battery-size record that D8 says must fold INTO this one."
+    - "so: claim fails (symmetric reading), class is D8-on-the-children, and the ledger line as written would send a fixer to fold the head record into something that does not exist."
+
+"car/volkswagen/id-buzz#name":
+  researcher: "defective(D7)"
+  verifier: CONFIRMED
+  evidence:
+    - "rank 3: https://www.vw.com/en/models/id-buzz.html HTTP 200 (1.07 MB) renders 'ID. Buzz' 146 times and 'ID.Buzz' 5 times; ZERO 'Id. Buzz'. Both marque spellings capitalise ID."
+    - "the catalog gets the unspaced siblings right (ID.3, ID.4, ID.5, ID.6, ID.7) — only the spaced form broke."
+
+"car/volkswagen/van#id":
+  researcher: "defective(D9)"
+  verifier: OVERTURNED(unverifiable)
+  evidence:
+    - "LIVE RDW merk=VOLKSWAGEN handelsbenaming='VAN' returns THREE vehicles that are three different products: VGP50V (N1 gesloten opbouw, DET 2018-12-03, 1968 cc, 2275 kg); AL6867 (M1 kampeerwagen, DET 1970-06-30, 1600 cc, 1350 kg); VRR68B (N1 gesloten opbouw, DET 2005-03-11, 3189 cc, 2327 kg)."
+    - "48 years and three drivetrains: no single live id (vanagon, transporter, bestel) denotes them, so no specific id can be named. nz gives aggregate only (VOLKSWAGEN 'VAN' 7)."
+
+"car/volkswagen/van#name":
+  researcher: "defective(D9)"
+  verifier: RECLASSIFIED(D3)
+  evidence:
+    - "D9's detector is 'code-string shape + single-source' and both halves fail: 'VAN' is an English body word, and it is two-source (nl 3 + nz 7)."
+    - "RDW's classification vocabulary lives in voertuigsoort/inrichting ('Bedrijfsauto'/'gesloten opbouw'), not in handelsbenaming — so this is free text, not a registry code."
+    - "a generic body word over an unresolved referent is D3 (placeholder), remedy rename-or-debt."
+
+"car/volvo/850-wagon#id":
+  researcher: "defective(D8)"
+  verifier: CONFIRMED
+  evidence:
+    - "cache/us_vehicles.csv: model='850 Wagon' baseModel='850' n=15 beside model='850' baseModel='850' n=15."
+    - "car/volvo/850's own raws already contain '850 AWD Wagon' and '850 T5 Wagon' — the same body word is folded inside the parent."
+
+"car/volvo/c303#id":
+  researcher: "defective(D6)"
+  verifier: "CONFIRMED (literal reading), fix belongs elsewhere"
+  evidence:
+    - "live counterpart: car/volvo/c303-4x4-1-v ('C303-4X4-1-V', fi+nl), whose only raw is 'VOLVO C303-4X4-1-V' — a string car/volvo/c303 has ALREADY folded ('C303 4X4-1-V' is in its variant list)."
+    - "car/volvo/c303 carries former_ids ['car/volvo/c-303'] and folded 12 spellings; C303 is Volvo's actual model name (Laplander C303)."
+    - "the twin also carries an embedded-brand defect (D5: the raw that created it is 'VOLVO C303-4X4-1-V')."
+
+"car/volvo/ec40-twin#id":
+  researcher: "defective(D8)"
+  verifier: CONFIRMED
+  evidence:
+    - "cache/us_vehicles.csv: model='EC40 Twin' baseModel='EC40' n=2 beside model='EC40' baseModel='EC40' n=2 — Twin is the dual-motor powertrain."
+    - "the same word is already folded on the sibling nameplate: car/volvo/xc40's raws include 'XC40 T5 TWIN ENGINE'."
+
+"car/volvo/p-54405-a#id + #name":
+  researcher: "defective(D9) on both"
+  verifier: CONFIRMED both
+  evidence:
+    - "RESOLVED, not guessed (NAMING §7.5): fi writes the SAME code family with and without the PV prefix — 'VOLVO P 54405 A' (M1 n=2) alongside '2D PV 54403 A' and '2D SEDAN PV 54403 A'."
+    - "RDW live merk=VOLVO: 'P 54405 A' 9, 'P54405 A' 41, 'P54405A' 2, 'P 54405A' 1, 'P54405' 2, beside 'P54403 A' 9, 'P54404 A' 66, 'P 54406' 21, 'P 54408' 13 and 'P 544' 41 / 'P544' 35 / 'PV544' 19 — one P544 population with variant digits."
+    - "named live target: car/volvo/pv544 ('PV544', fi+lu+nl+nz) carries both of this record's countries. Checked against the wrong family too: PV444 codes are 444xx (car/volvo/p-44404)."
+
+"car/volvo/xc40-b4#id + car/volvo/xc60-d5#id":
+  researcher: "defective(D8) on both"
+  verifier: CONFIRMED both
+  evidence:
+    - "cache/us_vehicles.csv: model='XC40 B4' baseModel='XC40'; the same file carries XC40 T4/T5 AWD/B5 AWD/Recharge all with baseModel='XC40'. B/T/D letters are Volvo powertrain designations."
+    - "the parents already absorb them: car/volvo/xc40 folded 'XC40 T5','XC40 T5 AWD','XC40 AWD BEV'; car/volvo/xc60 folded 40+ engine spellings incl. 'XC60 T5','XC60 T6 AWD','XC60 T8 AWD Recharge'."
+    - "es_dgt for the XC60 case: 'XC60 D5 AWD R' M1G 1 against 'XC60' M1G 1,181 + M1 101."
+    - "systemic, not isolated: car/volvo/xc40-b5 is the identical defect shape one row away."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 10 — MERCEDES-BENZ / RENAULT / SAXAS / SCANIA (26 claims re-derived)
+# The dominant mechanism found here, which the ledger does not name: a
+# ONE-SPACE SPLIT. observed_variants.json shows the SPACED spelling absorbed
+# into the canonical id while the GLUED spelling became a second live id.
+# ═════════════════════════════════════════════════════════════════════════════
+
+"truck/mercedes-benz/1223-l#id":
+  researcher: "defective(D6)"
+  verifier: CONFIRMED
+  evidence:
+    - "observed_variants: truck/mercedes-benz/1223 has already folded '1223 L', '1223 L-97025/416', '1223 L-97025/476', '1223 L-97025/536' — the spaced form is inside the bare-number id."
+    - "fi_agg: 'N2|Mercedes-Benz|1223 L-97025/416|15' vs 'N2|Mercedes-Benz|1223L-97025/416|3' — same Baumuster 970.25, same 4,160 mm wheelbase, one space apart. Also '1223-97025/416' 1 on the bare id, same Baumuster."
+    - "truck/mercedes-benz/1223-l carries former_ids ['truck/mercedes-benz/1223l'] — the glued spelling is its origin."
+
+"truck/mercedes-benz/1223-l#name":
+  researcher: "defective(D8)"
+  verifier: CONFIRMED
+  evidence:
+    - "the string is register-attested (LIVE RDW handelsbenaming '1223 L' N2 n=3), so this is not D1/D3 — it is an altitude error."
+    - "the register itself parenthesises the letter as a chassis/drive configuration: fi_agg 'ATEGO 1018 (L 4X2)', 'ATEGO, 1224 (L 4X2)'."
+    - "rank 5 en.wikipedia.org/wiki/Mercedes-Benz_Atego renders 'Atego 1222 L', 'Atego 1725 R', 'Atego 1016' — number = type, trailing letter = chassis variant. NAMING §7.2 blesses the bare truck type number; the catalog already publishes truck/mercedes-benz/1223."
+
+"truck/mercedes-benz/290#id":
+  researcher: "defective(D6)"
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "D6 is definitionally unavailable: the 240-record mercedes-benz truck listing contains NO second spelling of '290' (no 290-gd, no gd290)."
+    - "what the record actually holds: observed_variants = ['290 GD', '290 GD 4X4 3120'] only; LIVE RDW '290 GD 4X4 3120' N2 1 and '290GD' N2 3 — the 3,120 mm wheelbase W461 chassis-cab."
+    - "the live nameplate id IS present: truck/mercedes-benz/g [fi,gb,nl] has folded 'G 280 CDI','G 300 CDI','G 350 D','G 500','MERCEDES G CLASS'. 290 GD is an engine/generation designation of the G-Class → D8."
+
+"truck/mercedes-benz/290#name":
+  researcher: "defective(D1)"
+  verifier: CONFIRMED
+  evidence:
+    - "NAMING §7.1 forbids calling a bare integer a parser artifact without re-parsing — so both sources were re-parsed. fi_agg: every MB row starting 290 is '290 GD' (M1G 1, N1G 2, N2G 1), '290GD' (M1G 9, N1G 4), '290 GD TURBODIESEL' 1, '290 Lang Cabriolet A' 1, '290 Pullman' 1 — no bare '290' in ANY N-category."
+    - "LIVE RDW: the only bare '290' under MERCEDES-BENZ is M1, inrichting 'Niet geregistreerd', n=1 — nothing in N2/N3."
+    - "the published truck name '290' therefore appears in no truck-kind source row: the pipeline dropped the 'GD' token. D1 earned rather than assumed."
+
+"truck/mercedes-benz/312d-ka-903462-kasten#id + #name":
+  researcher: "defective(D9) on both"
+  verifier: CONFIRMED both
+  evidence:
+    - "the code is RESOLVED by the corpus, per §7.5: truck/mercedes-benz/sprinter has folded 'SPRINTER 312D-KA-903462-KASTEN' — the register itself binds this code to the Sprinter nameplate (live, [es,fi,gb,lu,nl])."
+    - "one-space split as well: truck/mercedes-benz/312 folded '312 D-KA-903462-KASTEN/355'; fi_agg has '312D-KA-903462-KASTEN/355' 182 vs '312 D-KA-903462-KASTEN/355' 1."
+    - "string decomposition confirmed in-corpus: 903462 = Baumuster 903.462 (siblings 903461/903463/903471/903472/903473 all present), KASTEN = body, /355 = 3,550 mm wheelbase. §7.2's bare-number defence does not reach a token chain containing a Baumuster and a German body word."
+
+"truck/mercedes-benz/609-d#id + truck/mercedes-benz/609d-ka#id":
+  researcher: "defective(D6) on both"
+  verifier: CONFIRMED both
+  evidence:
+    - "the pipeline's own fold record settles it: truck/mercedes-benz/609 has absorbed '609 D', '609 D-I', '609 DC', '609 D/3700', '609 D/4250', '609 D-KA', '609 D-KA-KASTEN', '609 D-KA-KASTEN/3700', '609 D-KA-KASTEN/4250'."
+    - "fi_agg: '609' 3, '609 D' 5, '609D' 22 (+MUU 10); '609D-KA-KASTEN' N2 15 + MUU 21 vs '609 D-KA-KASTEN' N2 3 + MUU 2. The glued spellings feed the two extra ids."
+    - "all three ids are live and all three are [fi,nl]."
+
+"truck/mercedes-benz/609d-ka#name":
+  researcher: "defective(D9)"
+  verifier: CONFIRMED
+  evidence:
+    - "'-KA' is register/type vocabulary, not a Mercedes suffix: it recurs across unrelated types in fi_agg — 'L 407 D-KA', '508 D-KA-4.6T-KASTEN/3700', '312D-KA-903462-KASTEN/355', '816 DA-KA', '609 D-KA-5.0T-KASTEN'."
+    - "rank 5 de.wikipedia.org/wiki/Mercedes-Benz_T2 renders the marque forms 'L 407 D' / 'L 508 D' — no KA token in marque naming."
+    - "the near-miss class is D8 (body as model), recorded as such rather than as a reclassification, since KA/KASTEN is the register's vocabulary rather than an MB body letter."
+
+"truck/mercedes-benz/816-d#id + truck/mercedes-benz/918-l#id":
+  researcher: "defective(D6) on both"
+  verifier: CONFIRMED both
+  evidence:
+    - "816: truck/mercedes-benz/816 folded BOTH '816 D' and '816 D VARIO'; fi_agg '816 D VARIO' 2 vs '816D VARIO' 1 and '816D VARIO/425' 2 — the same Vario 816 D split by one space. (The strongest counter — that MB sold two different 816s, a Vario and an Atego '816-7.49T-97001/422' — fails because mercedes-benz/816 absorbed both families.)"
+    - "918: fi_agg '918 L-97023/422' 7 vs '918L-97023/422' 10 — identical Baumuster 970.23, identical 4,220 mm wheelbase. mercedes-benz/918 also carries 970.23 rows ('918 ATECO 970.23/362', '918 L-97023/362'), so the same approval sits on both sides of the split. LIVE RDW '918 L' N2 n=1."
+
+"truck/mercedes-benz/967pkx2#id + #name":
+  researcher: "defective(D9) on both"
+  verifier: CONFIRMED both
+  evidence:
+    - "es_dgt: 'MERCEDES-BENZ | 967PKX2 | N2 | 1' — one Spanish row. LIVE RDW: '967PKX2' N2 n=1 AND 'ATEGO 967.000…' N2 n=1."
+    - "the family is explicitly badged elsewhere: truck/mercedes-benz/atego has folded 'ATEGO 967PKX3' and 'ATEGO 967.000…'. 967 is the Euro-VI Atego Baumuster and PKX2 a type/variant/version suffix."
+    - "named live target: truck/mercedes-benz/atego [es,fi,lu,nl]. §7.2's defence protects '1824'-shaped tonnage+power designations, not a Baumuster plus a version suffix."
+
+"truck/mercedes-benz/l508dg#id":
+  researcher: "defective(D6)"
+  verifier: CONFIRMED
+  evidence:
+    - "FIVE live ids hold this one product: truck/mercedes-benz/l-508 folded 'L508 DG/35','L508 DG/3500','L508 DG KASTEN','L508 DG-KA-KASTEN'; truck/mercedes-benz/l folded 'L 508 DG','L 508 DG/3500','L 508 DG-KASTEN/3500'; truck/mercedes-benz/508 folded '508 DG'; plus l508d and l508dg."
+    - "fi_agg: 'L 508 DG-KASTEN/3500' N2 4 + MUU 4, 'L508 D(G)/3500' MUU 13 + N2 9, 'L508DG/29', 'L508DG/35'."
+
+"truck/mercedes-benz/l508dg#name":
+  researcher: "defective(D7)"
+  verifier: CONFIRMED
+  evidence:
+    - "rank 3 unreachable and declared: mercedes-benz-trucks.com has no T2 model page, mercedes-benz-publicarchive.com returned no text. Rank 5 used: de.wikipedia.org/wiki/Mercedes-Benz_T2 renders 'L 407 D' ×2 and 'L 508 D'; en.wikipedia renders 'L 608 D' — SPACED in both."
+    - "published 'L508DG' glues all three tokens; the registers predominantly carry the spaced form (fi_agg 'L 508 DG-KASTEN/3500' 8, 'L 508 DG-5.6T-KASTEN/2950' 4, 'L 508 DG/3500' 2)."
+    - "the §7.3 closed-code defence was tested and rejected: §7.3 is the two-wheeler spacing rule (normalizer.rb#two_wheeler_spacing), not an MB truck rule."
+
+"truck/mercedes-benz/la#id":
+  researcher: "defective(D6)"
+  verifier: RECLASSIFIED(D1)
+  evidence:
+    - "the record is a PREFIX FRAGMENT holding at least 12 different type numbers: observed_variants = LA 1113 B, LA 1113/36, LA 1113/42, LA 113 B, LA 1513, LA 311-42, LA 311/42, LA 312/42, LA 312/4200, LA 321, LA 321-4X4/4299-59, LA 323, LA 3500, LA 3500/312.114, LA 710 KR, LA 911 B, LA-322-4X4/4200, LA-4500-4X4/4200 … (26 raws)."
+    - "so no single live id can denote 'the same vehicle' — because 'La' denotes no single vehicle. Live ids exist for its constituents (1113, 311, 312, 911, l-321, l-3500) but each covers a slice."
+    - "no second spelling exists either: the make's other L-prefix ids are l, laf, lak, lf, lk, lkw, lp, ls — all different prefixes. D6 cannot apply; the defect is a parser fragment (D1), matching the name verdict."
+
+"truck/mercedes-benz/la#name":
+  researcher: "defective(D1)"
+  verifier: CONFIRMED
+  evidence:
+    - "fi_agg exact-match for MB model 'LA'/'La' returns ZERO rows; every LA row carries a type number."
+    - "LIVE RDW handelsbenaming='LA' and ='La' under merk=MERCEDES-BENZ return nothing, while `like 'LA %'` returns LA 1113 B (2), LA 1113 B MA (3), LA 1513, LA 311/42, LA 323, LA 3500 (2), LA 911 B …"
+    - "the published 'La' exists in neither source: pipeline-produced."
+
+"truck/renault/d14#id":
+  researcher: "defective(D6)"
+  verifier: CONFIRMED
+  evidence:
+    - "one-space split: truck/renault/d folded 'D 14' and 'D 14 R250 E6'; truck/renault/d14 folded 'D14 MED P4X2 280 E6'. fi_agg 'N3|Renault|D 14 R250 E6|1' vs 'N3|Renault|D14|2'."
+    - "es_dgt: 'RENAULT | D14 MED P4X2 280 E6 | N3 | 1' beside 'D12 MED P4X2 240 E6' N2 1 and 'D19 WIDE P4X2' N3 1 — MED/WIDE are the D-range sub-families and the number is the tonnage."
+    - "and two live ids exist for the range before the tonnage split is even counted: truck/renault/d [es,fi,lu,nl] and truck/renault-trucks/d [es,gb,nl]."
+
+"truck/renault/d14#make":
+  researcher: "defective(D12)"
+  verifier: CONFIRMED
+  evidence:
+    - "containment signature: make `renault` holds 24 truck records (C, D, D-Wide, D12, D14, D280, K, Kerax, Magnum, Midlum, Premium, T, T460 …) while make `renault-trucks` holds 4 (C, D, Maxity, T) — 4 of 4 renault-trucks nameplates are ALSO live under renault."
+    - "it spans kinds: van/renault-trucks/master and van/renault-trucks/trafic are Renault nameplates."
+    - "the curation layer pins both strings deliberately: overrides/makes/aliases.yml 'RENAULT: Renault' and 'RENAULT TRUCKS: Renault Trucks'; observed_raw_makes.json also carries an unaliased third corporate string 'Renault Trucks Sas' ← ['RENAULT TRUCKS SAS']."
+    - "D11 was tested and rejected: Renault Trucks vehicles are approved TO Renault Trucks SAS (fi_agg shows E2*2007/46*0135 on a Renault D12 row), so 'RENAULT' in the make column is the badge, not an approval holder — remedy is an alias merge, not moves.yml."
+    - "MY OWN CORROBORATION (Part 5): the marque's own press release is published by Renault Trucks UK and titles the vehicle 'Renault Trucks D14'."
+  direction_left_open: "which of the two makes should survive is NOT resolved — deliberately, since record count is not authority (the VITO/MGA rule)."
+
+"truck/saxas-nutzfahrzeuge-werdau/atego#id + #make":
+  researcher: "id=defective(D6); make=defective(D11)"
+  verifier: CONFIRMED both (see also my own derivation in Part 7)
+  evidence:
+    - "id: observed_variants — the Atego record folded exactly ONE raw, 'ATEGO - MKD 61-M-E', while the sibling truck/saxas-nutzfahrzeuge-werdau/mkd folded 'MKD 61 - M - E', 'MKD 61-M-E', 'MKD 61- M - E', 'MKD61- M - E' among 21 raws. es_dgt carries all three spellings side by side: 'SAXAS NUTZFAHRZEUGE WERDAU | ATEGO - MKD 61-M-E | N2 | 1', 'SAXAS NUTZFAHRZEUGE WERDAU | MKD 61-M-E | N2 | 1', 'SAXAS | MKD 61-M-E | N2 | 2'."
+    - "make, rank 3: saxas.biz (fetched 2026-07-26) — 'Seit über 110 Jahren werden im sächsischen Werdau … Fahrzeuge und Fahrzeugaufbauten gefertigt. Seit 2004 erfolgt die Produktion unter dem Namen SAXAS Nutzfahrzeuge Werdau GmbH'. SAXAS builds BODIES; it has no nameplate called Atego."
+    - "the NAMING §1 'bodybuilder wins' row was tested and rejected: it is explicitly scoped to the BUS kind (Scania Irizar), and even on its own terms it would demand the model be 'MKD 61-M-E' — which is the sibling record."
+
+"truck/scania/143m#id":
+  researcher: "defective(D6)"
+  verifier: CONFIRMED
+  evidence:
+    - "truck/scania/143 has already folded '143 M', '143 MA', '143 MA 4X2', '143 MA 4X2 A', '143 H', '143 420', 'SCANIA 143'; truck/scania/143m folded '143M 450', '143M 500', '143M 2 DR'. fi_agg carries both 'N3|Scania|143|1' and 'N3|Scania|143M|1'."
+
+"truck/scania/143m#name":
+  researcher: "defective(D1)"
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "D1's detector is numeric_only + single-source and '143M' is NEITHER: it is alphanumeric and it is carried by two independent registers (fi_agg 'N3|Scania|143M|1'; nl raws '143M 450','143M 500','143M 2 DR')."
+    - "the real defect is altitude: M is Scania's chassis-height letter, visible alternating with H and E in the corpus — 'R143 M 4X2 AL 65115 E' vs 'R143 H 6X2 ZL 75180 E' vs 'R143 E-6X4' — one level below the type designation 143 that NAMING §7.2 explicitly blesses."
+
+"truck/scania/460#id + #name":
+  researcher: "defective(D1) on both"
+  verifier: "RECLASSIFIED(D8) on both — INDEPENDENTLY REACHED TWICE"
+  evidence:
+    - "I derived this myself (Part 7) and a separate re-derivation reached the identical conclusion from the same decisive artifact: RDW's `type` column on kenteken BFHN57 reads 'T 144 LA 4X2 NA 460' (14,090 cc, 8 cylinders, opleggertrekker, first reg 1997-03-14). That resolves the code per §7.5 and names a live id: truck/scania/144 (and truck/scania/t144), both [fi,nl]."
+    - "D1 is refuted: RDW's own handelsbenaming field literally reads '460' (2 vehicles) and es_dgt carries 'SCANIA | 460 | N3 | 1'. Two registers, no parser fabrication."
+    - "the two '460' rows predate the R/P/G/S-460 era (G460/R460/P460 carry e4*2018/858 approvals; the '460' rows carry no TAN), and RDW renders the resolved forms directly — '144 460' 3, '144L 460', '144G 460', 'R144 460', 'R 144 LA 4X2 NA 460'. The power figure is a SUFFIX on the type."
+
+"truck/scania/p230#id":
+  researcher: "defective(D6)"
+  verifier: CONFIRMED
+  evidence:
+    - "named live twin: truck/scania/p230db4x2mna ('P230DB4X2MNA', fi+nl), whose raw equals its name, against truck/scania/p230 which folded 'P230 DB4X2MNA', 'P230 DB 4X2 MNA', 'P230 DB4X2MNB', 'P230 DB6X2-4 MNB', 'Scania P230'."
+    - "fi_agg: 'N3|Scania|P 230 DB4X2MNA|1' and 'N3|Scania|P230DB4X2MNA|1'; also 'P 230' 38 vs 'P230' 24 — spaced and glued spellings of one designation."
+    - "the umbrella id truck/scania/p was considered and NOT used, because it holds P 94/P 124/P 380 and so does not denote 'the same vehicle'."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 11 — GMC / ISUZU / IVECO / LIEBHERR / MAN (21 claims re-derived)
+# ═════════════════════════════════════════════════════════════════════════════
+
+"truck/gmc/cckw#name":
+  researcher: "defective(D7)"
+  verifier: CONFIRMED
+  evidence:
+    - "rank 3 unavailable by construction (GMC publishes nothing current for a 1941-45 military truck); rank 5 en.wikipedia.org/wiki/GMC_CCKW writes 'CCKW' all-caps and decodes the acronym — C=1941 design, C=conventional cab, K=all-wheel drive, W=dual rear axles. The catalog publishes 'Cckw'."
+    - "all 37 folded raws are caps ('CCKW 353 VAB', 'CCKW-353-6X6/3570+1140', 'GMC CCKW 352')."
+    - "METHODOLOGICAL POINT worth carrying: FI Traficom is NOT a shouting register — the same column carries 'Isuzu | D-Max', 'Liebherr | A 914 Compact Litronic', 'Liebherr | LH 30 M Litronic'. Its capitals are meaningful evidence, though the binding rule still says registers do not decide casing."
+
+"truck/isuzu/nqr#name":
+  researcher: "defective(D7)"
+  verifier: CONFIRMED
+  evidence:
+    - "rank 3 blocked and enumerated: isuzucv.com/en/nqr + /pdfs/nqr_specs.pdf HTTP 403 (curl and WebFetch), isuzu.com.au TLS failure, isuzutruck.co.uk 404, isuzu.co.jp 404, isuzu.co.za 404 — but the marque's own hosted spec sheet is named nqr_specs.pdf. Rank 5 used: en.wikipedia.org/wiki/Isuzu_Elf — 'sold as the Chevrolet NKR, NPR, or NQR'."
+    - "four-register corroboration of the caps string: gb GenModel 'ISUZU TRUCKS NQR' / Model 'NQR' 11 + 'NQR 70' 9; fi 'NQR 70', 'NQR-NQR70LL-7.5T/336'; ua 'NQR 71P' 75, 'NQR 71R' 35, 'NQR 75P' 3."
+    - "zero vowels, three letters, sitting in Isuzu's NKR/NPR/NQR/NRR export-code series — 'Nqr' has no defensible source."
+
+"truck/iveco/260s#id":
+  researcher: "defective(D6)"
+  verifier: CONFIRMED
+  evidence:
+    - "named live id: truck/iveco/260 ('260', fi+nl). LIVE RDW 2026-07-26: handelsbenaming '260S/P' n=2 AND '260 S/P' n=1 — one designation, two spellings, and the pipeline sent them to different records (observed_variants: iveco/260 holds '260 S','260 S/P','260 S36Y-PS'; iveco/260s holds '260S/P','260S/PS')."
+    - "fi_agg: '260S' N3 16 vs '260 S' N3 1. This is the documented '280 Se' vs '280SE' shape."
+
+"truck/iveco/260s#name":
+  researcher: "defective(D9)"
+  verifier: CONFIRMED
+  evidence:
+    - "LIVE RDW: handelsbenaming '260S50 STRALIS' n=1 — the register cell carries the type code AND the nameplate."
+    - "every complete attested form has a power element: fi '260S42Y-PS/380', '260S45Y-FP/570+140', '260S48Y-FS-6X2/510+140', '260S45Y/FS', and an explicit enumeration row '260S-Y* 260S(31,33,36,42,45,50,56)Y-6X2'. The published '260S' is that with the power stripped."
+    - "the nameplate is separately live: truck/iveco/stralis [fi,gb,nl]. §7.2 tested: this is not the MB-1824 case, because no complete Iveco designation stops at 260S."
+
+"truck/iveco/40c17d#id":
+  researcher: "defective(D6)"
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "the TAN evidence proves FAMILY identity, not a spelling pair: LIVE RDW shows '40C17/T EURO V HD EEV' and '40C17D/T EURO V HD EEV' both under nl*2001/116*0144*02 (6/3), *03 (22/19), *04 (8/5) — but that same approval index also carries '40C15 EURO 4' 120, '40C18 EURO 4' 30, '40C15V EURO 4' 29, '40C15D EURO 4' 18."
+    - "'D' is a systematic designation element, not a spelling variant: RDW carries 40C15D, 40C15D/T, 40C15DT, 40C18D, 40C18D/T, 40C18DT, 40C18D/P, and the catalog already publishes 40c15d, 50c14d, 50c15d, 65c15d, 65c17d, 65c18d as separate ids."
+    - "rank 3 iveco.com Daily spec sheet (E6-Daily-Van-Spec-Sheet.pdf) heads its tables '35S, 50C & 70C' and 'Specifications 35S VAN' — the product is the Daily and the GVW+series+power codes are variants inside it. truck/iveco/daily is live [es,fi,gb,nl]."
+    - "so the defect is altitude (D8), and a duplicate-spelling remedy would be wrong."
+
+"truck/iveco/40c17d#name + truck/iveco/60c16#id + truck/iveco/60c16#name":
+  researcher: "40c17d#name=D8; 60c16#id=D8; 60c16#name=D8"
+  verifier: CONFIRMED all three
+  evidence:
+    - "40C17D's population is a build variant: LIVE RDW rows are 'opleggertrekker' wb 345-485 and 'open wagen' wb 375/410, gvw 3500, DET 2006-06-02…2012-08-24, sharing approvals with plain 40C17 (n=407)."
+    - "60C16: fi_agg 'N2|Iveco|60C16|1|e3*2007/46*0115*18'; the same approval series under IVECO carries 70C18 (*various), 70C14G (*24), 65C16 (*20) — the Daily 6.5-7.0 t range. RDW power ladder under one series letter: 60C14 1, 60C15 2, 60C16 1, 60C17 3, 60C18 7."
+    - "the typo theory was tested and killed: '16' is a real Daily power rating attested at scale (RDW '40C16' n=551; '65C16' holds its own approval index *20), and 60C16 has its own index *18."
+    - "named live parent for all three: truck/iveco/daily; the nearer sibling truck/iveco/60c15 is live too."
+
+"truck/iveco/80el#id + #name":
+  researcher: "id=defective(D8); name=defective(D9)"
+  verifier: CONFIRMED both
+  evidence:
+    - "the complete maker string exists in the same register: LIVE RDW merk=IVECO handelsbenaming like '%80EL%' → '80EL' n=53, '80EL/75' n=1, and 'ML80EL17' n=1 (ML = Medium Light prefix, 80 = 8 t, 17 = 170 hp). The published '80EL' is that with prefix and power stripped."
+    - "the family label is in the register too: '80E22 EUROCARGO' n=3, '80E(ML80E19/P)' n=1. Technical rows for 80EL: gvw 7,490/7,500/8,000 kg, wb 311-482 cm, DET 2001-07-04…2024-12-16 — a 7.5-8 t rigid, i.e. Eurocargo."
+    - "named live nameplate: truck/iveco/eurocargo [es,fi,gb,nl]. UA corroborates the EL element in a third country ('ВАНТАЖНИЙ|IVECO|120EL|1'), and the catalog already carries 120el, 120elg, 190el."
+
+"truck/liebherr/lg#name":
+  researcher: "defective(D7)"
+  verifier: CONFIRMED
+  evidence:
+    - "rank 3, liebherr.com fetched 2026-07-26 (HTTP 200, 487 KB lattice-boom page): 'LG 1750' ×18, 'LG 1800-1.0' ×4, 'LG 1550' ×2 — always caps, always spaced. Second page (LG 1800-1.0, HTTP 200): 'LG 1800-1.0' ×39, 'LG 1750' ×16. Catalog publishes 'Lg'."
+
+"truck/liebherr/utm#id":
+  researcher: "defective(D9)"
+  verifier: CONFIRMED
+  evidence:
+    - "named live id: truck/liebherr/ltm ('Ltm', es+fi+gb+nl). fi_agg puts both codes in ONE cell repeatedly: 'LTM 1030-2-UTM 625', 'LTM 1040-3-UTM 532-6X4/160+245', 'LTM 1045-UTM431-6X6/2010+3550', 'LTM 1050-1-UTM635-6X6', 'LTM 1055/1 UTM 735', 'LTM 1090-4.1/UTM 743', 'LTM 1130-5.1/UTM 851', 'LTM 1500 UTM 680', 'LTM1200-1-UTM755-10X4'."
+    - "the standalone UTM numbers overlap the paired ones: RDW 'UTM 625' 4, 'UTM 630' 3, 'UTM 532' 3, 'UTM 530' 2 — 532, 625 and 740 each appear BOTH alone and bolted to an LTM designation."
+    - "liebherr.com's mobile-crane line-up is LTM/LTC/LTF/LG/LR/MK — no UTM product page exists."
+
+"truck/liebherr/utm#name":
+  researcher: "defective(D7)"
+  verifier: RECLASSIFIED(D9)
+  evidence:
+    - "D7 needs a marque rendering to differ from, and there is none: both Liebherr crane pages fetched HTTP 200 (487 KB and 413 KB) contain ZERO occurrences of 'UTM'; no en.wikipedia article covers a Liebherr UTM."
+    - "every attested occurrence is a register or dealer string. The ABSENCE of marque material is itself the evidence: UTM NNN is the crane's chassis/undercarriage type number, always resolvable to an LTM designation → D9, not a casing defect."
+
+"truck/man/12#id":
+  researcher: "defective(D6)"
+  verifier: OVERTURNED(unverifiable)
+  evidence:
+    - "no live id can be named. The rows carry no power element: LIVE RDW '12 LL' 16, '12 L' 4, '12L' 3, '12LL' 2, '12 FL/BL-V' 2, '12 F-V' 1, '12 FL/BL' 1; fi '12. 192 FL-FL-B-12,8T', '12. 225 LL /458'. A '12 LL' could be a 12.170, 12.192, 12.224 or 12.225 — RDW carries all four — so it cannot be equated with the only 12-tonne sibling, truck/man/12-170f."
+    - "the era-correct nameplates are ABSENT from the catalog: no man/m90, no man/m2000 (a candidate truck/man/m2000 exists in observed_variants with ['M2000 L 18.285 LAK'] but was never published)."
+    - "no xrefs.tan on man/12, so the rank-1 route is unavailable."
+  consequence: "if the ledger wants this convicted, the prerequisite is publishing the missing MAN nameplates, not re-running the analysis."
+
+"truck/man/12#name":
+  researcher: "defective(D1)"
+  verifier: CONFIRMED
+  evidence:
+    - "the published string exists in NO row of ANY source. LIVE RDW merk=MAN, all 2,586 handelsbenaming groups scanned: '12 L','12 LL','12L','12LL','12 F-V','12 FL/BL','12 FL/BL-V','12-192','12.163','12.170 F','12.170F','12.192','12.192 F','12.220, TGL','12.224','12.232 F','12.250','12.262' — no bare '12'."
+    - "fi_agg exact-match for MAN model=='12': zero rows. ua: '12.163' 3, '12.220' 15, '12.224' 12 — no bare '12'. es_dgt: no MAN '12' row."
+    - "the §7.1 defence (consecutive integers under one make are presumptively REAL) was applied properly — by re-parsing the rows rather than concluding from shape — and it is the re-parse that convicts: the FI strings show the split point (a stray space after '12.')."
+
+"truck/man/18ml#name":
+  researcher: "defective(D9)"
+  verifier: CONFIRMED
+  evidence:
+    - "'ML' is a MAN cab/chassis suffix that FOLLOWS a power figure: es_dgt 'MAN | 12284MLC' (= 12.284 MLC); RDW '18.313 FLLC', '18.232 FL/BL' 11, '18.192 FA' 4, '18 MLL' 5, '18 MLT' 2, '18 M' 6."
+    - "the catalog string is that construction with the power element missing (RDW '18 ML' 14, '18ML' 2; fi 'N3|MAN|18ML|1'), and MAN's actual nameplates for an 18-tonner are live elsewhere: man/l2000, man/tga, man/tgx, man/tgs, man/tgm."
+
+"truck/man/8-150-f#id":
+  researcher: "defective(D8)"
+  verifier: OVERTURNED(unverifiable)
+  evidence:
+    - "the obvious fold target does not fit: truck/man/l2000 is live but its folded strings are 'L2000 8.153 BB/4250' and 'L2000 8 185 LC' — 8.153 and 8.185, not 8.150."
+    - "dating separates them: LIVE RDW puts every MAN 8.150* registration BEFORE the L2000 — '8.150' 1988/1990×2/1993/1997, '8.150 FAE 4X4' 1991, 1992, \"8.150'F\" 1993-08-06 — while RDW's 8.153 rows are 1993-11-16, 1994-05-03, 1996-03-05. The 8.150 sits in the preceding MAN G90 range."
+    - "and there is no man/g90 or man/g record in the catalog (a candidate truck/man/g held only ['G 90'] and was never published), so the correct target does not exist as a live id. NAMING §7.5 forbids resolving by resemblance."
+  honesty_note: "FI also carries '8.150 4X2 BB 7.49/395' and '8.150 BB/425', whose modern-looking BB suffix pulls the other way — the era genuinely does not close."
+
+"truck/man/8-150-f#name":
+  researcher: "defective(D6)"
+  verifier: RECLASSIFIED(D7)
+  evidence:
+    - "D6 is structurally unavailable: it needs two catalog records, and a scan of all 28 MAN truck records returns exactly one name beginning '8.15'."
+    - "the hyphen is a one-row outlier: fi has '8.150 F/425' 1 (space), '8.150 FL' 1, '8.150 BB/425' 2, '8.150 4X2 BB 7.49/395' 2 versus '8.150-F/425' 1; RDW has '8.150', '8.150 FAE 4X4' and \"8.150'F\" (apostrophe). MAN's suffix convention in both registers is a space ('12.170 F', '8.136 FAE', '8.163 LAEC', '18.232 FL/BL')."
+    - "caveat stated by the re-deriver: rank 3 is unavailable (MAN publishes nothing for a G90-era 8.150), so the space form rests on register shape, not marque authority."
+
+"truck/man/h39#id + #name":
+  researcher: "defective(D9) on both"
+  verifier: CONFIRMED both
+  evidence:
+    - "the register cell decodes itself: fi_agg 'N3 | MAN | H39 TGA 41.440 8x4 BB | 1' — type code followed by the actual MAN model. truck/man/tga is live [es,fi,lu,nl]."
+    - "H-numbers live in MAN's TYPE slot, proved by rows where RDW's two fields are transposed: handelsbenaming 'H09' / type '18.313 FLLC'; handelsbenaming 'H 19 FT' / type 'H05' and 'H06'; handelsbenaming '18 FLLC' / type 'H10'; handelsbenaming 'HS 19 F' / type 'H06'."
+    - "the series is dense — H02, H03, H05 (72), H06 (65), H08, H09 (26), H10, H12 … H96 — a numbered type register, not a product line. RDW 'H39' n=14, all N3, gvw 35,000-48,500 kg, DET 2005-01-26…2008-01-31 (the TGA window), bodies betonmixer/kolkenzuiger/asfaltkipper."
+
+"truck/man/hn#name":
+  researcher: "defective(D1)"
+  verifier: CONFIRMED
+  evidence:
+    - "a bare 'HN' exists in no source: LIVE RDW merk=MAN, all 2,586 groups scanned — 'HN 19 F' 1, 'HN 19 FT' 1, 'HN26 FNLC' 1, and no standalone 'HN'. es_dgt 'MAN | HN 19 F | N3 | 1'. fi_agg: no MAN 'HN' row at all."
+    - "the pipeline made sibling candidates the same way: truck/man/h, truck/man/hs ('HS 19 F','HS 26 FNLC'), truck/man/he ('HE 195 FT') — the published name is the leading token of a longer cell."
+    - "the D9-vs-D1 line is drawn empirically, not by analogy: 'H39' IS attested standalone (RDW n=14) so publishing it is a real code as a model (D9); 'HN' is attested only as a prefix, so publishing it is a string the parser produced (D1)."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 12 — AWD / BUCHER / CHEVROLET / DAF / DE SOTO / FORD / FORDSON (26 claims)
+# ═════════════════════════════════════════════════════════════════════════════
+
+"truck/all-wheel-drive/tl#name":
+  researcher: "defective(D7)"
+  verifier: CONFIRMED
+  evidence:
+    - "gb VEH0120: GenModel 'ALL WHEEL DRIVE TL 8-14' / Model 'TL 8-14' = 15 Licensed + 122 SORN; siblings TL 7-14, TL 9-14, TL 10-14, TL 12-16, TL 13-16, TL 17-18, TL 20-18, TL 21-16, plus 'MT 12-16', 'M 4X4' — the whole make publishes 2-letter caps codes."
+    - "rank 5 (AWD Ltd defunct 1992, no marque site): en.wikipedia.org/wiki/AWD_Trucks renders 'AWD TL', 'Bedford TL', 'AWD TK' — both letters capital in every designation; no 'Tl' form appears. Title-casing an initialism is the D23 error transposed to a model name."
+
+"truck/bucher/citycat#id":
+  researcher: "defective(D6)"
+  verifier: CONFIRMED
+  evidence:
+    - "named live id: truck/bucher/city ('City', fi+lu) — whose ONLY observed raws are ['CITY CAT 5006', 'CITY-CAT'], i.e. 100% CityCat strings and zero rows for any product called 'City'."
+    - "LIVE RDW 2026-07-26 merk like '%BUCHER%', N2: 'CITYCAT 5006' 22, 'CITYCAT VR50' 14, 'CITYCAT 5000' 3, 'CITY CAT 5000' 2 — one register writing the identical model both ways."
+    - "truck/bucher has exactly 2 records, and one of them is made entirely of the other's strings."
+
+"truck/bucher/citycat#name":
+  researcher: "defective(D7)"
+  verifier: CONFIRMED
+  evidence:
+    - "rank 3: https://www.buchermunicipal.com/ HTTP 200 (2026-07-26) renders 'Introducing the CityCat WR50', 'CityCat V20', 'Bucher CityCat VR50 80 km/h version', 'CityCat VR17a' — camel-case throughout. The 8 'Citycat' hits on the page are IMAGE FILENAMES only (…/Citycat_V20E_Charging_hell_RGB.jpg), never rendered text."
+    - "catalog publishes 'Citycat'. FI's own mixed-case rows already write 'CityCat 5006' / 'CityCat VR50'."
+
+"truck/chevrolet/20-starcraft-3-9t-fg25f#id":
+  researcher: "defective(D6)"
+  verifier: "CONFIRMED (with a stated near-miss: RECLASSIFIED(D8) is equally defensible)"
+  evidence:
+    - "named live id: truck/chevrolet/20-3-9t-fg25f ('20-3.9T-FG25F', fi). fi_agg: 'CHEVY VAN 20-STARCRAFT-3.9T-FG25F/343' n=593 vs 'CHEVY VAN 20-3.9T-FG25F/343' n=154 — identical GM type code FG25F, identical 3.9 t rating, identical /343 wheelbase; the only difference is the converter token STARCRAFT."
+    - "a second live id is the nameplate both are variants of: truck/chevrolet/20 (fi N2 'CHEVY VAN 20' 9 / N1 116)."
+  note: "this is also a NEW-1 instance (Starcraft is a US van converter), which the ledger itself lists under NEW-1's scale evidence."
+
+"truck/chevrolet/20-starcraft-3-9t-fg25f#name":
+  researcher: "defective(D1)"
+  verifier: CONFIRMED
+  evidence:
+    - "ZERO rows in fi or nl write the published string standalone: every source row is 'CHEVY VAN 20-STARCRAFT-3.9T-FG25F/343' (593), '…FG25F' (19), 'Chevy van 20-starcraft-3.9t-fg25f/343' (1)."
+    - "the strip is systematic in the truck kind: truck/chevrolet/20 folds 'CHEVY VAN 20'; /30 folds 'CHEVY VAN 30'; /express folds 'Chevy Van Express'; /g30 folds 'CHEVY VAN G30 VAN'."
+    - "the catalog renders the SAME family correctly in another kind: van/chevrolet/chevy-van-20-starcraft, name 'Chevy Van 20 Starcraft' [fi,nl] — which is what D1's 'records HEAL' remedy would restore."
+
+"truck/chevrolet/cheyenne#id":
+  researcher: "defective(D8)"
+  verifier: CONFIRMED
+  evidence:
+    - "named live ids: truck/chevrolet/c20 (LIVE RDW N2 'C20 CHEYENNE' n=1; fi 'Cheyenne C 20' n=1), truck/chevrolet/k2500 (fi N2G 'K2500 Cheyenne'; nl N2 'K20 CHEYENNE SUPER'), truck/chevrolet/2500 (fi '2500 CHEYENNE PICKUP-3.9T-GC24F/334'), /1500, /3500."
+    - "position test: in 6 of 15 FI Cheyenne strings and 2 of 10 NL N2 rows, CHEYENNE FOLLOWS the series number — trim position."
+  fixer_warning: >-
+    Chevrolet Cheyenne IS a standalone nameplate in Mexico (fi 'Cheyenne LTZ' 3,
+    'Cheyenne High Country' 1 — trims OF Cheyenne; nl bare 'CHEYENNE' 4). The
+    record is not purely a trim, so the remedy must not delete those rows.
+
+"truck/chevrolet/k#id + #name":
+  researcher: "id=defective(D6); name=defective(D9)"
+  verifier: CONFIRMED both
+  evidence:
+    - "named live twins: truck/chevrolet/k2500, /k3500, /k2500hd. LIVE RDW N2: 'K 2500' 6 vs 'K2500' 3; 'K 3500' 2 vs 'K3500' 3; 'K 30' 1 vs 'K30' 1 — the same register writes each truck both ways."
+    - "the split is perfectly clean: every raw in truck/chevrolet/k has a space; every raw in k2500/k3500/k2500hd is closed."
+    - "the project has already ruled this family: overrides/models/renames.yml:255 'K 1500: K1500 # … a short letter prefix glued to digits IS the nameplate for this make … so the fused form is canonical'."
+    - "name: no truck-kind source row is a bare 'K' (fi_agg $3=='K' under Chevrolet → zero; LIVE RDW handelsbenaming='K' merk=CHEVROLET → M1 only, n=2, i.e. the car kind). K is GM's 4WD chassis code (C=2WD)."
+
+"truck/chevrolet/pick-up#id":
+  researcher: "defective(D9)"
+  verifier: RECLASSIFIED(D6)
+  evidence:
+    - "named live twin: truck/chevrolet/pick ('Pick', fi+nl). LIVE RDW N2: 'PICKUP 2500 EXT CABTD 4X4' n=1 (→ pick-up) and 'PICK UP 2500 EXT CABTD4X4' n=1 (→ pick) — the same vehicle description, one space apart."
+    - "the project's own rule states the identity: overrides/models/renames.yml:252 'Pickup: Pick Up # spelling variant … same nameplate, different spacing/casing'; and overrides/models/former_ids.yml:1965 records truck/chevrolet/pickup → truck/chevrolet/pick-up — the rename fired and left the 'Pick' twin behind (a D14 shape)."
+    - "D9 cannot stand: 'pick-up' is an English body phrase, not a registry code."
+
+"truck/chevrolet/pick-up#name":
+  researcher: "defective(D9)"
+  verifier: RECLASSIFIED(D8)
+  evidence:
+    - "LIVE RDW's own inrichting for these rows is literally 'pick-up truck' / 'open wagen' — the published name is the BODY STYLE."
+    - "the real nameplates are inside the raws: 'PICKUP 2500 EXT CABTD 4X4' (a C/K 2500), 'PICK UP K 2500', 'PICKUP-GC29F/395'."
+    - "D3 was tested and rejected (its detector is a placeholder regex); D8 is 'trim/edition/BODY/engine published as model', remedy fold-into-nameplate."
+
+"truck/chevrolet/van#id":
+  researcher: "defective(D6)"
+  verifier: OVERTURNED(correct)
+  evidence:
+    - "all 38 truck/chevrolet ids enumerated: none is a spelling variant of 'Van'/'Chevy Van', and no truck id contains 'chevy' at all."
+    - "the near candidates are narrower vehicles, not spellings: /20 ['CHEVY VAN 20','VAN 20'], /30 ['CHEVY VAN 30'], /g30 ['CHEVY VAN G30 VAN'], /express ['Chevy Van Express'] — payload sub-series, i.e. D8-direction relatives."
+    - "car/chevrolet/chevy-van and van/chevrolet/chevy-van exist but are a DIFFERENT KIND, and D6 is defined 'same make+kind' (NAMING §3: each kind's files stand alone)."
+  note: "the record's real problem is its name, not a duplicate id."
+
+"truck/chevrolet/van#name":
+  researcher: "defective(D5)"
+  verifier: RECLASSIFIED(D1)
+  evidence:
+    - "D5's detector is a PREFIX TEST on the published name, and the published name is 'Van' — it contains no brand, so D5 cannot fire; its remedy (strip the brand) would make this worse."
+    - "the mass IS the nameplate: fi N2 'CHEVY VAN' 13 + nl N2 'CHEVY VAN' 9 + 'CHEVROLET CHEVY VAN' 1 = 23 registrations, against ~4 bare 'VAN' truck-kind rows."
+    - "mechanism: 'Chevy' is a registered make alias (overrides/makes/search_aliases.yml:15 '\"Chevy\": Chevrolet # universal nickname') and the truck kind strips it systematically. The catalog publishes the correct form in two other kinds (car/ and van/chevrolet/chevy-van, both 'Chevy Van')."
+    - "D1's remedy — fix the strip, record HEALS to 'Chevy Van' — is the available one."
+  verifier_dissent_noted: "my own first read agreed with the researcher's D5 label; the class table decided it, because a class describes the PUBLISHED record, and this record has already been over-stripped."
+
+"truck/daf/fancf#id + #name; truck/daf/fas#id + #name; truck/daf/ftg#id + #name; truck/daf/v1600dd#name":
+  researcher: "fancf id=D6 name=D9; fas id=D9 name=D9; ftg id=D9 name=D9; v1600dd name=D9"
+  verifier: CONFIRMED all seven
+  evidence:
+    - "THE LETTERS WERE RESOLVED FROM THE REGISTER, NOT GUESSED (§7.5): LIVE RDW 2026-07-26 — every DAF handelsbenaming containing 'FT' = 29,853 registrations, 99% inrichting 'opleggertrekker' (tractor); every one containing 'FA' = 10,078 registrations, 0% tractor (gesloten opbouw 41%, gecond. 11%). So F=forward control, A=rigid, T=tractor; the third letter is the axle layout. FTG specifically: 3,784 regs, 3,766 opleggertrekker (100%). FAS: 971 regs, haakarm 47% / afneembare bovenbouw 32% / 0% tractor."
+    - "THE SAME REGISTER WRITES BOTH ORDERS FOR THE SAME TRUCK — which is what mints the bogus ids: 'XF 480 FTG' 1,113 vs 'FTG XF105' 154; 'CF 410 FAS' 116 vs 'FAS CF85' 107; 'XF 480 FAS' 64, 'XF 530 FAS' 60 vs 'FAS XF105' 107; 'CF 410 FAN' vs 'FANCF85.410T'."
+    - "id targets are live: truck/daf/cf, /xf, /xg, /xd, /95. For fancf specifically the live twin is truck/daf/fan (raws 'FAN CF85', 'FAN CF 85', 'FAN CF75') — one space away."
+    - "v1600dd decomposes in the register: LIVE RDW 'V 1600 DD 358' n=7 SPACED beside 'V1600DD358' n=9, plus 'A1600DD425' 13, 'FA1600DF360' 9, 'FT1600DT265' 7, 'B1600DD600' 6 — leading letters = chassis config, 1600 = model, letter pair = engine code, trailing 3 digits = wheelbase in cm. No daf/1600 record exists for the code to resolve into, which is why D9's debt remedy applies rather than D8's fold."
+    - "MY OWN MARQUE CORROBORATION (Part 7): daf.com/en HTTP 200 renders the range as DAF XB/XD/XF/XG/XDC/XFC — FA/FAS/FAN/FT/FTG appear nowhere on the marque's own site."
+
+"truck/de-soto/sc#name":
+  researcher: "defective(D9)"
+  verifier: CONFIRMED
+  evidence:
+    - "the entire world population is 2 vehicles: fi_agg N2 'DE SOTO' / 'SC3-HA6-171/4340-56' n=1; LIVE RDW merk like '%SOTO%' N2 'SC-HA-171' n=1 (huifopbouw). Neither register ever wrote a bare 'SC'."
+    - "the compound decodes as a type designation: 171 in × 25.4 = 4,343 mm, and the FI string appends '/4340' while the make's sibling FI row 'L8-D500-171/4343-58' appends '/4343' — i.e. <type code>-<sub>-<wheelbase in inches>/<wheelbase in mm>-<year>."
+    - "§7.2 was given full weight and a §7.5 resolution was ATTEMPTED and came back empty — which is precisely why D9 (resolve-via-raw-else-debt) is the class rather than acceptance."
+  unclaimed_extra: "'Sc' also carries a D7 casing error the researcher did not claim."
+
+"truck/ford/350#id + #name":
+  researcher: "id=defective(D6); name=defective(D1)"
+  verifier: CONFIRMED both
+  evidence:
+    - "named live id: truck/ford/e-350 — whose OWN observed raws literally contain 'E-350 ECOLINE' and 'E-350 ECONOLINE', i.e. truck/ford/350's two raws with the 'E-' intact. Second live id: truck/ford/econoline ('ECONOLINE 350', 'ECONOLINE E-350')."
+    - "name: no truck-kind source row is a bare '350'. LIVE RDW merk=FORD handelsbenaming exactly '350' → one row, N1 (the VAN kind), n=2. The truck-kind rows are '350 ECONOLINE' (nl N2 2) and '350 ECOLINE' (fi N2 1)."
+    - "the §7.1 two-source defence was tested: both sources carry the SAME two-token string, so this is one string family, not independent corroboration of a bare '350'."
+
+"truck/ford/f250xlt#id + #name":
+  researcher: "id=defective(D6); name=defective(D7)"
+  verifier: CONFIRMED both
+  evidence:
+    - "named live id: truck/ford/f-250 (global_decile 2) — its own raws already include 'F-250 XLT', 'F-250 XLT 4x4', 'F-250 XLT SUPER DUTY'. LIVE RDW writes the same trim four ways: 'F250XLT' N2 2, 'F250 XLT' N2 6, 'F 250 XLT' N2 2."
+    - "the project already ruled the identity: overrides/models/renames.yml:593 'F250: F-250 # spelling variant … same nameplate, different spacing/casing' — f250xlt escaped it only because XLT is glued on."
+    - "truck/ford/f250xlt has NO entry in observed_variants.json at all: the id survives on the glued spelling alone."
+    - "name, rank 5 (ford.com unreachable: curl HTTP 000/exit 92 on ford.com and ford.co.uk, WebFetch timed out on ford.com and media.ford.com): en.wikipedia.org/wiki/Ford_Super_Duty renders 'F-250', 'F-250 XL', '2011 Ford F-250/F-350 Crew Cab Lariat' — hyphenated, trim as a separate token. 'F250XLT' is D7's own example shape (cf. 'RX450H')."
+
+"truck/ford/ranger#availability.nl":
+  researcher: "defective(D6)"
+  verifier: "CONFIRMED — independently derived twice (mine in Part 7, and a deeper re-derivation below)"
+  evidence:
+    - "LIVE RDW 2026-07-26: 141 distinct RANGER rows under merk=FORD; filtered to the truck categories N2/N3 → 18 rows / 22 registrations, and ZERO of them is handelsbenaming = 'RANGER'. Bare 'RANGER' exists only as M1 (20) and N1 (4,013)."
+    - "all 18 N2 rows are F-Series ('F-250 RANGER XLT', 'F250 RANGER', 'F350 RANGER XLT', 'F250 SUPERCAB RANGER XLT', 'RANGER F250', 'RANGER XCT F250', …)."
+    - "THE TWO AMBIGUOUS 'RANGER XLT' N2 ROWS WERE RESOLVED BY IDENTITY FIELDS, NOT ASSUMPTION: wielbasis 338, massa_ledig 1,970/2,010, GVW 3,500 — 3,380 mm is the F-250's wheelbase, corroborated by FI's own type designations 'F 250-F268-HF26M-3.9T-PICKUP-4X4/3380' n=2. No T6/T6.2 Ranger has a 3,380 mm wheelbase (RDW's N1 Ranger population sits at 275-339, the modern car at 320-322)."
+    - "named live target: truck/ford/f-250, whose own raws already include 'F-250 RANGER XLT'. 'Ranger' was an F-Series TRIM badge before it was a nameplate (fi 'F100 RANGER XLT', 'F150 RANGER')."
+
+"truck/fordson/wot#name":
+  researcher: "defective(D7)"
+  verifier: CONFIRMED
+  evidence:
+    - "rank 5 (Fordson ended 1964): en.wikipedia.org/wiki/Fordson_WOT renders 'Fordson WOT' in caps and expands it — War Office Type — with models WOT1, WOT2, WOT3, WOT6, WOT8. An initialism must never be Title-cased (the D23 logic)."
+    - "population is 2 vehicles: LIVE RDW merk like '%FORDSON%' N2 'WOT 6' n=1; fi_agg N2 'Fordson'/'WOT SUSSEX' n=1. FI also carries 'SUSSEX WOT 1/3970+970' and 'WOT1 SUSSEX' under the Ford make."
+  unclaimed_extra: "the record folds two different models (WOT6 and the Sussex 6-wheeler) — a separate, unclaimed altitude defect."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PART 13 — SPOT-CHECK OF 25 `correct` VERDICTS (the certified-stratum miss rate)
+# Deterministic selection: all 82 id/name claims the researcher marked correct,
+# sorted by "<id>#<claim>", every 82/25th taken. 24 re-derived adversarially +
+# truck/mecalac/revotruck#name re-derived by me in Part 2 = 25.
+# ═════════════════════════════════════════════════════════════════════════════
+spot_check:
+  misses_found: 4
+  of_checked: 25
+  miss_rate: 0.16
+  clopper_pearson_95: "[0.045, 0.365]  # 4/25, exact binomial"
+  what_broke_and_how: >-
+    None of the four misses is visible to a name-level duplicate scan. The
+    productive attack was reading observed_variants.json to see WHICH RAW
+    STRINGS each id actually swallowed, then checking the live register for the
+    alternate spelling. Two of the four are hidden by SINGLE-LETTER TRUNCATION
+    BUCKETS — truck/ford/f and truck/scania-vabis/l — which quietly absorb the
+    space-separated spelling of a vehicle that also has its own id. The truck
+    kind is full of these buckets (gmc/c, man/h, man/l, daf/fa, chevrolet/c…)
+    and they are duplicate-hiding machines.
+
+  misses:
+    "truck/ford/f-max#id":
+      researcher: correct
+      verifier: MISS(defective(D6))
+      evidence:
+        - "observed_variants: truck/ford/f ('F', [es,fi,nl]) has folded the raw 'F MAX' — I re-ran this myself and confirm the exact array member."
+        - "es_agg (my own build): 'N3|FORD|F-MAX|32', '(blank cat)|FORD|F-MAX|3', and 'N3|FORD|F MAX|1' — the register spells it both ways and the unhyphenated Spanish row is the one sitting in ford/f."
+        - "LIVE RDW: 'FORD | F-MAX | N3 | 166' (hyphenated only); fi_agg has no F-MAX row — so the 'F MAX' raw can only be the Spanish row."
+        - "both ids are live and both carry es+nl."
+      why_missed: "`grepname all 'f.?max'` returns ONE record — the twin is invisible at name level because truck/ford/f is itself a D1 truncation bucket (F 150 / F 250 / F 350 / F 600 / F MAX all collapsed to 'F')."
+
+    "truck/scania-vabis/l71#id":
+      researcher: correct
+      verifier: MISS(defective(D6))
+      evidence:
+        - "observed_variants: truck/scania-vabis/l ('L', [fi,nl]) contains 'L 71 38 REGENT' — re-verified by me directly."
+        - "LIVE RDW merk='SCANIA-VABIS': 'L71' n=1 AND 'L 71 38 REGENT' n=1 (also 'L7134' 1, 'LS 71 50' 1) — the same model glued and spaced."
+        - "fi_agg 'N2|SCANIA-VABIS|L71|1'; truck/scania-vabis/l71 has NO variants — it was built from the glued rows only."
+        - "the identical split is one model over: truck/scania-vabis/l51 holds 'L51 50 110' while truck/scania-vabis/l holds 'L 51', 'L 51-42HD', 'L 51-46 HD'."
+
+    "truck/man/hn#id":
+      researcher: correct
+      verifier: MISS(defective(D9))
+      evidence:
+        - "LIVE RDW merk='MAN' grouped by (type, handelsbenaming) over the H-codes: H05↔'H 19 FT'; H06↔'H06','H 19 FT','HS 19 F','MAN TGA','MAN'; H25↔'MAN TGA'; H26↔'MAN TGA','TGA'. The register's OWN type column equates MAN's H-series type codes with the MAN TGA."
+        - "detail rows: 'HN 19 F' 19,000 kg first admitted 2003-01-21; 'HN 19 FT' 18,600 kg 2001-02-01; 'HN26 FNLC' 26,000 kg 2001-09-05 — all inside the TGA window (2000-2007). RDW also holds 'H26 FNLC' (2004) and 'HS 26 FNLC' (2005) for the identical 26 t configuration, so H/HN/HS are sub-codes of ONE type family."
+        - "named live target: truck/man/tga [es,fi,lu,nl]. es_dgt corroborates the shape: 'MAN | HN 19 F | N3 | 1', 'MAN | H05 18 FLC | | 1'."
+        - "I independently reproduced the H/HN overlap before this result arrived: LIVE RDW returns 'H 19 FT' 2, 'H 19 F' 1, 'HN 19 F' 1, 'HN 19 FT' 1, 'HN26 FNLC' 1 — the same designations with and without the N."
+      honest_gap_stated: "the two HN rows themselves carry no `type` value; the H06→TGA anchor comes via the sibling rows 'HS 19 F' and 'H 19 FT'. Recorded rather than smoothed over."
+      blast_radius: "the same evidence implicates the live siblings man/h, man/h25, man/h36, man/h39 (H25 and H26 map directly to 'MAN TGA')."
+
+    "car/volvo/ec40-twin#name":
+      researcher: correct
+      verifier: MISS(defective(D8))
+      evidence:
+        - "cache/us_vehicles.csv is the ONLY source printing this string: 'Volvo | EC40 Twin | Small Sport Utility Vehicle 4WD | EC40 | 2025' and '2026' — EPA's own baseModel column says 'EC40'."
+        - "Volvo's own powertrain naming is 'Twin Motor' / 'Twin Motor Performance': the MY2025 Price & Specification PDF on volvocars.com gives Twin Motor 408 hp/300 kW and Twin Motor Performance 441 hp, and Volvo's own build-summary documents are named 'ec40-core-twin-motor-electric-2026-01-31…'. Volvo's support articles are titled 'EC40 Electric motor specifications'. No Volvo page renders the bare string 'EC40 Twin'."
+        - "car/volvo/ec40 ('EC40') is live in 9 countries including us — the same nameplate, same country."
+      caveat: "volvocars.com returned HTTP 403 on five direct fetches, so the evidence is Volvo-hosted document titles, slugs and spec-PDF contents rather than a rendered marque page."
+      blast_radius: "the same shape is live on c40-recharge-twin, ex40-twin, xc40-recharge-twin, ex30-twin-performance."
+
+  confirmed_21:
+    - "car/saturn/aura#id — 16 Saturn records enumerated across all six kinds; one Aura, and 'Aura Hybrid' is folded IN rather than standing as a second id."
+    - "car/saturn/l300#name — EPA's own baseModel is also 'L300'; rank 5 Saturn L-series: 'all L-Series sedan and wagon models were renamed \"L300\"' for 2004. The named trap (live siblings l100-200 and l200) is not a spelling relationship: L100/200 is EPA's own merged 2001-02 cell."
+    - "car/scion/xd#id — 8 Scion records, all kind=car, one xD; xA/xB are separate Scion nameplates."
+    - "car/srt/viper#name — EPA 'SRT | Viper | Viper | 2013/2014'; SRT was the badge for exactly those two model years."
+    - "car/suzuki/equator#name — EPA writes 'Equator 2WD/4WD' but its baseModel is 'Equator', and the qualifiers survive as variants, not sibling ids."
+    - "car/suzuki/sc#id — the code RESOLVES to the SC100 (gb Model column 'SC 100 GX'; nz 'SC100' 20) but there is NO live suzuki/sc100 or suzuki/cervo id to name, so id-canonical holds even though the NAME is defective."
+    - "car/toyota/camry-wagon#name — EXPECTED TO BE A MISS and flipped back: pressroom.toyota.com asset titles read '1992 Toyota Camry Wagon 003', '1995 Toyota Camry Wagon LE 003' (trim AFTER Wagon). The marque writes it; the altitude question rides on the #id claim, which is separately defective."
+    - "car/toyota/cressida#id — no second Cressida in any kind; the Mark II / Cresta relationship is an export-badge nameplate split, which the catalog treats as separate (the escudo/vitara precedent)."
+    - "car/uaz/469#id — 469 and 469B are two UAZ factory indices, kept apart by both registers (RDW '469' M1 5 vs '469B' 2 / '469 B' 3; fi '469' 2 vs '469B' 1) with no cross-contamination of raws."
+    - "car/volvo/480#name — rank 5 (volvocars.com 403): the base designation is '480'; ES/Turbo are variant qualifiers."
+    - "car/zeekr/009#name — rank 3 zeekrlife.com/global prints 'Zeekr 001', 'Zeekr 009', 'Zeekr 009 Grand', 'Zeekr X' in title case."
+    - "truck/citroen/jumper#id — only 2 Citroën truck records; ë-Jumper is the BEV line the catalog keeps separate BY POLICY (car/citroen/c3 and e-c3 both live; PRD §4 D17 lists 'ë-C3'→'c3' as the DEFECT, not the remedy)."
+    - "truck/de-soto/sc#id — 17 De Soto records, exactly one in kind=truck. A likely D9 name defect, but no second id to name."
+    - "truck/gmc/cckw#id — ran the same bucket attack that broke ford/f-max: truck/gmc/c holds only ['C 30','C 35','C 3500 CREW CAB','C 3500 HD'] — no CCKW string leaked in."
+    - "truck/land-rover/defender#name — rank 3 landrover.com/vehicles/defender HTTP 200 (112 KB): 'Defender' 18× in title case; the all-caps hits are styled headings 'DEFENDER 90/110/130'."
+    - "truck/mercedes-benz/2538#id — run as the direct parallel to 816-d: the 816 corpus is saturated with VARIO/ATEGO tokens, the 2538 corpus has NONE (fi '2538', '2538 DNA-6X2/385+136', '2538 K-6X4', '2538-NT-6X2/450+136'; LIVE RDW '2538 6 X4' n=1). The SK/NG-era number IS the whole product name — the case §7.2 blesses."
+    - "truck/mercedes-benz/816-d#name — EXPECTED TO BE A MISS and flipped back by the marque's own document: Mercedes' Vario W670 owner's manual (static.oneweb.mercedes-benz.com, 201 pp) §'Vehicle model designation' pp.187-188 decomposes 8 = GVW in tonnes, 18 = bhp×10, D/DA = engine+drive, KA = equipment, AND prints the designation '(814 DA)' WITH the space. The record's own raws are closed ('816D VARIO/425') and Wikipedia writes 816D closed — the marque still wins."
+    - "truck/mercedes-benz/vario#name — the same manual is titled 'Vario' and writes it in title case in running text."
+    - "truck/ram/2500#name — rank 3 ramtrucks.com HTTP 200 (369 KB): running text 'Ram 2500' ×4, 'Ram 2500 Tradesman', 'Ram 2500 Rebel'; the all-caps 'RAM 2500' ×6 are nav styling; the model URL is /ram-2500.html."
+    - "truck/saxas-nutzfahrzeuge-werdau/atego#name — rank 3 mercedes-benz-trucks.com/en_GB/models/atego-distribution.html HTTP 200 renders 'Atego', never 'ATEGO'. The NAME matches character-for-character even though the MAKE is wrong (that defect is claimed separately and confirmed)."
+    - "truck/mecalac/revotruck#name — re-derived by me (Part 2)."
+
+# ═════════════════════════════════════════════════════════════════════════════
+# SUMMARY
+# ═════════════════════════════════════════════════════════════════════════════
+SUMMARY:
+  scope_completed:
+    defective_claims_reviewed: "119 / 119 (every defective verdict in the ledger, re-derived from primary sources before the researcher's evidence was read)"
+    unverifiable_claims_reviewed: "9 / 9 (one independent alternative route each)"
+    correct_verdicts_spot_checked: "25 (deterministic every-82/25th over the sorted list of all 82 id/name claims marked correct)"
+    availability_claims_machine_re_checked: "107 / 245 (fi 64 + gb 17 + es 17 + ua 9) — my own automated re-derivation against the four artifact-backed registers"
+
+  defects_reviewed:
+    total: 119
+    confirmed: 99
+    overturned_correct: 3
+    overturned_unverifiable: 4
+    reclassified: 13
+    confirmation_rate: 0.832
+
+  overturned_to_correct:
+    - "car/suzuki/wagon#availability.nl — the register holds a row spelled exactly as the record (LIVE RDW kenteken 01GLL9, M1, DET 2001-02-06); protocol R4 says a wrong NAME is not an availability defect."
+    - "car/suzuki/wagon#availability.ua — 'ЛЕГКОВИЙ|SUZUKI|WAGON|5' is a row distinct from 'WAGON R|12' in my UA aggregate."
+    - "truck/chevrolet/van#id — all 38 truck/chevrolet ids enumerated; no same-make+kind spelling twin of 'Chevy Van' exists (the cross-kind car/ and van/chevrolet/chevy-van records are a different kind, and D6 is defined same make+kind)."
+
+  overturned_to_unverifiable:
+    - "car/suzuki/wagon#id — the assumed twin (wagon-r) is REFUTED by specs: the single NL vehicle is 1298 cc / wielbasis 238 / 885 kg, and RDW's 1298+238 cell is dominated by Baleno 1.3 (45 rows) while the Wagon R population is 1298/236 (6,649). §7.5 forbids naming it anyway."
+    - "car/volkswagen/van#id — the three NL rows are three different vehicles spanning 48 years (1970 1.6 camper M1; 2005 3.2 N1; 2018 2.0 N1); no single live id denotes them."
+    - "truck/man/12#id — the rows carry no power element ('12 LL' could be a 12.170/12.192/12.224/12.225, all of which RDW carries), and the era-correct nameplates (M90, M2000) are ABSENT from the catalog."
+    - "truck/man/8-150-f#id — LIVE RDW dates every 8.150 registration (1988-1997) BEFORE the L2000's 8.153 rows (1993-1996); the correct target is the MAN G90 range, and no man/g90 record exists."
+  overturned_to_unverifiable_note: >-
+      Two of these four are blocked by MISSING catalog records, not by weak
+      analysis. If the ledger wants man/12 and man/8-150-f convicted, the
+      prerequisite is publishing the absent MAN nameplates.
+
+  reclassified_13:
+    - "car/suzuki/wagon#name           D6 → D3   (the two strings do not NFKD-fold to one another; a bare body word with an unresolved referent is the placeholder shape)"
+    - "car/volkswagen/van#name         D9 → D3   (D9's detector is code-shape + single-source; 'VAN' is an English word and two-source)"
+    - "truck/chevrolet/pick-up#id      D9 → D6   (named twin truck/chevrolet/pick; the project's own renames.yml:252 states the identity, and former_ids shows the rename left the twin behind — a D14 shape)"
+    - "truck/chevrolet/pick-up#name    D9 → D8   ('Pick Up' is the body style RDW itself records in inrichting, not a registry code)"
+    - "truck/chevrolet/van#name        D5 → D1   (D5's prefix detector cannot fire on a name containing no brand; 'Van' is the RESIDUE of the Chevy make-alias strip)"
+    - "truck/iveco/40c17d#id           D6 → D8   (the shared approval index also covers 40C15/40C18/40C15V, so it proves family identity, not a spelling pair; 'D' recurs across six other live ids)"
+    - "truck/liebherr/utm#name         D7 → D9   (D7 needs a marque rendering to differ from; Liebherr publishes NO 'UTM' material — the absence is itself the evidence for a type code)"
+    - "truck/man/8-150-f#name          D6 → D7   (only one catalog record begins '8.15', so the catalog-side D6 detector cannot fire; the hyphen is a one-row register outlier against MAN's spaced convention)"
+    - "truck/mercedes-benz/290#id      D6 → D8   (no second spelling of '290' exists among 240 MB truck ids; 290 GD is an engine/generation designation of the live truck/mercedes-benz/g)"
+    - "truck/mercedes-benz/la#id       D6 → D1   ('La' is a prefix fragment holding ≥12 different type numbers — it denotes no single vehicle, so D6 is definitionally unavailable)"
+    - "truck/scania/143m#name          D1 → D8   (two independent registers carry '143M' verbatim, so nothing was fabricated; M is Scania's chassis-height letter)"
+    - "truck/scania/460#id             D1 → D8   (RDW's own handelsbenaming reads '460' and es_dgt carries it too; RDW's `type` column resolves it to 'T 144 LA 4X2 NA 460' → live truck/scania/144)"
+    - "truck/scania/460#name           D1 → D8   (same evidence; a bare power figure, not a parser artifact)"
+  reclassification_pattern: >-
+    Eleven of the thirteen are one of two mistakes, both worth a detector note:
+    (a) D1 asserted where the raw corpus actually carries the string — the
+    ledger reached for "parser artifact" five times on strings that two
+    independent registers write verbatim, which is exactly what NAMING §2.1
+    warns against; and (b) D6 asserted where no SECOND SPELLING exists — the
+    record is a fragment or a variant, so the honest classes are D1 or D8.
+    Both mistakes point a fixer at the wrong layer.
+
+  unverifiables_resolved: "7 of 9"
+  unverifiable_outcomes:
+    - "truck/scania/metago#make → CORRECT (overturned): the 16 NL rows are N3 registered under merk SCANIA and ARE Scania tractors; the third party sits in the MODEL column."
+    - "truck/scania/metago#id → defective (NEW-1/D5 shape): METAGO PRO is Kässbohrer Transport Technik's car-transporter — LIVE RDW carries it under merk KAESSBOHRER/KASSBOHRER as O4 trailers, and kaessbohrer.com links its own /en/vehicle/metago-pro page."
+    - "truck/scania/metago#name → defective (same)."
+    - "truck/renault/d14#name → CORRECT (resolved): Renault Trucks UK's own press release (HTTP 200) is titled 'Renault Trucks D14 …' and writes 'D14 4x2 rigid', 'D14 and D16 chassis'."
+    - "truck/scania/p230#name, p280#name, p380#name → defective(D7), DIRECTIONAL: scania.com/uk (HTTP 200) writes 'Scania R 410 LBG 4x2 Highline' — cab letter, SPACE, power figure. Single instance, different cab letter; I would not sweep three live ids on it alone."
+    - "car/volkswagen/caravelle-syncro#name → STILL UNVERIFIABLE: five VW-owned routes tried (newsroom search JS-only, classic.de redirect, classic-parts 404, vwn-presse shell, newsroom CV hub 404)."
+    - "car/volkswagen/211#id → STILL UNVERIFIABLE: I identified WHAT the vehicle is (VW Type 2 Transporter — wielbasis 240/241 cm, DET 1956-1975, 1200-1641 cc) but the catalog has no Type 2 nameplate id in kind car to name; the family is scattered across t2, combi, micro-bus, kleinbus, kombiwagen, bestel."
+
+  corrects_spot_checked: 25
+  misses_found: 4
+  certified_stratum_miss_rate: "0.160  (4/25; 95% Clopper-Pearson [0.045, 0.365])"
+  miss_list:
+    - "truck/ford/f-max#id → defective(D6)  — truck/ford/f has folded the raw 'F MAX'"
+    - "truck/scania-vabis/l71#id → defective(D6) — truck/scania-vabis/l has folded 'L 71 38 REGENT'"
+    - "truck/man/hn#id → defective(D9) — RDW's own `type` column ties the H-code family to 'MAN TGA' (live)"
+    - "car/volvo/ec40-twin#name → defective(D8) — 'EC40 Twin' is EPA's truncation of Volvo's 'Twin Motor'; no Volvo source prints it"
+  miss_rate_caveat: >-
+    NOT extrapolated (I-15: the audit finds, it does not sweep). For scale only:
+    25 of the 82 correct id/name claims were checked, so the measured rate is
+    the program's own error rate on the axes checked, and the remaining 57
+    unchecked correct id/name claims are the obvious place to look next. The
+    single highest-yield method is stated in PART 13 and costs nothing: diff
+    observed_variants.json against the id list to find single-letter truncation
+    buckets that have swallowed another live id's spelling.
+
+  adjusted_per_claim_tallies:
+    basis: "645 claims (100 records × 4 axes + 245 availability entries) — arithmetic independently verified, see PART 6"
+    researcher: { correct: 517, defective: 119, unverifiable: 9, clean_rate: 0.8016 }
+    verifier:   { correct: 518, defective: 121, unverifiable: 6, clean_rate: 0.8031 }
+    derivation: >-
+      correct 517 +3 (defects overturned to correct) +2 (unverifiables resolved
+      as correct) −4 (spot-check misses) = 518.  defective 119 −3 (→correct)
+      −4 (→unverifiable) +5 (unverifiables resolved as defective) +4 (spot-check
+      misses) = 121.  unverifiable 9 −7 (resolved) +4 (defects downgraded) = 6.
+      518+121+6 = 645 ✓
+    by_claim_type_adjusted:
+      id:           { correct: 38, defective: 58, unverifiable: 4 }
+      name:         { correct: 40, defective: 56, unverifiable: 4 }
+      make:         { correct: 98, defective: 2,  unverifiable: 0 }
+      kind:         { correct: 96, defective: 4,  unverifiable: 0 }
+      availability: { correct: 244, defective: 1, unverifiable: 0 }
+    defect_classes_adjusted:
+      D1:    9    # was 10 — three moved out (143m, 460×2), two moved in (chevrolet/van#name, mb/la#id)
+      D3:    2    # NEW to this slice — suzuki/wagon#name, volkswagen/van#name
+      D5:    0    # was 1 — the slice's only D5 reclassified to D1
+      D6:   26    # was 33
+      D7:   16    # was 13 — +3 from the resolved Scania P-series unverifiables
+      D8:   27    # was 21 — the biggest mover; six reclassifications land here
+      D9:   25    # was 27
+      D10:   4
+      D11:   1
+      D12:   1
+      NEW-1: 10   # was 8 — +2 from the resolved metago unverifiables
+      total: 121
+    honest_headline: >-
+      The clean rate barely moves (0.8016 → 0.8031). That is a coincidence of
+      offsetting corrections, not agreement: 20 of 119 defect verdicts were
+      wrong in verdict or in class, and 4 of 25 sampled `correct` verdicts were
+      misses. The ledger's NUMBER is sound; a meaningful fraction of its LINES
+      would send a fixer to the wrong record or the wrong layer.
+
+  headline_finding_verdict:
+    claim: "car/tesla/model-y is not id-canonical because car/tesla/y is live on a bare 'Y'"
+    verdict: CONFIRMED
+    strength: "stronger than the ledger states — the bare-Y rows are positively identified as Model Ys on register-carried dimensions (wielbasis 289 = 2,890 mm, matching MODEL Y's 55,598-row cluster and no other Tesla), not by elimination."
+    framing_correction: "the fix lands on car/tesla/y, not on car/tesla/model-y. See PART 8 — the same ambiguity moves four other id verdicts in this slice."
+
+  the_three_new_classes:
+    NEW-1: "CONFIRMED as a real, repeating defect, with a materially larger blast radius than the ledger states ('Burstner' is a MODEL under four chassis makes across three kinds; 'Atego' under five makes in truck alone) — but I file a taxonomy dissent: the detector is D5's, and the case for a new number rests on the REMEDY being blocked by drop.yml. Propose D5b, not an unrelated class. The proposed list-free detector (same model string under ≥2 unrelated chassis makes in one kind) is genuinely new and fires on every exemplar, including the metago case the ledger left unresolved."
+    NEW-2: "CONFIRMED on all four evidence lines, two of them worse than reported — Enyaq/Elroq share FOUR full TAN strings (e8*2007/46*0416*19/21/22/23), not one; and the '- (FMVSS)' placeholder is on 35 records across THREE kinds (22 car, 10 motorcycle, 3 truck), not 33 across four. I also supply the provenance the ledger lacks: the literal comes from fi_traficom's tyyppihyvaksyntanro column, where 74 distinct (class, make, model) triples carry it as Traficom's placeholder for a US-FMVSS admission."
+    NEW-3: "CONFIRMED verbatim at source level — us_fueleconomy.rb and ca_nrcan.rb both declare `def kinds = %i[car]`, both discard the kind argument (`rows(_kind)`) and emit a literal `kind: :car`, and overrides/kind_maps/ contains only de_kba_fz10.yml, nl_rdw.yml and uk_dft.yml. The unused class column is real (us_vehicles.csv col 63 VClass = 'Small Pickup Trucks 2WD' for the Equator)."
+
+  what_i_could_not_do:
+    - "138 of 245 availability claims were not machine-re-checked (nl 75, us 15, nz 15, ca 13, lu 9, my 5, th 3, de 2, ie 1). The nl ones were checked case-by-case where a record was under review; lu/my/th/de/ie/ca/us were not systematically swept."
+    - "the enrichment sub-check (protocol step 6) was out of scope for this slice and is not covered by this verification."
+    - "two marque-source gaps are real and unfixable from here: Scania (product pages 404/JS-render; one CMS caption is all I could get) and Volvo Cars (HTTP 403 on five direct fetches)."
+    - "I did not re-derive the researcher's 96 correct `kind` verdicts or 97 correct `make` verdicts beyond the ones entangled with reviewed claims."
+
+  verifier_recommendations_to_the_ledger:
+    - "Pick ONE reading of id-canonical (PART 8) and apply it uniformly; then make every id line name WHICH member the fix lands on. Four lines in this slice currently point at the canonical record."
+    - "Stop reaching for D1 before re-parsing: five D1 claims in this slice sit on strings that two registers write verbatim. NAMING §2.1 already says this; the ledger did it anyway on 143M, 460 (×2), and nearly on others."
+    - "Add the single-letter truncation bucket to the detector backlog — truck/ford/f, truck/scania-vabis/l, truck/mercedes-benz/la, truck/man/h, truck/chevrolet/k. They are duplicate-hiding machines and they produced 2 of my 4 spot-check misses."
+    - "Before any D6 merge in this slice, run NAMING §2's availability subset check: volkswagen/bestel [nl,nz] vs bestel-0 [fi,nl] loses fi; the same shape recurs across the Mercedes one-space splits."
+    - "NEW-1 should be filed as D5b with the researcher's list-free detector, and truck/mercedes-benz/mkd added as its mirror-image exemplar (same approval e1*2007/46*1366 as the SAXAS Atego, roles swapped)."

--- a/data/review/audit-v2026.07.5/audit-verify-3.yml
+++ b/data/review/audit-v2026.07.5/audit-verify-3.yml
@@ -248,7 +248,7 @@ ledger_arithmetic_check:
     - "car/skoda/enyaq-85x tans = *13,*16,*22 (all three also on car/skoda/enyaq — which is what makes its own D8 verdict stand)."
     - "car/skoda/elroq tans = *17,*18,*19,*20,*21,*22,*23 and car/skoda/enyaq carries *19,*21,*22,*23 — so Enyaq and Elroq share FOUR full TAN strings, not the one the ledger names. Two different nameplates cannot both own e8*2007/46*0416*{19,21,22,23}."
 
-"truck/ford/ranger#availability.nl":
+"truck/ford/ranger#availability.nl [superseded — earlier pass, kept for the audit trail; the later entry with the same claim is the verifier's final verdict]":
   researcher: "defective(D6)"
   verifier: CONFIRMED
   evidence:
@@ -256,7 +256,7 @@ ledger_arithmetic_check:
     - "'Ranger' was Ford's US TRIM name on F-series pickups, which is what these rows are; the actual Ranger pickup sits in NL at N1 (5,143 rows) and M1 (20) — i.e. in the VAN/CAR kinds, not truck."
     - "and the correct target id is live: truck/ford/f-250 [fi,nl]. So NL's truck-kind rows evidence a different, separately-identified nameplate."
 
-"truck/scania/460#id + #name":
+"truck/scania/460#id + #name [superseded — earlier pass, kept for the audit trail; the later entry with the same claim is the verifier's final verdict]":
   researcher: "defective(D1) on both — parser artifact"
   verifier: "RECLASSIFIED(D8) on both — the defect is real, the CLASS is wrong"
   evidence:
@@ -266,7 +266,7 @@ ledger_arithmetic_check:
     - "the four cab-series siblings that make '460' ambiguous are all live too: scania/r460 (nl 1,951 / es 423), scania/s460 (nl 1,208), scania/g460 (nl 131), scania/p460 (nl 32 / es 22)."
   why_it_matters: "D1's remedy is 'fix the parser; records HEAL, never delete'. Chasing a parser bug here would find nothing, because the register really does carry '460'."
 
-"car/triumph/tr2#id":
+"car/triumph/tr2#id [superseded — earlier pass, kept for the audit trail; the later entry with the same claim is the verifier's final verdict]":
   researcher: "defective(D6)"
   verifier: "CONFIRMED — and I can name the mechanism the ledger does not"
   evidence:
@@ -274,7 +274,7 @@ ledger_arithmetic_check:
     - "the mechanism is the roman-numeral collapse NAMING §6 mandates for the car kind ('Car-kind roman numerals still collapse — VARIANT_SUFFIXES strips them'): 'TR II' → 'TR'. So car/triumph/tr is a fold artifact that swallows TR2 AND TR3 AND TR3A."
     - "bonus finding, outside this slice: car/triumph/tr is therefore a THREE-nameplate merge, which is a worse defect than the one being audited."
 
-"car/skoda/octavia-a5#id + #name":
+"car/skoda/octavia-a5#id + #name [superseded — earlier pass, kept for the audit trail; the later entry with the same claim is the verifier's final verdict]":
   researcher: "defective(D8) on both"
   verifier: CONFIRMED
   evidence:

--- a/data/review/audit-v2026.07.5/audit-verify-4.yml
+++ b/data/review/audit-v2026.07.5/audit-verify-4.yml
@@ -1,0 +1,981 @@
+# VehiclesDB five-nines baseline audit — INDEPENDENT VERIFICATION of slice 4
+# I-11 verifier pass. AUDIT ONLY. Nothing was written into any git repo; no fix applied.
+slice: 4
+verifier: opus-verify-4
+researcher: opus-audit-4          # ledger under verification: scratchpad/audit-ledger-4.yml
+date: 2026-07-26
+tag_verified_against: v2026.07.5  # /Users/javi/GitHub/.vdb-worktrees/s4w-data (VERSION=2026.07.5)
+status: complete_on_in_repo_evidence
+                                  # every claim below is re-derived. Claims whose resolution
+                                  # NEEDS an external marque page are marked
+                                  # `pending_marque_fetch: true` and are NOT counted as resolved.
+
+method:
+  independence: >-
+    Every defective verdict was re-derived from primary artifacts BEFORE the researcher's evidence
+    line for that record was read. My primary artifacts were rebuilt rather than reused from their
+    scratchpad extracts: catalog/{six kinds}/models.json + makes.json flattened to allmodels.tsv
+    (16,825 rows), build/observed_variants.json flattened to ov.tsv (45,529 keys),
+    build/observed_model_names.json to omn.tsv, the raw uk_veh0120_uk.csv and
+    fi_traficom_register.zip read directly, live nl_rdw (opendata.rdw.nl m9d7-ebf2) queried, and
+    the repo's own detector scripts re-run. Their `evidence:` lines were read only afterwards.
+  two_facts_about_observed_variants_the_ledger_does_not_state:
+    - "ov.tsv has 45,529 keys against 16,825 published records: it also carries BELOW-THRESHOLD
+       candidate ids (e.g. van/kawasaki/mule, van/ssangyong/action-sport, van/nilsson/v70,
+       truck/saxas-nutfahr-werdau-ag/mkd). Reading a key there as 'live' would be an error; I
+       cross-checked every twin against allmodels.tsv before calling it live."
+    - "ABSENCE of an id from ov.tsv means the register string EQUALS the published name modulo
+       casing — no lossy variant to record. That is positive evidence, and several verdicts below
+       turn on it (e.g. 'TRANSIT COSTUM' and 'JUMPER ODER RELAY' are literal register strings)."
+  class_discipline: >-
+    DEFECT and CLASS judged separately. CONFIRMED = real defect AND defensible class.
+    RECLASSIFIED(X) = defect real, assigned class excluded by the taxonomy's own detector
+    definition, X fits. OVERTURNED(correct) = no defect. OVERTURNED(unverifiable) = evidence
+    reaches neither way. RESOLVED(...) = a researcher `unverifiable` that I settled.
+  rules_applied: ["fetch-never-assume", "majority-is-not-authority", "skipped-beats-assumed"]
+  ledger_arithmetic_check: >-
+    The ledger's summary is arithmetically honest: parsing its own records block yields exactly
+    622 claims / 494 correct / 109 defective / 19 unverifiable and the per-class split it states
+    (id 49/47/4, name 30/56/14, make 94/5/1, kind 100/0/0, availability 221/1/0). No inflation.
+
+# ===========================================================================
+# A. THE TWO PRE-TRIAGED FINDINGS
+# ===========================================================================
+
+pre_triaged:
+
+  "finding/D18-gate-miss-23-live-former-ids":
+    researcher: "blocking GATE MISS — former_ids alias names a LIVE id (23 occurrences), class D18"
+    verifier: OVERTURNED(correct)
+    maintainer_triage_confirmed: true
+    scope_note: >-
+      The brief asked me to confirm the REMAINING un-spot-checked ids behave the same. I did not
+      spot-check — I computed the full intersection, so all 23 are checked exhaustively.
+    evidence:
+      - "method: YAML.load_file(overrides/models/former_ids.yml) -> 2474 aliases; intersect alias
+         KEYS with the id set of catalog/*/models.json at v2026.07.5, then with the id set of the
+         fresh build at /Users/javi/GitHub/.vdb-worktrees/s4w-pipeline-schema/build/out/catalog/."
+      - "published catalog v2026.07.5 (16,825 ids): 23 alias keys still live — reproduces the
+         researcher's count exactly, so their detection is sound."
+      - "fresh build (16,823 ids): ZERO alias keys live. All twenty-three are dead there.
+         Enumerated: bus/man/lion, bus/man/lions, car/alfa-romeo/romeo-gtv,
+         car/aston-martin/dbx-707, car/austin-healey/3000-mk-2, car/austin-healey/3000-mk2,
+         car/chrysler/300c-srt-8, car/datsun/280-zx, car/faw/ehs9, car/hyundai/tucson-ix-35,
+         car/hyundai/tucson-ix35, car/hyundai/tucson-ix35-lm, car/infiniti/ex-35, car/kia/cee-d,
+         car/mazda/r-x-7, car/mercury/cougar-xr7, car/volkswagen/vw-1-11,
+         motorcycle/moto-guzzi/850le-mans-iii, motorcycle/norton/commando-850mk-iii,
+         van/mercedes-benz/639-vito-{109,111,115,120}."
+      - "STRONGER THAN THE TRIAGE REQUIRED — the shipped artifact is clean at the audited tag too:
+         van/mercedes-benz/vito in catalog/van/models.json carries NO `former_ids` key at all
+         (81 other van records do carry one). The alias lives only in the curation layer, which is
+         not shipped. The ledger's `why_it_matters` asserts 'consumers are told a LIVE id is an
+         alias of a different record' — no consumer is told anything of the sort. Severity
+         `blocking` is not sustained on the published artifact."
+      - "independent second probe: a fresh run of scripts/find_duplicate_spellings.rb against the
+         PUBLISHED catalog returns 14 groups / 28 records whose make set is EXACTLY the make set
+         of the 23 stale aliases (volkswagen, aston-martin, austin-healey, chrysler, datsun, faw,
+         hyundai, infiniti, karmann-mobil, kia, mazda, mercury, man). Two unrelated probes, same
+         one-cycle lag — the pending-publish window (PRD-QUALITY §20.1 hysteresis; the script's own
+         header warns catalog/ is the LAST RELEASE)."
+      - "I also tested the pending-publish hypothesis AGAINST the rest of the slice so it could not
+         quietly excuse everything: I diffed published vs fresh-build display names for all 55
+         flagged slice records. Only the four 639-vito-* ids differ (they are gone). Every other
+         flagged name — Atf, Sk, Dt, Dw, Cm, Fll, Fmd, Ak, Kaf, Iload, Caddy Sdi, Tge Multicab,
+         Transit Costum, Jumper Oder Relay, Kangoo Express Z.e, Mkd 43-L, 7J0, 906 BA-35, L, 24,
+         Transport, Kombiwagen, Igloocar, … — is BYTE-IDENTICAL in the fresh build. So the
+         hysteresis defence applies to the D18 finding and to nothing else in this slice."
+    residual_i_am_keeping: >-
+      (a) The class label is wrong in both directions: taxonomy D18 is 'id 404 (rename/merge
+      WITHOUT alias)'; this is the inverse (alias without retirement) and, if it is a class at
+      all, it is D22 (curation-layer YAML hazards). The distinction is not cosmetic — D18's remedy
+      is 'add former_ids', which is precisely what already happened.
+      (b) A real but NON-blocking detector-shape gap survives: former_ids HARD RULE 1 is a
+      statement about a BUILD, and validate.rb/lint_dataset lint the curation layer without one.
+      The rule as written cannot be enforced where it is currently asserted.
+
+  "finding/NEW-class-connector-merged-dual-market-cell":
+    researcher: "taxonomy — NEW DEFECT CLASS CANDIDATE, connector-merged dual-market cell"
+    verifier: CONFIRMED
+    exemplars_rederived: "4 of 5 (brief required >= 3)"
+    evidence:
+      - "van/citroen/jumper-oder-relay — catalog 'Jumper Oder Relay' {es,fi,nl}; NO ov.tsv entry,
+         so the register string IS the published string. LIVE nl_rdw fetch confirms it at source:
+         https://opendata.rdw.nl/resource/m9d7-ebf2.json?$where=handelsbenaming='JUMPER ODER RELAY'
+         -> count 47, split across voertuigsoort Personenauto AND Bedrijfsauto. van/citroen/jumper
+         is separately LIVE {es,fi,lu,nl}."
+      - "van/citroen/jumper-ou-relay — LIVE {es,nl}. Live nl_rdw count 1. FRENCH connector OU,
+         same nameplate pair. Second connector, so not a one-off row."
+      - "van/citroen/jumpy-oder-dispatch — LIVE {es,nl}. Live nl_rdw count 2. Same GERMAN
+         connector, DIFFERENT nameplate pair. So neither the connector nor the nameplate is the
+         accident — the mechanism is."
+      - "van/volkswagen/transporter-caravelle — LIVE {fi,nl}; sibling
+         van/volkswagen/transporter-ww-caravelle LIVE {fi,nl} ('WW.' connector);
+         van/volkswagen/transporter LIVE {de,es,fi,gb,lu,nl}. Three-way split of one nameplate."
+      - "detector gap verified by RUNNING the detectors, not by argument: D13's stated detector is
+         'comma-cell warn in source'; D6's is NFKD case+punct fold. I ran find_duplicate_spellings
+         against the published catalog — ZERO groups in ANY slice-4 make. Neither rule can see
+         ODER / OU / WW. / '/'."
+    scope_extension_the_researcher_missed:
+      - "The same mechanism is live under a SLASH and under a BARE SPACE, so the proposed
+         connector wordlist under-covers it. van/mitsubishi/pajero-montero is LIVE {fi,nl} with
+         raws 'MITSUBISHI PAJERO MONTERO' AND 'MITSUBISHI PAJERO/MONTERO' — Pajero and Montero are
+         the JDM/EU and Spanish market names of one vehicle — while van/mitsubishi/pajero AND
+         van/mitsubishi/montero are BOTH separately live. Identical defect; the researcher filed it
+         as plain D6 (see van/mitsubishi/montero#id below) and so did not feed it back into their
+         own class."
+      - "It also occurs at the MAKE axis, which the proposal does not contemplate:
+         catalog/van/makes.json contains {\"id\":\"iveco-igloocar\",\"name\":\"Iveco / Igloocar\"}
+         — a slash-joined make. A model-level detector will never reach it."
+      - "And it coexists with the genuine comma form in the same register, so a combined detector
+         is warranted: live nl_rdw VOLKSWAGEN grouped query returns handelsbenaming
+         'CALIFORNIA,CARAVELLE,MULT' (count 4) beside 'CARAVELLE' (count 1416)."
+      - "Recommended detector spec (mine, stricter than the ledger's): (comma | oder|ou|or|und|
+         and|y|/|&|ww\\.) AND at least two tokens that each match a KNOWN live nameplate of the
+         same make. The nameplate-adjacency test is what keeps 'Transit Custom' and 'Land Cruiser'
+         out of the net; a bare connector wordlist would flag them."
+    verdict_on_severity: >-
+      `taxonomy` upheld, and I-15 (class + detector spec BEFORE scaled fixing) correctly invoked.
+      No existing row covers it: D13 is temporally scoped ('temporal merge cell', example
+      'GLK, GLC' — SUCCESSIVE models in one KBA cell); these are two CONTEMPORANEOUS market names
+      on one type approval. Different cause, different remedy.
+
+# ===========================================================================
+# B. RE-DERIVED DEFECTIVE CLAIMS
+# ===========================================================================
+
+_systemic_finding_on_the_D6_label: >-
+  The researcher assigned D6 to 19 id claims. D6's detector, per its taxonomy row AND §10.1, is
+  NFKD case+punctuation fold equality; find_duplicate_spellings implements exactly that. Re-run
+  against the published catalog it reports 14 groups / 28 records and NOT ONE is in a slice-4
+  make. So none of the 19 are detector-D6. That does not make them non-defects — protocol check 1
+  asks the SEMANTIC question — but the class is wrong wherever the two ids differ by a real TOKEN
+  rather than by separators or a typo. I confirm D6 only where the underlying RAW strings fold,
+  and reclassify the rest. Net effect on the ledger: 8 of 19 keep D6, 9 move to D8/D3/new-class,
+  1 is overturned, 1 partially over-scoped.
+
+reviewed_claims:
+
+  # ---------------- id claims labelled D6 ----------------
+  "truck/scania/r142#id":
+    researcher: defective(D6)
+    verifier: CONFIRMED
+    evidence:
+      - "catalog: truck/scania/r142 'R142' {fi,nl} and truck/scania/r142h 'R142H' {fi,nl} both live."
+      - "ov.tsv r142 -> 'R142 H 4X2 42 CTG.N3 | R142 H 6X2 46 | R142 HL | R142 HL-SCAE2100-8X2 |
+         Scania R142 H 8x2 59'; ov.tsv r142h -> 'R142H 6X2'. 'R142 H 6X2 46' vs 'R142H 6X2' differ
+         by ONE SPACE — the raws DO fold, so D6 is earned and the defect is real."
+    my_own_finding: >-
+      The fold is at the RAW layer, but find_duplicate_spellings reads PUBLISHED names ('R142' vs
+      'R142H'), which do not fold. This collision is structurally invisible to the shipped
+      detector. Not recorded anywhere in the ledger or §10.
+    dissent_on_the_cited_evidence: >-
+      The claim's other leg is NOT established. truck/scania/142's raws are '142 H | 142 H 6X2 46 |
+      142 M | 142 MA 4X2' — cab-letter-less. truck/scania/t142 ('T142 H 6X2', 'T142 HL-6X2/4600+1320')
+      is ALSO live, and the leading letter IS the cab in Scania 2-series nomenclature. A bare
+      '142 H 6X2 46' is therefore ambiguous between R142 and T142 and cannot be assigned to R142.
+      truck/scania/142 is an under-specified fragment (D3), not a proven duplicate of R142. The
+      verdict stands on r142h alone; the evidence line overstates.
+
+  "truck/scania/r164#id":
+    researcher: defective(D6)
+    verifier: CONFIRMED
+    evidence:
+      - "catalog: r164, r164ga, r164gb, r164gb6x4nz all live {fi,nl}."
+      - "ov.tsv r164 contains 'R164 GA 4X2 NA 580', 'R164 GB6X2NB 480', 'R164 GB-6X4 NZ/410+135';
+         r164ga -> 'R164GA 4X2 NA 480'; r164gb -> 'R164GB 6X2/NA'; r164gb6x4nz -> 'R164GB6X4NZ 480'.
+         Spaced and fused writings of one designation split into four ids. Raws fold. D6 correct."
+
+  "truck/spierings/sk#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(D3)
+    evidence:
+      - "catalog: truck/spierings/sk 'Sk' {es,fi,nl}; truck/spierings/at 'At' {fi,nl} — the make's
+         entire published set is these two."
+      - "ov.tsv sk -> 'SK 1265-AT6 | SK 597-AT4 | SK1265-AT5 | SK2400-AT7 | SK365-AT3 | SK377-AT3 |
+         SK487-AT3 | SK488-AT4 | SK498-AT4 | SK597-AT4 | SK599-AT5'.
+         ov.tsv at -> 'AT 3 | AT 3 G | AT 3G | AT 4 | AT 5 | SPIERINGS AT4'."
+      - "AT<n> is the axle-count SUFFIX of the SK designation (SK599-AT5), never a separate
+         Spierings series. `at` is the tail of the same string with the head dropped. The DEFECT is
+         real — but 'sk' and 'at' share no characters, so no fold exists. This is a truncated
+         fragment (D3), whose remedy ('rename to honest family if identifiable; else debt') differs
+         materially from D6's ('merge to canonical')."
+
+  "van/chevrolet/3100-pick-up#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(D8)
+    evidence:
+      - "catalog: van/chevrolet/3100 '3100' {fi,lu,nl} and 3100-pick-up '3100 Pick-Up' {fi,nl} live."
+      - "ov.tsv 3100 -> 'CHEVROLET 3100'; 3100-pick-up has NO ov entry, so its register string is
+         literally '3100 PICK-UP'. The ids differ by the BODY WORD, not by separators. D8."
+
+  "van/chevrolet/astro-van#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(D8)
+    evidence:
+      - "catalog: van/chevrolet/astro 'Astro' {fi,nl} and astro-van 'Astro Van' {fi,nl} live."
+      - "ov.tsv astro -> 'ASTRO 4WD'; astro-van -> 'ASTRO VAN 4WD | CHEVROLET ASTRO VAN'. Same
+         vehicle; the split token is the body word VAN. D8."
+
+  "van/citroen/jumper-oder-relay#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(connector-merged dual-market cell)
+    evidence:
+      - "van/citroen/jumper LIVE {es,fi,lu,nl}; jumper-oder-relay LIVE {es,fi,nl}. Duplicate real,
+         claim is defective. Live nl_rdw count 47 for the exact string (see pre_triaged)."
+      - "Internally inconsistent in the ledger: the SAME record is D6 for [id] and the new class
+         for [name]. One cause, one class — and the researcher's own (correct, and independently
+         verified) argument is that no fold/comma detector can see 'ODER', which excludes D6."
+
+  "van/dodge/ram-van-2-8crd-aut-van#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(D8)
+    evidence:
+      - "catalog: van/dodge/ram-van 'Ram Van' {fi,nl} and ram-van-2-8crd-aut-van
+         'Ram Van 2.8CRD Aut.van' {fi,nl} live. ov.tsv ram-van -> 'DODGE RAM VAN | DODGE RAM-VAN';
+         the long id has no ov entry. Split tokens: ENGINE (2.8CRD) + TRANSMISSION (Aut.) + BODY
+         (van) — the textbook D8 shape."
+
+  "van/fiat/doblo-standard#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(D8)
+    evidence:
+      - "catalog: van/fiat/doblo 'Doblo' {de,es,fi,gb,lu,nl} and doblo-standard 'Doblo Standard'
+         {gb} live. ov.tsv doblo -> 'FIAT DOBLO | FIAT DOBLO'' | Fiat Doblo';
+         doblo-standard -> 'FIAT DOBLO STANDARD'. Split token is a TRIM word. D8."
+
+  "van/ford/transit-costum#id":
+    researcher: defective(D6)
+    verifier: CONFIRMED
+    evidence:
+      - "catalog: transit-custom 'Transit Custom' {de,es,fi,gb,lu,nl} and transit-costum
+         'Transit Costum' {es,nl} both live."
+      - "ov.tsv transit-custom -> 'FORD TRANSIT CUSTOM | TRANSIT CUSTOM KOMBI | …';
+         transit-costum has NO ov entry, so 'TRANSIT COSTUM' is the literal register spelling.
+         Same vehicle, two ids, one transposition typo. D6 in substance."
+    my_own_finding: >-
+      SECOND detector gap: an NFKD case+punct fold cannot equate costum/custom, so
+      find_duplicate_spellings is structurally blind to TYPO splits. Corroborated at scale outside
+      the slice — van/mercedes-benz publishes 'Sprinter' alongside LIVE 'Spinter', 'Spriner' AND
+      'Srinter'. A damerau-levenshtein<=1 pass over same-make+kind names would catch all four.
+      Detector proposal only; audit finds, it does not sweep.
+
+  "van/iveco/35s14-multitel#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(D8)
+    evidence:
+      - "catalog: van/iveco/35s14 '35S14' {es,fi,lu,nl} and 35s14-multitel '35S14 Multitel'
+         {es,fi,nl} live. ov.tsv 35s14 -> '35S14 V | 35S14, 2,3D WB3750 | …';
+         35s14-multitel -> 'IVECO 35S14 - MULTITEL | Iveco 35S14 - Multitel'. Split token is a
+         CONVERTER company (Multitel Pagliero) appended to a chassis code. Same chassis. D8."
+
+  "van/mercedes-benz/300-gd#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(D8)
+    evidence:
+      - "catalog: 300-gd '300 GD' {fi,nl} and 300-gd-2400-van '300 GD 2400 Van' {fi,nl} live.
+         ov.tsv 300-gd-2400-van -> 'MERCEDES-BENZ 300 GD 2400 VAN'. Split tokens are a WHEELBASE
+         (2400 mm) and a BODY word. D8."
+      - "The duplicate is in fact WIDER than charged: van/mercedes-benz/g 'G' is also live, and
+         '300 GD' is a G-Class engine designation, so the nameplate-level parent exists too."
+
+  "van/mercedes-benz/516-cdi#id":
+    researcher: defective(D6)
+    verifier: CONFIRMED
+    evidence:
+      - "catalog: van/mercedes-benz/516 '516' {fi,nl} and 516-cdi '516 CDI' {es,nl} live."
+      - "DECISIVE: ov.tsv for the SHORT id 516 is '516 CDI | 516 CDI (906.153) | 516 CDI F |
+         516 CDI-S' — the bare '516' record was itself derived from '516 CDI' raws. Both ids are
+         fed by one raw family; the split is pure spelling. D6 correct."
+
+  "van/mitsubishi/montero#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(connector-merged dual-market cell)
+    evidence:
+      - "catalog: van/mitsubishi/montero 'Montero' {fi,gb}, van/mitsubishi/pajero 'Pajero', and
+         van/mitsubishi/pajero-montero 'Pajero Montero' {fi,nl} are ALL live."
+      - "ov.tsv montero -> 'MITSUBISHI MONTERO'; pajero-montero -> 'MITSUBISHI PAJERO MONTERO |
+         MITSUBISHI PAJERO/MONTERO'. The raw literally carries both market names joined by '/'.
+         Defect real (three ids, one vehicle) — but this is the researcher's OWN new class, and
+         classing it D6 is what prevented their connector wordlist from covering '/' and
+         bare-space joins."
+
+  "van/opel/combo#id":
+    researcher: defective(D6)
+    verifier: CONFIRMED
+    evidence:
+      - "catalog: combo 'Combo' {de,es,fi,gb,lu,nl}; combo-van 'Combo Van' {es,fi,lu,nl};
+         combo-c-van 'Combo C-Van' {es,fi,nl}; combo-cargo 'Combo Cargo' {es,fi,lu,nl} — all live."
+      - "ov.tsv combo-van -> 'COMBO-C  VAN | COMBO-C VAN | COMBO-C-VAN | COMBO-C-VAN- |
+         OPEL COMBO-C-VAN'; combo-c-van has no ov entry. combo-van and combo-c-van are fed by the
+         SAME raw family differing only in hyphen placement — a true fold collision. D6 earned."
+    partial_dissent: >-
+      combo-cargo does not belong in the group. 'Combo Cargo' is Opel's own current product name
+      for the panel van (raws 'COMBO-E CARGO', 'Combo-e Cargo', 'COMBO CARGO XL 1000KG'), i.e. a
+      marque-attested nameplate. Folding it into 'Combo' is an ALTITUDE judgement (D8), not a
+      spelling merge. Listing it inflates the collision group by one.
+
+  "van/saxas-nutzfahrzeuge-werdau/mkd-43-l#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(D8)
+    confidence: low
+    evidence:
+      - "catalog: mkd-43-l 'Mkd 43-L' {fi,nl}; mkd-43-l-n 'Mkd 43 L N' {es,fi}; mkd-43-l-u
+         'Mkd 43 L U' {fi,nl} — all live, and these three are the make's entire van set."
+      - "No ov entries, so the published names are the register strings. The hyphen-placement half
+         ('43-L' vs '43 L') folds and is D6; the trailing N/U are content tokens of unknown meaning
+         that could be genuine body variants of a box body. I cannot settle N/U from in-repo
+         artifacts, so I uphold the defect on the fold half and mark the suffix half D8, low
+         confidence. Not upgraded to certainty on a guess."
+
+  "van/stx/master-horsebox#id":
+    researcher: defective(D6)
+    verifier: CONFIRMED
+    evidence:
+      - "catalog: van/stx/master 'Master' {es,fi,nl} and master-horsebox 'Master Horsebox'
+         {es,fi,nl} live — IDENTICAL country sets, itself a duplicate tell."
+      - "DECISIVE: ov.tsv van/stx/master -> 'MASTER, HORSEBOX | STX MASTER'. The horsebox raw is
+         attributed to the SHORT id as well, so both ids are fed by one string family. D6 correct."
+      - "corroborating same-shape sibling pair in the same make: van/stx/movano {es,lu,nl} +
+         van/stx/movano-horsebox {fi,nl}."
+
+  "van/vauxhall/astra#id":
+    researcher: defective(D6)
+    verifier: OVERTURNED(unverifiable)
+    evidence:
+      - "catalog: van/vauxhall/astra 'Astra' {gb} and van/vauxhall/astravan 'Astravan' {gb} live.
+         ov.tsv astra -> 'VAUXHALL ASTRA'; astravan -> 'VAUXHALL ASTRAVAN'. Two distinct register
+         strings, no fold, no shared raw."
+      - "I went to the UK source rather than the fold. cache/uk_veh0120_uk.csv carries TWO separate
+         GenModels with substantial independent LGV volume: GenModel 'VAUXHALL ASTRAVAN' with
+         Models ASTRAVAN ENVOY CDTI (1246 licensed / 1758 SORN), ASTRAVAN LS CDTI (152/187),
+         ASTRAVAN MERIT (13/182), ASTRAVAN EPIC (3/54); and GenModel 'VAUXHALL ASTRA' with LGV
+         Models ASTRA CLUB CDTI (3320/2212), ASTRA CLUB ECOFLEX (1187/286), ASTRA CLUB A/C CDTI
+         (149/67). Distinct trim ladders, comparable magnitudes."
+      - "Per the §10.4 logic (comparable volumes argue two products, skew argues one convention),
+         these do not read as a spelling split; and 'Astravan' is a one-word name Vauxhall itself
+         used. But both ARE Astra-derived vans, so distinctness is not proven either. The DEFECT is
+         not established, and I will not confirm it on a same-vehicle assumption. Downgraded to
+         unverifiable, which still counts against the clean rate — so the ledger's headline rate is
+         unaffected by this correction; only the class tally is."
+    pending_marque_fetch: true
+
+  "van/volkswagen/kombiwagen#id":
+    researcher: defective(D6)
+    verifier: RECLASSIFIED(D8)
+    evidence:
+      - "catalog: kombiwagen 'Kombiwagen' {fi,nl} and kombiwagen-23-2400 'Kombiwagen 23/2400'
+         {fi,nl} live — same country set. Split tokens are a TYPE number (23) and a payload figure
+         (2400): altitude, not spelling. D8."
+
+  "van/volkswagen/transport#id":
+    researcher: defective(D6)
+    verifier: CONFIRMED
+    evidence:
+      - "catalog: transport 'Transport' {es,fi,nl} and transporter 'Transporter'
+         {de,es,fi,gb,lu,nl} live. ov.tsv transport -> 'VOLKSWAGEN TRANSPORT' (single raw). VW has
+         no 'Transport' nameplate. A single truncation published beside the full nameplate is the
+         same-car-twice shape D6 names, and D6's remedy (merge to canonical) is the right one."
+
+  # ---------------- D8: trim/body/engine published as model ----------------
+  _D8_block_note: >-
+    All twelve D8 records below were re-derived the same way: confirm the PARENT nameplate is live
+    in the same make+kind, then read the register string that produced the child. Every one has a
+    live parent and a register string whose extra tokens are trim/engine/body/transmission. All
+    CONFIRMED; I found no D8 claim I disagree with. Listing the decisive pair per record.
+  "van/ford/f-150-xlt#id+name":
+    researcher: defective(D8) / defective(D8+D7)
+    verifier: CONFIRMED
+    evidence: ["parent van/ford/f-150 'F-150' {es,fi,gb,lu,nl} LIVE, raws 'F-150 XL', 'F150 4X4 LARIAT'; child raws 'F 150 XLT 4X4 | F-150 XLT 4X4 | F-150 XLT HYBRID'. XLT is a Ford trim level, and the same corpus shows XL/LARIAT/SPORT siblings folded into the parent — so the parent already absorbs trims and this one escaped."]
+  "van/gmc/sierra-at4#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/gmc/sierra 'Sierra' {fi,nl} LIVE (raws 'GMC SIERRA | SIERRA 4WD | SIERRA 4X4 EFI PICK-UP'); child raw 'GMC SIERRA AT4' only. AT4 is a GMC trim. Sibling van/gmc/sierra-denali and van/gmc/sierra-1500 are live too — the same trim-split debt, three ids deep."]
+  "van/ram/1500-laramie#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/ram/1500 '1500' {es,fi,lu,nl} LIVE with raws that ALREADY contain the trim: 'RAM 1500 4X4 LARAMIE | RAM 1500 4X4 LIMITED | RAM 1500 4X4 LONGHORN'. The parent absorbs LARAMIE from one register while another register's spelling minted a second id. Live siblings 1500-limited, 1500-rebel, 1500-rho, 1500-sport, 1500-trx confirm the pattern."]
+  "van/man/tge-multicab#id+name":
+    researcher: defective(D8) / defective(D7+D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/man/tge 'Tge' {de,es,fi,gb,lu,nl} LIVE (raws 'MAN TGE | TGE, 2.0 140 PK VAN FWD AUT'); 'Multicab' is a body/cab configuration. Same shape as live van/volkswagen/crafter-multicab."]
+  "van/iveco/daily-35s13v#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/iveco/daily 'Daily' {de,es,fi,gb,lu,nl} LIVE, and its OWN raws already carry the codes: 'DAILY, 35C16 A8 | DAILY, 35S14 | DAILY, 35S16H A8'. Child raw 'DAILY 35S13V, 5-TRIN'. The chassis code is a variant of a live nameplate."]
+  "van/opel/combo-van-y1-7dtl#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/opel/combo LIVE; child raw 'COMBO-C-VAN Y1.7DTL' — Y17DT is the Opel 1.7 diesel engine code. Engine code as model. D8."]
+  "van/peugeot/expert-2#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/peugeot/expert 'Expert' {de,es,fi,gb,lu,nl} LIVE; child raws 'EXPERT 2, 0 HDI 128 HK L2H2 | EXPERT 2,0 HDI | EXPERT 2,0 HDI 163 L2H1 | EXPERT 2,0HDI'. The '2' is not a generation — it is the truncated first half of the DISPLACEMENT '2,0 HDI'. Worth noting because 'Expert 2' reads like a generation and is not."]
+  "van/peugeot/expert-2-0hdi#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["same parent; child 'Expert 2.0HDI'. Engine designation. Note expert-2 and expert-2-0hdi are ALSO duplicates of each other, both derived from 'EXPERT 2,0 HDI' — a fold pair the D6 detector misses because one side lost a comma."]
+  "van/peugeot/partner-120-l1-1-6hdif#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/peugeot/partner LIVE; child raws 'PARTNER 120 L1 1.6HDIF 66KW - 2PL | … - 3PL'. Payload class + wheelbase + engine + power + seat count. The most extreme altitude case in the slice after the VW partition wall."]
+  "van/volkswagen/caddy-sdi#id+name":
+    researcher: defective(D8) / defective(D7+D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/volkswagen/caddy 'Caddy' LIVE, and the parent's own raws already contain the engine: 'CADDY 51 KW BESTEL 2,0 SDI | CADDY 51 KW BESTEL 2,0 SDI BASELINE'. Child raws 'CADDY SDI 47 KW | CADDY SDI 51 KW BESTEL'. Same engine, two ids."]
+  "van/volkswagen/crafter-aut#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/volkswagen/crafter LIVE; 'Aut' is a TRANSMISSION token. Live siblings crafter-30, crafter-35, crafter-35-bestel-l2-h2, crafter-4motion, crafter-multicab, crafter-z ('Crafter/z') — seven-way split of one nameplate."]
+  "van/volkswagen/id-buzz-cargo-modified-partition-wall#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/volkswagen/id-buzz-cargo 'Id. Buzz Cargo' {fi,lu,nl} LIVE with raws 'ID. BUZZ CARGO 150 KW'. The child's extra tokens describe a BULKHEAD MODIFICATION. This is the clearest single specimen of D8 in the slice and I confirm it without reservation."]
+  "van/volkswagen/touran-van#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["child raws 'TOURAN VAN TDI 100 KW | … 103 KW | … 66 KW | TOURAN VAN, 1,6 TDI' (nl only). VW markets no 'Touran Van'; the nameplate is Touran (live as car/volkswagen/touran) and 'Van' is a body/category word. Charged on the ALTITUDE, not on the cross-kind twin — correct under the researcher's own stated convention."]
+  "van/volkswagen/transporter-sn-double-cab#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["parent van/volkswagen/transporter LIVE {de,es,fi,gb,lu,nl}; 'Sn Double Cab' is a cab configuration. Same nameplate as transporter-caravelle and transporter-ww-caravelle — one nameplate, five live ids."]
+  "van/renault/kangoo-express-z-e#id":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["van/renault/kangoo-express 'Kangoo Express' {es,fi,lu,nl} LIVE (raw 'KANGOO EXPRESS MAXI'), van/renault/kangoo LIVE with 'KANGOO E-TECH ELECTRIC | KANGOO E-TECH BOX' — the electric variant is already absorbed by the parent under its current badge. Z.E. is a powertrain badge. D8."]
+  "van/volvo/940-hearse#name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["'Hearse' is a body word. Correctly charged on NAME ONLY: there is no van/volvo/940, so no same-kind twin exists and the researcher did not over-charge an id defect. car/volvo/940 is cross-kind and excluded by their stated convention. This is a record where their discrimination was right."]
+    my_note: "Inconsistent with the make layer, though: van/nilsson/v70-ambulance gets the CONVERTER as the make while this Volvo hearse (also a converter product) stays under Volvo. That is the researcher's own 'bodybuilder-as-make is applied inconsistently' observation, and this record is a cleaner exhibit than the ones they cite."
+  "van/mercedes-benz/108-d#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["van/mercedes-benz/108 '108' is LIVE alongside 108-d '108 D' — a same-make, same-kind twin at a finer engine altitude. D8."]
+  "van/mercedes-benz/213#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["raws '213 CDI | 213 CDI-9016-2.59T-KASTEN HOCH/300 | 213 CDI-9026-2.8T-KASTEN' — 9016/9026 are W906 Sprinter body codes, and van/mercedes-benz/sprinter is LIVE. A nameplate-less engine designation published beside its live nameplate. D8."]
+  "van/mercedes-benz/315#id+name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["TWO live twins, not one: van/mercedes-benz/315-cdi '315 CDI' AND van/mercedes-benz/sprinter. Raws '315 CDI | 315 CDI 3.2 | 315 CDI KASTENWAGEN | MERCEDES-BENZ 315 CDI'. D8 confirmed and under-stated."]
+  "van/mercedes-benz/516-cdi#name":
+    researcher: defective(D8)
+    verifier: CONFIRMED
+    evidence: ["Sprinter designation without its nameplate; van/mercedes-benz/sprinter live. D8."]
+
+  # ---------------- D7: non-canonical form ----------------
+  _D7_block_note: >-
+    Fifteen of the twenty D7 claims are the SAME mechanism: a model initialism the register writes
+    in caps is published Title-cased. I verified the mechanism rather than trusting it, in two
+    steps. (1) The corpora DO preserve case where the source has it — the same files carry
+    'Scania P94', 'Fiat Doblo', 'Iveco 35S14 - Multitel', 'Combo-e Cargo', 'MAXUS eDELIVER 5',
+    'Ssangyong Rexton'. So an all-caps run is a source fact, not a corpus artifact. (2) The
+    published form is byte-identical in the FRESH build, so none of these is a pending-publish
+    artifact. Both checks pass for every record below. The remaining question — what the MARQUE
+    writes — is what D7 actually turns on, and is marked pending where I did not reach a marque.
+  "truck/tadano-faun/atf#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Atf'; ov.tsv -> 'ATF 100G-4 | ATF 110G-5 | ATF 130G-5 | ATF 180 G-5 | ATF 220G-5 | ATF 400G-6 | ATF 50 G-3 | ATF-140-5.1 | ATF110G-5 …' — 21 distinct forms, EVERY ONE upper-case ATF, across fi+nl. No source anywhere writes 'Atf'."]
+    marque_route_attempted_by_me: >-
+      The ledger records tadano.com as 'JS-only, 404, or connection refused'. That is not why it
+      fails. I reached BOTH tadano.com/products/atf and tadanofaun.de: the second returns
+      302 -> https://www.tadano.com/, and the live product line is served as 'All Terrain Cranes'
+      with models 'AC 5.250L-2' and 'AC 7.450-1'. de.wikipedia.org/wiki/Tadano_Faun likewise shows
+      'Tadano AC 5.250L-2' and no ATF. The marque RETIRED the ATF designation after the Demag
+      acquisition, so no current marque page can render it — the gap is permanent, not transient,
+      and 'try again later' is the wrong queue entry. Recording the real reason changes what the
+      source_gap_queue should say.
+    my_note: "A second, uncharged defect on the same record: 'Atf' is also a SERIES PREFIX, not a model — every raw is ATF <capacity>G-<axles>. So the record is a fragment (D3) as well as mis-cased."
+  "truck/wacker-neuson/dw#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Dw'; ov.tsv -> 'WACKER NEUSON DW'. Sibling records in the same make are 'Dv' (raws 'WACKER NEUSON DV100 | DV125 | DV45 | DV50 | DV60 | DV90') and numeric '3000' (raw 'WACKER NEUSON 3000 SERIES'). Uniform upper-case in source."]
+  "truck/terberg/dt#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Dt'; ov.tsv -> 'TERBERG DT183'. I went to the UK source: uk_veh0120_uk.csv has GenModel 'TERBERG DT183', Model 'DT183LE', 506 licensed + 95 SORN HGV."]
+    my_note: "UNDER-CHARGED. The register model is DT183/DT183LE; the published name 'Dt' is a TRUNCATION as well as a mis-casing. The truncation is the larger defect and is not recorded. Same for sibling 'Yt' (raws YT182/YT193/YT203/YT223)."
+  "truck/sisu/cm#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Cm'; ov.tsv -> 'CM 13M K-APP-8x2/335+140+130 | CM 16M K-AKK-8x4/… | CM13M K-AKK-8X4/… | CM 16m 8x4' — note 'CM 16m' proves the source preserves lower case where it exists, so the caps are real."]
+  "truck/spierings/sk#name":
+    researcher: defective(D7+D9)
+    verifier: CONFIRMED
+    evidence: ["published 'Sk'; every raw is 'SK<number>-AT<n>'. Both halves of the compound verdict hold: mis-cased AND a series prefix standing in for a model."]
+  "truck/volvo/fll#name" :
+    researcher: defective(D9+D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Fll'; ov.tsv -> 'FLL 12 | FLL 240 | FLL 240 4X2R | FLL 42 R | FLL 42R(D)-12T/440 | FLL 42R-14T-A-44…' — uniform caps. Volvo's marketed truck ranges are FL/FE/FM/FMX/FH; 'FLL' with an axle/weight suffix is a type-approval string, and truck/volvo/fl 'FL' is LIVE {es,fi,gb,lu,nl}. D9 and D7 both hold."]
+  "truck/volvo/fmd#name":
+    researcher: defective(D9+D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Fmd'; ov.tsv -> 'FMD11-FM84RB-A12-VTA5411-10X4 | FMD13-FM62RB-VTA4211-8X2/323+137+137 | FMD13-FM84RB-VTA5411-10X4/200+230+137+137+133 | FMD13-VTA4211'. These are ENGINE+CHASSIS type strings (D13 = the 13-litre engine) and the string itself contains 'FM84RB' — i.e. the record IS a type code and truck/volvo/fm 'FM' is live. Strongest D9 in the slice."]
+  "truck/volvo/fll#id + truck/volvo/fmd#id":
+    researcher: defective(D9)
+    verifier: CONFIRMED
+    evidence: ["truck/volvo/fl and truck/volvo/fm are both LIVE across five countries; fll/fmd are code-altitude duplicates of them. Also live in the same make and the same shape: flc, flh, fmfh — so the family is six ids deep, not two."]
+  "van/citroen/ak#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Ak'; ov.tsv -> 'AK-B'. Uniform caps. (Citroën's own Type AK rendering is the pending marque question, but no source anywhere writes 'Ak'.)"]
+    pending_marque_fetch: true
+  "van/kawasaki/kaf#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Kaf'; ov.tsv -> 'KAWASAKI KAF'. Sibling live records Kdf/Kdt with raws 'KAWASAKI KDF'/'KAWASAKI KDT' — same mechanism three times in one make."]
+    my_note: "Uncharged: ov.tsv also carries van/kawasaki/mule ('KAWASAKI MULE') as a BELOW-THRESHOLD candidate. KAF is the type-code prefix of the MULE family, so if that candidate ever crosses the threshold this becomes a duplicate too. Not chargeable now — it is not live — but it is the pre-image of a D9/D6 pair."
+  "van/hyundai/iload#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Iload'; ov.tsv -> 'HYUNDAI ILOAD' (gb, single raw). No source writes 'Iload'; Hyundai's own rendering is the pending marque question but the published form matches neither the register's caps nor any camel-case form."]
+    pending_marque_fetch: true
+  "van/mercedes-benz/x#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["DECISIVE and better than register-only: the corpus itself carries the marque form. ov.tsv van/mercedes-benz/x -> 'MERCEDES X CLASS | X 250D | X-KLASSE | X-KLASSE XL | X-Klasse | X-klasse'. The register writes X-KLASSE/X CLASS and the catalog publishes bare 'X'. No marque fetch needed."]
+  "van/renault/kangoo-express-z-e#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Kangoo Express Z.e' — the lower-case 'e' after a period is not a form any source produces; it is `.capitalize` applied to a dotted initialism. The corpus writes Renault's electric badge as 'E-TECH' in the live parent ('KANGOO E-TECH ELECTRIC')."]
+    pending_marque_fetch: true
+  "van/volkswagen/caddy-sdi#name [D7 half]":
+    researcher: defective(D7+D8)
+    verifier: CONFIRMED
+    evidence: ["published 'Caddy Sdi'; every raw writes 'SDI' in caps ('CADDY SDI 47 KW', 'CADDY 51 KW BESTEL 2,0 SDI'). SDI is VW's engine initialism."]
+  "van/maxus/e-deliver-9#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'E-Deliver 9'; the corpus PROVES the marque's camel-case form because it survives elsewhere in the same make: ov.tsv van/maxus/edeliver-5 -> 'MAXUS EDELIVER 5 | MAXUS eDELIVER 5' and edeliver-7 -> 'MAXUS eDELIVER 7', and e-deliver-3 -> 'MAXUS e-DELIVER 3'. So a lower-case leading 'e' IS attested in-corpus and the catalog title-cased it."]
+    my_note: "Under-charged: the make also publishes 'Deliver 9', 'E-Deliver 3', 'Edeliver 5', 'Edeliver 7', 'E Terron 9' — five different renderings of one naming convention. The D7 defect here is a symptom of an unpinned make-wide styling, not a single record."
+  "van/ssangyong/actyon-sport#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Actyon Sport' (singular); ov.tsv van/ssangyong/actyon -> 'ACTYON SPORTS | ACTYON SPORTS A200 XDI 2WD | ACTYON SPORTS A200 XDI 4WD | SSANGYONG ACTYON SPORTS' — the PLURAL is what four of the five register forms say. The singular comes from one raw ('SSANGYONG ACTYON SPORT'). Confirmed on corpus evidence alone."]
+  "van/dodge/w-250#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'W 250'. Sibling van/dodge/w-200 shows the register's own spread: 'DODGE W 200 | DODGE W-200 | W 200 4X4' — the hyphenated form is attested in-source and the space form was chosen without a marque tiebreak."]
+    pending_marque_fetch: true
+  "van/saxas-nutzfahrzeuge-werdau/mkd-43-l#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["published 'Mkd 43-L'; the make's raws across BOTH its make-spellings are uniformly caps: 'MKD 61 - M - E | MKD 71-M-E | MKD 72-M-E | MKD 73 - M - E'. MKD is an initialism."]
+  "van/ford/transit-costum#name":
+    researcher: defective(D7)
+    verifier: CONFIRMED
+    evidence: ["'Transit Costum' is a misspelling of Transit Custom, and the correctly-spelled id is live in the same make+kind with six countries. Confirmed without needing Ford."]
+  "van/ford/f-150-xlt#name [D7 half]":
+    researcher: defective(D8+D7)
+    verifier: CONFIRMED
+    evidence: ["'Xlt' — every raw writes XLT in caps. Same initialism mechanism."]
+  "van/man/tge-multicab#name [D7 half]":
+    researcher: defective(D7+D8)
+    verifier: CONFIRMED
+    evidence: ["'Tge' — raws 'MAN TGE', 'TGE, 2.0 140 PK VAN FWD AUT'. Note the PARENT record van/man/tge is ALSO published as 'Tge', i.e. the same D7 defect sits on a six-country record that this slice did not sample. The scale claim in the ledger is if anything conservative."]
+
+  # ---------------- D9: registry/type code as model ----------------
+  "van/iveco/35s11v#id+name AND van/iveco/35s18#id+name":
+    researcher: defective(D9)
+    verifier: CONFIRMED
+    evidence: ["van/iveco/daily 'Daily' {de,es,fi,gb,lu,nl} is LIVE and its OWN raws carry these codes: 'DAILY, 35C16 A8 | DAILY, 35S14 | DAILY, 35S16H A8 | DAILY,35C11'. 35S11V/35S14/35S18 are Daily payload/power chassis codes; ov.tsv 35s18 -> 'IVECO 35S18'. Type code as model AND duplicate of a live nameplate."]
+  "van/mercedes-benz/906-ba-35#id+name":
+    researcher: defective(D9)
+    verifier: CONFIRMED
+    evidence: ["906 is the Sprinter W906 series and BA-35 a body/weight code; ov.tsv -> 'MERCEDES-BENZ 906 BA35'. van/mercedes-benz/906 '906' is LIVE, as are 906-ka-30, 906-ka-35, 906-ok-30, 902-ka, 903, 903-6-308cdi — and, decisively, van/mercedes-benz/906-ka-35-sprinter-315cdi, which shows the same series code with the nameplate ATTACHED. Nine live ids of one Sprinter."]
+  "van/volkswagen/7j0#id+name":
+    researcher: defective(D9)
+    verifier: CONFIRMED
+    evidence: ["'7J0' is a VW type/chassis code (T5-generation Transporter family), published {es,nl} beside the live 'Transporter'. No ov entry, so '7J0' is the literal register string. Numeric/alphanumeric type code as model."]
+  "van/teijo/24#name":
+    researcher: defective(D9)
+    verifier: CONFIRMED
+    evidence: ["I went to the Finnish source rather than the corpus, because Teijo has NO ov.tsv entry at all. Reading cache/fi_traficom_register.zip directly: Teijo's N1 rows carry model strings 'AVOLAVA-24-01/2420' and 'AVOLAVA-30-02/3000' (avolava = flatbed); the great majority of Teijo rows are O1/O3/O4 TRAILERS ('VP-3LK-86/135+405+135', 'PPB-2L-125', 'PP-2L-122'). The published name '24' is a fragment lifted out of the type string 'AVOLAVA-24-01/2420'."]
+    my_note: "D1 (parser artifact — fabricated name) fits at least as well as D9, and this exposes a detector hole worth recording: D1's detector is 'numeric_only + single-source', and van/teijo/24 is numeric-only but TWO-source (fi+nl), so it slips past. A numeric-only name should be suspect at any source count."
+  "van/mercedes-benz/l#id":
+    researcher: defective(D9)
+    verifier: RECLASSIFIED(D3)
+    evidence: ["ov.tsv van/mercedes-benz/l -> 'L 1500 | L 206 | L 206 AR | L 206 D | L 206 D/2,4 T | L 206 DG | L 207 | L 207 D | L 306 CR | L 306 D | L 306 DG | L 307 | L 311 | L 319 | L 319 B | L 319/319.040.'. The record pools L 206, L 306, L 307, L 311, L 319 and L 1500 — six distinct models spanning the Düsseldorf and Bremen transporters. 'L' is not a registry code (D9); it is a bare series letter, i.e. a fragment. D3, which the researcher themselves used for the NAME claim on the same record — the two halves of one record were given different classes for the same string."]
+  "van/mercedes-benz/l#name":
+    researcher: defective(D3)
+    verifier: CONFIRMED
+    evidence: ["same corpus evidence; a single letter spanning six nameplates is the D3 shape exactly."]
+  "van/volkswagen/kombiwagen#name AND van/volkswagen/transport#name":
+    researcher: defective(D3)
+    verifier: CONFIRMED
+    evidence: ["'Kombiwagen' is the German body word (estate/combi) and 'Transport' a truncation of Transporter; both are published beside the live 'Transporter'. Raw for transport is the single string 'VOLKSWAGEN TRANSPORT'. Body word and truncation are both D3."]
+
+  # ---------------- D11 / D12 / D4: make-layer ----------------
+  "van/renault/theault#make AND van/renault/theault#id":
+    researcher: defective(D11)
+    verifier: CONFIRMED
+    evidence: ["DECISIVE and in-repo: `theault` is ALREADY A LIVE MAKE. catalog/van/makes.json contains {\"id\":\"theault\",\"name\":\"Theault\",\"kinds\":[\"van\"],\"countries\":[\"fi\",\"lu\",\"nl\"]} with live models van/theault/first-eo (\"First'eo\") and van/theault/proteo. Théault is a French horsebox builder. So the register string 'RENAULT THEAULT' is unambiguously filing ONE marque's product under another — which is exactly the moves.yml rule-3 condition ('Only move when the register is unambiguously filing ONE marque's model under another'). D11 confirmed without any external fetch."]
+  "van/renault/theault#name":
+    researcher: "defective(third-party converter company as nameplate — taxonomy gap, no D number)"
+    verifier: RECLASSIFIED(D5)
+    evidence: ["D5 is 'embedded make/brand prefix' with remedy 'rename; if cross-make badge -> move'. This IS a cross-make badge, and the remedy the researcher wants (move to the live `theault` make) is D5's own remedy. The taxonomy is not silent here."]
+    partial_concession: "D5's example ('JAECOO5 EV', 'PIAGGIO VESPA…') is a PREFIX case, whereas here the badge is the whole string. So the researcher's instinct that the row does not describe this cleanly has some merit — but that is a wording gap in an existing row, not a missing class, and it must not be counted as a new class alongside their genuine one (which would inflate the taxonomy finding from one to two)."
+  "van/ford/swift#make":
+    researcher: defective(D11)
+    verifier: CONFIRMED
+    evidence: ["I went to the UK source. uk_veh0120_uk.csv GenModel 'FORD SWIFT' resolves to Models 'SWIFT VOYAGER 540 AUTOMATIC' (396 licensed LGV), 'SWIFT TREKKER X AUTO' (205), 'SWIFT MONZA AUTO' (202), 'SWIFT VOYAGER 584 AUTOMATIC' (293), 'SWIFT VOYAGER 594 AUTOMATIC' (281), plus HGV rows. Voyager / Trekker / Monza are Swift Group motorhome ranges on Ford Transit bases. The marque-of-sale is Swift; Ford is the chassis supplier."]
+  "van/ford/swift#name":
+    researcher: "defective(taxonomy gap)"
+    verifier: RECLASSIFIED(D5)
+    evidence: ["same reasoning as theault. Additionally the published name is doubly wrong: the actual nameplates in the source are Voyager/Trekker/Monza, so 'Swift' is not only the converter's company name but also discards the real model names."]
+    my_note: "No `swift` make exists in kind=van, so unlike theault this needs a make MINTED, not just a move. That is a real difference in remedy cost and the ledger does not distinguish the two cases."
+  "van/mercedes-benz/westfalia#make":
+    researcher: defective(D11)
+    verifier: CONFIRMED
+    evidence: ["ov.tsv -> 'MERCEDES WESTFALIA | WESTFALIA JAMES COOK'. 'James Cook' is Westfalia's Sprinter-based motorhome model, so the string names the converter's product line explicitly. A Westfalia make already exists in the catalog in another kind: catalog/car/makes.json has `westfalia-mobil-gmbh` with car/westfalia-mobil-gmbh/nugget."]
+    my_note: "The same make publishes four more converter-as-model records the slice did not sample — van/mercedes-benz/carthago, /hymer, /rapido, /kerstner. Five instances in one make makes this a make-level sweep candidate, not a record-level fix."
+  "van/mercedes-benz/westfalia#name":
+    researcher: "defective(taxonomy gap)"
+    verifier: RECLASSIFIED(D5)
+  "van/iveco-igloocar/igloocar#make":
+    researcher: defective(D12)
+    verifier: CONFIRMED
+    evidence: ["catalog/van/makes.json: {\"id\":\"iveco-igloocar\",\"slug\":\"iveco-igloocar\",\"name\":\"Iveco / Igloocar\",\"kinds\":[\"van\"],\"countries\":[\"lu\",\"nl\"]} — a make whose NAME is two marques joined by a slash, coexisting with the live `iveco` make {de,es,fi,gb,lu,nl}. D12 (make near-dupe / corporate string) holds."]
+    my_extension: "This is ALSO an instance of the researcher's own new connector class, at the MAKE axis, which their proposal (a model-cell detector) would never reach. Recorded under the new-class entry above."
+  "van/iveco-igloocar/igloocar#name":
+    researcher: defective(D4)
+    verifier: CONFIRMED
+    evidence: ["D4 is 'make-as-model, detector name==make'. The model name 'Igloocar' is literally the second half of its own make name 'Iveco / Igloocar'. Textbook D4."]
+  "van/iveco/35s14-multitel#make":
+    researcher: defective(D11)
+    verifier: OVERTURNED(correct)
+    evidence:
+      - "D11 is 'wrong make — approval holder', remedy moves.yml, and moves.yml rule 3 permits a move ONLY when 'the register is unambiguously filing ONE marque's model under another'. That condition FAILS here: the vehicle IS an Iveco Daily 35S14 — the chassis, the type approval and the model code are all Iveco's — carrying a Multitel aerial platform. Iveco is not the wrong marque; it is the marque of the base vehicle."
+      - "Contrast with theault/swift/westfalia, where the register string names ONLY the converter's product ('THEAULT', 'SWIFT VOYAGER 540', 'WESTFALIA JAMES COOK') and no base-vehicle model survives. Here the base model survives IN THE STRING ('IVECO 35S14 - MULTITEL'), which is precisely the distinguishing test."
+      - "The researcher's own OBSERVATION entry concedes the bodybuilder-as-make policy is applied inconsistently and is unsettled. Charging a per-record make DEFECT against an unsettled policy is the error §6.5 guards against (a batch may not conclude alone) and it double-counts: the same record is already charged D6 on id and D9 on name for the Multitel token. The name-layer defect is real; the make-layer one is not."
+    net_effect: "make tally 5 defective -> 4."
+
+  # ---------------- D10: availability ----------------
+  "van/fiat/strada#availability:gb":
+    researcher: defective(D10)
+    verifier: OVERTURNED(correct)
+    evidence:
+      - "The ledger asserts 'the only gb LGV rows are a SORN Strada Abarth MK3 hatchback'. Reading
+         cache/uk_veh0120_uk.csv directly (BodyType,Make,GenModel,Model,Fuel,LicenceStatus,2026 Q1),
+         Make=FIAT GenModel=FIAT STRADA has FOUR distinct Light-goods-vehicle Models, not one:
+           Light goods vehicles,FIAT,FIAT STRADA,STRADA 70 CL BIANCA,Diesel,Licensed
+           Light goods vehicles,FIAT,FIAT STRADA,STRADA SAN REMO,Diesel,Licensed
+           Light goods vehicles,FIAT,FIAT STRADA,STRADA ABARTH MK3,Diesel,Licensed
+           Light goods vehicles,FIAT,FIAT STRADA,STRADA ABARTH MK3,Diesel,SORN"
+      - "Three separate corrections to the claim: (a) there are four LGV rows, not one; (b) STRADA
+         ABARTH MK3 appears LICENSED as well as SORN, so even the cited row is not SORN-only;
+         (c) STRADA 70 CL BIANCA and STRADA SAN REMO are Licensed LGV rows and are not the Abarth."
+      - "There are ALSO Heavy-goods-vehicle rows (STRADA 65 L Licensed, STRADA SAN REMO Licensed),
+         so the UK register evidences the Fiat Strada as a commercial vehicle at both weights."
+      - "The gb availability entry on van/fiat/strada is therefore evidenced by the register under
+         the published derivation rule (UK BodyType LGV -> van). The claim is wrong on the facts."
+    significance: "This was the ledger's ONLY defective availability claim in 222. Overturning it takes availability to 222/222 correct and removes D10 from the slice entirely."
+
+# ===========================================================================
+# C. UNVERIFIABLE CLAIMS — alternative routes
+# ===========================================================================
+# Rule applied: an `unverifiable` is only allowed to stand if I ALSO failed by a
+# different route. Two of them turned out not to need any external source at all.
+
+unverifiable_review:
+
+  "van/saxas-nutzfahrzeuge-werdau/mkd-43-l#make":
+    researcher: "unverifiable(register spellings are corporate forms; marque page not reached)"
+    verifier: RESOLVED(defective D12)
+    route: "in-repo containment scan — no marque page needed"
+    evidence:
+      - "The stated blocker is not the binding one. D12's own detector is a CONTAINMENT SCAN plus
+         model-overlap evidence, and both fire here on published data alone."
+      - "catalog/truck/makes.json contains BOTH {\"id\":\"saxas\",\"name\":\"Saxas\",\"countries\":
+         [\"es\",\"lu\"]} AND {\"id\":\"saxas-nutzfahrzeuge-werdau\",\"name\":\"Saxas Nutzfahrzeuge
+         Werdau\",\"countries\":[\"es\",\"fi\",\"nl\"]} — the short marque form and the corporate
+         string are BOTH LIVE MAKES."
+      - "The model-overlap evidence D12 requires is present and exact: truck/saxas/mkd ('Mkd',
+         es+lu) and truck/saxas-nutzfahrzeuge-werdau/mkd ('Mkd', es+fi+nl) are both live, same
+         name, same kind — and their raw strings are the SAME family. ov.tsv truck/saxas/mkd ->
+         'MKD 1-M | MKD 61 - M - E | MKD 61-3-E | MKD 61-M-E | MKD 71 - M - E | MKD 72-M-E |
+         MKD 73 - M - E | MKD73-M-E'; ov.tsv truck/saxas-nutzfahrzeuge-werdau/mkd -> 'MKD 61 - M |
+         MKD 61-M-E | MKD 66-M-E | MKD 71-M-E | MKD 72-M-E | MKD 73 - M - E | …'. MKD 61-M-E,
+         MKD 71-M-E, MKD 72-M-E and MKD 73-M-E each appear under BOTH makes."
+      - "The curation layer already knows this marque has corporate-string variants and stops short
+         of the merge: overrides/makes/aliases.yml line 238 maps
+         \"SAXAS NUTZFAHR WRDAU GMBH\": Saxas Nutzfahrzeuge Werdau — it normalises a garbled
+         corporate string TO the corporate form, and never reconciles it with `saxas`."
+      - "Two further spellings sit in the candidate space below threshold:
+         truck/saxas-nutzfahr-werdau-ag/{cf,lf,mdk,mkd} and truck/saxas-nutzfahrzeuge/mkd — the
+         same marque under FOUR ids in total."
+    net_effect: "make tally: one unverifiable becomes one defective(D12). Also promotes the finding from a record-level note to a make-merge candidate the ledger does not carry."
+
+  "van/ssangyong/actyon-sport#id":
+    researcher: "unverifiable(cannot be determined from the published artifacts)"
+    verifier: RESOLVED(defective D6)
+    route: "the published pipeline artifact the researcher did not consult answers it directly"
+    evidence:
+      - "The stated blocker is 'whether they land on van/ssangyong/actyon or are dropped cannot be
+         determined from the published artifacts'. build/observed_variants.json IS a published
+         pipeline artifact and it states the attribution outright: van/ssangyong/actyon ->
+         'ACTYON SPORTS | ACTYON SPORTS A200 XDI 2WD | ACTYON SPORTS A200 XDI 4WD |
+         ACTYON SPORTS A200 XDI 4WD AUT. | SSANGYONG ACTYON SPORTS'."
+      - "So the ACTYON SPORTS rows DO land on the live id van/ssangyong/actyon {lu,nl}, and
+         van/ssangyong/actyon-sport {es,nl} (raw 'SSANGYONG ACTYON SPORT') is a second id for the
+         same pickup, differing only by the plural S. That folds — genuine D6."
+      - "corroborating third spelling below threshold: van/ssangyong/action-sport
+         ('SSANGYONG ACTION SPORT')."
+    net_effect: "id tally: one unverifiable becomes one defective(D6)."
+
+  "truck/scania/p460#id":
+    researcher: "unverifiable(sibling truck/scania/460 is a bare power rating; overlap unresolvable)"
+    verifier: CONFIRMED(unverifiable)
+    route: "catalog enumeration of the whole Scania designation space"
+    evidence:
+      - "I enumerated all 196 live truck/scania records. The power number 460 appears as
+         truck/scania/460 '460' {es,nl}, and as the cab-prefixed g460, p460, r460 — all live. A
+         bare '460' row cannot be assigned to the P cab rather than the G or R cab, because all
+         three exist. The researcher's reasoning is sound and I reach the same wall by an
+         independent route (whole-space enumeration rather than their two-row check)."
+      - "Same structure recurs at 480, 500, 410, 420, 440, 450, 490, 520, 560, 580, 590, 730, 770 —
+         so this is a systematic ~14-record ambiguity, not a one-record puzzle. That scale point is
+         not in the ledger and is the more useful form of the finding."
+
+  "truck/scania/p460#name AND r580#name AND s530#name":
+    researcher: "unverifiable(scania.com/scania.co.uk 404/JS-only to curl)"
+    verifier: CONFIRMED(unverifiable)
+    route_attempted: "SWEDISH Wikipedia (Scania's home market) — a route the ledger did not try"
+    evidence:
+      - "https://sv.wikipedia.org/wiki/Scania_3-serien — REACHED, and it renders the legacy
+         designations FUSED, cab letter and number and chassis letter run together: verbatim
+         'Scania 143H 450', 'Scania 143M 420', 'Scania T93M 250', 'Scania 113H', 'Scania T143H',
+         'Scania T143M 500', 'Scania 93M'."
+      - "This RESOLVES the legacy half of the Scania source gap — it is affirmative support for the
+         fused published forms R94, R142, R143, R164 (and therefore for the researcher's `correct`
+         verdicts on truck/scania/r94#name and r142#name, which they reached from the register)."
+      - "It does NOT resolve p460/r580/s530: the page carries no current-generation P/R/S
+         power-suffix designation at all, so the space-vs-fused question for 'R 580' remains open.
+         The researcher's unverifiable verdict on those three stands, now with a second failed
+         route behind it rather than one."
+      - "COLLATERAL: the same page writes '143H' AND 'T143H' as separate designations for the same
+         era, i.e. the cab letter is genuinely optional in the marque's own rendering. That is
+         independent support for my dissent on truck/scania/r142#id — a bare '142' really cannot be
+         assigned to the R cab rather than the T cab."
+
+  "truck/steyr/586#name":
+    researcher: "unverifiable(de.wikipedia 'Steyr 586' does not exist)"
+    verifier: CONFIRMED(unverifiable)
+    route: "in-repo corroboration attempt"
+    evidence:
+      - "ov.tsv truck/steyr/586 -> '586 AQZ | 586/4200'; sibling truck/steyr/680 -> '680 M3-6X6/276
+         | A 680 G | A 680 GL', and the make's other records are 8S14/9S18/12S14/13S23/19S24/27S42
+         type strings. So '586' is consistent with a real Steyr type number but the corpus cannot
+         establish the marque's rendering, and the make's own naming is dominated by a DIFFERENT
+         scheme (weight-class S power). Register-only would be an over-claim. Verdict upheld."
+
+  "truck/volvo/f610#name":
+    researcher: "unverifiable(en.wikipedia Volvo F4/F6/F7 is a stub)"
+    verifier: CONFIRMED(unverifiable)
+    evidence:
+      - "in-repo corroboration is stronger than the ledger records: ov.tsv truck/volvo/f (the bare
+         'F' record) contains the whole family as register strings — 'F 609 | F 610 | F 610 N |
+         F 610N | F 611 | F 612 | F 613 | F 613-1-V/4600 | F 614 | F 616 S'. So F610 sits inside a
+         contiguous attested run F609…F616, which is why it is not a defect. But an attested
+         REGISTER run is not a marque rendering, so unverifiable is right."
+
+  "van/fiat/280#id AND van/fiat/280#name":
+    researcher: "unverifiable(280 as nameplate vs Ducato Type-280 chassis code)"
+    verifier: PENDING(alternative-route fetch outstanding)
+    evidence_gathered:
+      - "ov.tsv van/fiat/280 -> '280 MAXI | 280 MAXI CAMPER | 280/ DR 65 | FIAT 280'. 'MAXI' is a
+         Ducato body/payload designation and van/fiat/ducato's own raws are saturated with it:
+         'DUCATO  MAXI | DUCATO MAXI 2.5 D | DUCATO MAXI 2.8 JTD | DUCATO MAXI 35 2.3 JTD'. That
+         is a strong in-repo pointer toward the Type-280 Ducato reading, and it is evidence the
+         ledger does not cite — but 'MAXI' is not exclusive to Ducato and I will not close a
+         nameplate question on a shared body word."
+    interim_position: "verdict held as unverifiable pending the marque route."
+    pending_marque_fetch: true
+
+  "van/goupil/g4l#id AND van/goupil/g4l#name":
+    researcher: "unverifiable(G4L not in the marque's listed range)"
+    verifier: PENDING(alternative-route fetch outstanding)
+    evidence_gathered:
+      - "in-repo evidence the ledger does not cite, and it cuts toward G4L being REAL: the
+         candidate space contains van/goupil/g4-l-n1-automatic with the raw string
+         'GOUPIL G4 L N1 AUTOMATIC' — i.e. a register writes 'G4 L' with N1 (the EU category) and
+         AUTOMATIC as separate trailing tokens, which reads as a genuine 'G4 L' variant rather than
+         a corrupted 'G4'. van/goupil/g4 and van/goupil/g6 and van/goupil/g3 are all live."
+    interim_position: "unverifiable upheld, but the ledger's framing ('whether G4L is a discontinued model or a register variant of G4') now has a concrete in-repo datum on the 'real variant' side."
+    pending_marque_fetch: true
+
+  "van/mercedes-benz/300-gd#name":
+    researcher: "unverifiable(no reachable Mercedes source for the W460 badge)"
+    verifier: PENDING(alternative-route fetch outstanding)
+    evidence_gathered: ["van/mercedes-benz/g 'G' is live, and siblings 240-gd, 250-gd, 290-gd, 290-gd-turbodiesel, 300-ge are all live with the same spaced two-token form — an internally consistent family, but the catalog agreeing with itself is not marque evidence."]
+    pending_marque_fetch: true
+
+  "REMAINING unverifiable name claims: ameline/master, edward-davies/ranger, dfsk/ec75, ford/fiesta-van, toyota/lite-ace, volkswagen/caddy-life":
+    researcher: unverifiable (various)
+    verifier: PENDING(alternative-route fetch outstanding)
+    routes_attempted: "delegated retrieval against manufacturer domains with a browser UA, plus fr/de/nl/fi/es/it Wikipedia; archive.org excluded as blocked. Not returned at time of writing."
+    in_repo_notes:
+      - "van/dfsk/ec75 — the family argument is stronger than the ledger states: the make publishes C31, C32, C35, EC31, EC35, EC75, K01H, Loadhopper, each with a single clean raw ('DFSK EC31', 'DFSK EC35', 'DFSK C35'…). EC75 is formally identical to six attested siblings."
+      - "van/toyota/lite-ace — ov.tsv holds only 'TOYOTA LITE ACE' (spaced). The ledger's claim that observed_model_names carries both 'Lite Ace' and 'Lite-Ace' is the sort of cross-market conflict that genuinely blocks a verdict, so the verdict is right; I simply could not add to it without Toyota."
+      - "van/ameline/master, van/edward-davies/ranger — both makes publish a converter name with the BASE MARQUE's nameplate as the model (Ameline/Master = Renault's, Edward Davies/Ranger = Ford's; edward-davies also publishes 'Transit Custom'). Whatever the marque pages say, this is the same converter-as-make shape as stx/nilsson/theault, and the ledger is right that `correct` would overstate."
+
+# ===========================================================================
+# D. SPOT-CHECK OF `correct` VERDICTS
+# ===========================================================================
+
+spot_check:
+  selection_rule: >-
+    Pool = every claim in the ledger of class `id` or `name` verdicted `correct` (49 + 30 = 79).
+    Sorted lexicographically on "<record>\t<claim>", every 3rd starting at index 0, first 25.
+    Reproducible verbatim:
+      awk -F'\t' '($2=="id"||$2=="name") && $3=="correct"' claims.tsv | sort | awk 'NR%3==1' | head -25
+    I chose the CLAIM pool rather than every-Nth RECORD because an every-Nth record walk over this
+    slice lands mostly on defective records and would have yielded far fewer than 25 `correct`
+    claims to test — i.e. it would have tested the researcher where they were already suspicious.
+  results:
+    matched: 21
+    misses: 1
+    probable_misses_flagged_not_asserted: 3
+  detail:
+    "truck/scania/r142#name": {verifier: MATCH, evidence: "published 'R142'; register forms 'R142 H 4X2 42 CTG.N3', 'R142 HL', 'Scania R142 H 8x2 59' — the base designation is what is published. Marque rendering outstanding but nothing contradicts it."}
+    "truck/scania/r94#id":    {verifier: MATCH, evidence: "no id in the 196-record Scania space folds with R94; raws 'R94 4X2 | R94 DB 4X2 NB230 | R94 LB4X2NA 300'. truck/scania/94 and /p94 are separate cab/cab-less designations, same non-assignability as the 142 case, so neither is a proven twin."}
+    "truck/sisu/cm#id":       {verifier: MATCH, evidence: "Sisu's published van/truck set is ck, cm, e11m, e12m, r500, sk, sm; no cm-family twin (cm13m, cm16m are not published). Raws 'CM 13M K-APP-8x2/…', 'CM13M K-AKK-8x4/…' fold to each other but both sit on the one id — correct."}
+    "truck/steyr/586#id":     {verifier: MATCH, evidence: "truck/steyr publishes only 586 and 680. No twin."}
+    "truck/toyota/dyna#id":   {verifier: MISS, severity: real, evidence: "truck/toyota/bu 'Bu' {fi,nl} is LIVE and its raws are 'BU 15 L-H | BU 92'. truck/toyota/dyna's OWN raws are 'DYNA DIESEL BU15L-H/3440', 'DYNA BU92L-MDDHTW', 'DYNA BU75L-MDDTW-3.5T', 'DYNA BU85L-MDDHTW' — the identical BU chassis codes with the nameplate attached. So a live id (the code-only `bu`) denotes the same vehicle as `dyna`, and the id-canonical claim fails. Class D9 (type code as model) on `bu`, making `dyna` non-canonical. Corroborating second pair in the same make that the slice did not sample: truck/toyota/cruiser (raws 'LAND CRUISER | LAND CRUISER 100 S | TOYOTA LAND CRUISER (200 SERIES)') is live beside truck/toyota/land-cruiser."}
+    "truck/volta-trucks/zero#name": {verifier: MATCH, evidence: "raws 'VOLTA TRUCKS ZERO | VOLTA ZERO'; published 'Zero' under make volta-trucks reconstructs 'Volta Zero' exactly."}
+    "van/ameline/master#id":  {verifier: MATCH, evidence: "van/ameline publishes exactly one model. No twin possible."}
+    "van/chevrolet/k10#id":   {verifier: MATCH, evidence: "van/chevrolet/k1500 is live but K10 (pre-1988 half-ton C/K) and K1500 (post-1988) are distinct designations with distinct raws ('CHEVROLET K10' vs 'CHEVROLET K 1500 | CHEVROLET K1500 | K 1500 4X4 SPORTSIDE-DK14K'). Not a fold, not a twin."}
+    "van/chevrolet/suburban#name": {verifier: MATCH, evidence: "raws 'CHEVROLET SUBURBAN | SUBURBAN 4WD | SUBURBAN 4WD U9'; published 'Suburban'."}
+    "van/daihatsu/midget#name": {verifier: MATCH, evidence: "raws 'DAIHATSU MIDGET | MIDGET II'; published 'Midget' is the family form and MIDGET II is the generation."}
+    "van/edward-davies/ranger#id": {verifier: MATCH, evidence: "make publishes ranger + transit-custom only; no twin."}
+    "van/ford/escort#id":     {verifier: MATCH, evidence: "van/ford publishes one Escort id; raws 'ESCORT ESTATE LASER 1.60 | ESCORT ESTATE VAN 1.3 | FORD ESCORT' all fold onto it. Notably the trim/body strings were absorbed here rather than minting ids — the opposite of the D8 records, so the pipeline is capable of it."}
+    "van/ford/swift#id":      {verifier: MATCH, evidence: "no second Swift id under Ford. (The make claim is separately defective; the id claim is sound.)"}
+    "van/goupil/g6#id":       {verifier: MATCH, evidence: "goupil publishes g3, g4, g4l, g6; no g6 twin."}
+    "van/great-wall/steed#name": {verifier: MATCH, evidence: "raw 'GREAT WALL STEED'; published 'Steed'."}
+    "van/hyundai/iload#id":   {verifier: PROBABLE_MISS, asserted: false, evidence: "van/hyundai/h-1 'H-1' {es,fi,nl} is live and its raw is a comma-merged multi-market cell — 'H1-, STAREX, GRAND STAREX' — i.e. the register itself pools this vehicle's market names. iLoad is the Australasian market name of the same TQ-generation van, which would make van/hyundai/iload {gb} a fourth market name for a live id. I am NOT asserting this: the raw names H1/Starex/Grand Starex and NOT iLoad, so the equivalence needs a Hyundai source I did not reach. Flagged, not charged."}
+    "van/ldv/200-series#id":  {verifier: MATCH, evidence: "ldv publishes 200-series, 400-series, cub, maxus, v80; raw 'LDV 200 SERIES'. van/leyland-daf/200 is a DIFFERENT make (the LDV/Leyland-DAF lineage question is a make-history matter, not an id collision within a make)."}
+    "van/ldv/cub#name":       {verifier: MATCH, evidence: "raw 'LDV CUB'; published 'Cub'. register-only, correctly classed as such by the researcher."}
+    "van/maxus/e-deliver-9#id": {verifier: MATCH, evidence: "the make publishes deliver-9, e-deliver-3, e-deliver-9, edeliver-5, edeliver-7 — but no edeliver-9 or e-deliver-9 twin. van/maxus/edeliver9 exists ONLY as a below-threshold candidate ('MAXUS EDELIVER9'), so it is not a live twin today. Correct as published, though it is one threshold crossing away from being a D6."}
+    "van/mercedes-benz/v-class#id": {verifier: PROBABLE_MISS, asserted: false, evidence: "van/mercedes-benz/v 'V' {fi,nl} is LIVE with no ov entry, i.e. its register string is the bare letter 'V'. van/mercedes-benz/v-class's raws are 'MERCEDES V CLASS | MERCEDES-BENZ V-KLASSE | V 200 CDI MPV | V 220 CDI | V 230 TD | V-KLASSE 220D'. A bare 'V' under Mercedes vans is almost certainly the same V-Class, which would make v-class#id non-canonical. I am NOT asserting it — 'V' could in principle be a truncation of something else — but I note the internal inconsistency: the researcher charged the exactly analogous bare 'X' record as D7 on name while leaving the bare 'V' unremarked and v-class#id correct."}
+    "van/mercedes-benz/westfalia#id": {verifier: MATCH, evidence: "one Westfalia id under mercedes-benz. The make claim is separately defective; the id claim holds."}
+    "van/mitsubishi/triton#id": {verifier: PROBABLE_MISS, asserted: false, evidence: "van/mitsubishi/l200 'L200' {es,fi,gb,lu,nl} is live; Triton {th} is the ASEAN market name of the same pickup. This is structurally IDENTICAL to van/mitsubishi/montero, which the researcher DID charge (Montero = the Spanish market name of the Pajero) — so by the ledger's own standard Triton should have been charged too. I flag rather than assert because, unlike the Pajero case, no raw string here joins the two names (montero had 'MITSUBISHI PAJERO/MONTERO' to prove it); establishing Triton==L200 needs a Mitsubishi source."}
+    "van/nilsson/v70-ambulance#name": {verifier: MATCH, evidence: "raw 'NILSSON V70 AMBULANCE'; published 'V70 Ambulance' under make nilsson reconstructs it exactly. register-only, correctly classed."}
+    "van/opel/olympia#name":  {verifier: MATCH, evidence: "raw 'OPEL OLYMPIA'; published 'Olympia'."}
+    "van/stx/master-horsebox#name": {verifier: MATCH_WITH_RESERVATION, evidence: "the raw is 'MASTER, HORSEBOX' — a COMMA cell. Publishing it as the compound 'Master Horsebox' silently converts a comma-separated cell into a compound nameplate, which is the shape D13's detector is supposed to warn on. The name is faithful to the string, so I do not overturn; but a `correct` verdict here sits awkwardly beside the same ledger's insistence that comma/connector cells are a defect class."}
+  miss_rate: "1 asserted miss in 25 = 4.0% (95% Clopper-Pearson 0.1%–20.4%). With the 3 flagged-but-unasserted candidates it would be 4 in 25 = 16.0%; I report the 4.0% figure as the defensible one and the 16.0% as the ceiling, because all three unasserted candidates are blocked on the same missing evidence class (a marque source for a cross-market nameplate identity) rather than on independent doubts."
+
+# ===========================================================================
+# E. SUMMARY
+# ===========================================================================
+
+summary:
+  defects_reviewed: 109
+  defects_confirmed_as_defect: 106      # the finding stands (class may have moved)
+  defects_overturned: 2                 # van/iveco/35s14-multitel#make ; van/fiat/strada#availability:gb
+  defects_downgraded_to_unverifiable: 1 # van/vauxhall/astra#id
+  defects_reclassified: 16
+  reclassification_detail:
+    D6_to_D8: ["van/chevrolet/3100-pick-up#id", "van/chevrolet/astro-van#id", "van/dodge/ram-van-2-8crd-aut-van#id", "van/fiat/doblo-standard#id", "van/iveco/35s14-multitel#id", "van/mercedes-benz/300-gd#id", "van/saxas-nutzfahrzeuge-werdau/mkd-43-l#id", "van/volkswagen/kombiwagen#id"]
+    D6_to_D3: ["truck/spierings/sk#id"]
+    D6_to_new_connector_class: ["van/citroen/jumper-oder-relay#id", "van/mitsubishi/montero#id"]
+    D9_to_D3: ["van/mercedes-benz/l#id"]
+    taxonomy_gap_to_D5: ["van/ford/swift#name", "van/mercedes-benz/westfalia#name", "van/renault/theault#name"]
+    D18_to_D22_or_none: ["van/mercedes-benz/vito#id"]
+  unverifiables_reviewed: 19
+  unverifiables_resolved_to_defective: 2   # saxas#make -> D12 ; ssangyong actyon-sport#id -> D6
+  unverifiables_upheld_by_a_second_independent_route: 6
+    # scania p460#id (whole-space enumeration), steyr 586#name, volvo f610#name,
+    # scania p460/r580/s530#name (sv.wikipedia reached — resolved the LEGACY half, not these three)
+  unverifiables_still_pending_external_fetch: 11
+  source_gap_queue_corrections:
+    - "tadano.com / tadanofaun.de are NOT 'JS-only / 404 / connection refused'. Both are reachable
+       (tadanofaun.de 302s to tadano.com); the marque RETIRED the ATF designation for the AC series
+       after the Demag acquisition, and de.wikipedia 'Tadano Faun' shows the same. The gap is
+       permanent. The queue entry should say 'designation retired by the marque', which routes to a
+       heritage/archive source, not to a retry."
+    - "The Scania entry is half-closable and was not tried in Scania's home language:
+       sv.wikipedia.org/wiki/Scania_3-serien renders the legacy designations fused ('Scania T143H',
+       'Scania 143M 420'), which supports the fused published forms for the 2/3-series records. Only
+       the CURRENT-generation P/R/S power-suffix spacing remains open."
+  corrects_spot_checked: 25
+  spot_check_misses_asserted: 1
+  spot_check_misses_flagged_unasserted: 3
+
+  adjusted_per_claim_tallies:
+    note: >-
+      Starting from the ledger's 622 claims. Changes: -2 defective (both overturned to correct),
+      -1 defective (downgraded to unverifiable), +2 defective (from unverifiable), +1 defective
+      (spot-check miss, truck/toyota/dyna#id).
+    id:           { correct: 47, defective: 49, unverifiable: 4 }
+    name:         { correct: 30, defective: 56, unverifiable: 14 }
+    make:         { correct: 95, defective: 5,  unverifiable: 0 }
+    kind:         { correct: 100, defective: 0, unverifiable: 0 }
+    availability: { correct: 222, defective: 0, unverifiable: 0 }
+    total:        { correct: 494, defective: 110, unverifiable: 18 }
+    claim_clean_rate: "494/622 = 79.4% — UNCHANGED from the researcher's figure"
+    why_unchanged: >-
+      The corrections very nearly cancel: two defectives became correct, one defective became
+      unverifiable, two unverifiables became defective, one correct became defective. Since
+      unverifiable already counts against the clean rate, the net movement in the numerator is
+      zero. This is worth stating plainly — the headline rate survived adversarial review, while
+      SIXTEEN of the class labels behind it did not. The rate was reliable; the taxonomy attached
+      to it was not, and the taxonomy is what a fix programme would be driven from.
+
+  verdict_on_the_ledger:
+    sound:
+      - "Detection is good. Of 109 defective claims, 106 name a real defect. The researcher found
+         essentially everything that is wrong in this slice."
+      - "The summary block is arithmetically honest — it reproduces exactly from its own records."
+      - "The discrimination is real, not blanket: van/volvo/940-hearse charged on name only (no
+         same-kind twin exists), van/mercedes-benz/207-d left correct where 108-d was charged
+         (108 has a bare twin, 207 does not). Those are the right calls and they are load-bearing
+         evidence that the pass was not rubber-stamping."
+      - "The new-class candidate is genuine, correctly withheld from scaled fixing per I-15, and
+         I extended rather than reduced it."
+    unsound:
+      - "CLASSIFICATION is the weak axis: 16 of 109 classes moved, and the D6 label was applied to
+         19 claims of which only 8 survive it. D6 has a specific operational detector (NFKD fold)
+         and was used as a general 'these are duplicates' bucket. Since D6's remedy (merge to
+         canonical) differs from D8's (fold into nameplate, record variant) and D3's (rename or
+         debt), a fix programme driven off these labels would apply the wrong remedy 9 times."
+      - "The single availability defect is wrong on the facts — the UK register has four Fiat
+         Strada LGV model rows, several Licensed, not one SORN Abarth. It is the one claim in the
+         slice that was argued from a summary rather than from the register file."
+      - "Two unverifiables were resolvable from artifacts already in the repo (a containment scan
+         over makes.json; observed_variants.json's own attribution). Both stated an external
+         blocker that was not the binding constraint. 'Skipped-beats-assumed' is the right rule,
+         but it does not license skipping the cheap in-repo route first."
+      - "One severity is overstated: the D18 finding is marked `blocking` on a consumer-facing harm
+         that does not exist in the published artifact."
+    my_own_findings_not_in_the_ledger:
+      - "TYPO-SPLIT detector gap: find_duplicate_spellings folds case and punctuation, so it cannot
+         see 'Transit Costum'/'Transit Custom' — or, at scale, van/mercedes-benz publishing
+         'Sprinter' beside live 'Spinter', 'Spriner' AND 'Srinter'. A damerau-levenshtein<=1 pass
+         over same-make+kind names would catch all of them. Detector proposal, not a fix."
+      - "RAW-LAYER fold gap: the Scania R142/R142H and R164/R164GA collisions fold at the RAW layer
+         but not at the published-name layer, so the shipped detector is structurally blind to
+         them even though the pipeline holds both strings."
+      - "SAXAS make duplication: `saxas` and `saxas-nutzfahrzeuge-werdau` are both live makes with
+         an overlapping 'Mkd' model and shared raw strings; two further spellings sit below
+         threshold. A make-merge candidate the ledger records as a per-record unverifiable."
+      - "truck/toyota/bu and truck/toyota/cruiser are code/fragment twins of Dyna and Land Cruiser
+         (the first is the asserted spot-check miss)."
+      - "D1's detector ('numeric_only + single-source') cannot reach van/teijo/24, which is
+         numeric-only but two-source. Numeric-only names deserve suspicion at any source count."
+      - "The connector-merge class also occurs at the MAKE axis ('Iveco / Igloocar') and under
+         '/' and bare-space joins ('MITSUBISHI PAJERO/MONTERO'), so the proposed connector
+         wordlist under-covers it; a nameplate-adjacency test is needed to avoid flagging
+         'Transit Custom' and 'Land Cruiser'."
+
+  caveats:
+    - "13 unverifiable claims and 6 D7 name claims depend on a marque page I had not received at
+       the time of writing (delegated multi-route retrieval was still outstanding). Each is marked
+       `pending_marque_fetch: true`. None is counted as resolved, and no verdict below rests on an
+       unfetched source — where I could not fetch, I upheld the researcher's verdict rather than
+       substituting my own inference."
+    - "I did not re-derive the 221 availability claims verdicted correct; the brief scoped the
+       spot-check to id and name claims. Only the single defective availability claim was
+       re-derived (and overturned)."
+    - "Nothing here was written into any git repo and no fix was applied."


### PR DESCRIPTION
The five-nines program's first real measurement: **2,624 claims, 83.23% clean (defect+unverifiable 16.77%, 95% CI 15.39–18.25%)**, four independent researcher+verifier pairs landing in one band. Availability ≈99.5% clean against the registers themselves; the damage is names/ids, concentrated in two structural generators now heading the fix queue (fix-then-certify adopted for D1a). Seven new defect classes with detector specs → taxonomy + DEBT; protocol v1.1 (two-route unverifiable minimum, symmetric pair-defects, class confirmation, evidence hygiene, multi-twin rule); QUALITY.md dashboard ships with the audit's own error rates published (7% researcher miss rate on corrects, ~96% defect confirmation). Every ledger and verification file committed — every number recomputable. S2W's half: sample pinned, round theirs to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)