### PR TITLE
#123: one naming convention per make — English "N Series" wins, serie-N ids aliased

### DIFF
--- a/NAMING.md
+++ b/NAMING.md
@@ -296,6 +296,42 @@ approval number and capacity that accompany the code (PR #1 did this for
 Derbi/Gas Gas/TRS via live RDW queries), or leave them alone. A code mapped by
 resemblance is a fabrication with a comment attached.
 
+### 7.6 Register LANGUAGE never decides the canonical form — English does `[S4W]`
+
+Registers write the same range label in their own language: `SERIE 3` (es_dgt),
+`3ER REIHE` (nl_rdw's Dutch-German), `R-SERIEN` (Swedish definite plural),
+`ALPINE SERIE` vs `ALPINE SERIES`. Which spelling a nameplate landed on is an
+artifact of **which register evidenced it first**, so a make ends up carrying two
+conventions at once — issue #123 measured exactly that on BMW, and a full-catalog
+sweep found it on five more makes.
+
+**The English marketing form wins, always.** Not by taste: it is what the
+pipeline's own family rules already emit (`normalizer.rb#bmw` returns
+`"#{$1} Series"`), so any other choice makes the overrides layer fight the code.
+Canonical shape is `<designation> Series` — spaced, capital S.
+
+Three rules that make the fix survive:
+
+1. **Every losing id becomes a `former_ids.yml` alias.** Stored consumer ids must
+   keep resolving (SCHEMA.md §Versioning; the #111 posture). A drop is a
+   different adjudication and needs its own evidence.
+2. **Key every spelling that reaches the SAME SLUG, in one change.** `R-Serien`
+   and `R Serien` both slugify to `r-serien`; `Serie I 80` and `Serie I-80` both
+   to `serie-i-80`. One key alone retires nothing — the record simply republishes
+   under the other display form. Same gotcha as BMW's `3 C` / `3. C`.
+3. **Pin the target's variant spellings too.** If the corpus also produces
+   `G-Series` for the slug you are folding onto, add it as a key pointing at the
+   canonical `G Series`, or the published display flaps between the two by row
+   count (`build/observed_model_names.json` is the detector).
+
+**What this rule does NOT settle:** whether a range label belongs in the catalog
+at all. `SERIE X, X3` and `R-SERIEN, R500` both name a model the label does not,
+and the published siblings (`x1`…`x7`, `r450`…`r730`) already carry that
+altitude. BMW's letter-only labels were therefore `null`ed with a removals.yml
+ledger line while its digit labels folded to real nameplates. Language and
+altitude are two questions; answer them separately or you will delete evidence
+while thinking you fixed a slug.
+
 ---
 
 ## 8. Placeholders and embedded brands `[S2W]`

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -4397,3 +4397,24 @@
 "van/mercedes-benz/x": "van/mercedes-benz/x-class" # family-rule gap: X is missing from the mercedes() letter list, so "MERCEDES X CLASS"/"X-KLASSE" (gb+nl) minted a bare-letter id (MB trim dossier, wave 3)
 "car/mercedes-benz/g": "car/mercedes-benz/g-class" # registry truncation to a bare letter; nz writes both "G" and "G-CLASS" (MB trim dossier, wave 3)
 "van/mercedes-benz/g": "car/mercedes-benz/g-class" # FLATTENED through the shipped van/mercedes-benz/g-class -> car/mercedes-benz/g-class ledger line: the van-side rows cross-kind prune into the car nameplate (fi,nl both present there) (MB trim dossier, wave 3)
+
+# ── issue #123: BMW model slugs mix two naming conventions (serie-N vs N-series).
+# Adjudicated in the issue thread: the ENGLISH marketing convention wins (it is
+# what the normalizer's own family rule already emits, normalizer.rb#bmw
+# "#{$1} Series"), and every losing id becomes a migration alias so stored
+# consumer ids keep resolving — the #111 posture. BMW's own serie-N ids were
+# already aliased in the 2026-07-26 trim-fold wave; these seven are the rest of
+# the PUBLISHED population, found by a full-catalog scan of all 6 kinds and
+# 15,677 records for serie-/serien-/series- shapes (see the PR for the table).
+# FILE-WIDE CHAIN SCAN, run before appending: former_ids.yml holds 3,960 entries
+# and ZERO unflattened chains (no value is also a key); for each of the seven
+# lines below the inbound set is EMPTY (nothing already aliases the retiring id,
+# so there is nothing to flatten), the target is not itself a retired key, and
+# the retiring id is not already present. Stated per line below.
+"car/land-rover/serie-i-80": "car/land-rover/series-i-80" # RENAME (no live twin): continental spelling of the 80-inch Series I; siblings series-i / series-i-88 already English. inbound 0 — nothing chains through this id
+"car/morris/oxford-serie": "car/morris/oxford-series" # FOLD: the English twin was in the candidate queue at nl 13; fi+nz join it. inbound 0 — nothing chains through this id
+"car/sunbeam/alpine-serie": "car/sunbeam/alpine-series" # FOLD onto a LIVE published twin (car/sunbeam/alpine-series, fi+nl); nl+nz join it. inbound 0 — nothing chains through this id
+"truck/scania/g-serien": "truck/scania/g-series" # FOLD: Swedish definite-plural range label; English twin was in the candidate queue at fi 1. inbound 0 — nothing chains through this id
+"truck/scania/r-serien": "truck/scania/r-series" # FOLD: same class; English twin was in the candidate queue at gb 1. inbound 0 — nothing chains through this id
+"truck/volvo/fh-serien": "truck/volvo/fh-series" # FOLD: English twin was in the candidate queue at gb 35. inbound 0 — nothing chains through this id
+"truck/volvo/fm-serien": "truck/volvo/fm-series" # FOLD onto a LIVE published twin (truck/volvo/fm-series, gb) — the two conventions were published side by side, the exact defect #123 reports. inbound 0 — nothing chains through this id

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1819,6 +1819,19 @@ Land Rover:
   "88 Wb": "88 W B"                           # spelling variant of "88 W B" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Rangerover: Range Rover                     # spelling variant of "Range Rover" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Landrover: null                             # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
+  # ── REGISTER-LANGUAGE CONVENTION (issue #123, adjudicated in the issue
+  # thread): where a make carries both the continental "Serie N" spelling and
+  # the English "N Series" spelling for the same designation, the ENGLISH
+  # marketing form wins — it is what the normalizer's own family rule already
+  # emits ("#{$1} Series", normalizer.rb#bmw) and what every published sibling
+  # of this record uses (series-i, series-i-88, series-1/2/3, 88-series).
+  # Every losing id becomes a former_ids alias (#111 posture; former_ids.yml
+  # carries car/land-rover/serie-i-80). Keys replay-verified byte-exact against
+  # pipeline origin/main with recording proxies at the `renames&.key?` site;
+  # blast radius is car-only (this make also lives in bus/truck/van and neither
+  # key is probed there). ──
+  "Serie I 80": Series I 80                   # raw "SERIE I 80 4X4/2235" fi_traficom 1 — the 80-inch Series I (the 1948 original, https://en.wikipedia.org/wiki/Land_Rover_series); continental spelling of a designation this make already publishes in English
+  "Serie I-80": Series I 80                   # raw "SERIE I-80" nl_rdw 1 — hyphenated spelling of the SAME designation and the SAME slug (serie-i-80), so it must move WITH the key above or the record stays alive on this display form (the BMW "3 C"/"3. C" gotcha)
 
 Leike:
   Leike: null                             # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
@@ -2572,6 +2585,10 @@ Morgan:
 Morris:
   MINI1000: "Mini 1000"      # fused register shape of the Morris Mini 1000 (en.wikipedia Mini); matches morris/mini-850, austin/mini-1000. NOTE morris/mini-mk-2 left dangling (dossier U6)
   Coopers: Cooper S                           # spelling variant of "Cooper S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  # ── REGISTER-LANGUAGE CONVENTION (issue #123): English marketing form wins;
+  # the losing id becomes a former_ids alias. Blast radius is car-only (Morris
+  # also lives in van; the key is not probed there). ──
+  "Oxford Serie": Oxford Series               # raw "OXFORD SERIE II/2460" fi_traficom 1, "OXFORD SERIE" nz_nzta 1 — continental spelling of the Morris Oxford Series (https://en.wikipedia.org/wiki/Morris_Oxford). The English twin is ALREADY in the candidate queue at nl 13 ("OXFORD SERIES II/III/VI", nl_rdw), so this is a FOLD, not a rename: fi+nz join nl and the published record gains a country. Sibling published records eight-series / eight-series-i / minor-series / 8-series-e already carry the English form
 
 Moto Guzzi:
   Moto-Guzzi: null                        # motorcycle es|nl — hyphenated by the caser from raw "MOTO-GUZZI"
@@ -3326,6 +3343,29 @@ Scania:
 # ES-brand audit (2026-07-12, multi-agent find→verify pass). NOTE these blocks
 # are make-scoped but kind-blind — kind hazards are tripwired in spotchecks.yml.
   Scania: null                                # registry rows where the make was written into the model column (bus+truck kinds) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
+  # ── REGISTER-LANGUAGE CONVENTION (issue #123): the Swedish "N-Serien" and the
+  # English "N Series" are the same Scania range label reaching two ids in one
+  # make. English wins per the issue adjudication; the losing ids become
+  # former_ids aliases (former_ids.yml carries truck/scania/g-serien and
+  # truck/scania/r-serien). Keys replay-verified byte-exact against pipeline
+  # origin/main with recording proxies; blast radius is truck-only (Scania also
+  # lives in bus and none of these keys is probed there).
+  #
+  # HONEST LIMIT, stated because the comment would otherwise overclaim: these
+  # rows are register RANGE labels, not nameplates at this catalog's Scania
+  # altitude — the trailing-model spellings ("R-SERIEN, R500", "G-SERIEN, G 480")
+  # name a model the label does not, and g450/g480/r500/r520/r530/r580/r650 are
+  # all separately published. That is the BMW "SERIE X, X3" shape, whose verdict
+  # was `null`. This change deliberately does NOT re-adjudicate that: #123 is a
+  # slug-convention issue and its ruling is that losing ids keep resolving, not
+  # that records are deleted. These four keys fix ONLY the register-language
+  # split; the altitude question (should Scania range labels be nameplates at
+  # all, given P/G/R/S ranges vs the published power-variant ids?) is filed as a
+  # follow-up in the PR body and must be decided on its own evidence. ──
+  "G-Serien": G Series                        # raw "G-SERIEN, G 480" es_dgt 1; "G-SERIEN ,G450" nl_rdw 1; "G-SERIEN,G450(LB8X2*6HNA)" nl_rdw 1 — Swedish definite-plural form of Scania's G-series (https://www.scania.com/group/en/home/products-and-services/trucks.html). The English twin is already in the candidate queue (fi_traficom "G-series G490 LB8X4 4HNB"), so this is a FOLD
+  "G-Series": G Series                        # raw "G-series G490 LB8X4 4HNB" fi_traficom 1 — SAME slug (g-series) as the key above; pinned so the merged record has ONE display form instead of flapping between "G Series" and "G-Series" by row count (the one-id-many-names class, build/observed_model_names.json)
+  "R-Serien": R Series                        # raw "R-SERIEN" nl 1 + 11 trailing-model spellings ("R-SERIEN, R500/R520/R530/R580/R650/560", "R-SERIEN R500", "R-SERIEN, R 580 (B8X4*4NB)", "R-SERIEN, R 650" nl_rdw; "R-SERIEN 420", "R-SERIEN R52O LB8XFHNA" es_dgt) — same class as G-Serien. English twin already in the candidate queue (uk_dft "SCANIA R SERIES EV")
+  "R Serien": R Series                        # raw "R SERIEN" nl_rdw 2 — SPACED spelling of the key above and the SAME slug (r-serien); without it the old id survives on this display form
 
 Sea:
   M 200: M200                                 # spelling variant of "M200" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -3450,6 +3490,10 @@ Studebaker:
 
 Sunbeam:
   Sunbeam: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
+  # ── REGISTER-LANGUAGE CONVENTION (issue #123): English marketing form wins;
+  # the losing id becomes a former_ids alias. Blast radius is car-only (Sunbeam
+  # also lives in motorcycle; the key is not probed there). ──
+  "Alpine Serie": Alpine Series               # raw "ALPINE SERIE V" nl 16, "ALPINE SERIE III" nl 5, "ALPINE SERIE IV" nl 2, "ALPINE SERIE II" nl 1, "ALPINE SERIE V CABRIOLET" nl 1, "ALPINE SERIE" nz 1 — the Rootes Alpine ran Series I-V (https://en.wikipedia.org/wiki/Sunbeam_Alpine); the Roman numeral is stripped by collapse_variant, leaving two ids for one nameplate. car/sunbeam/alpine-series is ALREADY PUBLISHED (fi, nl) from the English raws, so this is a pure FOLD onto a live twin
 
 Super Soco:
   Cpx: CPx                                  # THE CORRECT FORM IS NOT ALL-CAPS: VMoto Soco writes CPx/CUx with a LOWERCASE x (https://en.vmotosoco.com/cpx-en/). Wikipedia writes CPX and is wrong. A bulk "type codes are uppercase" rule would have produced "CPX" confidently — this is why the acronym worklist is stylings-first and per-token
@@ -4229,6 +4273,17 @@ Volkswagen:
   Dune Buggy: null  # SPACED sibling of the Dune-Buggy null above, measured live in the verification build (nz raws `DUNE BUGGY`); same kit-car class — https://en.wikipedia.org/wiki/Dune_buggy
 
 Volvo:
+  # ── REGISTER-LANGUAGE CONVENTION (issue #123): "FH Serien"/"FM Serien"
+  # (Swedish) and "FH Series"/"FM Series" (uk_dft GenModel) are the same range
+  # label reaching two ids in one make — truck/volvo/fm-serien and
+  # truck/volvo/fm-series were BOTH published side by side, which is the exact
+  # defect #123 reports. English wins; former_ids.yml carries the losers. Keys
+  # replay-verified byte-exact against pipeline origin/main with recording
+  # proxies; blast radius is truck-only (Volvo also lives in bus/car/van and
+  # neither key is probed there). The same altitude caveat recorded in the
+  # Scania block above applies here and is filed with it. ──
+  "FH Serien": FH Series                      # raw "FH SERIEN FH 16 750" es_dgt 1; "FH SERIEN, FH-420" nl_rdw 1; "FH- SERIEN FH 460" nl_rdw 1 — English twin already in the candidate queue (uk_dft "VOLVO FH SERIES", gb 35), so this FOLDS and publishes es+nl+gb
+  "FM Serien": FM Series                      # raw "FM SERIEN FM 450" es_dgt 1, "FM SERIEN FM500" es_dgt 1, "FM SERIEN, FM370" nl_rdw 1 — truck/volvo/fm-series is ALREADY PUBLISHED (gb, uk_dft "VOLVO FM SERIES" 166): the two conventions are live in the catalog simultaneously today. Pure FOLD onto the live twin
   240 Polar U9: null     # single-trim registration noise
   "123GT": "123 GT"                           # spelling variant of "123 GT" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "164E": "164 E"                             # spelling variant of "164 E" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence


### PR DESCRIPTION
Fixes #123.

Issue #123 reports BMW carrying two slug conventions in one make (`bmw/serie-1`,
`bmw/serie-3` alongside `bmw/2-series`). **Adjudicated in the issue thread:** the
English marketing convention wins — it is what the normalizer's own family rule
already emits (`normalizer.rb#bmw` returns `"#{$1} Series"`) — and every losing id
becomes a `former_ids` alias so stored consumer ids keep resolving (the #111
posture).

