### PR TITLE
Plates L0 completion: 73 series across NL/ES/DE/US-FL, NL corpus-proven

### DIFF
--- a/plates/_decode/es-provinces.yml
+++ b/plates/_decode/es-provinces.yml
@@ -1,0 +1,116 @@
+# plates/_decode/es-provinces.yml — Spanish province contraseñas.
+#
+# THE SOURCE FINDING: this table is PRIMARY, not Wikipedia. The EU research
+# dossier recorded that "Wikipedia supplies the full code table" for the
+# pre-2000 Spanish provincial system. It is in fact enacted law: Reglamento
+# General de Vehículos (RD 2822/1998) ANEXO XVIII, section
+# "II. Contraseñas de las placas — A. Siglas de provincias", which lists all
+# 52 codes. Every row below is that table, verbatim, in its own order
+# (alphabetical by province name as the BOE prints it).
+#
+# Referenced by: es-provincial (plates/es.yml) via region_encoding.
+#
+# PERIOD DISCIPLINE (PRD-PLATES §2.4 — "province codes changed over time"):
+# these codes are the set in force in the CONSOLIDATED Anexo XVIII, and they
+# use the CURRENT official province names (Illes Balears, Girona, Lleida,
+# Ourense, A Coruña). Historic contraseñas that predate the RGV and appear on
+# older plates — PM for Baleares, GE for Gerona, OR for Orense, and the
+# pre-1982 forms — are NOT in this primary and are NOT invented here; they are
+# a recorded gap for gate L1/L4. A decode of a physical plate older than the
+# RGV must therefore be treated as unresolved rather than mapped through this
+# table.
+jurisdiction: es
+topic: provinces
+authority:
+  name: Reglamento General de Vehículos (RD 2822/1998), Anexo XVIII II.A
+  url: "https://www.boe.es/buscar/act.php?id=BOE-A-1999-1826"
+sources:
+  - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII, II. Contraseñas de las placas, A. Siglas de provincias — all 52 rows"
+  - "https://www.boe.es/buscar/doc.php?id=BOE-A-1999-1826  # original enacted text (in force 26-07-1999), same section"
+period: { start: 1999 }
+period_evidence: instrument-in-force
+period_note: >-
+  The contraseñas long predate RD 2822/1998; 1999 is the date of the instrument
+  that ENACTS the list read here, not the date the codes came into use. Codes
+  remain decodable indefinitely because provincial plates stay valid: RD
+  2822/1998 disposición transitoria preserves them, and the Orden of 15-09-2000
+  only stopped ISSUING them (in force 17-09-2000).
+
+# Ambiguity notes a parse API must carry:
+#   * CC decodes to CÁCERES here AND is the consular series prefix
+#     (Anexo XVIII I.B.a).3). Disambiguate on group structure, not prefix:
+#     provincial = 4 digits + 1-2 letters; consular = two digit groups.
+#   * C (A Coruña) vs CA (Cádiz) vs CC (Cáceres) vs CE (Ceuta) vs CO (Córdoba)
+#     vs CR (Ciudad Real) vs CS (Castellón) vs CU (Cuenca): the code is
+#     MAXIMAL-MUNCH — always take the longest matching code before the digits.
+#   * S (Cantabria) vs SA / SE / SG / SO / SS: same rule.
+#   * L (Lleida) vs LE / LO / LU: same rule.
+#   * O (Asturias) vs OU (Ourense): same rule.
+#   * Z (Zaragoza) vs ZA (Zamora): same rule.
+#   * Ceuta (CE) and Melilla (ML) are autonomous cities, not provinces; the
+#     BOE table lists them under the same heading.
+maximal_munch: true
+
+codes:
+  - { code: VI,  name: "Álava" }
+  - { code: AB,  name: "Albacete" }
+  - { code: A,   name: "Alicante" }
+  - { code: AL,  name: "Almería" }
+  - { code: O,   name: "Asturias" }
+  - { code: AV,  name: "Ávila" }
+  - { code: BA,  name: "Badajoz" }
+  - { code: B,   name: "Barcelona" }
+  - { code: BU,  name: "Burgos" }
+  - { code: CC,  name: "Cáceres" }
+  - { code: CA,  name: "Cádiz" }
+  - { code: S,   name: "Cantabria" }
+  - { code: CS,  name: "Castellón" }
+  - { code: CR,  name: "Ciudad Real" }
+  - { code: CO,  name: "Córdoba" }
+  - { code: C,   name: "A Coruña" }
+  - { code: CU,  name: "Cuenca" }
+  - { code: GI,  name: "Girona" }
+  - { code: GR,  name: "Granada" }
+  - { code: GU,  name: "Guadalajara" }
+  - { code: SS,  name: "Guipúzcoa" }
+  - { code: H,   name: "Huelva" }
+  - { code: HU,  name: "Huesca" }
+  - { code: IB,  name: "Illes Balears" }
+  - { code: J,   name: "Jaén" }
+  - { code: LE,  name: "León" }
+  - { code: L,   name: "Lleida" }
+  - { code: LU,  name: "Lugo" }
+  - { code: M,   name: "Madrid" }
+  - { code: MA,  name: "Málaga" }
+  - { code: MU,  name: "Murcia" }
+  - { code: NA,  name: "Navarra" }
+  - { code: OU,  name: "Ourense" }
+  - { code: P,   name: "Palencia" }
+  - { code: GC,  name: "Las Palmas" }
+  - { code: PO,  name: "Pontevedra" }
+  - { code: LO,  name: "La Rioja" }
+  - { code: SA,  name: "Salamanca" }
+  - { code: TF,  name: "Santa Cruz de Tenerife" }
+  - { code: SG,  name: "Segovia" }
+  - { code: SE,  name: "Sevilla" }
+  - { code: SO,  name: "Soria" }
+  - { code: T,   name: "Tarragona" }
+  - { code: TE,  name: "Teruel" }
+  - { code: TO,  name: "Toledo" }
+  - { code: V,   name: "Valencia" }
+  - { code: VA,  name: "Valladolid" }
+  - { code: BI,  name: "Vizcaya" }
+  - { code: ZA,  name: "Zamora" }
+  - { code: Z,   name: "Zaragoza" }
+  - { code: CE,  name: "Ceuta",   kind: autonomous-city }
+  - { code: ML,  name: "Melilla", kind: autonomous-city }
+
+# State and NATO contraseñas from the SAME Anexo XVIII section (II.B) are
+# modelled as series in plates/es.yml (es-military-1999, es-nato-fae-1999,
+# es-government-1999, es-police-1999) rather than as decode rows, because they
+# are issuance series in their own right and not a geographic decode.
+state_codes_see_also:
+  - "plates/es.yml#es-military-1999   # ET Ejército de Tierra, FN Armada, EA Ejército del Aire"
+  - "plates/es.yml#es-government-1999 # MF Fomento, MMA Medio Ambiente, PME Parque Móvil del Estado"
+  - "plates/es.yml#es-police-1999     # CNP Cuerpo Nacional de Policía, PGC Guardia Civil"
+  - "plates/es.yml#es-nato-fae-1999   # FAE NATO international military headquarters in Spain"

