### PR TITLE
NSU: lux200 -> lux (the marque never used "Lux 200")

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2756,6 +2756,7 @@
 "motorcycle/moto-guzzi/850le-mans-iii": "motorcycle/moto-guzzi/850-le-mans-iii" # "850LE Mans III" -> "850 Le Mans III"
 "motorcycle/norton/commando-850mk-iii": "motorcycle/norton/commando-850-mk-iii" # "Commando 850MK III" -> "Commando 850 Mk III"
 "motorcycle/matchless/g12l": "motorcycle/matchless/g12" # ancestor fold, see renames.yml Matchless G12L. Pre-flight chain check run per this file footer: nothing aliased to g12l.
+"motorcycle/nsu/lux200": "motorcycle/nsu/lux" # "LUX200" -> "Lux"; pre-flight clean, nothing aliased to lux200
 
 # ── A NOTE ON CHAINS, after three in one session (S2W 2026-07-26) ───────────
 # Every one had the identical shape: I retire an id X (rename/fold), and

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -2443,6 +2443,7 @@ Norton:
 NSU:
   RO80:                      Ro 80                # the NSU Ro 80 (Ro = Rotationskolbenmotor, the Wankel) — two words. DEFUNCT marque
   "Prima III Kl":                            Prima III KL             # KL confirmed uppercase by the raw: nl_rdw carries "PRIMA 3 KL". (The published "III" against the raw's "3" comes from another source; left alone — this fix is the KL only.)
+  LUX200: Lux                     # NSU never used "Lux 200": the model is the Lux (1951-54, 198cc), upgraded as the Superlux. "produced from 1951-54 ... a capacity of 198cc" — https://www.motorcyclespecifications.com/nsu-lux-superlux-1951-54/ . LUX200 is a register artifact gluing a ROUNDED displacement (198 -> 200) onto the nameplate, so this is not the two-wheeler displacement-stays-separate case: dropping it is correct, "Lux 200" would be inventing a designation. Also unblocks the B2 identity match to Q927073 NSU Lux, which token-based prefix containment cannot reach from "lux200" (pipeline#54 finding f)
 
 Oldsmobile:
   SUPER88: Super 88                           # spelling variant of "Super 88" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence


### PR DESCRIPTION
**`nsu/lux200` → `nsu/lux`. NSU never used "Lux 200", and the register glued a *rounded* displacement onto the nameplate. Pairs with pipeline#(lux-enrich) — merge THIS ONE FIRST.**

## The defect

`motorcycle/nsu/lux200` publishes `"LUX200"`. NSU's model is the **Lux** (1951-54, 198cc), upgraded as the **Superlux**:

> *"The NSU Lux/Superlux motorcycle was produced from 1951-54"* with *"a capacity of 198cc"* — [motorcyclespecifications.com](https://www.motorcyclespecifications.com/nsu-lux-superlux-1951-54/)

The page never calls it "Lux 200", and neither does any source I reached.

## Why this is NOT the two-wheeler displacement rule

The 2W convention keeps displacement **separate** rather than glued, which would suggest `"Lux 200"`. That is wrong here for a specific reason:

> **The displacement in the string is not the machine's displacement.** The Lux is **198cc**. `LUX200` carries a *rounded* figure the marque never used, so "Lux 200" would be inventing a designation rather than un-gluing a real one.

Dropping the number entirely is the only reading the source supports. `nsu/lux` was free; nothing collided.

## A second-order benefit worth naming

This also unblocks a **B2 identity match**. The harvest (pipeline#54, finding f) showed `nsu/lux200` came out `no-entity` while `Q927073 NSU Lux` sat in the coverage queue — because prefix containment is token-based, so a nameplate glued to a displacement in one token can never reach the shorter entity. That failure is **silent**: it produces no blocked-candidate row, so nothing sizes it.

Renaming the record to `Lux` makes the match reachable at rung 1. So a naming fix and an identity gap turn out to be the same defect seen twice.

## Pre-flight

Chain check run before writing, per the `former_ids.yml` footer: **nothing aliased to `motorcycle/nsu/lux200`**, and `nsu/lux` was not taken. Zero chains file-wide after the change.

## Merge order — and note it INVERTS the BSA pair

This one is **data first**. The paired pipeline PR adds an `enrich` run keyed on `motorcycle/nsu/lux`, an id that does not exist until this merges — enrich-first would fail the liveness check.

> **Fold pairs are prune-first; mint pairs are data-first.** The BSA pair (pipeline#48 → data#96) removed enrich entries whose ids were dying, so the enrich half had to go first. This pair creates an id, so the data half goes first. Same coupling, opposite order, and the direction follows from whether the id is appearing or disappearing.

## Verification

Gate **0**. Reachability suite green. Curation lint green. `nsu/lux` publishes `"Lux"` carrying `former_ids: ["motorcycle/nsu/lux200"]`, so any consumer id still resolves.
