### PR TITLE
HELD: e-tron GT styling pin (pairs with pipeline normalizer-hygiene PR)

### DIFF
--- a/overrides/styling.yml
+++ b/overrides/styling.yml
@@ -12,6 +12,7 @@ stylings:
   UP: Up
   UP!: Up                # VW up! — bang dropped for id/dropdown sanity, alias keeps it findable
   E-TRON: e-tron         # Audi's official lowercase
+  E-TRON GT: e-tron GT   # same official lowercase, own nameplate (pairs with the pipeline e-tron GT split — INERT until that rule lands, ships lockstep)
   BZ4X: bZ4X             # Toyota's official camel-case
   ZOE: Zoe
   EOS: Eos


### PR DESCRIPTION
The data half of the e-tron GT split. INERT until the pipeline rule lands — merge minutes AFTER the pipeline PR, per coupled-change discipline. Note: if the inert-pin trap fires on CI before the pipeline half merges, that is expected — do not 'fix' by removing the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)