### PR TITLE
Peugeot + Hyundai wave-3 trim folds: 119 folds + the i80 phantom fix (-117 published ids)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1717,8 +1717,8 @@
 "car/omoda/omoda7": "car/omoda/omoda-7"
 "car/omoda/omoda9": "car/omoda/omoda-9"
 "car/panhard/pl-17": "car/panhard/pl17"
-"car/peugeot/206cc": "car/peugeot/206-cc"
-"car/peugeot/307cc": "car/peugeot/307-cc"
+"car/peugeot/206cc": "car/peugeot/206"       # REPOINT 2026-07-26 (was 206-cc, which now folds -> 206; wave-3 trim dossier) — chain flattened
+"car/peugeot/307cc": "car/peugeot/307"       # REPOINT 2026-07-26 (was 307-cc, which now folds -> 307) — chain flattened
 "car/plymouth/roadrunner": "car/plymouth/road-runner"
 "car/plymouth/special-deluxe": "car/plymouth/special-de-luxe"
 "car/polestar/2-bst-edition": "car/polestar/polestar-2"
@@ -2577,15 +2577,15 @@
 "van/dodge/ram1500":          "van/dodge/ram-1500"
 # 2026-07-26 — Peugeot collision batch (9 groups → 0; dossier in the Peugeot
 # renames block: uppercase trim codes, lowercase injection i, closed V6):
-"car/peugeot/205gr":     "car/peugeot/205-gr"
-"car/peugeot/305sr":     "car/peugeot/305-sr"
-"car/peugeot/307sw":     "car/peugeot/307-sw"
-"car/peugeot/405-mi-16": "car/peugeot/405-mi16"    # the closed Mi16 badge wins
-"car/peugeot/405sri":    "car/peugeot/405-sri"
-"car/peugeot/504gl":     "car/peugeot/504-gl"
-"car/peugeot/504ti":     "car/peugeot/504-ti"
-"car/peugeot/505gr":     "car/peugeot/505-gr"
-"car/peugeot/505v6":     "car/peugeot/505-v6"
+"car/peugeot/205gr":     "car/peugeot/205"      # REPOINT 2026-07-26 (was 205-gr, folds -> 205) — chain flattened
+"car/peugeot/305sr":     "car/peugeot/305"      # REPOINT 2026-07-26 (was 305-sr, folds -> 305) — chain flattened
+"car/peugeot/307sw":     "car/peugeot/307"      # REPOINT 2026-07-26 (was 307-sw, folds -> 307) — chain flattened
+"car/peugeot/405-mi-16": "car/peugeot/405"      # REPOINT 2026-07-26 (was 405-mi16, folds -> 405; the closed Mi16 badge ruling is preserved in enrich) — chain flattened
+"car/peugeot/405sri":    "car/peugeot/405"      # REPOINT 2026-07-26 (was 405-sri, folds -> 405) — chain flattened
+"car/peugeot/504gl":     "car/peugeot/504"      # REPOINT 2026-07-26 (was 504-gl, folds -> 504) — chain flattened
+"car/peugeot/504ti":     "car/peugeot/504"      # REPOINT 2026-07-26 (was 504-ti, folds -> 504) — chain flattened
+"car/peugeot/505gr":     "car/peugeot/505"      # REPOINT 2026-07-26 (was 505-gr, folds -> 505) — chain flattened
+"car/peugeot/505v6":     "car/peugeot/505"      # REPOINT 2026-07-26 (was 505-v6, folds -> 505) — chain flattened
 # 2026-07-26 — Renault collision batch (7 groups → 0; dossier in the Renault
 # renames block — incl. the four-id R4 GTL family folding to one):
 "car/renault/12tl":    "car/renault/12-tl"
@@ -3537,3 +3537,132 @@
 "car/audi/ur":            "car/audi/quattro"   # fi,nl ⊂ quattro
 # Audi e-tron GT trim rung -> the RS nameplate:
 "car/audi/rs-e-tron-gt-performance": "car/audi/rs-e-tron-gt" # fi,nl,us ⊂ rs-e-tron-gt
