### PR TITLE
Permutation folds tier A: 50 ids retired, 0 added

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -176,7 +176,7 @@
 "moped/stevens/e-triton45":                    "moped/stevens/e-triton-45"                    # E-TRITON45 -> E-Triton 45  [fi,nl]
 "moped/suzuki/lets2":                          "moped/suzuki/lets-2"                          # LETS2 -> Lets 2  [nz,ua]
 "moped/suzuki/lets4":                          "moped/suzuki/lets-4"                          # LETS4 -> Lets 4  [nz,ua]
-"moped/sym/fiddle2":                           "moped/sym/fiddle-2"                           # FIDDLE2 -> Fiddle 2  [nl,nz]
+"moped/sym/fiddle2": "moped/sym/fiddle-ii"                           # FIDDLE2 -> Fiddle 2  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "moped/tgb/rapido-rivana25":                   "moped/tgb/rapido-rivana-25"                   # Rapido RIVANA25 -> Rapido Rivana 25  [nl]
 "moped/vespa/50special":                       "moped/vespa/50-special"                       # 50SPECIAL -> 50 Special  [nl,nz]
 "moped/vespa/piaggio50":                       "moped/vespa/piaggio-50"                       # PIAGGIO50 -> Piaggio 50  [nl,nz]
@@ -286,7 +286,7 @@
 "motorcycle/buell/s1lightning":                "motorcycle/buell/s1-lightning"                # S1LIGHTNING -> S1 Lightning  [gb,nl]
 "motorcycle/buell/s3thunderbolt":              "motorcycle/buell/s3-thunderbolt"              # S3THUNDERBOLT -> S3 Thunderbolt  [gb,nl]
 "motorcycle/buell/x1lightning":                "motorcycle/buell/x1-lightning"                # X1LIGHTNING -> X1 Lightning  [gb,nl]
-"motorcycle/cagiva/125mito":                   "motorcycle/cagiva/125-mito"                   # 125MITO -> 125 Mito  [gb]
+"motorcycle/cagiva/125mito": "motorcycle/cagiva/mito-125"                   # 125MITO -> 125 Mito  [gb] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/cagiva/650alazzurra":              "motorcycle/cagiva/650-alazzurra"              # 650ALAZZURRA -> 650 Alazzurra  [fi,nl]
 "motorcycle/cagiva/750elefant":                "motorcycle/cagiva/750-elefant"                # 750ELEFANT -> 750 Elefant  [gb,nl]
 "motorcycle/cagiva/900elefant":                "motorcycle/cagiva/900-elefant"                # 900ELEFANT -> 900 Elefant  [gb,nl]
@@ -320,7 +320,7 @@
 "motorcycle/ducati/851superbike":              "motorcycle/ducati/851-superbike"              # 851SUPERBIKE -> 851 Superbike  [nl,nz]
 "motorcycle/ducati/888strada":                 "motorcycle/ducati/888-strada"                 # 888STRADA -> 888 Strada  [gb,nl,nz]
 "motorcycle/ducati/899panigale":               "motorcycle/ducati/899-panigale"               # 899PANIGALE -> 899 Panigale  [es,fi,gb,nl]
-"motorcycle/ducati/900monster":                "motorcycle/ducati/900-monster"                # 900MONSTER -> 900 Monster  [nl,nz]
+"motorcycle/ducati/900monster": "motorcycle/ducati/monster-900"                # 900MONSTER -> 900 Monster  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/ducati/900superlight":             "motorcycle/ducati/900-superlight"             # 900SUPERLIGHT -> 900 Superlight  [nl,nz]
 "motorcycle/ducati/906paso":                   "motorcycle/ducati/906-paso"                   # 906PASO -> 906 Paso  [fi,gb,nl,nz]
 "motorcycle/ducati/916biposto":                "motorcycle/ducati/916-biposto"                # 916BIPOSTO -> 916 Biposto  [gb,nl]
@@ -387,7 +387,7 @@
 "motorcycle/ducati/panigale-v4lamborghini":    "motorcycle/ducati/panigale-v4-lamborghini"    # Panigale V4LAMBORGHINI -> Panigale V4 Lamborghini  [nl,ua]
 "motorcycle/ducati/panigale-v4speciale":       "motorcycle/ducati/panigale-v4-speciale"       # Panigale V4SPECIALE -> Panigale V4 Speciale  [nl,th]
 "motorcycle/ducati/panigale-v4tricolore":      "motorcycle/ducati/panigale-v4-tricolore"      # Panigale V4TRICOLORE -> Panigale V4 Tricolore  [es,nl]
-"motorcycle/ducati/paso750":                   "motorcycle/ducati/paso-750"                   # PASO750 -> Paso 750  [nl,nz]
+"motorcycle/ducati/paso750": "motorcycle/ducati/750-paso"                   # PASO750 -> Paso 750  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/ducati/paul-smart1000le":          "motorcycle/ducati/paul-smart-1000le"          # Paul SMART1000LE -> Paul Smart 1000LE  [fi,nl]
 "motorcycle/ducati/scrambler-ducati1100pro":   "motorcycle/ducati/scrambler-ducati-1100pro"   # Scrambler DUCATI1100PRO -> Scrambler Ducati 1100PRO  [fi,lu,nl]
 "motorcycle/ducati/scrambler-ducati1100sport-pro": "motorcycle/ducati/scrambler-ducati-1100-sport-pro" # Scrambler DUCATI1100SPORT Pro -> Scrambler Ducati 1100 Sport Pro  [fi,nl]
@@ -417,9 +417,9 @@
 "motorcycle/harley-davidson/1200custom-limited": "motorcycle/harley-davidson/1200-custom-limited" # 1200CUSTOM Limited -> 1200 Custom Limited  [fi,nl]
 "motorcycle/harley-davidson/1200custom-limited-a": "motorcycle/harley-davidson/1200-custom-limited-a" # 1200CUSTOM Limited A -> 1200 Custom Limited A  [fi,nl]
 "motorcycle/harley-davidson/1200custom-limited-b": "motorcycle/harley-davidson/1200-custom-limited-b" # 1200CUSTOM Limited B -> 1200 Custom Limited B  [fi,nl]
-"motorcycle/harley-davidson/1200sportster":    "motorcycle/harley-davidson/1200-sportster"    # 1200SPORTSTER -> 1200 Sportster  [nl,nz]
+"motorcycle/harley-davidson/1200sportster": "motorcycle/harley-davidson/sportster-1200"    # 1200SPORTSTER -> 1200 Sportster  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/harley-davidson/883roadster":      "motorcycle/harley-davidson/883-roadster"      # 883ROADSTER -> 883 Roadster  [fi,nl]
-"motorcycle/harley-davidson/883sportster":     "motorcycle/harley-davidson/883-sportster"     # 883SPORTSTER -> 883 Sportster  [nl,nz]
+"motorcycle/harley-davidson/883sportster": "motorcycle/harley-davidson/sportster-883"     # 883SPORTSTER -> 883 Sportster  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/harley-davidson/breakout114":      "motorcycle/harley-davidson/breakout-114"      # BREAKOUT114 -> Breakout 114  [fi,nl]
 "motorcycle/harley-davidson/fat-boy114anniversary-v": "motorcycle/harley-davidson/fat-boy114-anniversary-v" # Fat BOY114ANNIVERSARY V -> Fat BOY114 Anniversary V  [fi,nl]
 "motorcycle/harley-davidson/flh1200electra-glide": "motorcycle/harley-davidson/flh1200-electra-glide" # FLH1200ELECTRA Glide -> FLH1200 Electra Glide  [fi,nl]
