### PR TITLE
Plates: the three #124 schema amendments — separator contract, matching:, sanctioned [- ] class

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,5 +42,12 @@ jobs:
             echo "::error::OWNERSHIP.yml is stale — run scripts/gen_ownership.rb and commit"
             exit 1
           }
+      - name: Lint the plates dataset (schema, periods, regex round-trip, separator contract)
+        # PRD-PLATES §5.2, gate L0. Also enforces the #124 amendments: the
+        # normative separator character set (_meta/separators.yml), the
+        # required `matching: strict|recall-only` key, and the regex tier
+        # order. Wired here because an unenforced contract is a suggestion.
+        run: ruby scripts/lint_plates.rb
+
       - name: Dataset name-shape report (non-blocking until debt is zero)
         run: ruby scripts/lint_dataset.rb --report

--- a/PRD-PLATES.md
+++ b/PRD-PLATES.md
@@ -93,12 +93,25 @@ series:
                                  # historic series will need it constantly).
                                  # Overlap legal iff distinct notes (parallel
                                  # series are REAL: old stock issues on).
+    matching: strict             # strict | recall-only — NORMATIVE, §2.7.
+                                 # Whether a regex hit is a validity claim or
+                                 # only a shape hit. Consumers READ this; they
+                                 # do not infer it from `regex_strict` being
+                                 # absent (that inference is wrong — most
+                                 # series without a strict twin are strict).
     format:
       pattern: "9-LLL-99"        # human pattern: 9=digit L=letter, literal
-                                 # separators as printed
+                                 # separators as printed, drawn only from the
+                                 # separator character set (§2.6)
       regex: "\\A\\d{1}-[A-Z]{3}-\\d{2}\\z"   # anchored; MUST pass the lint
                                  # round-trip (regex generates→pattern
                                  # matches) and the sample tests (§5.2)
+      regex_strict: "…"          # OPTIONAL tighter twin: the authority's own
+                                 # alphabet, which the round-trip forbids
+                                 # `regex` from carrying (§2.7 tier order)
+      regex_statutory: "…"       # OPTIONAL looser twin: the outer legal bound
+                                 # where the statute is wider than what is
+                                 # issued (§2.7 tier order)
       charset: { excluded: [...] }  # letters the authority never issues
                                  # (profanity/lookalike exclusions) — cited
       progression: note          # how serials advance, when known (fills
@@ -171,6 +184,117 @@ state (L2 indexes the programs with official links + counts; individual
 specialty DESIGNS are L4); plate FONTS as font files (we record name +
 licensing status; embedding decisions per §6).
 
