### PR TITLE
NSU: lux200 -> lux (re-cut of #101 with CI)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2766,6 +2766,7 @@
 "motorcycle/bsa/lightning-a65l": "motorcycle/bsa/lightning" # "Lightning A65L" -> Lightning, A65 fold
 "motorcycle/bsa/a65-lightning": "motorcycle/bsa/lightning" # "A65 Lightning" -> Lightning, A65 fold
 "motorcycle/bsa/a65l": "motorcycle/bsa/lightning" # "A65L" -> Lightning, A65 fold
+"motorcycle/nsu/lux200": "motorcycle/nsu/lux" # "LUX200" -> "Lux"; pre-flight clean, nothing aliased to lux200
 
 # ── A NOTE ON CHAINS, after three in one session (S2W 2026-07-26) ───────────
 # Every one had the identical shape: I retire an id X (rename/fold), and

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -2453,6 +2453,7 @@ Norton:
 NSU:
   RO80:                      Ro 80                # the NSU Ro 80 (Ro = Rotationskolbenmotor, the Wankel) — two words. DEFUNCT marque
   "Prima III Kl":                            Prima III KL             # KL confirmed uppercase by the raw: nl_rdw carries "PRIMA 3 KL". (The published "III" against the raw's "3" comes from another source; left alone — this fix is the KL only.)
+  LUX200: Lux                     # NSU never used "Lux 200": the model is the Lux (1951-54, 198cc), upgraded as the Superlux. "produced from 1951-54 ... a capacity of 198cc" — https://www.motorcyclespecifications.com/nsu-lux-superlux-1951-54/ . LUX200 is a register artifact gluing a ROUNDED displacement (198 -> 200) onto the nameplate, so this is NOT the two-wheeler displacement-stays-separate case: dropping it is correct, "Lux 200" would be inventing a designation. Also unblocks the B2 identity match to Q927073 NSU Lux, unreachable from "lux200" because prefix containment is token-based (pipeline#54 finding f)
 
 Oldsmobile:
   SUPER88: Super 88                           # spelling variant of "Super 88" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence


### PR DESCRIPTION
**Re-cut of data#101 per S4W Turn 151.** That PR never got a build check at all — not failed, *never fired* — and a mint pair merging with its one load-bearing check silently absent is the hole CI exists to close. Local green is necessary, not sufficient.

Identical change, **re-applied on current main rather than cherry-picked** (main moved with #102/#103, both of which touch `renames.yml`).

## The defect

`motorcycle/nsu/lux200` publishes `"LUX200"`. NSU's model is the **Lux** (1951-54, 198cc), upgraded as the **Superlux**:

> *"The NSU Lux/Superlux motorcycle was produced from 1951-54"* with *"a capacity of 198cc"* — [motorcyclespecifications.com](https://www.motorcyclespecifications.com/nsu-lux-superlux-1951-54/)

## Why this is NOT the two-wheeler displacement rule

That convention keeps displacement separate, which would suggest `"Lux 200"`. Wrong here:

> **The number in the string is not the machine's displacement.** The Lux is **198cc**. `LUX200` carries a *rounded* figure the marque never used, so "Lux 200" would be **inventing** a designation rather than un-gluing a real one.

## It also closes an identity gap

pipeline#54 finding (f): `nsu/lux200` came out `no-entity` while `Q927073 NSU Lux` sat in the coverage queue, because prefix containment is token-based — a nameplate glued to a displacement can never reach the shorter entity, and it fails **silently** (no blocked-candidate row, so nothing sizes it). A naming fix and an identity gap turn out to be the same defect seen twice.

## Order

**Merge this before pipeline#55** — mint pair, and the enrich entry is keyed on `motorcycle/nsu/lux`, which does not exist until this lands. (Fold pairs are prune-first; mint pairs are data-first.)

Pre-flight clean: nothing aliased to `lux200`, `nsu/lux` was free, zero chains file-wide. Curation lint green.