@@ -535,7 +535,7 @@
 "motorcycle/honda/vf700magna":                 "motorcycle/honda/vf700-magna"                 # VF700MAGNA -> VF700 Magna  [fi,nl,nz]
 "motorcycle/honda/vf750magna":                 "motorcycle/honda/vf750-magna"                 # VF750MAGNA -> VF750 Magna  [nl,nz]
 "motorcycle/honda/vfr800aniv":                 "motorcycle/honda/vfr800-aniv"                 # VFR800ANIV -> VFR800 Aniv  [gb,nl]
-"motorcycle/honda/vt1100c2shadow":             "motorcycle/honda/vt1100c2-shadow"             # VT1100C2SHADOW -> VT1100C2 Shadow  [fi,nl]
+"motorcycle/honda/vt1100c2shadow": "motorcycle/honda/shadow-vt1100c2"             # VT1100C2SHADOW -> VT1100C2 Shadow  [fi,nl] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/honda/vt1100shadow":               "motorcycle/honda/vt1100-shadow"               # VT1100SHADOW -> VT1100 Shadow  [fi,nl]
 "motorcycle/honda/vt700shadow":                "motorcycle/honda/vt700-shadow"                # VT700SHADOW -> VT700 Shadow  [fi,nl]
 "motorcycle/honda/vt750c2shadow":              "motorcycle/honda/vt750c2-shadow"              # VT750C2SHADOW -> VT750C2 Shadow  [fi,nl]
@@ -553,9 +553,9 @@
 "motorcycle/husqvarna/701enduro":              "motorcycle/husqvarna/701-enduro"              # 701ENDURO -> 701 Enduro  [es,fi,gb,nl]
 "motorcycle/husqvarna/701enduro-lr":           "motorcycle/husqvarna/701-enduro-lr"           # 701ENDURO Lr -> 701 Enduro Lr  [fi,nl]
 "motorcycle/husqvarna/701supermoto":           "motorcycle/husqvarna/701-supermoto"           # 701SUPERMOTO -> 701 Supermoto  [fi,gb,lu,nl]
-"motorcycle/husqvarna/801svartpilen":          "motorcycle/husqvarna/801-svartpilen"          # 801SVARTPILEN -> 801 Svartpilen  [fi,nl]
+"motorcycle/husqvarna/801svartpilen": "motorcycle/husqvarna/svartpilen-801"          # 801SVARTPILEN -> 801 Svartpilen  [fi,nl] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/husqvarna/801vitpilen":            "motorcycle/husqvarna/801-vitpilen"            # 801VITPILEN -> 801 Vitpilen  [es,nl]
-"motorcycle/husqvarna/901norden":              "motorcycle/husqvarna/901-norden"              # 901NORDEN -> 901 Norden  [es,fi,nl]
+"motorcycle/husqvarna/901norden": "motorcycle/husqvarna/norden-901"              # 901NORDEN -> 901 Norden  [es,fi,nl] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/husqvarna/901norden-expedition":   "motorcycle/husqvarna/901-norden-expedition"   # 901NORDEN Expedition -> 901 Norden Expedition  [fi,nl]
 "motorcycle/husqvarna/norden901":              "motorcycle/husqvarna/norden-901"              # NORDEN901 -> Norden 901  [fi,th,ua]
 "motorcycle/husqvarna/nuda900":                "motorcycle/husqvarna/nuda-900"                # NUDA900 -> Nuda 900  [es,fi,gb,nl,ua]
@@ -706,7 +706,7 @@
 "motorcycle/ktm/990superduke-r":               "motorcycle/ktm/990-superduke-r"               # 990SUPERDUKE R -> 990 Superduke R  [fi,nl]
 "motorcycle/ktm/990supermoto":                 "motorcycle/ktm/990-supermoto"                 # 990SUPERMOTO -> 990 Supermoto  [es,fi,gb,nl]
 "motorcycle/ktm/990supermoto85kw":             "motorcycle/ktm/990-supermoto-85kw"            # 990SUPERMOTO85KW -> 990 Supermoto 85KW  [fi,nl]
-"motorcycle/ktm/duke2":                        "motorcycle/ktm/duke-2"                        # DUKE2 -> Duke 2  [fi,gb,nl]
+"motorcycle/ktm/duke2": "motorcycle/ktm/duke-ii"                        # DUKE2 -> Duke 2  [fi,gb,nl] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/ktm/freeride250f":                 "motorcycle/ktm/freeride-250f"                 # FREERIDE250F -> Freeride 250F  [fi,nl]
 "motorcycle/kymco/agility-city125":            "motorcycle/kymco/agility-city-125"            # Agility CITY125 -> Agility City 125  [es,fi,nl]
 "motorcycle/kymco/agility125":                 "motorcycle/kymco/agility-125"                 # AGILITY125 -> Agility 125  [fi,nl]
@@ -817,9 +817,9 @@
 "motorcycle/mv-agusta/superveloce800":         "motorcycle/mv-agusta/superveloce-800"         # SUPERVELOCE800 -> Superveloce 800  [lu,nl,nz]
 "motorcycle/neco/azzuro125":                   "motorcycle/neco/azzuro-125"                   # AZZURO125 -> Azzuro 125  [lu,nl]
 "motorcycle/niu/nqix500":                      "motorcycle/niu/nqix-500"                      # NQIX500 -> Nqix 500  [es,nl]
-"motorcycle/norton/750commando":               "motorcycle/norton/750-commando"               # 750COMMANDO -> 750 Commando  [nl,nz]
+"motorcycle/norton/750commando": "motorcycle/norton/commando-750"               # 750COMMANDO -> 750 Commando  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/norton/7dominator":                "motorcycle/norton/7-dominator"                # 7DOMINATOR -> 7 Dominator  [nl,nz]
-"motorcycle/norton/850commando":               "motorcycle/norton/850-commando"               # 850COMMANDO -> 850 Commando  [nl,nz]
+"motorcycle/norton/850commando": "motorcycle/norton/commando-850"               # 850COMMANDO -> 850 Commando  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/norton/850commando-mkiii":         "motorcycle/norton/850-commando-mkiii"         # 850COMMANDO Mkiii -> 850 Commando Mkiii  [nl,nz]
 "motorcycle/norton/atlas750":                  "motorcycle/norton/atlas-750"                  # ATLAS750 -> Atlas 750  [nl,nz]
 "motorcycle/norton/commando750":               "motorcycle/norton/commando-750"               # COMMANDO750 -> Commando 750  [fi,nl,nz]
@@ -933,7 +933,7 @@
 "motorcycle/sym/crox125":                      "motorcycle/sym/crox-125"                      # CROX125 -> Crox 125  [gb]
 "motorcycle/sym/maxsym400i":                   "motorcycle/sym/maxsym-400i"                   # MAXSYM400I -> Maxsym 400I  [nl,th]
 "motorcycle/tm-racing/300-2tempi":             "motorcycle/tm-racing/300-2-tempi"             # 300 2TEMPI -> 300 2 Tempi  [fi,nl]