--- a/plates/de.yml
+++ b/plates/de.yml
@@ -1,0 +1,672 @@
+# plates/de.yml — Germany (PRD-PLATES gate L0 pilot).
+#
+# EVERY format, colour and class claim here comes from the consolidated
+# Fahrzeug-Zulassungsverordnung (FZV) of 20 July 2023, BGBl. 2023 I Nr. 199,
+# Textnachweis ab 1.9.2023, replacing FZV 2011 (V v. 3.2.2011 I 139), last
+# amended by Art. 5 G v. 12.5.2026 (BGBl. 2026 I Nr. 142) — the Vollzitat as
+# printed on gesetze-im-internet's own PDF front matter.
+#
+# THE THREE STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. THE DISTRICT CODES ARE NOT IN THE FZV. § 9 Abs. 3 FZV, verbatim: "Die
+#    Unterscheidungszeichen der Verwaltungsbezirke werden auf Antrag der Länder
+#    vom Bundesministerium für Verkehr festgelegt oder aufgehoben. ... Die
+#    Festlegung und Aufhebung der Unterscheidungszeichen ist vom
+#    Bundesministerium für Verkehr unverzüglich im Bundesanzeiger zu
+#    veröffentlichen." So the ~400-code district list is a BUNDESANZEIGER
+#    publication. It is therefore NOT authored here as 700 rows of guesswork:
+#    region_encoding points at a future _decode file and this file cites the
+#    MECHANISM. Anlage 2 FZV — which IS in the regulation — is inlined instead,
+#    because it is small, closed and primary.
+#    § 9 Abs. 3 also states the two rules a decode table must carry: a Land may
+#    apply for MORE THAN ONE code per district, and "Ein Kennzeichen, dessen
+#    Unterscheidungszeichen aufgehoben ist, darf bis zur Außerbetriebsetzung
+#    des betroffenen Fahrzeuges weitergeführt werden" — withdrawn codes stay on
+#    the road, so decode rows need period discipline, never deletion.
+#
+# 2. ANLAGE 1 IS THE SERIAL GRAMMAR, AND IT IS COMPLETE. Five shapes, verbatim,
+#    plus the letter rule: "Mit Ausnahme der Umlaute Ä, Ö und Ü können alle
+#    übrigen Buchstaben des Alphabets ... zugeteilt werden."
+#      a) A 1 – A 999    bis  Z 1 – Z 999
+#      b) AA 1 – AA 99   bis  ZZ 1 – ZZ 99
+#      c) AA 100 – AA 999 bis ZZ 100 – ZZ 999
+#      d) A 1000 – A 9999 bis Z 1000 – Z 9999
+#      e) AA 1000 – AA 9999 bis ZZ 1000 – ZZ 9999
+#    Union: 1–2 letters + 1–4 digits, with NO LEADING ZEROS (every block starts
+#    at 1, 100 or 1000). Combined with Anlage 4 Abschnitt 1 Nr. 4 — "Mehr als
+#    acht Stellen (Buchstaben des Unterscheidungszeichens sowie Buchstaben und
+#    Ziffern der Erkennungsnummer) auf einem Kennzeichen sind unzulässig" — the
+#    total is capped at eight positions, which the standard series' regex
+#    enforces with a negative lookahead (the only illegal combination the
+#    quantifiers alone would admit is 3 letters + 2 letters + 4 digits = 9).
+#
+# 3. PERIOD CLAIMS ARE INSTRUMENT-DATED, AND SAY SO. The German
+#    Unterscheidungszeichen + Erkennungsnummer system, and the Euro-Feld
+#    design, both predate the FZV 2023 by decades. NO PRIMARY for either origin
+#    date was secured in this pass (see the L0 report's gap list), so every
+#    entry carries `period_evidence: instrument-in-force` and a note saying in
+#    terms that the year is the date of the instrument that STATES the rule, not
+#    the date the series began. The two exceptions are dated from their own
+#    enabling statute: the E-Kennzeichen (Elektromobilitätsgesetz of
+#    5 June 2015) and the moped insurance-plate colour cycle (anchored on the
+#    Verkehrsjahr the FZV names).
+#
+# REGEX POLICY: as in plates/nl.yml, `format.regex` is the lint-round-trippable
+# regex and `format.regex_strict` (proposed schema addition) carries the
+# tighter, sourced form — here, the no-leading-zeros rule from Anlage 1, which
+# cannot go in `regex` because the lint generates "0" for a pattern "9".
+jurisdiction: de
+authority:
+  name: Fahrzeug-Zulassungsverordnung (FZV) — Bundesministerium für Digitales und Verkehr
+  url: "https://www.gesetze-im-internet.de/fzv_2023/"
+binding: vehicle
+instrument:
+  citation: "Fahrzeug-Zulassungsverordnung vom 20. Juli 2023 (BGBl. 2023 I Nr. 199, S. 2), zuletzt geändert durch Artikel 5 des Gesetzes vom 12. Mai 2026 (BGBl. 2026 I Nr. 142)"
+  # NOTE: quoted deliberately. scripts/lint_plates.rb calls
+  # YAML.safe_load_file(..., permitted_classes: []), so a BARE YAML date
+  # (2023-07-20) raises Psych::DisallowedClass and takes the whole lint run
+  # down with a backtrace rather than a LINT FAIL line. Every date-shaped
+  # value in the plates dataset must be a quoted string or an integer.
+  ausfertigungsdatum: "2023-07-20"
+  textnachweis_ab: "2023-09-01"
+  replaces: "FZV 2011 (V 9232-14 v. 3.2.2011 I 139)"
+  source: "https://www.gesetze-im-internet.de/fzv_2023/FZV.pdf  # front matter: Ausfertigungsdatum, Vollzitat, Stand, 'Ersetzt V 9232-14 v. 3.2.2011 I 139 (FZV 2011)', 'Textnachweis ab: 1.9.2023'"
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once.
+# ---------------------------------------------------------------------------
+common:
+  colours:
+    standard: "§ 12 Abs. 1 FZV, verbatim: 'Das Unterscheidungszeichen und die Erkennungsnummern sind mit schwarzer Schrift auf weißem schwarz gerandetem Grund auf ein Kennzeichenschild aufzubringen.' — black script on a white, black-bordered ground. This is the COLOUR SPEC; Anlage 4's drawings carry no separate RGB/RAL values for general plates."
+    source: "https://www.gesetze-im-internet.de/fzv_2023/__12.html  # § 12 Abs. 1 (colours), Abs. 2 (reflective, DIN 74069 Oct 2022 Abschnitte 1-8, DIN test mark + register number), Abs. 5 (front and rear required; rear only for trailers, motorcycles and class L5e)"
+  dimensions:
+    single_line: { w: 520, h: 110, unit: mm, note: "Größtmaß" }
+    two_line: { w: 340, h: 200, unit: mm, note: "Größtmaß; 280 mm on two- and three-wheeled motor vehicles" }
+    motorcycle: { w_min: 180, w_max: 220, h: 200, unit: mm }
+    reduced_two_line: { w: 255, h: 130, unit: mm, note: "Leichtkrafträder and § 12 Abs. 6 Nr. 1 vehicles only" }
+    source: "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 1 Nr. 1 a)-d), Fundstelle BGBl. 2023 I Nr. 199, S. 71-91"
+  font:
+    name: FE-Schrift (fälschungserschwerende Schrift)
+    statutory_basis: "Anlage 4 Abschnitt 1 Nr. 2.1: 'Die Beschriftung muss den Schriftmustern \"Schrift für Kfz-Kennzeichen\" entsprechen.' The Schriftmuster are obtainable from the Bundesanstalt für Straßen- und Verkehrswesen, Postfach 10 01 50, 51401 Bergisch Gladbach."
+    sizes: { mittelschrift: 75, engschrift: 75, verkleinerte_mittelschrift: 49, unit: mm, note: "verkleinerte Mittelschrift only for reduced two-line and motorcycle plates" }
+    alternate: "DIN 1451-2:1986-02 (Verkehrsschrift) for Bundeswehr plates and Versicherungskennzeichen"
+    licence: >-
+      NO LICENSABLE FONT IS MANDATED. The legal object is a statutory
+      Schriftmuster (a drawing), exactly as the EU dossier found for the UK and
+      Spain. Per PRD-PLATES §6 the render layer derives glyphs from the
+      statutory drawing, never from a third-party FE-Schrift TTF whose own
+      licence is unstated. Germany is additionally the affirmatively favourable
+      case (PD-VzKat / §5(1) UrhG: designs published inside statutory
+      instruments are public domain).
+    source: "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 1 Nr. 2.1-2.3.2"
+  euro_band:
+    side: left
+    content: eu-stars+D
+    geometry: "Anlage 4 Abschnitt 1 Nr. 3: 'Der Durchmesser des Sternenkranzes entspricht dem Sechsfachen des Durchmessers des einzelnen Sterns.' A light edge of at most 2.0 mm is permitted between the Euro-Feld and the black border. 'Die Ausführung des Erkennungsbuchstabens \"D\" erfolgt nach der Verordnung (EG) Nr. 2411/98 vom 3. November 1998.'"
+    note: >-
+      This is the ONE hard piece of Euroband geometry secured anywhere in the L0
+      pass: a ratio (star-circle diameter = 6x single-star diameter), given as
+      text in German law. Reg. 2411/98's own annex is a bitmap and Spain's
+      Cuadro 5 is a drawing, so DE Anlage 4 Nr. 3 is the citable source for the
+      star wreath's proportions.
+    source: "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 1 Nr. 3"
+  anlage1_grammar:
+    shapes:
+      - "a) A 1 – A 999 bis Z 1 – Z 999"
+      - "b) AA 1 – AA 99 bis ZZ 1 – ZZ 99"
+      - "c) AA 100 – AA 999 bis ZZ 100 – ZZ 999"
+      - "d) A 1000 – A 9999 bis Z 1000 – Z 9999"
+      - "e) AA 1000 – AA 9999 bis ZZ 1000 – ZZ 9999"
+    letters_excluded: ["Ä", "Ö", "Ü"]
+    no_leading_zeros: true
+    max_positions: 8
+    source: "https://www.gesetze-im-internet.de/fzv_2023/anlage_1.html  # Anlage 1 (zu § 9 Absatz 1 Satz 4), Fundstelle BGBl. 2023 I Nr. 199, S. 67 — the five shapes and the umlaut exclusion, verbatim"
+
+# Anlage 2 FZV — the SMALL, CLOSED, primary code table (contrast the district
+# list, which is not in the FZV at all). Inlined per PRD-PLATES §2.4's
+# "inline table (small) or a reference (large)" rule.
+region_encoding_tables:
+  anlage2_federal_and_diplomatic:
+    source: "https://www.gesetze-im-internet.de/fzv_2023/anlage_2.html  # Anlage 2 (zu § 9 Absatz 1 Satz 6), Fundstelle BGBl. 2023 I Nr. 199, S. 68-69"
+    bund:
+      BD: "Dienstfahrzeuge des Bundestages, Bundesrates, Bundespräsidialamtes, der Bundesregierung, Bundesministerien, Bundesfinanzverwaltung, des Bundesverfassungsgerichts und Bundeskriminalamtes"
+      BG: "Bundespolizei — noch gültig, wird nicht mehr zugeteilt (still valid, no longer assigned)"
+      BP: "Dienstfahrzeuge der Bundespolizei"
+      BW: "Bundes-Wasserstraßen- und Schifffahrtsverwaltung"
+      THW: "Bundesanstalt Technisches Hilfswerk"
+      Y: "Dienstfahrzeuge der Bundeswehr (Zentrale Militärkraftfahrtstelle, Mönchengladbach/Rheindahlen)"
+      X: "internationale militärische Hauptquartiere nach dem Nordatlantikvertrag mit Standort in Deutschland"
+    laender:
+      B: "Berlin — Senat und Abgeordnetenhaus"
+      BBL: "Brandenburg — Landesregierung, Landtag und Polizei"
+      BWL: "Baden-Württemberg — Landesregierung, Landtag und Polizei"
+      BYL: "Bayern — Landesregierung und Landtag"
+      HB: "Freie Hansestadt Bremen — Senat und Bürgerschaft"
+      HEL: "Hessen — Landesregierung und Landtag"
+      HH: "Freie und Hansestadt Hamburg — Senat und Bürgerschaft"
+      LSA: "Sachsen-Anhalt — Landesregierung, Landtag und Polizei"
+      LSN: "Sachsen — Landesregierung und Landtag"
+      MVL: "Mecklenburg-Vorpommern — Landesregierung (einschließlich Landespolizei) und Landtag"
+      NL: "Niedersachsen — Landesregierung und Landtag"
+      NRW: "Nordrhein-Westfalen — Landesregierung, Landtag und Polizei"
+      RPL: "Rheinland-Pfalz — Landesregierung, Landtag und Polizei"
+      SAL: "Saarland — Landesregierung, Landtag und Polizei"
+      SH: "Schleswig-Holstein — Landesregierung, Landtag und Polizei"
+      THL: "Thüringen — Landesregierung und Landtag"
+    diplomatic:
+      "0": "Diplomatische Vertretungen oder internationale Organisationen, abhängig vom Status der bevorrechtigten Person (Zulassungsbehörde Berlin/Bonn)"
+      B: "same, Berlin"
+      BN: "same, Bonn"
+      consular: "Berufskonsularische Vertretungen carry the UNTERSCHEIDUNGSZEICHEN OF THE DISTRICT WHERE THE CONSULATE SITS — i.e. an ordinary district code, which is why consular vehicles are not separable by prefix"
+    bundestag_president: { "1-1": "Dienstkraftwagen des Präsidenten des Deutschen Bundestages (Zulassungsbehörde Berlin)" }
+    note: >-
+      COLLISION WORTH FLAGGING: "B" is simultaneously a district code (Berlin),
+      a Land code (Berlin Senat/Abgeordnetenhaus) and a diplomatic code. "NL" is
+      the Niedersachsen Land code and also the Dutch international
+      distinguishing sign. Neither is resolvable from the prefix alone.
+
+series:
+
+  # =========================================================================
+  # THE STANDARD SERIES.
+  # =========================================================================
+  - id: de-standard
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "LL-LL 9999"
+      regex: '\A(?![A-Z]{3}-[A-Z]{2} ?\d{4}\z)[A-Z]{1,3}-[A-Z]{1,2} ?\d{1,4}\z'
+      regex_strict: '\A(?![A-Z]{3}-[A-Z]{2} ?\d{4}\z)[A-Z]{1,3}-[A-Z]{1,2} ?(?:[1-9]|[1-9]\d|[1-9]\d{2}|[1-9]\d{3})\z'
+      charset:
+        letters_excluded: ["Ä", "Ö", "Ü"]
+        notes: >-
+          Anlage 1 Nr. 1: every letter of the alphabet except the umlauts Ä, Ö and Ü
+          may be assigned in the Erkennungsnummer, singly or as a pair. The FZV
+          imposes no further letter exclusion on the Erkennungsnummer, but § 9 Abs. 1
+          Satz 3 forbids combinations that "gegen die guten Sitten verstoßen" — a
+          discretionary rule, not an enumerable exclusion list, and the reason no
+          profanity blacklist is authored here.
+      progression: >-
+        Anlage 1 Nr. 2 allocates the Erkennungsnummer in five blocks: a) 1 letter +
+        1-999, b) 2 letters + 1-99, c) 2 letters + 100-999, d) 1 letter + 1000-9999,
+        e) 2 letters + 1000-9999. Every block starts at 1, 100 or 1000, so NO LEADING
+        ZEROS are ever issued — regex_strict enforces this; `regex` cannot, because
+        the lint's pattern generator emits "0" for a "9" placeholder.
+      max_positions: 8
+      max_positions_note: >-
+        Anlage 4 Abschnitt 1 Nr. 4: at most eight positions counting the
+        Unterscheidungszeichen's letters plus the Erkennungsnummer's letters and
+        digits. The negative lookahead in both regexes excludes the single
+        over-length shape the quantifiers would otherwise admit (3 + 2 + 4 = 9).
+      separator_note: >-
+        The gap between Unterscheidungszeichen and Erkennungsnummer is physically
+        occupied by the two Plaketten (Stempelplakette + HU badge), not by a printed
+        separator. The hyphen and space in the pattern are the conventional textual
+        rendering; both regexes accept the space as optional.
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      plate_variants:
+        - { w: 340, h: 200, unit: mm, note: "zweizeilig; 280 mm wide on two- and three-wheeled motor vehicles" }
+        - { w_min: 180, w_max: 220, h: 200, unit: mm, note: "Kraftradkennzeichen" }
+        - { w: 255, h: 130, unit: mm, note: "verkleinertes zweizeiliges Kennzeichen — Leichtkrafträder and § 12 Abs. 6 Nr. 1 vehicles only, or by exception where a compliant rear plate cannot be fitted" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec, spec_note: "§ 12 Abs. 1 FZV: weißer Grund; retroreflection per DIN 74069 Oct 2022 (§ 12 Abs. 2)" }
+      foreground: "#000000"
+      border: { color: "#000000", note: "Anlage 4 permits black, GREEN or RED borders depending on plate type" }
+      band: { side: left, color: "#003399", content: eu-stars+D, hex_basis: observed, note: "the FZV states the star-wreath ratio and cross-references Reg. 2411/98 for the 'D', but gives no RGB/RAL for the blue field" }
+      emblem: { present: true, rendered: placeholder, note: "the Stempelplakette carries the FARBIGES WAPPEN DES LANDES (§ 12 Abs. 3) — a coat of arms per Land. PRD-PLATES §3 placeholder rule applies: 16 Land arms, none licence-cleared." }
+      seal: { name: Stempelplakette, diameter_mm: null, content: "coloured Land arms, Land name, registration authority name, unique Druckstücknummer, and a CONCEALED security code that can only be revealed irreversibly; self-destroying on removal", source_note: "§ 12 Abs. 3 FZV + Anlage 5" }
+      rear_differs: false
+      display: "front and rear on motor vehicles; rear only on trailers, motorcycles and class L5e vehicles; front only on single-axle tractors (§ 12 Abs. 5 FZV)"
+    region_encoding: "plates/_decode/de-districts.yml"
+    region_encoding_mechanism: >-
+      The Unterscheidungszeichen is 1-3 letters identifying the Verwaltungsbezirk of
+      registration (§ 9 Abs. 1 Nr. 1). The list is set by the BMDV on application by
+      the Länder and published in the BUNDESANZEIGER (§ 9 Abs. 3) — NOT in the FZV
+      and NOT by the KBA. A district may hold more than one code, applied for when
+      "ohne dieses ein Verbrauch der verfügbaren Kennzeichenkombinationen unmittelbar
+      bevorsteht". A withdrawn code may be carried until the vehicle is
+      deregistered, so decode rows close by period and are never deleted. The split
+      point between prefix and Erkennungsnummer is UNAMBIGUOUS because Anlage 1 fixes
+      the Erkennungsnummer to 1-2 letters + 1-4 digits.
+    variants:
+      - class: standard
+        note: >-
+          WECHSELKENNZEICHEN (interchangeable plate, § 9 Abs. 2 FZV + Anlage 4
+          Abschnitt 2a). Two vehicles of the same class (M1, L or O1) held by one
+          keeper share a common plate part plus a per-vehicle part; the common part
+          carries a "W" (20 mm high, 25 mm wide) above the Stempelplakette, and the
+          per-vehicle part is the LAST DIGIT of the Erkennungsnummer. Same eight-
+          position cap across both parts, excluding the "W". Cannot be combined with
+          Saison-, rote, Kurzzeit- or Ausfuhrkennzeichen. Recorded as a variant, not
+          a series, because the serial grammar is Anlage 1's — but note that a parse
+          API sees a SPLIT STRING, which the single-`pattern` schema cannot express.
+        sources:
+          - "https://www.gesetze-im-internet.de/fzv_2023/__9.html  # § 9 Abs. 2: eligibility (classes M1/L/O1, same keeper, same plate size), the common/vehicle-specific split, the one-at-a-time rule"
+          - "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 2a: the 'W' marking 20 x 25 mm, self-destroying security foil on the vehicle-specific part"
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/__9.html  # § 9 Abs. 1: Kennzeichen = Unterscheidungszeichen (1-3 letters for the Verwaltungsbezirk) + vehicle-specific Erkennungsnummer allocated per Anlage 1; Abs. 3: BMDV/Bundesanzeiger"
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_1.html  # Anlage 1: the five Erkennungsnummer shapes and the umlaut exclusion, verbatim"
+      - "https://www.gesetze-im-internet.de/fzv_2023/__12.html  # § 12 Abs. 1: black on white, black-bordered; Abs. 2: reflective + DIN 74069; Abs. 5: front/rear rules"
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 1: dimensions, FE-Schrift, Euro-Feld, the eight-position cap; Abschnitt 2: the general plates"
+    notes: >-
+      THE GERMAN STANDARD SERIES — the strongest region signal in the L0 pilot and
+      the only one of the four pilot jurisdictions whose plate names its place of
+      registration. PERIOD CAVEAT, stated plainly: 2023 is the date of the FZV that
+      STATES this format, not the date the system began. The
+      Unterscheidungszeichen + Erkennungsnummer system and the Euro-Feld design both
+      long predate it (FZV 2011 before, StVZO before that); no primary for either
+      origin date was secured, and inventing one was declined. No age is encoded on a
+      German plate at all — unlike the UK, a German plate string carries region but
+      never date.
+
+  # =========================================================================
+  # HISTORIC — H suffix.
+  # =========================================================================
+  - id: de-historic-h
+    class: historic
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "LL-LL 999H"
+      regex: '\A[A-Z]{1,3}-[A-Z]{1,2} ?\d{1,4}H\z'
+      regex_strict: '\A(?![A-Z]{3}-[A-Z]{2} ?\d{3,4}H\z)[A-Z]{1,3}-[A-Z]{1,2} ?(?:[1-9]|[1-9]\d|[1-9]\d{2}|[1-9]\d{3})H\z'
+      suffix: H
+      max_positions: 7
+      max_positions_note: >-
+        Anlage 4 Abschnitt 4 Nr. 4 caps a SINGLE-LINE Oldtimerkennzeichen at seven
+        positions EXCLUDING the H (and the Erkennungsnummer at five positions on a
+        340 mm two-line plate, four on a 280 mm two-line or motorcycle plate) — one
+        position tighter than the standard series, because the H itself consumes room.
+        regex_strict's lookahead removes the shapes that exceed seven.
+      charset: { notes: "Anlage 1 grammar unchanged; § 10 Abs. 1 adds the H" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+D }
+      note: "'Der Kennbuchstabe \"H\" ist der Erkennungsnummer ohne Leerzeichen in gleicher Schriftart anzufügen' — no space, same typeface (Anlage 4 Abschnitt 4 Nr. 4)"
+    region_encoding: "plates/_decode/de-districts.yml"
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/__10.html  # § 10 Abs. 1: on application, a vehicle with a § 23 StVZO Gutachten is ASSIGNED an Oldtimerkennzeichen; it consists of Unterscheidungszeichen + Erkennungsnummer per § 9 Abs. 1 plus 'den Kennbuchstaben \"H\" als amtlichen Zusatz hinter der Erkennungsnummer'"
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 4: the H suffix's typographic rule and the seven/five/four-position caps"
+    notes: >-
+      H-KENNZEICHEN. Note § 10 Abs. 1's discretion, which a claims model should
+      record: the authority "kann im Einzelfall" count periods before first placing
+      on the market during which the vehicle operated off public roads towards the
+      minimum age in § 2 Satz 1 Nr. 22 FZV. The 30-year threshold itself lives in
+      that definition and in § 23 StVZO, neither of which was fetched in this pass —
+      the threshold is therefore a recorded gap, and the widely-repeated "30 years"
+      is NOT asserted here as sourced. An H plate may also be a Saisonkennzeichen
+      (Anlage 4 Abschnitt 4 Nr. 4 last sentence) or a Wechselkennzeichen.
+
+  # =========================================================================
+  # ELECTRIC — E suffix. The one German series with a properly dated start.
+  # =========================================================================
+  - id: de-electric-e
+    class: electric
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2015 }
+    period_evidence: enabling-statute
+    format:
+      pattern: "LL-LL 999E"
+      regex: '\A[A-Z]{1,3}-[A-Z]{1,2} ?\d{1,4}E\z'
+      regex_strict: '\A(?![A-Z]{3}-[A-Z]{2} ?\d{3,4}E\z)[A-Z]{1,3}-[A-Z]{1,2} ?(?:[1-9]|[1-9]\d|[1-9]\d{2}|[1-9]\d{3})E\z'
+      suffix: E
+      max_positions: 7
+      max_positions_note: "Anlage 4 Abschnitt 5a Nr. 1 executes E-Kennzeichen 'entsprechend Abschnitt 4' (the Oldtimer rules), so the seven-position single-line cap carries over; Nr. 6 gives the tighter two-line caps (six positions on a single-line Saison variant, five on a 340 mm two-line, four on 280 mm/motorcycle/reduced)."
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+D }
+      note: "'Der Kennbuchstabe \"E\" ist der Erkennungsnummer ohne Leerzeichen in gleicher Schriftart anzufügen' (Anlage 4 Abschnitt 5a Nr. 6)"
+      foreign_vehicle_badge:
+        shape: circular
+        diameter_mm: 80
+        colour: "RAL 5017"
+        note: >-
+          For an electric vehicle admitted to traffic under ANOTHER state's rules, the
+          marking is a BADGE per Anlage 3 affixed visibly at the rear, not a plate
+          suffix; the issuing office writes the vehicle's registration into the
+          badge's window in lightfast script. Anlage 3 giving a hard RAL value is
+          unusual — most EU plate law specifies drawings, not colour codes.
+        source: "https://www.gesetze-im-internet.de/fzv_2023/anlage_3.html  # Anlage 3 (zu § 11 Absatz 4): Plakettenmuster, 80 mm diameter, RAL 5017"
+    region_encoding: "plates/_decode/de-districts.yml"
+    sources:
+      - "https://www.gesetze-im-internet.de/emog/EmoG.pdf  # Elektromobilitätsgesetz, Ausfertigungsdatum 05.06.2015 (BGBl. I S. 898) — the enabling statute § 11 FZV keys off; note § 8 Abs. 2: the Act EXPIRES at the end of 31.12.2026"
+      - "https://www.gesetze-im-internet.de/fzv_2023/__11.html  # § 11 Abs. 1-2: an E-Kennzeichen is the § 9 Abs. 1 plate (optionally also a green or seasonal one) with 'den Kennbuchstaben \"E\" als amtlichen Zusatz hinter der Erkennungsnummer'; Abs. 4: the Anlage 3 badge route for foreign vehicles; Abs. 5: foreign E-markings are recognised as equivalent"
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 5a: E-Kennzeichen executed per Abschnitt 4, plus the Saison variants and position caps"
+    notes: >-
+      E-KENNZEICHEN. period.start 2015 is a REAL start, not an instrument date: the
+      Elektromobilitätsgesetz of 5 June 2015 created the eligibility § 11 FZV
+      implements, so 2015 is the earliest possible issuance year. TIME BOMB WORTH
+      RECORDING NOW: EmoG § 8 Abs. 2 provides that the Act ceases to be in force at
+      the end of 31 December 2026 — inside the current audit horizon. Unless it is
+      extended, this series' `period.end` becomes 2026 and the quarterly audit should
+      re-check it. Also note § 79 Abs. 9 FZV carries a non-application footnote
+      against § 11 which was not resolved in this pass (recorded gap).
+
+  # =========================================================================
+  # SEASONAL.
+  # =========================================================================
+  - id: de-seasonal
+    class: seasonal
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "LL-LL 999"
+      regex: '\A[A-Z]{1,3}-[A-Z]{1,2} ?\d{1,4}\z'
+      regex_strict: '\A(?![A-Z]{3}-[A-Z]{2} ?\d{3,4}\z)[A-Z]{1,3}-[A-Z]{1,2} ?(?:[1-9]|[1-9]\d|[1-9]\d{2}|[1-9]\d{3})\z'
+      max_positions: 7
+      max_positions_note: "Anlage 4 Abschnitt 5 Nr. 4: seven positions on a single-line plate, five in the Erkennungsnummer on two-line/motorcycle/reduced plates"
+      fields_note: >-
+        THE OPERATING PERIOD IS A FIELD, NOT PART OF THE SERIAL. Anlage 4 Abschnitt 5
+        Nr. 4: in the Betriebszeitraum field, "die Zahl über dem Bindestrich" is the
+        start month and "die Zahl unter dem Bindestrich" the end month, set in
+        DIN 1451-2:1986-02. A single `pattern` string cannot carry a stacked
+        two-number field — this is the same schema pressure PRD-PLATES §2.2 records
+        for Japan, arriving in Germany.
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+D }
+      extra_field: { position: right, content: "start month over end month, separated by a hyphen", typeface: "DIN 1451-2:1986-02" }
+    validity:
+      min_months: 2
+      max_months: 11
+      note: >-
+        "Der Betriebszeitraum ist auf volle Monate zu bemessen. Der Betriebszeitraum
+        muss mindestens zwei Monate und darf höchstens elf Monate umfassen"
+        (§ 10 Abs. 3). Outside the period the vehicle may neither be operated NOR
+        PARKED on public roads. Trips to deregister, and return trips after the seal
+        is removed, count as unstamped plates under § 12 Abs. 4.
+    region_encoding: "plates/_decode/de-districts.yml"
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/__10.html  # § 10 Abs. 3: Saisonkennzeichen on application; Betriebszeitraum as an amtlicher Zusatz behind the Erkennungsnummer; full months, 2-11 months; green plates may also be seasonal; the operate-and-park prohibition"
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 5: the four seasonal plate forms and the month-field rule"
+    notes: >-
+      SAISONKENNZEICHEN. Its own series rather than a variant because the DESIGN
+      differs (an added operating-period field) while the serial grammar does not —
+      the PRD-PLATES §2.3 test resolves cleanly. It composes with other classes:
+      green plates (§ 10 Abs. 2), Oldtimerkennzeichen and E-Kennzeichen can all be
+      issued AS seasonal plates, which means class is genuinely multi-valued here and
+      the single-`class` schema cannot express the combination.
+
+  # =========================================================================
+  # GREEN — TAX-EXEMPT. Green lettering on white, and the class vocabulary has
+  # no home for it.
+  # =========================================================================
+  - id: de-green-taxexempt
+    class: agricultural
+    categories: [tractor, machine, trailer, truck]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "LL-LL 9999"
+      regex: '\A(?![A-Z]{3}-[A-Z]{2} ?\d{4}\z)[A-Z]{1,3}-[A-Z]{1,2} ?\d{1,4}\z'
+      regex_strict: '\A(?![A-Z]{3}-[A-Z]{2} ?\d{4}\z)[A-Z]{1,3}-[A-Z]{1,2} ?(?:[1-9]|[1-9]\d|[1-9]\d{2}|[1-9]\d{3})\z'
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#008000"
+      foreground_note: "§ 10 Abs. 2 FZV, verbatim: 'ein Kennzeichen mit grüner Beschriftung auf weißem Grund (grünes Kennzeichen)'. The statute names the colour GREEN without an RAL or RGB value, so the hex is observed within a named colour."
+      border: { color: "#008000", note: "Anlage 4 Abschnitt 1 Nr. 2.1 contemplates black, GREEN or red borders; the green plate takes the green one" }
+      band: { side: left, color: "#003399", content: eu-stars+D }
+    region_encoding: "plates/_decode/de-districts.yml"
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/__10.html  # § 10 Abs. 2: green lettering on white for vehicles whose keeper is exempt from motor-vehicle tax, with the seven-item exclusion list, plus the trailer special rule under § 10 KraftStG"
+    notes: >-
+      GRÜNES KENNZEICHEN. CLASS CAVEAT, and it is a real one: the legal criterion is
+      not agriculture at all — it is that "der Halter von der Kraftfahrzeugsteuer
+      befreit ist". _meta/classes.yml has no tax-exempt class, so `agricultural` is
+      recorded as the closest fit and the dominant population, but the statute's own
+      exclusion list shows how much wider the category is: authority vehicles,
+      diplomatic and consular staff vehicles, buses and 8-9-seat cars mainly in
+      scheduled service and their trailers, Leichtkrafträder and Kleinkrafträder,
+      vehicles of severely disabled persons under § 3a KraftStG, particularly
+      low-emission vehicles, and any vehicle on a Wechselkennzeichen are all EXCLUDED
+      from the green plate. Flagged as a vocabulary gap in the L0 report.
+
+  # =========================================================================
+  # DEALER — rote Kennzeichen, digits-only beginning 06.
+  # =========================================================================
+  - id: de-dealer-red
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "LL-06999"
+      regex: '\A[A-Z]{1,3}-06\d{1,4}\z'
+      charset: { notes: "the Erkennungsnummer is DIGITS ONLY and begins with 06 — no letters at all, so Anlage 1's letter blocks do not apply" }
+      max_positions_note: "the eight-position cap of Anlage 4 Abschnitt 1 Nr. 4 still applies, so a three-letter district code limits the digit tail; the regex quantifies width and the cap is recorded here rather than encoded, because the interaction is not stated in a single provision"
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#FF0000"
+      foreground_note: "§ 41 Abs. 1 Nr. 2 FZV, verbatim: 'ein Kennzeichen mit roter Beschriftung auf weißem rot gerandetem Grund (rotes Kennzeichen)'. Colour named, not numbered."
+      border: { color: "#FF0000" }
+      band: { side: left, color: "#003399", content: eu-stars+D }
+      note: "Anlage 4 Abschnitt 7: executed as the general plates but in red script with a red border; the § 29 StVZO roadworthiness badge is NOT applied"
+    binding: business
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/__41.html  # § 41: Prüfungs-, Probe- und Überführungsfahrten; Abs. 1 the red-on-white colour rule; Abs. 2 assignment to trustworthy manufacturers, parts makers, workshops, dealers and trailer makers (plus THW, Bundespolizei, BKA, Länder police, Bundeswehr, customs) for REPEATED use on DIFFERENT vehicles, and 'einer nur aus Ziffern bestehenden und mit \"06\" beginnenden Erkennungsnummer'; Abs. 3 the per-trip Fahrzeugscheinheft log, kept one year"
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 7: red script and red border; Anlage 13 is the Fahrzeugscheinheft"
+    notes: >-
+      ROTE KENNZEICHEN — the German dealer/trade plate, and the cleanest "06"
+      identification in the dataset. BINDING NOTE: like Swiss plates but for a
+      different reason, this plate does NOT bind to a vehicle — it binds to a
+      BUSINESS and moves between vehicles, which is why `binding: business` is set on
+      the series and why a vehicle-keyed consumer must not join on it. § 41 Abs. 3
+      requires a written per-trip record (plate, date, start and end, driver and
+      address, vehicle class, make, VIN and route), retained for a year — the
+      compensating audit trail for an untethered plate.
+
+  - id: de-oldtimer-red
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "LL-07999"
+      regex: '\A[A-Z]{1,3}-07\d{1,4}\z'
+      charset: { notes: "digits only, beginning 07" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#FF0000"
+      border: { color: "#FF0000" }
+      band: { side: left, color: "#003399", content: eu-stars+D }
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/__43.html  # § 43: trips to and from Oldtimer events need neither Betriebserlaubnis nor Zulassung if the vehicle carries a rotes Oldtimerkennzeichen; Abs. 2 applies § 41 Abs. 2-6 and requires 'einer nur aus Ziffern bestehenden und mit den Ziffern \"07\" beginnenden Erkennungsnummer', with the Anlage 15 Fahrzeugscheinheft"
+    notes: >-
+      ROTES OLDTIMERKENNZEICHEN — the 07 series. Distinguished from the 06 dealer
+      plate by two digits and by one crucial restriction: § 43 Abs. 2 provides that
+      this plate "nur an dem Fahrzeug verwendet werden darf, für das es ausgegeben
+      wurde", so unlike the 06 plate it is NOT freely transferable between vehicles.
+      CLASS CAVEAT: recorded as `dealer` because it shares § 41's machinery, but it
+      is functionally a historic-vehicle event plate; a class vocabulary with a
+      `historic` and a `dealer` value cannot express "both".
+
+  # =========================================================================
+  # SHORT-TERM AND EXPORT — the two date-bearing German plates.
+  # =========================================================================
+  - id: de-shortterm
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "LL-03999"
+      regex: '\A[A-Z]{1,3}-0[34]\d{1,4}\z'
+      charset: { notes: "digits only, beginning '03' OR '04' — the pattern shows 03 as a representative literal and the regex carries both" }
+      fields_note: "the plate additionally bears an EXPIRY DATE as a stacked three-number field (day over month over year), which a single pattern string cannot express"
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+D }
+      extra_field:
+        position: right
+        content: "day over month over year of expiry"
+        background: { color: "#FFFF00" }
+        foreground: "#000000"
+        note: "Anlage 4 Abschnitt 6 Nr. 4: 'Die Farbe dieses Feldes ist gelb mit schwarzer Beschriftung'; digits in DIN 1451-2:1986-02"
+      seal: { diameter_mm: 35, background: "blue per DIN 6171 (blau – Euro-Feld)", note: "Anlage 4 Abschnitt 6 Nr. 4: a 35 mm Stempelplakette with the authority's Dienststempel on a BLUE ground, positioned between prefix and Erkennungsnummer (single-line) or top-left beside the prefix (two-line); the § 29 StVZO badge is not applied" }
+    validity: { days: 5, note: "§ 42 Abs. 4: the expiry date is set 'bis zum Ablauf des fünften auf die Zuteilung folgenden Tages'; after it the vehicle may not be operated on public roads" }
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/__42.html  # § 42 Abs. 1: conditions (type-approved or individually approved, valid HU/SP, insurance); Abs. 4: 'einer nur aus Ziffern bestehenden und mit \"03\" oder \"04\" beginnenden Erkennungsnummer' plus the five-day expiry date; Abs. 3: need not be firmly affixed"
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 6: the three Kurzzeitkennzeichen forms, the yellow/black date field, the 35 mm blue seal"
+    notes: >-
+      KURZZEITKENNZEICHEN — five days, a yellow expiry field, and a blue seal
+      instead of the usual Land-arms Stempelplakette. Unlike the 06 dealer plate it
+      is tied to ONE vehicle (§ 42 Abs. 3 Nr. 2) and, unlike an ordinary plate, it
+      need not be firmly attached.
+
+  - id: de-export
+    class: export
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "LL-9999L"
+      regex: '\A[A-Z]{1,3}-\d{1,4}[A-Z]\z'
+      regex_strict: '\A[A-Z]{1,3}-(?:[1-9]|[1-9]\d|[1-9]\d{2}|[1-9]\d{3})[A-Z]\z'
+      charset:
+        notes: >-
+          § 45 Abs. 2 FZV, verbatim: "Die Erkennungsnummer hat zu bestehen aus einer
+          ein- bis vierstelligen Zahl und einem nachfolgenden Buchstaben." Digits
+          FIRST, letter LAST — the inverse of every other German series, and the
+          single most useful structural tell for an export plate.
+      fields_note: "plus a stacked three-number expiry field (day over month over year)"
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: none }
+      band_note: >-
+        NO EURO-FIELD. Anlage 4 Abschnitt 8 Nr. 3 expressly disapplies the Euro-Feld
+        provision (Abschnitt 1 Nr. 3), the verkleinerte Mittelschrift and the § 29
+        StVZO badge for Ausfuhrkennzeichen. The only German road plate without the EU
+        band — which makes sense: the vehicle is leaving the Union's registration.
+      extra_field:
+        position: right
+        content: "day over month over year on which the registration's validity ends in the FZV's territory"
+        background: { color: "#FF0000", finish: non-retroreflective }
+        foreground: "#000000"
+        note: "Anlage 4 Abschnitt 8 Nr. 3: 'Der rote Untergrund darf nicht retroreflektierend sein' — the one field in German plate law required NOT to retroreflect"
+      seal: { diameter_mm: 35, background: "RAL 2002 red", note: "Anlage 4 Abschnitt 8 Nr. 3: Stempelplakette with the authority's Dienstsiegel on a red ground, RAL 2002" }
+    validity: { max_months: 12, note: "§ 45 Abs. 1 Nr. 2: the registration is limited to the duration of the proven third-party insurance, 'längstens auf ein Jahr'" }
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/__45.html  # § 45: Fahrten zur dauerhaften Verbringung eines Fahrzeuges in das Ausland; Abs. 1 the insurance/HU conditions and the one-year cap; Abs. 2 'einer ein- bis vierstelligen Zahl und einem nachfolgenden Buchstaben' plus the expiry-date field"
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 8: no Euro-Feld, the non-retroreflective red date field, the RAL 2002 seal"
+    notes: >-
+      AUSFUHRKENNZEICHEN. Three things make it unique in Germany: the digits-then-
+      letter Erkennungsnummer, the absence of the Euro-band, and a field the law
+      requires NOT to be retroreflective. § 45 Abs. 1 also carries a nice
+      period-logic constraint for a claims model: the plate may only be issued if
+      the next roadworthiness inspection date falls AFTER the registration's expiry
+      date, otherwise the inspection must be done first.
+
+  # =========================================================================
+  # ANLAGE 2 SERIES — federal, Land, diplomatic, military. § 9 Abs. 1 Satz 7:
+  # "Die Erkennungsnummern dieser Fahrzeuge dürfen nur aus höchstens
+  # sechsstelligen Zahlen bestehen" — digits only, at most six.
+  # =========================================================================
+  - id: de-federal-government
+    class: government
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "BD-999999"
+      regex: '\A(?:BD|BG|BP|BW|THW|BBL|BWL|BYL|HEL|LSA|LSN|MVL|NRW|RPL|SAL|THL|HB|HH|NL|B)-\d{1,6}\z'
+      charset: { notes: "§ 9 Abs. 1 Satz 7: the Erkennungsnummern of Anlage 2 vehicles 'dürfen nur aus höchstens sechsstelligen Zahlen bestehen' — digits only, maximum six" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+D }
+    region_encoding: inline
+    region_encoding_note: "decode via region_encoding_tables.anlage2_federal_and_diplomatic (bund + laender) at the top of this file — a closed, primary, 23-row table, unlike the district list"
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_2.html  # Anlage 2 Nr. 1 (Bund: BD, BG, BP, BW, THW, Y, X with their registering authorities) and Nr. 2 (the 16 Land codes and which organs they cover)"
+      - "https://www.gesetze-im-internet.de/fzv_2023/__9.html  # § 9 Abs. 1 Satz 6-7: which bodies may receive Anlage 2 plates, and the digits-only, max-six-digit Erkennungsnummer rule"
+    notes: >-
+      FEDERAL AND LAND OFFICIAL SERIES. Two facts a decode table must carry, both
+      verbatim from Anlage 2: BG (Bundespolizei) is "noch gültig, wird nicht mehr
+      zugeteilt" — still valid, no longer assigned, exactly the ended-but-on-the-road
+      case PRD-PLATES's `ended: true` semantics exist for at the series level and
+      that decode rows need at the row level. And the CONSULAR case has no code of
+      its own: career consular posts carry "das Unterscheidungszeichen des
+      Verwaltungsbezirkes am Sitz des Konsulats", i.e. an ordinary district prefix,
+      so German consular vehicles are NOT identifiable from the plate string. Also
+      here: 1-1 for the Bundestag President's official car (Anlage 2 Nr. 4), the only
+      German plate whose prefix is a digit.
+
+  - id: de-diplomatic
+    class: diplomatic
+    categories: [car, van, motorcycle]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "0-999999"
+      regex: '\A(?:0|B|BN)-\d{1,6}\z'
+      charset: { notes: "digits only, max six (§ 9 Abs. 1 Satz 7); the prefix is 0, B or BN depending on the body and the privileged person's status" }
+      progression: "Anlage 2 Nr. 3 states only that the prefix depends on the body and the status of the privileged person; the mission-number allocation inside the Erkennungsnummer is NOT in the FZV — see notes"
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+D }
+    region_encoding: inline
+    region_encoding_note: "prefix decode in region_encoding_tables.anlage2_federal_and_diplomatic.diplomatic; the mission-number sub-decode is NOT authored (PRD-PLATES puts diplomatic decode tables at L4)"
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_2.html  # Anlage 2 Nr. 3: '0, B oder BN — Diplomatische Vertretungen oder internationale Organisationen und in Abhängigkeit vom Status der bevorrechtigten Person', registered at Berlin or Bonn"
+      - "https://www.gesetze-im-internet.de/fzv_2023/__9.html  # § 9 Abs. 1 Satz 6-7"
+    notes: >-
+      GERMAN DIPLOMATIC SERIES. Unlike Spain — where CD/OI/CC/TA each get their own
+      background colour — Germany keeps the ordinary black-on-white design and
+      signals status only through the prefix, so a German diplomatic plate is
+      visually a normal plate. The mission-identifying number group inside the
+      Erkennungsnummer is a Foreign Office allocation and is not published in the
+      FZV; it is a recorded gap, deliberately not guessed.
+
+  - id: de-military-bundeswehr
+    class: military
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "Y-999999"
+      regex: '\A(?:Y|X)-\d{1,6}\z'
+      charset: { notes: "digits only, max six; Y = Bundeswehr, X = NATO international military headquarters based in Germany" }
+      group_note: "Anlage 4 Abschnitt 3 Nr. 5: on single-line 'andere Kraftfahrzeuge und Anhänger' plates the LAST THREE DIGITS are separated from the preceding digits by a group gap three times the normal spacing — a real grouping rule inside a digits-only serial"
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#FFFFFF", finish: painted, hex_basis: spec, spec_note: "Anlage 4 Abschnitt 3 Nr. 5: 'Die Farbtöne des Untergrundes, des Randes und der Beschriftung sind dem Farbregister RAL 840 HR zu entnehmen, und zwar für schwarz RAL 9005 und weiß RAL 9001.' A rare hard RAL pair in EU plate law." }
+      foreground: "#000000"
+      foreground_spec: "RAL 9005"
+      background_spec: "RAL 9001"
+      band: { side: none }
+      band_note: "no Euro-Feld on Bundeswehr plates; § 12 Abs. 2 also exempts them from the DIN 74069 reflectivity requirement and the DIN test mark, as it does plates on NATO headquarters vehicles"
+      font: { name: "DIN 1451-2:1986-02 (Verkehrsschrift)", note: "Anlage 4 Abschnitt 1 Nr. 2.3: Bundeswehr plates and Versicherungskennzeichen use DIN 1451-2, NOT the FE-Schrift; bold Engschrift where the length does not suffice" }
+      federal_colours: { black: "RAL 9005", red: "RAL 3002", gold: "RAL 1006", note: "Anlage 4 Abschnitt 3 Nr. 5 gives the Bundesfarben where they are used" }
+      digit_one_rule: "Anlage 4 Abschnitt 3 Nr. 5: where the digit '1' is used, or a line holds fewer digits than the model, the gaps between that line's digits enlarge uniformly — a layout rule the render layer must honour"
+    region_encoding: none
+    sources:
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_2.html  # Anlage 2 Nr. 1: 'Y Dienstfahrzeuge der Bundeswehr (Zentrale Militärkraftfahrtstelle – ZMK, Hardter Straße 9, 41179 Mönchengladbach/Rheindahlen)' and 'X Dienstfahrzeuge der auf Grund des Nordatlantikvertrages errichteten internationalen militärischen Hauptquartiere'"
+      - "https://www.gesetze-im-internet.de/fzv_2023/anlage_4.html  # Anlage 4 Abschnitt 3: Bundeswehr plate forms (Leichtkrafträder/Kleinkrafträder, other Krafträder, other vehicles single- and two-line) plus RAL 9005/9001, the Bundesfarben, the digit-1 spacing rule and the last-three-digits group gap"
+      - "https://www.gesetze-im-internet.de/fzv_2023/__12.html  # § 12 Abs. 2 last sentence: Bundeswehr and NATO-HQ plates are exempt from DIN 74069 and the DIN test mark"
+    notes: >-
+      BUNDESWEHR (Y) AND NATO HEADQUARTERS (X). Its own series and not a variant of
+      the federal one: the FONT differs (DIN 1451-2 instead of FE-Schrift), the
+      Euro-band is absent, the reflectivity standard is disapplied and the colours
+      are given as RAL codes rather than named. Y is famously a single letter serving
+      the entire armed forces, which is why it looks like a district code and is not
+      one.