+
+# ── wave-3 Peugeot+Hyundai trim-fold batch (2026-07-26, dossier-trims-
+# peugeot-hyundai): 119 folds + 1 correction (car/hyundai/i80 -> i800 — the
+# family-rule truncation phantom, 7,793 registrations under a nameplate
+# Hyundai never sold). Union-checked: 0 (country,id) pairs lost; 226
+# duplicate pairs dedup; 7 survivors gain a country. MINTS car/peugeot/
+# e-5008, van/peugeot/j5, car/hyundai/i800. File-wide chain scan run at
+# apply time: 11 inbound aliases repointed in place (marked REPOINT above),
+# zero other entries point at a retiring id, zero chains left. ──
+"car/peugeot/205-cj":                          "car/peugeot/205"        # nl,nz -> 205
+"car/peugeot/205-cj-roland-garros":            "car/peugeot/205"        # fi,nl -> 205
+"car/peugeot/205-cti":                         "car/peugeot/205"        # es,fi,nl,nz -> 205
+"car/peugeot/205-cti-1":                       "car/peugeot/205"        # fi,nl -> 205
+"car/peugeot/205-gl":                          "car/peugeot/205"        # es,nl -> 205
+"car/peugeot/205-gr":                          "car/peugeot/205"        # nl,nz -> 205 ; inbound alias "car/peugeot/205gr" repointed to the survivor (chain flattened)
+"car/peugeot/205-gt":                          "car/peugeot/205"        # nl,nz -> 205
+"car/peugeot/205-rallye":                      "car/peugeot/205"        # lu,nl -> 205
+"car/peugeot/205-xe":                          "car/peugeot/205"        # nl,nz -> 205
+"car/peugeot/307-1-6i":                        "car/peugeot/307"        # es,nl -> 307
+"car/peugeot/307-2-0i":                        "car/peugeot/307"        # es,nl -> 307
+"car/peugeot/307-cc":                          "car/peugeot/307"        # fi,nl,ua -> 307 ; inbound alias "car/peugeot/307cc" repointed to the survivor (chain flattened)
+"car/peugeot/307-sw":                          "car/peugeot/307"        # ar,fi,nl,ua -> 307 ; inbound alias "car/peugeot/307sw" repointed to the survivor (chain flattened)
+"car/peugeot/307-xt-1":                        "car/peugeot/307"        # fi,nl -> 307
+"car/peugeot/308-1-2i-stt":                    "car/peugeot/308"        # es,nl -> 308
+"car/peugeot/308-1-6i":                        "car/peugeot/308"        # es,nl -> 308
+"car/peugeot/308-cc":                          "car/peugeot/308"        # fi,nl,ua -> 308
+"car/peugeot/308-gt":                          "car/peugeot/308"        # gb,nl -> 308
+"car/peugeot/308-sw":                          "car/peugeot/308"        # ar,nl,ua -> 308
+"car/peugeot/308-sw-style":                    "car/peugeot/308"        # es,fi -> 308
+"car/peugeot/208-5p-allure":                   "car/peugeot/208"        # es -> 208
+"car/peugeot/208-5p-allure-turbo-10":          "car/peugeot/208"        # es -> 208
+"car/peugeot/208-5p-style":                    "car/peugeot/208"        # es -> 208
+"car/peugeot/208-allure":                      "car/peugeot/208"        # gb,nl -> 208
+"car/peugeot/208-gt-premium-auto":             "car/peugeot/208"        # gb -> 208
+"car/peugeot/2008-allure":                     "car/peugeot/2008"       # es -> 2008
+"car/peugeot/2008-allure-turbo-100":           "car/peugeot/2008"       # es -> 2008
+"car/peugeot/3008-allure":                     "car/peugeot/3008"       # es -> 3008
+"car/peugeot/3008-gt":                         "car/peugeot/3008"       # es,gb -> 3008
+"car/peugeot/5008-gt":                         "car/peugeot/5008"       # es,gb -> 5008
+"car/peugeot/e-5008-allure":                   "car/peugeot/e-5008"     # gb -> e-5008
+"car/peugeot/405-gr":                          "car/peugeot/405"        # nl,nz,ua -> 405
+"car/peugeot/405-mi16":                        "car/peugeot/405"        # fi,nl,nz -> 405 ; inbound alias "car/peugeot/405-mi-16" repointed to the survivor (chain flattened)
+"car/peugeot/405-srdt":                        "car/peugeot/405"        # nl,nz -> 405
+"car/peugeot/405-sri":                         "car/peugeot/405"        # nl,nz,ua -> 405 ; inbound alias "car/peugeot/405sri" repointed to the survivor (chain flattened)
+"car/peugeot/504-gl":                          "car/peugeot/504"        # nl,nz -> 504 ; inbound alias "car/peugeot/504gl" repointed to the survivor (chain flattened)
+"car/peugeot/504-ti":                          "car/peugeot/504"        # fi,nl,nz -> 504 ; inbound alias "car/peugeot/504ti" repointed to the survivor (chain flattened)
+"car/peugeot/504d":                            "car/peugeot/504"        # nl,nz -> 504
+"car/peugeot/505-gr":                          "car/peugeot/505"        # nl,nz -> 505 ; inbound alias "car/peugeot/505gr" repointed to the survivor (chain flattened)
+"car/peugeot/505-gr-family":                   "car/peugeot/505"        # nl,nz -> 505
+"car/peugeot/505-v6":                          "car/peugeot/505"        # nl,nz -> 505 ; inbound alias "car/peugeot/505v6" repointed to the survivor (chain flattened)
+"car/peugeot/604-d-turbo":                     "car/peugeot/604"        # fi,nl -> 604
+"car/peugeot/604-sl":                          "car/peugeot/604"        # nl,nz -> 604
+"car/peugeot/604-sti":                         "car/peugeot/604"        # nl,nz -> 604
+"car/peugeot/605-sld":                         "car/peugeot/605"        # nl,ua -> 605
+"car/peugeot/309-gl-profil":                   "car/peugeot/309"        # fi,nl -> 309
+"car/peugeot/309-gr":                          "car/peugeot/309"        # nl,nz -> 309
+"car/peugeot/309-sr":                          "car/peugeot/309"        # nl,nz -> 309
+"car/peugeot/305-grd":                         "car/peugeot/305"        # nl,nz -> 305
+"car/peugeot/305-sr":                          "car/peugeot/305"        # fi,nl,nz -> 305 ; inbound alias "car/peugeot/305sr" repointed to the survivor (chain flattened)
+"car/peugeot/301-d":                           "car/peugeot/301"        # fi,nl -> 301
+"car/peugeot/104-sr":                          "car/peugeot/104"        # fi,nl -> 104
+"car/peugeot/106-xr":                          "car/peugeot/106"        # nl,nz -> 106
+"car/peugeot/107-1-0i":                        "car/peugeot/107"        # es,nl -> 107
+"car/peugeot/203-a":                           "car/peugeot/203"        # nl,nz -> 203
+"car/peugeot/203c":                            "car/peugeot/203"        # nl,nz -> 203
+"car/peugeot/403-b5":                          "car/peugeot/403"        # fi,nl -> 403
+"car/peugeot/403b":                            "car/peugeot/403"        # nl,nz -> 403
+"car/peugeot/403u5":                           "car/peugeot/403"        # nl,nz -> 403
+"car/peugeot/404c":                            "car/peugeot/404"        # nl,nz -> 404
+"car/peugeot/206-1-4i":                        "car/peugeot/206"        # es,nl -> 206
+"car/peugeot/206-cc":                          "car/peugeot/206"        # fi,nl,ua -> 206 ; inbound alias "car/peugeot/206cc" repointed to the survivor (chain flattened)
+"car/peugeot/206-xr":                          "car/peugeot/206"        # nl,ua -> 206
+"car/peugeot/207-sw":                          "car/peugeot/207"        # fi,nl -> 207
+"car/peugeot/508-rxh":                         "car/peugeot/508"        # nl,ua -> 508
+"car/peugeot/508-sw":                          "car/peugeot/508"        # fi,nl,ua -> 508
+"van/peugeot/boxer-335":                       "van/peugeot/boxer"      # fi,gb,nl -> boxer
+"van/peugeot/boxer-435":                       "van/peugeot/boxer"      # gb,nl -> boxer
+"van/peugeot/boxer-multicab":                  "van/peugeot/boxer"      # lu,nl -> boxer
+"van/peugeot/boxer-van":                       "van/peugeot/boxer"      # fi,nl -> boxer
+"van/peugeot/boxter":                          "van/peugeot/boxer"      # es,nl -> boxer
+"van/peugeot/expert-2":                        "van/peugeot/expert"     # fi,nl -> expert
+"van/peugeot/expert-2-0hdi":                   "van/peugeot/expert"     # fi,nl -> expert
+"van/peugeot/expert-227-l1h1-1-6hdi-16v-90":   "van/peugeot/expert"     # nl -> expert
+"van/peugeot/expert-asphalt":                  "van/peugeot/expert"     # gb -> expert
+"van/peugeot/expert-furgon-m-diesel":          "van/peugeot/expert"     # es -> expert
+"van/peugeot/expert-professional":             "van/peugeot/expert"     # gb -> expert
+"van/peugeot/expert-traveller":                "van/peugeot/expert"     # fi,nl -> expert
+"van/peugeot/partner-1":                       "van/peugeot/partner"    # fi,nl -> partner
+"van/peugeot/partner-120-l1-1-6hdif":          "van/peugeot/partner"    # nl -> partner
+"van/peugeot/partner-170c-1-6hdi":             "van/peugeot/partner"    # nl -> partner
+"van/peugeot/partner-170c-1-9d":               "van/peugeot/partner"    # nl -> partner
+"van/peugeot/partner-170c-2-0hdi":             "van/peugeot/partner"    # nl -> partner
+"van/peugeot/partner-furgon-m-die":            "van/peugeot/partner"    # es -> partner
+"van/peugeot/partner-prfssionl-stndard-ev":    "van/peugeot/partner"    # gb -> partner
+"van/peugeot/rifter-active-business":          "van/peugeot/rifter"     # es -> rifter
+"van/peugeot/404-pick-up":                     "van/peugeot/404"        # fi,nl -> 404
+"car/peugeot/280":                             "car/peugeot/j5"         # nl,ua -> j5
+"car/peugeot/280l":                            "car/peugeot/j5"         # es,nl -> j5
+"car/peugeot/290":                             "car/peugeot/j5"         # fi,nl -> j5
+"car/peugeot/290-g-52-8-kampeerauto":          "car/peugeot/j5"         # es,nl -> j5
+"van/peugeot/290":                             "van/peugeot/j5"         # nl -> j5
+"car/hyundai/elantra-blue":                    "car/hyundai/elantra"    # ca,us -> elantra
+"car/hyundai/elantra-gt":                      "car/hyundai/elantra"    # ca,nl,ua,us -> elantra
+"car/hyundai/elantra-n":                       "car/hyundai/elantra"    # ca,th,us -> elantra
+"car/hyundai/elantra-touring":                 "car/hyundai/elantra"    # ca,us -> elantra
+"car/hyundai/elantra-wagon":                   "car/hyundai/elantra"    # ca,us -> elantra
+"car/hyundai/genesis-r-spec":                  "car/hyundai/genesis"    # ca,us -> genesis
+"car/hyundai/santa-fe-sport":                  "car/hyundai/santa-fe"   # ca,nl,us -> santa-fe
+"car/hyundai/santa-fe-sport-ultimate":         "car/hyundai/santa-fe"   # ca,us -> santa-fe
+"car/hyundai/santa-fe-ultimate":               "car/hyundai/santa-fe"   # ca,us -> santa-fe
+"car/hyundai/sonata-se":                       "car/hyundai/sonata"     # ca,us -> sonata
+"car/hyundai/sonata-sport-limited":            "car/hyundai/sonata"     # ca,us -> sonata
+"car/hyundai/veloster-n":                      "car/hyundai/veloster"   # ca,us -> veloster
+"car/hyundai/veloster-turbo":                  "car/hyundai/veloster"   # ca,nl -> veloster
+"car/hyundai/kona-n":                          "car/hyundai/kona"       # ca,fi,lu,nl,us -> kona
+"car/hyundai/kona-kauai":                      "car/hyundai/kona"       # es,fi,lu -> kona
+"car/hyundai/xg300":                           "car/hyundai/xg"         # ca,us -> xg
+"car/hyundai/xg350":                           "car/hyundai/xg"         # ca,us -> xg
+"car/hyundai/tucson-fuel-cell":                "car/hyundai/tucson"     # nl,us -> tucson
+"car/hyundai/tucson-advance":                  "car/hyundai/tucson"     # gb -> tucson
+"car/hyundai/bayon-advance":                   "car/hyundai/bayon"      # gb -> bayon
+"car/hyundai/bayon-premium":                   "car/hyundai/bayon"      # gb -> bayon
+"car/hyundai/bayon-ultimate":                  "car/hyundai/bayon"      # gb -> bayon
+"car/hyundai/atos-prime":                      "car/hyundai/atos"       # es,nl,ua -> atos
+"car/hyundai/pony-gls":                        "car/hyundai/pony"       # nl,nz -> pony
+"car/hyundai/staria-premium":                  "car/hyundai/staria"     # lu,nl -> staria
+"car/hyundai/ionic":                           "car/hyundai/ioniq"      # fi,nl -> ioniq
+"car/hyundai/i80":                             "car/hyundai/i800"       # gb,nz -> i800
+"van/hyundai/galopper":                        "van/hyundai/galloper"   # fi,nl -> galloper

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1366,6 +1366,50 @@ Hyundai:
   H1: H-1                                     # spelling variant of "H-1" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Scoupe: S-Coupe                             # spelling variant of "S-Coupe" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Santafe: Santa FE                           # spelling variant of "Santa FE" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  # ── wave-3 trim-fold batch (2026-07-26, dossier-trims-peugeot-hyundai): 28