BMW's own `serie-N` ids were already aliased in the 2026-07-26 trim-fold wave. This
PR lands **the rest of the population**, because the reporter's question ("which
convention did this nameplate land on?") is unanswerable for five more makes.

---

## 1. Full population scan — all makes, all kinds

Scanned every `catalog/<kind>/models.json` on `origin/main` (**15,677 published
records** across bus 411 · car 6,224 · moped 1,252 · motorcycle 5,805 · truck 1,246
· van 739) for any `id`, `slug` or `name` matching `serie-` / `serien-` / `series-`
(net: `/seri/i`, deliberately wider than the three literals). Also swept
`makes.json` in every kind, and ran a second pass for accented and other-language
forms (`/s[eéèê]ri|reihe|reeks|sarja|série/i`).

| result | count |
|---|---|
| records matching `/seri/i` | **77** |
| → **KEEP** — genuine English `Series` nameplates | **70** |
| → **FOLD** onto an English twin | **6** |
| → **RENAME** to the English form (no twin) | **1** |
| make-level (`makes.json`) hits, any kind | **0** |
| live non-English forms outside `/seri/i` (`REIHE`, `REEKS`, `SARJA`, `Série`) | **0** |

**Zero non-English-register records remain in the KEEP bucket after the fix** —
i.e. the 7 acted rows are the complete non-English population, not a sample.