--- a/plates/es.yml
+++ b/plates/es.yml
@@ -1,0 +1,692 @@
+# plates/es.yml — Spain (PRD-PLATES gate L0 pilot).
+#
+# EVERY format, colour and letter-exclusion claim in this file comes from
+# Real Decreto 2822/1998 (Reglamento General de Vehículos) ANEXO XVIII, read
+# in BOTH texts, because they differ and the difference IS the era boundary:
+#
+#   * ORIGINAL text, BOE-A-1999-1826, in force 26-07-1999 — its Anexo XVIII
+#     I.A.a) still describes the PROVINCIAL ordinary-car system
+#     (province contraseña + 4 digits + 1-2 letters), while I.A.b)-d) and all
+#     of I.B/I.C already use the modern "prefix letter + 4 digits + 3 letters"
+#     shape. RD 2822/1998's own preamble states the novelty: "la supresión de
+#     las siglas de la provincia en todas las placas de matrícula, a excepción
+#     de las ordinarias de los vehículos automóviles".
+#   * ORDEN de 15 de septiembre de 2000, BOE-A-2000-16805, IN FORCE
+#     17-09-2000 — replaces I.A.a) wholesale with the 4-digits + 3-letters
+#     national series AND adds the blue EU band (Cuadro 5). Its stated reason:
+#     "El sistema actual de numeración ... está próximo a agotarse en las
+#     provincias de Madrid y Barcelona".
+#   * CONSOLIDATED text (BOE-A-1999-1826-consolidado) — current wording,
+#     including the modern additions (decorative geometric designs permitted;
+#     ISO/IEC 30116:2016 OCR quality).
+#
+# This settles the "Spanish 2000 cutover" that PRD-PLATES §5.3 flags as a
+# folklore-prone boundary: the instrument is dated, published and its entry
+# into force is stated by BOE itself as 17-09-2000. No averaging required.
+#
+# COLOUR POLICY: Anexo XVIII Cuadro 3 specifies, per colour, a FOUR-CORNER
+# CIE chromaticity box plus a MINIMUM luminance factor. That constrains a
+# GAMUT, not a value — so no single hex is a sourced claim. Each design below
+# therefore carries `hex_basis: observed` for the rendered hex, plus
+# `color_spec` with the cited Cuadro 3 box, plus `hex_cie_centroid` (the box
+# centroid converted to sRGB at maximum in-gamut luminance) so the render
+# layer can choose a spec-anchored value instead of the conventional one.
+jurisdiction: es
+authority:
+  name: Dirección General de Tráfico (DGT) — Reglamento General de Vehículos, RD 2822/1998, Anexo XVIII
+  url: "https://www.boe.es/buscar/act.php?id=BOE-A-1999-1826"
+binding: vehicle
+
+charset_defaults:
+  letters: [B, C, D, F, G, H, J, K, L, M, N, P, R, S, T, V, W, X, Y, Z]
+  excluded_letters: [A, E, I, O, U, "Ñ", Q]
+  excluded_digraphs: [CH, LL]
+  excluded_letters_note: >-
+    Anexo XVIII, verbatim: "tres letras, empezando por las letras BBB y
+    terminando por las letras ZZZ, suprimiéndose las cinco vocales, y las letras
+    Ñ y Q" — with the reasons given in the text itself: the vowels "se evitan
+    palabras malsonantes o acrósticos especialmente significados"; Ñ and Q "por
+    ser fácil su confusión con la letra N y el número 0, respectivamente"; and
+    CH and LL "por incompatibilidad con el diseño de la placa de matrícula que no
+    admitiría la consignación de cuatro caracteres en el último grupo". That
+    leaves exactly 20 letters. Note the sequence starts at BBB, NOT AAA.
+  source: "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.A: the BBB->ZZZ rule and every exclusion, verbatim"
+
+color_spec_table:                # cited once; referenced by each design below
+  source: "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII Cuadro 3, 'Coordenadas cromáticas' + luminance factors"
+  blanco:   { cie_x: [0.355, 0.305, 0.285, 0.335], cie_y: [0.355, 0.305, 0.325, 0.375], luminance_factor_min: 0.35 }
+  rojo:     { cie_x: [0.690, 0.595, 0.569, 0.655], cie_y: [0.310, 0.315, 0.341, 0.345], luminance_factor_min: 0.05 }
+  verde:    { cie_x: [0.007, 0.248, 0.177, 0.026], cie_y: [0.703, 0.409, 0.362, 0.399], luminance_factor_min: 0.04 }
+  azul:     { cie_x: [0.078, 0.150, 0.210, 0.137], cie_y: [0.171, 0.220, 0.160, 0.038], luminance_factor_min: 0.01 }
+  amarillo: { cie_x: [0.545, 0.487, 0.427, 0.465], cie_y: [0.454, 0.423, 0.483, 0.534], luminance_factor_min: 0.27 }
+
+display_rules:                   # Anexo XVIII III, verbatim-sourced
+  two_plates: "automóviles except motorcycles and three-wheelers: one front (vertical axis on the median longitudinal plane; exceptionally left or right if construction forbids) and one rear"
+  one_plate_rear_only: "ciclomotores, motocicletas, vehículos de tres ruedas, cuatriciclos ligeros y pesados — one rear plate only; light and heavy quadricycles MAY additionally carry a front plate of the same characteristics"
+  trailers: "remolques/semirremolques over 750 kg carry their own plate at the rear plus, on the right, a second plate bearing the TOWING vehicle's registration; lighter ones carry only a repeat of the towing vehicle's registration"
+  source: "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII III. Número y ubicación de las placas"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT NATIONAL SERIES — 4 digits + 3 letters, EU band.
+  # =========================================================================
+  - id: es-national-2000
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2000 }        # Orden de 15-09-2000, in force 17-09-2000
+    period_evidence: instrument-in-force
+    format:
+      pattern: "9999 LLL"
+      regex: '\A\d{4} [A-Z]{3}\z'
+      regex_strict: '\A\d{4} [BCDFGHJKLMNPRSTVWXYZ]{3}\z'
+      charset:
+        letters: [B, C, D, F, G, H, J, K, L, M, N, P, R, S, T, V, W, X, Y, Z]
+        notes: "see charset_defaults; digits run 0000-9999; the letter group runs BBB to ZZZ"
+      progression: >-
+        Digits cycle 0000-9999 within a fixed letter triple, then the letter triple
+        advances one step in the 20-letter alphabet. Nationally sequential and
+        MONOTONIC from BBB, which makes the letter triple an approximate-age signal
+        and the ONLY decodable dimension of a post-2000 Spanish plate — there is no
+        geography whatsoever in this series.
+      separator_note: >-
+        Anexo XVIII prescribes "dos grupos de caracteres" and gives the inter-group
+        spacing in mm (Cuadro 1: 41 mm on the ordinaria larga) but prescribes no
+        separator GLYPH. The space in the pattern is the printed gap.
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      plate_variants:
+        - { w: 340, h: 220, unit: mm, reflective_surface: { w: 330, h: 210 }, note: "ordinaria alta (two-line)" }
+        - { w: 340, h: 110, unit: mm, reflective_surface: { w: 330, h: 100 }, note: "ordinaria larga delantera — the small FRONT plate, for M1 vehicles whose mounting cannot take the long plate, and for three-wheelers and quadricycles" }
+        - { w: 220, h: 160, unit: mm, reflective_surface: { w: 210, h: 150 }, note: "motocicletas ordinaria" }
+        - { w: 132, h: 96, unit: mm, reflective_surface: { w: 122, h: 86 }, note: "motocicletas corta — trial and enduro two-wheelers only" }
+      characters: { w: 45, h: 77, stroke: 10, gap: 14, group_gap: 41, unit: mm, note: "ordinaria larga; the 340x110 front plate uses 30 x 60 with a 6 mm stroke; motorcycle plates 30 x 60 / 6 mm; motocicletas corta 13 x 30 / 3.5 mm" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, hex_cie_centroid: "#FFFEF3", spec: blanco }
+      foreground: "#000000"
+      foreground_note: "caracteres estampados EN RELIEVE, pintados en color negro MATE — the statute specifies embossed characters and a matte finish, which the render layer should record even if it cannot depict it"
+      band: { side: left, color: "#003399", content: eu-stars+E, hex_basis: observed, spec: azul }
+      band_note: >-
+        "sobre una banda azul dispuesta verticalmente, el símbolo de la bandera
+        europea, que constará de 12 estrellas de color amarillo, y la sigla
+        distintiva de España representada por la letra E de color blanco, de
+        acuerdo con el cuadro 5". CUADRO 5 IS TITLED "DIMENSIONES Y COLORES DEL
+        DISTINTIVO COMUNITARIO (Dimensiones en mm.)" but renders as a DRAWING in
+        the BOE consolidated PDF — the millimetres are not text-extractable.
+        Corrects the EU dossier's expectation that ES Anexo XVIII Cuadro 5 supplies
+        Euroband geometry as text.
+      decoration_allowed: >-
+        Consolidated text only: "se permite la inclusión de diseños geométricos sin
+        significado reconocible, siempre que no afecten a las condiciones de
+        retrorreflexión y legibilidad", subject to ISO/IEC 30116:2016 OCR quality
+        testing. A modern addition absent from the 1999 original.
+      emblem: { present: false }
+      rear_differs: false
+      plate_construction: { border: "reborde plano sin cubrir ni pintar, 5 mm wide around the whole contour, embossed 0.8 +/-0.1 mm", corner_radius: { inner: 6, outer: 10, unit: mm }, character_relief: "0.9 mm +0.3/-0.2 above the ground", manipulator_number: "stamped in a 35 x 5 mm rectangle inside the left-hand bead" }
+    region_encoding: none
+    variants:
+      - class: taxi
+        design:
+          rear_differs: true
+          rear: { background: { color: "#003399", finish: retroreflective, hex_basis: observed, spec: azul }, foreground: "#FFFFFF" }
+          front: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, spec: blanco }, foreground: "#000000" }
+        note: >-
+          THE REAR PLATE ONLY is blue with white matte characters, for taxis and for
+          hire-with-driver vehicles of up to nine seats. The front plate stays
+          white/black. Same serial, same period, so a sub-entry per PRD-PLATES §2.3
+          — but note this is a genuine front/rear ASYMMETRY, not a colour-only
+          swap, and secondary sources routinely get it wrong by colouring both.
+        sources:
+          - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.A.a) and Cuadro 1 note (7): 'salvo las placas de matrícula TRASERAS de los vehículos destinados al servicio de taxi y de alquiler con conductor de hasta nueve plazas'"
+      - class: motorcycle
+        design: { plate: { w: 220, h: 160, unit: mm } }
+        note: "Motorcycles carry the SAME national serial on a 220 x 160 plate (122 x 86 reflective on the 132 x 96 trial/enduro plate). Size-only variant, hence a sub-entry; recorded with a class so class-keyed queries can still reach it."
+        sources:
+          - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII Cuadro 1: Motocicletas ordinaria 220x160 / 210x150; Motocicletas corta 132x96"
+    sources:
+      - "https://www.boe.es/buscar/doc.php?id=BOE-A-2000-16805  # Orden de 15-09-2000: replaces Anexo XVIII I.A.a) with '4 cifras + 3 letras' and adds the EU band; BOE's own Análisis block states 'Fecha de entrada en vigor: 17/09/2000'"
+      - "https://www.boe.es/eli/es/o/2000/09/15/(1)  # canonical ELI for that Orden"
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.A.a) current wording: white retroreflective ground, black matte embossed characters, 4 digits 0000-9999 + 3 letters BBB->ZZZ minus vowels/Ñ/Q; Cuadro 1 dimensions; Cuadro 3 colour boxes"
+      - "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:31998R2411  # Reg. 2411/98 Art. 3 — the mutual-recognition rule the Orden's preamble invokes by name"
+    notes: >-
+      THE CURRENT SPANISH SERIES. Purely sequential and non-geographic: the 2000
+      reform deliberately removed the province code. Anexo XVIII adds the
+      reciprocal-recognition clause in terms: a Spanish car whose plate shows the EU
+      flag and the E sign "no será necesario que lleven en su parte posterior el
+      signo distintivo de la nacionalidad española previsto en la señal V-7".
+      DIMENSION CORRECTION worth recording: the statute says 520 x 110 mm, not the
+      500 x 110 that circulates in secondary sources.
+
+  # =========================================================================
+  # THE PRE-2000 PROVINCIAL SERIES.
+  # =========================================================================
+  - id: es-provincial
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1999, end: 2000 }
+    period_evidence: instrument-window
+    format:
+      pattern: "LL-9999-LL"
+      regex: '\A[A-Z]{1,2}-\d{4}-[A-Z]{1,2}\z'
+      regex_strict: '\A(?:AB|AL|AV|BA|BI|BU|CA|CC|CE|CO|CR|CS|CU|GC|GI|GR|GU|HU|IB|LE|LO|LU|MA|ML|MU|NA|OU|PO|SA|SE|SG|SO|SS|TE|TF|TO|VA|VI|ZA|A|B|C|H|J|L|M|O|P|S|T|V|Z)-\d{4}-[A-Z]{1,2}\z'
+      charset:
+        notes: >-
+          Anexo XVIII I.A.a) as ORIGINALLY enacted, verbatim: "tres grupos de
+          caracteres, constituidos por la contraseña de la provincia donde se
+          matricula el vehículo; un número de cuatro cifras, que irá desde el 0000 al
+          9999, y una o dos letras de una serie, que comienza por la letra A y
+          termina por las letras ZZ, sin emplearse aquellas letras del alfabeto que
+          puedan dar lugar a confusión." Note the trailing letter group here starts at
+          A (not BBB) and is ONE OR TWO letters, and that the excluded letters are
+          NOT enumerated in this text — hence regex_strict keeps [A-Z]{1,2} for that
+          group and constrains only the province contraseña, which IS enumerated
+          (Anexo XVIII II.A, 52 codes).
+      separator_note: "Anexo XVIII prescribes three groups and their mm spacing (Cuadro 1 rows 'ordinaria ... con siglas de provincia'), not a separator glyph; the hyphen is the conventional printed rendering."
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      plate_variants:
+        - { w: 340, h: 220, unit: mm, note: "ordinaria alta con siglas de provincia" }
+        - { w: 340, h: 110, unit: mm, note: "ordinaria larga delantera con siglas de provincia" }
+        - { w: 220, h: 160, unit: mm, note: "motocicletas ordinaria con siglas de provincia" }
+      characters: { w: 45, h: 77, stroke: 10, gap: 8, group_gap: 27, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, spec: blanco }
+      foreground: "#000000"
+      band: { side: none }
+      note: >-
+        No EU band: the band arrived with the Orden of 15-09-2000. Owners of
+        pre-2000 vehicles MAY voluntarily re-plate to the banded design while
+        KEEPING their provincial registration (Disposición transitoria primera), and
+        MUST adopt the new dimensions if they replace plates after loss, theft or
+        deterioration (Disposición transitoria segunda) — which is why the
+        consolidated Cuadro 1 still carries four "con siglas de provincia" rows
+        today, footnoted "Placas de matrícula con arreglo a lo establecido en las
+        disposiciones transitorias de la Orden de 15 de septiembre de 2000".
+    region_encoding: "plates/_decode/es-provinces.yml"
+    sources:
+      - "https://www.boe.es/buscar/doc.php?id=BOE-A-1999-1826  # ORIGINAL RD 2822/1998 text, Anexo XVIII I.A.a): province contraseña + 4 digits + 1-2 letters (A..ZZ); BOE Análisis block: 'Fecha de entrada en vigor: 26/07/1999'"
+      - "https://www.boe.es/buscar/doc.php?id=BOE-A-2000-16805  # the Orden that replaced it, in force 17-09-2000, plus both disposiciones transitorias (voluntary re-plating; mandatory new dimensions on replacement)"
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII II.A: the 52 province contraseñas; Cuadro 1 'con siglas de provincia' rows"
+    notes: >-
+      THE PROVINCIAL SYSTEM — Spain's only region-decodable series. PERIOD CAVEAT,
+      stated plainly: start/end here record the INSTRUMENT WINDOW in which this
+      format was the enacted ordinary-car format (RD 2822/1998 in force 26-07-1999;
+      superseded for new registrations 17-09-2000), NOT the life of the system. The
+      province + 4 digits + 1-2 letters shape is much older — commonly given as
+      1971 — but no primary for that start was secured in this pass, so it is a
+      recorded gap rather than an invented date, and the id is deliberately
+      `es-provincial` and not `es-provincial-1971`. Plates already issued remain
+      valid indefinitely and are re-issued on request; RGV Art. 27.2 lets an owner
+      swap a provincial plate for a national one on a change of province.
+
+  # =========================================================================
+  # ORDINARY SPECIAL SERIES — prefix letter + 4 digits + 3 letters, all from
+  # RD 2822/1998 itself (in force 26-07-1999), all still current.
+  # =========================================================================
+  - id: es-special-vehicles-1999
+    class: agricultural
+    categories: [tractor, machine]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "E9999LLL"
+      regex: '\AE\d{4}[A-Z]{3}\z'
+      regex_strict: '\AE\d{4}[BCDFGHJKLMNPRSTVWXYZ]{3}\z'
+      charset: { notes: "letter E prefix; 4 digits 0000-9999; 3 letters BBB->ZZZ minus vowels/Ñ/Q/CH/LL" }
+    design:
+      plate: { w: 340, h: 110, unit: mm, reflective_surface: { w: 330, h: 100 } }
+      plate_variants:
+        - { w: 280, h: 200, unit: mm, reflective_surface: { w: 270, h: 190 }, note: "vehículos especiales alta" }
+      characters: { w: 30, h: 60, stroke: 6, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, spec: blanco }
+      foreground: "#CE1126"
+      foreground_note: "RED matte embossed characters on white — 'Los caracteres estampados en relieve irán pintados en color rojo mate'. hex_basis observed; Cuadro 3 'rojo' gamut applies (CIE centroid #FF111A)."
+      band: { side: none }
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.A.b) vehículos especiales: white ground, red matte characters, letter E + 4 digits + 3 letters; Cuadro 1: 340x110 larga / 280x200 alta, characters 30x60/6"
+      - "https://www.boe.es/buscar/doc.php?id=BOE-A-1999-1826  # original text, same wording minus the CH/LL inciso; in force 26-07-1999"
+    notes: >-
+      VEHÍCULOS ESPECIALES (agricultural and works/services machinery). The only
+      Spanish series with RED characters on white, and notably NOT 520 mm wide — the
+      long form is 340 x 110. CLASS CAVEAT: _meta/classes.yml has no "special
+      vehicle"/"works machinery" class; `agricultural` is the closest fit and covers
+      the dominant population (maquinaria agrícola), but the statutory category is
+      broader ("de obras y servicios"). Flagged as a vocabulary gap.
+
+  - id: es-trailer-1999
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "R9999LLL"
+      regex: '\AR\d{4}[A-Z]{3}\z'
+      regex_strict: '\AR\d{4}[BCDFGHJKLMNPRSTVWXYZ]{3}\z'
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      plate_variants:
+        - { w: 340, h: 220, unit: mm, reflective_surface: { w: 330, h: 210 }, note: "remolques alta" }
+      characters: { w: 45, h: 77, stroke: 10, gap: 12, group_gap: 30, unit: mm }
+      background: { color: "#CE1126", finish: retroreflective, hex_basis: observed, hex_cie_centroid: "#FF111A", spec: rojo }
+      foreground: "#000000"
+      band: { side: none }
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.A.c): 'El fondo de las placas será retrorreflectante, de color rojo. Los caracteres estampados en relieve irán pintados en color negro mate'; letter R + number + 3 letters; Cuadro 1 dimensions"
+    notes: >-
+      REMOLQUES Y SEMIRREMOLQUES — a RED plate with black characters, the inverse of
+      the special-vehicle plate. Trailers over 750 kg carry this plus a second
+      plate on the right bearing the towing vehicle's registration (Anexo XVIII
+      III.4). Trailers and semi-trailers share one series here because Anexo XVIII
+      treats them in one subparagraph with one prefix letter — contrast the
+      Netherlands, where W and O split them.
+
+  - id: es-moped-1999
+    class: moped
+    categories: [moped, quadricycle]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "C9999LLL"
+      regex: '\AC\d{4}[A-Z]{3}\z'
+      regex_strict: '\AC\d{4}[BCDFGHJKLMNPRSTVWXYZ]{3}\z'
+      layout: >-
+        THREE ROWS as originally enacted: row 1 = letter C plus the thousands digit
+        of the 0000-9999 number; row 2 = the remaining three digits; row 3 = the
+        three letters. The consolidated text describes it as "tres grupos"; the
+        three-row layout survives in the 100 x 168 "ciclomotores alta" plate.
+    design:
+      plate: { w: 100, h: 168, unit: mm, reflective_surface: { w: 90, h: 158 }, note: "ciclomotores alta (portrait, three rows)" }
+      plate_variants:
+        - { w: 140, h: 120, unit: mm, reflective_surface: { w: 130, h: 110 }, note: "ciclomotores larga" }
+        - { w: 210, h: 85, unit: mm, reflective_surface: { w: 200, h: 75 }, note: "cuatriciclos ligeros — also used for three-wheeled ciclomotores" }
+        - { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 }, note: "cuatriciclos ligeros larga" }
+      characters: { w: 13, h: 30, stroke: 3.5, unit: mm, tolerance: "+/- 3 mm between characters" }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed, hex_cie_centroid: "#FFC000", spec: amarillo }
+      foreground: "#000000"
+      band: { side: none }
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.A.d) ciclomotores: yellow retroreflective ground, black matte characters, letter C + 4 digits + 3 letters; Cuadro 1 ciclomotores/cuatriciclos rows"
+      - "https://www.boe.es/buscar/doc.php?id=BOE-A-1999-1826  # original text: the explicit THREE-ROW layout for ciclomotores"
+    notes: >-
+      CICLOMOTORES Y CICLOS DE MOTOR — yellow ground, black characters. RGV
+      transitional provision required mopeds bought before the RGV and registered
+      only with municipalities to be brought onto the national register within six
+      months of entry into force. Light quadricycles and three-wheeled mopeds share
+      this yellow design (Cuadro 1 note 6), which is why `quadricycle` appears in
+      categories — a kinds-vocabulary extension the schema takes without change.
+
+  - id: es-historic-1999
+    class: historic
+    categories: [car, van, truck, bus, motorcycle, moped]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "H9999LLL"
+      regex: '\AH\d{4}[A-Z]{3}\z'
+      regex_strict: '\AH\d{4}[BCDFGHJKLMNPRSTVWXYZ]{3}\z'
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      plate_variants:
+        - { w: 340, h: 220, unit: mm, note: "vehículo histórico alta" }
+        - { w: 220, h: 160, unit: mm, note: "vehículo histórico motocicletas" }
+        - { w: 100, h: 168, unit: mm, note: "vehículo histórico ciclomotores" }
+      characters: { w: 45, h: 77, stroke: 10, gap: 10, group_gap: 35, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, spec: blanco }
+      foreground: "#000000"
+      band: { side: none }
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.B.c) vehículo histórico: white ground, black matte characters, letter H + 4 digits + 3 letters; Cuadro 1 four histórico rows"
+    notes: >-
+      VEHÍCULO HISTÓRICO. Visually near-identical to the ordinary series (white/black)
+      and distinguished by the H prefix rather than by colour — the opposite design
+      choice to the Netherlands, whose oldtimer plate is dark blue but keeps its
+      original serial. Spain has a dedicated historic SERIAL SERIES; the Netherlands
+      has a dedicated historic DESIGN. The age threshold sits in the historic-vehicle
+      regulation (RD 1247/1995), which was not fetched in this pass — recorded gap.
+
+  - id: es-tourist-1999
+    class: temporary
+    categories: [car, van, motorcycle]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "T9999LLL"
+      regex: '\AT\d{4}[A-Z]{3}\z'
+      regex_strict: '\AT\d{4}[BCDFGHJKLMNPRSTVWXYZ]{3}\z'
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      plate_variants:
+        - { w: 340, h: 220, unit: mm, note: "turística alta" }
+      characters: { w: 45, h: 77, stroke: 10, gap: 10, group_gap: [20, 30], unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, spec: blanco }
+      foreground: "#000000"
+      band:
+        side: right
+        color: "#CE1126"
+        hex_basis: observed
+        spec: rojo
+        content: expiry-month-roman-over-year-arabic
+        note: >-
+          "La banda vertical en donde se consignan el mes y el año en que caducan,
+          expresándose el primero en caracteres romanos y el segundo en caracteres de
+          tipo árabe, será retrorreflectante de color rojo. Los caracteres que en
+          ella se consignan serán adhesivos de color blanco mate" — 15 x 8 x 2 mm
+          adhesive characters, band width 30 mm (Cuadro 3).
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.B.b) matrícula turística: white ground, black matte characters, letter T + 4 digits + 3 letters, RED expiry band with white adhesive characters; Cuadro 3: band 30 mm, characters 15x8x2 mm"
+    notes: >-
+      MATRÍCULA TURÍSTICA — a tax-privileged temporary registration with the expiry
+      month in ROMAN numerals and the year in Arabic on a red vertical band. The
+      only Spanish plate that carries its own expiry date on its face, and the only
+      one whose band sits on the right. CLASS CAVEAT: recorded as `temporary`; the
+      statutory category is its own ("matrícula especial") and is neither ordinary
+      nor a circulation permit.
+
+  - id: es-temporary-private-1999
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, moped, trailer, semitrailer]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "P9999LLL"
+      regex: '\AP\d{4}[A-Z]{3}\z'
+      regex_strict: '\AP\d{4}[BCDFGHJKLMNPRSTVWXYZ]{3}\z'
+      layout: "Motor vehicles and trailers: three groups on one line. CICLOMOTORES: three ROWS — row 1 = letter P plus the thousands digit, row 2 = the remaining three digits, row 3 = the three letters."
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      plate_variants:
+        - { w: 280, h: 200, unit: mm, reflective_surface: { w: 270, h: 190 }, note: "temporal particular alta" }
+        - { w: 100, h: 168, unit: mm, reflective_surface: { w: 90, h: 158 }, note: "temporal particular ciclomotores" }
+      characters: { w: 30, h: 60, stroke: 6, gap: 16, unit: mm }
+      background: { color: "#007A33", finish: retroreflective, hex_basis: observed, hex_cie_centroid: "#00FFB3", spec: verde }
+      foreground: "#FFFFFF"
+      band: { side: none }
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.C.a) permisos temporales para particulares: 'El fondo de las placas será retrorreflectante, de color verde. Los caracteres estampados en relieve irán pintados en color blanco mate'; letter P; the three-row ciclomotor layout"
+    notes: >-
+      TEMPORARY PERMIT FOR PRIVATE INDIVIDUALS — GREEN ground, white characters,
+      prefix P. Spain colour-codes temporary permits by HOLDER TYPE: green for
+      individuals (this entry), red for companies (es-temporary-company-*). Note the
+      Cuadro 3 green box is wide and its minimum luminance factor is only 0.04, so
+      the rendered hex is a conventional choice, not a spec value — the centroid
+      conversion lands at a much lighter #00FFB3.
+
+  - id: es-temporary-company-unregistered-1999
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, moped, trailer, semitrailer]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "S9999LLL"
+      regex: '\AS\d{4}[A-Z]{3}\z'
+      regex_strict: '\AS\d{4}[BCDFGHJKLMNPRSTVWXYZ]{3}\z'
+      layout: "one line for motor vehicles and trailers; three rows for ciclomotores (letter S + thousands digit / three digits / three letters)"
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      plate_variants:
+        - { w: 280, h: 200, unit: mm, note: "temporal empresas alta" }
+        - { w: 100, h: 168, unit: mm, note: "temporal empresas ciclomotores" }
+      characters: { w: 30, h: 60, stroke: 6, gap: 16, group_gap: 57.5, unit: mm }
+      background: { color: "#CE1126", finish: retroreflective, hex_basis: observed, hex_cie_centroid: "#FF111A", spec: rojo }
+      foreground: "#FFFFFF"
+      band:
+        side: right
+        color: "#FFFFFF"
+        hex_basis: observed
+        spec: blanco
+        content: expiry-month-roman-over-year-arabic
+        note: "WHITE band with RED matte adhesive characters — the inverse of the tourist plate's red band with white characters. Band width 30 mm (20 mm on the ciclomotor plate)."
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.C.b): red ground, white matte characters, 'la letra S, para los vehículos no matriculados'; white expiry band with red adhesive characters; Cuadro 3 band widths 30/20 mm"
+    notes: >-
+      TEMPORARY PERMIT FOR COMPANIES, UNREGISTERED VEHICLES — prefix S. This is
+      Spain's functional dealer/trade plate. Its own series and not a variant of the
+      V plate below, because the statute assigns a DIFFERENT PREFIX LETTER, which is
+      a format difference (PRD-PLATES §2.3). CLASS CAVEAT: recorded as `dealer`
+      because it is bound to a business rather than a vehicle; the statutory name is
+      "permiso temporal para empresas".
+
+  - id: es-temporary-company-registered-1999
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, moped, trailer, semitrailer]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "V9999LLL"
+      regex: '\AV\d{4}[A-Z]{3}\z'
+      regex_strict: '\AV\d{4}[BCDFGHJKLMNPRSTVWXYZ]{3}\z'
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      plate_variants:
+        - { w: 280, h: 200, unit: mm }
+        - { w: 100, h: 168, unit: mm }
+      characters: { w: 30, h: 60, stroke: 6, gap: 16, group_gap: 57.5, unit: mm }
+      background: { color: "#CE1126", finish: retroreflective, hex_basis: observed, spec: rojo }
+      foreground: "#FFFFFF"
+      band: { side: right, color: "#FFFFFF", hex_basis: observed, spec: blanco, content: expiry-month-roman-over-year-arabic }
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.C.b): '...o la letra V, para los matriculados' — same red design, different prefix"
+    notes: >-
+      TEMPORARY PERMIT FOR COMPANIES, ALREADY-REGISTERED VEHICLES — prefix V.
+      Identical design to the S series; the prefix letter is the only difference and
+      it encodes whether the vehicle already holds a registration. A parse API must
+      keep them apart, which is why they are two series with distinct notes rather
+      than one entry with an alternation.
+
+  # =========================================================================
+  # DIPLOMATIC AND OFFICIAL SERIES. Anexo XVIII specifies the LETTERS and the
+  # GROUP STRUCTURE ("dos grupos de guarismos") but NOT the digit widths and
+  # NOT the separator glyph — so every regex here uses unbounded \d+ and a
+  # permissive separator, deliberately making no width claim.
+  # =========================================================================
+  - id: es-diplomatic-cd-1999
+    class: diplomatic
+    categories: [car, van, motorcycle]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "CD-999-999"
+      regex: '\ACD[- ]\d+[- ]\d+\z'
+      pattern_note: >-
+        The three-digit groups in the pattern are REPRESENTATIVE ONLY. Anexo XVIII
+        says "las letras CD, seguidas por dos grupos de guarismos" and fixes neither
+        width; the regex is intentionally unbounded so it makes no width claim.
+      progression: >-
+        Group 1 is an invariable per-mission prefix, assigned in the alphabetical
+        order of the Foreign Ministry's most recent official diplomatic list, with
+        prefix "-1-" reserved for the Decanato del Cuerpo Diplomático; missions that
+        later accredit permanent ambassadors are appended by seniority. Group 2 is a
+        serial within the mission, proposed by the mission itself.
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      characters: { w: 45, h: 77, stroke: 10, gap: 14, group_gap: [80, 48], unit: mm }
+      background: { color: "#CE1126", finish: retroreflective, hex_basis: observed, hex_cie_centroid: "#FF111A", spec: rojo }
+      foreground: "#FFFFFF"
+      band: { side: none }
+    region_encoding: "mission prefix — decode table not authored (see notes)"
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.B.a).1: Cuerpo diplomático — red retroreflective ground, white matte embossed characters, letters CD + two digit groups, prefix assignment rule and the '-1-' Decanato reservation; Cuadro 1 dimensions"
+    notes: >-
+      CUERPO DIPLOMÁTICO — red ground, white characters. The mission-prefix DECODE
+      TABLE is not authored: Anexo XVIII states the ASSIGNMENT RULE (alphabetical
+      order of the Foreign Ministry's official diplomatic list) but not the resulting
+      codes, and that list was not fetched in this pass. PRD-PLATES puts diplomatic
+      decode tables at gate L4; this entry carries the mechanism so the table can be
+      hung off it later without an id change.
+
+  - id: es-international-oi-1999
+    class: diplomatic
+    categories: [car, van, motorcycle]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "OI-999-999"
+      regex: '\AOI[- ]\d+[- ]\d+\z'
+      pattern_note: "digit-group widths are representative only; Anexo XVIII fixes neither"
+      progression: "group 1 is an invariable per-organisation prefix, assigned by seniority in a series running consecutively after the one reserved for diplomatic missions; group 2 is a serial within the organisation"
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      characters: { w: 45, h: 77, stroke: 10, gap: 14, group_gap: [80, 48], unit: mm }
+      background: { color: "#003399", finish: retroreflective, hex_basis: observed, hex_cie_centroid: "#0083FF", spec: azul }
+      foreground: "#FFFFFF"
+      band: { side: none }
+    region_encoding: "organisation prefix — decode table not authored"
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.B.a).2: organizaciones internacionales — blue retroreflective ground, white matte characters, letters OI + two digit groups"
+    notes: >-
+      ORGANIZACIONES INTERNACIONALES — blue ground, white characters. CLASS CAVEAT:
+      recorded as `diplomatic` because _meta/classes.yml has no
+      international-organisation class; the statutory category is its own and its
+      prefix series is explicitly separate from (though consecutive with) the
+      diplomatic one. Flagged as a vocabulary gap.
+
+  - id: es-consular-cc-1999
+    class: consular
+    categories: [car, van, motorcycle]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "CC-999-999"
+      regex: '\ACC[- ]\d+[- ]\d+\z'
+      pattern_note: "digit-group widths are representative only"
+      progression: "group 1 is the prefix of the diplomatic mission the consular office depends on; where there is no such dependency a prefix is assigned to the state itself. Group 2 follows the diplomatic rule, or the head of the consular office's proposal where the office is not attached to an accredited mission."
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      characters: { w: 45, h: 77, stroke: 10, gap: 14, group_gap: [80, 48], unit: mm }
+      background: { color: "#007A33", finish: retroreflective, hex_basis: observed, hex_cie_centroid: "#00FFB3", spec: verde }
+      foreground: "#FFFFFF"
+      band: { side: none }
+    region_encoding: "mission prefix — decode table not authored"
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.B.a).3: oficinas consulares — green retroreflective ground, white matte characters, letters CC + two digit groups; prefix inherited from the parent diplomatic mission"
+    notes: >-
+      OFICINAS CONSULARES — green ground, white characters. COLLISION WORTH FLAGGING
+      for the parse API: "CC" is also the province contraseña for CÁCERES in Anexo
+      XVIII II.A, so the string "CC-1234-AB" is a valid provincial car plate while
+      "CC-12-345" is consular. Disambiguation is by group structure (4 digits + 1-2
+      letters vs two digit groups), not by prefix.
+
+  - id: es-diplomatic-staff-ta-1999
+    class: diplomatic
+    categories: [car, van, motorcycle]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "TA-999-999"
+      regex: '\ATA[- ]\d+[- ]\d+\z'
+      pattern_note: "digit-group widths are representative only"
+      progression: "group 1 identifies the diplomatic mission, international organisation or consular office; group 2 is a serial among that body's technical-administrative staff, on its proposal"
+    design:
+      plate: { w: 520, h: 110, unit: mm, reflective_surface: { w: 510, h: 100 } }
+      characters: { w: 45, h: 77, stroke: 10, gap: 14, group_gap: [80, 48], unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed, hex_cie_centroid: "#FFC000", spec: amarillo }
+      foreground: "#000000"
+      band: { side: none }
+    region_encoding: "body prefix — decode table not authored"
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII I.B.a).4: personal técnico-administrativo — yellow retroreflective ground, black matte characters, letters TA + two digit groups"
+    notes: >-
+      PERSONAL TÉCNICO-ADMINISTRATIVO of missions, international organisations and
+      consular offices — yellow ground, black characters. RGV transitional provision
+      three preserved existing matrícula turística permits held by this staff until
+      their validity expired, which is the documented bridge from the pre-1999
+      arrangement.
+
+  - id: es-military-1999
+    class: military
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "ET-999999"
+      regex: '\A(?:ET|FN|EA)[- ]\d+(?:-VE)?\z'
+      pattern_note: "digit width is representative only — Anexo XVIII II.B lists the contraseñas but states no numbering grammar"
+      charset: { contraseñas: { ET: "Ejército de Tierra", FN: "Armada", EA: "Ejército del Aire" }, suffix: "special vehicles append '-VE' after a hyphen" }
+    design:
+      band: { side: none }
+      note: >-
+        Anexo XVIII II.B lists the contraseñas ONLY — it prescribes no colours and no
+        dimensions for state plates, and section I (Colores e inscripciones) does not
+        cover them. Colours are therefore deliberately ABSENT here rather than
+        guessed; recorded gap.
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII II.B: 'ET, FN y EA: Para vehículos pertenecientes al Ministerio de Defensa, correspondientes, respectivamente al Ejército de Tierra, Armada y Ejército del Aire' and the '-VE' rule for vehículos especiales"
+    notes: >-
+      MINISTRY OF DEFENCE fleets — Army (ET), Navy (FN), Air Force (EA). One series
+      because Anexo XVIII II.B treats the three contraseñas in a single provision
+      with a single numbering rule; the branch is decodable from the contraseña.
+      Colours and dimensions are NOT in Anexo XVIII for state plates and are not
+      invented here.
+
+  - id: es-nato-fae-1999
+    class: military
+    categories: [car, van, truck, bus]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "FAE-999999"
+      regex: '\AFAE[- ]\d+(?:-VE)?\z'
+      pattern_note: "digit width representative only"
+    design:
+      band: { side: none }
+      note: "no colour or dimension specified in Anexo XVIII II.B — recorded gap"
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII II.B: 'FAE: Para los vehículos al servicio de los Cuarteles Generales Militares Internacionales de la OTAN matriculados en España'"
+    notes: >-
+      NATO INTERNATIONAL MILITARY HEADQUARTERS registered in Spain. The Spanish
+      counterpart of Germany's "X" Unterscheidungszeichen (FZV Anlage 2), and worth
+      pairing with it when the encyclopedia covers NATO-status vehicles.
+
+  - id: es-government-1999
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "PME-999999"
+      regex: '\A(?:PME|MF|MMA)[- ]\d+(?:-VE)?\z'
+      pattern_note: "digit width representative only"
+      charset: { contraseñas: { PME: "Parque Móvil del Estado", MF: "Parque del Ministerio de Fomento", MMA: "Parque del Ministerio de Medio Ambiente" } }
+    design:
+      band: { side: none }
+      note: "no colour or dimension specified in Anexo XVIII II.B — recorded gap"
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII II.B: MF, MMA and PME contraseñas"
+    notes: >-
+      CENTRAL GOVERNMENT FLEETS. PERIOD-ROT WARNING for the decode discipline
+      PRD-PLATES §9 calls out: MF (Ministerio de Fomento) and MMA (Ministerio de
+      Medio Ambiente) name ministries that have since been reorganised and renamed,
+      yet the consolidated Anexo XVIII still lists them. The codes are current law;
+      the ministry names behind them are not current fact. Recorded as-enacted.
+
+  - id: es-police-1999
+    class: police
+    categories: [car, van, truck, motorcycle]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    format:
+      pattern: "CNP-999999"
+      regex: '\A(?:CNP|PGC)[- ]\d+(?:-VE)?\z'
+      pattern_note: "digit width representative only"
+      charset: { contraseñas: { CNP: "Cuerpo Nacional de Policía", PGC: "Cuerpo de la Guardia Civil" } }
+    design:
+      band: { side: none }
+      note: "no colour or dimension specified in Anexo XVIII II.B — recorded gap"
+    region_encoding: none
+    sources:
+      - "https://www.boe.es/buscar/pdf/1999/BOE-A-1999-1826-consolidado.pdf  # Anexo XVIII II.B: CNP and PGC, both under the Dirección General de la Policía y de la Guardia Civil"
+    notes: >-
+      NATIONAL POLICE (CNP) and GUARDIA CIVIL (PGC). Note that RGV Art. 27.5 lets
+      an autonomous community's police force use plates "con una contraseña y
+      numeración propias" within that community, in addition to ordinary
+      registration — so autonomous-community police codes exist OUTSIDE Anexo XVIII
+      and are a recorded gap for L1 (Ertzaintza, Mossos d'Esquadra, Policía Foral).

--- a/plates/nl.yml
+++ b/plates/nl.yml
@@ -1,96 +1,972 @@
-# plates/nl.yml — Netherlands (PRD-PLATES L0 pilot seed).
+# plates/nl.yml — Netherlands (PRD-PLATES gate L0 pilot, COMPLETION PASS).
 #
-# THE NL MODELLING RULE (EU dossier finding 6, binding): sidecode is a
+# Supersedes the 4-entry L0 seed. Entry ids from the seed are preserved
+# verbatim (nl-sidecode11-moped, nl-sidecode11-agricultural,
+# nl-sidecode11-car, nl-historic-darkblue) per the id contract
+# (PRD-QUALITY I-5/I-6); their DATA is corrected where the RDW pages
+# contradicted the seed — corrections are called out in each `notes`.
+#
+# THE NL MODELLING RULE (EU dossier finding 6, binding): a sidecode is a
 # PATTERN identity, not a period — the same pattern reaches each vehicle
 # category on its own date (RDW's official series table). One pattern ×
 # one category-group = one series entry. Age inference is one-sided (a
-# pattern gives the EARLIEST date; series run until exhausted).
+# pattern gives the EARLIEST date; series run until exhausted). RDW says
+# so in its own words on the series page: "Bij een nieuwe kentekenserie
+# krijgen niet direct alle voertuigcategorieën deze combinatie. Eerst maken
+# we de huidige serie 'vol', wat soms lang duurt."
 #
-# Dutch plates encode NO geography. Category is encoded in first letters
-# (M motorcycle, D/F moped, V light commercial, B heavy commercial,
-# W trailer, O semi-trailer — rdw.nl cijfers-en-letters page).
+# Dutch plates encode NO geography. Category IS encoded, in the first letter
+# of the registration (RDW cijfers-en-letters page):
+#   M motorcycle · D/F moped · E special moped · V light commercial ·
+#   B heavy commercial · W trailer · O semi-trailer · GV border traffic ·
+#   T agricultural tractor/mobile machine/MMBS ·
+#   L agricultural trailer & interchangeable towed equipment ·
+#   passenger cars: G H J K L N P R S T X Z (L and T dropped from sidecode 11).
 #
-# This seed carries the sidecode-11 family (the current-issue pattern) as
-# the schema shape-prover; the remaining sidecodes 1–14 land with the L0
-# completion pass from https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries
-# (the single most important NL URL — official pattern + start date per
-# category).
+# REGEX POLICY IN THIS FILE (schema stressor, see the L0 report):
+#   `format.regex` is the LINT-ROUND-TRIPPABLE regex — the lint generates
+#   serials from `format.pattern` (L -> any A-Z, 9 -> any 0-9) and requires
+#   the regex to accept every one of them, so the regex can never be
+#   narrower than the pattern's own alphabet.
+#   `format.regex_strict` (NOT yet lint-validated — proposed amendment) is
+#   the regex the AUTHORITY actually supports: no vowels since sidecode 4,
+#   no C, no Q, and the category first-letter sets above. Consumers doing
+#   validation should prefer regex_strict; consumers doing recall should use
+#   regex. Where a single first letter is mandated and that letter is not
+#   "L" or "9", it is written as a literal in the pattern and regex needs no
+#   strict twin.
 jurisdiction: nl
 authority:
-  name: RDW
+  name: RDW (Dienst Wegverkeer)
   url: "https://www.rdw.nl/de-kentekenplaat"
+binding: vehicle          # NL plates bind to the VEHICLE (contrast CH: owner)
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide charset facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+charset_defaults:
+  letters: [B, D, F, G, H, J, K, L, M, N, P, R, S, T, V, W, X, Y, Z]
+  excluded_letters: [A, E, I, O, U, C, Q]
+  excluded_letters_note: >-
+    "Sinds kentekencombinatie 4 gebruiken we geen klinkers meer in het kenteken
+    (met uitzondering van het kenteken voor opleggers). De letter C en Q
+    gebruiken we ook niet omdat deze letters teveel op een nul lijken."
+    Semi-trailer (oplegger) registrations are the stated exception and DO use
+    the vowel O.
+  excluded_combinations: [GVD, KKK, NSB, PKK, PSV, TBS, SS, SD, PVV, SGP, VVD, FVD, BBB]
+  source: "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # no vowels since combination 4 (opleggers excepted); no C/Q; the 13 forbidden letter combinations"
+
 series:
-  - id: nl-sidecode11-moped
-    class: moped
-    categories: [moped]
-    period: { start: 2015 }        # open — series issue until exhausted
+
+  # =========================================================================
+  # PASSENGER CARS — RDW table "Auto's". class standard, categories [car].
+  # First letter from {G H J K L N P R S T X Z}; L and T withdrawn from
+  # sidecode 11 onward.
+  # =========================================================================
+  - id: nl-sidecode6-car
+    class: standard
+    categories: [car]
+    period: { start: 2000 }        # 20-01-2000; open — series run until exhausted
+    format:
+      pattern: "99-LL-LL"
+      regex: '\A\d{2}-[A-Z]{2}-[A-Z]{2}\z'
+      regex_strict: '\A\d{2}-[GHJKLNPRSTXZ][BDFGHJKLMNPRSTVWXYZ]-[BDFGHJKLMNPRSTVWXYZ]{2}\z'
+      charset:
+        first_letter: [G, H, J, K, L, N, P, R, S, T, X, Z]
+        notes: "no vowels, no C/Q — see charset_defaults"
+      progression: "letter groups advance; RDW does not publish the intra-series allocation order"
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      plate_variants:
+        - { w: 340, h: 210, unit: mm, note: "rechthoekig (two-line) model 27.2" }
+        - { w: 310, h: 110, unit: mm, note: "'Amerikaans model' 18.2 — only where the vehicle record carries code 55 'kentekenplaat model 18.2 toegestaan'" }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      border: { color: "#000000", note: "zwart kader voor de leesbaarheid" }
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: none
+    variants:
+      - class: taxi
+        design: { background: { color: "#7CB9E8", finish: retroreflective, hex_basis: observed }, foreground: "#000000", plate: { w: 520, h: 110, unit: mm } }
+        note: >-
+          Light-blue taxi plates carry the vehicle's OWN registration — colour-only
+          variant of this series, so a sub-entry per PRD-PLATES §2.3, not a series.
+          Models 27.30 (long), 27.31 (rectangular), 18.2 (American, light blue).
+        sources:
+          - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # taxikentekenplaat lichtblauw met zwarte letters en cijfers; 520x110 / 340x210 / 310x110"
+          - "https://www.rdw.nl/zakelijke-partners/erkende-bedrijven/kentekenplaatfabrikanten/extra-eisen-per-kleur-en-model/kentekenplaat-voor-auto-motorfiets-trike-of-quad  # taxi models 27.30 / 27.31 / 18.2"
+      - class: trailer
+        design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000" }
+        note: >-
+          Trailers and appendages (bike racks) up to 750 kg have NO registration of
+          their own — they repeat the towing vehicle's registration on a WHITE plate.
+          Colour-only variant, hence a sub-entry.
+        sources:
+          - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # witte kentekenplaat, aanhangwagens <751 kg, zelfde kenteken als het trekkende voertuig"
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Auto's: serie 6, combinatie 99-XX-XX, ingangsdatum 20-01-2000"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # personenauto first letters G H J K L N P R S T X Z"
+      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # gele plaat, zwart kader, blauw EU-vlak met NL; 520x110 of 340x210"
+    notes: >-
+      Sidecode 6 for PASSENGER CARS, from 20-01-2000. The first NL series to be
+      issued under the EU-band yellow design. Parallel with sidecodes 7-11: RDW
+      exhausts a series before switching, so all six car series remain live stock.
+
+  - id: nl-sidecode7-car
+    class: standard
+    categories: [car]
+    period: { start: 2008 }        # 19-05-2008
+    format:
+      pattern: "99-LLL-9"
+      regex: '\A\d{2}-[A-Z]{3}-\d\z'
+      regex_strict: '\A\d{2}-[GHJKLNPRSTXZ][BDFGHJKLMNPRSTVWXYZ]{2}-\d\z'
+      charset: { first_letter: [G, H, J, K, L, N, P, R, S, T, X, Z], notes: "no vowels, no C/Q" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Auto's: serie 7, combinatie 99-XXX-9, ingangsdatum 19-05-2008"
+      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # colours + dimensions"
+    notes: >-
+      Sidecode 7 for PASSENGER CARS, from 19-05-2008. Same pattern reached HEAVY
+      commercial vehicles four years later (20-07-2012) — the pattern-x-category
+      rule; see nl-sidecode7-heavycommercial.
+
+  - id: nl-sidecode8-car
+    class: standard
+    categories: [car]
+    period: { start: 2013 }        # 05-03-2013
+    format:
+      pattern: "9-LLL-99"
+      regex: '\A\d-[A-Z]{3}-\d{2}\z'
+      regex_strict: '\A\d-[GHJKLNPRSTXZ][BDFGHJKLMNPRSTVWXYZ]{2}-\d{2}\z'
+      charset: { first_letter: [G, H, J, K, L, N, P, R, S, T, X, Z], notes: "no vowels, no C/Q" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Auto's: serie 8, combinatie 9-XXX-99, ingangsdatum 05-03-2013"
+    notes: >-
+      Sidecode 8 for PASSENGER CARS, from 05-03-2013. The same pattern had already
+      been running for LIGHT commercial vehicles since 26-02-2009 — a four-year
+      lead, and the clearest single counter-example to "sidecode = era".
+
+  - id: nl-sidecode9-car
+    class: standard
+    categories: [car]
+    period: { start: 2015 }        # 30-03-2015
+    format:
+      pattern: "LL-999-L"
+      regex: '\A[A-Z]{2}-\d{3}-[A-Z]\z'
+      regex_strict: '\A[GHJKLNPRSTXZ][BDFGHJKLMNPRSTVWXYZ]-\d{3}-[BDFGHJKLMNPRSTVWXYZ]\z'
+      charset: { first_letter: [G, H, J, K, L, N, P, R, S, T, X, Z], notes: "no vowels, no C/Q" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Auto's: serie 9, combinatie XX-999-X, ingangsdatum 30-03-2015"
+    notes: >-
+      Sidecode 9 for PASSENGER CARS, from 30-03-2015. Mopeds got this pattern in
+      2006 and light commercials in 2012 — cars are the LAST category to reach it.
+
+  - id: nl-sidecode10-car
+    class: standard
+    categories: [car]
+    period: { start: 2019 }        # 19-08-2019
+    format:
+      pattern: "L-999-LL"
+      regex: '\A[A-Z]-\d{3}-[A-Z]{2}\z'
+      regex_strict: '\A[GHJKLNPRSTXZ]-\d{3}-[BDFGHJKLMNPRSTVWXYZ]{2}\z'
+      charset: { first_letter: [G, H, J, K, L, N, P, R, S, T, X, Z], notes: "no vowels, no C/Q" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Auto's: serie 10, combinatie X-999-XX, ingangsdatum 19-08-2019"
+    notes: >-
+      Sidecode 10 for PASSENGER CARS, from 19-08-2019. Note the single-letter first
+      group: the category first-letter rule still applies to it.
+
+  - id: nl-sidecode11-car          # seed id — PRESERVED
+    class: standard
+    categories: [car]              # CORRECTED from the seed's [car, van]: RDW's
+                                   # "Auto's" table is passenger cars only; light
+                                   # commercials reached sidecode 11 on 13-06-2019
+                                   # (see nl-sidecode11-lightcommercial).
+    period: { start: 2024 }        # 04-06-2024
     format:
       pattern: "LLL-99-L"
       regex: '\A[A-Z]{3}-\d{2}-[A-Z]\z'
-      charset: { notes: "no vowels in letter groups (profanity/lookalike exclusion) — https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat; moped series lead with D/F" }
+      regex_strict: '\A[GHJKNPRSXZ][BDFGHJKLMNPRSTVWXYZ]{2}-\d{2}-[BDFGHJKLMNPRSTVWXYZ]\z'
+      charset:
+        first_letter: [G, H, J, K, N, P, R, S, X, Z]
+        notes: >-
+          "Vanaf kentekenserie 11 worden de medeklinkers L en T niet langer gebruikt
+          als eerste letter voor personenauto's" — L and T are withdrawn for CARS
+          from sidecode 11, which is why this series' first-letter set is 10 letters
+          where sidecodes 6-10 have 12.
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Auto's: serie 11, combinatie XXX-99-X, ingangsdatum 04-06-2024"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # L and T withdrawn as car first letters from serie 11"
+    notes: >-
+      Sidecode 11 for PASSENGER CARS, from 04-06-2024 — the current car issue.
+      The same pattern reached mopeds in 2015 and agricultural trailers in 2021;
+      the trio is the pattern-x-category rule demonstrated. Seed correction: the
+      seed listed categories [car, van] and no first-letter narrowing.
+
+  # =========================================================================
+  # LIGHT COMMERCIAL — RDW "Bedrijfsauto's licht" (<= 3500 kg). First letter V.
+  # V is not a pattern metacharacter, so the literal goes in the pattern and
+  # the regex is exact without a strict twin.
+  # =========================================================================
+  - id: nl-sidecode8-lightcommercial
+    class: standard
+    categories: [van]
+    period: { start: 2009 }        # 26-02-2009
+    format:
+      pattern: "9-VLL-99"
+      regex: '\A\d-V[A-Z]{2}-\d{2}\z'
+      regex_strict: '\A\d-V[BDFGHJKLMNPRSTVWXYZ]{2}-\d{2}\z'
+      charset: { first_letter: [V], notes: "light commercial registrations always begin with V" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Lichte bedrijfsauto's: serie 8, combinatie 9-XXX-99, ingangsdatum 26-02-2009"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # Lichte bedrijfsauto's (tot 3500 kg): eerste letter V"
+    notes: >-
+      Sidecode 8 for LIGHT COMMERCIAL vehicles, from 26-02-2009 — four years ahead
+      of the same pattern's car rollout. Campers registered as light commercial
+      also carry V.
+
+  - id: nl-sidecode9-lightcommercial
+    class: standard
+    categories: [van]
+    period: { start: 2012 }        # 12-12-2012
+    format:
+      pattern: "VL-999-L"
+      regex: '\AV[A-Z]-\d{3}-[A-Z]\z'
+      regex_strict: '\AV[BDFGHJKLMNPRSTVWXYZ]-\d{3}-[BDFGHJKLMNPRSTVWXYZ]\z'
+      charset: { first_letter: [V] }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Lichte bedrijfsauto's: serie 9, combinatie XX-999-X, ingangsdatum 12-12-2012"
+    notes: Sidecode 9 for LIGHT COMMERCIAL vehicles, from 12-12-2012.
+
+  - id: nl-sidecode10-lightcommercial
+    class: standard
+    categories: [van]
+    period: { start: 2016 }        # 14-10-2016
+    format:
+      pattern: "V-999-LL"
+      regex: '\AV-\d{3}-[A-Z]{2}\z'
+      regex_strict: '\AV-\d{3}-[BDFGHJKLMNPRSTVWXYZ]{2}\z'
+      charset: { first_letter: [V] }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Lichte bedrijfsauto's: serie 10, combinatie X-999-XX, ingangsdatum 14-10-2016"
+    notes: Sidecode 10 for LIGHT COMMERCIAL vehicles, from 14-10-2016.
+
+  - id: nl-sidecode11-lightcommercial
+    class: standard
+    categories: [van]
+    period: { start: 2019 }        # 13-06-2019
+    format:
+      pattern: "VLL-99-L"
+      regex: '\AV[A-Z]{2}-\d{2}-[A-Z]\z'
+      regex_strict: '\AV[BDFGHJKLMNPRSTVWXYZ]{2}-\d{2}-[BDFGHJKLMNPRSTVWXYZ]\z'
+      charset: { first_letter: [V] }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Lichte bedrijfsauto's: serie 11, combinatie XXX-99-X, ingangsdatum 13-06-2019"
+    notes: >-
+      Sidecode 11 for LIGHT COMMERCIAL vehicles, from 13-06-2019 — FIVE YEARS
+      before the same pattern reached cars (04-06-2024). The single most useful
+      NL age-inference fact: a XXX-99-X plate starting with V can be 2019+, while
+      the same pattern on a car cannot predate June 2024.
+
+  - id: nl-sidecode12-lightcommercial
+    class: standard
+    categories: [van]
+    period: { start: 2024 }        # 08-01-2024
+    format:
+      pattern: "V-99-LLL"
+      regex: '\AV-\d{2}-[A-Z]{3}\z'
+      regex_strict: '\AV-\d{2}-[BDFGHJKLMNPRSTVWXYZ]{3}\z'
+      charset: { first_letter: [V] }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Lichte bedrijfsauto's: serie 12, combinatie X-99-XXX, ingangsdatum 08-01-2024"
+    notes: >-
+      Sidecode 12 for LIGHT COMMERCIAL vehicles, from 08-01-2024 — light
+      commercials are the ONLY road category on sidecode 12 besides special mopeds
+      (2025) and agricultural tractors (2021). Cars have never reached it.
+
+  # =========================================================================
+  # HEAVY COMMERCIAL — RDW "Bedrijfsauto's zwaar" (> 3500 kg). First letter B.
+  # =========================================================================
+  - id: nl-sidecode5-heavycommercial
+    class: standard
+    categories: [truck, bus]
+    period: { start: 1994 }        # 03-01-1994 — the oldest date RDW publishes
+                                   # for a still-listed series other than the
+                                   # 1951 GV block.
+    format:
+      pattern: "BL-LL-99"
+      regex: '\AB[A-Z]-[A-Z]{2}-\d{2}\z'
+      regex_strict: '\AB[BDFGHJKLMNPRSTVWXYZ]-[BDFGHJKLMNPRSTVWXYZ]{2}-\d{2}\z'
+      charset: { first_letter: [B], notes: "heavy commercial registrations always begin with B" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+      band_note: >-
+        The EU band is a property of the CURRENT plate, not of the 1994 series:
+        plates made today for a 1994-series registration carry it. RDW does not
+        publish the date the band became mandatory in NL — recorded gap.
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Zware bedrijfsauto's: serie 5, combinatie XX-XX-99, ingangsdatum 03-01-1994"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # Zware bedrijfsauto's (boven 3500 kg): eerste letter B"
+    notes: >-
+      Sidecode 5 for HEAVY COMMERCIAL vehicles, from 03-01-1994. This is the ONLY
+      sidecode-5 rollout RDW publishes — the pattern's car-era dates are not on
+      any RDW page (recorded gap).
+
+  - id: nl-sidecode7-heavycommercial
+    class: standard
+    categories: [truck, bus]
+    period: { start: 2012 }        # 20-07-2012
+    format:
+      pattern: "99-BLL-9"
+      regex: '\A\d{2}-B[A-Z]{2}-\d\z'
+      regex_strict: '\A\d{2}-B[BDFGHJKLMNPRSTVWXYZ]{2}-\d\z'
+      charset: { first_letter: [B] }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Zware bedrijfsauto's: serie 7, combinatie 99-XXX-9, ingangsdatum 20-07-2012"
+    notes: >-
+      Sidecode 7 for HEAVY COMMERCIAL vehicles, from 20-07-2012 — four years after
+      the car rollout of the same pattern. Heavy commercials skipped sidecode 6.
+
+  # =========================================================================
+  # MOTORCYCLES — RDW "Motoren". First letter M.
+  # =========================================================================
+  - id: nl-sidecode6-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2011 }        # 19-08-2011
+    format:
+      pattern: "99-ML-LL"
+      regex: '\A\d{2}-M[A-Z]-[A-Z]{2}\z'
+      regex_strict: '\A\d{2}-M[BDFGHJKLMNPRSTVWXYZ]-[BDFGHJKLMNPRSTVWXYZ]{2}\z'
+      charset: { first_letter: [M], notes: "motorcycle registrations always begin with M" }
     design:
       plate: { w: 210, h: 143, unit: mm }
-      background: { color: "#F9B700", finish: retroreflective }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+      rear_differs: false
+      note: "one plate, rear only (motorcycle model 27.10)"
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Motoren: serie 6, combinatie 99-XX-XX, ingangsdatum 19-08-2011"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # Motoren: eerste letter M"
+      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # motorkentekenplaat 210x143 mm"
+    notes: >-
+      Sidecode 6 for MOTORCYCLES, from 19-08-2011 — eleven years after the same
+      pattern reached cars (20-01-2000). This is the ONLY motorcycle rollout on
+      RDW's table: motorcycles registered before 2011 carry earlier sidecodes
+      whose motorcycle dates RDW does not publish (recorded gap). The
+      210x143 mm plate also serves three-wheelers, agricultural vehicles, MMBS,
+      mobile machines and agricultural trailers.
+
+  # =========================================================================
+  # MOPEDS — RDW "Brom- en snorfietsen". First letters D and F.
+  # Two options, so the pattern keeps its generic L and regex carries [DF].
+  # =========================================================================
+  - id: nl-sidecode7-moped
+    class: moped
+    categories: [moped]
+    period: { start: 2005 }        # 01-09-2005
+    format:
+      pattern: "99-LLL-9"
+      regex: '\A\d{2}-[A-Z]{3}-\d\z'
+      regex_strict: '\A\d{2}-[DF][BDFGHJKLMNPRSTVWXYZ]{2}-\d\z'
+      charset: { first_letter: [D, F], notes: "moped registrations begin with D or F" }
+    design:
+      plate: { w: 145, h: 125, unit: mm }
+      plate_variants:
+        - { w: 100, h: 175, unit: mm, note: "staand (portrait) model 30.1" }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    variants:
+      - class: moped
+        design: { background: { color: "#7CB9E8", finish: retroreflective, hex_basis: observed }, foreground: "#000000" }
+        note: >-
+          SNORFIETS (25 km/h max) carries the same registration on a LIGHT BLUE
+          plate — models 30.3 (portrait) / 30.4 (landscape). Yellow is the
+          45 km/h bromfiets and the speed-pedelec. Colour-only variant, so a
+          sub-entry, but note this loses the light-blue/yellow distinction to
+          class-keyed queries (see the L0 report's schema stressors).
+        sources:
+          - "https://www.rdw.nl/zakelijke-partners/erkende-bedrijven/kentekenplaatfabrikanten/extra-eisen-per-kleur-en-model/kentekenplaat-voor-snor-of-bromfiets  # 45 km/h = geel model 30.1/30.2; 25 km/h snorfiets = lichtblauw model 30.3/30.4"
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Brom- en snorfietsen: serie 7, combinatie 99-XXX-9, ingangsdatum 01-09-2005"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # Brom- en snorfietsen: eerste letters D en F"
+      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # bromfietsplaat 145x125 liggend of 100x175 staand"
+    notes: >-
+      Sidecode 7 for MOPEDS, from 01-09-2005 — the NL moped registration
+      obligation's first series, and three years ahead of the car rollout of the
+      same pattern.
+
+  - id: nl-sidecode9-moped
+    class: moped
+    categories: [moped]
+    period: { start: 2006 }        # 11-08-2006
+    format:
+      pattern: "LL-999-L"
+      regex: '\A[A-Z]{2}-\d{3}-[A-Z]\z'
+      regex_strict: '\A[DF][BDFGHJKLMNPRSTVWXYZ]-\d{3}-[BDFGHJKLMNPRSTVWXYZ]\z'
+      charset: { first_letter: [D, F] }
+    design:
+      plate: { w: 145, h: 125, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
       foreground: "#000000"
       band: { side: left, color: "#003399", content: eu-stars+NL }
     region_encoding: none
     sources:
-      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # pattern XXX-99-X reached mopeds 2015 (official series table)"
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Brom- en snorfietsen: serie 9, combinatie XX-999-X, ingangsdatum 11-08-2006"
+    notes: >-
+      Sidecode 9 for MOPEDS, from 11-08-2006 — NINE YEARS before cars reached the
+      same pattern (30-03-2015). Mopeds skipped sidecode 8 entirely.
+
+  - id: nl-sidecode10-moped
+    class: moped
+    categories: [moped]
+    period: { start: 2008 }        # 11-12-2008
+    format:
+      pattern: "L-999-LL"
+      regex: '\A[A-Z]-\d{3}-[A-Z]{2}\z'
+      regex_strict: '\A[DF]-\d{3}-[BDFGHJKLMNPRSTVWXYZ]{2}\z'
+      charset: { first_letter: [D, F] }
+    design:
+      plate: { w: 145, h: 125, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Brom- en snorfietsen: serie 10, combinatie X-999-XX, ingangsdatum 11-12-2008"
+    notes: Sidecode 10 for MOPEDS, from 11-12-2008 — eleven years ahead of the car rollout.
+
+  - id: nl-sidecode11-moped         # seed id — PRESERVED
+    class: moped
+    categories: [moped]
+    period: { start: 2015 }        # 16-01-2015 (seed said 2015 — confirmed)
+    format:
+      pattern: "LLL-99-L"
+      regex: '\A[A-Z]{3}-\d{2}-[A-Z]\z'
+      regex_strict: '\A[DF][BDFGHJKLMNPRSTVWXYZ]{2}-\d{2}-[BDFGHJKLMNPRSTVWXYZ]\z'
+      charset: { first_letter: [D, F] }
+    design:
+      plate: { w: 145, h: 125, unit: mm }
+      plate_variants:
+        - { w: 100, h: 175, unit: mm, note: "staand model" }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Brom- en snorfietsen: serie 11, combinatie XXX-99-X, ingangsdatum 16-01-2015"
       - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # colours + dimensions"
-    notes: sidecode 11 for the MOPED category — the pattern's first rollout (2015).
-  - id: nl-sidecode11-agricultural
+    notes: >-
+      Sidecode 11 for MOPEDS, from 16-01-2015 — the pattern's FIRST rollout of all,
+      nine years before cars. Seed correction: the seed gave 520x110 as an implied
+      default and the D/F rule only in prose; dimensions here are the moped models.
+
+  - id: nl-sidecode12-specialmoped
+    class: moped
+    categories: [moped]
+    period: { start: 2025 }        # 01-07-2025
+    format:
+      pattern: "E-99-LLL"
+      regex: '\AE-\d{2}-[A-Z]{3}\z'
+      regex_strict: '\AE-\d{2}-[BDFGHJKLMNPRSTVWXYZ]{3}\z'
+      charset: { first_letter: [E], notes: "bijzondere bromfietsen begin with E — the one place a VOWEL is issued outside the oplegger exception" }
+    design:
+      plate: { w: 100, h: 120, unit: mm }
+      background: { color: "#7CB9E8", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+      note: "model 31.1; mounted at the rear, but front-mounted on Ninebot Urban, Ninebot type E, Trikke and Paukool S1"
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Bijzondere bromfietsen: serie 12, combinatie X-99-XXX, ingangsdatum 01-07-2025"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # Bijzondere bromfietsen: eerste letter E"
+      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # bijzondere bromfiets 100x120 mm; lichtblauw for 25 km/h"
+      - "https://www.rdw.nl/zakelijke-partners/erkende-bedrijven/kentekenplaatfabrikanten/extra-eisen-per-kleur-en-model/kentekenplaat-voor-snor-of-bromfiets  # bijzondere bromfiets = lichtblauw, model 31.1"
+    notes: >-
+      Sidecode 12 for BIJZONDERE BROMFIETSEN (special mopeds — e-scooters and
+      similar light electric vehicles), from 01-07-2025. The newest NL series and
+      the smallest NL plate. Distinct from the 45 km/h bromfiets and the 25 km/h
+      snorfiets, both of which carry ordinary moped registrations.
+
+  # =========================================================================
+  # TRAILERS AND SEMI-TRAILERS — RDW "Aanhangwagens" / "Opleggers", both
+  # sidecode 4 from 01-10-1988, but different first letters (W vs O), which is
+  # exactly why they are two entries and not one.
+  # =========================================================================
+  - id: nl-sidecode4-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 1988 }        # 01-10-1988
+    format:
+      pattern: "WL-99-LL"
+      regex: '\AW[A-Z]-\d{2}-[A-Z]{2}\z'
+      regex_strict: '\AW[BDFGHJKLMNPRSTVWXYZ]-\d{2}-[BDFGHJKLMNPRSTVWXYZ]{2}\z'
+      charset: { first_letter: [W], notes: "trailer registrations always begin with W" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      plate_variants:
+        - { w: 340, h: 210, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+      note: "yellow plate + own registration only ABOVE 750 kg maximum permitted mass; at or below 750 kg the trailer repeats the towing vehicle's registration on a white plate"
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Aanhangwagens: serie 4, combinatie XX-99-XX, ingangsdatum 01-10-1988"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # Aanhangwagens: eerste letter W"
+      - "https://www.rdw.nl/zakelijke-partners/erkende-bedrijven/kentekenplaatfabrikanten/extra-eisen-per-kleur-en-model/kentekenplaat-voor-aanhangwagen-of-caravan  # 'Het kenteken van een aanhangwagen begint altijd met de letter W'; >750 kg = eigen kenteken"
+    notes: >-
+      Sidecode 4 for TRAILERS AND CARAVANS over 750 kg, from 01-10-1988 — the
+      oldest continuously-issuing NL series on RDW's table, still not exhausted
+      after 38 years.
+
+  - id: nl-sidecode4-semitrailer
+    class: trailer
+    categories: [semitrailer]
+    period: { start: 1988 }        # 01-10-1988
+    format:
+      pattern: "OL-99-LL"
+      regex: '\AO[A-Z]-\d{2}-[A-Z]{2}\z'
+      regex_strict: '\AO[ABDEFGHIJKLMNOPRSTUVWXYZ]-\d{2}-[ABDEFGHIJKLMNOPRSTUVWXYZ]{2}\z'
+      charset:
+        first_letter: [O]
+        notes: >-
+          Semi-trailer registrations always begin with O — and the no-vowels rule
+          is expressly disapplied for opleggers ("met uitzondering van het kenteken
+          voor opleggers"), so this is the one NL series whose regex_strict keeps
+          the vowels. C and Q remain excluded (nought-lookalikes).
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Opleggers: serie 4, combinatie XX-99-XX, ingangsdatum 01-10-1988"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # Opleggers: eerste letter O; no-vowels rule excepted for opleggers"
+    notes: >-
+      Sidecode 4 for SEMI-TRAILERS, from 01-10-1988 — same pattern and same date as
+      trailers but a different letter space, which is why RDW publishes them as two
+      tables and why they are two series here.
+
+  # =========================================================================
+  # AGRICULTURAL / MOBILE MACHINERY. First letter T for tractors, mobile
+  # machines and MMBS; L for agricultural trailers and interchangeable towed
+  # equipment. "L" collides with the pattern DSL's letter placeholder, so the
+  # L-prefix survives only in charset + regex_strict (schema stressor).
+  # =========================================================================
+  - id: nl-sidecode12-agritractor
     class: agricultural
-    categories: [truck]            # agricultural vehicles/trailers register here
-    period: { start: 2021 }
+    categories: [tractor, machine]
+    period: { start: 2021 }        # 01-12-2021
     format:
-      pattern: "LLL-99-L"
-      regex: '\A[A-Z]{3}-\d{2}-[A-Z]\z'
-      charset: { notes: "no vowels; see moped entry" }
+      pattern: "T-99-LLL"
+      regex: '\AT-\d{2}-[A-Z]{3}\z'
+      regex_strict: '\AT-\d{2}-[BDFGHJKLMNPRSTVWXYZ]{3}\z'
+      charset: { first_letter: [T], notes: "agricultural/forestry tractors, mobile machines and MMBS all begin with T" }
     design:
       plate: { w: 520, h: 110, unit: mm }
-      background: { color: "#F9B700", finish: retroreflective }
+      plate_variants:
+        - { w: 340, h: 210, unit: mm }
+        - { w: 210, h: 143, unit: mm, note: "motorcycle-size model permitted for agricultural vehicles" }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
       foreground: "#000000"
       band: { side: left, color: "#003399", content: eu-stars+NL }
     region_encoding: none
     sources:
-      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # same pattern, agricultural rollout 2021"
-    notes: sidecode 11 for AGRICULTURAL vehicles — same pattern, own 2021 rollout (the pattern-x-category rule).
-  - id: nl-sidecode11-car
-    class: standard
-    categories: [car, van]
-    period: { start: 2024 }
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Land- en bosbouwtrekkers (trekkend): serie 12, combinatie X-99-XXX, ingangsdatum 01-12-2021"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # Land-/bosbouwtrekkers, mobiele machines, MMBS'en: eerste letter T"
+      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # 520x110 / 340x210 / 210x143 for (land)bouwvoertuigen, MMBS, mobiele machines"
+    notes: >-
+      Sidecode 12 for AGRICULTURAL AND FORESTRY TRACTORS, mobile machines and MMBS,
+      from 01-12-2021 — the NL agricultural registration obligation. Sidecode 12
+      reached tractors before it reached light commercials (2024) or special
+      mopeds (2025).
+
+  - id: nl-sidecode11-agricultural  # seed id — PRESERVED
+    class: agricultural
+    categories: [trailer]          # CORRECTED from the seed's [truck]: this is the
+                                   # agricultural TRAILER / interchangeable towed
+                                   # equipment series (RDW's own table heading).
+    period: { start: 2021 }        # 01-01-2021 (seed said 2021 — confirmed)
     format:
       pattern: "LLL-99-L"
       regex: '\A[A-Z]{3}-\d{2}-[A-Z]\z'
-      charset: { notes: "no vowels; V leads light-commercial series — cijfers-en-letters page" }
+      regex_strict: '\AL[BDFGHJKLMNPRSTVWXYZ]{2}-\d{2}-[BDFGHJKLMNPRSTVWXYZ]\z'
+      charset:
+        first_letter: [L]
+        notes: >-
+          "Het kenteken van een aanhangwagen of verwisselbaar getrokken
+          uitrustingsstuk van een land- of bosbouwtrekker, MMBS of mobiele machine
+          begint altijd met de letter 'L'." The literal L CANNOT be written into
+          format.pattern because L is the pattern DSL's letter placeholder — it
+          survives only here and in regex_strict. See the L0 report.
     design:
       plate: { w: 520, h: 110, unit: mm }
-      background: { color: "#F9B700", finish: retroreflective }
+      plate_variants:
+        - { w: 340, h: 210, unit: mm }
+        - { w: 210, h: 143, unit: mm, note: "model 27.10 permitted for agricultural trailers" }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
       foreground: "#000000"
       band: { side: left, color: "#003399", content: eu-stars+NL }
     region_encoding: none
     sources:
-      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # same pattern, cars 2024"
-      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # yellow ground, black characters, blue EU strip NL; 520x110"
-    notes: sidecode 11 for CARS/light commercial — same pattern, 2024 rollout. Third entry of one pattern; the trio IS the pattern-x-category rule demonstrated.
-  - id: nl-historic-darkblue
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Land- en bosbouwaanhangwagens en verwisselbare getrokken uitrustingsstukken: serie 11, combinatie XXX-99-X, ingangsdatum 01-01-2021"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # Land-/bosbouwaanhangwagens: eerste letter L"
+      - "https://www.rdw.nl/zakelijke-partners/erkende-bedrijven/kentekenplaatfabrikanten/extra-eisen-per-kleur-en-model/kentekenplaat-voor-aanhangwagen-of-caravan  # 'begint altijd met de letter L'"
+    notes: >-
+      Sidecode 11 for AGRICULTURAL TRAILERS and interchangeable towed equipment,
+      from 01-01-2021. Seed correction: the seed carried categories [truck] and
+      called this "agricultural vehicles/trailers"; RDW's table separates the
+      TOWING agricultural vehicles (sidecode 12, first letter T, 01-12-2021) from
+      the TOWED ones (this entry, first letter L, 01-01-2021).
+
+  # =========================================================================
+  # GRENSVERKEER (GV). The only place RDW dates sidecodes 1, 2 and 3, and the
+  # only NL series whose LETTER GROUP IS A LITERAL: "GV - altijd in combinatie
+  # met 4 cijfers" (cijfers-en-letters). All five GV patterns carry exactly
+  # four digits and the pair GV, which is self-consistent with the shapes.
+  # =========================================================================
+  - id: nl-gv-sidecode1
+    class: agricultural
+    categories: [tractor, machine]
+    period: { start: 1951 }
+    format:
+      pattern: "GV-99-99"
+      regex: '\AGV-\d{2}-\d{2}\z'
+      charset: { fixed_letters: "GV", notes: "the letter pair is literally GV" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Grensverkeer (GV-serie): 1951, afwisselend series 1, 2 en 3; serie 1 = XX-99-99"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # 'Grensverkeer: GV - altijd in combinatie met 4 cijfers'"
+    notes: >-
+      GV series on SIDECODE 1 (XX-99-99), from 1951 — RDW's series page states the
+      national kenteken began in 1951 and that the GV series ran series 1, 2 and 3
+      alternately ("Afwisselend 1, 2 en 3"). CLASS CAVEAT: RDW publishes the GV
+      table under its "Landbouwvoertuigen, mobiele machines en MMBS'en" heading, so
+      the class is recorded as agricultural on that placement; RDW's plate pages do
+      not define the grensverkeer series' scope. Flagged for L1 verification.
+
+  - id: nl-gv-sidecode2
+    class: agricultural
+    categories: [tractor, machine]
+    period: { start: 1951 }
+    format:
+      pattern: "99-99-GV"
+      regex: '\A\d{2}-\d{2}-GV\z'
+      charset: { fixed_letters: "GV" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Grensverkeer: serie 2 = 99-99-XX, from 1951"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # GV always with 4 digits"
+    notes: >-
+      GV series on SIDECODE 2 (99-99-XX), from 1951. One of the three alternating
+      1951 shapes; separate entry because a series is one PATTERN, and the parse
+      API must be able to score each shape independently.
+
+  - id: nl-gv-sidecode3
+    class: agricultural
+    categories: [tractor, machine]
+    period: { start: 1951 }
+    format:
+      pattern: "99-GV-99"
+      regex: '\A\d{2}-GV-\d{2}\z'
+      charset: { fixed_letters: "GV" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Grensverkeer: serie 3 = 99-XX-99, from 1951"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # GV always with 4 digits"
+    notes: >-
+      GV series on SIDECODE 3 (99-XX-99), from 1951. Third of the three alternating
+      1951 shapes.
+
+  - id: nl-gv-sidecode13
+    class: agricultural
+    categories: [tractor, machine]
+    period: { start: 2016 }        # 23-05-2016
+    format:
+      pattern: "9-GV-999"
+      regex: '\A\d-GV-\d{3}\z'
+      charset: { fixed_letters: "GV" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Grensverkeer: serie 13, combinatie 9-XX-999, ingangsdatum 23-05-2016"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # GV always with 4 digits"
+    notes: >-
+      GV series on SIDECODE 13, from 23-05-2016. Sidecode 13 exists ONLY for the GV
+      series — no other NL category has ever been issued this pattern, which makes
+      a 9-GV-999 plate a one-shot identification.
+
+  - id: nl-gv-sidecode14
+    class: agricultural
+    categories: [tractor, machine]
+    period: { start: 2019 }        # 13-06-2019
+    format:
+      pattern: "999-GV-9"
+      regex: '\A\d{3}-GV-\d\z'
+      charset: { fixed_letters: "GV" }
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+NL }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # Grensverkeer: serie 14, combinatie 999-XX-9, ingangsdatum 13-06-2019"
+      - "https://www.rdw.nl/de-kentekenplaat/cijfers-en-letters-op-de-kentekenplaat  # GV always with 4 digits"
+    notes: >-
+      GV series on SIDECODE 14, from 13-06-2019 — the highest sidecode RDW
+      publishes, and like sidecode 13 exclusive to the GV series.
+
+  # =========================================================================
+  # HISTORIC (donkerblauw). A DESIGN REGIME laid over pre-existing sidecode
+  # 1/2/3 registrations, not a serial series of its own: RDW requires the
+  # registration to consist of "2 groepen van 2 cijfers en 1 groep van 2
+  # letters", which is exactly sidecodes 1, 2 and 3. Hence three entries plus
+  # one for the agricultural exemption.
+  # =========================================================================
+  - id: nl-historic-darkblue        # seed id — PRESERVED
     class: historic
-    categories: [car, van, truck, bus]
-    period: { start: 1978, ended: true }   # the REGIME applies to pre-1978
-                                           # vehicles; issuance continues but the
-                                           # eligible fleet is closed — recorded
-                                           # ended pending an RDW statement on
-                                           # the regime's own issuance window
+    categories: [car, van, motorcycle]
+    period: { start: 1978 }
+    period_evidence: eligibility-cutoff   # NOT an issuance-start claim; see notes
     format:
       pattern: "LL-99-99"
       regex: '\A[A-Z]{2}-\d{2}-\d{2}\z'
-      charset: { notes: "historic plates reuse the vehicle's original registration in old sidecodes; pattern here is the dominant sidecode-1 shape — refine in the L0 completion pass" }
+      regex_strict: '\A[BDFGHJKLMNPRSTVWXYZ]{2}-\d{2}-\d{2}\z'
+      charset: { notes: "sidecode-1 shape; the historic regime accepts only registrations of 2+2 digits and 2 letters" }
     design:
-      plate: { w: 520, h: 110, unit: mm }
-      background: { color: "#1D2E5B", finish: painted }   # dark blue, white chars
+      plate: { w: 445, h: 105, unit: mm }
+      plate_variants:
+        - { w: 275, h: 195, unit: mm, note: "rechthoekig" }
+        - { w: 200, h: 145, unit: mm, note: "motorcycle, 200 mm maximum" }
+        - { w: 310, h: 110, unit: mm, note: "American model 18.2 in dark blue" }
+      background: { color: "#1D2E5B", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      note: "models 1.1 to 18.1; no duplicaatcode and no lamineercode, and not registered in GAIK"
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # donkerblauwe plaat, DET before 1-1-1978, kenteken = 2 groepen van 2 cijfers en 1 groep van 2 letters; 445x105 / 275x195 / 200x145 / 310x110"
+      - "https://www.rdw.nl/de-kentekenplaat/kentekenplaten-voor-oldtimer-aanvragen  # eligibility (auto, bedrijfsauto, kampeerauto, motor, landbouwvoertuig, mobiele machine, aanhangwagen >=751 kg); mopeds excluded; EUR 50 to swap to a historisch kenteken"
+      - "https://www.rdw.nl/zakelijke-partners/erkende-bedrijven/kentekenplaatfabrikanten/extra-eisen-per-kleur-en-model/donkerblauwe-kentekenplaten-historisch  # models 1.1 t/m 18.1; no duplicaatcode/lamineercode; not registered in GAIK"
+    notes: >-
+      Oldtimer regime on a SIDECODE-1 registration (XX-99-99). SEED CORRECTIONS,
+      both material: (1) the seed set `ended: true`; RDW still issues these today
+      (the oldtimer page takes applications and prices the swap at EUR 50), so the
+      series is OPEN. (2) The seed's pattern was flagged "refine in the L0
+      completion pass" — refined here: RDW's eligibility text pins the accepted
+      shapes to exactly sidecodes 1, 2 and 3, so the regime is modelled as three
+      format entries plus the agricultural exemption. period.start 1978 records the
+      ELIGIBILITY CUTOFF ("datum eerste toelating" before 1 January 1978), not an
+      issuance start — the date the dark-blue regime itself began is on no RDW page
+      and is a recorded gap.
+
+  - id: nl-historic-darkblue-sidecode2
+    class: historic
+    categories: [car, van, motorcycle]
+    period: { start: 1978 }
+    period_evidence: eligibility-cutoff
+    format:
+      pattern: "99-99-LL"
+      regex: '\A\d{2}-\d{2}-[A-Z]{2}\z'
+      regex_strict: '\A\d{2}-\d{2}-[BDFGHJKLMNPRSTVWXYZ]{2}\z'
+    design:
+      plate: { w: 445, h: 105, unit: mm }
+      background: { color: "#1D2E5B", finish: painted, hex_basis: observed }
       foreground: "#FFFFFF"
       band: { side: none }
     region_encoding: none
     sources:
-      - "https://www.rdw.nl/de-kentekenplaat/kentekenplaten-voor-oldtimer-aanvragen  # dark-blue historic plates, pre-1978 eligibility rule"
-    notes: oldtimer regime — dark blue, pre-1978 vehicles. Shape/period to be refined against the RDW page in the completion pass; seeded to exercise the historic class and ended semantics.
+      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # the 2+2 digits / 2 letters rule admits the sidecode-2 shape 99-99-XX"
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # sidecode 2 = 99-99-XX"
+    notes: >-
+      Oldtimer regime on a SIDECODE-2 registration (99-99-XX). Second of the three
+      shapes RDW's "2 groepen van 2 cijfers en 1 groep van 2 letters" rule admits.
+
+  - id: nl-historic-darkblue-sidecode3
+    class: historic
+    categories: [car, van, motorcycle]
+    period: { start: 1978 }
+    period_evidence: eligibility-cutoff
+    format:
+      pattern: "99-LL-99"
+      regex: '\A\d{2}-[A-Z]{2}-\d{2}\z'
+      regex_strict: '\A\d{2}-[BDFGHJKLMNPRSTVWXYZ]{2}-\d{2}\z'
+    design:
+      plate: { w: 445, h: 105, unit: mm }
+      background: { color: "#1D2E5B", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # the 2+2 digits / 2 letters rule admits the sidecode-3 shape 99-XX-99"
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # sidecode 3 = 99-XX-99"
+    notes: >-
+      Oldtimer regime on a SIDECODE-3 registration (99-XX-99). Third of the three
+      admitted shapes. A vehicle whose registration has another shape must first
+      swap to a "historisch kenteken" before blue plates can be made.
+
+  - id: nl-historic-darkblue-agricultural
+    class: historic
+    categories: [tractor, machine, trailer]
+    period: { start: 1978 }
+    period_evidence: eligibility-cutoff
+    format:
+      pattern: "LLL-99-L"
+      regex: '\A(?:[A-Z]{2}-\d{2}-\d{2}|\d{2}-\d{2}-[A-Z]{2}|\d{2}-[A-Z]{2}-\d{2}|[A-Z]{2}-\d{2}-[A-Z]{2}|[A-Z]{2}-[A-Z]{2}-\d{2}|\d{2}-[A-Z]{2}-[A-Z]{2}|\d{2}-[A-Z]{3}-\d|\d-[A-Z]{3}-\d{2}|[A-Z]{2}-\d{3}-[A-Z]|[A-Z]-\d{3}-[A-Z]{2}|[A-Z]{3}-\d{2}-[A-Z]|[A-Z]-\d{2}-[A-Z]{3}|\d-[A-Z]{2}-\d{3}|\d{3}-[A-Z]{2}-\d)\z'
+      pattern_note: >-
+        The pattern shown is ONE representative shape (sidecode 11). This series has
+        no format of its own: RDW expressly exempts agricultural vehicles, mobile
+        machines and >=751 kg trailers from the 2+2+2 rule ("Bij een landbouwvoertuig
+        hoeft het kenteken niet 'historisch' te zijn"), so ANY current NL sidecode may
+        appear on a dark-blue plate here. The regex is therefore the union of all
+        fourteen RDW-published sidecode shapes.
+    design:
+      plate: { w: 445, h: 105, unit: mm }
+      background: { color: "#1D2E5B", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/kentekenplaten-voor-oldtimer-aanvragen  # agricultural vehicles, mobile machines and trailers >=751 kg need only pre-1978 first admission"
+      - "https://www.rdw.nl/zakelijke-partners/erkende-bedrijven/kentekenplaatfabrikanten/extra-eisen-per-kleur-en-model/donkerblauwe-kentekenplaten-historisch  # 'Bij een landbouwvoertuig hoeft het kenteken niet historisch te zijn'"
+      - "https://www.rdw.nl/de-kentekenplaat/overzicht-van-kentekenseries  # the fourteen sidecode shapes the union regex is built from"
+    notes: >-
+      Oldtimer regime for AGRICULTURAL vehicles, mobile machines, MMBS and trailers
+      of 751 kg or more, which RDW exempts from the 2+2+2 registration-shape rule.
+      The only NL entry whose regex is a union rather than a single shape.
+
+  # =========================================================================
+  # EXPORT. RDW: the export plate REUSES the vehicle's existing registration,
+  # so its regex is the union of all NL shapes, exactly like the agricultural
+  # historic entry above, and for the same sourced reason.
+  # =========================================================================
+  - id: nl-export
+    class: export
+    categories: [car, van, truck, bus, motorcycle, moped, trailer, semitrailer, tractor, machine]
+    period: { start: 1951 }
+    period_evidence: earliest-underlying-series   # the regime's own start is unsourced
+    format:
+      pattern: "LLL-99-L"
+      regex: '\A(?:[A-Z]{2}-\d{2}-\d{2}|\d{2}-\d{2}-[A-Z]{2}|\d{2}-[A-Z]{2}-\d{2}|[A-Z]{2}-\d{2}-[A-Z]{2}|[A-Z]{2}-[A-Z]{2}-\d{2}|\d{2}-[A-Z]{2}-[A-Z]{2}|\d{2}-[A-Z]{3}-\d|\d-[A-Z]{3}-\d{2}|[A-Z]{2}-\d{3}-[A-Z]|[A-Z]-\d{3}-[A-Z]{2}|[A-Z]{3}-\d{2}-[A-Z]|[A-Z]-\d{2}-[A-Z]{3}|\d-[A-Z]{2}-\d{3}|\d{3}-[A-Z]{2}-\d)\z'
+      pattern_note: "representative shape only; the regex is the union of all fourteen RDW sidecode shapes because the export plate carries the vehicle's existing registration"
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      plate_variants:
+        - { w: 340, h: 210, unit: mm }
+        - { w: 210, h: 143, unit: mm, note: "motorcycle" }
+        - { w: 100, h: 175, unit: mm, note: "moped, portrait" }
+        - { w: 145, h: 125, unit: mm, note: "moped, landscape" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      note: "models 27.24 (long) / 27.25 (rectangular) / 27.26 (motorcycle) / 30.13 / 30.14; owners may make these plates themselves; no duplicaatcode, no lamineercode, not registered in GAIK"
+    validity: { days: 14, note: "valid 14 days, and never longer than the vehicle's APK (roadworthiness) certificate" }
+    region_encoding: none
+    sources:
+      - "https://www.rdw.nl/de-kentekenplaat/soorten-kentekenplaten  # uitvoerkentekenplaat: wit met zwarte cijfers en letters; 'U mag hiervoor het bestaande kenteken van het voertuig gebruiken'; 14 dagen geldig, niet langer dan de APK"
+      - "https://www.rdw.nl/zakelijke-partners/erkende-bedrijven/kentekenplaatfabrikanten/extra-eisen-per-kleur-en-model/witte-kentekenplaten-tijdelijk  # export models 27.24/27.25/27.26/30.13/30.14; checked against papieren kentekenbewijs deel II voor uitvoer"
+    notes: >-
+      EXPORT plates (uitvoerkentekenplaat). White with black characters, carrying
+      the vehicle's OWN existing registration, valid 14 days. period.start records
+      the earliest date any reusable NL registration was issued (1951), not the
+      date the export regime began — that date is on no RDW page and is a recorded
+      gap. Distinct from the TRANSIT (transito) plate, which issues a NEW number to
+      a vehicle that never held a Dutch registration; the transit number's grammar
+      is not published by RDW and is therefore NOT modelled here (see the L0 report).

--- a/plates/us-fl.yml
+++ b/plates/us-fl.yml
@@ -1,0 +1,518 @@
+# plates/us/fl.yml — Florida (PRD-PLATES gate L0 pilot; the federated case).
+#
+# WHY FLORIDA IS THE PILOT STATE, restated from the source law: the US has NO
+# federal plate mandate and per-state IP posture VARIES. Florida is the
+# affirmatively favourable case — its constitution and public-records statutes
+# bar copyright claims over public records, and Microdecisions, Inc. v. Skinner
+# (2004) held government-produced text, communications AND IMAGES to be public
+# domain. See `artwork_risk` below.
+#
+# SOURCING RULE APPLIED HERE: Florida's plate FACTS come from the STATUTE, not
+# the brochure. Edicts of government are public domain at every level, and
+# PRD-PLATES §4 says always prefer the statute over the brochure. So every
+# format, dimension, legend, display and replacement-cycle claim below cites
+# Chapter 320 or Chapter 316 of the Florida Statutes. The FLHSMV brochure and
+# the specialty portal are cited only for the two things the statute does not
+# carry: which standard VARIANTS are currently offered, and how many specialty
+# programs exist.
+#
+# WHAT IS DELIBERATELY NOT HERE (PRD-PLATES §2.5): the individual specialty
+# DESIGNS. L2 indexes the programs with official links and counts; individual
+# designs are L4. `us-fl-specialty-index` is that index entry and nothing more.
+jurisdiction: us-fl
+authority:
+  name: Florida Department of Highway Safety and Motor Vehicles (FLHSMV)
+  url: "https://www.flhsmv.gov/motor-vehicles-tags-titles/license-plates-registration/"
+binding: vehicle
+statute_edition: "The 2025 Florida Statutes (Title XXIII Motor Vehicles, Chapters 316 and 320) — the edition read for this pass; leg.state.fl.us serves editions back to 1997"
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: public-domain-favourable
+  basis: >-
+    Florida is the strongest public-domain posture of any US state surveyed: the
+    state constitution plus the public-records statutes prohibit copyright claims
+    over public records, and Microdecisions, Inc. v. Skinner (2004) held that
+    government-produced text, communications and IMAGES are public domain.
+    Wikimedia Commons carries and actively uses the {{PD-FLGov}} tag. Contrast
+    Arizona, which expressly asserts copyright, and NY/PA/WA, which are adverse.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default still applies to the ORANGE BLOSSOM and
+    STATE MAP graphic until the emblem is affirmatively cleared per-emblem. Even
+    under a favourable copyright posture, state seals and emblems carry
+    protection INDEPENDENT of copyright (state-seal misuse statutes), and that
+    question is unresearched. Render `emblem: {present: true, rendered:
+    placeholder}` and revisit as a named decision.
+  photograph_caution: >-
+    Commons photographs of Florida plates are dominantly CC BY-SA — but that is
+    the PHOTOGRAPHER's licence on the PHOTOGRAPH, and the uploader had no
+    standing over the design. Measured examples: File:FL-2010.jpg CC BY-SA 4.0,
+    File:1983 Florida license plate - XRN 061.jpg CC BY-SA 3.0, File:License
+    plates of Florida 1844.jpg CC BY-SA 4.0. Because our renders are generated
+    from the statute and never derived from a photograph, those share-alike
+    obligations never attach.
+  sources:
+    - "https://commons.wikimedia.org/wiki/Template:PD-FLGov  # the Florida PD tag exists and is in active use (Category:PD Florida)"
+    - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # the statutory design spec itself — an edict of government, PD"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Recorded once, because it is voluntary and because
+# the delegation trap matters: AAMVA sends dimensions to SAE J686, whose own
+# text is PAYWALLED and UNPINNED. Nothing below quotes J686.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA has no enforcement power; it writes recommendations in the declarative present, which must be read as RECOMMENDED PRACTICE, not requirement."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1: 'License plate dimensions and bolt holes comply with the SAE International Motor Vehicle License Plates Standard J686.' So the dimension authority is SAE J686 — not AAMVA, not any federal body. J686's own text is paywalled and was NOT obtained; no J686 dimension is quoted anywhere in this dataset."
+    retroreflectivity: "AAMVA §3.3: readable 'in both daylight and nighttime from distances of at least 75 feet'; materials per ASTM D4956-19 and ISO 7591:1982 clause 3; test geometry entrance angle 0.2°, observation angle -4°, minimum 45 cd/lx/m²"
+    jurisdiction_name_layout: "AAMVA §2.1: the jurisdiction name 'appears in the top center location between the bolt holes', at least 0.25 in above the plate number and at least 0.125 in from the top edge; jurisdiction characters 0.75-1.0 in"
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of the top and bottom edges"
+    stacked_characters: "AAMVA: 'If stacked characters are used, they are part of the official license plate number. No more than two characters are to be stacked.' Consequential for regex and normalisation — a stacked pair is SERIAL, not decoration."
+    replacement_cycle: "AAMVA §1.1: 'Because license plates lose significant retro-reflectivity within 7 years, a required rolling or full replacement cycle not to exceed 7 to 10 years is recommended.' Florida legislated 10 (see us-fl-standard)."
+    licence_posture: "AAMVA © — freely downloadable without click-through; facts extractable, text not reproducible. Cited, not quoted at length."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The famous "1956 AMA standardization agreement" that supposedly fixed the
+    6x12 inch plate is UNCITED in its Wikipedia source — a `citation needed`
+    since 2017, copied verbatim across articles, i.e. circular. It is recorded
+    here as COMMONLY REPEATED, UNSOURCED, and Florida's 6x12 minimum is instead
+    cited to § 320.06(3)(a) F.S., which states it in law.
+
+# ---------------------------------------------------------------------------
+# Display rules. Florida is a REAR-ONLY state with two statutory exceptions,
+# one of which is genuinely unusual (truck tractors are FRONT-ONLY).
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "ONE plate, rear. § 320.06(1)(a): the department issues 'one registration license plate, unless two plates are required for display by s. 320.0706, for each vehicle so registered'. § 316.605(1) then requires display of 'the license plate or both of the license plates assigned to it by the state, one on the rear and, if two, the other on the front'."
+  front_plate_required_when:
+    - "commercial truck of gross vehicle weight 26,001 lb or more: front AND rear (§ 320.0706)"
+    - "TRUCK TRACTOR: the owner 'shall be required to display the registration license plate only on the FRONT of such vehicle' (§ 320.0706) — front-only, the inverse of the state default and a genuine outlier in the US"
+  dump_truck: "the rear plate may be placed on the gate, no higher than 60 inches, for better visibility (§ 320.0706)"
+  exempt: "display is excused for described former military vehicles under § 320.086(5) (cross-referenced by § 316.605(1))"
+  mounting: "§ 316.605(1): securely fastened outside the main body, not higher than 60 in and not lower than 12 in from the ground, no more than 24 in left or right of the vehicle centreline, and not swinging; plainly visible and legible at 100 feet"
+  orientation: "§ 316.605(1): letters and numerals read left to right PARALLEL TO THE GROUND; no inverted or reversed display; nothing may be placed on the face of a Florida plate except as permitted by law or agency rule"
+  penalty: "violation of § 316.605(1) is a noncriminal traffic infraction, punishable as a NONMOVING violation; violation of § 320.0706 is punishable as a MOVING violation"
+  sources:
+    - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(1)(a): one plate unless two required by s. 320.0706"
+    - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0316/Sections/0316.605.html  # § 316.605(1): display, mounting heights, 100-foot legibility, orientation, the face-of-plate rule, penalty"
+    - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.0706.html  # § 320.0706: 26,001 lb trucks front and rear; truck tractors FRONT ONLY; dump-truck gate rule"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES.
+  # =========================================================================
+  - id: us-fl-standard
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, moped, trailer]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: >-
+          § 320.06(1)(a): the department assigns 'a registration license number
+          consisting of letters and numerals or numerals'. § 320.06(3)(a): the plate
+          'must be imprinted with a combination of bold letters and numerals or
+          numerals, NOT TO EXCEED SEVEN DIGITS'. That is the whole statutory
+          constraint — Florida law fixes a MAXIMUM LENGTH and an alphabet, and
+          nothing else. No letter exclusions are stated anywhere in Chapter 320.
+      pattern_note: >-
+        `regex` encodes the CURRENT passenger arrangement (three letters, three
+        numerals). `regex_statutory` encodes what the STATUTE actually permits — up
+        to seven alphanumeric characters — and is the honest bound for any
+        Florida plate of unknown vintage. Historical and parallel Florida
+        arrangements reported by secondary sources (ABC D12, A12 3BC, 12A BCD,
+        123 4AB, AB1 2CD, A12 34B) all fall inside `regex_statutory`; they are NOT
+        given series of their own here because no primary establishing their
+        periods was obtained (recorded gap).
+      stacked_characters_note: "AAMVA treats stacked characters as part of the official number, at most two stacked. Florida's statute is silent on stacking; a normaliser must decide, and the decision belongs in the parse layer, not here."
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: >-
+        § 320.06(3)(a), verbatim: the plate 'must be at least 6 inches wide and not
+        less than 12 inches in length, unless a plate with reduced dimensions is
+        deemed necessary by the department to accommodate motorcycles, mopeds,
+        similar smaller vehicles, or trailers'. Note the statute states MINIMA, and
+        note its axes read oddly ('6 inches wide', '12 inches in length') — the
+        conventional US plate is 12 in across by 6 in tall, recorded that way here.
+        The reduced motorcycle/moped/trailer sizes are set by DEPARTMENT DISCRETION,
+        not by statute, and were not obtained (recorded gap).
+      material: "metal, 'specially treated with a retroreflection material, as specified by the department', designed to increase nighttime visibility and legibility (§ 320.06(3)(a))"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#006747"
+      colour_note: >-
+        NEITHER COLOUR IS IN THE STATUTE. § 320.06(3)(a) mandates a retroreflection
+        material and says nothing about hue. The reflective-white ground and green
+        characters are `hex_basis: observed`, taken from the design as depicted in
+        FLHSMV's own brochure (fetched, but its plates are raster images) and
+        corroborated only by a Wikipedia LOCATOR. Treat both hexes as unverified
+        pending a departmental rule or a colour spec in the Florida Administrative
+        Code.
+      legend_top: "FLORIDA"
+      legend_bottom_options: ["<county name>", "<state motto>", "Sunshine State"]
+      legend_rule: >-
+        § 320.06(3)(a), verbatim: 'The license plate must be imprinted with the word
+        "Florida" at the top and the name of the county in which it is sold, the
+        state motto, or the words "Sunshine State" at the bottom.' And: 'Any county
+        may, upon majority vote of the county commission, elect to have the county
+        name removed from the license plates sold in that county. The state motto or
+        the words "Sunshine State" shall be printed in lieu thereof.' So the
+        county-name legend is a COUNTY-LEVEL OPT-OUT, which means the bottom legend
+        is not a property of the series at all but of the selling county — a real
+        modelling wrinkle for a jurisdiction-keyed schema.
+      graphic: { present: true, rendered: placeholder, description: "orange blossom over a state map, centred — observed from the official brochure images and a Wikipedia locator, NOT from a statutory drawing" }
+      emblem: { present: true, rendered: placeholder }
+      validation_sticker: { position: "upper right corner of the plate", content: "owner's birth month, plate number, and year of expiration or the applicable renewal period where the owner is not a natural person", material: "retroreflection-treated, adhesive", source_note: "§ 320.06(1)(b)1" }
+      band: { side: none }
+      rear_differs: false
+      variants_offered: ["Sunshine State", "County Name", "In God We Trust (state motto)", "America 250"]
+      variants_note: >-
+        All four are STANDARD plates, all orderable as personalized, and all four are
+        confirmed present in FLHSMV's official brochure. They are recorded as
+        `variants_offered` rather than as four series because § 320.06(3)(a) makes
+        the bottom legend a choice within one statutory design — format, period and
+        everything else are identical.
+    replacement_cycle:
+      years: 10
+      statutory_text: "§ 320.06(1)(b)1: 'Registration license plates bearing a graphic symbol and the alphanumeric system of identification shall be issued for a 10-year period. At the end of the 10-year period, upon renewal, the plate shall be replaced. The department shall extend the scheduled license plate replacement date from a 6-year period to a 10-year period.'"
+      fee: "$28 replacement, prepaid at $2.80 per year and credited toward the next $28"
+      note: >-
+        FLORIDA LEGISLATED THE TOP OF AAMVA'S RANGE. AAMVA §1.1 recommends a cycle
+        'not to exceed 7 to 10 years'; Florida chose 10 and, in the same sentence,
+        recorded that it moved UP from 6. This is the answer to "is there a US
+        redesign cadence?" — there is no redesign schedule anywhere, only
+        per-state REPLACEMENT cycles, and here is one in statute.
+    registration_period: "12 months standard, 24 months extended, or permanent for qualifying rental vehicles and certain semitrailers provided the taxes and fees are paid annually; expirations key off the owner's BIRTH MONTH (§ 320.06(1)(b)1, (1)(c))"
+    region_encoding: "county name appears as a LEGEND, not as a code — it is printed text, is opt-out at county-commission level, and encodes nothing in the serial. There is no geographic decode in a Florida plate string."
+    sources:
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(1)(a) one plate + 'letters and numerals or numerals'; (1)(b)1 the 10-year cycle, $28 fee, birth-month validation sticker; (1)(c) registration periods; (3)(a) 6x12 minimum, retroreflection, seven-character cap, FLORIDA top / county-motto-Sunshine State bottom, county opt-out"
+      - "https://www.flhsmv.gov/pdf/specialtyplates/FLPB.pdf  # official FLHSMV 'Florida License Plates' brochure, 27 pp — confirms the four standard variants: Sunshine State, County Name, In God We Trust (State Motto), America 250"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1 replacement-cycle recommendation Florida's 10 years sits at the top of"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Florida  # LOCATOR ONLY (PRD-PLATES §4): the reported February 2026 rollout of the orange-blossom design and the seven historical serial arrangements. Neither is asserted as sourced here."
+    notes: >-
+      FLORIDA STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED. PRD-PLATES's own
+      example id is `us-fl-standard-2003`, but no primary establishing the boundary
+      between Florida base-design generations was obtained in this pass: the FLHSMV
+      brochure carries designs as images with no dates, and the reported February
+      2026 rollout of the orange-blossom base is Wikipedia-grade. Rather than mint a
+      dated id on a folklore boundary and then have to alias it, this entry is the
+      undated statutory series; when a primary lands, a dated id is added and this id
+      becomes its former-id alias under the PRD-QUALITY I-5/I-6 contract.
+      PERIOD CAVEAT: `start: 2025` is the edition of the Florida Statutes read and is
+      an UPPER BOUND on the true start — Florida has issued alphanumeric plates for
+      the better part of a century. Recorded as an upper bound rather than invented.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Count and official
+  # links only; no individual designs.
+  # =========================================================================
+  - id: us-fl-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      charset: { notes: "specialty plates carry ORDINARY serials on an alternative design — the § 320.06(3)(a) seven-character cap and alphabet apply unchanged" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised program; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: "over 100"
+      count_official_quote: "FLHSMV, in its own words: 'Florida offers over 100 different specialty license plates for various organizations in support of the causes they represent.'"
+      count_secondary: "over 120 per Wikipedia — LOCATOR ONLY, not reconciled with FLHSMV's own figure; the discrepancy is recorded, not averaged (PRD-PLATES §5.3)"
+      official_list_url: "https://www.flhsmv.gov/motor-vehicles-tags-titles/personalized-specialty-license-plates/specialty-license-plates/"
+      official_catalogue_url: "https://www.flhsmv.gov/pdf/specialtyplates/FLPB.pdf"
+      official_military_catalogue_url: "https://www.flhsmv.gov/pdf/specialtyplates/military_brochure.pdf"
+      registration_counts_url: "https://services.flhsmv.gov/specialtyplates/"
+      registration_counts_note: >-
+        THE DIFFERENTIATOR NO COMPETITOR HAS. services.flhsmv.gov/specialtyplates/ is
+        a REPORTING PORTAL, not a gallery: it publishes a Monthly Active Specialty
+        Plates report ('all active registration as of the first of each month' —
+        active meaning a current/valid decal) and a Monthly Revenue Collections
+        report with three years of history. That is per-plate ISSUANCE VOLUME from
+        the issuing agency. No enthusiast site and no competing dataset carries
+        issuance volumes. The active-plate report explicitly has NO HISTORICAL DATA,
+        so it must be snapshotted monthly or the history is lost forever.
+      brochure_sections_observed: ["STANDARD", "SPECIALTY - COLLEGIATE", "SPECIAL - COMMERCIAL VEHICLE", "SPECIAL - FRONT END FOR EMERGENCY PERSONNEL", "SPECIAL - HISTORICAL VEHICLE", "SPECIAL - MISCELLANEOUS"]
+      special_requirement_subtype: "FLHSMV distinguishes SPECIAL REQUIREMENT plates as 'a subtype of specialty license plates' — those needing the registrant to furnish proof before purchase (military decorations, disabled veteran, etc.). Medal of Honor, Air Force Cross, Navy Cross, Distinguished Service Cross, Silver Star, Distinguished Flying Cross and World War II Veteran plates must be ordered through the Department, not a service centre."
+      churn_note: "§ 320.08056(8)(a) obliges the department to DISCONTINUE issuance of an approved specialty plate in stated circumstances, so the index is a moving target with authorised-but-dead programs in it. The numeric threshold triggering discontinuation was not extracted in this pass (recorded gap)."
+      gift_certificate_program: "FLHSMV authorises specialty-plate GIFT CERTIFICATES redeemable at any authorised motor-vehicle office; money passes to the sponsoring entity on purchase, so refunds are not available."
+    region_encoding: none
+    sources:
+      - "https://www.flhsmv.gov/motor-vehicles-tags-titles/personalized-specialty-license-plates/  # FLHSMV: 'Florida offers over 100 different specialty license plates'; the special-requirement subtype; the military-plate ordering rule; the gift-certificate program"
+      - "https://services.flhsmv.gov/specialtyplates/  # Monthly Active Specialty Plates report (no historical data) + Monthly Revenue Collections report (3-year history)"
+      - "https://www.flhsmv.gov/pdf/specialtyplates/FLPB.pdf  # the 27-page official catalogue and its section structure"
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.08056.html  # § 320.08056: specialty plate authorisation, annual use fees, and the (8)(a) discontinuation duty"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — one entry standing for the whole program, which
+      is what PRD-PLATES §2.5 asks for at this gate. Two things worth carrying
+      forward. First, the count is CONTESTED: FLHSMV says over 100, Wikipedia says
+      over 120, and the honest record is both figures with their sources, not a
+      split. Second, the monthly active-plate report is the single most valuable
+      structured artefact found in the whole US pass and it is NOT archived by its
+      publisher — a monthly capture job should be scheduled before L2, because every
+      month not captured is permanently gone.
+
+  - id: us-fl-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      charset: { notes: "owner-chosen inside the § 320.06(3)(a) frame: bold letters and numerals or numerals, at most seven characters. Availability is checked through FLHSMV's Personalized License Plate Inquiry before order." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#006747"
+      note: "any standard OR specialty design may be personalized — FLHSMV: 'Standard license plates listed above can be ordered as personalized'"
+    fee: "$15 additional annual fee per personalized plate; HSMV form 83043 completed and presented at a local office"
+    region_encoding: none
+    sources:
+      - "https://www.flhsmv.gov/motor-vehicles-tags-titles/personalized-specialty-license-plates/  # personalized plates ordered in person, $15 annual fee, HSMV form 83043, the Personalized License Plate Inquiry availability service"
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(3)(a): the seven-character cap and alphabet a personalized configuration must fit"
+      - "https://www.flhsmv.gov/pdf/specialtyplates/FLPB.pdf  # 'Note: Standard license plates listed above can be ordered as personalized.'"
+    notes: >-
+      PERSONALIZED PLATES. Modelled as its own series because the SERIAL SOURCE
+      differs — owner-chosen rather than department-assigned — which is a format
+      property even though the character frame is identical. The regex given is the
+      letters-only shape most vanity configurations take; regex_statutory is the true
+      bound. Florida's content-refusal criteria are not in Chapter 320 and were not
+      obtained (recorded gap).
+
+  # =========================================================================
+  # HISTORIC — Florida runs TWO permanent numeric series, both in statute, and
+  # they are among the best-specified series in the whole L0 pass.
+  # =========================================================================
+  - id: us-fl-horseless-carriage
+    class: historic
+    categories: [car]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    format:
+      pattern: "999"
+      regex: '\A\d+\z'
+      charset:
+        notes: >-
+          § 320.086(1), verbatim: 'The registration numbers and special license plates
+          assigned to such motor vehicles shall run in a separate numerical series,
+          commencing with "Horseless Carriage No. 1"'. A SEPARATE NUMERICAL SERIES
+          with a stated origin and NO STATED WIDTH — hence the unbounded quantifier,
+          which makes no width claim. The § 320.06(3)(a) seven-character cap still
+          bounds it in practice.
+      progression: "strictly sequential from 1"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: >-
+        § 320.086(1) requires only that 'the plates shall be of a distinguishing
+        color' — the statute names NO colour, so none is recorded. This is the
+        cleanest example in the pilot of a legislature specifying a design PROPERTY
+        (distinctness) rather than a design VALUE.
+      legend: "Horseless Carriage"
+    eligibility: "motor vehicle for private use manufactured in MODEL YEAR 1945 OR EARLIER, operated on the state's streets and highways"
+    validity: "permanent — 'valid for use without renewal so long as the vehicle is in existence'"
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.086.html  # § 320.086(1): model year 1945 or earlier, the separate numerical series from 'Horseless Carriage No. 1', distinguishing colour, permanent validity, manufacture-cost fee"
+    notes: >-
+      HORSELESS CARRIAGE. Florida sets its historic threshold by a FIXED MODEL YEAR
+      (1945 or earlier) rather than a rolling age — the opposite design choice to the
+      Antique series below, which is rolling, and to Germany's H plate. A plates
+      dataset must model both kinds of threshold: fixed-cutoff eligibility never
+      changes, rolling eligibility silently changes every year, and only the second
+      needs re-auditing. The Netherlands' pre-1978 dark-blue rule is the fixed kind
+      too.
+
+  - id: us-fl-antique
+    class: historic
+    categories: [car, truck, bus]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    format:
+      pattern: "999"
+      regex: '\A\d+\z'
+      charset: { notes: "§ 320.086(2)(a): 'shall run in a separate numerical series, commencing with \"Antique No. 1\"' — again a stated origin and no stated width" }
+      progression: "strictly sequential from 1"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "'the plates shall be of a distinguishing color' — no value stated (§ 320.086(2)(a))"
+      legend: "Antique"
+    eligibility: "motor vehicle for private use manufactured in a model year AFTER 1945 and 'of the age of 30 years or more after the model year' — a ROLLING threshold. § 320.086(3) extends the same plates to ancient or antique firefighting apparatus, FORMER MILITARY VEHICLES and other historical motor vehicles 30 years old or older that are 'used only in exhibitions, parades, or public display', with permanent validity tied to that restricted use."
+    opt_out: "§ 320.086(2)(a): the owner may instead take 'a regular Florida license plate or specialty license plate in lieu of the special \"Antique\" license plate' — so an eligible vehicle need not be identifiable as antique at all"
+    superseded_variants:
+      - "permanent plates issued under this section BEFORE 1 October 1999 are maintained unless the vehicle transfers to a new owner (§ 320.086(2)(b))"
+      - "'Collectible' plates issued BEFORE 1 October 1999 may be retained until the next regularly scheduled replacement (§ 320.086(2)(b))"
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.086.html  # § 320.086(2)(a) the rolling 30-year threshold, the 'Antique No. 1' series, distinguishing colour, the regular/specialty opt-out; (2)(b) the 1 October 1999 permanent and 'Collectible' transitions; (3) firefighting apparatus, former military and other historical vehicles"
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0316/Sections/0316.605.html  # § 316.605(1) cross-reference to s. 320.086(5), which EXEMPTS display of plates on described former military vehicles"
+    notes: >-
+      ANTIQUE. § 320.086(2)(b) is direct evidence bearing on this series' true start:
+      it legislates for plates issued under this section BEFORE 1 OCTOBER 1999, so
+      the series demonstrably predates that date. That makes 1999 an upper bound too,
+      and a tighter one than the statute edition — but the actual start needs the
+      section's History line and the Laws of Florida, which were not pursued in this
+      pass. Recorded rather than guessed. The 'Collectible' plate is a genuinely
+      DEAD series that is still lawfully on the road — exactly the case
+      PRD-PLATES's `ended: true` + `year_end_min:` semantics exist for; it is not
+      given its own entry here because no primary for its own format was obtained.
+
+  # =========================================================================
+  # STATUTORY LEGEND SERIES. § 320.06(3)(a) mandates a specific bottom legend
+  # for five vehicle-tax classes. Each is a design difference on the standard
+  # serial, so each is its own series under PRD-PLATES §2.3.
+  # =========================================================================
+  - id: us-fl-apportioned
+    class: standard
+    categories: [truck, bus]
+    period: { start: 2024 }
+    period_evidence: statutory-date
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_top: "FLORIDA"
+      legend_bottom: "Apportioned"
+      legend_rule: "§ 320.06(3)(a), verbatim: 'Apportioned license plates must have the word \"Apportioned\" at the bottom.'"
+      validation_sticker: { content: "month of expiration" }
+    replacement_cycle:
+      years: 3
+      statutory_text: "§ 320.06(1)(b)2: 'Beginning July 1, 2024, a vehicle registered in accordance with the International Registration Plan must be issued a license plate for a 3-year period. At the end of the 3-year period, upon renewal, the license plate must be replaced.'"
+      note: "a CAB CARD stating the declared gross vehicle weight per apportioned jurisdiction is issued annually, $28 original or renewal; a damaged or worn plate is replaced at no charge on surrender"
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(1)(b)2: the IRP 3-year plate 'Beginning July 1, 2024', the annual cab card, the $28 fee, free replacement of damaged plates; (3)(a): the 'Apportioned' bottom legend"
+    notes: >-
+      APPORTIONED (International Registration Plan) PLATES — THE ONE FLORIDA SERIES
+      WITH A PROPERLY DATED START. § 320.06(1)(b)2 says 'Beginning July 1, 2024' in
+      terms, so `period_evidence: statutory-date` and 2024 is a real claim, not an
+      upper bound. It is also the only Florida plate on a 3-year rather than a
+      10-year cycle, and the only one whose sticker shows a month rather than the
+      owner's birth month — apportioned vehicles are fleet-registered, so the
+      birth-month scheme cannot apply.
+
+  - id: us-fl-restricted
+    class: standard
+    categories: [truck, trailer]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_top: "FLORIDA"
+      legend_bottom: "Restricted"
+      legend_rule: "§ 320.06(3)(a): plates for vehicles taxed under s. 320.08(3)(d), (4)(m) or (n), (5)(b) or (c), or (14) 'must have the word \"Restricted\" at the bottom'"
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(3)(a): the 'Restricted' bottom legend and the exact list of § 320.08 tax paragraphs it applies to"
+    notes: >-
+      RESTRICTED-USE PLATES. The class is defined ENTIRELY BY CROSS-REFERENCE to six
+      paragraphs of the vehicle-tax schedule (§ 320.08(3)(d), (4)(m), (4)(n), (5)(b),
+      (5)(c), (14)), which were not resolved to vehicle descriptions in this pass —
+      the legend and its trigger list are sourced, the underlying vehicle types are a
+      recorded gap. Categories are recorded conservatively.
+
+  - id: us-fl-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_top: "FLORIDA"
+      legend_bottom: "Dealer"
+      legend_rule: >-
+        § 320.06(3)(a), verbatim: 'License plates issued for vehicles taxed under
+        s. 320.08(12) must be imprinted with the word "Florida" at the top and the
+        word "Dealer" at the bottom UNLESS the license plate is a specialty license
+        plate as authorized in s. 320.08056.' The exception matters: a Florida dealer
+        may run a SPECIALTY design instead of the Dealer legend, so absence of the
+        legend does not prove absence of dealer status.
+    binding: business
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(3)(a): the 'Dealer' legend, the § 320.08(12) tax hook, and the specialty-plate exception"
+    notes: >-
+      DEALER PLATES. `binding: business` for the same reason as Germany's rote
+      Kennzeichen: the plate follows the dealership, not a vehicle. The specialty
+      carve-out is the interesting fact and a trap for any classifier that keys off
+      the legend.
+
+  - id: us-fl-manufacturer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_top: "FLORIDA"
+      legend_bottom: "Manufacturer"
+      legend_rule: "§ 320.06(3)(a): 'Manufacturer license plates issued for vehicles taxed under s. 320.08(12) must be imprinted with the word \"Florida\" at the top and the word \"Manufacturer\" at the bottom.' Note it takes NO specialty exception, unlike the Dealer legend in the immediately preceding sentence."
+    binding: business
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(3)(a): the 'Manufacturer' legend under the same § 320.08(12) tax hook as Dealer, without the specialty exception"
+    notes: >-
+      MANUFACTURER PLATES. Its own series and not a variant of the dealer plate
+      because the statute draws the distinction itself, in adjacent sentences, and
+      because only the Dealer legend may be displaced by a specialty design. CLASS
+      CAVEAT: recorded as `dealer` — _meta/classes.yml has no `manufacturer` value,
+      and the PRD's definition of dealer ('trade/garage plates bound to a business,
+      not a vehicle') fits the binding but not the trade.
+
+  - id: us-fl-wrecker
+    class: standard
+    categories: [truck]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_top: "FLORIDA"
+      legend_bottom: "Wrecker"
+      legend_rule: "§ 320.06(3)(a): 'License plates issued for vehicles taxed under s. 320.08(5)(d) or (e) must be imprinted with the word \"Wrecker\" at the bottom.'"
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(3)(a): the 'Wrecker' bottom legend and its § 320.08(5)(d)-(e) tax hook"
+    notes: >-
+      WRECKER (tow truck) PLATES. Completes the five statutory bottom legends —
+      Apportioned, Restricted, Dealer, Manufacturer, Wrecker — which together are the
+      whole of Florida's legend taxonomy and, notably, are legislated rather than left
+      to departmental design. CLASS CAVEAT: no `commercial` or `tow` class exists in
+      the vocabulary; recorded as `standard` with the legend carrying the meaning.

--- a/scripts/lint_plates.rb
+++ b/scripts/lint_plates.rb
@@ -55,6 +55,12 @@ files.sort.each do |abs|
   rescue Psych::SyntaxError => e
     fail! "#{rel}: does not parse — #{e.message}"
     next
+  rescue Psych::DisallowedClass => e
+    # One bare YAML date anywhere used to raise out of the whole run and
+    # blind the gate for every other file (L0-completion finding). Years are
+    # Integers; anything date-like must be quoted.
+    fail! "#{rel}: disallowed YAML type (#{e.message}) — quote date-like scalars; periods use integer years"
+    next
   end
   juris = doc["jurisdiction"].to_s
   fail! "#{rel}: jurisdiction missing" if juris.empty?


### PR DESCRIPTION
The four-jurisdiction pilot data, every claim on primary sources (RDW/BOE/FzV/FL statutes). Highlights: NL corpus test at 100% joint coverage found an unpublished RDW rollout; ES 2000 cutover settled on BOE in-force dates; three seed corrections; the lint's bare-date blind spot fixed. Nine schema stressors (period_evidence enum, regex_strict, per-sub-entry class, fields[] at L0, vocabulary gaps incl. transit) filed in the report for PRD-PLATES amendments — landing in pipeline aux next to the research dossiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)