+  # Hyundai ids fold + 2 corrections. The ca/us cluster is settled by the
+  # regulator's own baseModel column (us_fueleconomy cache/us_vehicles.csv col
+  # 66, https://www.fueleconomy.gov/feg/download.shtml) cross-read against
+  # NRCan — the Ford precedent. All 31 lines are ADDITIONS: none of the
+  # settled Tucson/ix35, Inster, Kona Advance, Atos-Prime, H1, Scoupe,
+  # Santafe lines above is touched or reversed. "Santa FE" keeps its settled
+  # FE acronym casing — the fold values are keyed to the live canonical. ──
+  "Elantra Blue":            Elantra     # "Elantra Blue" baseModel Elantra; Blue is the eco trim
+  "Elantra GT":              Elantra     # "Elantra GT" baseModel Elantra (the 5-door hatch trim)
+  "Elantra N":               Elantra     # "Elantra N" baseModel Elantra; N is Hyundai's performance TRIM (https://www.hyundai.com/worldwide/en/hyundai-n)
+  "Elantra Touring":         Elantra     # "Elantra Touring" baseModel Elantra, VClass "Small Station Wagons"
+  "Elantra Wagon":           Elantra     # "Elantra Wagon" baseModel Elantra, same VClass
+  "Genesis R-Spec":          Genesis     # "Genesis R-Spec" baseModel Genesis (as are Genesis AWD / RWD / Coupe)
+  "Genesis R Spec":          Genesis     # the unhyphenated form us_fueleconomy also ships
+  "Santa FE Sport":          Santa FE    # "Santa Fe Sport 4WD"/"AWD" baseModel Santa Fe
+  "Santa FE Sport Ultimate": Santa FE    # "Santa Fe Sport Ultimate AWD" baseModel Santa Fe; Ultimate is the top trim
+  "Santa FE Ultimate":       Santa FE    # "Santa Fe Ultimate 4WD"/"AWD" baseModel Santa Fe
+  "Sonata Se":               Sonata      # "Sonata SE" baseModel Sonata
+  "Sonata Sport/Limited":    Sonata      # NRCan writes the slashed pair; "Sonata Sport Limited" baseModel Sonata
+  "Sonata Sport Limited":    Sonata      # the us_fueleconomy spelling of the same row
+  "Veloster N":              Veloster    # "Veloster N" baseModel Veloster
+  "Veloster Turbo":          Veloster    # engine/trim badge; sibling of Veloster N, same ladder
+  "Kona N":                  Kona        # "Kona N" baseModel Kona (as are Kona AWD / Electric / FWD)
+  "XG300":                   XG          # "XG300" baseModel XG; the displacement is the trim
+  "XG350":                   XG          # "XG350" baseModel XG; carries ca+us ONTO car/hyundai/xg, which has neither
+  "Tucson Fuel Cell":        Tucson      # "Tucson Fuel Cell" baseModel Tucson; a powertrain, not a nameplate (contrast: Nexo IS its own baseModel and is KEPT)
+  # — UK DfT genmodel drift: the settled "Inster 01 EV"/"Kona Advance HEV S"
+  # class, unhandled Bayon/Tucson siblings (the Bayon has no family rule, so
+  # its trims became models). Grade names are Hyundai UK's own (hyundai.co.uk). —
+  "Bayon Advance":  Bayon    # drift-adoption fold; raw "HYUNDAI BAYON ADVANCE" (1,589)
+  "Bayon Premium":  Bayon    # same class; raw "HYUNDAI BAYON PREMIUM" (3,339)
+  "Bayon Ultimate": Bayon    # same class; raw "HYUNDAI BAYON ULTIMATE" (2,163)
+  "Tucson Advance": Tucson   # same class; raw "HYUNDAI TUCSON ADVANCE PHEV AUTO" (6,678)
+  # — remaining folds —
+  "Atos Prime":     Atos       # COMPLETES the settled "Atos-Prime": Atos fold — the spaced form (15 regs) was left behind. Same facelift trim, same nameplate.
+  "Kona Kauai":     Kona       # dual-market label in one cell; the register writes "KONA, KAUAI" ×1,500+ (already folded by the comma split) and "KONA KAUAI" ×29 (not). The Karl/Viva precedent.
+  "Pony GLS":       Pony       # GLS is Hyundai's standard trim code (raws "PONY GLS"; "SCOUPE GTI U9" shows the same ladder on the S-Coupe)
+  "Staria Premium": Staria     # Premium is a trim level of the Staria (raws "STARIA PREMIUM" lu+nl)
+  "Ionic":          Ioniq      # registry misspelling of Ioniq (fi 1 + nl 1); NOT a product
+  "Galopper":       Galloper   # registry misspelling of Galloper (fi 1 + nl 7); the double-P/single-L transposition
+  # — corrections, not folds (dossier §5) —
+  "i80": "i800"    # the family rule's /^I\s?(\d0)/ truncates "I800" to "i80"; Hyundai sells the i800 (the H-1/iLoad people carrier, hyundai.co.uk), never an i80 — 7,793 registrations were published under a fabricated nameplate. Stopgap for the pipeline regex fix (filed); retire with a comment when that lands (the QASHQAI+2 dead-key precedent).
+  "I45": i45       # the i-series is lowercase-i by settled convention (i10/i20/i30/i40, ix20/ix35/ix55); the family rule's /(\d0)/ misses I45 so the casing never applies. Display-only: slug unchanged, no id moves.
 
 I-Coco:
   Lt-018:                    LT018                # closed type code
