### PR TITLE
BSA A65: fold 12 live ids into 2 (Thunderbolt x5, Lightning x7)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -267,20 +267,20 @@
 "motorcycle/brixton/crossfire125":             "motorcycle/brixton/crossfire-125"             # CROSSFIRE125 -> Crossfire 125  [es,lu]
 "motorcycle/brixton/crossfire500x":            "motorcycle/brixton/crossfire-500x"            # CROSSFIRE500X -> Crossfire 500X  [lu,nl]
 "motorcycle/brixton/crossfire500xc":           "motorcycle/brixton/crossfire-500xc"           # CROSSFIRE500XC -> Crossfire 500XC  [es,nl]
-"motorcycle/bsa/650lightning":                 "motorcycle/bsa/650-lightning"                 # 650LIGHTNING -> 650 Lightning  [nl,nz]
-"motorcycle/bsa/650thunderbolt":               "motorcycle/bsa/650-thunderbolt"               # 650THUNDERBOLT -> 650 Thunderbolt  [nl,nz]
+"motorcycle/bsa/650lightning": "motorcycle/bsa/lightning"                 # 650LIGHTNING -> 650 Lightning  [nl,nz] [REPOINTED by the A65 fold: its old target is now an alias]
+"motorcycle/bsa/650thunderbolt": "motorcycle/bsa/thunderbolt"               # 650THUNDERBOLT -> 650 Thunderbolt  [nl,nz] [REPOINTED by the A65 fold: its old target is now an alias]
 "motorcycle/bsa/a10golden-flash":              "motorcycle/bsa/a10-golden-flash"              # A10GOLDEN Flash -> A10 Golden Flash  [nl,nz]
 "motorcycle/bsa/a10super-rocket":              "motorcycle/bsa/a10-super-rocket"              # A10SUPER Rocket -> A10 Super Rocket  [fi,nl,nz]
-"motorcycle/bsa/a65lightning":                 "motorcycle/bsa/a65-lightning"                 # A65LIGHTNING -> A65 Lightning  [fi,nl,nz]
+"motorcycle/bsa/a65lightning": "motorcycle/bsa/lightning"                 # A65LIGHTNING -> A65 Lightning  [fi,nl,nz] [REPOINTED by the A65 fold: its old target is now an alias]
 "motorcycle/bsa/a7star-twin":                  "motorcycle/bsa/a7-star-twin"                  # A7STAR Twin -> A7 Star Twin  [nl,nz]
 "motorcycle/bsa/b44victor":                    "motorcycle/bsa/b44-victor"                    # B44VICTOR -> B44 Victor  [nl,nz]
 "motorcycle/bsa/b44victor-special":            "motorcycle/bsa/b44-victor-special"            # B44VICTOR Special -> B44 Victor Special  [nl,nz]
 "motorcycle/bsa/dbd34gold-star":               "motorcycle/bsa/dbd34-gold-star"               # DBD34GOLD Star -> DBD34 Gold Star  [fi,nl]
 "motorcycle/bsa/gold-star250":                 "motorcycle/bsa/gold-star-250"                 # Gold STAR250 -> Gold Star 250  [fi,nl]
-"motorcycle/bsa/lightning650":                 "motorcycle/bsa/lightning-650"                 # LIGHTNING650 -> Lightning 650  [nl,nz]
+"motorcycle/bsa/lightning650": "motorcycle/bsa/lightning"                 # LIGHTNING650 -> Lightning 650  [nl,nz] [REPOINTED by the A65 fold: its old target is now an alias]
 "motorcycle/bsa/rocket3":                      "motorcycle/bsa/rocket-3"                      # ROCKET3 -> Rocket 3  [nl,nz]
 "motorcycle/bsa/starfire250":                  "motorcycle/bsa/starfire-250"                  # STARFIRE250 -> Starfire 250  [nl,nz]
-"motorcycle/bsa/thunderbolt650":               "motorcycle/bsa/thunderbolt-650"               # THUNDERBOLT650 -> Thunderbolt 650  [nl,nz]
+"motorcycle/bsa/thunderbolt650": "motorcycle/bsa/thunderbolt"               # THUNDERBOLT650 -> Thunderbolt 650  [nl,nz] [REPOINTED by the A65 fold: its old target is now an alias]
 "motorcycle/bsa/victor500":                    "motorcycle/bsa/victor-500"                    # VICTOR500 -> Victor 500  [fi,nl]
 "motorcycle/buell/m2cyclone":                  "motorcycle/buell/m2-cyclone"                  # M2CYCLONE -> M2 Cyclone  [fi,gb,nl]
 "motorcycle/buell/s1lightning":                "motorcycle/buell/s1-lightning"                # S1LIGHTNING -> S1 Lightning  [gb,nl]
