### PR TITLE
Renault+Dacia trim folds: 104 records to nameplate altitude; the junk-dropped Renault 4/5 rescued (wave 3)

### DIFF
--- a/overrides/makes/aliases.yml
+++ b/overrides/makes/aliases.yml
@@ -93,6 +93,8 @@ MCLAREN: McLaren
 "MC LAREN": McLaren   # lu/nl registry spelling with a space — was minting a SPLIT make (mc-laren, 2 models incl. a 570S duplicate of the real one); the last make-name collision the detector reported
 LOTUS: Lotus
 ALPINE: Alpine
+"ALPINE-RENAULT": Alpine   # dealer/registry double-branding of ONE marque (Alpine, Dieppe — Renault-owned since 1973); nl_rdw files A110/A310/A610/V6 GTA rows under this string, all Alpine products (RD trim dossier §4.2)
+"RENAULT-ALPINE": Alpine   # same marque, hyphen-reversed; feeds the published car/renault-alpine/a310 (fi,nl) — pure dedup of a genuine duplicate of car/alpine/a310. NB the SPACED "RENAULT ALPINE" is deliberately NOT aliased: the corpus carries "RENAULT ALPINE | CAPTUR" (an Esprit-Alpine trim Captur whose make column ate the trim word) — a blanket alias would file a Captur under Alpine
 MORGAN: Morgan
 CATERHAM: Caterham
 GREAT WALL: Great Wall

--- a/overrides/models/aliases.yml
+++ b/overrides/models/aliases.yml
@@ -7,6 +7,14 @@ Citroën:
 Cupra:
   Leon: [León]                  # ES official spelling — Cupra's Spanish site writes "CUPRA León" (https://www.cupraofficial.es/coches/leon)
 
+Dacia:
+  # Dacia↔Renault rebadges: the same vehicle wears two badges in two market
+  # sets — cross-references, NOT duplicates (the Pajero/Montero/Shogun
+  # precedent: both ids stay live, the relation is recorded here).
+  Duster:  [Renault Duster]     # the same vehicle wears the Renault badge in RU/UA/IN/BR/MX (car/renault/duster is the same car, kept as its own id)
+  Logan:   [Renault Logan, Renault Symbol, Renault Tondar 90]  # Renault badge in RU/UA/BR; Symbol/Tondar in TR/IR
+  Sandero: [Renault Sandero]    # Renault badge in RU/UA/BR/ZA (the Stepway rebadge rides on this relation — sandero-stepway keeps its own id per the marque's two model pages)
+
 Derbi:
   Senda 50: [Senda DRD]         # DRD (Derbi Racing Development) sub-badge on 2004+ Senda 50s — how the bikes are commonly listed ("Senda DRD Racing/X-Treme")
 
@@ -42,6 +50,16 @@ Montesa:
 Nissan:
   Z: [Fairlady Z]                                    # JP domestic name for the Z line
   Patrol: [Safari]                                   # JP domestic market name
+
+Renault:
+  # reverse side of the Dacia↔Renault rebadge cross-references (see the Dacia
+  # block), plus the US/CA identities the EPA bulk file settles.
+  Duster:  [Dacia Duster]       # reverse cross-reference so the relation is discoverable from either id
+  Logan:   [Dacia Logan]        # reverse of the Dacia block's Logan rebadge line
+  Sandero: [Dacia Sandero]      # reverse of the Dacia block's Sandero rebadge line
+  "21":    [Eagle Medallion, Renault Medallion]      # US/CA identity; EPA col-66 baseModel "Renault Medallion" (us_vehicles.csv, 1988-89 Eagle rows)
+  "9":     [Renault Alliance]   # the AMC-built Alliance is the R9 (car/renault/alliance kept as its own id — EPA baseModel "Alliance/Encore")
+  "11":    [Renault Encore]     # the R11's US name, per the same EPA baseModel pairing
 
 Rieju:
   Aventura Rally 307: [Rally 307]  # documented short form — press and the ES registry drop the family prefix (https://advhead.com/fr/rieju-307-rally-first-ride-review/)

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -165,7 +165,7 @@
 "moped/puch/maxi25":                           "moped/puch/maxi-25"                           # MAXI25 -> Maxi 25  [nl]
 "moped/puch/radical40km-h":                    "moped/puch/radical"                    # RADICAL40KM/H -> Radical 40KM/H  [nl] [re-chained 2026-07-25: original successor was itself relocated by a later move/rename]
 "moped/qwic/performance-rd11speed":            "moped/qwic/performance-rd11-speed"            # Performance RD11SPEED -> Performance RD11 Speed  [nl]
-"moped/renault/twizy45":                       "moped/renault/twizy-45"                       # TWIZY45 -> Twizy 45  [es,fi,nl]
+"moped/renault/twizy45":                       "moped/renault/twizy"                          # TWIZY45 -> Twizy  [es,fi,nl] [flattened 2026-07-26: twizy45 -> twizy-45 -> twizy; Twizy 45 (the 45 km/h L6e version) folds into the nameplate in the RD trim batch — chains must not dangle]
 "moped/romet-motors/pony50":                   "moped/romet-motors/pony-50"                   # PONY50 -> Pony 50  [fi,nl]
 "moped/skyteam/monkey50":                      "moped/skyteam/monkey-50"                      # MONKEY50 -> Monkey 50  [fi,nl]
 "moped/skyteam/skymini50":                     "moped/skyteam/skymini-50"                     # SKYMINI50 -> Skymini 50  [fi,nl]
@@ -1739,10 +1739,10 @@
 "car/pontiac/transam": "car/pontiac/trans-am"
 "car/porsche/924s": "car/porsche/924-s"
 "car/ram/1500-trx": "van/ram/1500-trx"
-"car/renault/r-12": "car/renault/r12"
-"car/renault/r-19": "car/renault/r19"
-"car/renault/r-4": "car/renault/r4"
-"car/renault/r-5": "car/renault/r5"
+"car/renault/r-12": "car/renault/12" # [flattened 2026-07-26: r-12 -> r12 -> 12; the R-prefix shorthand folds into the numeral in the RD trim batch]
+"car/renault/r-19": "car/renault/19" # [flattened 2026-07-26: r-19 -> r19 -> 19; same]
+"car/renault/r-4": "car/renault/4"   # [flattened 2026-07-26: r-4 -> r4 -> 4; same]
+"car/renault/r-5": "car/renault/5"   # [flattened 2026-07-26: r-5 -> r5 -> 5; same]
 "car/renault/velsatis": "car/renault/vel-satis"
 "car/riley/rma": "car/riley/r-m-a"
 "car/rolls-royce/silvershadow": "car/rolls-royce/silver-shadow"
@@ -2076,7 +2076,7 @@
 "van/nissan/nv-200": "van/nissan/nv200"
 "van/nissan/nv-400": "van/nissan/nv400"
 "van/nissan/pickup": "van/nissan/pick-up"
-"van/renault/master-t35": "van/renault/master-t-35"
+"van/renault/master-t35": "van/renault/master" # [flattened 2026-07-26: master-t35 -> master-t-35 -> master; the T35 GVW class folds into the nameplate in the RD trim batch]
 "van/saab/9-7x": "car/saab/9-7-x"
 "van/toyota/landcruiser": "van/toyota/land-cruiser"
 "van/volkswagen/lt-28": "van/volkswagen/lt28"
@@ -2588,15 +2588,15 @@
 "car/peugeot/505v6":     "car/peugeot/505"      # REPOINT 2026-07-26 (was 505-v6, folds -> 505) — chain flattened
 # 2026-07-26 — Renault collision batch (7 groups → 0; dossier in the Renault
 # renames block — incl. the four-id R4 GTL family folding to one):