+### 2.6 The separator character set (NORMATIVE — `_meta/separators.yml`)
+
+*Amendment, 2026-07-27, from the vehicles gem 0.6.0 implementation (#124).*
+
+A consumer with a separator-forgiving validation tier canonicalizes
+`1234XYZ`, `1234 xyz` and `1234-XYZ` to one serial, and derives
+separator-free twins of our regexes to match against. **That derivation is
+sound only if the dataset commits to which characters are ever separators.**
+It does, here, once, normatively — machine-readable in
+`plates/_meta/separators.yml`, enforced by `lint_plates.rb`, which hardcodes
+nothing and reads that file:
+
+| set | members | rule |
+|---|---|---|
+| **serial alphabet** | `A–Z` `0–9` | the only characters a SERIAL is ever made of, dataset-wide. Uppercase; consumers upcase input before matching |
+| **emitted separators** | `-` (U+002D), ` ` (U+0020) | the only characters the dataset itself ever writes as a separator, in `pattern`, `regex`, `regex_strict`, `regex_statutory`. Any other literal is a lint failure |
+| **forgiving set** | the emitted pair + every Unicode dash (U+2010–U+2015, U+2212), the Unicode spaces (U+00A0, U+2007, U+202F, tab), `·` `•` `.` `_` `/` | what a lenient consumer MAY delete from input, and from a regex to derive its separator-free twin |
+
+Three consequences, and they are the point:
+
+1. **The forgiving set is disjoint from the serial alphabet**, so deleting
+   every forgiving character is information-preserving *by construction* —
+   it can never destroy a serial. The gem's lenient tier is therefore
+   provably sound, not sound-by-luck.
+2. **Every regex in the dataset is written in PRINTED form** — separators
+   included, exactly as the plate shows them and as `pattern` spells them.
+   The canonical (separator-free) form is DERIVED by deleting emitted
+   separators together with their quantifiers; the dataset never ships the
+   canonical form as if it were the printed one. (This rule found a defect
+   on eight `us-fl` `regex_statutory` values, fixed in the same PR.)
+3. **A jurisdiction that prints a glyph *inside* a serial is a schema
+   amendment, not a data entry.** If one lands, it goes to
+   `_meta/separators.yml`'s `never_separator` list with its source, and
+   every consumer learns about it from one place.
+
+### 2.7 `matching:` — strict vs recall-only (NORMATIVE, required per series)
+
+*Amendment, 2026-07-27, from the same implementation (#124).*
+
+Some series' regexes are deliberately **broader than any grammar the
+authority issues**. `nl-export` and `nl-historic-darkblue-agricultural` are
+the L0 cases: an export plate carries the vehicle's *existing* registration,
+so its regex is the union of all fourteen sidecode shapes. A match against a
+union like that says only "this string has a shape the Netherlands has
+issued" — it is emphatically not the claim that the string is a valid export
+registration, and it will happily accept vowel serials the standard series
+reject.
+
+Consumers must be able to see that difference **without inferring it**. The
+absent-`regex_strict` inference is wrong: of the 31 L0 series with no strict
+twin, 29 are strict — their `regex` already *is* the sourced grammar, because
+the mandated letters are literals in the pattern (`GV-99-99`, `Y-999999`,
+`CD-999-999`). So every series carries, as a top-level key beside `class:`:
+
+```yaml
+matching: strict        # or: recall-only
+```
+
+- **`strict`** — `format.regex` lies at or inside the series' own issuing
+  grammar. A match is a well-formedness claim for THIS series. A tighter
+  `regex_strict` may narrow it further; it never widens it.
+- **`recall-only`** — `format.regex` is deliberately wider than the series'
+  own issuing grammar (a union, a catch-all). A match is a shape hit and
+  nothing more. `regex_strict` on a `recall-only` series is a contradiction
+  and a lint failure.
+
+The test is one question: *is this regex wider than what the authority
+issues?* Narrower is still `strict` — `us-fl-standard`'s `regex` is the
+current three-letter/three-numeral arrangement while the statute permits any
+seven alphanumerics, and a match there is a real claim; the outer bound lives
+in `regex_statutory`.
+
+**The regex tier order**, which `matching:` presupposes and the lint checks
+by sampling:
+
+```
+regex_strict   ⊆   regex   ⊆   regex_statutory
+(authority         (round-trippable    (the outer legal bound,
+ alphabet)          against `pattern`)  where the statute is wider)
+```
+
+Only `regex` is required, and only `regex` is round-tripped against
+`pattern` — which is precisely why it cannot carry charset restrictions
+(no vowels, no leading zeros) and why `regex_strict` exists.
+
+Backward compatibility: a consumer reading a dataset older than this
+amendment sees no `matching:` key and MUST default to `strict`, which is the
+safe reading for 71 of the 73 L0 series. In this repo the key is required.
+
+### 2.8 Separator-only character classes are sanctioned
+
+*Amendment, 2026-07-27 (#124, third finding).*
+
+`es-consular-cc-1999` spells its separator as a class — `\ACC[- ]\d+[- ]\d+\z`
+— rather than as a literal. It is not a one-off: **eight** Spanish
+state/diplomatic series do, and the reason is sourced. Anexo XVIII prescribes
+"dos grupos de guarismos" and their millimetre spacing but **no separator
+glyph**, so `[- ]` is the honest encoding of a real gap in the authority's
+own text. Normalizing it to a bare `-` would narrow the regex and lose that
+fact, so the class form is **sanctioned**, under one rule the lint enforces:
+
+> A character class that contains any separator character must contain
+> **only** separator characters, and must not be negated.
+
+Never `[-A-Z]`, never `[^-]`. The rule is what makes a separator position
+mechanically detectable: a consumer deriving a separator-free twin deletes
+every emitted-separator literal and every separator-only class (with its
+quantifier) and can never accidentally delete part of a serial alphabet.
+`pattern` always shows the **canonical printed** separator (`CC-999-999`);
+the regex may accept any subset of the separator set at that position.
+
 ## 3. Rendering — our own SVGs, spec-driven, licensing-clean
 
 A pipeline tool (`pipeline/tools/render_plate.rb`, gate L1) renders every
@@ -239,7 +363,15 @@ national plates — end ≤ current+1); overlap-legal-iff-distinct-notes;
 regex COMPILES, is anchored, and round-trips the human pattern (generate
 100 serials from the pattern → all must match the regex, and vice-versa
 fuzzing); every series carries ≥1 source line; class ∈ vocabulary; hex
-colors well-formed; jurisdiction files match ISO codes.
+colors well-formed; jurisdiction files match ISO codes. Since the #124
+amendments it also enforces §2.6–§2.8: every literal character in a pattern
+or a regex is in the serial alphabet or the emitted separator set read from
+`_meta/separators.yml`; every character class is separator-only or
+serial-only, never mixed, never negated; `matching:` is present and in
+`{strict, recall-only}`, with `recall-only` forbidding `regex_strict`; and
+`regex_strict` / `regex_statutory` compile, are anchored, accept at least one
+pattern-generated serial, and respect the tier order (every sampled serial
+matching `regex_strict` must match `regex`).
 `test_plates_corpora.rb` (pipeline): where a validation corpus exists
 (nl kenteken), the CURRENT series' regexes must jointly match ≥99.9% of
 real current plates — a regression net no competitor has.

--- a/plates/_meta/separators.yml
+++ b/plates/_meta/separators.yml
@@ -1,0 +1,102 @@
+# plates/_meta/separators.yml — THE NORMATIVE SEPARATOR CHARACTER SET.
+#
+# PRD-PLATES §2.6 declares this contract in prose; this file is its
+# machine-readable form, and `scripts/lint_plates.rb` enforces the dataset
+# against THIS file (single source of truth — the lint hardcodes nothing).
+#
+# WHY IT EXISTS (issue #124, from the vehicles gem 0.6.0 implementation):
+# a consumer with a separator-forgiving tier canonicalizes user input by
+# deleting punctuation, and derives separator-free twins of our regexes to
+# match against. That derivation is only sound if the dataset commits, once
+# and normatively, to which characters are EVER separators and which are
+# serial-significant. Without the commitment, deleting a character might
+# destroy a serial. With it, deletion is information-preserving by
+# construction, and every consumer forgives exactly the same punctuation.
+#
+# Grow this file by PR with a rationale — never ad hoc in data files.
+schema_version: 1
+
+# ---------------------------------------------------------------------------
+# 1. The serial alphabet. Every character a SERIAL is made of, dataset-wide.
+#    Disjoint from `forgiving` below: that disjointness is the whole contract.
+# ---------------------------------------------------------------------------
+serial_alphabet: "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+serial_alphabet_note: >-
+  Uppercase A-Z and 0-9 and nothing else. No plate serial in this dataset
+  contains punctuation, and none ever will: a jurisdiction that prints a
+  glyph inside the serial (rather than between groups) is a schema amendment,
+  not a data entry. Serials are RECORDED uppercase; consumers upcase input
+  before matching, since every regex in the dataset is written in uppercase.
+case: upper
+
+# ---------------------------------------------------------------------------
+# 2. EMITTED — the only characters this dataset itself ever writes as a
+#    separator, in `format.pattern`, `format.regex`, `format.regex_strict`
+#    and `format.regex_statutory`. The lint rejects any other literal.
+# ---------------------------------------------------------------------------
+emitted:
+  - char: "-"
+    codepoint: "U+002D"
+    name: HYPHEN-MINUS
+    note: >-
+      The group separator as printed on NL (2-2-2 sidecodes), DE
+      (Unterscheidungszeichen - Erkennungsnummer) and ES state/diplomatic
+      plates. In NL it is a physical feature of the plate, not typography.
+  - char: " "
+    codepoint: "U+0020"
+    name: SPACE
+    note: >-
+      The printed GAP where the authority prescribes group spacing in
+      millimetres but no separator glyph: ES ordinary (Anexo XVIII Cuadro 1,
+      41 mm inter-group), DE between Erkennungsnummer groups, US-FL.
+
+# ---------------------------------------------------------------------------
+# 3. FORGIVING — the characters a lenient consumer MAY delete from user input
+#    (and from a regex, to derive its separator-free twin) before matching.
+#    A superset of `emitted`: humans, OCR and copy-paste substitute these
+#    freely. None of them is ever serial-significant (§1), so deleting them
+#    cannot destroy a serial — that is the guarantee this list exists to make.
+#    Deleting them from a regex means deleting the literal or the
+#    separator-only class AND its quantifier (`[- ]`, ` ?` -> nothing).
+# ---------------------------------------------------------------------------
+forgiving:
+  - { char: " ",  codepoint: "U+0020", name: SPACE }
+  - { char: "\t", codepoint: "U+0009", name: "CHARACTER TABULATION" }
+  - { char: " ", codepoint: "U+00A0", name: "NO-BREAK SPACE" }
+  - { char: " ", codepoint: "U+2007", name: "FIGURE SPACE" }
+  - { char: " ", codepoint: "U+202F", name: "NARROW NO-BREAK SPACE" }
+  - { char: "-",  codepoint: "U+002D", name: HYPHEN-MINUS }
+  - { char: "‐", codepoint: "U+2010", name: HYPHEN }
+  - { char: "‑", codepoint: "U+2011", name: "NON-BREAKING HYPHEN" }
+  - { char: "‒", codepoint: "U+2012", name: "FIGURE DASH" }
+  - { char: "–", codepoint: "U+2013", name: "EN DASH" }
+  - { char: "—", codepoint: "U+2014", name: "EM DASH" }
+  - { char: "―", codepoint: "U+2015", name: "HORIZONTAL BAR" }
+  - { char: "−", codepoint: "U+2212", name: "MINUS SIGN" }
+  - { char: "·", codepoint: "U+00B7", name: "MIDDLE DOT" }
+  - { char: "•", codepoint: "U+2022", name: BULLET }
+  - { char: ".",  codepoint: "U+002E", name: "FULL STOP" }
+  - { char: "_",  codepoint: "U+005F", name: "LOW LINE" }
+  - { char: "/",  codepoint: "U+002F", name: SOLIDUS }
+forgiving_note: >-
+  The vehicles gem 0.6.0 strips [\s\-–—·.] — a subset of this list. Widening
+  it to the full list is safe by construction (nothing here is ever
+  serial-significant) and covers the Unicode dashes an OCR or a word
+  processor produces. SOLIDUS and LOW LINE are here because keyboards and
+  URL slugs produce them, not because any plate prints them.
+
+# ---------------------------------------------------------------------------
+# 4. NOT separators — glyphs that look like punctuation but are NOT, so no
+#    consumer may strip them. Recorded so the list above stays honest as
+#    coverage grows past the L0 pilot.
+# ---------------------------------------------------------------------------
+never_separator_note: >-
+  Nothing in the L0 pilot (NL, ES, DE, US-FL). Known candidates for later
+  gates, each of which is a SYMBOL inside the plate's identity rather than a
+  gap between serial groups, and none of which may be deleted: the coats of
+  arms / seals that sit between groups on several German and Austrian plates
+  (a design element, carried in `design.emblem`, never in the serial); the
+  hyphen INSIDE the ES military "-VE" suffix, which is a literal part of a
+  sourced token rather than a group boundary — it is spelled as an emitted
+  hyphen today and a separator-stripping consumer collapses "ET-1234-VE" to
+  "ET1234VE", which is correct and still unambiguous.

--- a/plates/de.yml
+++ b/plates/de.yml
@@ -175,6 +175,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, trailer]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "LL-LL 9999"
       regex: '\A(?![A-Z]{3}-[A-Z]{2} ?\d{4}\z)[A-Z]{1,3}-[A-Z]{1,2} ?\d{1,4}\z'
@@ -269,6 +270,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, trailer]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "LL-LL 999H"
       regex: '\A[A-Z]{1,3}-[A-Z]{1,2} ?\d{1,4}H\z'