@@ -2756,6 +2756,16 @@
 "motorcycle/moto-guzzi/850le-mans-iii": "motorcycle/moto-guzzi/850-le-mans-iii" # "850LE Mans III" -> "850 Le Mans III"
 "motorcycle/norton/commando-850mk-iii": "motorcycle/norton/commando-850-mk-iii" # "Commando 850MK III" -> "Commando 850 Mk III"
 "motorcycle/matchless/g12l": "motorcycle/matchless/g12" # ancestor fold, see renames.yml Matchless G12L. Pre-flight chain check run per this file footer: nothing aliased to g12l.
+"motorcycle/bsa/thunderbolt-650": "motorcycle/bsa/thunderbolt" # "Thunderbolt 650" -> Thunderbolt, A65 fold
+"motorcycle/bsa/650-thunderbolt": "motorcycle/bsa/thunderbolt" # "650 Thunderbolt" -> Thunderbolt, A65 fold
+"motorcycle/bsa/thunderbolt-a65": "motorcycle/bsa/thunderbolt" # "Thunderbolt A65" -> Thunderbolt, A65 fold
+"motorcycle/bsa/a65t": "motorcycle/bsa/thunderbolt" # "A65T" -> Thunderbolt, A65 fold
+"motorcycle/bsa/lightning-650": "motorcycle/bsa/lightning" # "Lightning 650" -> Lightning, A65 fold
+"motorcycle/bsa/650-lightning": "motorcycle/bsa/lightning" # "650 Lightning" -> Lightning, A65 fold
+"motorcycle/bsa/lightning-a65": "motorcycle/bsa/lightning" # "Lightning A65" -> Lightning, A65 fold
+"motorcycle/bsa/lightning-a65l": "motorcycle/bsa/lightning" # "Lightning A65L" -> Lightning, A65 fold
+"motorcycle/bsa/a65-lightning": "motorcycle/bsa/lightning" # "A65 Lightning" -> Lightning, A65 fold
+"motorcycle/bsa/a65l": "motorcycle/bsa/lightning" # "A65L" -> Lightning, A65 fold
 
 # ── A NOTE ON CHAINS, after three in one session (S2W 2026-07-26) ───────────
 # Every one had the identical shape: I retire an id X (rename/fold), and

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -282,6 +282,16 @@ BSA:
   A-10:                      A10                  # BSA type codes are closed (A10 Golden Flash, A65)
   Goldstar:                  Gold Star            # TWO words on BSA's own site (bsacompany.co.uk/bsa-goldstar) — and Thunderbolt is ONE, same catalogue
   Thunder Bolt:              Thunderbolt          # ...ONE word (A65 Thunderbolt). Opposite convention to Gold Star, same marque
+  "Thunderbolt 650":     Thunderbolt    # FOLD into the dominant raw (103 rows): register spelling of the same machine; 650 is the displacement, which the A65 family shares. enrich/bsa.yml already called these "same machine" and nothing scheduled it (A2 audit)
+  "650 Thunderbolt":     Thunderbolt    # FOLD into the dominant raw (103 rows): register spelling of the same machine; 650 is the displacement, which the A65 family shares. enrich/bsa.yml already called these "same machine" and nothing scheduled it (A2 audit)
+  "Thunderbolt A65":     Thunderbolt    # FOLD into the dominant raw (103 rows): register spelling of the same machine; A65 is the family code, already its own record. enrich/bsa.yml already called these "same machine" and nothing scheduled it (A2 audit)
+  "A65T":                Thunderbolt    # FOLD into the dominant raw (103 rows): BSA's factory code for the Thunderbolt; nl pairs them in one cell ("THUNDERBOLT A65T"). 5 nz rows vs 103 for the nameplate. enrich/bsa.yml already called these "same machine" and nothing scheduled it (A2 audit)
+  "Lightning 650":       Lightning      # FOLD into the dominant raw (155 rows): register spelling of the same machine; 650 is the displacement, which the A65 family shares. enrich/bsa.yml already called these "same machine" and nothing scheduled it (A2 audit)
+  "650 Lightning":       Lightning      # FOLD into the dominant raw (155 rows): register spelling of the same machine; 650 is the displacement, which the A65 family shares. enrich/bsa.yml already called these "same machine" and nothing scheduled it (A2 audit)
+  "Lightning A65":       Lightning      # FOLD into the dominant raw (155 rows): register spelling of the same machine; A65 is the family code, already its own record. enrich/bsa.yml already called these "same machine" and nothing scheduled it (A2 audit)
+  "Lightning A65L":      Lightning      # FOLD into the dominant raw (155 rows): register spelling of the same machine; A65 is the family code, already its own record. enrich/bsa.yml already called these "same machine" and nothing scheduled it (A2 audit)
+  "A65 Lightning":       Lightning      # FOLD into the dominant raw (155 rows): register spelling of the same machine; A65 is the family code, already its own record. enrich/bsa.yml already called these "same machine" and nothing scheduled it (A2 audit)
+  "A65L":                Lightning      # FOLD into the dominant raw (155 rows): BSA's factory code for the Lightning; nz pairs them ("LIGHTNING A65L" x4, "650 A65L" x2). 15 nz rows vs 155 for the nameplate. enrich/bsa.yml already called these "same machine" and nothing scheduled it (A2 audit)
 
 BTC:
   Btc: null                               # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)