-"car/renault/12tl":    "car/renault/12-tl"
-"car/renault/16ts":    "car/renault/16-ts"
-"car/renault/4-cv":    "car/renault/4cv"      # the CLOSED 4CV name wins
-"car/renault/4gtl":    "car/renault/4-gtl"
-"car/renault/5gtl":    "car/renault/5-gtl"
-"car/renault/r-4-gtl": "car/renault/4-gtl"    # R-prefix shorthand folds
-"car/renault/r4-gtl":  "car/renault/4-gtl"
-"car/renault/r5-gtl":  "car/renault/5-gtl"
-"car/renault/r5gtl":   "car/renault/5-gtl"
+"car/renault/12tl":    "car/renault/12"       # [flattened 2026-07-26: 12tl -> 12-tl -> 12; the TL trim folds into the numeral in the RD trim batch]
+"car/renault/16ts":    "car/renault/16"       # [flattened 2026-07-26: 16ts -> 16-ts -> 16; same]
+"car/renault/4-cv":    "car/renault/4cv"      # the CLOSED 4CV name wins — NOT touched by the RD trim batch (a different car from the Renault 4)
+"car/renault/4gtl":    "car/renault/4"        # [flattened 2026-07-26: 4gtl -> 4-gtl -> 4; the GTL trim folds into the numeral in the RD trim batch]
+"car/renault/5gtl":    "car/renault/5"        # [flattened 2026-07-26: 5gtl -> 5-gtl -> 5; same]
+"car/renault/r-4-gtl": "car/renault/4"        # R-prefix shorthand folds [flattened 2026-07-26: r-4-gtl -> 4-gtl -> 4]
+"car/renault/r4-gtl":  "car/renault/4"        # [flattened 2026-07-26: r4-gtl -> 4-gtl -> 4]
+"car/renault/r5-gtl":  "car/renault/5"        # [flattened 2026-07-26: r5-gtl -> 5-gtl -> 5]
+"car/renault/r5gtl":   "car/renault/5"        # [flattened 2026-07-26: r5gtl -> 5-gtl -> 5]
 "motorcycle/velocette/mac350": "motorcycle/velocette/mac" # Velocette duplicate fold, see renames.yml
 "motorcycle/velocette/mss500": "motorcycle/velocette/mss" # Velocette duplicate fold, see renames.yml
 "motorcycle/velocette/200le": "motorcycle/velocette/le200" # Velocette duplicate fold, see renames.yml
@@ -3755,3 +3755,120 @@
 "van/fiat/ducato-multicab": "van/fiat/ducato"
 "van/fiat/scudo-combi-dc": "van/fiat/scudo"
 "van/fiat/scudo-standard": "van/fiat/scudo"