-"motorcycle/triumph/650tiger":                 "motorcycle/triumph/650-tiger"                 # 650TIGER -> 650 Tiger  [nl,nz]
+"motorcycle/triumph/650tiger": "motorcycle/triumph/tiger-650"                 # 650TIGER -> 650 Tiger  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/triumph/bonneville-t120black":     "motorcycle/triumph/bonneville-t120-black"     # Bonneville T120BLACK -> Bonneville T120 Black  [es,fi,lu,nl,th]
 "motorcycle/triumph/bonneville120":            "motorcycle/triumph/bonneville-120"            # BONNEVILLE120 -> Bonneville 120  [nl,nz]
 "motorcycle/triumph/bonneville650":            "motorcycle/triumph/bonneville-650"            # BONNEVILLE650 -> Bonneville 650  [nl,nz]
@@ -977,8 +977,8 @@
 "motorcycle/triumph/sprint900":                "motorcycle/triumph/sprint-900"                # SPRINT900 -> Sprint 900  [nl,nz]
 "motorcycle/triumph/street-triple765rx":       "motorcycle/triumph/street-triple-765rx"       # Street TRIPLE765RX -> Street Triple 765RX  [es,nl]
 "motorcycle/triumph/t100tiger":                "motorcycle/triumph/t100-tiger"                # T100TIGER -> T100 Tiger  [fi,nl]
-"motorcycle/triumph/t140bonneville":           "motorcycle/triumph/t140-bonneville"           # T140BONNEVILLE -> T140 Bonneville  [nl,nz]
-"motorcycle/triumph/t160trident":              "motorcycle/triumph/t160-trident"              # T160TRIDENT -> T160 Trident  [nl,nz]
+"motorcycle/triumph/t140bonneville": "motorcycle/triumph/bonneville-t140"           # T140BONNEVILLE -> T140 Bonneville  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
+"motorcycle/triumph/t160trident": "motorcycle/triumph/trident-t160"              # T160TRIDENT -> T160 Trident  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/triumph/t309trophy":               "motorcycle/triumph/t309-trophy"               # T309TROPHY -> T309 Trophy  [gb,nl]
 "motorcycle/triumph/t312trophy":               "motorcycle/triumph/t312-trophy"               # T312TROPHY -> T312 Trophy  [gb,nl]
 "motorcycle/triumph/t509speed-triple":         "motorcycle/triumph/t509-speed-triple"         # T509SPEED Triple -> T509 Speed Triple  [gb,nl]
@@ -1055,7 +1055,7 @@
 "motorcycle/vespa/sprint150iget-abs":          "motorcycle/vespa/sprint-150-iget"         # SPRINT150IGET Abs -> Sprint 150 Iget Abs  [th]
 "motorcycle/vespa/sprint150iget-abs-s":        "motorcycle/vespa/sprint-150-iget-s"       # SPRINT150IGET Abs S -> Sprint 150 Iget Abs S  [th]
 "motorcycle/vespa/super-sport180":             "motorcycle/vespa/super-sport-180"             # Super SPORT180 -> Super Sport 180  [fi,nl]
-"motorcycle/vespa/super150":                   "motorcycle/vespa/super-150"                   # SUPER150 -> Super 150  [fi,nl]
+"motorcycle/vespa/super150": "motorcycle/vespa/150-super"                   # SUPER150 -> Super 150  [fi,nl] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/victoria/v35bergmeister":          "motorcycle/victoria/v35-bergmeister"          # V35BERGMEISTER -> V35 Bergmeister  [fi,nl]
 "motorcycle/victory/8ball":                    "motorcycle/victory/8-ball"                    # 8BALL -> 8 Ball  [gb,nl,nz]
 "motorcycle/victory/vegas8-ball":              "motorcycle/victory/vegas-8-ball"              # VEGAS8-Ball -> Vegas 8 Ball  [nl,nz]
@@ -2349,7 +2349,7 @@
 "motorcycle/kawasaki/zx10r": "motorcycle/kawasaki/zx-10r" # "ZX10R" -> "ZX-10R"
 "motorcycle/kawasaki/zx6r": "motorcycle/kawasaki/zx-6r" # "ZX6R" -> "ZX-6R"
 "motorcycle/kawasaki/zx9r": "motorcycle/kawasaki/zx-9r" # "ZX9R" -> "ZX-9R"
-"motorcycle/kawasaki/zx9r-ninja": "motorcycle/kawasaki/zx-9r-ninja" # "ZX9R Ninja" -> "ZX-9R Ninja"
+"motorcycle/kawasaki/zx9r-ninja": "motorcycle/kawasaki/ninja-zx-9r" # "ZX9R Ninja" -> "ZX-9R Ninja" [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/kawasaki/zzr1100": "motorcycle/kawasaki/zz-r1100" # "ZZR1100" -> "ZZ-R1100"
 "motorcycle/kawasaki/zzr600": "motorcycle/kawasaki/zz-r600" # "ZZR600" -> "ZZ-R600"
 "motorcycle/ducati/750-super-sport": "motorcycle/ducati/750-supersport" # "750 Super Sport" -> "750 SuperSport"
@@ -2769,6 +2769,56 @@
 "motorcycle/nsu/lux200": "motorcycle/nsu/lux" # "LUX200" -> "Lux"; pre-flight clean, nothing aliased to lux200
 "motorcycle/enfield/500": "motorcycle/royal-enfield/500" # Enfield -> Royal Enfield model-level move. A MOVE still retires the id from a consumer's view, so it needs the disposition pair exactly like a fold — the no-vanish gate caught this and it was right to.
 "motorcycle/enfield/bullet": "motorcycle/royal-enfield/bullet" # same
