### PR TITLE
BMW+Audi trim folds: 37 fold aliases, 18 organized removals, 3 minted canonicals (pairs with pipeline#51)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1197,7 +1197,7 @@
 "car/alfa-romeo/gt1300junior": "car/alfa-romeo/gt-1300-junior"
 "car/alvis/tc-21": "car/alvis/tc21"
 "car/aston-martin/db-9": "car/aston-martin/db9"
-"car/audi/5000s": "car/audi/5000-s"
+"car/audi/5000s": "car/audi/5000" # FLATTENED 2026-07-26 (was -> car/audi/5000-s): 5000-s retires into the 5000 nameplate in the trim-fold batch at EOF, and a former_ids value may never also be a key (no chains)
 "car/audi/a-2": "car/audi/a2"
 "car/audi/a-3": "car/audi/a3"
 "car/audi/a-4": "car/audi/a4"
@@ -2316,10 +2316,10 @@
 "moped/honda/z50ak2": "moped/honda/z50a-k2" # "Z50AK2" -> "Z50A K2"
 "car/bmw/i-3": "car/bmw/i3" # "I 3" -> "i3"
 "car/bmw/z-3": "car/bmw/z3" # "Z 3" -> "Z3"
-"car/bmw/1-er-reihe": "car/bmw/1er-reihe" # "1 Er Reihe" -> "1er Reihe"
-"car/bmw/1erreihe": "car/bmw/1er-reihe" # "1ERREIHE" -> "1er Reihe"
-"car/bmw/serie3": "car/bmw/serie-3" # "SERIE3" -> "Serie 3"
-"car/bmw/activehybrid-7-l": "car/bmw/activehybrid-7l" # "Activehybrid 7 L" -> "ActiveHybrid 7L"
+"car/bmw/1-er-reihe": "car/bmw/1-series" # FLATTENED 2026-07-26 (was -> car/bmw/1er-reihe): 1er-reihe itself retires into 1-series in the trim-fold batch below, and a former_ids value may never also be a key (no chains) — inbound aliases of a retiring id point straight at the destination
+"car/bmw/1erreihe": "car/bmw/1-series" # FLATTENED 2026-07-26 (was -> car/bmw/1er-reihe): same flatten, same reason
+"car/bmw/serie3": "car/bmw/3-series" # FLATTENED 2026-07-26 (was -> car/bmw/serie-3): serie-3 retires into 3-series in the trim-fold batch below — no chains
+"car/bmw/activehybrid-7-l": "car/bmw/activehybrid-7" # FLATTENED 2026-07-26 (was -> car/bmw/activehybrid-7l): the 7L body variant retires into activehybrid-7 in the trim-fold batch below — no chains
 "car/bmw/30cs": "car/bmw/3-0cs" # "30CS" -> "3.0CS"
 "motorcycle/bmw/r-nine-t": "motorcycle/bmw/r-ninet" # "R Nine T" -> "R nineT"
 "motorcycle/bmw/r-nine-t-pure": "motorcycle/bmw/r-ninet-pure" # "R Nine T Pure" -> "R nineT Pure"
@@ -3477,3 +3477,53 @@
 "van/citroen/e-berlingo-van":                        "van/citroen/e-berlingo"
 "van/citroen/ak400":                                 "van/citroen/ak"
 "car/opel/ampera-ev":                                "car/opel/ampera-e"
+# 2026-07-26 — BMW+Audi trim-fold batch (wave-2 granularity dossier;
+# aux/research/trims-2026-07/dossier-bmw-audi.md in the pipeline repo).
+# Chain pre-flight run per this file's rules: the four inbound aliases of
+# retiring ids (1-er-reihe, 1erreihe, serie3, activehybrid-7-l) and
+# audi/5000s were FLATTENED in place above — no value below is also a key,
+# no key is live post-fold, every target is live (or minted by the same
+# change: m535i, m635csi, audi/5000).
+# BMW register group labels WITH the family digit -> the series:
+"car/bmw/1er-reihe":   "car/bmw/1-series"   # "1er Reihe" was itself a register family label (es,lu,nl ⊂ 1-series)
+"car/bmw/3-er-reihe":  "car/bmw/3-series"   # es,fi,lu,nl ⊂ 3-series
+"car/bmw/5-er-reihe":  "car/bmw/5-series"   # es,nl ⊂ 5-series
+"car/bmw/7-er-reihe":  "car/bmw/7-series"   # nl,ua ⊂ 7-series
+"car/bmw/serie-1":     "car/bmw/1-series"   # es,lu,nl ⊂ 1-series
+"car/bmw/serie-2":     "car/bmw/2-series"   # es,nl ⊂ 2-series
+"car/bmw/serie-3":     "car/bmw/3-series"   # es,nl ⊂ 3-series
+"car/bmw/serie-4":     "car/bmw/4-series"   # es,lu,nl ⊂ 4-series
+"car/bmw/serie-5":     "car/bmw/5-series"   # es,nl ⊂ 5-series
+"car/bmw/serie-6":     "car/bmw/6-series"   # es,nl ⊂ 6-series
+"car/bmw/serie-7":     "car/bmw/7-series"   # es,lu,nl ⊂ 7-series
+# BMW Performance-M trims -> their series; M535i/M635CSi badge closures:
+"car/bmw/m-135i":      "car/bmw/1-series"   # es,fi ⊂ 1-series
+"car/bmw/m-140i":      "car/bmw/1-series"   # fi,nl ⊂ 1-series
+"car/bmw/m-550d":      "car/bmw/5-series"   # fi,nl ⊂ 5-series
+"car/bmw/m-535":       "car/bmw/m535i"      # nl,nz = m535i (union of both aliased ids)
+"car/bmw/m-535-i":     "car/bmw/m535i"      # nl,nz = m535i
+"car/bmw/m-635-csi":   "car/bmw/m635csi"    # fi,nl = m635csi (KEEP-and-rename, badge closure)
+# BMW body/portfolio folds:
+"car/bmw/compact":     "car/bmw/3-series"   # fi,nl,nz ⊂ 3-series ("3 Series Compact" is BMW's own name)
+"car/bmw/xm-50e":      "car/bmw/xm"         # es,fi,nl,ua ⊂ xm
+"car/bmw/xm-label":    "car/bmw/xm"         # ca,es,fi,lu,nl,ua,us ⊂ xm
+"car/bmw/m":           "car/bmw/m-roadster" # ca,es,fi,gb,lu,nl,nz,us = m-roadster (618/674 veh are "M COUPE" strings)
+"car/bmw/activehybrid-7l": "car/bmw/activehybrid-7" # ca,nl,us -> activehybrid-7 GAINS ca (fi,nl,us before)
+# Audi pre-A/Q numeric-family trims -> their nameplates:
+"car/audi/100-cc":        "car/audi/100"    # fi,nl ⊂ 100
+"car/audi/200-turbo":     "car/audi/200"    # fi,nl,nz ⊂ 200
+"car/audi/80-gt":         "car/audi/80"     # fi,nl ⊂ 80
+"car/audi/80-s":          "car/audi/80"     # fi,lu,nl ⊂ 80
+"car/audi/81":            "car/audi/80"     # nl,ua ⊂ 80 (Typ 81 = the 80 B2 chassis code)
+"car/audi/5000-s":        "car/audi/5000"   # nl,nz,us = 5000 (union of both aliased ids; new US-name canonical, dossier U-4)
+"car/audi/5000-cs-turbo": "car/audi/5000"   # nl,us ⊂ 5000
+# Audi token-order inversions -> the correctly-ordered live sibling:
+"car/audi/avant-rs2":     "car/audi/rs2"    # fi,nz -> rs2 GAINS fi (gb,nl,nz before)
+"car/audi/avant-s6":      "car/audi/s6"     # fi,nl ⊂ s6
+"car/audi/quattro-rs4":   "car/audi/rs4"    # fi,nl ⊂ rs4
+"car/audi/coupe-gt":      "car/audi/coupe"  # fi,nl,us ⊂ coupe
+"car/audi/gt":            "car/audi/coupe"  # nl,nz ⊂ coupe
+"car/audi/cabriolet-2":   "car/audi/cabriolet" # fi,nl ⊂ cabriolet
+"car/audi/ur":            "car/audi/quattro"   # fi,nl ⊂ quattro
+# Audi e-tron GT trim rung -> the RS nameplate:
+"car/audi/rs-e-tron-gt-performance": "car/audi/rs-e-tron-gt" # fi,nl,us ⊂ rs-e-tron-gt

--- a/overrides/models/removals.yml
+++ b/overrides/models/removals.yml
@@ -690,3 +690,35 @@
 "bus/van-hool/t": "series-collapse stub retired (pipeline stub fix 2026-07-26): pooled letter-series rows now land on their real series ids; no single alias target exists because the evidence redistributes across the family — see the control-build diff in the PR"
 "bus/volvo/b": "series-collapse stub retired (pipeline stub fix 2026-07-26): pooled letter-series rows now land on their real series ids; no single alias target exists because the evidence redistributes across the family — see the control-build diff in the PR"
 "bus/wrightbus/gb": "series-collapse stub retired (pipeline stub fix 2026-07-26): pooled letter-series rows now land on their real series ids; no single alias target exists because the evidence redistributes across the family — see the control-build diff in the PR"
+# ---------------------------------------------------------------------------
+# 2026-07-26 — BMW+Audi trim-fold batch: records with NO honest single
+# successor (each spans several live ids, or denotes no vehicle at all), so a
+# former_ids alias would assert an identity that does not exist. Every one is
+# dropped by an explicit null rename in renames.yml (same-line reason there)
+# and recorded HERE with its measured register population, per the
+# never-delete-silently directive. Evidence: the wave-2 granularity dossier,
+# aux/research/trims-2026-07/dossier-bmw-audi.md in the pipeline repo.
+# ── BMW register GROUP LABELS (family letter only — the register's "family
+# unknown" placeholders). normalizer.rb#bmw already drops the spelling-twins
+# "X REIHE" (12,077 veh) and "Z REIHE" (7,167 veh); these lines make the whole
+# class consistent (normalizer gaps G-2/G-3 are filed for the in-code cure).
+"car/bmw/m-series":  "register group label ('BMW M SERIES' uk_dft GenModel 6,112; 'M SERIES' nz 107). Spans M2/M3/M4/M5/M6/M8/X5 M/X6 M/XM - bmwusa.com/vehicles/bmw-m/models.html lists all of them separately. Not a nameplate; no single successor."
+"car/bmw/i":         "register group label ('I' nz_nzta 1,319; 'BMW i' fi_traficom make-column 1). 'i' is BMW's EV sub-brand letter, spanning i3/i4/i5/i7/i8/iX/iX1/iX2/iX3 - nz carries I3 (594), I8 (27), I4 (6), IX1 (2) separately, so these are the UNRESOLVED residue. Audit v2026.07.5: id D6 + name D9."
+"car/bmw/x-series":  "register group label ('X SERIES' nl_rdw 382, es_dgt 1). Spans X1-X7 + iX. Sibling 'X REIHE' (nl 12,009) is already dropped by normalizer.rb#bmw."
+"car/bmw/serie-x":   "register group label ('SERIE X' es_dgt 97, nl 6 + 'SERIE  X', 'SERIE X, X3', 'SERIE X, X3 2.0D', 'SERIE X XDRIVE40D'). Spanish DGT form of X-Reihe; the trailing-model rows prove the label wraps a specific X model it does not name."
+"car/bmw/xreihe":    "register group label ('XREIHE' es_dgt 1, nl_rdw 1) - the fused spelling of the already-dropped 'X REIHE'."
+"car/bmw/z-reihe":   "register group label ('Z-REIHE' nl_rdw 4, es_dgt 1) - the HYPHENATED spelling of the already-dropped 'Z REIHE' (nl 7,143 + es 24). z1/z3/z4/z8 are all live. Audit v2026.07.5: id D6 + name D9."
+"car/bmw/m-z-reihe": "register group label ('M Z REIHE' nl_rdw 48; 'M Z REIHE, M ROADSTER-' es 1) - Z-Reihe with an M prefix; the es row names M Roadster, which is separately live."
+"car/bmw/x":         "register group label ('X' lu_snca 2, es_dgt 1, fi_traficom 1; 'X SDRIVE 18D' es 1). Bare family letter."
+# ── BMW body-style words / register fragments / one phantom:
+"car/bmw/cabrio":    "body-style word in the model column ('CABRIO' nl 1 nz 1, 'BMW CABRIO' nl 1). BMW's cabrio bodies span 1/2/3/4/6/8 Series and Z1/Z3/Z4/Z8 - no single successor."
+"car/bmw/cabriolet": "body-style word ('CABRIOLET' nl 2 nz 2). Same class as car/bmw/cabrio."
+"car/bmw/coupe":     "body-style word ('COUPE' nl 2 es 1). Spans 2/4/6/8 Series + M Coupe."
+"car/bmw/tourer":    "body-style suffix ('Tourer' fi 1, 'TOURER' nz 1) - BMW's Active Tourer / Gran Tourer bodies are 2 Series; car/bmw/2-series' raw set already carries 40+ '216d Gran Tourer'-class strings."
+"car/bmw/ci":        "trim suffix, not a model ('BMW CI' uk_dft GenModel 375, 'CI CABRIO' nl 1). Ci = coupe+injection (318Ci/325Ci/330Ci/645Ci/840Ci); those strings are already on 3/6/8-Series. Audit v2026.07.5 name D9; two-country attestation of the STRING does not make it a nameplate (the VITO/MGA rule)."
+"car/bmw/3-c":       "unresolvable designation ('3/C' nl 4 fi 1, '3 C' nl 1, 'BMW 3. C' nl 1). No BMW article or archive maps to '3/C' - not 3/15 Dixi, not 3/20; enrich/bmw.yml already records it as unsourceable."
+"car/bmw/e90":       "DEVELOPMENT CODE published as a model ('E90' nl 2 nz 1). The corpus carries E12/E16/E21/E28/E30/E34/E36/E46/E60/E63/E70/E83/E84 in the same column the same way; enrich/bmw.yml's car/bmw/e90 entry re-keys to car/bmw/3-series."
+"car/bmw/x8":        "PHANTOM MODEL. Sole producer is the chassis-type string 'X83' (nl_rdw 3, fi_traficom 2) - the E83 X3's code, captured as 'X8' by normalizer.rb#bmw's /^(X\\d)/ (gap G-5). BMW has never sold an X8: bmwusa.com/vehicles.html lists X1,X2,X3,X5,X6,X7,iX3,iX,XM only; the X8 programme was rebadged XM."
+# ── Audi body-word / register fragments:
+"car/audi/avant": "body-style suffix in the model column ('AUDI AVANT' uk_dft GenModel 31; 'AVANT' nz 6 nl 3 fi 1; 'AVANT QUATTRO' + 4 engine-suffixed forms). Avant is Audi's estate body, spanning A4/A6/80/100/RS2/RS4/RS6 - no single successor. The correctly-qualified siblings (car/audi/a4, /a6, /80, /100, /rs2, /rs4, /rs6) already carry Avant rows."
+"car/audi/c":     "uk_dft GenModel truncation ('AUDI C' 155 + nl_rdw 5; 'C' nl 1). A bare letter with no Audi designation behind it - same class as the dropped 'BMW CI'. Two-country attestation of the STRING is not a nameplate (the VITO/MGA rule)."

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -61,7 +61,7 @@ Aston Martin:
   Db 9: DB9                                   # spelling variant of "DB9" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 Audi:
-  "5000S": "5000 S"                           # spelling variant of "5000 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  "5000S": "5000"                             # RETARGET (2026-07-26 trim-fold dossier), was "5000 S" — S is a US trim-ladder rung on the 5000 (the US-market C2/C3 100/200); the earlier consolidation intent is preserved and now lands on the nameplate. Renames are single-pass, so this key moves WITH the "5000 S" key below (dossier §7)
   Audi: null                                  # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   AUDIA6: A6                                  # es_dgt/nl_rdw glue artifact ("AUDIA6") — the make fused onto the nameplate; merges into the 14-source A6 id
   Audi Q5: Q5                                 # make repeated in the model column with a space, which strip_make_prefix misses when the RAW make spelling differs from the model's prefix; merges into the 14-source Q5 id
@@ -73,6 +73,35 @@ Audi:
   A 8: A8                                     # spelling variant of "A8" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Q 5: Q5                                     # spelling variant of "Q5" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Ag: null                                    # NOT A VEHICLE. Raw is verbatim "AUDI AG" in BOTH es_dgt and fi_traficom — the company's legal name where a model belongs, with strip_make_prefix leaving the residue "Ag". Verified from the raws by S4W (NEGOTIATION Turn 102), who found it also carries an EU type-approval xref: a misfiled APPROVAL row, not a vehicle. NOTE two independent registers agreeing does NOT clear the class — it is a shared clerk habit, the same reasoning as the Jeep null note. Second instance after zundapp/werke; detector at scripts/find_corporate_strings.rb.
+  # ── 2026-07-26 trim-fold dossier (BMW+Audi wave 2; full evidence at
+  # aux/research/trims-2026-07/dossier-bmw-audi.md in the pipeline repo).
+  # Pre-A/Q numeric-family trims: normalizer.rb#audi has NO rule for the
+  # 60/80/100/200/5000/Coupe/Cabriolet/quattro era (gap G-7, filed), so its
+  # trims survived as models. ──
+  "100 CC":      "100"    # raw "100 CC" nl 2 fi 1, "AUDI 100 CC" nl 3, "AUDI 100 CC 101KW" nl 1, "AUDI 100 CC 101 KW" nl 1 — CC is a C3 trim level; nl_rdw ITSELF lists "AUDI 100,-CS,-CD,-CC" (nl 7) enumerating CC/CD/CS as 100 trims (dossier §7)
+  "200 Turbo":   "200"    # raw "200 TURBO" nz 3 nl 1, "AUDI 200 TURBO" nl 2, "200 Turbo" fi 1 — the 200 was turbocharged throughout; car/audi/200's raws already fold "200 QUATTRO"/"200 quattro 20v" (dossier §7)
+  "80 GT":       "80"     # raw "80 GT" fi 1 nl 1, "AUDI 80 GT" nl 1 — B1 trim; car/audi/80's raws already fold "80 QUATTRO", "80 AVANT", "80 CABRIO", "AUDI 80, GLS" (dossier §7)
+  "80 S":        "80"     # raw "80 S" fi 1 lu 1 nl 1 — same trim class (dossier §7)
+  "81":          "80"     # raw "81" nl 2 ua 2 — Typ 81 is the INTERNAL chassis designation of the Audi 80 B2, not a model name; a digit-only id with no marque source (dossier §7)
+  "5000 S":      "5000"   # raw "5000 S" nl 1 nz 1, "AUDI 5000S" nl 1, "5000 S quattro" us — S is a US trim rung; 5000 = the US-market name of the C2/C3 100/200: https://www.audi.com/en/innovation/product-innovation/audi-c-family/ (NEW-CANONICAL caution recorded, dossier U-4; audi/4000 is the in-catalog precedent for keeping the US name)
+  "5000 Cs Turbo": "5000" # raw "5000 CS TURBO" nl 1, "5000 CS Turbo" us — CS Turbo is the top rung of the US trim ladder (dossier §7)
+  # ── token-order inversions (gap G-8, filed): the family rule anchors at ^,
+  # so an Avant-/quattro-FIRST register string never reaches it. The correctly
+  # ordered sibling is separately live in every case. ──
+  "Avant RS2":   RS2      # raw "AVANT RS2 QUATTRO /260" fi 1, "AVANT RS2" nz 1 — Audi's own form is "RS 2 Avant"; car/audi/rs2 is live (uk 127, nz 11, nl 2). MAJORITY IS NOT AUTHORITY: both registers carry the inverted form, the marque's order wins (audit v2026.07.5: name D7 + MISSED_DEFECTS)
+  "Avant S6":    S6       # raw "Avant S6 quattro" fi 1, "AUDI AVANT S6" nl 1 — car/audi/s6 is live (dossier §8)
+  "Quattro RS4": RS4      # raw "Audi Quattro RS4" fi 1, "QUATTRO RS4 AVANT" nl 1, "QUATTRO RS4 AVANT 4.2" nl 1 — car/audi/rs4 is live (dossier §8)
+  "Coupe GT":    Coupe    # raw "COUPE GT" fi 1 nl 1, "Coupe GT" fi 1, "AUDI COUPE GT" nl 1, "COUPE GT 100 KW" nl 1 — GT is a trim word on the B2/B3 Coupé, which is separately live (dossier §8)
+  "GT":          Coupe    # raw "GT" nz 5 nl 1, "GT COUPE" nz 4 — nz_nzta's truncation of Coupe GT; the "GT COUPE" rows carry the body word explicitly (dossier §8)
+  "Cabriolet 2": Cabriolet  # raw "Cabriolet 2,3E" fi 1, "AUDI CABRIOLET 2,0 TFSI" nl 1 — an ENGINE code (2.3E / 2.0 TFSI) whose decimal comma the slugifier turned into a model number (dossier §8)
+  "Ur":          Quattro  # raw "UR QUATTRO" fi 1 nl 1 — "Ur-quattro" is the enthusiasts' retronym for the original; Audi's own name is "Audi quattro", and car/audi/quattro is live (dossier §8)
+  "Avant":       null     # body suffix: raw "AUDI AVANT" uk_dft GenModel 31, "AVANT" nz 6 nl 3 fi 1 + "AVANT QUATTRO" and 4 engine-suffixed forms — Avant is Audi's estate BODY word spanning A4/A6/80/100/RS2/RS4/RS6; no single successor (removals.yml carries the ledger line)
+  "C":           null     # register fragment: raw "AUDI C" uk_dft GenModel 155 + nl 5, "C" nl 1 — a bare letter with no Audi designation behind it; uk_dft GenModel truncation class, same shape as "BMW CI" (the VITO/MGA rule; removals.yml)
+  # ── e-tron GT family (dossier §9): the RS trim rung folds into the RS
+  # nameplate. NOTE the e-tron vs e-tron GT SPLIT itself (gap G-9: 1,619 GT
+  # vehicles inside audi/e-tron, incl. ALL 457 de rows) is a normalizer rule
+  # change — a rename cannot split one id into two — and is FILED, not here. ──
+  "RS E-Tron GT Performance": RS E-Tron GT   # raw "RS E-TRON GT PERFORMANCE" nl 17, "RS e-tron GT performance" fi 5, "RS e-tron GT Performance" us — "the new variants of the e-tron GT series", one rung above the RS: https://www.audi.com/en/press-releases/audis-most-powerful-production-vehicle-the-new-rs-e-tron-gt-performance-16222
 
 Austin:
   # ── swarm-dossier batch: Mk goes FUSED ROMAN here — Austin registers EMIT
@@ -135,14 +164,22 @@ BMW:
   # Airhead type codes keep their SLASH: R 80 G/S, R 90/S, R 60/2 — the slash
   # is part of the designation, not punctuation noise. R100GS (1987) genuinely
   # has no slash where R80G/S (1980) does.
-  # CARS: "i3" keeps its lowercase i (BMW i sub-brand). German-register rows
-  # carry "1er Reihe" / "Serie 3" — those are the German for "1 Series" and
-  # stay as the register wrote them; they are NOT the English nameplate.
-  "1 Er Reihe":                1er Reihe              # German-register nameplate; NOT the English 1 Series — left as the register wrote it
-  "1ERREIHE":                  1er Reihe              # German-register nameplate; NOT the English 1 Series — left as the register wrote it
+  # CARS: "i3" keeps its lowercase i (BMW i sub-brand).
+  # SETTLED-LINE NOTICE (2026-07-26 trim-fold dossier, aux/research/trims-2026-07/
+  # dossier-bmw-audi.md in the pipeline repo): the two keys below used to
+  # consolidate spellings onto "1er Reihe" as a German-register nameplate. The
+  # register emits "N-er Reihe"/"Serie N" ONLY when the specific model is
+  # unknown, and the digit resolves the family unambiguously — so the same
+  # consolidation now lands on the real nameplate (intent preserved+extended,
+  # not reversed). The fused "3ER REIHE" already folds in normalizer.rb#bmw;
+  # these are the spaced/fused forms it misses (gaps G-1/G-3, filed for the
+  # pipeline lane). If G-1/G-3 land in-code, these keys go DEAD and must be
+  # retired in the same change (the reachability test will list them).
+  "1 Er Reihe":                1 Series               # RETARGET, was "1er Reihe" — register family label WITH the digit; raw "1 ER REIHE" es 2 nl 2 lu 1 (dossier §1a)
+  "1ERREIHE":                  1 Series               # RETARGET, was "1er Reihe" — fused spelling of the same label; raw "1ERREIHE" es 2 nl 1 (dossier §1a)
   "30CS":                      3.0CS                  # closed/spaced per BMW usage
-  Activehybrid 7 L:            ActiveHybrid 7L        # closed/spaced per BMW usage
-  Activehybrid 7L:             ActiveHybrid 7L        # closed/spaced per BMW usage
+  Activehybrid 7 L:            ActiveHybrid 7         # RETARGET, was "ActiveHybrid 7L" — the 7L is the long-wheelbase BODY of the ActiveHybrid 7 (sole hybrid body 2012-2015), variant-layer inventory; raw "ACTIVEHYBRID 7 L" nl 18 (dossier §5; enrich/bmw.yml car/bmw/activehybrid-7 holds the variant)
+  Activehybrid 7L:             ActiveHybrid 7         # RETARGET, was "ActiveHybrid 7L" — same fold; raw "ActiveHybrid 7L" ca/us catalog rows (dossier §5)
   I 3:                         i3                     # BMW i sub-brand keeps the lowercase i
   R Nine T:                    R nineT                # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
   R Nine T Pure:               R nineT Pure           # BMW styles it R nineT — lowercase nine, uppercase T (bmwmotorcycles.com)
@@ -162,9 +199,81 @@ BMW:
   # its own, so no replacement key is needed.
   R90/S: R90S                             # nl/nz registries DO write "R90/S" (operator habit) — those rows are the sport model; the /6-series would be written R90/6. Folds the miswriting into the real designation
   R90 / S: R90S                           # third raw shape (spaced slash) — the one-id-many-names flap set includes slash spacing too
-  SERIE3:                      Serie 3                # German-register nameplate; NOT the English 1 Series — left as the register wrote it
+  SERIE3:                      3 Series               # RETARGET, was "Serie 3" — register family label WITH the digit resolves to the nameplate (see the SETTLED-LINE NOTICE above); raw "SERIE3" es_dgt (dossier §1a; renames are single-pass, so this key moves WITH the "Serie 3" key below)
   Z 3:                         Z3                     # closed/spaced per BMW usage
   "Ce":                                  "CE"                                   # uniformly-wrong casing (invisible to the contradiction detector): BMW CE 04 and CE 02, the electric scooters (bmw-motorrad.com) (bmw/ce)
+  # ── 2026-07-26 trim-fold dossier (BMW+Audi wave 2; full evidence at
+  # aux/research/trims-2026-07/dossier-bmw-audi.md in the pipeline repo).
+  # CARS. Register GROUP LABELS carrying the family DIGIT resolve to the
+  # series; the fused "3ER REIHE"/"3 SERIES" already fold in normalizer.rb#bmw,
+  # these are the spaced/hyphenated/Spanish forms it misses (gaps G-1/G-3,
+  # filed for the pipeline lane — if they land in-code these keys go dead). ──
+  "3 Er Reihe":  3 Series      # raw "3 ER REIHE" nl 7 es 2 lu 1; "3 er Reihe" fi 2; "3-ER REIHE" nl 2; "3-ER REIHE CABRIO" nl 1 — register family label WITH the digit (dossier §1a)
+  "5 Er Reihe":  5 Series      # raw "5 ER REIHE" es 1 nl 1 — same class (dossier §1a)
+  "7 Er Reihe":  7 Series      # raw "7 ER REIHE" nl 1 ua 1 — same class (dossier §1a)
+  "Serie 1":     1 Series      # raw "SERIE 1" es 235 nl 3 lu 1 (+ "SERIE  1", "SERIE 1, 118D", "SERIE 1, 116I", "SERIE 1,116I", "SERIE 1,116D", "BMW SERIE 1") — Spanish DGT family label (dossier §1a)
+  "Serie 2":     2 Series      # raw "SERIE 2" es 3 nl 1 (dossier §1a)
+  "Serie 3":     3 Series      # raw "SERIE 3" es 117 nl 7 (+ "SERIE 3, 330 CI", "SERIE 3, 320D", "SERIE 3, 330D", "SERIE 3 CABRIOLET E93", "SERIE 3, X3 3.0D") (dossier §1a)
+  "Serie 4":     4 Series      # raw "SERIE 4" nl 2 es 1 lu 1 (dossier §1a)
+  "Serie 5":     5 Series      # raw "SERIE 5" es 41 nl 1 (+ "SERIE 5,520D", "SERIE 5, 530D") (dossier §1a)
+  "Serie 6":     6 Series      # raw "SERIE 6" es 7 nl 2 (dossier §1a)
+  "Serie 7":     7 Series      # raw "SERIE 7" es 5 lu 1 nl 1 (dossier §1a)
+  # ── family-letter-ONLY group labels: the register's "family unknown" rows.
+  # None resolves to one nameplate ("M SERIES" spans M2…M8+X5 M+XM; "X SERIES"
+  # spans X1…X7+iX; "I" spans the i/iX EV sub-brand), so no alias is honest —
+  # each drop's measured population is recorded in removals.yml. The spaced
+  # twins "X REIHE"/"Z REIHE" are already dropped by normalizer.rb#bmw; this
+  # makes the class consistent from the overrides layer (dossier §1b; the
+  # in-code cure is gaps G-2/G-3, filed). ──
+  "M Series":    null   # register group label: "BMW M SERIES" uk_dft GenModel 6,112 + "M SERIES" nz 107 — spans M2/M3/M4/M5/M6/M8/X5 M/X6 M/XM, all listed separately on bmwusa.com/vehicles/bmw-m/models.html (removals.yml carries the ledger line)
+  "I":           null   # register group label: "I" nz_nzta 1,319 — BMW's EV sub-brand letter; nz carries I3 (594), I8 (27), I4 (6), IX1 (2) separately, so these rows are the UNRESOLVED residue (audit v2026.07.5: id D6 + name D9)
+  "X":           null   # register group label: "X" lu_snca 2 es_dgt 1 fi_traficom 1; "X SDRIVE 18D" es 1 — bare family letter spanning X1-X7+iX (removals.yml)
+  "X Series":    null   # register group label: "X SERIES" nl_rdw 382 es_dgt 1 — sibling "X REIHE" (nl 12,009) is already dropped by normalizer.rb#bmw (removals.yml)
+  "Serie X":     null   # register group label: "SERIE X" es_dgt 97 nl 6 (+ "SERIE  X", "SERIE X, X3", "SERIE X, X3 2.0D", "SERIE X XDRIVE40D") — Spanish DGT form of X-Reihe; the trailing-model rows prove the label wraps a model it does not name (removals.yml)
+  "Xreihe":      null   # register group label: "XREIHE" es_dgt 1 nl_rdw 1 — the FUSED spelling of the already-dropped "X REIHE" (removals.yml)
+  "Z-Reihe":     null   # register group label: "Z-REIHE" nl_rdw 4 es_dgt 1 — the HYPHENATED spelling of the already-dropped "Z REIHE" (nl 7,143 + es 24); z1/z3/z4/z8 all live (audit v2026.07.5: id D6 + name D9; removals.yml)
+  "M Z Reihe":   null   # register group label: "M Z REIHE" nl_rdw 48 + "M Z REIHE, M ROADSTER-" es 1 — Z-Reihe with an M prefix; the es row names the M Roadster, which is separately live (removals.yml)
+  # ── "Performance M" TRIMS split from their series by a SPACE: normalizer.rb
+  # #bmw already folds the fused M340I class via /^M?(\d)\d\d/; the spaced
+  # register forms miss it (gap G-4, filed). bmwusa.com files M135i/M140i/M550d
+  # under "Performance M Models" — trims of the base series, NOT nameplates. ──
+  "M 135I":      1 Series      # raw "M 135I XDRIVE" es 2, "M 135I" es 1, "M 135i xDRIVE" fi 1 — "Performance M Models": https://www.bmwusa.com/vehicles/bmw-m/models.html
+  "M 140I":      1 Series      # raw "M 140i" fi 1, "M 140I XDRIVE" nl 1 — same source, same trim class
+  "M 550D":      5 Series      # raw "M 550D XDRIVE" nl 334; "M 550d xDRIVE" fi 131, "M 550d xDrive" fi 130, "M 550D xDrive" fi 2, "M 550d XDRIVE" fi 1 — Performance M trim of the 5 Series (same source; diesel-market sibling of M550i)
+  # ── M535i / M635CSi: PRODUCTS, kept — KEEP-and-rename to BMW's closed badge;
+  # the slug moves, so former_ids.yml carries the aliases. ──
+  "M 535":       M535i         # raw "M 535" nl 1 nz 1 — truncated register form of the M535i (E12 1980-81, E28 1985-88); BMW's badge is closed
+  "M 535 I":     M535i         # raw "M 535 I" nl 8 nz 1; "BMW M 535 I" nl 1 — one product, three register spellings, previously two ids (dossier §2)
+  "M 635 Csi":   M635CSi       # raw "M 635 CSI" nl 69 fi 1; "BMW M 635 CSI" nl 2 — closed badge M635CSi; "Csi" was the title-caser's output, present in no register and no marque source (audit v2026.07.5: name D7)
+  # ── body-style words / register fragments in the model column: each spans
+  # several series (or, X8, no vehicle at all) — no single alias target is
+  # honest, so each carries a removals.yml ledger line with its population. ──
+  "Cabrio":      null   # body word: raw "CABRIO" nl 1 nz 1, "BMW CABRIO" nl 1 — BMW cabrios span 1/2/3/4/6/8 Series + Z1/Z3/Z4/Z8 (dossier §3; removals.yml)
+  "Cabriolet":   null   # body word: raw "CABRIOLET" nl 2 nz 2 — same class (removals.yml)
+  "Coupe":       null   # body word: raw "COUPE" nl 2 es 1 — spans 2/4/6/8 Series + M Coupe (removals.yml)
+  "Tourer":      null   # body suffix: raw "Tourer" fi 1, "TOURER" nz 1 — BMW's Active/Gran Tourer bodies are 2 Series; the 2-Series raw set already carries 40+ "216d Gran Tourer"-class strings (removals.yml)
+  "Ci":          null   # trim suffix: raw "BMW CI" uk_dft GenModel 375, "CI CABRIO" nl 1 — Ci = coupe+injection (318Ci/325Ci/330Ci/645Ci/840Ci), those strings already live on the 3/6/8-Series raw sets; two-country attestation of a STRING is not a nameplate — the VITO/MGA rule (audit v2026.07.5: name D9; removals.yml)
+  "3/C":         null   # unresolvable designation: raw "3/C" nl 4 fi 1 — no BMW article or archive maps to "3/C" (not 3/15 Dixi, not 3/20); enrich/bmw.yml records it as unsourceable (removals.yml)
+  "3 C":         null   # sibling spelling of "3/C" (raw "3 C" nl 1) — same slug 3-c, so one key alone leaves the record alive on this form (caught by the post-fold control build, which republished bmw/3-c as "3 C")
+  "3. C":        null   # third sibling spelling (raw "BMW 3. C" nl 1) — same unresolvable designation, same slug after collapse
+  "E90":         null   # DEVELOPMENT CODE published as a model: raw "E90" nl 2 nz 1 — the corpus carries bare E12/E16/E21/E28/E30/E34/E36/E46/E60/E63/E70/E83/E84 in the same column the same way (gap G-5 filed; removals.yml; enrich facts re-keyed to car/bmw/3-series)
+  "X8":          null   # PHANTOM MODEL: sole producer is raw "X83" (nl 3, fi 2) = the E83 X3's type code, mis-captured by /^(X\d)/ (gap G-5, filed). BMW has never sold an X8 — bmwusa.com/vehicles.html lists X1,X2,X3,X5,X6,X7,iX3,iX,XM and no X8; the X8 programme was rebadged XM (removals.yml)
+  "Compact":     3 Series      # real body variant: raw "COMPACT" nz 310 nl 5 fi 1 — BMW's own name is "3 Series Compact" (E36/5 1993-2000, E46/5 2001-2005): https://www.press.bmwgroup.com/united-kingdom/article/detail/T0020291EN_GB/bmw-announces-3-series-compact-prices-and-two-new-models
+  # ── XM portfolio (dossier §4): press.bmwgroup.com/usa T0450677EN_US — "Two
+  # become one: the BMW XM portfolio is sharpening its focus, now offering just
+  # a single model; the BMW XM Label." Label and 50e are PORTFOLIO MEMBERS. ──
+  "Xm 50E":      XM     # raw "XM 50E" nl 379 es 75 ua 26; "XM 50e" nl 9 fi 3 — the six-cylinder PHEV powertrain variant of the XM (variant captured in enrich/bmw.yml)
+  "Xm Label":    XM     # raw "XM LABEL" nl 118 es 33 ua 17 lu 1; "XM Label" fi 2 nl 2 — https://www.press.bmwgroup.com/usa/article/detail/T0450677EN_US/the-2026-bmw-xm-label
+  "Xm":          XM     # D7 casing: BMW writes XM, the title-caser wrote "Xm" — display-only (slug unchanged), fixes the fold parent in the same block
+  # ── same-product duplicates (dossier §5). NOTE: the dossier's Isetta 250/300
+  # folds are deliberately NOT applied — bmw/isetta is live in TWO kinds
+  # (car fi,nl,nz + motorcycle nl,nz) and the kind boundary is unresolved
+  # (PROPOSAL-kind-boundary.md), so that fold is HELD, not implied. ──
+  "M":           M Roadster    # raw "BMW M COUPE" uk 486, "M COUPE" nl 126 fi 2 lu 1 nz 1, "BMW M Coupe" fi 1, "M COUPE-CM91/246" fi 1 = 618 of 674 veh — the Z3/Z4 M Coupé population dominates this record; the residual bare "M" (nz 54, nl 1, es 1) is unresolvable register residue riding along (dossier U-3 records the E36/8S-vs-E86 ambiguity)
+  "Activehybrid 7":  ActiveHybrid 7    # D7 casing — BMW's own camel case, emitted verbatim by fi_traficom and us_fueleconomy (audit v2026.07.5: name D7); display-only, slug unchanged
+  "Activehybrid 3":  ActiveHybrid 3    # same casing class, display-only (dossier §5)
+  "Activehybrid 5":  ActiveHybrid 5    # same casing class, display-only (dossier §5)
+  "Activehybrid X6": ActiveHybrid X6   # same casing class, display-only (dossier §5)
 
 Bricklin:
   Sv-1: SV1                                   # spelling variant of "SV1" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical


### PR DESCRIPTION
## BMW+Audi trim folds: 37 fold aliases, 18 organized removals, 3 minted canonicals — wave-2 granularity dossier applied

Pairs with pipeline PR vehiclesdb/vehiclesdb-pipeline#51 (enrich re-keys + the research dossier at `aux/research/trims-2026-07/dossier-bmw-audi.md`). **Merge the pipeline PR first** — this PR retires ids that pipeline-main's `enrich/bmw.yml` still keys, so this one alone turns `lint_enrich` red (the coupled-change law).

### Headline numbers

| | BMW | Audi | total |
|---|---|---|---|
| car records before | 97 | 71 | 168 |
| car records after | 61 | 55 | 116 |
| fold-away ids (rename + former_ids alias) | 22 | 15 | **37** |
| removals (null rename + removals.yml ledger line) | 16 | 2 | **18** |
| new canonical ids minted | 2 (`m535i`, `m635csi`) | 1 (`5000`) | 3 |
| register vehicles re-homed onto canonical ids | ~11,3k | 286 | **~11.6k** |
| register vehicles on the removals ledger | ~8.5k | ~210 | **~8.7k** |
| **availability: countries lost / gained** | | | **0 lost / 2 gained** (`bmw/activehybrid-7` +ca, `audi/rs2` +fi) |

Fold set = the wave-2 dossier's 59 FOLD verdicts (41 BMW + 18 Audi) minus the explicitly HELD items (see the applied-vs-filed table). Every fold is rename + `former_ids` alias + drafted `variants:` capture on the pipeline side; every removal is a null rename + a removals.yml line carrying its measured population — nothing deleted silently.

### ⚠️ FILED FOR OWNER ADJUDICATION — the BMW M-nameplate rule (115,585 vehicles; NOT touched here)

`normalizer.rb#bmw`'s `/^M(\d)\b/` folds **M2/M3/M4/M5/M6/M8 into their number series** (M3 → 3 Series: 43,318 veh; M2: 29,396; M4: 23,753; M5: 14,917; M6: 2,195; M8: 1,796; M7-labelled: 210 — **115,585 vehicles total**). The rule's own comment says "(variant layer holds M)" — an explicit in-code decision — but `bmwusa.com/vehicles/bmw-m/models.html` splits its lineup into **"High-Performance M Models"** (M2/M3/M4/M5, X5 M, X6 M — nameplates) vs **"Performance M Models"** (M235i/M340i… — trims), and bmwusa.com lists M3/M5 beside 3/5 in the sedan lineup. The catalog today asserts both "M3 is a 3 Series" (fused raws) and "M 3 is not" (spaced raws → live `bmw/m-3`). Because the in-code comment states the opposite intent, this is an **owner call, not a maintainer call** (dossier U-1; both one-line resolutions are drafted in dossier §CLUSTER 2). `bmw/m-3` (80 veh) and `bmw/m-5` (6 veh) stay live pending that ruling. BMW's own nomenclature spec (press.bmwgroup.com T0163831SK) could not be fetched — two routes failed, recorded in the dossier.

### Applied vs filed — every dossier disposition accounted

| dossier item | disposition | where |
|---|---|---|
| §1a 11 digit-carrying group labels (serie-1…7, N-er-reihe) | **APPLIED** — fold to N Series | renames + former_ids |
| §1b 8 family-letter-only group labels (m-series, i, x, x-series, serie-x, xreihe, z-reihe, m-z-reihe) | **APPLIED** — organized removal | null renames + removals.yml (populations in the lines) |
| §2 Performance-M spacing trims (m-135i, m-140i, m-550d) | **APPLIED** — fold to series | renames + former_ids |
| §2 M535i / M635CSi badge closures (slug-affecting) | **APPLIED** — KEEP-and-rename | renames + former_ids + enrich re-key |
| §2 `bmw/m-3`, `bmw/m-5` | **HELD** — depends on the M-rule adjudication above | untouched, live |
| §3 8 body words / fragments / phantom X8 | **APPLIED** — organized removal | null renames + removals.yml |
| §3 Compact | **APPLIED** — fold to 3 Series | renames + former_ids |
| §4 XM 50e / XM Label (+ Xm casing) | **APPLIED** — fold to XM | renames + former_ids + enrich variants |
| §5 `bmw/m` → m-roadster; ActiveHybrid 7L fold + casing fixes | **APPLIED** | renames + former_ids |
| §5 Isetta 250/300 → isetta | **SKIPPED ENTIRELY** — see isetta flag below | nothing written |
| §6 MINI (8 ids, 6,656 veh) + Alpina (8 ids, 1,038 veh) | **FILED** — MOVE-lane (make question), measured in the dossier | not this lane |
| §7 Audi numeric-family trims (7 ids) | **APPLIED** — incl. new `audi/5000` canonical (U-4 caution recorded in-line) | renames + former_ids |
| §8 token-order inversions (7 ids) + avant/c removals | **APPLIED** | renames + former_ids + removals.yml |
| §9 RS e-tron GT performance → RS e-tron GT | **APPLIED** | renames + former_ids |
| §9 **e-tron GT split** (`audi/e-tron-gt`, 1,619 veh; ALL 457 de rows of audi/e-tron are GT rows) | **FILED** — normalizer rule change (G-9), handled separately; a rename cannot split one id into two | pipeline lane |
| §10 `audi/ai` (3 veh) | **HELD** — unverifiable after two failed routes (U-6) | untouched, live |
| G-1…G-10 normalizer gaps | **FILED** — pipeline lane (listed in the pipeline PR) | pipeline lane |
| Phantom chassis codes `Z85`→z8, `X70`→x7 (U-2) | **FILED** — remedy is the G-5 pipeline fix; NOT shipped as verified fold blocks, so not applied (ruling 3) | pipeline lane |
| Group-label 5-dispositions inconsistency (X REIHE dropped / X SERIES published / …) | **FLAGGED** — §1b makes the overrides-visible slice consistent; the in-code X/Z REIHE drops (19,248 veh, U-9) predate this PR and stay as-is | this PR body |
| §UNCERTAIN U-1…U-10 | **FILED** — none acted on beyond what each cluster's applied block states | dossier |

### 🚩 Flags

- **`bmw/isetta` exists in TWO kinds** (car `fi,nl,nz` + motorcycle `nl,nz`) — found by the dossier's kind-blind sweep. The isetta-250/isetta-300 folds are correct *within* the car kind but were **skipped entirely** (no renames, no aliases, no variant capture) so this PR implies no kind verdict. Venue: `PROPOSAL-kind-boundary.md`.
- **Group-label inconsistency** (dossier headline §0.2): one semantic object — the register "family unknown" label — currently gets five dispositions by spelling (`X REIHE` dropped in-code, 12,077 veh; `X SERIES` was published; `SERIE X` was published; `XREIHE` published; `Z SERIES` candidate). This PR aligns the published slice with the in-code drops via the removals ledger; the candidate-queue strings and the in-code drops themselves are the G-2/G-3 pipeline fix.
- **removals.yml count is 18, not the dossier checklist's "12"** — the checklist under-counted its own drafted blocks (8 §1b + 8 §3 + 2 §8); all 18 drafted lines applied with their populations.

### Removal populations (the ledger, summarized)

`m-series` 6,219 (uk 6,112 + nz 107) · `i` 1,320 · `x-series` 383 · `serie-x` 107 · `m-z-reihe` 49 · `z-reihe` 5 · `x` 4 · `xreihe` 2 · `ci` 376 · `cabrio` 3 · `cabriolet` 4 · `coupe` 3 · `tourer` 2 · `3-c` 7 · `e90` 3 · `x8` 5 (the phantom — sole producer is the E83 chassis string `X83`) · `audi/avant` ~47 · `audi/c` 161. Each line in removals.yml carries the full producing-raw breakdown.

### Adaptations (departures from the dossier's drafted blocks, all documented)

1. **§1b drop mechanism**: the dossier wanted the family-letter labels dropped in the normalizer (G-2/G-3). The normalizer is out of this PR's scope, so the drops use the repo's established overrides mechanism instead — null rename + removals.yml manifest (the `car/audi/audi` / `car/bmw/bmw` precedent). If G-2/G-3 land in-code, these keys go dead and the reachability test lists them for retirement (noted in the block comment).
2. **`3/C` sibling spellings**: the first control build caught `bmw/3-c` re-publishing as **"3 C"** (nl) — the dossier's single `"3/C": null` key missed the space/dot spellings that share slug `3-c`. Added `"3 C"` and `"3. C"` null keys and re-verified by replaying all raw shapes through `classify` (all drop). This is the post-#42 adaptation protocol in action (live display pulled from the build output; fold kept, key completed).
3. **`car/bmw/e90` enrich entry**: not in the dossier's checklist of enrich re-keys, but its §3 removals line requires it — folded into the 3-series variants block in the pipeline PR.
4. **Inbound-alias flattening**: five existing former_ids lines pointed at ids this PR retires (`1-er-reihe`, `1erreihe` → 1er-reihe; `serie3` → serie-3; `activehybrid-7-l` → activehybrid-7l; `audi/5000s` → 5000-s). Each was retargeted **in place** to the final destination — no chains, per the file's own rules; the six settled rename lines were likewise retargeted with SETTLED-LINE notices preserving their original intent.

### Verification (full battery, `VDB_DATA_REPO=<this branch>` from the pipeline branch)

- **Pre-flight**: duplicate-key scan (Psych parse tree), YAML round-trip — all 99 BMW+Audi rename keys and values survive as Strings; no former_ids chains/self-refs; expected-value assertions for all 66 touched mappings. PASS.
- **Reachability test**: 5 runs, 10 assertions, 0 failures (every key is a produced nameplate — keys taken byte-exact from the published catalog).
- **`lint_overrides` / `lint_curation --base=origin/main` / `reorg_make_blocks --check`**: OK.
- **`lint_enrich`** (with the paired pipeline branch): 40 files, 515 ids, OK.
- **Full offline build ×2** (before the 3/C adaptation and after): **ALL GATES GREEN** both times — id-contract (no-vanish, alias liveness), spotchecks, license, delta (car delta well inside limits; the 28% truck delta is the pre-existing #42 ack, untouched).
- **Availability-union contract** (baseline build vs this build, all 23 fold groups): **0 countries lost; gains exactly `bmw/activehybrid-7` +ca and `audi/rs2` +fi** (plus the three minted ids coming live with their producers' unions: m535i nl,nz · m635csi fi,nl · audi/5000 nl,nz,us). Held records (isetta×3, m-3, m-5, active, ai, e-tron) verified byte-identical availability.
- **`propose_former_ids.rb` as verifier** (published dist vs this build): **0 new proposals** (all 37 fold aliases already authored), **0 evidence loss**, 6 dead keys — ALL pre-existing on main (chrysler/hyundai/jaguar/mercedes/nissan/yamaha lanes, verified against origin/main; none BMW/Audi), 71 unexplained = exactly the removals-manifest ids (mine 18 + the pre-existing series-collapse lane); full accounting: 139 gone ids vs the published dist = 68 aliased + 71 manifested + **0 unaccounted**
- Unit suites: normalizer (27 runs), normalizer_families (17), enrich (17), id_contract_gate (14) — 0 failures.

### Replay note
Catalog baseline = the post-#42 pipeline replayed on unmodified overrides — verified **byte-identical** on all 168 bmw/audi car records to the published catalog before authoring, so the dossier's measured keys were still exact (the coordinator's post-#42 drift warning materialized only as the 3/C sibling-spelling case above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