+# 2026-07-26 — Renault+Dacia trim-fold batch (wave 3; dossier-trims-renault-
+# dacia.md in the pipeline repo, evidence per line there). 104 trim/body/
+# GVW/powertrain/market-synonym records fold to nameplate altitude; union
+# contract: 0 (id,country) pairs lost, 41 gained. Countries below are from
+# the pristine-overrides control build of 2026-07-26.
+"car/renault/r4":                          "car/renault/4"              # de,fi,lu,nl,nz -> MINTS the target
+"car/renault/r4-tl":                       "car/renault/4"              # lu,nl -> MINTS the target
+"car/renault/r4l":                         "car/renault/4"              # fi,nl -> MINTS the target
+"car/renault/4-l":                         "car/renault/4"              # fi,nl -> MINTS the target
+"car/renault/4-gtl":                       "car/renault/4"              # es,fi,lu,nl,nz -> MINTS the target
+"car/renault/4-iconic":                    "car/renault/4"              # gb,ie -> MINTS the target
+"car/renault/r5":                          "car/renault/5"              # de,fi,lu,nl,nz,ua -> MINTS the target
+"car/renault/5-gtl":                       "car/renault/5"              # nl,nz -> MINTS the target
+"car/renault/5-gtx":                       "car/renault/5"              # fi,nl -> MINTS the target
+"car/renault/5tl":                         "car/renault/5"              # nl,nz -> MINTS the target
+"car/renault/5-gt-turbo":                  "car/renault/5"              # fi,nl -> MINTS the target
+"car/renault/r5-gt-turbo":                 "car/renault/5"              # nl,nz -> MINTS the target
+"car/renault/r5-alpine-turbo":             "car/renault/5"              # lu,nl -> MINTS the target
+"car/renault/5-iconic":                    "car/renault/5"              # gb -> MINTS the target
+"car/renault/5-techno":                    "car/renault/5"              # gb -> MINTS the target
+"car/renault/r8":                          "car/renault/8"              # fi,nl,nz -> MINTS the target
+"car/renault/r08":                         "car/renault/8"              # fi,nl -> MINTS the target
+"car/renault/r-1135-gordini":              "car/renault/8"              # fi,nl -> MINTS the target
+"car/renault/r9":                          "car/renault/9"              # fi,nl -> MINTS the target
+"car/renault/r10":                         "car/renault/10"             # nl,nz → target gains nz
+"car/renault/r11":                         "car/renault/11"             # fi,nl,nz → target gains fi,nz
+"car/renault/r12":                         "car/renault/12"             # fi,lu,nl → target gains fi,lu
+"car/renault/12-tl":                       "car/renault/12"             # fi,nl,nz → target gains fi
+"car/renault/r14":                         "car/renault/14"             # fi,nl → target gains fi
+"car/renault/r16":                         "car/renault/16"             # fi,nl → target gains fi
+"car/renault/r16tx":                       "car/renault/16"             # nl,nz ⊂ 16
+"car/renault/16-ts":                       "car/renault/16"             # nl,nz ⊂ 16
+"car/renault/r-16-tl":                     "car/renault/16"             # fi,nl → target gains fi
+"car/renault/17ts":                        "car/renault/17"             # nl,nz → target gains nl
+"car/renault/r18":                         "car/renault/18"             # fi,nl → target gains fi
+"car/renault/18gts":                       "car/renault/18"             # nl,nz ⊂ 18
+"car/renault/r19":                         "car/renault/19"             # fi,lu,nl,nz,ua → target gains lu
+"car/renault/19-gtx":                      "car/renault/19"             # nl,nz ⊂ 19
+"car/renault/20ts":                        "car/renault/20"             # nl,nz ⊂ 20
+"car/renault/r21":                         "car/renault/21"             # fi,lu,nl → target gains fi,lu
+"car/renault/21-nevada":                   "car/renault/21"             # nl,ua ⊂ 21
+"car/renault/21-rx":                       "car/renault/21"             # nl,nz ⊂ 21
+"car/renault/21-turbo":                    "car/renault/21"             # nl,nz ⊂ 21
+"car/renault/21-turbo-quadra":             "car/renault/21"             # nl,nz ⊂ 21
+"car/renault/r25":                         "car/renault/25"             # fi,nl,nz ⊂ 25
+"car/renault/25-gtx":                      "car/renault/25"             # fi,nl ⊂ 25
+"car/renault/25-txi":                      "car/renault/25"             # nl,nz ⊂ 25
+"car/renault/25-v6-turbo":                 "car/renault/25"             # nl,nz ⊂ 25
+"car/renault/30tx":                        "car/renault/30"             # nl,nz → target gains nz
+"van/renault/master-2":                    "van/renault/master"         # fi,nl ⊂ master
+"van/renault/master-f3500":                "van/renault/master"         # fi,nl ⊂ master
+"van/renault/master-t-35":                 "van/renault/master"         # fi,nl ⊂ master
+"van/renault/master-ze":                   "van/renault/master"         # fi,nl ⊂ master
+"van/renault/e-tech-master":               "van/renault/master"         # fi,nl ⊂ master
+"van/renault/master-horsebox":             "van/renault/master"         # lu,nl ⊂ master
+"van/renault/master-jpm":                  "van/renault/master"         # es,lu,nl ⊂ master
+"van/renault/master-theault":              "van/renault/master"         # fi,nl ⊂ master
+"van/renault/master-be-combi-lvc":         "van/renault/master"         # es,nl ⊂ master
+"van/renault/filovan-master":              "van/renault/master"         # fi,nl ⊂ master
+"van/renault/fd-master":                   "van/renault/master"         # fi,nl ⊂ master
+"truck/renault/c380":                      "truck/renault/c"            # es,fi ⊂ c
+"truck/renault/c430":                      "truck/renault/c"            # es,fi,nl ⊂ c
+"truck/renault/c440":                      "truck/renault/c"            # es,fi ⊂ c
+"truck/renault/c520":                      "truck/renault/c"            # fi,nl ⊂ c
+"truck/renault/d12":                       "truck/renault/d"            # es,fi,nl ⊂ d
+"truck/renault/d13":                       "truck/renault/d"            # es,fi ⊂ d
+"truck/renault/d14":                       "truck/renault/d"            # es,fi,nl ⊂ d
+"truck/renault/d16":                       "truck/renault/d"            # fi,nl ⊂ d
+"truck/renault/k480":                      "truck/renault/k"            # lu,nl → target gains lu
+"truck/renault/t380":                      "truck/renault/t"            # fi,nl ⊂ t
+"truck/renault/t460":                      "truck/renault/t"            # es,fi,nl ⊂ t
+"truck/renault/t480":                      "truck/renault/t"            # fi,nl ⊂ t
+"truck/renault/ae385":                     "truck/renault/ae"           # fi,nl → target gains fi
+"truck/renault/ae420":                     "truck/renault/ae"           # fi,nl → target gains fi
+"van/renault/kangoo-express":              "van/renault/kangoo"         # es,fi,lu,nl ⊂ kangoo
+"van/renault/kangoo-express-z-e":          "van/renault/kangoo"         # es,fi,nl ⊂ kangoo
+"van/renault/kangoo-rapid":                "van/renault/kangoo"         # fi,lu,nl ⊂ kangoo
+"van/renault/kangoo-van":                  "van/renault/kangoo"         # es,fi,lu,nl ⊂ kangoo
+"van/renault/fc-kangoo":                   "van/renault/kangoo"         # fi,nl ⊂ kangoo
+"van/renault/kango":                       "van/renault/kangoo"         # lu,nl ⊂ kangoo
+"car/renault/arkana-megane-conquest":      "car/renault/arkana"         # es,lu,nl ⊂ arkana
+"car/renault/megane-conquest":             "car/renault/arkana"         # es,nl ⊂ arkana
+"car/renault/megane-break":                "car/renault/megane"         # fi,nl ⊂ megane
+"car/renault/megane-sport":                "car/renault/megane"         # es,fi,ua ⊂ megane
+"car/renault/meganescenic":                "car/renault/scenic"         # es,nl ⊂ scenic
+"car/renault/clio-societe":                "car/renault/clio"           # nl,ua ⊂ clio
+"car/renault/clio-sport":                  "car/renault/clio"           # lu,nl ⊂ clio
+"car/renault/clio-symbol":                 "car/renault/symbol"         # es,ua → target gains es
+"car/renault/capture":                     "car/renault/captur"         # es,fi,lu,nl ⊂ captur
+"van/renault/traffic":                     "van/renault/trafic"         # fi,nl ⊂ trafic
+"van/renault/trafic-dubbele-cabine":       "van/renault/trafic"         # es,nl ⊂ trafic
+"van/renault/trafic-fourgon":              "van/renault/trafic"         # fi ⊂ trafic
+"car/dacia/bigster-expression-hev-auto":   "car/dacia/bigster"          # gb → target gains gb
+"car/dacia/duster-extreme":                "car/dacia/duster"           # not in the pristine control build (published-catalog id or sub-threshold there)
+"car/dacia/logan-mcv":                     "car/dacia/logan"            # es,fi,nl,ua ⊂ logan
+"car/renault/grand-espace":                "car/renault/espace"         # gb,nl,ua ⊂ espace
+"car/renault/grand-modus":                 "car/renault/modus"          # fi,nl,ua ⊂ modus
+"car/renault/caravelle-1100":              "car/renault/caravelle"      # fi,nl ⊂ caravelle
+"car/renault/r-1133-caravelle":            "car/renault/caravelle"      # fi,nl ⊂ caravelle
+"car/renault/dauphine-gordini":            "car/renault/dauphine"       # fi,nl ⊂ dauphine
+"car/renault/dauphine-r1090":              "car/renault/dauphine"       # fi,nl ⊂ dauphine
+"car/renault/floride-s":                   "car/renault/floride"        # nl,nz ⊂ floride
+"car/renault/fuego-gtx":                   "car/renault/fuego"          # nl,nz ⊂ fuego
+"car/renault/fuego-turbo":                 "car/renault/fuego"          # nl,nz ⊂ fuego
+"car/renault/fluence-z-e":                 "car/renault/fluence"        # fi,nl ⊂ fluence
+"car/renault/wind-roadster":               "car/renault/wind"           # gb → target gains gb
+"car/renault/rodeo-6":                     "car/renault/rodeo"          # es,nl → target gains es
+"van/renault/mascott-150-35":              "van/renault/mascott"        # es,nl → target gains es
+"moped/renault/twizy-45":                  "moped/renault/twizy"        # es,fi,nl → target gains nl
+# — applied nominations (same batch): the two van-side Renault Trucks
+# moves (renault-trucks.co.uk distributes Renault's LCVs — the marque's
+# own product pages are the evidence) and the hyphenated Alpine make-
+# alias dedup (one marque, five raw strings; only the hyphenated forms
+# are safe — the spaced form is contaminated by an Esprit-Alpine Captur):
+"van/renault-trucks/master":               "van/renault/master"         # es,gb,nl ⊂ master
+"van/renault-trucks/trafic":               "van/renault/trafic"         # gb ⊂ trafic
+"car/renault-alpine/a310":                 "car/alpine/a310"            # fi,nl ⊂ a310

--- a/overrides/models/moves.yml
+++ b/overrides/models/moves.yml
@@ -224,3 +224,21 @@
 "Toyota|Scion Xb":     "Scion|xB"        # car/toyota/scion-xb (fi,nl)
 "Toyota|Xa":           "Scion|xA"        # car/toyota/xa (nl,ua) — bare "Xa" is the Scion xA
 "Toyota|Lexus NX300H": "Lexus|NX"        # car/toyota/lexus-nx300h (es,fi) — Lexus marque + NX nameplate; 300h is the hybrid engine grade
+
+# ── Renault Trucks vans → Renault (RD trim-fold dossier §4.1, 2026-07-26) ────
+# Renault Trucks (Volvo Group) is a REAL distinct marque and KEEPS its heavy
+# ranges — but it is also the UK distribution channel for Renault's LCVs, and
+# the marque's own site sells them as such (renault-trucks.co.uk/product/
+# renault-trucks-master-red-edition, /l/renault-trucks-trafic-ultimate,
+# /product/renault-trucks-e-tech-master-electric). The RENAULT TRUCKS MASTER /
+# TRAFIC rows are the SAME vehicles as the Renault-make ones, filed under the
+# distributor's entity name; both targets exist and the availability union is
+# unchanged (pure dedup: master es,gb,nl / trafic gb are subsets). moves.yml is
+# kind-blind: these keys also fire in truck (truck/renault/master exists and is
+# the correct target — benign, desirable) and would route the sub-threshold
+# bus/renault-trucks/master candidate to bus/renault/master, which exists.
+# The HEAVY-range boundary (truck c/d/t, maxity) is deliberately NOT decided
+# here — it is one policy decision spanning four companion pairs
+# (renault-trucks, scania-vabis, leyland-daf, mitsubishi-fuso); see PR worklist.
+"Renault Trucks|Master": "Renault|Master"   # van: a Renault nameplate on a Renault type approval, distributed by Renault Trucks UK
+"Renault Trucks|Trafic": "Renault|Trafic"   # same (renault-trucks.co.uk/l/renault-trucks-trafic-ultimate)

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -578,6 +578,15 @@ Cupra:
   Tavascan V1 EV: Tavascan          # V1 = UK entry trim (V1/V2/VZ1/VZ2 lineup) + EV fuel marker in the uk_dft string; adds gb to the nameplate
   Terramar Amrica Cp Ed: Terramar   # truncated uk_dft string for the "Terramar America's Cup Edition" launch edition; editions fold
 