+"moped/sym/fiddle-2": "moped/sym/fiddle-ii" # "Fiddle 2" -> "Fiddle II", tier-A permutation fold
+"motorcycle/kawasaki/zx-6r-ninja": "motorcycle/kawasaki/ninja-zx-6r" # "ZX-6R Ninja" -> "Ninja ZX-6R", tier-A permutation fold
+"motorcycle/yamaha/virago-xv535": "motorcycle/yamaha/xv535-virago" # "Virago XV535" -> "XV535 Virago", tier-A permutation fold
+"motorcycle/yamaha/virago-xv750": "motorcycle/yamaha/xv750-virago" # "Virago XV750" -> "XV750 Virago", tier-A permutation fold
+"motorcycle/harley-davidson/street-glide-flhx": "motorcycle/harley-davidson/flhx-street-glide" # "Street Glide Flhx" -> "Flhx Street Glide", tier-A permutation fold
+"motorcycle/harley-davidson/road-glide-cvo": "motorcycle/harley-davidson/cvo-road-glide" # "Road Glide CVO" -> "CVO Road Glide", tier-A permutation fold
+"motorcycle/harley-davidson/fat-boy-flstf": "motorcycle/harley-davidson/flstf-fat-boy" # "Fat Boy FLSTF" -> "FLSTF Fat Boy", tier-A permutation fold
+"motorcycle/honda/gold-wing-gl1000": "motorcycle/honda/gl1000-gold-wing" # "Gold Wing GL1000" -> "GL1000-Gold Wing", tier-A permutation fold
+"motorcycle/harley-davidson/flstc-softail-heritage-classic": "motorcycle/harley-davidson/flstc-heritage-softail-classic" # "Flstc/Softail Heritage Classic" -> "Flstc Heritage Softail Classic", tier-A permutation fold
+"motorcycle/triumph/speed-triple-t509": "motorcycle/triumph/t509-speed-triple" # "Speed Triple T509" -> "T509 Speed Triple", tier-A permutation fold
+"motorcycle/honda/africa-twin-xrv750": "motorcycle/honda/xrv750-africa-twin" # "Africa Twin XRV750" -> "XRV750 Africa Twin", tier-A permutation fold
+"motorcycle/vespa/super-150": "motorcycle/vespa/150-super" # "Super 150" -> "150 Super", tier-A permutation fold
+"motorcycle/harley-davidson/flhtcu-ultra-classic-electra-glide": "motorcycle/harley-davidson/flhtcu-electra-glide-ultra-classic" # "Flhtcu Ultra Classic Electra Glide" -> "Flhtcu Electra Glide Ultra Classic", tier-A permutation fold
+"motorcycle/triumph/t120r-bonneville": "motorcycle/triumph/bonneville-t120r" # "T120R Bonneville" -> "Bonneville T120R", tier-A permutation fold
+"motorcycle/harley-davidson/low-rider-fxs": "motorcycle/harley-davidson/fxs-low-rider" # "Low Rider FXS" -> "FXS Low Rider", tier-A permutation fold
+"motorcycle/ducati/paso-750": "motorcycle/ducati/750-paso" # "Paso 750" -> "750 Paso", tier-A permutation fold
+"motorcycle/harley-davidson/electra-glide-police": "motorcycle/harley-davidson/police-electra-glide" # "Electra Glide Police" -> "Police Electra Glide", tier-A permutation fold
+"motorcycle/harley-davidson/softail-heritage": "motorcycle/harley-davidson/heritage-softail" # "Softail Heritage" -> "Heritage Softail", tier-A permutation fold
+"motorcycle/harley-davidson/883-sportster": "motorcycle/harley-davidson/sportster-883" # "883 Sportster" -> "Sportster 883", tier-A permutation fold
+"motorcycle/harley-davidson/xl-sportster": "motorcycle/harley-davidson/sportster-xl" # "XL Sportster" -> "Sportster XL", tier-A permutation fold
+"motorcycle/harley-davidson/flhtcui-ultra-classic-electra-glide": "motorcycle/harley-davidson/flhtcui-electra-glide-ultra-classic" # "Flhtcui-Ultra Classic Electra Glide" -> "Flhtcui Electra Glide Ultra Classic", tier-A permutation fold
+"motorcycle/harley-davidson/electra-glide-ultra-classic-flhtcui": "motorcycle/harley-davidson/flhtcui-electra-glide-ultra-classic" # "Electra Glide Ultra Classic Flhtcui" -> "Flhtcui Electra Glide Ultra Classic", tier-A permutation fold
+"motorcycle/norton/850-commando": "motorcycle/norton/commando-850" # "850 Commando" -> "Commando 850", tier-A permutation fold
+"motorcycle/husqvarna/801-svartpilen": "motorcycle/husqvarna/svartpilen-801" # "801 Svartpilen" -> "Svartpilen 801", tier-A permutation fold
+"motorcycle/harley-davidson/roadster-xls": "motorcycle/harley-davidson/xls-roadster" # "Roadster Xls" -> "Xls Roadster", tier-A permutation fold
+"moped/honda/chaly-cf50": "moped/honda/cf50-chaly" # "Chaly CF50" -> "CF50 Chaly", tier-A permutation fold
+"motorcycle/suzuki/intruder-vl1500": "motorcycle/suzuki/vl1500-intruder" # "Intruder VL1500" -> "VL1500 Intruder", tier-A permutation fold
+"motorcycle/harley-davidson/fxsts-softail-springer": "motorcycle/harley-davidson/fxsts-springer-softail" # "FXSTS Softail Springer" -> "FXSTS Springer Softail", tier-A permutation fold
+"motorcycle/husqvarna/901-norden": "motorcycle/husqvarna/norden-901" # "901 Norden" -> "Norden 901", tier-A permutation fold
+"motorcycle/triumph/650-tiger": "motorcycle/triumph/tiger-650" # "650 Tiger" -> "Tiger 650", tier-A permutation fold
+"moped/honda/z50a-monkey": "moped/honda/monkey-z50a" # "Z50A Monkey" -> "Monkey Z50A", tier-A permutation fold
+"motorcycle/harley-davidson/sportster-xlh": "motorcycle/harley-davidson/xlh-sportster" # "Sportster XLH" -> "XLH Sportster", tier-A permutation fold
+"motorcycle/harley-davidson/sportster-xl1200": "motorcycle/harley-davidson/xl1200-sportster" # "Sportster XL1200" -> "XL1200 Sportster", tier-A permutation fold
+"motorcycle/ktm/duke-2": "motorcycle/ktm/duke-ii" # "Duke 2" -> "Duke II", tier-A permutation fold
+"motorcycle/buell/lightning-xb12s": "motorcycle/buell/xb12s-lightning" # "Lightning XB12S" -> "XB12S Lightning", tier-A permutation fold
+"motorcycle/ducati/900-monster": "motorcycle/ducati/monster-900" # "900 Monster" -> "Monster 900", tier-A permutation fold
+"motorcycle/triumph/t160-trident": "motorcycle/triumph/trident-t160" # "T160 Trident" -> "Trident T160", tier-A permutation fold
+"motorcycle/norton/750-commando": "motorcycle/norton/commando-750" # "750 Commando" -> "Commando 750", tier-A permutation fold
+"motorcycle/indian/scout-bobber-sixty": "motorcycle/indian/scout-sixty-bobber" # "Scout Bobber Sixty" -> "Scout Sixty Bobber", tier-A permutation fold
+"moped/suzuki/lets-ii": "moped/suzuki/lets-2" # "Lets II" -> "Lets 2", tier-A permutation fold
+"motorcycle/cagiva/125-mito": "motorcycle/cagiva/mito-125" # "125 Mito" -> "Mito 125", tier-A permutation fold
+"motorcycle/harley-davidson/1200-sportster": "motorcycle/harley-davidson/sportster-1200" # "1200 Sportster" -> "Sportster 1200", tier-A permutation fold
+"motorcycle/kawasaki/zx-9r-ninja": "motorcycle/kawasaki/ninja-zx-9r" # "ZX-9R Ninja" -> "Ninja ZX-9R", tier-A permutation fold
+"motorcycle/triumph/t140-bonneville": "motorcycle/triumph/bonneville-t140" # "T140 Bonneville" -> "Bonneville T140", tier-A permutation fold
+"motorcycle/harley-davidson/ultra-classic-electra-glide": "motorcycle/harley-davidson/electra-glide-ultra-classic" # "Ultra Classic Electra Glide" -> "Electra Glide Ultra Classic", tier-A permutation fold
+"motorcycle/honda/vt1100c2-shadow": "motorcycle/honda/shadow-vt1100c2" # "VT1100C2 Shadow" -> "Shadow VT1100C2", tier-A permutation fold
+"motorcycle/harley-davidson/softail-springer": "motorcycle/harley-davidson/springer-softail" # "Softail Springer" -> "Springer Softail", tier-A permutation fold
+"moped/honda/z50j-monkey": "moped/honda/monkey-z50j" # "Z50J Monkey" -> "Monkey Z50J", tier-A permutation fold
+"motorcycle/harley-davidson/road-glide-special-fltrxs": "motorcycle/harley-davidson/fltrxs-road-glide-special" # "Road Glide Special Fltrxs" -> "Fltrxs Road Glide Special", tier-A permutation fold
+"motorcycle/triumph/t140v-bonneville": "motorcycle/triumph/bonneville-t140v" # "T140V Bonneville" -> "Bonneville T140V", tier-A permutation fold
 
 # ── A NOTE ON CHAINS, after three in one session (S2W 2026-07-26) ───────────
 # Every one had the identical shape: I retire an id X (rename/fold), and

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -296,6 +296,9 @@ BSA:
 BTC:
   Btc: null                               # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