### PR DESCRIPTION
**BSA A65: 12 live ids → 2. The audit's own headline case, fixed. Pairs with pipeline#48 — merge THAT ONE FIRST.**

`RESULTS-s2w.md` put id-canonical at **25% defective** and named this as the worked example: twelve live ids for two motorcycles, documented only in an `enrich/bsa.yml` comment and scheduled by nothing.

## Evidence — three independent kinds agreeing

**1. Dominant raw**, measured over the flattened register corpus:

```
THUNDERBOLT  nz 67 + nl 36 = 103        LIGHTNING  nz 124 + nl 31 = 155
every other spelling ≤ 15, most = 1
```

**2. In-corpus code↔nameplate join** — the `honda/sd02` form, needing no external source. nl writes `THUNDERBOLT A65T` in one cell; nz writes `LIGHTNING A65L` (×4) and `650 A65L` (×2). The register itself joins the code to the name.

**3. Our own file already said so.** `enrich/bsa.yml` carried *"same machine as a65t"*, *"same machine — FIVE ids for one motorcycle"*, and *"same machine — SEVEN ids for one motorcycle, the worst cluster in this make"*. It was written down and unscheduled, which is exactly why an audit found it and no detector did.

## Canonical choice

`bsa/thunderbolt` and `bsa/lightning`. Both carry three countries (fi, nl, nz) against two for every sibling, and both are the dominant raw by an order of magnitude.

**`bsa/a65` is NOT folded in.** A65 is the *family* — Star, Rocket, Thunderbolt, Lightning, Spitfire Hornet, Firebird — enriched separately at 1962-72 against the models' 1964-72, and the same registers carry `A65 FIREBIRD SCRAMBLER`, `A65 SPITFIRE HORNET`, `A65R`, `A65S`, `ROCKET A65`. A bare `A65` row cannot be attributed to the Thunderbolt. The audit's researcher put it in the cluster; its verifier overturned that.

## Never delete

Every retired spelling survives as a `former_ids` alias — 16 total on the two survivors, so any consumer id keeps resolving. Genuine product variants (the Lightning Rocket) move to `enrich variants:` in pipeline#48. Register spellings are **not** variants; they are id history.

## The pre-flight earned its keep: 5 of 10 targets were already alias destinations

Before writing a line I ran the chain check the footer of `former_ids.yml` prescribes — the habit added after three chains in one day. **Five of the ten ids I was about to retire were already alias targets**, so writing the fold blind would have created five `A→X→Y` chains at once:

```
650lightning → 650-lightning → lightning        (repointed to lightning)
a65lightning → a65-lightning → lightning
lightning650 → lightning-650 → lightning
650thunderbolt → 650-thunderbolt → thunderbolt
thunderbolt650 → thunderbolt-650 → thunderbolt
```

All five repointed to the final target. Lint 1f would have caught them; the point of the pre-flight is not to need it. The script asserts zero chains remain across the whole file, not just these.

## Scope: why only these two clusters

BSA has other suspicious shapes — `victor*`, `star*`, `gold-*`, bare numerics `250/350/500/650`. **They are not audited, and several are genuinely distinct** (B44 Victor Special vs Victor 500 vs Victor Enduro). Folding on resemblance is the trap this repo keeps filing. Scope stays at what is proven; the rest goes to the worklist.

## A process mistake worth recording

I ran `pipeline/run.rb --publish` in the worktree I was about to commit from. That writes the **released catalog** into the data repo — `catalog/`, `dist/`, `manifest.json`, `VERSION`, 86,000 lines — and it was staged alongside my 25 lines of override edits. Caught by reading `git diff --stat` before committing, not by any lint.

It also poisoned my first control build, which showed 59 ids retired instead of 10, because the stash/pop cycle compared inconsistent trees. **Never run `--publish` from a branch you intend to commit.**

## Verification

Clean control build (validate only), overrides stashed then applied: **17,155 → 17,145**, and the diff is exactly the ten intended ids and nothing else. Gate **0**. Reachability green. Curation lint green. Zero alias chains file-wide.
