### PR TITLE
yamaha: correct an inert rename key ("Mt  09SP" -> "MT 09SP")

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -4361,7 +4361,7 @@ Yamaha:
   MT09A:                     MT-09A                 # MT series — hyphenated (yamaha-motor.eu)
   MT09SP:                    MT-09SP                # MT series — hyphenated (yamaha-motor.eu)
   MT125:                     MT-125                 # MT series — hyphenated (yamaha-motor.eu)
-  "Mt  09SP":                MT-09SP                # MT series — hyphenated (yamaha-motor.eu) (display-only)
+  "MT 09SP":                 MT-09SP                # MT series — hyphenated (yamaha-motor.eu) (display-only). KEY CORRECTED 2026-07-27: it read "Mt  09SP" — title-case AND a double space — and was therefore INERT, which is why propose_former_ids kept surfacing it as a dead key across three 4W applies. The record publishes "MT 09SP": caps because MT is a pinned acronym (my own tranche-2 pin, which changed the produced form under a key written before it), single space because whitespace is collapsed. A rename key must be the string the pipeline PRODUCES.
   Mt-01:                     MT-01                  # MT series — hyphenated (yamaha-motor.eu) (display-only)
   Mt-03:                     MT-03                  # MT series — hyphenated (yamaha-motor.eu) (display-only)
   Mt-07:                     MT-07                  # MT series — hyphenated (yamaha-motor.eu) (display-only)


### PR DESCRIPTION
**The 2W half of the four dead keys `propose_former_ids` kept surfacing across three wave-3 applies.**

`renames.yml` carried:

```
"Mt  09SP":   MT-09SP     # title-case Mt, and a DOUBLE space
```

while the record publishes **`"MT 09SP"`** — caps, single space. The key could never match, so it sat inert and kept showing up as a dead key in someone else's tooling.

## Both halves of the mismatch have a cause, and one of them is mine

- **caps**: `MT` is a pinned acronym — *my own tranche-2 pin*. The key was written when the produced form was title-cased; pinning `MT` changed what the pipeline emits and silently invalidated it.
- **double space**: whitespace is collapsed on the way to the produced name, so a two-space key is unreachable by construction.

> This is the fifth instance today of the same class: **`renames.yml` is keyed on the output of the casing pipeline, so any change to that pipeline stales the keys describing its output.** A pin is the smallest such change.

What makes this one different from the others is that it was found by **the other session's tooling**, not mine — `propose_former_ids` surfaces dead keys as a side effect, and it flagged this across three unrelated applies before anyone looked. Worth knowing that a dead-key report is a stale-produced-name report.

## Verification

Display-only — `MT 09SP` and `MT-09SP` both slugify to `mt-09sp`, so **no id moves**. `mt-09sp` now publishes `"MT-09SP"`, matching yamaha-motor.eu's hyphenated MT rendering that the line always intended.

Gate **0**, reachability suite green, curation lint green.