+Buell:
+  "Lightning XB12S":                         "XB12S Lightning"              # PERMUTATION FOLD (verified batch, tier A): Code-first 289 vs name-first 4 (72:1).
+
 Buick:
   Lesabre: Le Sabre                           # spelling variant of "Le Sabre" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Lesabre Custom: Le Sabre Custom             # spelling variant of "Le Sabre Custom" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -315,6 +318,9 @@ Cadillac:
   Lasalle: La Salle                           # spelling variant of "La Salle" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Sedan Deville: Sedan De Ville               # spelling variant of "Sedan De Ville" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Cadillac: null                              # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
+
+Cagiva:
+  "125 Mito":                                "Mito 125"                     # PERMUTATION FOLD (verified batch, tier A): AGAINST THE RAW TOTAL (359 vs 224), because the 359 is one register contradicting itself while the manufacturer's own type designation and three other registers agree on Mito-first.
 
 Can-Am:
   Can-Am: null   # moped fi. Make survives on motorcycle/spyder + motorcycle/ryker-900 (both genuine L5e trikes). Raws show it is mostly ATV leakage anyway ("CAN-AM ATV" n=12, "OUTLANDER" n=4) — same class as the POLARIS drop, which is parked pending a quad kind
@@ -717,6 +723,8 @@ DS:
 
 Ducati:
   Ducati: null                            # motorcycle nl|nz
+  "Paso 750":                                "750 Paso"                     # PERMUTATION FOLD (verified batch, tier A): Displacement-first 150 vs name-first 4 (37:1).
+  "900 Monster":                             "Monster 900"                  # PERMUTATION FOLD (verified batch, tier A): Name-first 34 vs displacement-first 10 (3.4:1).
 
 # REKEYED 2026-07-25 from `Emax:` when makes/aliases.yml merged raw EMAX into
 # the E-Max marque. `@o.model_renames[make]` is keyed on the RESOLVED DISPLAY
@@ -1377,7 +1385,7 @@ Harley-Davidson:
   Wlc:                         WLC                      # type code — uppercase, closed (display-only, id stable)
   "Vrscawa V-Rod Abs":         VRSCAWA V-Rod        # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); the non-ABS sibling is published from the same countries
   "Fxrs Super Glide II":                     FXRS Super Glide II      # FXRS is a Harley frame code, attested in caps elsewhere in this catalog (fxrs-sp, fxrs-sport). Not pinned globally in tranche 2 because it appears in only three records — a per-record fix is cheaper than a global token and carries no rename-key blast radius.
-  "Fat Boy Flstf":                             "Fat Boy FLSTF"                            # resolves an intra-make casing contradiction: FLSTF attested x2 in-make (harley-davidson/fat-boy-flstf)
+  "Fat Boy Flstf":                             FLSTF Fat Boy  # resolves an intra-make casing contradiction: FLSTF attested x2 in-make (harley-davidson/fat-boy-flstf) — RETARGETED: its old target slugged to an id this batch folds away. Renames are SINGLE-PASS, so leaving it pointed at the dead display MISROUTES every matching raw row; retiring the key is also wrong because the un-renamed nameplate slugs to the same dead id.
   "Flh":                                       FLH                                        # resolves an intra-make casing contradiction: FLH attested x1 in-make (harley-davidson/flh)
   "Flh Duo Glide":                             "FLH Duo Glide"                            # resolves an intra-make casing contradiction: FLH attested x1 in-make (harley-davidson/flh-duo-glide)
   "Flhrc":                                     FLHRC                                      # resolves an intra-make casing contradiction: FLHRC attested x1 in-make (harley-davidson/flhrc)
@@ -1398,13 +1406,33 @@ Harley-Davidson:
   "Fxstc 1340":                                "FXSTC 1340"                               # resolves an intra-make casing contradiction: FXSTC attested x1 in-make (harley-davidson/fxstc-1340)
   "Fxstc Softail":                             "FXSTC Softail"                            # resolves an intra-make casing contradiction: FXSTC attested x1 in-make (harley-davidson/fxstc-softail)
   "Fxstc Softail Custom":                      "FXSTC Softail Custom"                     # resolves an intra-make casing contradiction: FXSTC attested x1 in-make (harley-davidson/fxstc-softail-custom)
-  "Fxsts Softail Springer":                    "FXSTS Softail Springer"                   # resolves an intra-make casing contradiction: FXSTS attested x1 in-make (harley-davidson/fxsts-softail-springer)
+  "Fxsts Softail Springer":                    FXSTS Springer Softail  # resolves an intra-make casing contradiction: FXSTS attested x1 in-make (harley-davidson/fxsts-softail-springer) — RETARGETED: its old target slugged to an id this batch folds away. Renames are SINGLE-PASS, so leaving it pointed at the dead display MISROUTES every matching raw row; retiring the key is also wrong because the un-renamed nameplate slugs to the same dead id.
   "Fxsts Springer Softail":                    "FXSTS Springer Softail"                   # resolves an intra-make casing contradiction: FXSTS attested x1 in-make (harley-davidson/fxsts-springer-softail)
   "Heritage Softail Nostalgia Flstn":          "Heritage Softail Nostalgia FLSTN"         # resolves an intra-make casing contradiction: FLSTN attested x1 in-make (harley-davidson/heritage-softail-nostalgia-flstn)
-  "Low Rider Fxs":                             "Low Rider FXS"                            # resolves an intra-make casing contradiction: FXS attested x1 in-make (harley-davidson/low-rider-fxs)
+  "Low Rider Fxs":                             FXS Low Rider  # resolves an intra-make casing contradiction: FXS attested x1 in-make (harley-davidson/low-rider-fxs) — RETARGETED: its old target slugged to an id this batch folds away. Renames are SINGLE-PASS, so leaving it pointed at the dead display MISROUTES every matching raw row; retiring the key is also wrong because the un-renamed nameplate slugs to the same dead id.
   "Vrsca":                                     VRSCA                                      # resolves an intra-make casing contradiction: VRSCA attested x1 in-make (harley-davidson/vrsca)
   "Fxrs-Sp":                             "FXRS-Sp"                              # uniformly-wrong casing (invisible to the contradiction detector): Harley frame code, already caps on FXRS Super Glide II and attested x3 in-make (harley-davidson/fxrs-sp)
   "Fxrs-Sport":                          "FXRS-Sport"                           # uniformly-wrong casing (invisible to the contradiction detector): Harley frame code, already caps on FXRS Super Glide II and attested x3 in-make (harley-davidson/fxrs-sport)