@@ -310,6 +312,7 @@ series:
     categories: [car, van, truck, bus, motorcycle]
     period: { start: 2015 }
     period_evidence: enabling-statute
+    matching: strict
     format:
       pattern: "LL-LL 999E"
       regex: '\A[A-Z]{1,3}-[A-Z]{1,2} ?\d{1,4}E\z'
@@ -357,6 +360,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, trailer]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "LL-LL 999"
       regex: '\A[A-Z]{1,3}-[A-Z]{1,2} ?\d{1,4}\z'
@@ -406,6 +410,7 @@ series:
     categories: [tractor, machine, trailer, truck]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "LL-LL 9999"
       regex: '\A(?![A-Z]{3}-[A-Z]{2} ?\d{4}\z)[A-Z]{1,3}-[A-Z]{1,2} ?\d{1,4}\z'
@@ -440,6 +445,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, trailer]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "LL-06999"
       regex: '\A[A-Z]{1,3}-06\d{1,4}\z'
@@ -472,6 +478,7 @@ series:
     categories: [car, van, truck, bus, motorcycle]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "LL-07999"
       regex: '\A[A-Z]{1,3}-07\d{1,4}\z'
@@ -501,6 +508,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, trailer]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "LL-03999"
       regex: '\A[A-Z]{1,3}-0[34]\d{1,4}\z'
@@ -533,6 +541,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, trailer]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "LL-9999L"
       regex: '\A[A-Z]{1,3}-\d{1,4}[A-Z]\z'
@@ -583,6 +592,7 @@ series:
     categories: [car, van, truck, bus, motorcycle]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "BD-999999"
       regex: '\A(?:BD|BG|BP|BW|THW|BBL|BWL|BYL|HEL|LSA|LSN|MVL|NRW|RPL|SAL|THL|HB|HH|NL|B)-\d{1,6}\z'
@@ -614,6 +624,7 @@ series:
     categories: [car, van, motorcycle]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "0-999999"
       regex: '\A(?:0|B|BN)-\d{1,6}\z'
@@ -642,6 +653,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, trailer]
     period: { start: 2023 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "Y-999999"
       regex: '\A(?:Y|X)-\d{1,6}\z'

--- a/plates/es.yml
+++ b/plates/es.yml
@@ -76,6 +76,7 @@ series:
     categories: [car, van, truck, bus, motorcycle]
     period: { start: 2000 }        # Orden de 15-09-2000, in force 17-09-2000
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "9999 LLL"
       regex: '\A\d{4} [A-Z]{3}\z'
@@ -164,6 +165,7 @@ series:
     categories: [car, van, truck, bus, motorcycle]
     period: { start: 1999, end: 2000 }
     period_evidence: instrument-window
+    matching: strict
     format:
       pattern: "LL-9999-LL"
       regex: '\A[A-Z]{1,2}-\d{4}-[A-Z]{1,2}\z'
@@ -226,6 +228,7 @@ series:
     categories: [tractor, machine]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "E9999LLL"
       regex: '\AE\d{4}[A-Z]{3}\z'
@@ -257,6 +260,7 @@ series:
     categories: [trailer, semitrailer]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "R9999LLL"
       regex: '\AR\d{4}[A-Z]{3}\z'
@@ -285,6 +289,7 @@ series:
     categories: [moped, quadricycle]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "C9999LLL"
       regex: '\AC\d{4}[A-Z]{3}\z'
@@ -321,6 +326,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, moped]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "H9999LLL"
       regex: '\AH\d{4}[A-Z]{3}\z'
@@ -351,6 +357,7 @@ series:
     categories: [car, van, motorcycle]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "T9999LLL"
       regex: '\AT\d{4}[A-Z]{3}\z'
@@ -390,6 +397,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, moped, trailer, semitrailer]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "P9999LLL"
       regex: '\AP\d{4}[A-Z]{3}\z'
@@ -420,6 +428,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, moped, trailer, semitrailer]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "S9999LLL"
       regex: '\AS\d{4}[A-Z]{3}\z'
@@ -456,6 +465,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, moped, trailer, semitrailer]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "V9999LLL"
       regex: '\AV\d{4}[A-Z]{3}\z'
@@ -490,6 +500,7 @@ series:
     categories: [car, van, motorcycle]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "CD-999-999"
       regex: '\ACD[- ]\d+[- ]\d+\z'
@@ -525,6 +536,7 @@ series:
     categories: [car, van, motorcycle]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "OI-999-999"
       regex: '\AOI[- ]\d+[- ]\d+\z'
@@ -551,6 +563,7 @@ series:
     categories: [car, van, motorcycle]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "CC-999-999"
       regex: '\ACC[- ]\d+[- ]\d+\z'
@@ -577,6 +590,7 @@ series:
     categories: [car, van, motorcycle]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "TA-999-999"
       regex: '\ATA[- ]\d+[- ]\d+\z'
@@ -603,6 +617,7 @@ series:
     categories: [car, van, truck, bus, motorcycle, trailer]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "ET-999999"
       regex: '\A(?:ET|FN|EA)[- ]\d+(?:-VE)?\z'
@@ -630,6 +645,7 @@ series:
     categories: [car, van, truck, bus]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "FAE-999999"
       regex: '\AFAE[- ]\d+(?:-VE)?\z'
@@ -650,6 +666,7 @@ series:
     categories: [car, van, truck, bus]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "PME-999999"
       regex: '\A(?:PME|MF|MMA)[- ]\d+(?:-VE)?\z'
@@ -673,6 +690,7 @@ series:
     categories: [car, van, truck, motorcycle]
     period: { start: 1999 }
     period_evidence: instrument-in-force
+    matching: strict
     format:
       pattern: "CNP-999999"
       regex: '\A(?:CNP|PGC)[- ]\d+(?:-VE)?\z'

--- a/plates/nl.yml
+++ b/plates/nl.yml
@@ -67,6 +67,7 @@ series:
     class: standard
     categories: [car]
     period: { start: 2000 }        # 20-01-2000; open — series run until exhausted
+    matching: strict
     format:
       pattern: "99-LL-LL"
       regex: '\A\d{2}-[A-Z]{2}-[A-Z]{2}\z'
@@ -118,6 +119,7 @@ series:
     class: standard
     categories: [car]
     period: { start: 2008 }        # 19-05-2008