@@ -2613,40 +2657,151 @@ Panther:
   Panther: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Peugeot:
-  # ── casing-contradiction batch: the trim-code ladder finished (205 GR /
-  # 305 SR / 307 SW were fixed earlier, nine siblings weren't). ──
-  104 Sr: 104 SR                    # trim codes all-caps ("SR, SRD, SR Injection") — https://en.wikipedia.org/wiki/Peugeot_309 ; matches 305 Sr: 305 SR
-  207 Sw: 207 SW                    # SW = estate suffix; raw "207 SW GTI"
-  308 Sw: 308 SW                    # matches the block's 307 Sw: 307 SW
-  308 Sw Style: 308 SW Style        # raws "308 SW STYLE BLUEHDI 1", "308 SW STYLE HYBRID 14"
-  309 Gr: 309 GR                    # "XR, GR: 1580cc XU5" verbatim — Peugeot 309 article
-  309 Sr: 309 SR                    # "SR, SRD, SR Injection" verbatim, same article
-  405 Gr: 405 GR                    # same house trim ladder; matches 205 GR / 505 GR
-  505 Gr Family: 505 GR Family      # same; "Family" is the Familiale estate body word, stays title-case
-  508 Sw: 508 SW                    # same estate suffix
+  # ── wave-3 trim-fold batch (2026-07-26, dossier-trims-peugeot-hyundai): 92
+  # Peugeot ids fold onto 26 nameplates — trim badges, engine/displacement
+  # suffixes, body designations, Sevel chassis type codes, GVW/payload strings,
+  # registry truncations, one misspelling. 0 country pairs lost (union-checked);
+  # 205/305/104/j5 GAIN countries. 28 lines are EDITs of the settled casing/
+  # collision batches: the uppercase-trim-code and lowercase-injection-i
+  # rulings are NOT reversed — each survives verbatim as a variants: name in
+  # pipeline enrich/peugeot.yml (the HY 78 precedent). QUOTE EVERY NUMERAL on
+  # BOTH sides of the colon: an unquoted VALUE (205) parses as Integer and
+  # Support.slugify(Integer) crashes the build; an unquoted KEY (280) parses
+  # as Integer and renames.key?("280") never matches — silently inert. ──
+  # — 205: the GL/GR/GT/SR/XE ladder + cabriolet trims + the Rallye —
+  "205 Cj":                "205"   # CJ = the 1.1 cabriolet trim (raws "205 CJ CABRIOLET 1.1 U9" ×88)
+  "205 Cj/Roland Garros":  "205"   # CJ + the Roland Garros special edition (raw "205 CJ/ROLAND GARROS")
+  "205 Cti":               "205"   # CTI = injected cabriolet trim (raw "205 CTI CABRIOLET 1.9 U9" ×174)
+  "205 Cti 1":             "205"   # CTI + a truncated displacement (raws "205 CTI 1,6", "205 CTI 1,9")
+  "205 GL":                "205"   # base trim of the 205 ladder (GL/GR/GT); the GL token is acronym-pinned so the key keeps its caps
+  "205 Gr":                "205"   # EDIT (was 205 GR) — trim code; the uppercase ruling moves to enrich as the variant name
+  "205GR":                 "205"   # EDIT (was 205 GR) — fused registry variant of the same trim
+  "205 GT":                "205"   # trim code
+  "205 Rallye":            "205"   # Rallye is the stripped 1.3/1.9 homologation TRIM of the 205, not a nameplate — https://en.wikipedia.org/wiki/Peugeot_205
+  "205 Xe":                "205"   # XE trim (raw "205 XE" ×48)
+  # — 307 / 308: displacement + CC/SW bodies + XT/GT/Style trims —
+  "307 1.6I":       "307"   # litre displacement is a spec, NAMING.md §6 (raw "307 1.6I ST.CAR")
+  "307 2.0I":       "307"   # same (raw "307 2.0I CABRIO")
+  "307 CC":         "307"   # CC = coupé-cabriolet BODY of the 307
+  "307CC":          "307"   # EDIT (was 307 CC) — fused registry form of the same body
+  "307 Sw":         "307"   # EDIT (was 307 SW) — SW = the estate BODY (peugeot.com archive); the caps ruling moves to enrich
+  "307SW":          "307"   # EDIT (was 307 SW) — fused registry form
+  "307 Xt 1":       "307"   # XT trim + truncated displacement (raws "307 XT 1,6 5D TI", "307 XT 1,6 KOMBI")
+  "308 1.2I Stt":   "308"   # 1.2 PureTech + Stop&Start = engine spec
+  "308 1.6I":       "308"   # displacement
+  "308 CC":         "308"   # coupé-cabriolet body
+  "308 GT":         "308"   # GT trim (raw "PEUGEOT 308 GT PHEV AUTO" — DfT genmodel drift)
+  "308 Sw":         "308"   # EDIT (was 308 SW) — estate body
+  "308 Sw Style":   "308"   # EDIT (was 308 SW Style) — estate body + Style trim; ES 22-char truncations "308 SW STYLE BLUEHDI 1"
+  # — 208 / 2008 / 3008 / 5008 / E-5008: the LIVE-registry trim generator
+  # (ES DGT 22-char MODELO_ITV truncation, es_dgt.rb:18 + UK DfT trim-flavored
+  # genmodels). Trim strips; the e- PRODUCT survives per the settled
+  # data/review/citroen-e-prefix-verdict.md — E-5008 Allure folds to the MINTED
+  # E-5008, never to 5008. —
+  "208 5P Allure":            "208"      # "5P" = 5-portes (door count) + Allure trim; ES raw "208 5P ALLURE HYBRID 1"
+  "208 5P Allure Turbo 10":   "208"      # same, + the 100 hp turbo, truncated mid-number
+  "208 5P Style":             "208"      # same, Style trim
+  "208 Allure":               "208"      # GB raw "PEUGEOT 208 ALLURE MHEV AUTO" — DfT trim-flavored genmodel
+  "208 GT Premium Auto":      "208"      # GB raw "PEUGEOT 208 GT PREMIUM AUTO"; GT+Premium are trim, Auto is the gearbox
+  "2008 Allure":              "2008"     # ES raws "2008 ALLURE HYBRID 145" ×2,932 / "…HYBRID 110" / "…BLUEHDI 13"
+  "2008 Allure Turbo 100":    "2008"     # ES raw "2008 ALLURE TURBO 100" ×1,528
+  "3008 Allure":              "3008"     # ES raws "3008 ALLURE HYBRID 145" ×1,220 / "…PLUG-IN HY" / "…BLUEHDI 13"
+  "3008 GT":                  "3008"     # ES "3008 GT HYBRID 145 E-D" + GB "PEUGEOT 3008 GT PHEV AUTO"
+  "5008 GT":                  "5008"     # ES "5008 GT HYBRID 145 EDC" / "5008 GT PLUG-IN HYBRID"
+  "E-5008 Allure":            "E-5008"   # trim strips, the e- product survives (citroen-e-prefix-verdict.md); MINTS car/peugeot/e-5008 (gb 5,289 — publishes)
+  # — 405 / 504 / 505 / 604 / 605: the rear-drive-era GR/SR/TI/SL ladder,
+  # Mi16/V6 engine badges, Familiale body. 13 EDITs — every settled spelling
+  # ruling of the 2026-07-26 collision batch relocates to enrich, none reversed. —
+  "405 Gr":         "405"   # EDIT (was 405 GR)    — trim code
+  "405 MI16":       "405"   # EDIT (was 405 Mi16)  — 16-valve engine badge, not a nameplate
+  "405 Mi 16":      "405"   # EDIT (was 405 Mi16)  — spaced registry form
+  "405 Mi-16":      "405"   # EDIT (was 405 Mi16)  — hyphenated registry form
+  "405 Srdt":       "405"   # SRD + Turbo: the diesel trim ladder (GLD/GRD/SRD — https://en.wikipedia.org/wiki/Peugeot_309)
+  "405 Sri":        "405"   # EDIT (was 405 SRi)   — injection trim badge
+  "405SRI":         "405"   # EDIT (was 405 SRi)   — fused registry form
+  "504 GL":         "504"   # trim code (the spaced form cases correctly via the GL acronym pin)
+  "504GL":          "504"   # EDIT (was 504 GL)    — fused registry form
+  "504 Ti":         "504"   # EDIT (was 504 TI)    — injection trim badge
+  "504TI":          "504"   # EDIT (was 504 TI)    — fused registry form
+  "504D":           "504"   # D = the diesel 504 (NL first reg 1972 — era-checked)
+  "505 Gr":         "505"   # EDIT (was 505 GR)    — trim code
+  "505GR":          "505"   # EDIT (was 505 GR)    — fused registry form
+  "505 Gr Family":  "505"   # EDIT (was 505 GR Family) — GR trim + the Familiale 8-seat estate BODY (en.wikipedia Peugeot_505)
+  "505 V6":         "505"   # engine badge (the PRV V6)
+  "505V6":          "505"   # EDIT (was 505 V6)    — fused registry form
+  "604 D Turbo":    "604"   # turbodiesel engine designation
+  "604 SL":         "604"   # trim code
+  "604 Sti":        "604"   # injection trim badge
+  "605 Sld":        "605"   # SL + D (diesel) trim
+  # — 309 / 305 / 301 / 104 / 106 / 107: the GLD/GRD/SRD diesel-era ladder
+  # ("the 1905 cc … GLD, GRD, followed by the SRD" — en.wikipedia Peugeot_309) —
+  "309 GL Profil": "309"   # GL trim + "Profil" equipment pack (raws "309 XL PROFIL 1.4 U9", "309 GL PROFIL")
+  "309 Gr":        "309"   # EDIT (was 309 GR) — "XR, GR: 1580cc XU5" verbatim, Peugeot 309 article
+  "309 Sr":        "309"   # EDIT (was 309 SR) — "SR, SRD, SR Injection" verbatim, same article
+  "305 Grd":       "305"   # GR + D: the diesel trim (raw "305 GRD ESTATE")
+  "305 Sr":        "305"   # EDIT (was 305 SR) — trim code
+  "305SR":         "305"   # EDIT (was 305 SR) — fused registry form
+  "301 D":         "301"   # D = diesel (raws "301 D COUPE", "301 D CABRIO" — the 1930s 301; NL first regs 1935-37, era-checked against the nameplate)
+  "104 Sr":        "104"   # EDIT (was 104 SR) — trim code; matches the 305/309 ladder
+  "106 Xr":        "106"   # XR trim
+  "107 1.0I":      "107"   # litre displacement is a spec (NAMING.md §6)
+  # — factory type codes (203A/203C/403B/403U5/404C — the Citroën HY 78 class)
+  # + 206/207/508 bodies. Era-checked via RDW first regs: 203 A 1950-55,
+  # 403B 1960-63, 404C 1963-68 — all inside their nameplate's run. —
+  "203 A":     "203"   # 203A = the 1948-55 series letter (raw "203A CABRIOLET" shows it is a series, not a badge)
+  "203C":      "203"   # 203C = the 1955-60 series letter (raws "203-C SEDAN", "203C5 FAMIALE")
+  "403-B5":    "403"   # B5 body/series code (raw "403-B5 KOMBI/2900-61")
+  "403 B5":    "403"   # spaced form of the same code
+  "403B":      "403"   # B series code (sibling raws 403-B, 403-B7, 403/B7)
+  "403U5":     "403"   # U5 = the utility/fourgonnette series of the 403
+  "404C":      "404"   # C = the coupé series letter (raw "404C CABRIOLET")
+  "206 1.4I":  "206"   # litre displacement
+  "206+ 1.4I": "206"   # same, on the "206+" facelift string
+  "206 CC":    "206"   # coupé-cabriolet BODY
+  "206CC":     "206"   # EDIT (was 206 CC) — fused registry form
+  "206 Xr":    "206"   # XR trim
+  "207 Sw":    "207"   # EDIT (was 207 SW) — estate body; raw "207 SW GTI"
+  "508 Rxh":   "508"   # RXH = the raised HYbrid4 estate BODY of the 508
+  "508 Sw":    "508"   # EDIT (was 508 SW) — estate body
+  # — Sevel type codes. The register writes "290/J5", "280 L J5", "280L (J5)",
+  # "J5/280 G52" — the type code and the nameplate in ONE cell (NL-RDW, 200+
+  # rows). Type 280 = J5 1981-90, Type 290 = J5 1990-94 (RDW first regs
+  # 1984-99, era-checked). Nearly every row is a KAMPEERAUTO (camper)
+  # conversion registered in the CAR kind; the van-kind "290" MINTS
+  # van/peugeot/j5 (nl 654 > threshold 300). https://en.wikipedia.org/wiki/Fiat_Ducato
+  # THE THREE QUOTED NUMERAL KEYS ARE LOAD-BEARING: unquoted they parse as
+  # Integer and never match. —
+  "280":                     "J5"   # Sevel Type 280 = the J5 (car 8 + van 17 registrations)
+  "280L":                    "J5"   # Type 280, L body (car 37 + van 204)
+  "290":                     "J5"   # Sevel Type 290 = the J5 (car 43 + van 401) — MINTS van/peugeot/j5
+  "290 G 52/8 Kampeerauto":  "J5"   # Type 290 + G52 body code + Dutch "kampeerauto" (motorhome)
+  # — van: Boxer GVW series / Expert / Partner payload+trim strings / Rifter.
+  # The settled "Boxer 35 Professional": Boxer line (kept verbatim below) is
+  # the precedent the 335/435 siblings complete (the Ford Transit 100-350
+  # GVW-class shape). —
   "Boxer 35 Professional": Boxer    # drift-adoption fold: GVW-series trim string of the Boxer