+Dacia:
+  # ── trim-fold batch (2026-07-26, wave 3 apply; dossier-trims-renault-dacia
+  # .md §2.8): FIRST Dacia block in this file. The heading must equal the
+  # resolved display name — exactly "Dacia", which is what makes/aliases.yml
+  # ("DACIA: Dacia") produces (the E-Max lesson in the reachability test). ──
+  Bigster Expression HEV Auto: Bigster # THREE specs in one cell: "Expression" trim + "HEV" powertrain + "Auto" transmission (uk_dft genmodel) — https://www.dacia.co.uk/hybrid-and-electric-range/bigster-suv.html
+  Duster Extreme: Duster    # "Extreme" is a Dacia TRIM LEVEL (Essential/Expression/Journey/Extreme ladder) — https://www.dacia.co.uk/hybrid-and-electric-range/duster-suv.html
+  Logan Mcv: Logan          # MCV = "Multi Convivial Vehicle", the ESTATE BODY of the Logan; car/dacia/logan already carries body_types [hatchback, wagon] — https://en.wikipedia.org/wiki/Dacia_Logan
+
 Daihatsu:
   Hijet: Hi-Jet                               # spelling variant of "Hi-Jet" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
@@ -2965,36 +2974,189 @@ Ram:
   Ram: null                                   # registry rows where the make was written into the model column (truck kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Renault:
-  R 16 Tl: R 16 TL                  # version ladder L/TL/TS/TX all-caps — https://en.wikipedia.org/wiki/Renault_16 ; matches 12 Tl: 12 TL
-  R4 Tl: R4 TL                      # same ladder on the R4; R-prefix is the catalog's Renault house form
-  # ── collision batch (2026-07-26): trim codes uppercase-spaced; the 4CV is
-  # CLOSED (it IS the name, a different car from the R4); the R prefix is
-  # shorthand and folds into the numeric designation. ──
-  12 Tl: 12 TL                              # trim codes badge uppercase-spaced (Renault 12 TL, period brochures; renaultclassic heritage)
-  12TL: 12 TL                               # fused registry variant
-  16 Ts: 16 TS                              # same trim-code convention (Renault 16 TS)
-  16TS: 16 TS                               # fused registry variant
-  4 Cv: 4CV                                 # the 1947-1961 4CV is officially CLOSED — it IS the model name, not a 4 + CV trim (renault.com heritage); a DIFFERENT car from the R4. Detector proposed "4 CV", wrong
+  # ── trim-fold batch (2026-07-26, wave 3 apply; evidence per line in the
+  # pipeline repo's aux/research/trims-2026-07/dossier-trims-renault-dacia.md):
+  # 101 Renault records fold across six kinds (renames are kind-blind; the
+  # dossier's six-kind blast drill found ZERO keys hitting a live id in more
+  # than one kind — the one intended cross-kind reach is "4"/"5" into van,
+  # where es_dgt files "RENAULT 4 E-TECH ELECT" N1 rows, the R4 Société van).
+  # THE R-PREFIX SELF-CONTRADICTION this block carried ("R4 Gtl: 4 GTL" — the
+  # designation is the NUMBER — vs "R 12: R12" — the fused form is canonical)
+  # is decided in THIS commit, in ONE commit, for the NUMERAL: R 12's identity
+  # claim stands (R 12 and R12 are one car; repointed below, not reversed) and
+  # the R4 Gtl rationale wins the direction, because the marque's own current
+  # copy badges the cars with the bare number and the catalog already
+  # publishes 10/11/12/14/16/17/18/19/20/21/25/30 as bare numerals.
+  # Every numeral key AND value is QUOTED — unquoted they parse as Integer,
+  # renames.key?("4") never matches, and the line is silently inert (the
+  # Citroën "375" failure). All pairs round-trip YAML.safe_load as Strings. ──
+  #
+  # ── THE RESCUE (5 lines). junk? deletes a bare single-digit nameplate
+  # (name !~ /[A-Za-z]/ && name !~ /\A\d{2,4}\+?\z/). An explicit rename entry
+  # is an AUTHOR'S STATEMENT and beats the heuristic (normalizer.rb ORDER FIX
+  # 2026-07-25) — the same rescue Mazda "3"/"6"/"2", Polestar "2"/"3"/"4",
+  # DS "3"/"4"/"7"/"8" already carry, in identity form here because Renault's
+  # canonical IS the bare numeral. Measured cost of NOT having these: nl_rdw
+  # 7,927 rows on the 5-family + 2,050 on the 4-family, es_dgt 1,063 rows of
+  # "RENAULT 5 E-TECH ELECT" + 182 of "RENAULT 4 E-TECH ELECT" in three
+  # months — all junk-dropped today, on the current European Car of the Year. ──
+  "4": "4"                  # the nameplate IS the numeral — renault.co.uk/electric-vehicles/r4-e-tech-electric.html renders "Renault 4 E-Tech electric" throughout (x69); the house form for Renault numerals is bare (the catalog already publishes 10-30 that way)
+  "5": "5"                  # same — renault.co.uk/electric-vehicles/r5-e-tech-electric.html renders "Renault 5 E-Tech 100% electric" (x100 on page); 2025 European Car of the Year
+  "6": "6"                  # Renault 6 (1968-1980) — https://en.wikipedia.org/wiki/Renault_6 . NB likely stays sub-threshold (nl 16 rows, single source) and lands in candidates; the line is correct either way
+  "8": "8"                  # Renault 8 (1962-1973), the R8/R8 Gordini — https://en.wikipedia.org/wiki/Renault_8
+  "9": "9"                  # Renault 9, European Car of the Year 1982 — https://en.wikipedia.org/wiki/Renault_9
+  # ── the numeral line: R-prefix shorthand and the TL/TS/TX/GTL/GTS/GTX/TXi/
+  # RX trim ladder fold into the numeral designation ──
+  R4: "4"                   # R-prefix is registry shorthand; the badge is "Renault 4" — nl_rdw raws "R 4", "R4", "R4:", "R 4 Limousine Luxe"
+  "R4:": "4"                # trailing-colon register form (nl_rdw "R4:") — its own produced string; caught by the post-#42 multi-form drill (n=1 today, keyed so the folded id cannot re-mint on corroboration)
+  "R4: 4X4": "4"            # same trailing-colon form + 4x4 drivetrain spec (multi-form drill)
+  R4-Tl: "4"                # hyphenated register form of the R4 TL (multi-form drill)
+  R4L: "4"                  # "4L" is the French colloquial name (quatrelle) for the R4 L (Luxe) — a trim, not a nameplate
+  4 L: "4"                  # spaced form of the same L (Luxe) trim
+  4 Iconic: "4"             # Iconic is a Renault TRIM LEVEL (evolution/techno/iconic ladder) on the 2025 Renault 4 E-Tech — raw "RENAULT 4 ICONIC E-TECH EV"
+  R4 Tl: "4"                # EDIT (was → "R4 TL"): TL trim of the Renault 4 — the same altitude fix one level up; the old value is a display this batch retires, and a new line keyed on it would be silently inert (renames never chain)
+  4 Gtl: "4"                # EDIT (was → "4 GTL"): GTL trim of the Renault 4 — its most famous badge, and still a trim
+  R5: "5"                   # as R4 — nl_rdw raws "R 5", "R5", "R 5 GTE"
+  5TL: "5"                  # TL trim, fused register form
+  5 Gtl: "5"                # EDIT (was → "5 GTL"): GTL trim of the Renault 5
+  5 Gtx: "5"                # GTX trim
+  5 GT Turbo: "5"           # GT Turbo = the hot-hatch trim of the front-engined Supercinq (NOT the mid-engined 5 Turbo, which KEEPS as its own id — a structurally different car, the F-150 Lightning precedent) — https://en.wikipedia.org/wiki/Renault_5
+  R5 GT Turbo: "5"          # R-prefix spelling of the same trim
+  R5 Alpine Turbo: "5"      # Alpine/Gordini Turbo trim of the Supercinq — https://en.wikipedia.org/wiki/Renault_5
+  5 Iconic: "5"             # Iconic trim level on the 2024 Renault 5 E-Tech — raw "RENAULT 5 ICONIC E-TECH EV"
+  5 Techno: "5"             # Techno trim level, same ladder — raw "RENAULT 5 TECHNO E-TECH EV"
+  R8: "8"                   # R-prefix shorthand for the Renault 8
+  R08: "8"                  # zero-padded register rendering of R8 (nl_rdw n=4)
+  R 1135 Gordini: "8"       # R1135 is Renault's TYPE number for the R8 Gordini; a type code is not a nameplate — https://en.wikipedia.org/wiki/Renault_8
+  R9: "9"                   # R-prefix shorthand for the Renault 9
+  R10: "10"                 # R-prefix shorthand for the Renault 10
+  R11: "11"                 # R-prefix shorthand for the Renault 11
+  R12: "12"                 # R-prefix shorthand for the Renault 12
+  12 Tl: "12"               # EDIT (was → "12 TL"): TL trim of the Renault 12
+  R14: "14"                 # R-prefix shorthand for the Renault 14
+  R16: "16"                 # R-prefix shorthand for the Renault 16
+  R16TX: "16"               # TX trim, fused register form
+  16 Ts: "16"               # EDIT (was → "16 TS"): TS trim of the Renault 16
+  R 16 Tl: "16"             # EDIT (was → "R 16 TL"): R-prefix + TL trim of the Renault 16
+  17TS: "17"                # TS trim of the Renault 17; nl_rdw raws "17TS COUPE", "17TS CABRIOLET"
+  R18: "18"                 # R-prefix shorthand for the Renault 18
+  18GTS: "18"               # GTS trim; EPA col-66 (us_fueleconomy baseModel) gives "18i/Wagon/Sportwagon" for every 18 body/trim string — one line settles the whole 18 body/trim question
+  R19: "19"                 # R-prefix shorthand for the Renault 19
+  19 Gtx: "19"              # GTX trim
+  20TS: "20"                # TS trim of the Renault 20
+  R21: "21"                 # R-prefix shorthand for the Renault 21
+  21 Nevada: "21"           # Nevada is the ESTATE BODY name of the 21 (UK: Savanna) — a body, not a nameplate — https://en.wikipedia.org/wiki/Renault_21
+  21 RX: "21"               # RX trim
+  21 Turbo: "21"            # Turbo engine variant of the 21 saloon
+  21 Turbo Quadra: "21"     # Turbo + Quadra = the 4WD drivetrain option on the same car
+  R25: "25"                 # R-prefix shorthand for the Renault 25
+  25 Gtx: "25"              # GTX trim
+  25 Txi: "25"              # TXi trim (fuel-injected TX)
+  25 V6 Turbo: "25"         # V6 Turbo engine variant
+  30TX: "30"                # TX trim of the Renault 30
+  # ── Master: GVW classes, powertrain badges and body converters fold onto
+  # the nameplate (the Transit GVW precedent) ──
+  Master 2: Master          # NOT a generation: the RDW comma rule (model.split(",").first) truncates "MASTER 2,3 DCI"/"MASTER 2,5 DCI" at the DECIMAL COMMA — the "2" is engine displacement; every feeding string is "MASTER 2,<n> DCI …" (pipeline defect filed, dossier §6.4)
+  Master F3500: Master      # F3500 = 3,500 kg GVW chassis code — a payload designation, not a nameplate (Transit GVW precedent) — https://en.wikipedia.org/wiki/Renault_Master
+  Master T 35: Master       # T35 = the 3.5-tonne GVW class; French/Nordic registers write "T35"/"T 35"/"T29" for Master and Trafic alike — https://en.wikipedia.org/wiki/Renault_Master
+  Master Ze: Master         # Z.E. = Zéro Émission, Renault's electric powertrain badge — a powertrain marker (Fluence Z.e folds the same way below)
+  E-Tech Master: Master     # E-Tech is Renault's electrification BADGE, applied across the whole group (renault-trucks.co.uk sells "Renault Trucks E-Tech Master"); prefix position is why collapse_variant's E-TECH suffix rule misses it (pipeline defect filed, dossier §6.3)
+  Master Horsebox: Master   # "Horsebox" is a body conversion, not a nameplate (uk_dft/lu strings)
+  Master Jpm: Master        # JPM Concept, French bodybuilder on Master chassis — a converter, not a Renault nameplate
+  Master Theault: Master    # Théault, French horsebox builder on Master chassis — same class
+  Master Be-Combi Lvc: Master # "BE-Combi" = the BE-driving-licence combi conversion, "LVC" the converter code — body conversion strings
+  Filovan Master: Master    # Filovan, Italian/Spanish converter — the row is a converted Master
+  Fd Master: Master         # "FD" is a register chassis/body code prefix, not a nameplate; nl_rdw carries "FD / MASTER", "Fd Master" and "RENAULT FD MASTER" for the same vehicle
+  Fd / Master: Master       # the spaced-slash rendering produces "Fd / Master" — a distinct key (the Arkana spaced-slash seam; multi-form drill)
+  # ── Renault Trucks ranges: the LETTER is the range, the NUMBER is engine
+  # power in hp (C/K/T/AE) or GVW class in tonnes (D). renault-trucks.co.uk
+  # publishes six diesel product pages (-c, -d, -d-wide, -k, -t, -t-high) and
+  # none is numeric; the marque's press copy writes "Renault Trucks C-430" as
+  # a spec after the range name. T High and D Wide KEEP — own product pages.
+  # The retired #89 stubs r/s are NOT re-created: r365/s140/s150/s180 KEEP
+  # (no bare R or S range was ever marketed — dossier U2). ──
+  C380: C       # C-range, 380 hp — a power rating, not a nameplate — https://www.renault-trucks.co.uk/product/renault-trucks-c
+  C430: C       # C-range, 430 hp; the marque writes it "Renault Trucks C-430" (press release, 2026)
+  C440: C       # C-range, 440 hp
+  C520: C       # C-range, 520 hp; raw "C 520 8x4" carries the axle config in the same cell
+  D12: D        # D-range, 12 t GVW class — a payload designation (Transit GVW precedent); raw "D 12 LOW 4X2 R 240 E6" shows GVW and power as separate specs
+  D13: D        # D-range, 13 t GVW class
+  D14: D        # D-range, 14 t GVW class
+  D16: D        # D-range, 16 t GVW class
+  K480: K       # K-range (construction), 480 hp — raw "K 480 10X8"
+  T380: T       # T-range (long haul), 380 hp — https://www.renault-trucks.co.uk/product/renault-trucks-t
+  T460: T       # T-range, 460 hp
+  T480: T       # T-range, 480 hp
+  AE385: Ae     # AE range (the pre-1993 Magnum), 385 hp — raws "AE 385 19 T", "AE 385 TI-11AZA1/635"; the fused sibling spellings ("AE385TI-19") already land on Ae. NOT a truck-path fixpoint (the spaced/fused seam, dossier §6.2) but a fixpoint on the car/van path — which is what the reachability test measures — and corpus-attested as the produced string on real truck rows; corpus beats test
+  AE420: Ae     # AE range, 420 hp — raws "AE 420 TI", "AE 420 TI-18T"; same seam note as AE385
+  # ── Kangoo: market/body names on one nameplate ──
+  Kangoo Express: Kangoo    # "Express" is the panel-van BODY name of the Kangoo, NOT the separate Renault Express nameplate (which keeps its own id — the 1985-2000 and 2021- Express); nl_rdw carries "Kangoo Express", "KANGOO EXPRESS MAXI", "Kangoo-Express" for the same vehicle
+  Kangoo-Express: Kangoo    # the hyphenated rendering produces its own string (multi-form drill; n=1 today, keyed against re-mint)
+  Kangoo Express Z.e: Kangoo # same body + Z.E. electric powertrain badge
+  Kangoo Rapid: Kangoo      # "Rapid" is the GERMAN market name for the Kangoo panel van — a market synonym on one nameplate
+  Kangoo Van: Kangoo        # "Van" is the body configuration; raws "KANGOO VAN E-TECH ELECTRIC" etc.
+  Fc Kangoo: Kangoo         # "FC" is a register chassis/body code prefix (cf. "Fd Master"), not a nameplate
+  Kango: Kangoo             # register misspelling, one letter short (nl_rdw n=2 car + n=1 van)
+  # ── Megane · Scenic · Arkana ──
+  Arkana/Megane Conquest: Arkana # ONE registry cell carrying BOTH market names of one car (the Karl / Viva precedent); es/lu/nl type-approval strings
+  Arkana/megane Conquest: Arkana # split_slashes twin: smart_case lower-cases the token after the slash, so BOTH forms must be keyed (the S400 Hev / S400 HEV precedent)
+  Arkana Megane Conquest: Arkana # the SPACE-separated third rendering (es_dgt/lu_snca/nl_rdw; TAN e6*2018/858*00003*11 — the same approval). The dossier attested this raw among the six but keyed only the two fused-slash forms; the id-contract liveness gate caught the still-alive id in the apply build
+  Arkana / Megane Conquest: Arkana # the SPACED-SLASH fourth rendering (nl_rdw "ARKANA / MEGANE CONQUEST", n=13) — produced form replay-verified "Arkana / Megane Conquest": with spaces around the slash the tokens title-case normally, so the fused-form key never matches. Second liveness-gate catch on the same member; all four produced forms of the dual-label cell are now keyed
+  Megane Conquest: Arkana   # the Arkana's launch name in Türkiye/CEE; the dual-label rows above prove the identity
+  Megane Break: Megane      # "Break" is French for ESTATE — a body word, not a nameplate (the settled "Megane Scenic: Scenic" line is the same class)
+  Megane Sport: Megane      # NOT a sports trim: the raw is "MEGANE SPORT TOURER" (the estate) and collapse_variant strips " TOURER…" but has no "SPORT TOURER" phrase (pipeline rule gap filed, dossier §6.5)
+  Meganescenic: Scenic      # fused register form of "Mégane Scénic", the first-generation Scenic's full badge; matches the settled "Megane Scenic: Scenic"
+  # ── Clio · Captur · Symbol (generation suffixes II/III/IV are ALREADY
+  # absorbed by the VARIANT_SUFFIXES roman-numeral rule; this is what the
+  # suffix rules cannot see) ──
+  Clio Societe: Clio        # "Société" is the FRENCH UTILITY/VAT-van body designation (2 seats, blanked rear) — a body/tax class, not a nameplate
+  Clio Sport: Clio          # "Clio Sport" is the Renault Sport trim (Clio RS); the corpus's "CLIO RS"/"CLIO RS 200EDC" already collapse to Clio via the RS rule
+  Clio Symbol: Symbol       # the Clio-based SALOON, badged "Clio Symbol" in Türkiye and "Symbol"/"Thalia" elsewhere — folds onto the saloon nameplate the catalog already publishes (Thalia↔Symbol deliberately NOT touched — dossier U7, the Pajero/Montero market-name class)
+  Capture: Captur           # register misspelling of Captur, with an -E; raws "CAPTURE", "CAPTURE E-TECH PLUG-IN", "Capture E-Tech plug-in hybrid"
+  # ── Trafic ──
+  Traffic: Trafic           # register misspelling with a doubled F; raws "RENAULT TRAFFIC", "TRAFFIC, 1.6 DCI 125 T29 L2H1" sit beside correctly-spelled TRAFIC rows carrying the same T29 GVW class
+  Trafic Dubbele Cabine: Trafic # Dutch for "double cab" — a body configuration (nl_rdw)
+  Trafic Fourgon: Trafic    # French for "panel van" — a body configuration (fi_traficom)
+  # ── the remaining single-cluster folds ──
+  Grand Espace: Espace      # "Grand" = the long-wheelbase body of the Espace; matches the settled "Grand Scenic: Scenic" line in this same block
+  Grand Modus: Modus        # "Grand" = the long-wheelbase Modus — https://en.wikipedia.org/wiki/Renault_Modus
+  Caravelle 1100: Caravelle # 1100 = engine displacement in cc; raw "CARAVELLE 1100 COUPE-R1133/2270" carries body + type code in the same cell
+  R 1133 Caravelle: Caravelle # R1133 is Renault's TYPE number for the Caravelle — a type code is not a nameplate
+  Dauphine Gordini: Dauphine # Gordini = the tuned performance version of the Dauphine — https://en.wikipedia.org/wiki/Renault_Dauphine
+  Dauphine R1090: Dauphine  # R1090 is the Dauphine's own type number
+  Floride S: Floride        # "S" = the 956 cc version of the Floride — https://en.wikipedia.org/wiki/Renault_Floride
+  Fuego Gtx: Fuego          # GTX trim of the Fuego; EPA col-66 gives baseModel "Fuego" for every Fuego row
+  Fuego Turbo: Fuego        # Turbo engine variant of the Fuego
+  Fluence Z.e: Fluence      # Z.E. = Zéro Émission, the electric powertrain badge (same class as Master Ze)
+  Wind Roadster: Wind       # the Renault Wind IS a roadster — "Roadster" is the body word restated — https://en.wikipedia.org/wiki/Renault_Wind
+  Rodeo 6: Rodeo            # the 4/6 in "Rodéo 4"/"Rodéo 6" names the DONOR platform (R4 / R6), not a separate nameplate; corpus carries "RENAULT 6 RODEO" and "RODEO 6" for the same Teilhol-built car (LOWER CONFIDENCE — dossier U8; dropping this one line costs nothing else in the batch)
+  Mascott 150.35: Mascott   # 150 hp / 3.5 t — power + GVW, the Mascott's standard designation grammar ("MASCOTT 110-5.5T", "MASCOTT 130-5T" all already land on Mascott)
+  Mascott 150-35: Mascott   # hyphenated rendering of the same designation (multi-form drill)
+  Twizy 45: Twizy           # moped kind: "45" = the 45 km/h L6e speed-limited version; kind=moped already encodes the class (the Silence S01LS/S02LS precedent)
+  # ── REPOINTED lines: their VALUE was a display name this batch retires;
+  # left pointing at a dead display they would re-mint the folded id ──
+  12TL: "12"                # REPOINT (was "12 TL"): fused registry variant of the TL trim
+  16TS: "16"                # REPOINT (was "16 TS"): fused registry variant of the TS trim
+  4GTL: "4"                 # REPOINT (was "4 GTL"): fused registry variant of the GTL trim
+  R4 Gtl: "4"               # REPOINT (was "4 GTL"): the settled line whose rationale — "the R prefix is shorthand — the model designation is the NUMBER" — this batch extends to the whole numeral line
+  R 4 Gtl: "4"              # REPOINT (was "4 GTL"): spaced R-prefix variant
+  R4/GTL: "4"               # REPOINT (was "4 GTL"): slashed observed form (observed_model_names.json)
+  5GTL: "5"                 # REPOINT (was "5 GTL"): fused registry variant
+  R5 Gtl: "5"               # REPOINT (was "5 GTL"): R-prefix variant
+  R5GTL: "5"                # REPOINT (was "5 GTL"): fused R-prefix variant
+  R 5 GTL: "5"              # REPOINT (was "5 GTL"): spaced R-prefix variant (flap insurance)
+  Master T35: Master        # REPOINT (was "Master T 35"): fused GVW-class form; the "Master T 35" display retires with the Master T 35 fold above
+  R 12: "12"                # REPOINT (was "R12"): the identity claim stands — R 12 and R12 are the SAME car — but the canonical is the numeral, per the block-header decision; the old "fused form is canonical" rationale is superseded in this commit
+  R 19: "19"                # REPOINT (was "R19"): as R 12
+  R 4: "4"                  # REPOINT (was "R4"): as R 12
+  R 5: "5"                  # REPOINT (was "R5"): as R 12
+  # ── untouched settled lines ──
+  4 Cv: 4CV                                 # the 1947-1961 4CV is officially CLOSED — it IS the model name, not a 4 + CV trim (renault.com heritage); a DIFFERENT car from the R4. Detector proposed "4 CV", wrong. NB the numeral rescue "4" does NOT reach it — 4 Cv / 4-CV are separately keyed
   4-CV: 4CV                                 # hyphenated registry variant of the same closed name