### The 7 acted records

| published id (before) | name | countries | becomes | action |
|---|---|---|---|---|
| `car/land-rover/serie-i-80` | `"Serie I 80"` | fi nl | `car/land-rover/series-i-80` | **RENAME** |
| `car/morris/oxford-serie` | `"Oxford Serie"` | fi nz | `car/morris/oxford-series` | **FOLD** |
| `car/sunbeam/alpine-serie` | `"Alpine Serie"` | nl nz | `car/sunbeam/alpine-series` | **FOLD** |
| `truck/scania/g-serien` | `"G-Serien"` | es nl | `truck/scania/g-series` | **FOLD** |
| `truck/scania/r-serien` | `"R-Serien"` | es nl | `truck/scania/r-series` | **FOLD** |
| `truck/volvo/fh-serien` | `"FH Serien"` | es nl | `truck/volvo/fh-series` | **FOLD** |
| `truck/volvo/fm-serien` | `"FM Serien"` | es nl | `truck/volvo/fm-series` | **FOLD** |

`truck/volvo/fm-serien` **and** `truck/volvo/fm-series` were both published
simultaneously — the defect #123 describes is live outside BMW, not hypothetical.
Two folds land on an already-published twin (`sunbeam/alpine-series` fi+nl,
`volvo/fm-series` gb); four land on a twin sitting in the candidate queue
(`morris/oxford-series` nl 13, `volvo/fh-series` gb 35, `scania/g-series` fi 1,
`scania/r-series` gb 1), so those records *gain* a country rather than merely
changing slug.