+  "Street Glide Flhx":                       "FLHX Street Glide"            # PERMUTATION FOLD (verified batch, tier A): Code-first 1331 vs name-first 51, and H-D's own code page pairs FLHX with the Street Glide nameplate.
+  "Road Glide CVO":                          "CVO Road Glide"               # PERMUTATION FOLD (verified batch, tier A): CVO-first 516 vs Road-Glide-first 7, and H-D's own model pages put CVO first.
+  "Fat Boy FLSTF":                           "FLSTF Fat Boy"                # PERMUTATION FOLD (verified batch, tier A): Code-first 3425 vs name-first 121 (28:1).
+  "Flstc/Softail Heritage Classic":          "Flstc Heritage Softail Classic" # PERMUTATION FOLD (verified batch, tier A): 1957 vs 14 (140:1), and H-D's own code page gives the word order verbatim.
+  "Flhtcu Ultra Classic Electra Glide":      "Flhtcu Electra Glide Ultra Classic" # PERMUTATION FOLD (verified batch, tier A): MARQUE ORDER, AGAINST THE COUNT.
+  "Low Rider FXS":                           "FXS Low Rider"                # PERMUTATION FOLD (verified batch, tier A): Code-first 91 vs name-first 3, and H-D's code page pairs FXS with Low Rider.
+  "Electra Glide Police":                    "Police Electra Glide"         # PERMUTATION FOLD (verified batch, tier A): Police-first 113 vs Electra-Glide-first 4 (28:1).
+  "Softail Heritage":                        "Heritage Softail"             # PERMUTATION FOLD (verified batch, tier A): Heritage-first 157 vs Softail-first 6 (26:1), and the canonical is an already-adjudicated family record.
+  "883 Sportster":                           "Sportster 883"                # PERMUTATION FOLD (verified batch, tier A): Name-first 30 vs displacement-first 18, AND H-D's code page gives the nameplate verbatim.
+  "XL Sportster":                            "Sportster XL"                 # PERMUTATION FOLD (verified batch, tier A): Sportster-first 84 vs XL-first 8 (10:1).
+  "Flhtcui Ultra Classic Electra Glide":     "FLHTCUI Electra Glide Ultra Classic" # PERMUTATION FOLD (verified batch, tier A): MARQUE ORDER, AGAINST THE COUNT, consistent with [73] and [278].
+  "Electra Glide Ultra Classic Flhtcui":     "FLHTCUI Electra Glide Ultra Classic" # PERMUTATION FOLD (verified batch, tier A): MARQUE ORDER, AGAINST THE COUNT, consistent with [73] and [278].
+  "Roadster Xls":                            "Xls Roadster"                 # PERMUTATION FOLD (verified batch, tier A): Code-first 40 vs name-first 3 (13:1).
+  "FXSTS Softail Springer":                  "FXSTS Springer Softail"       # PERMUTATION FOLD (verified batch, tier A): MARQUE ORDER, AGAINST THE COUNT (63 vs 10 the other way).
+  "Sportster XLH":                           "XLH Sportster"                # PERMUTATION FOLD (verified batch, tier A): Code-first 147 vs name-first 81 (1.8:1).
+  "Sportster XL1200":                        "XL1200 Sportster"             # PERMUTATION FOLD (verified batch, tier A): Code-first 15 vs name-first 4 (3.75:1).
+  "1200 Sportster":                          "Sportster 1200"               # PERMUTATION FOLD (verified batch, tier A): Name-first 22 vs displacement-first 12, AND H-D's code page gives the nameplate verbatim.
+  "Ultra Classic Electra Glide":             "Electra Glide Ultra Classic"  # PERMUTATION FOLD (verified batch, tier A): Electra-Glide-first 50 vs Ultra-Classic-first 32, AND H-D's code page writes the whole FLHT family Electra-Glide-first.
+  "Softail Springer":                        "Springer Softail"             # PERMUTATION FOLD (verified batch, tier A): Springer-first 10 vs Softail-first 7, AND H-D's code page writes 'FXSTS: Springer™ Softail®'.
+  "Road Glide Special Fltrxs":               "Fltrxs Road Glide Special"    # PERMUTATION FOLD (verified batch, tier A): Code-first 7 vs name-first 2, and H-D's code page pairs FLTRXS with Road Glide Special.
 
 Honda:
   Honda: null                             # motorcycle fi|nl AND moped nl|nz — one make-scoped key covers both kinds (renames are kind-blind)
@@ -1440,6 +1468,12 @@ Honda:
   S 2000:                      S2000                  # closed alphanumeric type code
   Z50AK2:                      Z50A K2                # closed alphanumeric type code
   Zrv:                         ZR-V                   # Honda car letter-pairs hyphenate: CR-V, CR-Z, ZR-V
+  "Gold Wing GL1000":                        "GL1000 Gold Wing"             # PERMUTATION FOLD (verified batch, tier A): Code-first 676 vs name-first 11.
+  "Africa Twin XRV750":                      "XRV750 Africa Twin"           # PERMUTATION FOLD (verified batch, tier A): Code-first 163 vs name-first 7.
+  "Chaly CF50":                              "CF50 Chaly"                   # PERMUTATION FOLD (verified batch, tier A): Code-first 22 vs name-first 13.
+  "Z50A Monkey":                             "Monkey Z50A"                  # PERMUTATION FOLD (verified batch, tier A): Name-first 15 vs code-first 2.
+  "VT1100C2 Shadow":                         "Shadow VT1100C2"              # PERMUTATION FOLD (verified batch, tier A): Name-first 14 vs code-first 3, and the manufacturer's type designations are name-first.
+  "Z50J Monkey":                             "Monkey Z50J"                  # PERMUTATION FOLD (verified batch, tier A): Name-first 20 vs code-first 9 (2.2:1).
 
 Humber:
   Humber: null                                # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
@@ -1450,6 +1484,8 @@ Hummer:
 Husqvarna:
   "Te":                                  "TE"                                   # uniformly-wrong casing (invisible to the contradiction detector): Husqvarna's enduro line is TE — TE 300, TE 150 (husqvarna-motorcycles.com) (husqvarna/te)
   "Te E610":                             "TE E610"                              # uniformly-wrong casing (invisible to the contradiction detector): Husqvarna's enduro line is TE — TE 300, TE 150 (husqvarna-motorcycles.com) (husqvarna/te-e610)
+  "801 Svartpilen":                          "Svartpilen 801"               # PERMUTATION FOLD (verified batch, tier A): MARQUE ORDER, AGAINST THE COUNT (43 vs 3 the other way), on the ruling already signed off in-repo for this exact make.
+  "901 Norden":                              "Norden 901"                   # PERMUTATION FOLD (verified batch, tier A): MARQUE ORDER, AGAINST THE COUNT (222 vs 25 the other way).
 
 Hyundai:
   # ── singleton-tail dossier: the LM-generation (2009-15) Tucson was sold as
@@ -1527,6 +1563,7 @@ Indian:
   "741-B":                   741B                 # the WWII Indian 741B — closed type code
   Power Plus:                PowerPlus            # Indian styles it PowerPlus, camelCase (indianmotorcycle.com/powerplus)
   Powerplus:                 PowerPlus            # Indian styles it PowerPlus, camelCase (indianmotorcycle.com/powerplus)