-  4 Gtl: 4 GTL                              # trim code on the Renault 4; uppercase-spaced
-  4GTL: 4 GTL                               # fused registry variant
-  5 Gtl: 5 GTL                              # trim code on the Renault 5
-  5GTL: 5 GTL                               # fused registry variant
-  R4 Gtl: 4 GTL                             # the R prefix is shorthand — the model designation is the NUMBER (Renault 4 GTL); folds the duplicate id family
-  R 4 Gtl: 4 GTL                            # spaced R-prefix variant, same fold
-  R4/GTL: 4 GTL                             # slashed observed form (observed_model_names.json)
-  R5 Gtl: 5 GTL                             # same R-prefix fold for the 5
-  R5GTL: 5 GTL                              # fused R-prefix variant
-  R 5 GTL: 5 GTL                            # spaced R-prefix variant (flap insurance)
   Megane Scenic: Scenic  # first-gen Scenic was badged Megane Scenic
   Grand Scenic: Scenic   # LWB variant
   Velsatis: Vel Satis                         # spelling variant of "Vel Satis" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Master T35: Master T 35                     # spelling variant of "Master T 35" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Renault: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
-  R 12: R12                                   # spelling variant of "R12" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
-  R 19: R19                                   # spelling variant of "R19" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
-  R 4: R4                                     # spelling variant of "R4" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
-  R 5: R5                                     # spelling variant of "R5" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 Rewaco:
   Rewaco: null                            # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)