-  # ── collision batch (2026-07-26): 9 groups, one dossier — trim codes
-  # uppercase-spaced; injection-era badges keep Peugeot's lowercase i;
-  # engine badges closed. Two detector proposals overridden (Mi16, V6). ──
-  205 Gr: 205 GR                            # trim codes badge UPPERCASE (GR = Grand Routier; period brochures)
-  205GR: 205 GR                             # fused registry variant
-  305 Sr: 305 SR                            # same uppercase trim-code convention
-  305SR: 305 SR                             # fused registry variant
-  307 Sw: 307 SW                            # SW is the official estate designation ("307 SW", peugeot.com archive)
-  307SW: 307 SW                             # fused registry variant
-  405 Mi 16: 405 Mi16                       # the badge is CLOSED with the lowercase injection i: "Mi16" — the 16v flagship; detector proposed "MI 16", wrong on both counts
-  405 Mi-16: 405 Mi16                       # hyphenated observed form (observed_model_names.json)
-  405 MI16: 405 Mi16                        # all-caps registry variant of the same badge
-  405 Sri: 405 SRi                          # Peugeot injection badges keep the lowercase i (SRi, GRi — as on the 205 GTi)
-  405SRI: 405 SRi                           # fused registry variant
-  504GL: 504 GL                             # fused variant; the spaced form cases correctly via the GL acronym token
-  504 Ti: 504 TI                            # period 504 trim badge is uppercase TI (brochures; the injected 504)
-  504TI: 504 TI                             # fused registry variant
-  505 Gr: 505 GR                            # uppercase trim code, as 205/305
-  505GR: 505 GR                             # fused registry variant
-  505V6: 505 V6                             # V6 is an engine badge, CLOSED — the spaced "V 6" the detector proposed appears nowhere
-  "206CC": "206 CC"                           # spelling variant of "206 CC" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "307CC": "307 CC"                           # spelling variant of "307 CC" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  "Boxer 335":      "Boxer"   # 335 = 3.5 t GVW series (Boxer 330/335/435 …), the class the settled "Boxer 35 Professional" line already folds
+  "Boxer 435":      "Boxer"   # 4.35 t GVW series
+  "Boxer Multicab": "Boxer"   # Multicab is the CREW-CAB body; the Citroën "Jumper Multicab: Jumper" precedent (raw "BOXER, MULTICAB" already folds via the comma split)
+  "Boxer Van":      "Boxer"   # "Van" is the panel-van BODY; the Citroën "Berlingo Van: Berlingo" precedent (raw "BOXER VAN, 2.0 HDI 163 HK L2H2")
+  "Boxter":         "Boxer"   # registry misspelling of Boxer (es+nl); NOT the Porsche Boxster, which is a different make
+  "Expert 2":                       "Expert"   # displacement fragment (raws "EXPERT 2,0 HDI"); the Citroën "Jumper 2: Jumper" precedent
+  "Expert 2.0HDI":                  "Expert"   # engine spec suffix
+  "Expert 227 L1H1 1.6HDI 16V-90":  "Expert"   # 227 = Sevel type code, L1H1 = length/height class, then engine+valves+kW (NL-RDW, 494 registrations)
+  "Expert Asphalt":                 "Expert"   # "Asphalt" is a UK trim level (raw "PEUGEOT EXPERT ASPHALT")
+  "Expert Furgón M Diesel":         "Expert"   # ES "furgón" (panel van) + size M + fuel; EXACT twin of the settled Citroën "Jumpy Furgón M Diesel: Jumpy"
+  "Expert Professional":            "Expert"   # UK trim; same class as the settled "Boxer 35 Professional": Boxer (7,139 GB registrations)
+  "Expert Traveller":               "Expert"   # Traveller is the PASSENGER version of the Expert; folds WITHIN its kind — renaming to Traveller would cross kinds (the Jumpy Spacetourer ruling, Citroën dossier §3.9/U6)
+  "Partner 1":                      "Partner"   # truncated displacement (raws "PARTNER 1,6 HDI", "PARTNER 1,6 VTI", "PARTNER 1,6I")
+  "Partner 120 L1 1.6HDIF":         "Partner"   # 120 = payload class, L1 = short body, HDIF = particulate-filter engine
+  "Partner 170C 1.6HDI":            "Partner"   # 170C = 1,700 kg payload class + engine (raw "PARTNER 170C 1.6HDI - 55KW")
+  "Partner 170C 1.9D":              "Partner"   # same class, 1.9 diesel (1,573 NL registrations)
+  "Partner 170C 2.0HDI":            "Partner"   # same class, 2.0 HDi
+  "Partner Furgón M Die":           "Partner"   # ES "furgón" + size M + fuel, truncated at 22 chars (raw "PARTNER - FURGÓN M DIE"); twin of the Citroën "Berlingo Talla M Blueh" fold
+  "Partner Prfssionl + Stndard EV": "Partner"   # UK DfT genmodel with the vowels stripped to fit its field: "Professional + Standard EV" (7,503 GB registrations)
+  "Rifter Active Business": "Rifter"   # ES fleet trim level (raw "RIFTER ACTIVE BUSINESS", 1,482 registrations)
+  "404 Pick-Up":            "404"      # pickup BODY of the 404
+  "404 Pick Up":            "404"      # unhyphenated registry form of the same body
   Peugeot: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   DJANGO125: Django 125                   # registry form with the space collapsed; Peugeot writes "Django 125" (https://www.peugeot-motocycles.com/)
   "BUXI45KM/H": Buxi                      # "45 km/h" is the L1e speed class, which kind=moped already encodes — it is not part of the nameplate (NAMING.md §6). Rename CREATES the Buxi nameplate.