+    matching: strict
     format:
       pattern: "99-LLL-9"
       regex: '\A\d{2}-[A-Z]{3}-\d\z'
@@ -141,6 +143,7 @@ series:
     class: standard
     categories: [car]
     period: { start: 2013 }        # 05-03-2013
+    matching: strict
     format:
       pattern: "9-LLL-99"
       regex: '\A\d-[A-Z]{3}-\d{2}\z'
@@ -163,6 +166,7 @@ series:
     class: standard
     categories: [car]
     period: { start: 2015 }        # 30-03-2015
+    matching: strict
     format:
       pattern: "LL-999-L"
       regex: '\A[A-Z]{2}-\d{3}-[A-Z]\z'
@@ -184,6 +188,7 @@ series:
     class: standard
     categories: [car]
     period: { start: 2019 }        # 19-08-2019
+    matching: strict
     format:
       pattern: "L-999-LL"
       regex: '\A[A-Z]-\d{3}-[A-Z]{2}\z'
@@ -208,6 +213,7 @@ series:
                                    # commercials reached sidecode 11 on 13-06-2019
                                    # (see nl-sidecode11-lightcommercial).
     period: { start: 2024 }        # 04-06-2024
+    matching: strict
     format:
       pattern: "LLL-99-L"
       regex: '\A[A-Z]{3}-\d{2}-[A-Z]\z'
@@ -243,6 +249,7 @@ series:
     class: standard
     categories: [van]
     period: { start: 2009 }        # 26-02-2009
+    matching: strict
     format:
       pattern: "9-VLL-99"
       regex: '\A\d-V[A-Z]{2}-\d{2}\z'
@@ -266,6 +273,7 @@ series:
     class: standard
     categories: [van]
     period: { start: 2012 }        # 12-12-2012
+    matching: strict
     format:
       pattern: "VL-999-L"
       regex: '\AV[A-Z]-\d{3}-[A-Z]\z'
@@ -285,6 +293,7 @@ series:
     class: standard
     categories: [van]
     period: { start: 2016 }        # 14-10-2016
+    matching: strict
     format:
       pattern: "V-999-LL"
       regex: '\AV-\d{3}-[A-Z]{2}\z'
@@ -304,6 +313,7 @@ series:
     class: standard
     categories: [van]
     period: { start: 2019 }        # 13-06-2019
+    matching: strict
     format:
       pattern: "VLL-99-L"
       regex: '\AV[A-Z]{2}-\d{2}-[A-Z]\z'
@@ -327,6 +337,7 @@ series:
     class: standard
     categories: [van]
     period: { start: 2024 }        # 08-01-2024
+    matching: strict
     format:
       pattern: "V-99-LLL"
       regex: '\AV-\d{2}-[A-Z]{3}\z'
@@ -354,6 +365,7 @@ series:
     period: { start: 1994 }        # 03-01-1994 — the oldest date RDW publishes
                                    # for a still-listed series other than the
                                    # 1951 GV block.
+    matching: strict
     format:
       pattern: "BL-LL-99"
       regex: '\AB[A-Z]-[A-Z]{2}-\d{2}\z'
@@ -381,6 +393,7 @@ series:
     class: standard
     categories: [truck, bus]
     period: { start: 2012 }        # 20-07-2012
+    matching: strict
     format:
       pattern: "99-BLL-9"
       regex: '\A\d{2}-B[A-Z]{2}-\d\z'
@@ -405,6 +418,7 @@ series:
     class: motorcycle
     categories: [motorcycle]
     period: { start: 2011 }        # 19-08-2011
+    matching: strict
     format:
       pattern: "99-ML-LL"
       regex: '\A\d{2}-M[A-Z]-[A-Z]{2}\z'
@@ -438,6 +452,7 @@ series:
     class: moped
     categories: [moped]
     period: { start: 2005 }        # 01-09-2005
+    matching: strict
     format:
       pattern: "99-LLL-9"
       regex: '\A\d{2}-[A-Z]{3}-\d\z'
@@ -475,6 +490,7 @@ series:
     class: moped
     categories: [moped]
     period: { start: 2006 }        # 11-08-2006
+    matching: strict
     format:
       pattern: "LL-999-L"
       regex: '\A[A-Z]{2}-\d{3}-[A-Z]\z'
@@ -496,6 +512,7 @@ series:
     class: moped
     categories: [moped]
     period: { start: 2008 }        # 11-12-2008
+    matching: strict
     format:
       pattern: "L-999-LL"
       regex: '\A[A-Z]-\d{3}-[A-Z]{2}\z'
@@ -515,6 +532,7 @@ series:
     class: moped
     categories: [moped]
     period: { start: 2015 }        # 16-01-2015 (seed said 2015 — confirmed)
+    matching: strict
     format:
       pattern: "LLL-99-L"
       regex: '\A[A-Z]{3}-\d{2}-[A-Z]\z'
@@ -540,6 +558,7 @@ series:
     class: moped
     categories: [moped]
     period: { start: 2025 }        # 01-07-2025
+    matching: strict
     format:
       pattern: "E-99-LLL"
       regex: '\AE-\d{2}-[A-Z]{3}\z'
@@ -572,6 +591,7 @@ series:
     class: trailer
     categories: [trailer]
     period: { start: 1988 }        # 01-10-1988
+    matching: strict
     format:
       pattern: "WL-99-LL"
       regex: '\AW[A-Z]-\d{2}-[A-Z]{2}\z'
@@ -599,6 +619,7 @@ series:
     class: trailer
     categories: [semitrailer]
     period: { start: 1988 }        # 01-10-1988
+    matching: strict
     format:
       pattern: "OL-99-LL"
       regex: '\AO[A-Z]-\d{2}-[A-Z]{2}\z'
@@ -634,6 +655,7 @@ series:
     class: agricultural
     categories: [tractor, machine]
     period: { start: 2021 }        # 01-12-2021
+    matching: strict
     format:
       pattern: "T-99-LLL"
       regex: '\AT-\d{2}-[A-Z]{3}\z'
@@ -664,6 +686,7 @@ series:
                                    # agricultural TRAILER / interchangeable towed
                                    # equipment series (RDW's own table heading).
     period: { start: 2021 }        # 01-01-2021 (seed said 2021 — confirmed)
+    matching: strict
     format:
       pattern: "LLL-99-L"
       regex: '\A[A-Z]{3}-\d{2}-[A-Z]\z'
@@ -706,6 +729,7 @@ series:
     class: agricultural
     categories: [tractor, machine]
     period: { start: 1951 }
+    matching: strict
     format:
       pattern: "GV-99-99"
       regex: '\AGV-\d{2}-\d{2}\z'
@@ -731,6 +755,7 @@ series:
     class: agricultural
     categories: [tractor, machine]
     period: { start: 1951 }
+    matching: strict
     format:
       pattern: "99-99-GV"
       regex: '\A\d{2}-\d{2}-GV\z'
@@ -753,6 +778,7 @@ series:
     class: agricultural
     categories: [tractor, machine]
     period: { start: 1951 }
+    matching: strict
     format:
       pattern: "99-GV-99"
       regex: '\A\d{2}-GV-\d{2}\z'
@@ -774,6 +800,7 @@ series:
     class: agricultural
     categories: [tractor, machine]
     period: { start: 2016 }        # 23-05-2016
+    matching: strict
     format:
       pattern: "9-GV-999"
       regex: '\A\d-GV-\d{3}\z'
@@ -796,6 +823,7 @@ series:
     class: agricultural
     categories: [tractor, machine]
     period: { start: 2019 }        # 13-06-2019
+    matching: strict
     format:
       pattern: "999-GV-9"
       regex: '\A\d{3}-GV-\d\z'