--- a/scripts/lint_curation.rb
+++ b/scripts/lint_curation.rb
@@ -366,6 +366,18 @@ renames_all.each do |make, map|
     next if value.nil? # drops have no target to war with
     next unless map.key?(value.to_s) && value.to_s != key.to_s
     onward = map[value.to_s]
+    # A CONVERGED IDENTITY TARGET is not a war: `R4: "4"` beside `"4": "4"`
+    # sends every spelling to the SAME final ("4"), because the target key is
+    # an IDENTITY rename — the junk?-override rescue class (normalizer ORDER
+    # FIX 2026-07-25: an explicit rename entry beats the single-digit junk
+    # heuristic). Renault "4"/"5"/"8"/"9" are the first identity-FORM rescues:
+    # the marque's canonical form IS the bare numeral (renault.co.uk badges
+    # the current cars "Renault 4"/"Renault 5"), unlike Mazda's "3": MAZDA3
+    # where the canonical embeds the marque word. The war this check hunts is
+    # two spellings landing on DIFFERENT finals; a fixed-point target cannot
+    # produce that — flagging it would make every rescue key unusable as a
+    # fold target. (Renault+Dacia trim-fold batch, 2026-07-26.)
+    next if onward == value
     fail! "overrides/models/renames.yml: DIRECTION WAR in #{make.inspect} — #{key.inspect} → " \
           "#{value.inspect}, but #{value.to_s.inspect} is itself a key (→ #{onward.inspect}). " \
           "Renames apply once, so these raws land on DIFFERENT finals and both records publish. " \


### PR DESCRIPTION
## Renault+Dacia trim folds: 104 records to nameplate altitude; the junk-dropped Renault 4/5 rescued (wave 3 apply)

Dossier: `aux/research/trims-2026-07/dossier-trims-renault-dacia.md` (pipeline
repo). Companion pipeline PR: **vehiclesdb/vehiclesdb-pipeline#62** (enrich variant capture) — **merges first**;
its four numeral-mint enrich entries ride this PR's pending-publish tolerance.

### The headline

The Renault 4 and Renault 5 — the marque's two current best-selling EVs, the 5
being the **2025 European Car of the Year** — had NO catalog record under their
own names: `junk?` deletes a bare single-digit nameplate. Measured cost: nl_rdw
7,927 rows (5-family) + 2,050 (4-family), es_dgt 1,063 + 182 rows in three
months — all dropped. Five **quoted** rescue keys (`"4" "5" "6" "8" "9"`,
identity renames — an explicit entry beats the heuristic per the normalizer
ORDER FIX) are the override-layer stopgap; the `junk?` rule's real cure is
filed on the pipeline side (dossier §6.1), normalizer frozen until wave 3 lands.

### Numbers

- **104 fold members** across six kinds (car 68, van 21, truck 14, moped 1 —
  47.5% of the in-scope records); **4 fold-carried mints, all published**:
  `car/renault/4` arrives with **8 countries** (de,es,fi,gb,ie,lu,nl,nz),
  `/5` with **9** (+ua), `/8` with 4, `/9` with 4 (the dossier's two-source-
  floor worry for the R9 is moot — it lands with fi,gb,nl,ua). **Plus a fifth,
  pure-rescue mint the dossier called sub-threshold: `car/renault/6` publishes
  with gb,nl,nz on 3 sources** — the rescue key alone un-junked it (no fold
  members feed it, so no alias is needed).
- `renames.yml`: **104 new Renault fold keys + 5 rescue keys + 6 EDITs of
  settled lines + 15 repoints** (Renault block 27 → 136 keys), plus the **new
  `Dacia:` block** (3 keys, first ever, alphabetical — `reorg_make_blocks
  --check` green). 113 fold rename lines total for 104 members: the dossier's
  105, + the two gate-caught Arkana dual-label forms, + six multi-form-drill
  keys (below).
- `former_ids.yml`: **103 fold appends + 3 nomination appends** (append-only,
  at EOF, per-line country evidence from the control build) + **14 inbound
  repoints** flattened and stated per line. File-wide chain scan: **3284 keys,
  0 chains, 0 cycles, 0 duplicate keys**.
- `models/aliases.yml`: Dacia↔Renault **rebadge cross-references** (Duster /
  Logan / Sandero both ways — the settled Pajero/Montero/Shogun shape; both
  ids stay live, nothing merges) + the US identities the EPA bulk file
  settles: `"21": [Eagle Medallion, Renault Medallion]`, `"9": [Renault
  Alliance]`, `"11": [Renault Encore]` (us_fueleconomy col-66 `baseModel`).
- `makes/aliases.yml`: **hyphenated** `ALPINE-RENAULT` / `RENAULT-ALPINE` →
  Alpine ONLY. The spaced `RENAULT ALPINE` is deliberately NOT aliased — the
  corpus carries `RENAULT ALPINE | CAPTUR` (an Esprit-Alpine trim Captur whose
  make column ate the trim word); a blanket alias would file a Captur under
  Alpine.