### KEEP bucket (70) — evidence

Genuine nameplates that contain the English word *Series*; no action. `Series 62`
(Cadillac), `Series I`/`88 Series` (Land Rover, 13 records), `E-Type Series 3 V12`
(Jaguar, 11), `800 Series` (Rover, 6), `Series 40 Special` (Buick, 3),
`B Series`/`E Series` (Mazda), `K Series`/`R Series` (BMW motorcycles), plus
Beauford, Bentley, Daimler, Isuzu, Kubota, LDV, Morgan, Morris (4), NIU,
Oldsmobile, Singer, Wacker Neuson. BMW's 10 car+motorcycle records are the
already-corrected side of #123 and carry `car/bmw/serie-N` in `former_ids`.

---

## 2. Ten rename keys for seven records — and why

Two published ids are reached by **two display forms that slugify identically**, so
a single key retires nothing: the record simply republishes under the other form
(the `3 C` / `3. C` gotcha already documented in the BMW block).

* `slug r-serien` ← `"R-Serien"` (12 raw spellings) **and** `"R Serien"` (nl 2)
* `slug serie-i-80` ← `"Serie I 80"` (fi) **and** `"Serie I-80"` (nl)

One more key protects the *target*: the corpus produces `"G-Series"` (fi_traficom
`G-series G490 LB8X4 4HNB`) for the same `g-series` slug the fold lands on, so it is
pinned onto the canonical `"G Series"` — otherwise the merged record's display name
flaps between the two spellings by row count.