+  "Scout Bobber Sixty":                      "Scout Sixty Bobber"           # PERMUTATION FOLD (verified batch, tier A): MARQUE'S CURRENT FORM, against a 70-vs-49 count.
 
 Infiniti:
   EX 35: EX35                                 # Infiniti writes EX-family codes closed (https://en.wikipedia.org/wiki/Infiniti_EX); nl_rdw EX35 n=7 vs EX 35 n=3; matches the block's Fx-35/Q 50 folds. Key is "EX 35" (EX is a styling acronym, so the produced form keeps caps)
@@ -1720,15 +1757,17 @@ Kawasaki:
   ZX10R:                       ZX-10R                 # ZX/ZZ-R/ER designations hyphenate before the trailing letter
   ZX6R:                        ZX-6R                  # ZX/ZZ-R/ER designations hyphenate before the trailing letter
   ZX9R:                        ZX-9R                  # ZX/ZZ-R/ER designations hyphenate before the trailing letter
-  ZX9R Ninja:                  ZX-9R Ninja            # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  ZX9R Ninja:                  Ninja ZX-9R  # ZX/ZZ-R/ER designations hyphenate before the trailing letter — RETARGETED: its old target slugged to an id this batch folds away. Renames are SINGLE-PASS, so leaving it pointed at the dead display MISROUTES every matching raw row; retiring the key is also wrong because the un-renamed nameplate slugs to the same dead id.
   ZZR1100:                     ZZ-R1100               # ZX/ZZ-R/ER designations hyphenate before the trailing letter
   ZZR600:                      ZZ-R600                # ZX/ZZ-R/ER designations hyphenate before the trailing letter
   Zx-10R:                      ZX-10R                 # ZX/ZZ-R/ER designations hyphenate before the trailing letter
   Zx-6R:                       ZX-6R                  # ZX/ZZ-R/ER designations hyphenate before the trailing letter
   Zx-9R:                       ZX-9R                  # ZX/ZZ-R/ER designations hyphenate before the trailing letter
-  Zx-9R Ninja:                 ZX-9R Ninja            # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  Zx-9R Ninja:                 Ninja ZX-9R  # ZX/ZZ-R/ER designations hyphenate before the trailing letter — RETARGETED: its old target slugged to an id this batch folds away. Renames are SINGLE-PASS, so leaving it pointed at the dead display MISROUTES every matching raw row; retiring the key is also wrong because the un-renamed nameplate slugs to the same dead id.
   Zz R1100:                    ZZ-R1100               # ZX/ZZ-R/ER designations hyphenate before the trailing letter
   Zz-R600:                     ZZ-R600                # ZX/ZZ-R/ER designations hyphenate before the trailing letter
+  "ZX-6R Ninja":                             "Ninja ZX-6R"                  # PERMUTATION FOLD (verified batch, tier A): Ninja-first 3947 vs ZX-first 9, and Kawasaki hyphenates+leads with Ninja.
+  "ZX-9R Ninja":                             "Ninja ZX-9R"                  # PERMUTATION FOLD (verified batch, tier A): Ninja-first 972 vs ZX-first 513 (1.9:1), and Kawasaki leads with Ninja across the range.
 
 Kia:
   "Cee''d": Ceed                              # doubled-apostrophe register shape (nl_rdw "CEE''D"); Kia dropped the apostrophe in 2018 — https://en.wikipedia.org/wiki/Kia_Ceed
@@ -1764,6 +1803,7 @@ KTM:
   "1290 Superduke R":        1290 Super Duke R    # ditto
   E-XC:                      EXC                  # KTM's enduro line, closed. NOTE the fold already merges 'E-XC' here and Freeride E-XC is a DIFFERENT electric model — if that ever publishes separately this needs revisiting, not extending
   Exc:                       EXC                  # KTM's enduro line, closed. NOTE the fold already merges 'E-XC' here and Freeride E-XC is a DIFFERENT electric model — if that ever publishes separately this needs revisiting, not extending
+  "Duke 2":                                  "Duke II"                      # PERMUTATION FOLD (verified batch, tier A): AGAINST THE RAW TOTAL (276 Arabic vs 91 Roman), on a rank-4 register-corroboration argument plus the manufacturer's own filed type designation.
 
 Lada:
   "1200S": "1200 S"                           # spelling variant of "1200 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -2660,6 +2700,8 @@ Nissan:
 Norton:
   Norton: null                            # motorcycle nl|nz
   "Commando 850MK III":                      Commando 850 Mk III      # Ungluing "850MK" and casing MK the British way. nl_rdw carries "850 COMMANDO MKIII" and "850 COMMANDO MK3 ROADSTER" — the 850 is always spaced off in the register, and MK is Mark, which British usage writes "Mk III" not "MK III". Word order preserved as published rather than reordered to match the raw: this display comes from another source and reordering would be a second, unevidenced change.
+  "850 Commando":                            "Commando 850"                 # PERMUTATION FOLD (verified batch, tier A): Name-first 670 vs displacement-first 22 (30:1); both DVLA columns agree.
+  "750 Commando":                            "Commando 750"                 # PERMUTATION FOLD (verified batch, tier A): Name-first 391 vs displacement-first 17 (23:1); both DVLA columns agree.
 
 NSU:
   RO80:                      Ro 80                # the NSU Ro 80 (Ro = Rotationskolbenmotor, the Wankel) — two words. DEFUNCT marque
@@ -3443,6 +3485,8 @@ Suzuki:
   GSX650: GSX650F                             # FOLD half of the threshold-edge disposition (alias in former_ids). The uk_dft genmodel "GSX650" is the FAMILY BUCKET; folded to the base variant. Three 650 GSX ids are live — gsx650f, gsx650fa (ABS), gsx650fu (restricted) — so this is the base of three, NOT a sole survivor. Inert in the drifted cache state, routes the rows in the pre-drift one.
   GSXS: null                                  # FOLD half, and DROPPED not folded-to: "GSXS" is a bare family fragment with TEN live gsx-s* siblings, so no target is honest. Paired with a removals.yml manifest entry rather than a former_ids alias — a consumer holding this id gets an explained removal, not a guessed redirect.
   GSX1300 Rrqm 5 Hayabusa: Hayabusa           # FOLD half. A mangled uk_dft genmodel of the Hayabusa; folded to the live nameplate. BOTH former_ids arms point at hayabusa — the pre-existing gsx1300rrqm5hayabusa alias was repointed in the same commit rather than left to chain through this now-dead id.
+  "Intruder VL1500":                         "VL1500 Intruder"              # PERMUTATION FOLD (verified batch, tier A): Code-first 72 vs name-first 11 (6.5:1), and the manufacturer's own type designation is code-first.
+  "Lets II":                                 "Lets 2"                       # PERMUTATION FOLD (verified batch, tier A): Arabic 30 vs Roman 17 (1.8:1), and the registers write the LATER generations of this same family in Arabic.
 
 SWM:
   Sixdays: Six Days                      # SWM Six Days — two words (the ISDE reference), from the tail batch
@@ -3451,6 +3495,7 @@ SYM:
   "N.a.": null   # small placeholder block against SYM's 56 real names (FIDDLE alone is 36,746 registrations)
   "JET14EVO125LC Abs":               JET14EVO125LC              # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
   Xpro:                      X Pro                # SYM writes X Pro with a space
