### PR TITLE
Enfield -> Royal Enfield: MODEL-level moves, not a make alias

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2767,6 +2767,8 @@
 "motorcycle/bsa/a65-lightning": "motorcycle/bsa/lightning" # "A65 Lightning" -> Lightning, A65 fold
 "motorcycle/bsa/a65l": "motorcycle/bsa/lightning" # "A65L" -> Lightning, A65 fold
 "motorcycle/nsu/lux200": "motorcycle/nsu/lux" # "LUX200" -> "Lux"; pre-flight clean, nothing aliased to lux200
+"motorcycle/enfield/500": "motorcycle/royal-enfield/500" # Enfield -> Royal Enfield model-level move. A MOVE still retires the id from a consumer's view, so it needs the disposition pair exactly like a fold — the no-vanish gate caught this and it was right to.
+"motorcycle/enfield/bullet": "motorcycle/royal-enfield/bullet" # same
 
 # ── A NOTE ON CHAINS, after three in one session (S2W 2026-07-26) ───────────
 # Every one had the identical shape: I retire an id X (rename/fold), and

--- a/overrides/models/moves.yml
+++ b/overrides/models/moves.yml
@@ -247,3 +247,23 @@
 "Volkswagen|914": "Porsche|914"           # the badge-free twin of the line above (candidate volkswagen/914) — the move-split gate named it in the verification build (the 17-Vespa incident shape: moving only the badge-prefixed spelling leaves both halves sub-threshold). Same vehicle, same target — https://en.wikipedia.org/wiki/Porsche_914
 "SEAT|Cupra Formentor": "Cupra|Formentor" # candidate car/seat/cupra-formentor (nl n=2, raws `CUPRA FORMENTOR`, `CUPRA FORMENTOR E-HYBRID`) — the Formentor is Cupra-exclusive (https://www.cupra.com/en/cars); the exact shape of the two shipped "SEAT|Cupra Leon"/"SEAT|Cupra Ateca" lines, which never enumerated Formentor. Inert until the candidate publishes (QASHQAI+2 precedent)
 "SEAT|Roomster": "Škoda|Roomster"         # candidate car/seat/roomster (nl n=1) — the Roomster is a Škoda nameplate, never a SEAT; make-in-model misfiling, the Toyota|Scion precedent. skoda/roomster is live, pure re-attachment. Inert until the candidate publishes — https://en.wikipedia.org/wiki/%C5%A0koda_Roomster
+
+# ── Enfield -> Royal Enfield, MODEL-LEVEL (2026-07-26) ──────────────────────
+# NOT a make alias. RDW merk=ENFIELD is 605 rows spanning BOTH eras: ~430
+# pre-1999 Enfield India machines AND post-2008 Royal Enfields under the
+# clipped spelling. A make-wide alias would mislabel the Enfield India
+# EXPLORER (131 rows), DIESEL 325 (Taurus) and ZUNDAPP MADRAS CS25 — products
+# Royal Enfield never sold. Those three stay under `enfield` and are not moved.
+# The Bullet line moves on company continuity: Enfield India was RENAMED Royal
+# Enfield Motors in 1994 and the UK trademark cleared in 1999, so the register
+# spelling is the badge of the day. That is materially different from the
+# scania-vabis shape, which separates merger-era marques rather than one
+# company before and after its own rename.
+"Enfield|Bullet":                "Royal Enfield|Bullet"             # 269 BULLET 500 + 156 BULLET 350 + 11 bare BULLET under merk=ENFIELD. The Bullet is one continuous model line from one continuous company: Enfield India was RENAMED Royal Enfield Motors in 1994 (Eicher acquisition) and the trademark cleared in 1999, so the clipped register spelling is the badge of the day, not a different marque. royal-enfield/bullet is already live in fi,gb,nl,nz — this joins it rather than minting anything
+"Enfield|500":                   "Royal Enfield|500"                # same continuity argument; royal-enfield/500 is already live (nl,nz)
+"Enfield|Bullet 500":            "Royal Enfield|Bullet 500"         # 269 rows, currently SUPPRESSED as single-source under enfield; royal-enfield/bullet-500 is live (fi,nl) and this makes them multi-source
+"Enfield|Bullet 350":            "Royal Enfield|Bullet 350"         # 156 rows, same shape; royal-enfield/bullet-350 is live (es,fi,nl,th)
+"Enfield|500 Bullet":            "Royal Enfield|500 Bullet"         # 3 rows, the inverted spelling of the same machine
+"Enfield|Classic 500":           "Royal Enfield|Classic 500"        # post-2008 Royal Enfield launch — decides itself: Enfield India never built a Classic 500
+"Enfield|Bullet Classic 500":    "Royal Enfield|Bullet Classic 500" # same, modern-only
+"Enfield|Continental GT":        "Royal Enfield|Continental GT"     # 2013 Royal Enfield launch — modern-only, decides itself


### PR DESCRIPTION
Settles the Enfield make-split. S4W ran the RDW query that made it decidable — **605 `merk=ENFIELD` rows, ~430 pre-1999** — and both discriminating tests fire in **opposite** directions:

| | |
|---|---|
| **India-only present** | `EXPLORER` **131 rows**, `DIESEL 325` (Taurus), `ZUNDAPP MADRAS` — Royal Enfield never sold any of them |
| **Modern-only present** | `CLASSIC 500` ×3 forms, `CONTINENTAL GT` — post-2008 RE launches under the clipped spelling |

The population is **mixed**, so a make-wide alias is indefensible: it would mislabel 131 Explorer rows. The disposition has to be model-level.

**Moved (8):** the Bullet line on company continuity — Enfield India was *renamed* Royal Enfield Motors in 1994, UK trademark cleared 1999, so the clipped register spelling is the badge of the day rather than a separate marque. Plus the three modern-only strings, which decide themselves.

**Not moved:** Explorer, Diesel 325, Zundapp Madras.

Distinguished from the **scania-vabis** precedent deliberately: that separates *merger-era* marques; this is one company before and after its own rename.

## A correction to my own framing

I have been saying **409 nl rows were "suppressed entirely"** and that the split was *deleting evidence*. The control build shows `royal-enfield/bullet-350` **already published with nl** (`es,fi,nl,th`) — as did `bullet-500` and `bullet`.

> The machines were already represented. What was suppressed was a duplicate **id**, not the evidence.

This consolidates duplicate evidence onto the right records; it does not rescue lost coverage, and royal-enfield gains **no** country. I overstated it twice. The argument for the move is **correctness, not data rescue** — which is a weaker argument, and the right one.

## The gate caught a missing disposition pair

A **move** still retires an id from a consumer's view, so it needs `former_ids` exactly like a fold. Added for both; chain pre-flight derived from parsed YAML (0 incoming).

## Consequence, stated plainly

`enfield` now has **zero published models** — the India-only products are single-source and below threshold. They were already suppressed, so no regression, but the marque disappears from the catalog until a second source appears for one of them.

## Verification

Control build **16,146 → 16,144**: exactly the 2 moved ids retired, 0 added. Gate **0**, reachability green, curation lint green, zero chains file-wide.