---

## 3. Verification

**Replay-verified byte-exact against pipeline `origin/main`.** Reachability was
measured with the **recording-proxy method** documented in
`pipeline/tools/gen_review_pack.rb` — `@o.model_renames` wrapped in a proxy that
records every `key?` probe at the exact consultation point
(`renames = @o.model_renames[make]; curated = renames&.key?(nameplate)`) while
delegating unchanged to the real data. No disable-seam, no behavioural distortion;
all five makes already have a `renames.yml` block, so no stub block was synthesised.

```
probes recorded (distinct make|nameplate pairs): 134302

Land Rover  "Serie I 80"   -> "Series I 80"    REACHABLE  rows=1  {"car"=>1}
Land Rover  "Serie I-80"   -> "Series I 80"    REACHABLE  rows=1  {"car"=>1}
Morris      "Oxford Serie" -> "Oxford Series"  REACHABLE  rows=2  {"car"=>2}
Sunbeam     "Alpine Serie" -> "Alpine Series"  REACHABLE  rows=6  {"car"=>6}
Scania      "G-Serien"     -> "G Series"       REACHABLE  rows=3  {"truck"=>3}
Scania      "G-Series"     -> "G Series"       REACHABLE  rows=1  {"truck"=>1}
Scania      "R-Serien"     -> "R Series"       REACHABLE  rows=12 {"truck"=>12}
Scania      "R Serien"     -> "R Series"       REACHABLE  rows=1  {"truck"=>1}
Volvo       "FH Serien"    -> "FH Series"      REACHABLE  rows=3  {"truck"=>3}
Volvo       "FM Serien"    -> "FM Series"      REACHABLE  rows=3  {"truck"=>3}
```

