### PR TITLE
Permutation folds tier B: 5 more, direction settled by sibling consistency (replaces #109)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -111,7 +111,7 @@
 "moped/honda/magna50":                         "moped/honda/magna-50"                         # MAGNA50 -> Magna 50  [nl,nz]
 "moped/honda/tact50":                          "moped/honda/tact-50"                          # TACT50 -> Tact 50  [nz,ua]
 "moped/honda/today50":                         "moped/honda/today-50"                         # TODAY50 -> Today 50  [nz,ua]
-"moped/honda/z50monkey":                       "moped/honda/z50-monkey"                       # Z50MONKEY -> Z50 Monkey  [nl,nz]
+"moped/honda/z50monkey": "moped/honda/monkey-z50"                       # Z50MONKEY -> Z50 Monkey  [nl,nz] [REPOINTED: tier-B fold]
 "moped/honda/zoomer50":                        "moped/honda/zoomer-50"                        # ZOOMER50 -> Zoomer 50  [nz,ua]
 "moped/horwin/ek1comfort-range":               "moped/horwin/ek1-comfort-range"               # EK1COMFORT Range -> EK1 Comfort Range  [fi,nl]
 "moped/italjet/formula50":                     "moped/italjet/formula-50"                     # FORMULA50 -> Formula 50  [nl,nz]
@@ -976,7 +976,7 @@
 "motorcycle/triumph/speedmaster900":           "motorcycle/triumph/speedmaster-900"           # SPEEDMASTER900 -> Speedmaster 900  [fi,nl,nz]
 "motorcycle/triumph/sprint900":                "motorcycle/triumph/sprint-900"                # SPRINT900 -> Sprint 900  [nl,nz]
 "motorcycle/triumph/street-triple765rx":       "motorcycle/triumph/street-triple-765rx"       # Street TRIPLE765RX -> Street Triple 765RX  [es,nl]
-"motorcycle/triumph/t100tiger":                "motorcycle/triumph/t100-tiger"                # T100TIGER -> T100 Tiger  [fi,nl]
+"motorcycle/triumph/t100tiger": "motorcycle/triumph/tiger-t100"                # T100TIGER -> T100 Tiger  [fi,nl] [REPOINTED: tier-B fold]
 "motorcycle/triumph/t140bonneville": "motorcycle/triumph/bonneville-t140"           # T140BONNEVILLE -> T140 Bonneville  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/triumph/t160trident": "motorcycle/triumph/trident-t160"              # T160TRIDENT -> T160 Trident  [nl,nz] [REPOINTED: old target folded away by the tier-A batch]
 "motorcycle/triumph/t309trophy":               "motorcycle/triumph/t309-trophy"               # T309TROPHY -> T309 Trophy  [gb,nl]
@@ -1046,7 +1046,7 @@
 "motorcycle/vespa/primavera125":               "motorcycle/vespa/primavera-125"               # PRIMAVERA125 -> Primavera 125  [nl,ua]
 "motorcycle/vespa/primavera150iget-abs":       "motorcycle/vespa/primavera-150-iget"      # PRIMAVERA150IGET Abs -> Primavera 150 Iget Abs  [th]
 "motorcycle/vespa/primavera150iget-abs-s":     "motorcycle/vespa/primavera-150-iget-s"    # PRIMAVERA150IGET Abs S -> Primavera 150 Iget Abs S  [th]
-"motorcycle/vespa/rally200":                   "motorcycle/vespa/rally-200"                   # RALLY200 -> Rally 200  [nl,nz]
+"motorcycle/vespa/rally200": "motorcycle/vespa/200-rally"                   # RALLY200 -> Rally 200  [nl,nz] [REPOINTED: tier-B fold]
 "motorcycle/vespa/s125iget":                   "motorcycle/vespa/s125-iget"                   # S125IGET -> S125 Iget  [th]
 "motorcycle/vespa/s150iget-abs":               "motorcycle/vespa/s150-iget"               # S150IGET Abs -> S150 Iget Abs  [th]
 "motorcycle/vespa/sprint-tech150":             "motorcycle/vespa/sprint-tech-150"             # Sprint TECH150 -> Sprint Tech 150  [th]
@@ -2819,6 +2819,11 @@
 "moped/honda/z50j-monkey": "moped/honda/monkey-z50j" # "Z50J Monkey" -> "Monkey Z50J", tier-A permutation fold
 "motorcycle/harley-davidson/road-glide-special-fltrxs": "motorcycle/harley-davidson/fltrxs-road-glide-special" # "Road Glide Special Fltrxs" -> "Fltrxs Road Glide Special", tier-A permutation fold
 "motorcycle/triumph/t140v-bonneville": "motorcycle/triumph/bonneville-t140v" # "T140V Bonneville" -> "Bonneville T140V", tier-A permutation fold
+"motorcycle/vespa/rally-200": "motorcycle/vespa/200-rally" # "Rally 200" -> "200 Rally", tier-B permutation fold
+"motorcycle/triumph/t100-tiger": "motorcycle/triumph/tiger-t100" # "T100 Tiger" -> "Tiger T100", tier-B permutation fold
+"motorcycle/honda/gold-wing-gl1100": "motorcycle/honda/gl1100-gold-wing" # "Gold Wing GL1100" -> "GL1100 Gold Wing", tier-B permutation fold
+"moped/honda/z50-monkey": "moped/honda/monkey-z50" # "Z50 Monkey" -> "Monkey Z50", tier-B permutation fold
+"motorcycle/triumph/tr6r-tiger": "motorcycle/triumph/tiger-tr6r" # "TR6R Tiger" -> "Tiger TR6R", tier-B permutation fold
 
 # ── A NOTE ON CHAINS, after three in one session (S2W 2026-07-26) ───────────
 # Every one had the identical shape: I retire an id X (rename/fold), and

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1474,6 +1474,8 @@ Honda:
   "Z50A Monkey":                             "Monkey Z50A"                  # PERMUTATION FOLD (verified batch, tier A): Name-first 15 vs code-first 2.
   "VT1100C2 Shadow":                         "Shadow VT1100C2"              # PERMUTATION FOLD (verified batch, tier A): Name-first 14 vs code-first 3, and the manufacturer's type designations are name-first.
   "Z50J Monkey":                             "Monkey Z50J"                  # PERMUTATION FOLD (verified batch, tier A): Name-first 20 vs code-first 9 (2.2:1).
+  "Gold Wing GL1100":                "GL1100 Gold Wing"       # PERMUTATION FOLD (tier B, direction settled by sibling consistency): code-first 4v2 is thin alone, but the SAME nameplate one displacement down (GL1000 Gold Wing) shipped in tier A at 676:11. A family should not render two ways because one member has six rows
+  "Z50 Monkey":                      "Monkey Z50"             # PERMUTATION FOLD (tier B, direction settled by sibling consistency): name-first 7v5 is thin, but Monkey Z50A shipped in tier A on its own count and a third Monkey sibling agrees — three members, one order
 
 Humber:
   Humber: null                                # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
@@ -3758,6 +3760,8 @@ Triumph:
   "T160 Trident":                            "Trident T160"                 # PERMUTATION FOLD (verified batch, tier A): Name-first 17 vs code-first 6 (2.8:1), and Triumph's own order is name-then-designation.
   "T140 Bonneville":                         "Bonneville T140"              # PERMUTATION FOLD (verified batch, tier A): Name-first 8 vs code-first 5, AND Triumph's own page writes 'Bonneville T120' — the identical Bonneville + T-designation scheme.
   "T140V Bonneville":                        "Bonneville T140V"             # PERMUTATION FOLD (verified batch, tier A): MARQUE ORDER on a 3-vs-4 count, i.e.
+  "T100 Tiger":                      "Tiger T100"             # PERMUTATION FOLD (tier B, direction settled by sibling consistency): DIRECTION FLIPPED from the proposal, which had code-first on a thin 7v4. Two things outrank that count: the Triumph Owners MC club renders it name-first, "Tiger 100 (T100)" (https://www.tomcc.org/Triumph/Model/45), which is NAMING.md rank 3; and tier A shipped `Tiger 650` NAME-first in this same make while the proposal had this one code-first, so the batch contradicted itself
+  "TR6R Tiger":                      "Tiger TR6R"             # PERMUTATION FOLD (tier B, direction settled by sibling consistency): FIVE ROWS TOTAL (3v2) — the count decides nothing. Shipped on consistency alone: name-first matches Tiger 650 and the flipped Tiger T100, so all three Triumph Tigers render one way
 
 TRS:
   Trrs One: One          # strip the embedded badge — bikes are badged TRRS but the make resolves to TRS, so the prefix strip missed (trsmotorcycles.com); CREATES the One canonical
@@ -3812,6 +3816,7 @@ Vespa:
   G.s.:                      GS                   # Gran Sport, closed; the register's 'G.s.' is punctuation noise
   Seigiorni:                 Sei Giorni           # Italian for Six Days — two words, as Vespa writes it
   "Super 150":                               "150 Super"                    # PERMUTATION FOLD (verified batch, tier A): Displacement-first 410 vs name-first 11 (37:1), AND the override layer has already chosen this form twice as a sourced decision.
+  "Rally 200":                       "200 Rally"              # PERMUTATION FOLD (tier B, direction settled by sibling consistency): displacement-first 96 vs 13 (7:1) AND consistent with the sibling vintage Vespa `150 Super` shipped in tier A on a sourced moves.yml choice. museopiaggio.it uses BOTH orders on one page, so the marque cannot settle it and the in-repo sibling does
 
 Vinfast:
   VF8: VF 8    # VinFast spaces the range — VF 5/6/7/8/9 (https://en.wikipedia.org/wiki/VinFast_VF_8); sibling car/vinfast/vf-6 already publishes "VF 6"


### PR DESCRIPTION
Replaces **#109**, which GitHub auto-CLOSED when #107 merged and its base branch
`s2w/perm-tierA` was deleted. A closed PR cannot be retargeted
(`422: Cannot change the base branch of a closed pull request`), so this is a
fresh PR onto `main` with identical content.

*(S4W: if you already have a replacement in flight, close this one — the branch
was in your worktree and I said I'd stay off it. I cut this only because the
queue emptied and the branch was sitting pushed-and-rebased with your CI-nudge
commit on top. Content untouched by me.)*

### What this is

The 5 tier-B permutation folds — the ones whose **counts were too thin to decide
alone**, settled instead by consistency with a sibling that tier A already
shipped on its own evidence.

| fold | why |
|---|---|
| `Rally 200` → `200 Rally` | displacement-first 96v13 (7:1) **and** matches vintage sibling `150 Super` from tier A. museopiaggio.it uses BOTH orders on one page, so the marque can't settle it and the in-repo sibling does |
| `T100 Tiger` → `Tiger T100` | **DIRECTION FLIPPED from the proposal.** Proposal had code-first on a thin 7v4. Two things outrank it: Triumph Owners MC renders it `Tiger 100 (T100)` (https://www.tomcc.org/Triumph/Model/45), NAMING.md rank 3; and tier A shipped `Tiger 650` name-first in this same make, so the batch contradicted itself |
| `TR6R Tiger` → `Tiger TR6R` | **five rows total (3v2)** — the count decides nothing. Shipped on consistency alone: matches `Tiger 650` and the flipped `Tiger T100`, so all three Triumph Tigers render one way |
| `Gold Wing GL1100` → `GL1100 Gold Wing` | code-first 4v2 is thin alone, but the same nameplate one displacement down (`GL1000 Gold Wing`) shipped in tier A at **676:11**. A family shouldn't render two ways because one member has six rows |
| `Z50 Monkey` → `Monkey Z50` | name-first 7v5 is thin, but `Monkey Z50A` shipped in tier A on its own count and a third Monkey sibling agrees — three members, one order |

### Disposition pairs, and three repoints

Every fold carries its `former_ids` alias. Three **pre-existing** aliases had to
be REPOINTED because tier B retires their old targets — marked
`[REPOINTED: tier-B fold]`:

    moped/honda/z50monkey        -> moped/honda/monkey-z50    (was z50-monkey)
    motorcycle/triumph/t100tiger -> motorcycle/triumph/tiger-t100
    motorcycle/vespa/rally200    -> motorcycle/vespa/200-rally

**This is the chain class that bit three times in one session.** Renames are
single-pass (`normalizer.rb:178-186`), so a stale alias *misroutes* rather than
going inert. The repoints were derived from parsed YAML comparing TARGETS, never
by grepping id strings — a grep encodes an assumption about id shape, which is
exactly what missed `moped/honda/z50monkey` the first time.

### Verification

- `lint_curation.rb`: OK
- `reorg_make_blocks.rb --check`: alphabetical
- chain scan, file-wide, derived from parsed YAML: **0 chains**
- tier A's 50 folds merged in #107 and are green on main; this builds on them
- `merge-tree` simulated against current main: no conflict, does not revert
  NEGOTIATION Turn 184

Context: NEGOTIATION Turns 177–184. Blocked for hours behind `pipeline#61` →
`#117`; both are now merged and #107 went green on the first run afterwards.