@@ -825,6 +853,7 @@ series:
     categories: [car, van, motorcycle]
     period: { start: 1978 }
     period_evidence: eligibility-cutoff   # NOT an issuance-start claim; see notes
+    matching: strict
     format:
       pattern: "LL-99-99"
       regex: '\A[A-Z]{2}-\d{2}-\d{2}\z'
@@ -862,6 +891,7 @@ series:
     categories: [car, van, motorcycle]
     period: { start: 1978 }
     period_evidence: eligibility-cutoff
+    matching: strict
     format:
       pattern: "99-99-LL"
       regex: '\A\d{2}-\d{2}-[A-Z]{2}\z'
@@ -884,6 +914,7 @@ series:
     categories: [car, van, motorcycle]
     period: { start: 1978 }
     period_evidence: eligibility-cutoff
+    matching: strict
     format:
       pattern: "99-LL-99"
       regex: '\A\d{2}-[A-Z]{2}-\d{2}\z'
@@ -907,6 +938,12 @@ series:
     categories: [tractor, machine, trailer]
     period: { start: 1978 }
     period_evidence: eligibility-cutoff
+    # RECALL-ONLY (PRD-PLATES §2.7): RDW exempts these vehicles from the
+    # 2+2+2 registration-shape rule, so the regex is the same fourteen-shape
+    # union as nl-export. A match is a SHAPE hit — it says the string has a
+    # shape the Netherlands has issued, not that it is a valid historic
+    # agricultural registration.
+    matching: recall-only
     format:
       pattern: "LLL-99-L"
       regex: '\A(?:[A-Z]{2}-\d{2}-\d{2}|\d{2}-\d{2}-[A-Z]{2}|\d{2}-[A-Z]{2}-\d{2}|[A-Z]{2}-\d{2}-[A-Z]{2}|[A-Z]{2}-[A-Z]{2}-\d{2}|\d{2}-[A-Z]{2}-[A-Z]{2}|\d{2}-[A-Z]{3}-\d|\d-[A-Z]{3}-\d{2}|[A-Z]{2}-\d{3}-[A-Z]|[A-Z]-\d{3}-[A-Z]{2}|[A-Z]{3}-\d{2}-[A-Z]|[A-Z]-\d{2}-[A-Z]{3}|\d-[A-Z]{2}-\d{3}|\d{3}-[A-Z]{2}-\d)\z'
@@ -942,6 +979,13 @@ series:
     categories: [car, van, truck, bus, motorcycle, moped, trailer, semitrailer, tractor, machine]
     period: { start: 1951 }
     period_evidence: earliest-underlying-series   # the regime's own start is unsourced
+    # RECALL-ONLY (PRD-PLATES §2.7): the export plate carries the vehicle's
+    # OWN existing registration, so the regex is the union of all fourteen
+    # RDW sidecode shapes. A match is a SHAPE hit, never the claim that the
+    # string is a valid export registration — the union admits vowel serials
+    # the standard series reject. This is the field the vehicles gem's
+    # Match#strict? needs and could not previously read (issue #124).
+    matching: recall-only
     format:
       pattern: "LLL-99-L"
       regex: '\A(?:[A-Z]{2}-\d{2}-\d{2}|\d{2}-\d{2}-[A-Z]{2}|\d{2}-[A-Z]{2}-\d{2}|[A-Z]{2}-\d{2}-[A-Z]{2}|[A-Z]{2}-[A-Z]{2}-\d{2}|\d{2}-[A-Z]{2}-[A-Z]{2}|\d{2}-[A-Z]{3}-\d|\d-[A-Z]{3}-\d{2}|[A-Z]{2}-\d{3}-[A-Z]|[A-Z]-\d{3}-[A-Z]{2}|[A-Z]{3}-\d{2}-[A-Z]|[A-Z]-\d{2}-[A-Z]{3}|\d-[A-Z]{2}-\d{3}|\d{3}-[A-Z]{2}-\d)\z'

--- a/plates/us-fl.yml
+++ b/plates/us-fl.yml
@@ -16,6 +16,14 @@
 # carry: which standard VARIANTS are currently offered, and how many specialty
 # programs exist.
 #
+# REGEX FORM (PRD-PLATES §2.6, issue #124): every regex in this file is written
+# in PRINTED form — the separator is spelled where the plate shows it. That is
+# why `regex_statutory` reads '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z' and not
+# '\A[A-Z0-9]{1,7}\z': the statutory claim is § 320.06(3)(a)'s SEVEN
+# ALPHANUMERIC CHARACTERS, unchanged, but the earlier spelling silently also
+# claimed the plate is printed without a gap, so it rejected "ABC 123" —
+# every real Florida plate. The cap is the claim; the gap is not.
+#
 # WHAT IS DELIBERATELY NOT HERE (PRD-PLATES §2.5): the individual specialty
 # DESIGNS. L2 indexes the programs with official links and counts; individual
 # designs are L4. `us-fl-specialty-index` is that index entry and nothing more.
@@ -110,10 +118,11 @@ series:
     categories: [car, van, truck, bus, motorcycle, moped, trailer]
     period: { start: 2025 }
     period_evidence: instrument-in-force-upper-bound
+    matching: strict
     format:
       pattern: "LLL 999"
       regex: '\A[A-Z]{3} ?\d{3}\z'
-      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
       charset:
         notes: >-
           § 320.06(1)(a): the department assigns 'a registration license number
@@ -217,10 +226,11 @@ series:
     categories: [car, van, truck, motorcycle]
     period: { start: 2025 }
     period_evidence: instrument-in-force-upper-bound
+    matching: strict
     format:
       pattern: "LLL 999"
       regex: '\A[A-Z]{3} ?\d{3}\z'
-      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
       charset: { notes: "specialty plates carry ORDINARY serials on an alternative design — the § 320.06(3)(a) seven-character cap and alphabet apply unchanged" }
     design:
       plate: { w: 12, h: 6, unit: in }
@@ -269,10 +279,11 @@ series:
     categories: [car, van, truck, motorcycle]
     period: { start: 2025 }
     period_evidence: instrument-in-force-upper-bound
+    matching: strict
     format:
       pattern: "LLLLLLL"
       regex: '\A[A-Z]{1,7}\z'
-      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
       charset: { notes: "owner-chosen inside the § 320.06(3)(a) frame: bold letters and numerals or numerals, at most seven characters. Availability is checked through FLHSMV's Personalized License Plate Inquiry before order." }
     design:
       plate: { w: 12, h: 6, unit: in }
@@ -302,6 +313,7 @@ series:
     categories: [car]
     period: { start: 2025 }
     period_evidence: instrument-in-force-upper-bound
+    matching: strict
     format:
       pattern: "999"
       regex: '\A\d+\z'
@@ -342,6 +354,7 @@ series:
     categories: [car, truck, bus]
     period: { start: 2025 }
     period_evidence: instrument-in-force-upper-bound
+    matching: strict
     format:
       pattern: "999"
       regex: '\A\d+\z'
@@ -382,10 +395,11 @@ series:
     categories: [truck, bus]
     period: { start: 2024 }
     period_evidence: statutory-date
+    matching: strict
     format:
       pattern: "LLL 999"
       regex: '\A[A-Z]{3} ?\d{3}\z'
-      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
     design:
       plate: { w: 12, h: 6, unit: in }
       background: { finish: retroreflective }
@@ -414,10 +428,11 @@ series:
     categories: [truck, trailer]
     period: { start: 2025 }
     period_evidence: instrument-in-force-upper-bound
+    matching: strict
     format:
       pattern: "LLL 999"
       regex: '\A[A-Z]{3} ?\d{3}\z'