**Kind-blind blast check.** `renames.yml` blocks are make-scoped but kind-blind
(NAMING.md §3), and all five makes live in 2-4 kinds each. Every key fires in
**exactly one** kind — Land Rover/Morris/Sunbeam car-only (they also publish in
bus/truck/van, motorcycle), Scania/Volvo truck-only (they also publish in bus, and
Volvo in car/van). Zero cross-kind collateral.

**Full build.** `VDB_DATA_REPO=<this branch> ruby pipeline/run.rb` → **exit 0,
`validate: ALL GATES GREEN`**. `former_ids: 3967 migration aliases over 2382
records` (was 3960/2375). Published ids 15,626 → 15,624: 7 old ids retired, 5 new
minted (2 folds landed on already-live twins) — the arithmetic closes exactly.

**`propose_former_ids.rb` verifier** (baseline pristine build vs fix build):

```
intents=11395 proposed=0 dead_keys=2 evidence_loss=0 unexplained=0
# ---- PROPOSED (0 new; 9 already in former_ids.yml) ----
```

* `proposed=0` — the 7 authored entries fully cover the override layer's intent.
* `evidence_loss=0` — rule 4 (successor countries ⊇ old countries) holds everywhere.
* `unexplained=0` — no orphan disappearance.
* `dead_keys=2` — **investigated and pre-existing**: `Chrysler: Town&country
  Touring -> Town & Country` (published as `"Town & Country Touring"`) and
  `Jaguar: Xj-Sc -> XJ-S` (published as `"Xj Sc"`). Both reproduce byte-for-byte
  running the verifier against a pristine `origin/main` worktree and both keys are
  present on `origin/main` — unrelated to #123, reported here rather than batched
  into this PR.

**Availability union, per fold — 0 lost, or STOP:**

| old id | old cc | successor cc | gained | verdict |
|---|---|---|---|---|
| `car/land-rover/serie-i-80` | fi,nl | fi,nl | — | OK (0 lost, aliased) |
| `car/morris/oxford-serie` | fi,nz | fi,nl,nz | **nl** | OK (0 lost, aliased) |
| `car/sunbeam/alpine-serie` | nl,nz | fi,nl,nz | — | OK (0 lost, aliased) |
| `truck/scania/g-serien` | es,nl | es,fi,nl | **fi** | OK (0 lost, aliased) |
| `truck/scania/r-serien` | es,nl | es,gb,nl | **gb** | OK (0 lost, aliased) |
| `truck/volvo/fh-serien` | es,nl | es,gb,nl | **gb** | OK (0 lost, aliased) |
| `truck/volvo/fm-serien` | es,nl | es,gb,nl | — | OK (0 lost, aliased) |

Each row also asserts the old id is *gone* from the new build and that the
successor's `former_ids` carries it. 7/7 pass.