- `moves.yml`: the two **van-side** Renault Trucks lines (`|Master`,
  `|Trafic` → Renault) — the marque's own product pages are the evidence
  (renault-trucks.co.uk sells the Master/Trafic Red Editions; Renault Trucks
  is the UK distribution channel for Renault's LCVs). Pure dedup, unions
  unchanged.
- `scripts/lint_curation.rb`: the DIRECTION WAR check learns a
  **converged-identity-target exclusion** — `R4: "4"` beside `"4": "4"` sends
  every spelling to the SAME final, so a fixed-point rescue target cannot
  produce the war the check hunts. Required because these are the corpus's
  first identity-FORM rescues (Renault's canonical IS the bare numeral, unlike
  `"3": MAZDA3`). One `next if onward == value`, commented; no check weakened
  (true wars still fail — verified zero in the block).

### Rulings applied

1. **The R4 Gtl / R 12 self-contradiction** (the data#102 class): decided in
   THIS one commit, for the **numeral**. `R 12`'s identity claim stands (R 12
   and R12 are one car — repointed, not reversed); the settled `R4 Gtl`
   rationale ("the R prefix is shorthand — the model designation is the
   NUMBER") wins the direction, because renault.co.uk's own copy badges the
   current cars "Renault 4"/"Renault 5" and the catalog already publishes
   10–30 bare. No half-applied direction: all 15 repoints land here.
2. **Vintage-vs-modern rule (era-spanning folds): RAN.** Two era-spanning
   clusters — `4` (1961-1994 + 2025 revival) and `5` (1972-1996 + 2024
   revival). Both are **marque-declared nameplate revivals** (fetched page
   copy: "All-New Renault 5"), i.e. generations of ONE nameplate (the Clio
   II/III/IV precedent), NOT the Vespa `150-sprint`/`sprint-150` failure —
   the sibling-cohort test shows one cohort, not two disjoint ones. The three
   true vintage-vs-modern boundaries in scope stay separate ids: **4CV ≠ 4**
   (closed, untouched — the rescue key does not reach it), **5 Turbo ≠ 5**
   (mid-engined homologation special; F-150 Lightning precedent, kept with
   Clio V6), **Alliance ≠ 9** (own nameplate; relation recorded as an alias).
3. **#89 not reversed**: `truck/renault/{r,s}` stay retired; `r365`,
   `s140/s150/s180/s130-11` deliberately NOT folded (no bare R/S range was
   ever marketed — folding would re-create the retired stubs). `t-high` and
   `d-wide` KEEP (own product pages).
4. **String hazard**: every numeral key AND value quoted; whole-file YAML
   round-trip — all keys/values parse as String (the Citroën `"375"` lesson).
5. Variant typing per Turn 142 lives in the companion enrich PR.

### What the gates caught (kept loud on purpose — two catches, same member)

The apply builds FAILED the id-contract liveness gate twice on
`car/renault/arkana-megane-conquest`. The dossier attested six raw renderings
of the dual-label cell but keyed only the two fused-slash forms:

1. the SPACE-separated `ARKANA MEGANE CONQUEST` produces
   `Arkana Megane Conquest` — its own key;
2. the SPACED-SLASH `ARKANA / MEGANE CONQUEST` (nl n=13) produces
   `Arkana / Megane Conquest` — with spaces around the slash the tokens
   title-case normally, so the fused-form key (`Arkana/megane Conquest`,
   lowercased after the fused slash) never matches. Recording-proxy replay
   confirmed the byte-exact produced form before the key was written.

Dossier's 105 fold keys → **107**; third build green. Exactly the failure
class the liveness gate exists for, and a finding for the dossier author: the
dual-label cell has FOUR distinct produced forms, not two.

That prompted the full **post-#42 multi-form drill** over all 104 members
(every observed produced form + every attested raw, replayed through classify
with the branch overrides): **6 more member-re-minting forms found**, all n=1
singles today (sub-threshold, so the liveness gate stays quiet — but each is a
scheduled re-mint of a folded id the moment a second register corroborates):
`"R4:"` and `"R4: 4X4"` (trailing-colon register forms), `R4-Tl`,
`Fd / Master` (the same spaced-slash seam), `Kangoo-Express`,
`Mascott 150-35`. All six keyed (→ **113** fold lines); drill re-run:
**0 member-re-minting forms over 145 tested**.

### Verification (VDB_DATA_REPO = this branch, pipeline @ its companion branch)

- `test_override_key_reachability.rb`: 5 runs, 0 failures.
- `lint_curation.rb` / `lint_overrides.rb` / `lint_enrich.rb`: all OK, bare runs.
- `reorg_make_blocks.rb --check`: alphabetical (new Dacia + Renault alias
  blocks land in position).
- Full offline build: **ALL GATES GREEN**; truck delta rides #89's existing
  adjudicated ack (1026→1302, ceiling 1400) — no new ack needed.
- **Union contract: 0 (child id, country) pairs lost** (measured control
  build vs apply build, per (child,country) pair over all 107 mappings);
  **+46 pairs gained across the 22 predicted survivors** — more than the
  dossier's +41 because the live cache corroborates the numeral mints beyond
  its replay (gains only grew; the survivor set is identical).
- `scripts/propose_former_ids.rb` (verifier, published dist vs apply dist):
  intents=8898, **proposed=0 new** (every override-layer intent already
  covered), **evidence_loss=0**. Its 5 dead-key and 70 unexplained-
  disappearance findings are ALL outside the renault/dacia/alpine scope —
  pre-existing on main (the #89 stub retirements diffing against the stale
  published catalog, plus 5 older dead keys in Chrysler/Hyundai/Jaguar/
  Mercedes-Benz/Yamaha). Observed, filed, not touched here.
- Renault+Dacia scope: **218 → 120 ids** (car 140→78, van 36→15, truck
  38→24, bus 1→1, moped 2→1, motorcycle 1→1); (id,country) mass 712 → 521 —
  the −191 is deduplication, not loss, per the pair-level check above.
  (The dossier's frame said 219→~119/712→512: its replay build carried
  `duster-extreme`, and its mint gains were smaller — both re-measured
  against the current build per checklist item 10.)
- `car/dacia/duster-extreme` alias deliberately omitted: the id never shipped
  (absent from the published catalog AND the control build) — propose_former_
  ids safety rule 1; the `Duster Extreme: Duster` rename stands for future
  ingests.

### Filed, NOT touched (worklists with owners)

- **The truck-side companion boundary — HELD.** `truck/renault/{c,d,t}` vs
  `truck/renault-trucks/{c,d,t}` (+ `maxity`) are the same products; whether
  post-2001 heavy trucks file under `renault` (bulk of evidence) or
  `renault-trucks` (legal marque) is **one policy decision spanning four
  companion pairs** — `renault-trucks`, `scania`/`scania-vabis`,
  `daf`/`leyland-daf`, `mitsubishi`/`mitsubishi-fuso` — owner/coordination
  worklist, not four ad-hoc calls.
- **All five pipeline defects** (§6.1–§6.7): listed in the companion PR;
  normalizer FROZEN until wave 3 lands. §6.7 (search-alias leak) blocks U1
  (`truck/renault/hd`, `/320`).
- **Everything §UNCERTAIN**: U1 hd/320 (blocked on §6.7), U2 r365/S-range
  (must not fold — #89), U3 AE↔Magnum (+ the `Ae`→`AE` styling decision, same
  commit when taken), U4 d280 (era mismatch risk), U5 bare Gordini
  (unresolvable base), U6 the GTA split (TWO different cars, one per country
  — renames cannot split by country), U7 Thalia↔Symbol (market-name class),
  U8 Rodeo 6 (lowest-confidence line, flagged), U9 type-code ids, U10 the
  Duster double-ranking in ua (popularity owner), U11 cross-kind twins
  (PROPOSAL-kind-boundary).
- §4.3 Samsung QM6 move (marque naming decision), §4.4 coachbuilder/motorhome
  raw-make tail (drop/alias policy), `Renault|Alpine` `?`-target move
  (row re-parse first, DO-NOT-GUESS).

DO NOT MERGE until pipeline#62 is in (pipeline-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
