### PR TITLE
Honda cluster folds: CB600 and CBR900 — 8 records to 2

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -486,13 +486,13 @@
 "motorcycle/honda/benly125":                   "motorcycle/honda/benly-125"                   # BENLY125 -> Benly 125  [nl,nz]
 "motorcycle/honda/bros400":                    "motorcycle/honda/bros-400"                    # BROS400 -> Bros 400  [nl,ua]
 "motorcycle/honda/cb500four":                  "motorcycle/honda/cb500-four"                  # CB500FOUR -> CB500 Four  [fi,nl]
-"motorcycle/honda/cb600hornet":                "motorcycle/honda/cb600-hornet"                # CB600HORNET -> CB600 Hornet  [fi,nl,ua]
+"motorcycle/honda/cb600hornet": "motorcycle/honda/cb600f-hornet"                # CB600HORNET -> CB600 Hornet  [fi,nl,ua] [REPOINTED: old target folded into the Honda cluster]
 "motorcycle/honda/cb650custom":                "motorcycle/honda/cb650-custom"                # CB650CUSTOM -> CB650 Custom  [fi,nl]
 "motorcycle/honda/cb650nighthawk":             "motorcycle/honda/cb650-nighthawk"             # CB650NIGHTHAWK -> CB650 Nighthawk  [fi,nl]
 "motorcycle/honda/cb900f2hornet":              "motorcycle/honda/cb900f2-hornet"              # CB900F2HORNET -> CB900F2 Hornet  [nl,ua]
 "motorcycle/honda/cb900hornet":                "motorcycle/honda/cb900-hornet"                # CB900HORNET -> CB900 Hornet  [fi,nl,ua]
 "motorcycle/honda/cbr250four":                 "motorcycle/honda/cbr250-four"                 # CBR250FOUR -> CBR250 Four  [nl,nz]
-"motorcycle/honda/cbr900fireblade":            "motorcycle/honda/cbr900-fireblade"            # CBR900FIREBLADE -> CBR900 Fireblade  [fi,nl]
+"motorcycle/honda/cbr900fireblade": "motorcycle/honda/cbr900rr-fireblade"            # CBR900FIREBLADE -> CBR900 Fireblade  [fi,nl] [REPOINTED: old target folded into the Honda cluster]
 "motorcycle/honda/click125":                   "motorcycle/honda/click-125"                   # CLICK125 -> Click 125  [th]
 "motorcycle/honda/click160":                   "motorcycle/honda/click-160"                   # CLICK160 -> Click 160  [th]
 "motorcycle/honda/cr250enduro":                "motorcycle/honda/cr250-enduro"                # CR250ENDURO -> CR250 Enduro  [nl]
@@ -2867,6 +2867,12 @@
 "motorcycle/yamaha/ns": "moped/yamaha/ns50" # G-1: UK Model column splits the pooled stub by displacement; single successor
 "motorcycle/yamaha/nxc": "motorcycle/yamaha/nxc125" # G-1: UK Model column splits the pooled stub by displacement; single successor
 "motorcycle/yamaha/ys": "motorcycle/yamaha/ys125" # G-1: UK Model column splits the pooled stub by displacement; single successor
+"motorcycle/honda/cb600": "motorcycle/honda/cb600f-hornet" # Honda cluster fold: Honda publishes one nameplate and the register spellings are truncations of it.
+"motorcycle/honda/cb600-hornet": "motorcycle/honda/cb600f-hornet" # Honda cluster fold: Honda publishes one nameplate and the register spellings are truncations of it.
+"motorcycle/honda/cb600f": "motorcycle/honda/cb600f-hornet" # Honda cluster fold: Honda publishes one nameplate and the register spellings are truncations of it.
+"motorcycle/honda/cbr900": "motorcycle/honda/cbr900rr-fireblade" # Honda cluster fold: Honda publishes one nameplate and the register spellings are truncations of it.
+"motorcycle/honda/cbr900-fireblade": "motorcycle/honda/cbr900rr-fireblade" # Honda cluster fold: Honda publishes one nameplate and the register spellings are truncations of it.
+"motorcycle/honda/cbr900rr": "motorcycle/honda/cbr900rr-fireblade" # Honda cluster fold: Honda publishes one nameplate and the register spellings are truncations of it.
 
 # ── A NOTE ON CHAINS, after three in one session (S2W 2026-07-26) ───────────
 # Every one had the identical shape: I retire an id X (rename/fold), and

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1730,6 +1730,12 @@ Harley-Davidson:
   "Road Glide Special Fltrxs":               "Fltrxs Road Glide Special"    # PERMUTATION FOLD (verified batch, tier A): Code-first 7 vs name-first 2, and H-D's code page pairs FLTRXS with Road Glide Special.
 
 Honda:
+  "CB600": "CB600F Hornet"                 # HONDA CLUSTER FOLD: Honda's page heading is "1998 HORNET 600/CB600F HORNET" (https://global.honda/en/CB/models/1998_hornet-600/) and Honda publishes NO bare CB600 — "CB600", "CB600F" and "CB600 Hornet" are register truncations of one machine.
+  "CB600 Hornet": "CB600F Hornet"          # same cluster, same source
+  "CB600F": "CB600F Hornet"                # same cluster, same source
+  "CBR900": "CBR900RR Fireblade"           # HONDA CLUSTER FOLD: Honda publishes "CBR900RR Fireblade" (https://global.honda/en/CBR/models/1992_cbr900rr/); there is no bare "CBR900" model, so "CBR900", "CBR900 Fireblade" and "CBR900RR" are truncations of one machine.
+  "CBR900 Fireblade": "CBR900RR Fireblade" # same cluster, same source
+  "CBR900RR": "CBR900RR Fireblade"         # same cluster, same source
   Honda: null                             # motorcycle fi|nl AND moped nl|nz — one make-scoped key covers both kinds (renames are kind-blind)
   "ST1100P.EUROPEAN Abs-Tcs":        ST1100P.EUROPEAN           # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
   "HR-V Exl Cvt":                HR-V                   # trim/transmission tokens fold into the nameplate (NAMING.md); EXL is a trim, CVT a gearbox, SH-AWD a drivetrain


### PR DESCRIPTION
First slice of the Honda duplicate work. A read-only dossier covered all **53** code-vs-marketing-name pairs; these are the two clusters where Honda's own page settles the name and the base is unambiguous.

    CB600 · CB600F · CB600 Hornet · CB600F Hornet   ->  CB600F Hornet
    CBR900 · CBR900RR · CBR900 Fireblade · …        ->  CBR900RR Fireblade

    8 published records -> 2

Sources: [`1998 HORNET 600/CB600F HORNET`](https://global.honda/en/CB/models/1998_hornet-600/) — Honda publishes no bare CB600 — and [the 1992 CBR900RR Fireblade page](https://global.honda/en/CBR/models/1992_cbr900rr/).

### These are clusters, not pairs — which is the finding

A pair-by-pair pass over `^([a-z]+\d+[a-z]*)-([a-z][a-z-]+)$` sees `cb600`/`cb600-hornet` and `cb600f`/`cb600f-hornet` as two unrelated pairs, and would fold them to **two different survivors**.

The Gold Wing block is worse: **20 GL1200/GL1500 records for two machines**, of which the pair regex catches only 7 pairs covering 10 records. `gl1200a`, `gl1500c-f6c`, `gl1500sev` and seven others are invisible to it, so a pair pass leaves the cluster half-merged. **That block is deliberately not in this PR** — it needs a cluster pass.

### Two repoints, found by the chain assertion

Renames are **single-pass** (`normalizer.rb:178-186`), so an alias whose target a fold retires does not go inert — it *misroutes* to a dead id:

    honda/cb600hornet      -> cb600f-hornet        (was -> cb600-hornet)
    honda/cbr900fireblade  -> cbr900rr-fireblade   (was -> cbr900-fireblade)

The assertion caught both before anything was written. (It caught them the second time — the first version of my script wrote the file *before* verifying and left a chained file on disk. Now it verifies then writes.)

### The availability question, measured rather than assumed

The dossier warned that folding could delete evidence, because **18 of the 53** folded records carry countries their base record lacks. True of the records — but not of this pipeline. Renames apply in the normalizer, *upstream* of where the reconciler builds evidence from `e.evidence`, so a fold unions by construction. Verified on the build:

    four CB600 records held   es,nl,nz · es,fi,lu,nl,nz,ua · fi,nl,ua · fi,nl,ua
    survivor cb600f-hornet    es,fi,lu,nl,nz,ua        <- exactly the union

That is worth recording because it changes the shape of the remaining work: the folds are safe without a manual availability merge.

### Also from the dossier, not acted on here

**4 pairs are genuinely different machines and must both survive** — `cb500`/`cb500-four`, `cb750`/`cb750-four`, `crf250`/`crf250-rally`, `crf300`/`crf300-rally`. Independently, those CRF pairs are the **only two** of the 53 with disjoint availability (`gb,nl` vs `th,ua`; `gb` vs `th`), so the disjointness heuristic fired on exactly the pairs first-party evidence says are distinct. Strong signal, and a good check to keep.

### Verification

    0 chains across 3,973 aliases — derived from parsed YAML comparing TARGETS
    lint_curation OK · reorg_make_blocks --check alphabetical
    build adds ZERO gate failures (the 5 remaining are the suzuki drift ids data#129 fixes)