**Resulting records:**

```
car/land-rover/series-i-80  "Series I 80"    fi,nl     former_ids=["car/land-rover/serie-i-80"]
car/morris/oxford-series    "Oxford Series"  fi,nl,nz  former_ids=["car/morris/oxford-serie"]
car/sunbeam/alpine-series   "Alpine Series"  fi,nl,nz  former_ids=["car/sunbeam/alpine-serie"]
truck/scania/g-series       "G Series"       es,fi,nl  former_ids=["truck/scania/g-serien"]
truck/scania/r-series       "R Series"       es,gb,nl  former_ids=["truck/scania/r-serien"]
truck/volvo/fh-series       "FH Series"      es,gb,nl  former_ids=["truck/volvo/fh-serien"]
truck/volvo/fm-series       "FM Series"      es,gb,nl  former_ids=["truck/volvo/fm-serien"]
```

**`former_ids.yml` chain scan (file-wide, before appending).** 3,960 existing
entries, **0 unflattened chains** (no value is also a key). For each of the seven
new lines: inbound edge set **empty** (nothing already aliases the retiring id, so
there is nothing to flatten), target is not itself a retired key, retiring id not
already present. Stated per line in the file. Appended only — nothing rewritten.

**Other gates.** `scripts/lint_curation.rb` OK (109 files) · `scripts/lint_overrides.rb`
OK · `scripts/reorg_make_blocks.rb --check` OK (blocks already alphabetical, no
reorder needed) · pipeline `test_override_key_reachability`,
`test_id_contract_gate`, `test_normalizer`, `test_normalizer_families` all PASS
against this branch. `scripts/lint_dataset.rb` reports its 6 pre-existing
`code_string` suspects (`daf/xf410`, `daf/xg430`, `heuliez-bus/gx437`,
`leyland-daf/fa45|fa50|fa55`) — byte-identical on pristine `origin/main`, untouched
here. Never built with `--publish`.

---

## 4. Documentation

`NAMING.md` gains **§7.6 "Register LANGUAGE never decides the canonical form —
English does"**, so the next occurrence is a rule and not a rediscovery. It records
the adjudication, the canonical shape (`<designation> Series`, spaced, capital S),
and the three things that make the fix survive: alias every losing id; key **every**
spelling that reaches the same slug in one change; pin the target's variant
spellings too.

---

## 5. Two findings this PR deliberately does NOT act on

**(a) The altitude question for heavy-vehicle range labels.** `R-SERIEN, R500`,
`G-SERIEN, G 480`, `FH SERIEN FH 16 750` — the raw rows *name a model the label does
not*, and `scania/r450…r730`, `scania/g450/g480`, `volvo/fh420/fh460/fh16` are all
separately published. That is structurally the BMW `SERIE X, X3` shape, whose
verdict was `null` with a `removals.yml` ledger line. #123 is a slug-convention
issue and its ruling is that losing ids keep **resolving**, not that records are
deleted, so re-adjudicating altitude here would smuggle a deletion into a rename
PR. The caveat is written into the Scania and Volvo blocks verbatim; it wants its
own issue and its own evidence.

**(b) The candidate-queue residue (unpublished) is 30× the published one.** The same
defect class sits in the candidate queue at **341 records** — car 254 · van 44 ·
motorcycle 18 · moped 13 · truck 12 — concentrated in `car/bmw` (75),
`car/land-rover` (43), `car/citroen` (21), `van/citroen` (15), `car/cadillac` (15),
`van/land-rover` (14), `truck/scania` (7). Highest-count examples:
`truck/scania/s-serien` nl 11, `truck/scania/r-serie` nl 6, `truck/renault/d-serie`
nl 4, `truck/daf/cf-serien` nl 3, `truck/daf/xf-serien` nl 2, `truck/volvo/fl-serien`
es 1. Folding those would *add* published records by pushing unions over the
two-country threshold — a scope change, not a convention fix, and at 341 instances
it is rule-first territory (NAMING.md §4: a defect class above ~20 instances is a
normalizer rule, not N override lines). Filed as measured follow-up work; the
measurement is the contribution here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