-      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
     design:
       plate: { w: 12, h: 6, unit: in }
       background: { finish: retroreflective }
@@ -439,10 +454,11 @@ series:
     categories: [car, van, truck, bus, motorcycle, trailer]
     period: { start: 2025 }
     period_evidence: instrument-in-force-upper-bound
+    matching: strict
     format:
       pattern: "LLL 999"
       regex: '\A[A-Z]{3} ?\d{3}\z'
-      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
     design:
       plate: { w: 12, h: 6, unit: in }
       background: { finish: retroreflective }
@@ -470,10 +486,11 @@ series:
     categories: [car, van, truck, bus, motorcycle]
     period: { start: 2025 }
     period_evidence: instrument-in-force-upper-bound
+    matching: strict
     format:
       pattern: "LLL 999"
       regex: '\A[A-Z]{3} ?\d{3}\z'
-      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
     design:
       plate: { w: 12, h: 6, unit: in }
       background: { finish: retroreflective }
@@ -497,10 +514,11 @@ series:
     categories: [truck]
     period: { start: 2025 }
     period_evidence: instrument-in-force-upper-bound
+    matching: strict
     format:
       pattern: "LLL 999"
       regex: '\A[A-Z]{3} ?\d{3}\z'
-      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
     design:
       plate: { w: 12, h: 6, unit: in }
       background: { finish: retroreflective }

--- a/scripts/lint_plates.rb
+++ b/scripts/lint_plates.rb
@@ -13,15 +13,145 @@
 #     serials must not (the fuzz side)
 #   * every series carries >= 1 source line; colors well-formed hex
 #
+# The #124 amendments (PRD-PLATES §2.6-§2.8), from the vehicles gem 0.6.0:
+#   * SEPARATOR CONTRACT (§2.6): patterns and regexes may spell only the
+#     serial alphabet and the EMITTED separators declared in
+#     plates/_meta/separators.yml. Nothing is hardcoded here — that file is
+#     the single source of truth, so widening the contract is a data PR.
+#   * matching: strict|recall-only (§2.7) required per series, plus the regex
+#     tier order regex_strict <= regex <= regex_statutory, sampled.
+#   * SEPARATOR-ONLY CLASSES (§2.8): a character class containing a separator
+#     must contain only separators and must not be negated — the rule that
+#     makes a separator position mechanically detectable by a consumer
+#     deriving separator-free twins.
+#
 # Usage: ruby scripts/lint_plates.rb    (repo root relative)
 
 require "yaml"
+require "set"
 
 ROOT = File.expand_path("..", __dir__)
 CLASSES = YAML.safe_load_file(File.join(ROOT, "plates", "_meta", "classes.yml")).keys.map(&:to_s).freeze rescue abort("classes.yml missing/unparsable")
 NOW = Time.now.year
 FAILURES = []
 def fail!(m) = FAILURES << m