### PR DESCRIPTION
Data half of the wave-3 Peugeot+Hyundai trim-fold batch (dossier: `dossier-trims-peugeot-hyundai.md`, replay-verified byte-exact against the real corpus). **Merge pipeline PR vehiclesdb-pipeline#59 first** — it carries the enrich files this batch relocates settled rulings into, plus a test decoupling that closes the coupled-pair red window (#96 class) before this PR opens it.

## Headline

**`car/hyundai/i80` does not exist.** The family rule `/^I\s?(\d0)/` truncates `I800` to `i80`, publishing **7,793 UK+NZ registrations under a nameplate Hyundai has never sold** (decile 5 — well inside the visible catalog). `"i80": "i800"` is the data-side stopgap available today; the regex cure `(\d0)(?!\d)` is filed on the pipeline PR (normalizer frozen until wave 3 lands). When the pipeline fix lands, retire the stopgap **with a comment** (QASHQAI+2 precedent). `car/hyundai/i800` publishes with gb+nz, 2 sources, former_id `car/hyundai/i80` attached — verified in a full build.

## Numbers

- **renames.yml: 137 lines** — 106 Peugeot (**28 EDITs of settled lines in place**, rest additions) + 31 Hyundai (all additions, **zero collisions re-verified against current origin/main**: exactly the 28 overlap keys, all with the dossier's expected old values; the settled Tucson/ix35 · Inster · Kona Advance · Atos-Prime · H1 · Scoupe · Santafe lines untouched).
- **former_ids.yml: 131 lines** — 120 retirements APPENDED + **11 existing entries repointed in place** (205gr, 305sr, 307sw, 307cc, 206cc, 405-mi-16, 405sri, 504gl, 504ti, 505gr, 505v6 — their targets now fold; chains flattened). File-wide chain scan after the edit: **0 values that are also keys, 0 values pointing at a retiring id, 0 duplicate raw keys** (3,297 entries).
- **Catalog: −117 published Peugeot+Hyundai ids.** 120 retired (119 folds + 1 correction), 3 minted.

## THE STRING HAZARD (checked, both sides)

81 of the 106 Peugeot lines carry a **pure-numeral VALUE** and 2 carry a **pure-numeral KEY** (`"280"`, `"290"`) — the first batch where both hazards co-occur. Unquoted value → `Support.slugify(Integer)` → **NoMethodError, build dies**. Unquoted key → `renames.key?("280")` false → **silently inert**. Every numeral is quoted on both sides; post-write the whole file was round-tripped through `YAML.safe_load` asserting **every key AND every value in the Peugeot+Hyundai blocks is a String** (only the two settled `make: null` drop lines are non-String, by design). A String-only lint is filed on the pipeline PR (§7.1).

## Mints (all three publish — verified live in the full build)

| id | evidence | mechanism |
|---|---|---|
| `car/peugeot/e-5008` | gb 5,289 | `E-5008 Allure` strips the trim, the e- PRODUCT survives (`data/review/citroen-e-prefix-verdict.md` — applied, not reopened) |
| `van/peugeot/j5` | nl 654 (> van threshold 300) | Sevel Type 290 — NL-RDW writes `"290/J5"`, `"280 L J5"`, `"J5/280 G52"`: type code and nameplate in ONE cell, 200+ rows |
| `car/hyundai/i800` | gb 7,789 + nz 4, 2 sources | the phantom corrected |

## Verification (in dossier checklist order)

1. `test_override_key_reachability.rb` (VDB_DATA_REPO=this branch): 5 runs, 0 failures.
2. `lint_enrich.rb`: OK — 46 files, 700 ids (mints pass on the pending-publish alias tolerance).
3. **Full six-kind build** (`--kinds=car,van,truck,bus,moped,motorcycle`): exit 0, **ALL GATES GREEN**, no delta ack needed (the truck delta is the pre-existing ack, ceiling 1400).
4. `scripts/propose_former_ids.rb` (published dist → new build): **0 new proposals needed** — every retired P+H id already covered. Every finding investigated: 4 dead keys (Chrysler/Jaguar/MB/Yamaha) pre-exist on origin/main, 0 mine; 71 unexplained disappearances, **0 Peugeot/Hyundai**; 4 evidence-loss flags of which 2 touch this batch (`307-sw`/`308-sw` "lost ar") — **proven corpus drift, not fold loss**: the replay corpus and a pristine-overrides baseline build at the same cache both lack any ar row for `307 SW`/`308 SW` (ar_dnrpa is a rolling 1-month window; the published pairs pre-date it).
5. `scripts/reorg_make_blocks.rb --check`: OK. Bare `lint_curation.rb` + `lint_overrides.rb`: OK.
6. **The §0 contract, measured baseline-vs-applied at the SAME cache** (pristine origin/main overrides vs this branch, both full real builds):
   - P+H ids **330 → 213 (−117 exactly)** — the published catalog says 331 because it predates the settled ix35 fold (`tucson-ix-35/-ix35/-ix35-lm` are already gone at baseline, dossier §1.3) and two new corpus arrivals.
   - **Country evidence LOST by folding: 0.** Retiring ids still published: 0. Non-member P+H ids vanished: 0. Unexpected new ids: 0.
   - **7 survivors GAIN countries**, exactly the dossier's seven: `xg` +ca,us · `elantra` +th · `pony` +nl · `j5` +es · `205` +es · `305` +nz · `104` +fi.
   - **223 (id,country) pairs deduplicated** (dossier predicted 226): the 3-pair shortfall is enumerated drift — `307-sw`+`308-sw` lost ar (rolling window) and `5008-gt`/`boxer-335`/`boxer-435` lost gb (DfT re-bucketed those genmodels since the catalog release) — all five pairs left the corpus before this batch touched anything.
7. **Vintage-vs-modern drill (Indian 101-scout rule) RAN**, against RDW first-registration data: `301 D` → 1935-37 (the 1930s diesel 301, folding at nameplate level), `203 A` 1950-55, `203C` 1953+, `403B/B5/U5` 1958-63, `404C` 1963-68, `504D` 1972, Sevel `280/280L/290` 1984-99 (squarely the J5 era). **No fold spans eras.**
8. Settled rulings preserved: every uppercase-trim-code and lowercase-i casing decision survives as a `variants:` name in the pipeline enrich files; `Santa FE` keeps its acronym casing (fold values keyed to the live canonical). Hysteresis ids not re-created (`inster-01-ev`, `boxer-35-professional` — verified absent).
9. Kind-blind: the 7 multi-kind keys (`290 280 280L "301 D" "403 B5" 403U5 i80`) written exactly once each; the two pure-numeral keys produce **zero** moped/motorcycle rows (the 61 Peugeot two-wheelers are untouched).

## NOT in this batch — filed, with reasons

- **Horizon (8,202 gb) / Ranch / 222 / 230L** — all four blocked by the **drop-pattern/rename mutual-defeat mechanism** (§7.4): their fold targets (`Rifter`/`Partner`/`Expert`/`Boxer`) are car-kind drop patterns, and a rename VALUE matching a drop pattern mints exactly what the pattern forbids. `280`/`290` fold only because `J5` is not drop-patterned. Belongs to the kind-boundary batch, with the lint guard filed on the pipeline PR.
- **The family-rule regex cure** `(\d0)(?!\d)` — pipeline-side, frozen until wave 3 lands; filed on vehiclesdb-pipeline#59.
- **Citroën U10 cross-resolution**: `car/citroen/280-l` is the same Sevel Type 280 on the C25 (the J5's twin, identical NL KAMPEERAUTO signature) — evidence noted for the Citroën worklist; no Citroën change made here.
- **Everything §UNCERTAIN**: U1/U2 Hyundai market-name constellations (`aliases.yml` shape, not renames — `H-1/Starex/iLoad/iMax/i800/H200` are export names of one family), U7 coachbuilders (Théault/Auto-Sleepers/Bailey/Elddis — makes/drop concern, note the Citroën twins are demoted while these are live), U10 two-wheelers.
- **Forward-looking observations**: `car/peugeot/2008-gt-premium-ev` appeared in the corpus AFTER the dossier snapshot (new DfT drift arrival, same class as the folded `208 GT Premium Auto`) — next wave. Sub-threshold `Bayon Black`(413)/`Bayon Tech`(434) not keyed (not published ids; dossier §3.12 note).

DO NOT MERGE before vehiclesdb-pipeline#59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)