### PR TITLE
ci: key the data-build concurrency group by ref

### DIFF
--- a/.github/workflows/monthly-build.yml
+++ b/.github/workflows/monthly-build.yml
@@ -42,7 +42,25 @@ on:
       - ".github/workflows/monthly-build.yml"
 
 concurrency:
-  group: data-build
+  # KEYED BY REF, not global. With a single `data-build` group, every push to
+  # main enters the same queue as every open PR check — and GitHub cancels
+  # PENDING runs when a newer one joins a group. `cancel-in-progress: false`
+  # protects only the run already executing, not the queue behind it.
+  #
+  # MEASURED 2026-07-26 during the wave-3 merge burst: three open PR builds
+  # were CANCELLED — not failed — while main-builds from the other session's
+  # merges kept entering the group. An earlier PR (data#101) showed "no checks"
+  # at all for the same reason and had to be re-cut on a fresh branch.
+  #
+  # The effect is asymmetric and silent: whichever maintainer is merging
+  # starves the other's checks, and "merge on green" becomes unobtainable for
+  # the one who is not merging. A cancelled check reads as absent, not failed,
+  # so it looks like flakiness rather than contention.
+  #
+  # Keying by ref keeps publishes serialised against each other — they all
+  # share refs/heads/main — while letting PR checks run. That is the original
+  # intent; it was only accidentally coupled to PR traffic.
+  group: data-build-${{ github.ref }}
   cancel-in-progress: false # never kill a publish mid-release
 
 permissions:

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -4361,7 +4361,7 @@ Yamaha:
   MT09A:                     MT-09A                 # MT series — hyphenated (yamaha-motor.eu)
   MT09SP:                    MT-09SP                # MT series — hyphenated (yamaha-motor.eu)
   MT125:                     MT-125                 # MT series — hyphenated (yamaha-motor.eu)
-  "Mt  09SP":                MT-09SP                # MT series — hyphenated (yamaha-motor.eu) (display-only)
+  "MT 09SP":                 MT-09SP                # MT series — hyphenated (yamaha-motor.eu) (display-only). KEY CORRECTED 2026-07-27: it read "Mt  09SP" — title-case AND a double space — and was therefore INERT, which is why propose_former_ids kept surfacing it as a dead key across three 4W applies. The record publishes "MT 09SP": caps because MT is a pinned acronym (my own tranche-2 pin, which changed the produced form under a key written before it), single space because whitespace is collapsed. A rename key must be the string the pipeline PRODUCES.
   Mt-01:                     MT-01                  # MT series — hyphenated (yamaha-motor.eu) (display-only)
   Mt-03:                     MT-03                  # MT series — hyphenated (yamaha-motor.eu) (display-only)
   Mt-07:                     MT-07                  # MT series — hyphenated (yamaha-motor.eu) (display-only)


### PR DESCRIPTION
**Three of my open PR builds were CANCELLED — not failed — during the wave-3 merge burst. One earlier PR showed no checks at all and had to be re-cut. This is why.**

`monthly-build.yml` uses a single global concurrency group:

```yaml
concurrency:
  group: data-build
  cancel-in-progress: false   # never kill a publish mid-release
```

Every push to `main` enters the same queue as every open PR check. **GitHub cancels *pending* runs when a newer one joins a group** — `cancel-in-progress: false` protects only the run already executing, not the queue behind it.

## Measured

During the wave-3 merges (`2026-07-26`), one cancelled build each on `s2w/perm-tierA`, `s2w/perm-tierB`, `s2w/enfield-moves`. Earlier, `data#101` showed **no checks whatsoever** and was re-cut on a fresh branch on that basis — same cause, and the re-cut was treating a symptom.

## Why it matters more than it looks

The effect is **asymmetric and silent**:

> Whichever maintainer is merging starves the other's checks. And a cancelled check reads as *absent*, not *failed* — so it looks like GitHub flakiness rather than contention, which is exactly how I diagnosed it wrong twice.

With a "merge on green" protocol, green becomes unobtainable for whoever is not currently merging.

## The fix

Key the group by ref. Publishes still serialise against each other — they all share `refs/heads/main` — while PR checks stop contending with them. That is the original intent; it was only accidentally coupled to PR traffic. `cancel-in-progress: false` is unchanged, so a publish still can't be killed mid-release.

## Note on ownership

This touches release gating, which the 4W half holds standing authority over, so it is a **proposal with an implementation** rather than something I'd merge myself. If you'd rather solve it another way — separate workflow, or `group: data-build-${{ github.workflow }}-${{ github.ref }}` — the diagnosis stands either way and the evidence is above.