+
+# --- the separator contract, read from data (PRD-PLATES §2.6) --------------
+SEP = begin
+  YAML.safe_load_file(File.join(ROOT, "plates", "_meta", "separators.yml"))
+rescue StandardError => e
+  abort("plates/_meta/separators.yml missing/unparsable — #{e.message}")
+end
+SERIAL_ALPHABET = SEP.fetch("serial_alphabet").chars.to_set rescue abort("separators.yml: serial_alphabet required")
+EMITTED = SEP.fetch("emitted").map { |h| h.fetch("char") }.to_set
+FORGIVING = SEP.fetch("forgiving").map { |h| h.fetch("char") }.to_set
+abort("separators.yml: emitted must be a subset of forgiving") unless EMITTED.subset?(FORGIVING)
+abort("separators.yml: forgiving overlaps the serial alphabet — the contract is broken at its root") if FORGIVING.intersect?(SERIAL_ALPHABET)
+PATTERN_TOKENS = %w[9 L].to_set          # the human-pattern DSL (9=digit, L=letter)
+MATCHING_VALUES = %w[strict recall-only].freeze
+
+# Expand a character-class body into its members. Handles ranges (A-Z),
+# a leading negation, and backslash escapes. The dataset's dialect has no
+# nested classes and no POSIX brackets.
+def class_members(body)
+  neg = body.start_with?("^")
+  b = neg ? body[1..].to_s : body
+  members = []
+  k = 0
+  while k < b.length
+    if b[k] == "\\"
+      members << "\\#{b[k + 1]}"            # \d and friends, kept marked
+      k += 2
+    elsif b[k + 1] == "-" && b[k + 2] && b[k + 2] != "]"
+      (b[k]..b[k + 2]).each { |x| members << x }
+      k += 3
+    else
+      members << b[k]
+      k += 1
+    end
+  end
+  [neg, members]
+end
+
+# Walk a regex source in the restricted dialect the dataset uses and return
+# the LITERAL characters and the CHARACTER CLASSES it spells. Metacharacters,
+# escapes (\A \z \d ...), groups ((?: (?! (?= (?<= (?<!), alternation and
+# quantifiers contribute nothing — only what a human could read off a plate.
+def regex_atoms(src)
+  literals = []
+  classes  = []
+  i = 0
+  while i < src.length
+    c = src[i]
+    case c
+    when "\\"
+      nxt = src[i + 1]
+      literals << nxt unless nxt.nil? || nxt =~ /[AzZdDwWsSbBGhHkpRXK]/
+      i += 2
+    when "["
+      j = i + 1
+      j += 1 if src[j] == "^"
+      j += 1 if src[j] == "]"                       # ']' first is a literal member
+      j += 1 while j < src.length && src[j] != "]"
+      classes << src[(i + 1)...j]
+      i = j + 1
+    when "("
+      m = src[i..].match(/\A\(\?(?::|!|=|<=|<!|<[A-Za-z_]\w*>)/)
+      i += m ? m[0].length : 1
+    when ")", "|", "?", "*", "+", "^", "$"
+      i += 1
+    when "{"
+      j = src.index("}", i)
+      if j && src[(i + 1)...j] =~ /\A\d+(?:,\d*)?\z/
+        i = j + 1
+      else
+        literals << c
+        i += 1
+      end
+    when "."
+      literals << c                                  # '.' unescaped: wildcard,
+      i += 1                                         # not sanctioned here
+    else
+      literals << c
+      i += 1
+    end
+  end
+  [literals, classes]
+end
+
+# §2.6 + §2.8 — one regex, checked against the separator contract.
+def check_separator_contract(rel, id, key, src)
+  literals, classes = regex_atoms(src)
+  literals.uniq.each do |ch|
+    next if SERIAL_ALPHABET.include?(ch) || EMITTED.include?(ch)
+    hint = if FORGIVING.include?(ch)
+             "it is in the FORGIVING set but not the EMITTED set — the dataset writes only #{EMITTED.to_a.map(&:inspect).join(' and ')}"
+           else
+             "not in the serial alphabet and not an emitted separator"
+           end
+    fail! "#{rel}: #{id} #{key} spells literal #{ch.inspect} (U+%04X) — #{hint} (PRD-PLATES §2.6)" % ch.ord
+  end
+  classes.each do |body|
+    neg, members = class_members(body)
+    seps = members.select { |m| FORGIVING.include?(m) }
+    if seps.any?
+      fail! "#{rel}: #{id} #{key} class [#{body}] is NEGATED and contains a separator — a separator position must be positively spelled (PRD-PLATES §2.8)" if neg
+      strays = members - seps
+      unless strays.empty?
+        fail! "#{rel}: #{id} #{key} class [#{body}] MIXES separators #{seps.inspect} with #{strays.inspect} — a class containing a separator must contain only separators, or a consumer deriving separator-free twins cannot detect the position (PRD-PLATES §2.8)"
+      end
+      seps.each do |s|
+        next if EMITTED.include?(s)
+        fail! "#{rel}: #{id} #{key} class [#{body}] spells non-emitted separator #{s.inspect} — forgiveness is the consumer's job, not the dataset's (PRD-PLATES §2.6)"
+      end
+    else
+      members.each do |m|
+        next if m.start_with?("\\") || SERIAL_ALPHABET.include?(m)
+        fail! "#{rel}: #{id} #{key} class [#{body}] member #{m.inspect} is outside the serial alphabet (PRD-PLATES §2.6)"
+      end
+    end
+  end
+end
 
 # Generate serials from a human pattern: 9=digit, L=letter, else literal.
 def serials_from(pattern, n = 50)
@@ -47,6 +177,8 @@ files = Dir[File.join(ROOT, "plates", "*.yml")] + Dir[File.join(ROOT, "plates", 
 files = files.reject { |f| f.include?("/_meta/") || f.include?("/_decode/") }
 seen_series = {}
 series_count = 0
+matching_tally = Hash.new(0)
+twin_tally = Hash.new(0)
 
 files.sort.each do |abs|
   rel = abs.sub("#{ROOT}/", "")
@@ -89,16 +221,36 @@ files.sort.each do |abs|
     fail! "#{rel}: #{id} period.ended must be true or absent" unless p["ended"].nil? || p["ended"] == true
     fail! "#{rel}: #{id} period has both end and ended" if en && p["ended"]
 
+    # matching: strict | recall-only (PRD-PLATES §2.7) — a FIRST-CLASS field,
+    # because "no regex_strict" does NOT mean "not strict": 29 of the 31 L0
+    # series without a strict twin carry the sourced grammar in `regex`.
+    matching = s["matching"].to_s
+    matching_tally[matching.empty? ? "(missing)" : matching] += 1
+    if matching.empty?
+      fail! "#{rel}: #{id} matching: required — strict|recall-only (PRD-PLATES §2.7); consumers must not have to infer it"
+    elsif !MATCHING_VALUES.include?(matching)
+      fail! "#{rel}: #{id} matching #{s['matching'].inspect} not in #{MATCHING_VALUES.inspect} (PRD-PLATES §2.7)"
+    end
+
     # format: pattern + anchored regex + round trip
     fmt = s["format"] || {}
     pattern, regex_s = fmt["pattern"].to_s, fmt["regex"].to_s
     fail! "#{rel}: #{id} format.pattern required" if pattern.empty?
+
+    # §2.6 — the human pattern spells DSL tokens, serial characters and
+    # emitted separators, and nothing else.
+    pattern.chars.uniq.each do |ch|
+      next if PATTERN_TOKENS.include?(ch) || SERIAL_ALPHABET.include?(ch) || EMITTED.include?(ch)
+      fail! "#{rel}: #{id} format.pattern spells #{ch.inspect} (U+%04X) — patterns carry 9/L, serial characters and emitted separators only (PRD-PLATES §2.6)" % ch.ord
+    end
+
     if regex_s.empty?
       fail! "#{rel}: #{id} format.regex required"
     else
       begin
         re = Regexp.new(regex_s)
         fail! "#{rel}: #{id} regex not anchored (\\A...\\z)" unless regex_s.start_with?('\A') && regex_s.end_with?('\z')
+        check_separator_contract(rel, id, "format.regex", regex_s)
         unless pattern.empty?
           srand(id.sum) # deterministic per series
           serials_from(pattern).each do |ser|
@@ -109,6 +261,59 @@ files.sort.each do |abs|
         end
       rescue RegexpError => e
         fail! "#{rel}: #{id} regex does not compile — #{e.message}"
+      end
+    end
+
+    # The regex TIERS (PRD-PLATES §2.7): regex_strict <= regex <= regex_statutory.
+    # Only `regex` is round-tripped against `pattern` — which is exactly why it
+    # cannot carry charset restrictions and why the twins exist. The twins are
+    # compiled, anchored, separator-checked, and sampled against `pattern`:
+    # a twin that accepts NOTHING the pattern generates is written against a
+    # different form of the serial than the pattern is (this is how eight
+    # us-fl `regex_statutory` values were caught writing the separator-free
+    # form while `regex` wrote the printed one).
+    strict_re = nil
+    %w[regex_strict regex_statutory].each do |key|
+      src = fmt[key].to_s
+      next if src.empty?
+      twin_tally[key] += 1
+      begin
+        r = Regexp.new(src)
+        fail! "#{rel}: #{id} #{key} not anchored (\\A...\\z)" unless src.start_with?('\A') && src.end_with?('\z')
+        check_separator_contract(rel, id, "format.#{key}", src)
+        strict_re = r if key == "regex_strict"
+        next if pattern.empty?
+        srand(id.sum + key.sum)
+        sample = serials_from(pattern, 2000)
+        hits = sample.select { |ser| r.match?(ser) }
+        if hits.empty?
+          fail! "#{rel}: #{id} #{key} matches NONE of 2000 serials generated from format.pattern #{pattern.inspect} — a twin must describe the same printed form as the pattern (PRD-PLATES §2.6 rule 2)"
+        elsif key == "regex_strict" && !regex_s.empty?
+          loose = (Regexp.new(regex_s) rescue nil)
+          if loose
+            stray = hits.find { |ser| !loose.match?(ser) }
+            fail! "#{rel}: #{id} regex_strict is NOT contained in regex — #{stray.inspect} matches the strict twin but not the loose one (PRD-PLATES §2.7 tier order)" if stray
+          end
+        end
+      rescue RegexpError => e
+        fail! "#{rel}: #{id} #{key} does not compile — #{e.message}"
+      end
+    end
+    if matching == "recall-only" && strict_re
+      fail! "#{rel}: #{id} matching: recall-only carries a regex_strict — a deliberately over-broad regex cannot also be the authority's own grammar (PRD-PLATES §2.7)"
+    end
+
+    # §2.6 — variant patterns are held to the same alphabet.
+    (s["variants"] || []).each_with_index do |v, vi|
+      vpat = v.dig("format", "pattern").to_s
+      next if vpat.empty?
+      vpat.chars.uniq.each do |ch|
+        next if PATTERN_TOKENS.include?(ch) || SERIAL_ALPHABET.include?(ch) || EMITTED.include?(ch)
+        fail! "#{rel}: #{id} variant[#{vi}] pattern spells #{ch.inspect} (U+%04X) — see PRD-PLATES §2.6" % ch.ord
+      end
+      %w[regex regex_strict regex_statutory].each do |key|
+        vsrc = v.dig("format", key).to_s
+        check_separator_contract(rel, id, "variant[#{vi}].#{key}", vsrc) unless vsrc.empty?
       end
     end
 
@@ -141,6 +346,9 @@ files.sort.each do |abs|
 end
 
 puts "plates lint: #{files.size} files, #{series_count} series"
+puts "plates lint: matching #{matching_tally.sort.map { |k, v| "#{k}=#{v}" }.join(' ')}" \
+     " | twins #{twin_tally.sort.map { |k, v| "#{k}=#{v}" }.join(' ')}" \
+     " | separators emitted #{EMITTED.to_a.map(&:inspect).join(',')} forgiving #{FORGIVING.size}"
 if FAILURES.any?
   FAILURES.each { |f| puts "LINT FAIL: #{f}" }
   puts "#{FAILURES.size} failure(s)."


### PR DESCRIPTION
Closes #124.

All three findings from the `vehicles` gem 0.6.0 implementation, applied to the schema, the lint and all 73 L0 series. **Additive only** — no existing key renamed, no series loses information, one new key. `ruby scripts/lint_plates.rb` is green (73 series, 4 files).

---

## 1. The separator character set is now normative

**PRD-PLATES §2.6 + `plates/_meta/separators.yml`** (new, machine-readable, the single source of truth — the lint hardcodes nothing and reads that file).

| set | members | rule |
|---|---|---|
| **serial alphabet** | `A–Z` `0–9` | the only characters a serial is ever made of, dataset-wide. Uppercase; consumers upcase input |
| **emitted** | `-` U+002D, ` ` U+0020 | the only separators the dataset itself ever writes, in `pattern` / `regex` / `regex_strict` / `regex_statutory` |
| **forgiving** | emitted + every Unicode dash (U+2010–U+2015, U+2212), the Unicode spaces (U+00A0, U+2007, U+202F, tab), `·` `•` `.` `_` `/` | what a lenient consumer MAY delete from input, and from a regex to derive its separator-free twin |

The forgiving set is **disjoint from the serial alphabet**, and the lint enforces that disjointness at load. So deleting every forgiving character is information-preserving *by construction* — the gem's lenient tier is provably sound, not sound-by-luck. The gem currently strips `[\s\-–—·.]`, a subset; widening to the full list is safe and covers what OCR and word processors produce.

Rule 2 of the contract — **every regex in the dataset is written in PRINTED form**, separators spelled where the plate shows them — found a real defect. Eight `us-fl` `regex_statutory` values were written in the separator-**free** form: `\A[A-Z0-9]{1,7}\z` rejects `"ABC 123"`, i.e. every real Florida plate, so a consumer using the exact tier against `regex_statutory` would reject the whole state. Widened to `\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z`. The statutory claim — § 320.06(3)(a)'s seven alphanumeric characters — is preserved exactly; only the silent "and no gap is printed" claim is gone.

## 2. `matching: strict|recall-only`, first-class, on all 73 series

**PRD-PLATES §2.7.** A top-level series key beside `class:`.

The inference the gem was forced to make is **wrong**. Of the 31 L0 series with no `regex_strict`, **29 are strict** — their `regex` already *is* the sourced grammar, because the mandated letters are literals in the pattern (`GV-99-99`, `Y-999999`, `CD-999-999`, `ET-999999`). Only two series are genuinely recall-only, and it is the same construct both times: the fourteen-sidecode union on `nl-export` and `nl-historic-darkblue-agricultural`.

Applied: **71 `strict`, 2 `recall-only`.**

- **`strict`** — `format.regex` lies at or inside the series' own issuing grammar. A match is a well-formedness claim for THIS series.
- **`recall-only`** — `format.regex` is deliberately *wider* than the series' own issuing grammar. A match is a shape hit and nothing more. `regex_strict` on a `recall-only` series is a lint failure.

The test is one question: *is this regex wider than what the authority issues?* **Narrower is still `strict`** — `us-fl-standard`'s `regex` is the current three-letter/three-numeral arrangement while the statute permits any seven alphanumerics, and a match there is a real claim; the outer bound is what `regex_statutory` is for.

The tier order this presupposes is now documented and sampled by the lint:

```
regex_strict  ⊆  regex  ⊆  regex_statutory
```

Only `regex` is required, and only `regex` is round-tripped against `pattern` — which is precisely why it cannot carry charset restrictions and why the twins exist.

## 3. The `[- ]` class is sanctioned, not normalized

**PRD-PLATES §2.8.** Two corrections to the issue's third point:

**It is not a one-off.** Eight Spanish state/diplomatic series spell the separator as a class, not one: `es-diplomatic-cd-1999`, `es-international-oi-1999`, `es-consular-cc-1999`, `es-diplomatic-staff-ta-1999`, `es-military-1999`, `es-nato-fae-1999`, `es-government-1999`, `es-police-1999`.

**And it is sourced.** Anexo XVIII prescribes "dos grupos de guarismos" and their millimetre spacing but **no separator glyph** — `es.yml` says so in the section comment above those eight entries. Normalizing to a bare `-` would narrow the regex and delete a fact about the authority's own text, so the class form stands, sanctioned, under one rule the lint enforces:

> A character class that contains any separator character must contain **only** separator characters, and must not be negated.

Never `[-A-Z]`, never `[^-]`. That rule is what makes a separator position mechanically detectable: a consumer deriving separator-free twins deletes every emitted-separator literal and every separator-only class (with its quantifier) and can never accidentally delete part of a serial. `pattern` always shows the canonical printed separator (`CC-999-999`); the regex may accept any subset of the separator set at that position.

---

## The lint (`scripts/lint_plates.rb`, +208 lines)

- a **regex-source scanner** over the dataset's dialect (literals, escapes, classes, groups incl. `(?!`, alternation, quantifiers): every literal must be in the serial alphabet or the emitted set; every class is separator-only or serial-only, never mixed, never negated
- pattern alphabet check (`9`/`L` tokens, serial characters, emitted separators) — on series patterns and variant patterns
- `matching:` present and in-enum; `recall-only` forbids `regex_strict`
- `regex_strict` / `regex_statutory`: compile, anchored, separator-checked, must accept ≥ 1 of 2000 deterministic pattern-generated serials, and `regex_strict ⊆ regex` by sampling

Every one of the seven new failure modes was verified firing against a synthetic fixture before any data landed. The "twin matches nothing the pattern generates" check is what found the eight `us-fl` values on the real corpus.

Summary line now reports the split, which is the number to watch as coverage grows:

```
plates lint: 4 files, 73 series
plates lint: matching recall-only=2 strict=71 | twins regex_statutory=8 regex_strict=42 | separators emitted "-"," " forgiving 18
plates lint: OK
```

**One hunk to review deliberately:** `lint_plates.rb` is now wired into `.github/workflows/lint.yml`. It had never run in CI, so "the lint enforces it" was aspirational. This makes `matching:` a hard requirement for any future plates PR — correct, but it is a new obligation on in-flight authoring work, so drop that hunk if you'd rather stage it.

## What the gem should adopt

1. **Read `matching:` instead of inferring** from `regex_strict` being absent. `Match#strict?` is currently false for 29 series that are strict. Old datasets have no key — **default to `strict`** when it is absent; that is the safe reading for 71 of 73 and PRD-PLATES §2.7 says so normatively.
2. **Load `plates/_meta/separators.yml`** rather than hardcoding `[\s\-–—·.]`. Widening to the published `forgiving` list is safe by construction; when a jurisdiction lands that prints a glyph *inside* a serial, it goes to that file's `never_separator` list and every consumer learns it from one place.
3. **Separator-free twin derivation** may now assume: delete every emitted-separator literal and every separator-only class *with its quantifier* (`[- ]`, ` ?` → nothing), and nothing else. §2.8 guarantees no class mixes the two.
4. **`regex_statutory` exists and is the outer bound**, on 8 `us-fl` series (`regex_strict` is on 42). If the gem only reads `regex`/`regex_strict`, Florida plates of unknown vintage are being rejected that the statute permits — the tier order in §2.7 is the map.
5. **Not fixed here, flagged for the amendment queue:** seven `us-fl` series share one identical `regex` (`\A[A-Z]{3} ?\d{3}\z` — standard, specialty-index, apportioned, restricted, dealer, manufacturer, wrecker). A serial match cannot discriminate between them; the bottom **legend** does, and the legend is not in the serial. That is a different axis from strict-vs-recall and deliberately not modelled by this binary flag, but a consumer ranking candidates should know that a `us-fl` match is 7-way ambiguous by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