+  "Fiddle 2":                                "Fiddle II"                    # PERMUTATION FOLD (verified batch, tier A): Roman beats Arabic ~2900:1 in-corpus.
 
 Talaria:
   TL3000: Sting   # type code for the Sting: raws "TL3000, STING" (53) and "TL3000 STING" (14) pair them explicitly, and bare "STING" (42) + "STING PRO" (54) are the same line (https://talaria.bike/)
@@ -3707,6 +3752,12 @@ Triumph:
   TR6PI: TR6 PI                           # ditto
   "Dolomite Automatic":          Dolomite               # transmission, not a nameplate
   SPITFIRE1500:              Spitfire 1500        # the final Spitfire generation; space before the displacement, matching its Mk siblings
+  "Speed Triple T509":                       "T509 Speed Triple"            # PERMUTATION FOLD (verified batch, tier A): Code-first 516 vs name-first 7 (74:1).
+  "T120R Bonneville":                        "Bonneville T120R"             # PERMUTATION FOLD (verified batch, tier A): Name-first 136 vs code-first 7, AND Triumph's own current page writes 'Bonneville T120'.
+  "650 Tiger":                               "Tiger 650"                    # PERMUTATION FOLD (verified batch, tier A): Name-first 15 vs displacement-first 2.
+  "T160 Trident":                            "Trident T160"                 # PERMUTATION FOLD (verified batch, tier A): Name-first 17 vs code-first 6 (2.8:1), and Triumph's own order is name-then-designation.
+  "T140 Bonneville":                         "Bonneville T140"              # PERMUTATION FOLD (verified batch, tier A): Name-first 8 vs code-first 5, AND Triumph's own page writes 'Bonneville T120' — the identical Bonneville + T-designation scheme.
+  "T140V Bonneville":                        "Bonneville T140V"             # PERMUTATION FOLD (verified batch, tier A): MARQUE ORDER on a 3-vs-4 count, i.e.
 
 TRS:
   Trrs One: One          # strip the embedded badge — bikes are badged TRRS but the make resolves to TRS, so the prefix strip missed (trsmotorcycles.com); CREATES the One canonical
@@ -3760,6 +3811,7 @@ Vespa:
   "Sprint 150 Iget Abs S":           Sprint 150 Iget S          # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
   G.s.:                      GS                   # Gran Sport, closed; the register's 'G.s.' is punctuation noise
   Seigiorni:                 Sei Giorni           # Italian for Six Days — two words, as Vespa writes it
+  "Super 150":                               "150 Super"                    # PERMUTATION FOLD (verified batch, tier A): Displacement-first 410 vs name-first 11 (37:1), AND the override layer has already chosen this form twice as a sourced decision.
 
 Vinfast:
   VF8: VF 8    # VinFast spaces the range — VF 5/6/7/8/9 (https://en.wikipedia.org/wiki/VinFast_VF_8); sibling car/vinfast/vf-6 already publishes "VF 6"
@@ -4408,6 +4460,8 @@ Yamaha:
   Bws:                       BW's                 # Yamaha's BW's keeps the apostrophe — confirmed via MBK's platform history, the MBK Booster being the BW's twin
   "Sr":                                  "SR"                                   # uniformly-wrong casing (invisible to the contradiction detector): Yamaha SR400 / SR500, caps in every Yamaha catalogue (yamaha/sr)
   "Xj":                                  "XJ"                                   # uniformly-wrong casing (invisible to the contradiction detector): Yamaha XJ6, XJR1300 — the XJ line is always caps (yamaha/xj)
+  "Virago XV535":                            "XV535 Virago"                 # PERMUTATION FOLD (verified batch, tier A): XV-first 17 vs Virago-first 3.
+  "Virago XV750":                            "XV750 Virago"                 # PERMUTATION FOLD (verified batch, tier A): XV-first 493 vs Virago-first 2.
 
 Zero Motorcycles:
   # Residue of a SINGULAR/PLURAL mismatch between the two columns, not a naming


### PR DESCRIPTION
**50 permutation folds, adjudicated by one agent and independently verified by another. 50 ids retired, 0 added, gate 0. Pairs with pipeline#61 — merge THAT first.**

From the 310-group duplicate worklist (data#103). This is the **58 groups containing a PERMUTATION edge** — identical token multiset, different order — worked end to end.

## The verification earned its keep

**One fold would have corrupted data and was overturned:** `indian/101-scout` ← `scout-101`.

```
101-scout   1250cc   registered 2025, 2026   TAN e4*168/2013*00175*01..03
scout-101    744cc / 750cc   registered 1928, 1929   no TAN
```

Two motorcycles 96 years apart. Folding relabels **20 pre-war machines** as a 2025 1250cc bike and destroys the only clean vintage record. The availability rule could never have caught it — 8 countries against 2, nothing lost. The researcher *saw* the capacity conflict, noted it, and dismissed it as pre-existing.

It surfaced because the verifier used two fi fields the researcher never touched — `iskutilavuus` and `ensirekisterointipvm` — and because it re-ran the cohort test across **all 59 pairs** rather than the 3 the researcher had doubted. That selectivity was the actual defect.

## What shipped, and what didn't

| tier | keys | |
|---|---:|---|
| **A — shipped here** | **50** | marque source verified verbatim, or rank-1 TAN overlap, or >20:1 with an in-corpus join |
| B — held | 5 | fold is right; the *surviving slug* is a coin-flip on single-digit rows |
| C — dropped | 4 | the Indian overturn, the Norton 4-id cluster, 2 Enfield blocked on make routing |
| D — record only | 1 | keep-separate stands, but its stated reasoning is withdrawn |

## Preconditions, all applied

- **17 incoming aliases repointed.** Derived, not transcribed — and the derivation is what let me reconcile against the verifier's 23: that figure covers the full 59-fold batch, and the 6-alias difference is exactly the 9 folds I dropped and held. Copying "23" would have sent me hunting six repoints that don't belong here.
- **5 rename keys RETARGETED, not retired.** Renames are single-pass (`normalizer.rb:178-186`), so a raw `FAT BOY FLSTF` row still renames to the dead display and lands on the folded-away id; retiring the key leaves the un-renamed nameplate slugging to the same dead id. One of these carries **512 rows**.
- **2 enrich keys pruned** (pipeline#61).
- **3 canonical display defects fixed** — `Flhx Street Glide`, `GL1000-Gold Wing`, `Flhtcui …` casing. Display-only: hyphen and space both slugify to `-`.

## Two things caught by checks rather than by me

**My own lint from #102 fired on this batch** — the fold introduced a `FLHTCUI`/`Flhtcui` value-spelling split in one make block. The detector I shipped an hour ago catching a defect in my own work is the best evidence it was worth writing.

**Then the gate caught a stale rename key**: one key carried a hyphen where the current build produces a space, because my derivation ran against a build made before the recent merges. The sharpened lesson — it is not enough to re-read `renames.yml` at apply time, **the build must be current too**, because the keys are keyed on what the build produces.

## Verification

Control build, overrides stashed then applied: **16,450 → 16,400**, exactly **50 retired, 0 added**. Gate **0**. Reachability green. `rake test` 21/0. Curation lint green. `reorg_make_blocks --check` clean. **Zero alias chains file-wide** — asserted across the whole file, not just the touched blocks.
