### PR TITLE
ci: run the claims lint (report-only) after the pipeline tests

### DIFF
--- a/.github/workflows/monthly-build.yml
+++ b/.github/workflows/monthly-build.yml
@@ -139,6 +139,19 @@ jobs:
           VDB_DATA_REPO: ${{ github.workspace }}/data-repo
         run: rake test
 
+      # Claims lint — checks the PROSE we ship against the code behind it.
+      # REPORT-ONLY on purpose: six claims are unbacked as this lands (a public
+      # licence offering no-attribution use over CC-BY/OGL sources, and three
+      # PRD coverage lines that describe their own adapters wrongly). Those are
+      # the owner's and the release maintainer's calls, so this surfaces them
+      # rather than breaking the build to force a decision. Flip to --strict
+      # once the ledger is clear. See NEGOTIATION Turns 189-196.
+      - name: Claims lint (report-only)
+        working-directory: pipeline-repo
+        env:
+          VDB_DATA_REPO: ${{ github.workspace }}/data-repo
+        run: ruby pipeline/tools/lint_claims.rb
+
       - name: Build (validate always; sync only when publishing)
         working-directory: pipeline-repo
         env:


### PR DESCRIPTION
Data half of **pipeline#82**. Adds one report-only CI step.

**Merge `pipeline#82` first** — this step invokes
`pipeline/tools/lint_claims.rb`, and `monthly-build.yml` checks the pipeline out
at its **default branch with no `ref:`**, so the reverse order is one red build.
Same ordering law as `pipeline#42` → `data#89` and `pipeline#61` → `data#107`.

It runs in the build job because that is the only workflow with **both repos
checked out** — the lint needs the pipeline's adapters and this repo's
`LICENSE`/`README` together, and `lint.yml` checks out this repo alone.

**Report-only**: the script exits 0 with findings by design, so this step cannot
fail the build. Six claims are unbacked as it lands — a public licence offering
no-attribution use over CC-BY/OGL sources, and three PRD coverage lines that
describe their own adapters wrongly. Those are the owner's and the release
maintainer's decisions; the lint's only job is to stop them being invisible.

Context: NEGOTIATION Turns 189-196.

---

Two process notes, both self-inflicted and both worth the reader's time:

**I duplicated this step before catching it.** I ran the wiring script twice —
once on a detached `main`, then again after cutting the branch, and the
working-tree change carried across. The validator I had written checked *"is the
step present?"* and passed happily on **two** copies. Fixed to assert exactly
one, which is what it should have asserted from the start; `git diff --stat`
showing 26 insertions where 13 were expected is what actually caught it.

**The squiggly heredoc broke this file once.** `<<~YML` strips leading
whitespace, which is precisely wrong for YAML, and the first attempt wrote a
malformed workflow before validating. The script now writes, parses, and
**restores the original on any failure** — verified by having it do exactly
that. Worth remembering next time anyone edits YAML from Ruby.
