### PR TITLE
folds: Jaguar / Rover / Land Rover — 348 records → 168, 0 country evidence lost, 9,656 vehicles re-attributed

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1342,7 +1342,7 @@
 "car/jaguar/mki": "car/jaguar/mk-i"
 "car/jaguar/ss-100": "car/jaguar/ss100"
 "car/jaguar/xj-12": "car/jaguar/xj12"
-"car/jaguar/xj-12-l": "car/jaguar/xj12l"
+"car/jaguar/xj-12-l": "car/jaguar/xj12" # FLATTENED (was -> car/jaguar/xj12l): the wave-4 JLR fold retires xj12l as a long-wheelbase BODY variant of the XJ12, so this alias would have chained into a dead id
 "car/jaguar/xj-40": "car/jaguar/xj40"
 "car/jaguar/xj-8": "car/jaguar/xj8"
 "car/jaguar/xj-s-he": "car/jaguar/xj-s"
@@ -1352,7 +1352,7 @@
 "car/jaguar/xj-sovereign": "car/jaguar/xj-s"
 "car/jaguar/xj-sport": "car/jaguar/xj-s"
 "car/jaguar/xj-supercharged": "car/jaguar/xj-s"
-"car/jaguar/xj6-l": "car/jaguar/xj6l"
+"car/jaguar/xj6-l": "car/jaguar/xj6" # FLATTENED (was -> car/jaguar/xj6l): same fold, same reason
 "car/jaguar/xjrs": "car/jaguar/xjr-s"
 "car/jaguar/xjs": "car/jaguar/xj-s"
 "car/jaguar/xjs-auto": "car/jaguar/xj-s"
@@ -1363,7 +1363,7 @@
 "car/jaguar/xk-120": "car/jaguar/xk120"
 "car/jaguar/xk-140": "car/jaguar/xk140"
 "car/jaguar/xk-150": "car/jaguar/xk150"
-"car/jaguar/xk-150-s": "car/jaguar/xk150s"
+"car/jaguar/xk-150-s": "car/jaguar/xk150" # FLATTENED (was -> car/jaguar/xk150s): S is the triple-carburettor engine grade and xk150s folds into xk150
 "car/jaguar/xk-8": "car/jaguar/xk8"
 "car/jaguar/xkrs": "car/jaguar/xkr-s"
 "car/kia/ev-3": "car/kia/ev3"
@@ -1373,9 +1373,9 @@
 "car/kia/xceed": "car/kia/x-ceed"
 "car/lada/1200s": "car/lada/1200-s"
 "car/lancia/montecarlo": "car/lancia/monte-carlo"
-"car/land-rover/109-hardtop": "car/land-rover/109-hard-top"
-"car/land-rover/88-hardtop": "car/land-rover/88-hard-top"
-"car/land-rover/88-wb": "car/land-rover/88-w-b"
+"car/land-rover/109-hardtop": "car/land-rover/109" # FLATTENED (was -> car/land-rover/109-hard-top): Hard Top is a BODY and the id folds into the 109
+"car/land-rover/88-hardtop": "car/land-rover/88" # FLATTENED (was -> car/land-rover/88-hard-top): same fold, same reason
+"car/land-rover/88-wb": "car/land-rover/88" # FLATTENED (was -> car/land-rover/88-w-b): WB is the wheel base the number already names
 "car/land-rover/rangerover": "car/land-rover/range-rover"
 "car/lexus/ct-200": "car/lexus/ct"
 "car/lexus/ct-200-h": "car/lexus/ct"
@@ -1746,12 +1746,19 @@
 "car/renault/velsatis": "car/renault/vel-satis"
 "car/riley/rma": "car/riley/r-m-a"
 "car/rolls-royce/silvershadow": "car/rolls-royce/silver-shadow"
-"car/rover/2300s": "car/rover/2300-s"
-"car/rover/2600s": "car/rover/2600-s"
-"car/rover/3500-vanden-plas": "car/rover/3500-van-den-plas"
-"car/rover/3500s": "car/rover/3500-s"
-"car/rover/landrover": "car/rover/land-rover"
-"car/rover/rangerover": "car/rover/range-rover"
+"car/rover/2300s": "car/rover/2300" # FLATTENED (was -> car/rover/2300-s): S is an SD1 trim grade and the id folds into 2300
+"car/rover/2600s": "car/rover/2600" # FLATTENED (was -> car/rover/2600-s): same fold, same reason
+"car/rover/3500-vanden-plas": "car/rover/3500" # FLATTENED (was -> car/rover/3500-van-den-plas): Vanden Plas is a TRIM and the id folds into 3500
+"car/rover/3500s": "car/rover/3500" # FLATTENED (was -> car/rover/3500-s): same fold, same reason
+# "car/rover/landrover": "car/rover/land-rover"  — RETIRED as an alias by the
+# wave-4 JLR batch, and re-disposed as a REMOVAL (see overrides/models/removals.yml).
+# Its target car/rover/land-rover is a marque-in-the-model-column row that names
+# no Land Rover MODEL, so this pass drops it with no successor — which left this
+# alias pointing into a 404 and failed the id-contract liveness gate. An alias
+# whose target has died is strictly worse than a documented removal, so the
+# reasoning moves to removals.yml rather than being deleted (the rule-1g remedy,
+# applied in the other direction). lint_curation rule 1g forbids carrying both.
+"car/rover/rangerover": "car/land-rover/range-rover" # FLATTENED (was -> car/rover/range-rover): the Range Rover is a Land Rover and moves out of the Rover make in this change, so this alias must follow it ACROSS the make or a consumer holding the old fused spelling lands on a retired id
 "car/rover/vanden-plas": "car/rover/van-den-plas"
 "car/saab/9-4x": "car/saab/9-4-x"
 "car/saab/9-7x": "car/saab/9-7-x"
@@ -2039,7 +2046,7 @@
 "van/isuzu/nlr85exxxb": "van/isuzu/n-series"
 "van/iveco/35s": "van/iveco/35-s"
 "van/iveco/35s13": "van/iveco/35-s-13"
-"van/land-rover/90-defender": "car/land-rover/90-defender"
+"van/land-rover/90-defender": "car/land-rover/90" # FLATTENED (was -> car/land-rover/90-defender): the wave-4 fold retires 90-defender onto the 90 nameplate; this is the one cross-KIND inbound alias in the set
 "van/maxus/edeliver-9": "van/maxus/e-deliver-9"
 "van/mazda/bt-50": "van/mazda/bt50"
 "van/mercedes-benz/108d": "van/mercedes-benz/108-d"
@@ -4781,3 +4788,170 @@
 "van/chevrolet/van-20": "van/chevrolet/chevy-van" # (fi+nl) the Chevy Van 20 with the make nickname dropped by the register (raws "VAN 20"/"CHEVROLET VAN 20")
 "car/chevrolet/chevy-van-g20-sportvan": "car/chevrolet/sportvan" # (fi+nl) the SPORTVAN is the passenger configuration and is a live Chevrolet nameplate — https://en.wikipedia.org/wiki/Chevrolet_Van ; the G20 is the payload class
 "car/chevrolet/g20-sportvan": "car/chevrolet/sportvan" # (ca+nl) same: payload class on the Sportvan. CARRIES ca INTO the survivor
+# ── wave-4 JLR fold batch (Jaguar · Rover · Land Rover), dossier §A ──────────
+# 151 folds, 24 drops, 10 cross-make moves, 4 minted ids. Chain pre-flight run
+# before this block was written: 12 inbound aliases pointed at ids this pass
+# retires and were FLATTENED in place above (each says so on its line); no
+# target here is itself an alias; no self-references; no id appears in both
+# this file and removals.yml (lint_curation rule 1g).
+"car/jaguar/xe-series": "car/jaguar/xe" # FOLD onto car/jaguar/xe: uk_dft VEH0120 genmodel "JAGUAR XE SERIES" x43,700 — a DVLA range label, not a nameplate; Jaguar sells one XE (https://www.jaguar.co.uk/jaguar-range/xe/index.html). ADDS gb to jaguar/xe, which has no UK evidence today
+"car/jaguar/xf-series": "car/jaguar/xf" # FOLD onto car/jaguar/xf: uk_dft "JAGUAR XF SERIES" x94,120 — same class; ADDS gb to jaguar/xf (https://www.jaguar.co.uk/jaguar-range/xf/index.html)
+"car/jaguar/xk-series": "car/jaguar/xk" # FOLD onto car/jaguar/xk: uk_dft "JAGUAR XK SERIES" x28,729 car + x5 van — same class; ADDS gb to jaguar/xk (https://en.wikipedia.org/wiki/Jaguar_XK_(X150)). FIRES IN car AND van — the twin van/jaguar/xk-series is a candidate row, same fold, intended
+"car/jaguar/e": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: raws "E COUPE"/"E CABRIOLET"/"E SPORTS-COUPE"/"JAGUAR E" (lu,nl,nz x34) — the bare launch badge of the E-type, 1961-75 (https://www.jaguarheritage.com/vehicles/e-type/)
+"car/jaguar/xke": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: XK-E is the US-market name of the same car (ar,fi,nl,nz x12) — https://en.wikipedia.org/wiki/Jaguar_E-Type
+"car/jaguar/xke-e-type": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: same string, hyphenated register spelling — SAME SLUG as the line above, so both keys are required or the id republishes under the other display form (the BMW "3 C"/"3. C" gotcha)
+"car/jaguar/xke-v12": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: hyphenated spelling of the same, SAME SLUG (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+"car/jaguar/2-2-e-type": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: 2+2 is the long-wheelbase COUPE BODY of the Series 1/2, not a model — https://en.wikipedia.org/wiki/Jaguar_E-Type
+"car/jaguar/e-type-2-2": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: the register wrote the plus as a hyphen; same 2+2 body (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+"car/jaguar/e-type-roadster": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: hyphenated spelling, SAME SLUG (https://www.jaguarheritage.com/vehicles/e-type/)
+"car/jaguar/e-type-series": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: bare "Series" residue of a Series 1/2/3 string (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+"car/jaguar/e-type-series-2": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: Series 2 is a GENERATION (1968-71), not a nameplate — https://en.wikipedia.org/wiki/Jaguar_E-Type
+"car/jaguar/e-type-series-2-4": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: generation + a truncated 4.2-litre displacement (the comma-decimal generator, DEBT hygiene-2) — https://en.wikipedia.org/wiki/Jaguar_E-Type
+"car/jaguar/e-type-series-3-roadster": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: unhyphenated spelling, SAME SLUG (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+"car/jaguar/e-type-series-3-v12": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: generation + engine (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+"car/jaguar/e-type-v12": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: hyphenated spelling, SAME SLUG (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+"car/jaguar/e-type-v12-roadster": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: unhyphenated spelling, SAME SLUG (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+"car/jaguar/e-v12-roadster": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: bare-E badge + engine + body (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+"car/jaguar/series-three-e-type-v12": "car/jaguar/e-type" # FOLD onto car/jaguar/e-type: generation spelled in words (an fi_traficom habit) + engine — https://en.wikipedia.org/wiki/Jaguar_E-Type
+"car/jaguar/xk-120-roadster": "car/jaguar/xk120" # FOLD onto car/jaguar/xk120: OTS/Roadster is the open two-seater BODY of the XK120 (1948-54) — https://www.jaguarheritage.com/vehicles/xk120/
+"car/jaguar/xk-120-se": "car/jaguar/xk120" # FOLD onto car/jaguar/xk120: SE = the Special Equipment engine/equipment grade, not a model (https://www.jaguarheritage.com/vehicles/xk120/)
+"car/jaguar/xk-140-fhc": "car/jaguar/xk140" # FOLD onto car/jaguar/xk140: FHC = fixed-head coupe BODY of the XK140 (1954-57) — https://en.wikipedia.org/wiki/Jaguar_XK140
+"car/jaguar/xk-140-fixed-head": "car/jaguar/xk140" # FOLD onto car/jaguar/xk140: the same body, spelled out (https://en.wikipedia.org/wiki/Jaguar_XK140)
+"car/jaguar/xk-140-ots": "car/jaguar/xk140" # FOLD onto car/jaguar/xk140: OTS = open two-seater BODY (https://en.wikipedia.org/wiki/Jaguar_XK140)
+"car/jaguar/xk140-dhc": "car/jaguar/xk140" # FOLD onto car/jaguar/xk140: DHC = drophead coupe BODY (https://en.wikipedia.org/wiki/Jaguar_XK140)
+"car/jaguar/xk-150-drop-head": "car/jaguar/xk150" # FOLD onto car/jaguar/xk150: unhyphenated spelling — SAME SLUG (xk-150-drop-head), so both keys are required (https://en.wikipedia.org/wiki/Jaguar_XK150)
+"car/jaguar/xk-150-roadster": "car/jaguar/xk150" # FOLD onto car/jaguar/xk150: Roadster BODY of the XK150 (1957-61) — https://en.wikipedia.org/wiki/Jaguar_XK150
+"car/jaguar/xk150s": "car/jaguar/xk150" # FOLD onto car/jaguar/xk150: S = the triple-carburettor engine grade (XK150 S), an equipment grade of the XK150 — https://en.wikipedia.org/wiki/Jaguar_XK150
+"car/jaguar/xk120c": "car/jaguar/c-type" # FOLD onto car/jaguar/c-type: XK120C IS the C-type — the factory designation of the 1951-53 Le Mans car — https://www.jaguarheritage.com/vehicles/c-type/
+"car/jaguar/xj-executive": "car/jaguar/xj" # FOLD onto car/jaguar/xj: Executive is an XJ TRIM LEVEL (fi,nl x188) — https://en.wikipedia.org/wiki/Jaguar_XJ
+"car/jaguar/xjl": "car/jaguar/xj" # FOLD onto car/jaguar/xj: XJL = the long-wheelbase XJ BODY; the EPA/DOE baseModel column maps "XJL"/"XJL AWD" to XJ (cache/us_vehicles.csv col 66) — https://en.wikipedia.org/wiki/Jaguar_XJ
+"car/jaguar/xjl-supercharged": "car/jaguar/xj" # FOLD onto car/jaguar/xj: LWB body + supercharged engine badge; EPA baseModel "XJL FFV" to XJ (cache/us_vehicles.csv col 66)
+"car/jaguar/xj-220": "car/jaguar/xj220" # FOLD onto car/jaguar/xj220: SPELLING: Jaguar writes the supercar fused, XJ220 (1992-94, 275 built) — https://www.jaguarheritage.com/vehicles/xj220/ . This key MINTS the correct nameplate (the Cee D precedent)
+"car/jaguar/xj12-auto": "car/jaguar/xj12" # FOLD onto car/jaguar/xj12: automatic transmission is not a model (https://en.wikipedia.org/wiki/Jaguar_XJ)
+"car/jaguar/xj12-he": "car/jaguar/xj12" # FOLD onto car/jaguar/xj12: HE = "High Efficiency" (May-head) V12, an ENGINE spec from 1981 — https://en.wikipedia.org/wiki/Jaguar_XJ
+"car/jaguar/xj12c": "car/jaguar/xj12" # FOLD onto car/jaguar/xj12: the two-door COUPE body of the Series 2 (1975-77) — https://en.wikipedia.org/wiki/Jaguar_XJ
+"car/jaguar/xj12l": "car/jaguar/xj12" # FOLD onto car/jaguar/xj12: L = long-wheelbase BODY; EPA baseModel folds the same shape (XJ6L to XJ, cache/us_vehicles.csv col 66)
+"car/jaguar/xj6-2": "car/jaguar/xj6" # FOLD onto car/jaguar/xj6: truncated displacement: raws "XJ6 - 2,7 TD" / "XJ6/2" — the COMMA-decimal generator (DEBT hygiene-2), not a variant (https://en.wikipedia.org/wiki/Jaguar_XJ)
+"car/jaguar/xj6-4": "car/jaguar/xj6" # FOLD onto car/jaguar/xj6: truncated displacement: raws "XJ6 4,2 SERIES 2" x22, "XJ6 4,2 SERIES 2 AUTOMATIC" x21 — same generator (https://en.wikipedia.org/wiki/Jaguar_XJ)
+"car/jaguar/xj6-auto": "car/jaguar/xj6" # FOLD onto car/jaguar/xj6: automatic transmission is not a model (https://en.wikipedia.org/wiki/Jaguar_XJ)
+"car/jaguar/xj6-series": "car/jaguar/xj6" # FOLD onto car/jaguar/xj6: bare "Series" residue of a Series 1/2/3 string (https://en.wikipedia.org/wiki/Jaguar_XJ)
+"car/jaguar/xj6-series-1": "car/jaguar/xj6" # FOLD onto car/jaguar/xj6: Series 1 is a GENERATION (1968-73) — https://en.wikipedia.org/wiki/Jaguar_XJ
+"car/jaguar/xj6-sovereign": "car/jaguar/xj6" # FOLD onto car/jaguar/xj6: Sovereign is the TOP TRIM of the XJ6 from 1983 — https://en.wikipedia.org/wiki/Jaguar_XJ
+"car/jaguar/xj6c": "car/jaguar/xj6" # FOLD onto car/jaguar/xj6: the two-door COUPE body of the Series 2 (1975-77) — https://en.wikipedia.org/wiki/Jaguar_XJ
+"car/jaguar/xj6l": "car/jaguar/xj6" # FOLD onto car/jaguar/xj6: L = long-wheelbase BODY; EPA baseModel "XJ6L" to XJ (cache/us_vehicles.csv col 66)
+"car/jaguar/xj8-executive": "car/jaguar/xj8" # FOLD onto car/jaguar/xj8: Executive TRIM (https://en.wikipedia.org/wiki/Jaguar_XJ)
+"car/jaguar/xj8l": "car/jaguar/xj8" # FOLD onto car/jaguar/xj8: long-wheelbase BODY; EPA baseModel "XJ8L"/"XJ8l" to XJ (cache/us_vehicles.csv col 66)
+"car/jaguar/xj-sc": "car/jaguar/xj-s" # FOLD onto car/jaguar/xj-s: the SPACED twin of the settled "Xj-Sc": XJ-S line above. Raws nl_rdw "JAGUAR XJ SC"/"XJ SC" and nz_nzta "XJ SC" reach the SAME SLUG (xj-sc) and kept the record alive under the display "Xj Sc" — which is what propose_former_ids reported as a dead key. It is NOT dead: "Xj-Sc" fires on fi/nl/us rows and gen_review_pack reports no dead override keys for this make (dossier §E-3). XJ-SC is the 1983-88 targa/cabriolet BODY of the XJ-S (https://www.jaguarheritage.com/jaguar-world-may-2018-jaguar-convertible-at-30/)
+"car/jaguar/sovereign-auto": "car/jaguar/sovereign" # FOLD onto car/jaguar/sovereign: automatic transmission is not a model (https://en.wikipedia.org/wiki/Jaguar_XJ)
+"car/jaguar/sovereign-he": "car/jaguar/sovereign" # FOLD onto car/jaguar/sovereign: HE = High Efficiency V12 ENGINE spec (https://en.wikipedia.org/wiki/Jaguar_XJ)
+"car/jaguar/sovereign-v12": "car/jaguar/sovereign" # FOLD onto car/jaguar/sovereign: engine badge, not a model (https://en.wikipedia.org/wiki/Jaguar_XJ)
+"car/jaguar/s-type-4": "car/jaguar/s-type" # FOLD onto car/jaguar/s-type: truncated displacement from raw "S-TYPE 4,2 V8" (the comma-decimal generator) — https://en.wikipedia.org/wiki/Jaguar_S-Type
+"car/jaguar/s-type-executive": "car/jaguar/s-type" # FOLD onto car/jaguar/s-type: Executive TRIM (https://en.wikipedia.org/wiki/Jaguar_S-Type)
+"car/jaguar/s-type-r": "car/jaguar/s-type" # FOLD onto car/jaguar/s-type: the EPA/DOE baseModel column says "S-Type R" to "S-type" (cache/us_vehicles.csv col 66); R is the supercharged performance TRIM, 2002-08 (https://en.wikipedia.org/wiki/Jaguar_S-Type)
+"car/jaguar/x-type-2": "car/jaguar/x-type" # FOLD onto car/jaguar/x-type: truncated displacement from raws "X-TYPE 2,0 D I4 EXECUTIVE"/"X-TYPE 2,5 V6" — https://en.wikipedia.org/wiki/Jaguar_X-Type
+"car/jaguar/x-type-sport-brake": "car/jaguar/x-type" # FOLD onto car/jaguar/x-type: Sport Brake = the ESTATE BODY; EPA baseModel "X-Type Sport Brake" to "X-Type" (cache/us_vehicles.csv col 66)
+"car/jaguar/xf-s": "car/jaguar/xf" # FOLD onto car/jaguar/xf: hyphenated register spelling — SAME SLUG (xf-s), so both keys are required (https://en.wikipedia.org/wiki/Jaguar_XF)
+"car/jaguar/xf-30t": "car/jaguar/xf" # FOLD onto car/jaguar/xf: 30t = a POWER/engine badge; EPA baseModel "XF 30t" to "XF" (cache/us_vehicles.csv col 66)
+"car/jaguar/xf-p250": "car/jaguar/xf" # FOLD onto car/jaguar/xf: P250 = a power badge (250 PS); EPA baseModel to "XF" (cache/us_vehicles.csv col 66)
+"car/jaguar/xf-p300": "car/jaguar/xf" # FOLD onto car/jaguar/xf: P300 power badge; EPA baseModel to "XF" (cache/us_vehicles.csv col 66)
+"car/jaguar/xf-supercharged": "car/jaguar/xf" # FOLD onto car/jaguar/xf: engine badge; EPA baseModel "XF Supercharged" to "XF" (cache/us_vehicles.csv col 66)
+"car/jaguar/xf-sportbrake": "car/jaguar/xf" # FOLD onto car/jaguar/xf: Sportbrake = the ESTATE BODY; EPA baseModel "XF Sportbrake AWD" to "XF" (cache/us_vehicles.csv col 66). FIRES IN car AND van — the twin van/jaguar/xf-sportbrake is a candidate row, same fold, intended
+"car/jaguar/xe-25t": "car/jaguar/xe" # FOLD onto car/jaguar/xe: 25t = a POWER/engine badge (https://en.wikipedia.org/wiki/Jaguar_XE)
+"car/jaguar/xe-p250": "car/jaguar/xe" # FOLD onto car/jaguar/xe: P250 power badge; EPA baseModel "XE P250"/"XE P250 AWD" to "XE" (cache/us_vehicles.csv col 66)
+"car/jaguar/xe-p300": "car/jaguar/xe" # FOLD onto car/jaguar/xe: P300 power badge; EPA baseModel to "XE" (cache/us_vehicles.csv col 66)
+"car/jaguar/f-pace-25t": "car/jaguar/f-pace" # FOLD onto car/jaguar/f-pace: 25t power badge (https://en.wikipedia.org/wiki/Jaguar_F-Pace)
+"car/jaguar/f-pace-30t": "car/jaguar/f-pace" # FOLD onto car/jaguar/f-pace: EPA baseModel "F-Pace 30t" to "F-Pace" (cache/us_vehicles.csv col 66)
+"car/jaguar/f-pace-p340": "car/jaguar/f-pace" # FOLD onto car/jaguar/f-pace: EPA baseModel "F-Pace P340 MHEV" to "F-Pace" (cache/us_vehicles.csv col 66)
+"car/jaguar/f-pace-p400": "car/jaguar/f-pace" # FOLD onto car/jaguar/f-pace: EPA baseModel "F-Pace P400 MHEV" to "F-Pace" (cache/us_vehicles.csv col 66)
+"car/jaguar/f-pace-s": "car/jaguar/f-pace" # FOLD onto car/jaguar/f-pace: S equipment grade (https://en.wikipedia.org/wiki/Jaguar_F-Pace)
+"car/jaguar/f-pace-svr": "car/jaguar/f-pace" # FOLD onto car/jaguar/f-pace: EPA baseModel "F-Pace SVR" to "F-Pace" (cache/us_vehicles.csv col 66); SVR is the SV performance TRIM
+"car/jaguar/f-type-p450": "car/jaguar/f-type" # FOLD onto car/jaguar/f-type: EPA baseModel "F-Type P450 ..." to "F-Type" (cache/us_vehicles.csv col 66)
+"car/jaguar/f-type-r": "car/jaguar/f-type" # FOLD onto car/jaguar/f-type: EPA baseModel "F-Type R ..." to "F-Type" (cache/us_vehicles.csv col 66)
+"car/jaguar/f-type-s": "car/jaguar/f-type" # FOLD onto car/jaguar/f-type: EPA baseModel "F-Type S ..." to "F-Type" (cache/us_vehicles.csv col 66)
+"car/jaguar/f-type-svr": "car/jaguar/f-type" # FOLD onto car/jaguar/f-type: EPA baseModel "F-Type SVR ..." to "F-Type" (cache/us_vehicles.csv col 66)
+"car/jaguar/f-type-v8-s": "car/jaguar/f-type" # FOLD onto car/jaguar/f-type: EPA baseModel "F-Type V8 S Convertible" to "F-Type" (cache/us_vehicles.csv col 66)
+"car/jaguar/e-pace-p250": "car/jaguar/e-pace" # FOLD onto car/jaguar/e-pace: EPA baseModel "E-Pace P250" to "E-Pace" (cache/us_vehicles.csv col 66)
+"car/jaguar/e-pace-p300": "car/jaguar/e-pace" # FOLD onto car/jaguar/e-pace: EPA baseModel "E-Pace P300" to "E-Pace" (cache/us_vehicles.csv col 66)
+"car/jaguar/i-pace-ev400": "car/jaguar/i-pace" # FOLD onto car/jaguar/i-pace: EV400 is a POWER designation, not a model; EPA baseModel "I-Pace EV400" to "I-Pace" (cache/us_vehicles.csv col 66), and NAMING's own "Leaf 40KWH to Leaf" precedent
+"car/jaguar/range-rover-evoque": "car/land-rover/range-rover-evoque" # MOVE Jaguar -> Land Rover (4 vehicles: es 1, nl 3). normalizer.rb#split_compound_make already routes raw make JAGUAR LAND ROVER by nameplate; these rows arrive under a bare JAGUAR make string, so the split never sees them
+"van/jaguar/defender": "van/land-rover/defender" # MOVE Jaguar -> Land Rover (3 vehicles, es+nl, van kind). Same shared-registrant defect as the Evoque row above
+"car/rover/100-series": "car/rover/100" # FOLD onto car/rover/100: uk_dft VEH0120 genmodel "ROVER 100 SERIES" x4,218 — a DVLA range label, not a nameplate; Rover sold the "Rover 100" (1994-98) — https://en.wikipedia.org/wiki/Rover_100 . ADDS gb to rover/100. FIRES IN car AND van (van/rover/100-series, same fold, intended)
+"car/rover/200-series": "car/rover/200" # FOLD onto car/rover/200: "ROVER 200 SERIES" x9,588 uk_dft + nl/fi — range label; the car is the Rover 200 (1984-2005) — https://en.wikipedia.org/wiki/Rover_200 . ADDS fi+gb to rover/200. FIRES IN car AND van (van/rover/200-series, same fold, intended)
+"car/rover/400-series": "car/rover/400" # FOLD onto car/rover/400: "ROVER 400 SERIES" x4,246 — range label; the car is the Rover 400 (1990-99) — https://en.wikipedia.org/wiki/Rover_400 . ADDS fi+gb to rover/400
+"car/rover/600-series": "car/rover/600" # FOLD onto car/rover/600: "ROVER 600 SERIES" x2,135 — range label; the car is the Rover 600 (1993-99) — https://en.wikipedia.org/wiki/Rover_600 . ADDS gb+nl to rover/600
+"car/rover/800-series": "car/rover/800" # FOLD onto car/rover/800: "ROVER 800 SERIES" x1,603 — range label; the car is the Rover 800 (1986-99) — https://en.wikipedia.org/wiki/Rover_800 . MINTS rover/800 (the Cee D precedent); the 820/825/827 engine-variant records already publish beneath it. FIRES IN car AND van (van/rover/800-series, same fold, intended)
+"car/rover/2000-series": "car/rover/2000" # FOLD onto car/rover/2000: "ROVER 2000 SERIES" x2,152 — range label for the P6 2000 (1963-77) — https://en.wikipedia.org/wiki/Rover_P6 . ADDS gb to rover/2000. FIRES IN car AND van; the bus-kind row series-collapses to "2000" and is NOT probed with this key
+"car/rover/10-hp": "car/rover/10" # FOLD onto car/rover/10: HP is the RAC horsepower TAX RATING, not part of the name; Rover sold the "Rover Ten" — https://en.wikipedia.org/wiki/Rover_10
+"car/rover/12hp": "car/rover/12" # FOLD onto car/rover/12: the same rating suffix on the Rover Twelve — https://en.wikipedia.org/wiki/Rover_12
+"car/rover/p4-75": "car/rover/75" # FOLD onto car/rover/75: hyphenated register spelling — SAME SLUG (p4-75), so both keys are required (https://en.wikipedia.org/wiki/Rover_P4)
+"car/rover/2000-sc": "car/rover/2000" # FOLD onto car/rover/2000: SC = the single-carburettor ENGINE spec of the P6 2000 — https://en.wikipedia.org/wiki/Rover_P6
+"car/rover/2000-tc": "car/rover/2000" # FOLD onto car/rover/2000: TC = the twin-carburettor ENGINE spec of the P6 2000 — https://en.wikipedia.org/wiki/Rover_P6
+"car/rover/tc-2000": "car/rover/2000" # FOLD onto car/rover/2000: spaced spelling — SAME SLUG (tc-2000), so both keys are required (https://en.wikipedia.org/wiki/Rover_P6)
+"car/rover/2200-tc": "car/rover/2200" # FOLD onto car/rover/2200: TC engine spec; MINTS rover/2200 — the P6 2200 (1973-77) is its own model, a 2.2-litre that replaced the 2000 — https://en.wikipedia.org/wiki/Rover_P6
+"car/rover/2300-s": "car/rover/2300" # FOLD onto car/rover/2300: S = a trim/engine grade of the SD1 2300 — https://en.wikipedia.org/wiki/Rover_SD1
+"car/rover/2600-s": "car/rover/2600" # FOLD onto car/rover/2600: S grade of the SD1 2600 — https://en.wikipedia.org/wiki/Rover_SD1
+"car/rover/2600-automatic": "car/rover/2600" # FOLD onto car/rover/2600: transmission is not a model (https://en.wikipedia.org/wiki/Rover_SD1)
+"car/rover/2600-van-den-plas": "car/rover/2600" # FOLD onto car/rover/2600: Vanden Plas = the luxury TRIM (a British Leyland coachbuilder name used as a trim level) — https://en.wikipedia.org/wiki/Rover_SD1
+"car/rover/2600se": "car/rover/2600" # FOLD onto car/rover/2600: SE equipment grade (https://en.wikipedia.org/wiki/Rover_SD1)
+"car/rover/3500-auto": "car/rover/3500" # FOLD onto car/rover/3500: transmission is not a model (https://en.wikipedia.org/wiki/Rover_SD1)
+"car/rover/3500-s": "car/rover/3500" # FOLD onto car/rover/3500: S grade of the P6B/SD1 3500 — https://en.wikipedia.org/wiki/Rover_P6
+"car/rover/3500-sdi": "car/rover/3500" # FOLD onto car/rover/3500: engine/injection badge (https://en.wikipedia.org/wiki/Rover_SD1)
+"car/rover/3500-van-den-plas": "car/rover/3500" # FOLD onto car/rover/3500: Vanden Plas TRIM (https://en.wikipedia.org/wiki/Rover_SD1)
+"car/rover/3500-vitesse": "car/rover/3500" # FOLD onto car/rover/3500: Vitesse = the SD1 performance TRIM — https://en.wikipedia.org/wiki/Rover_SD1
+"car/rover/214-i": "car/rover/214" # FOLD onto car/rover/214: i = fuel injection, an engine spec (https://en.wikipedia.org/wiki/Rover_200)
+"car/rover/216-sli": "car/rover/216" # FOLD onto car/rover/216: SLi equipment grade (https://en.wikipedia.org/wiki/Rover_200)
+"car/rover/220-turbo": "car/rover/220" # FOLD onto car/rover/220: a forced-induction ENGINE badge (https://en.wikipedia.org/wiki/Rover_200)
+"car/rover/416-si": "car/rover/416" # FOLD onto car/rover/416: Si equipment grade (https://en.wikipedia.org/wiki/Rover_400)
+"car/rover/416-sli": "car/rover/416" # FOLD onto car/rover/416: SLi equipment grade (https://en.wikipedia.org/wiki/Rover_400)
+"car/rover/420-d": "car/rover/420" # FOLD onto car/rover/420: D = diesel ENGINE (https://en.wikipedia.org/wiki/Rover_400)
+"car/rover/620-si": "car/rover/620" # FOLD onto car/rover/620: Si equipment grade — ADDS fi to rover/620 (https://en.wikipedia.org/wiki/Rover_600)
+"car/rover/825i": "car/rover/825" # FOLD onto car/rover/825: i = fuel injection (https://en.wikipedia.org/wiki/Rover_800)
+"car/rover/827-sterling": "car/rover/827" # FOLD onto car/rover/827: Sterling = the top TRIM of the 800 (and the US marque name); car/rover/sterling stays live for rows that carry ONLY that word — https://en.wikipedia.org/wiki/Rover_800
+"car/rover/mini-cooper-1-3i": "car/rover/mini-cooper" # FOLD onto car/rover/mini-cooper: 1.3i is the displacement + injection ENGINE spec, not a model — https://en.wikipedia.org/wiki/Mini
+"car/rover/range-rover": "car/land-rover/range-rover" # MOVE Rover -> Land Rover. The Range Rover is a Land Rover product: British Leyland created Land Rover Limited in 1978 (https://en.wikipedia.org/wiki/Rover_Company) and landrover.co.uk lists RANGE ROVER as one of its three families while Rover lists nothing. 8,427 car vehicles, incl. the DVLA's own genmodel ROVER RANGE ROVER x7,227. The make changes, so no rename could do this — moves.yml carries it and this alias keeps the old id resolvable
+"van/rover/range-rover": "car/land-rover/range-rover" # MOVE Rover -> Land Rover, van kind (gb,nl), and a CROSS-KIND alias by measurement. The dossier expected this to mint van/land-rover/range-rover; the build says otherwise and the build wins. Reconciler.cross_kind_prune! (reconciler.rb:105-130) drops a kind's copy of an id when one kind holds >=97% of its total count: before the move, rover/range-rover was car 8,427 / van 659 (92.7%, under the bar, so the van record lived); after it, every Range Rover row consolidates onto land-rover/range-rover at car ~149,000 vs van ~1,200 (>99%), so the van twin is pruned as mis-kinded. That is the pruner working — the Range Rover IS a car — so the alias names the car record, exactly like the shipped van/land-rover/90-defender -> car/land-rover/90-defender line. No evidence is lost: the van rows' gb+nl counts are carried on the car record, which already publishes both countries
+"car/rover/range": "car/land-rover/range-rover" # MOVE after a pre-move rename: nz_nzta truncates the genmodel to RANGE (x59) and the same register carries the full RANGE ROVER x146, so `Range: Range Rover` normalises it first and moves.yml then re-attaches it to Land Rover
+"car/rover/ranger-rover": "car/land-rover/range-rover" # MOVE after a pre-move TYPO fix: RANGER ROVER (nl x2) / RANGER/ROVER (nz x1) against RANGE ROVER x1,130 in the same two registers — 2,809:1, and the same typo appears independently under make LAND ROVER. Renamed to Range Rover, then moved
+"van/rover/defender": "van/land-rover/defender" # MOVE Rover -> Land Rover (fi 2, nl 4). The Defender name dates from the 1991 model year, thirteen years after Land Rover Limited was created — it was never a Rover-marque product (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+"car/rover/mgf": "car/mg/mgf" # MOVE Rover -> MG (489 vehicles: fi 2, lu 1, nl 27, nz 459). The MGF is an MG (1995-2002); MG was a Rover Group marque 1986-2000, which is why the registers file it under ROVER. Target car/mg/mgf is live (fi,gb,lu,nl,nz)
+"car/rover/mg-zt": "car/mg/zt" # MOVE Rover -> MG (2 vehicles, fi+nl). The MG ZT is an MG (2001-05); target car/mg/zt is live (gb,nl) and GAINS fi from this move
+"car/land-rover/86-wb": "car/land-rover/86" # FOLD onto car/land-rover/86: WB = wheel base — the register spelling out what the number already says (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-hard-top": "car/land-rover/88" # FOLD onto car/land-rover/88: Hard Top is a Land Rover BODY, built on every wheelbase (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-ht": "car/land-rover/88" # FOLD onto car/land-rover/88: HT = hard top, abbreviated by the register (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-pick-up": "car/land-rover/88" # FOLD onto car/land-rover/88: hyphenated spelling — SAME SLUG (88-pick-up), so both keys are required. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"van/land-rover/88-pick-up": "van/land-rover/88" # FOLD onto van/land-rover/88: hyphenated spelling — SAME SLUG (88-pick-up), so both keys are required. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-series": "car/land-rover/88" # FOLD onto car/land-rover/88: bare "Series" residue of a Series II/III string. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-series-2a": "car/land-rover/88" # FOLD onto car/land-rover/88: Series 2A is a GENERATION (1961-71), not a nameplate. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-series-3": "car/land-rover/88" # FOLD onto car/land-rover/88: Series III generation (1971-85). FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-series-iia": "car/land-rover/88" # FOLD onto car/land-rover/88: the Roman spelling of Series 2A — a DIFFERENT slug from the line above, so both are needed. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-station": "car/land-rover/88" # FOLD onto car/land-rover/88: Station Wagon BODY, truncated by the register (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-sw": "car/land-rover/88" # FOLD onto car/land-rover/88: SW = station wagon (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-truck": "car/land-rover/88" # FOLD onto car/land-rover/88: Truck Cab BODY (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-truck-cab": "car/land-rover/88" # FOLD onto car/land-rover/88: Truck Cab BODY, written out. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/88-w-b": "car/land-rover/88" # FOLD onto car/land-rover/88: WB = wheel base, spaced (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/series-i-88": "car/land-rover/88" # FOLD onto car/land-rover/88: generation + wheelbase; the wheelbase is the nameplate (https://en.wikipedia.org/wiki/Land_Rover_series)
+"van/land-rover/series-88": "van/land-rover/88" # FOLD onto van/land-rover/88: the same with the generation word dropped — van kind only, and it ADDS fi to van/land-rover/88 (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/lr88": "car/land-rover/88" # FOLD onto car/land-rover/88: LR = LandRover, a registry abbreviation prefix (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/90-county": "car/land-rover/90" # FOLD onto car/land-rover/90: County is the Land Rover station-wagon TRIM, from 1982 (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+"car/land-rover/90-defender": "car/land-rover/90" # FOLD onto car/land-rover/90: raws "90 DEFENDER TDI" (nl+nz). Folded to the NUMBER, not to Defender: the number is what the row leads with, land-rover/90 is a live four-country nameplate with 2,202 car registrations, and the DVLA keeps LAND ROVER 90 and LAND ROVER DEFENDER as separate genmodels over the same years — https://en.wikipedia.org/wiki/Land_Rover_Defender . The deeper 90/110/130-into-Defender question is HELD for the owner (dossier §E-6). FIRES IN car AND van
+"car/land-rover/lr90": "car/land-rover/90" # FOLD onto car/land-rover/90: LR abbreviation prefix. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+"car/land-rover/ninety": "car/land-rover/90" # FOLD onto car/land-rover/90: "in 1984 the 'Land Rover Ninety' was added" — the launch name of the same vehicle, spelled as a word — https://en.wikipedia.org/wiki/Land_Rover_Defender
+"car/land-rover/109-hard-top": "car/land-rover/109" # FOLD onto car/land-rover/109: Hard Top BODY. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/109-lwb": "car/land-rover/109" # FOLD onto car/land-rover/109: LWB = long wheel base, i.e. the 109 itself. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/109-pick-up": "car/land-rover/109" # FOLD onto car/land-rover/109: the RDW slash spelling — SAME SLUG again; all three keys are required or the id republishes under whichever form has the most rows (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/109-v8": "car/land-rover/109" # FOLD onto car/land-rover/109: the 3.5 V8 ENGINE (Stage 1 V8, 1979-85, 109in only). FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/lr-109": "car/land-rover/109" # FOLD onto car/land-rover/109: LR abbreviation prefix — ADDS fi to car/land-rover/109. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/series-3-109": "car/land-rover/109" # FOLD onto car/land-rover/109: generation + wheelbase. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+"car/land-rover/110-4c": "car/land-rover/110" # FOLD onto car/land-rover/110: 4C = four-cylinder ENGINE (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+"car/land-rover/110-defender": "car/land-rover/110" # FOLD onto car/land-rover/110: raws "110 DEFENDER TDI"/"110 DEFENDER ESTATE"/"110 DEFENDER 4X4" (nl+nz). Folded to the NUMBER for the same reason as "90 Defender" above — land-rover/110 carries 3,549 car registrations and the DVLA keeps both genmodels — https://en.wikipedia.org/wiki/Land_Rover_Defender . FIRES IN car AND van
+"car/land-rover/110-hardtop": "car/land-rover/110" # FOLD onto car/land-rover/110: Hard Top BODY. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+"car/land-rover/110-v8": "car/land-rover/110" # FOLD onto car/land-rover/110: V8 ENGINE (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+"car/land-rover/one-ten": "car/land-rover/110" # FOLD onto car/land-rover/110: hyphenated spelling — SAME SLUG (one-ten) (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+"van/land-rover/ld-defender": "van/land-rover/defender" # FOLD onto van/land-rover/defender: LD is a Traficom/RDW body-code prefix; the nameplate is Defender (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+"car/land-rover/evoque": "car/land-rover/range-rover-evoque" # FOLD onto car/land-rover/range-rover-evoque: bare badge; Land Rover's own model name is "Range Rover Evoque" — https://www.landrover.co.uk/vehicles/index.html . lu,nl,nz,us are a strict subset of the survivor's 14 countries
+"car/land-rover/velar": "car/land-rover/range-rover-velar" # FOLD onto car/land-rover/range-rover-velar: bare badge; the model name is "Range Rover Velar" — https://www.landrover.co.uk/vehicles/index.html
+"car/land-rover/sport": "car/land-rover/range-rover-sport" # FOLD onto car/land-rover/range-rover-sport: raws "LAND ROVER SPORT" (fi 1, nl 2). TWO referents are possible — Range Rover Sport (186,186 vehicles) and Discovery Sport (7,332) — and the measured prior is 25:1; stated as a prior, not a certainty (https://www.landrover.co.uk/vehicles/index.html)
+"car/land-rover/vogue": "car/land-rover/range-rover" # FOLD onto car/land-rover/range-rover: Vogue is the Range Rover's flagship TRIM, not a model — the same corpus produces 30+ "RANGE ROVER VOGUE ..." strings that already resolve to range-rover (https://en.wikipedia.org/wiki/Range_Rover)
+"car/land-rover/rangerover-vogue": "car/land-rover/range-rover" # FOLD onto car/land-rover/range-rover: fused make-spelling + the Vogue trim (https://en.wikipedia.org/wiki/Range_Rover)
+"car/land-rover/ranger-rover": "car/land-rover/range-rover" # FOLD onto car/land-rover/range-rover: , attested under BOTH makes: car/land-rover/ranger-rover (es 1, fi 1) sits beside car/land-rover/range-rover (140,744). Here the correct target already exists in-make, so a rename is the whole fix — https://www.landrover.co.uk/vehicles/index.html
+"car/land-rover/ranger-rover-sport": "car/land-rover/range-rover-sport" # FOLD onto car/land-rover/range-rover-sport: the same typo on the Sport (es, nl, 4 vehicles) beside range-rover-sport (186,186) — https://www.landrover.co.uk/vehicles/index.html

--- a/overrides/models/moves.yml
+++ b/overrides/models/moves.yml
@@ -277,3 +277,71 @@
 # deliberately not moved: neither `lahti` nor `vest` exists as a make, so a line
 # here would MINT one, which a cleanup pass should not do unilaterally. ──
 "Scania|Tdx": "Van Hool|Tdx"   # bus/scania/tdx (nl+ua): raws "SCANIA TDX27 ASTROMEGA" (nl) and "TDX-27 ASTROMEGA" (ua). The TDX27 Astromega is VAN HOOL's double-deck coach (https://www.vanhool.com/en/vehicles/coaches/tdx-range/tdx27-astromega) — Scania supplies the driveline, Van Hool builds the bus. Target bus/van-hool/tdx is ALREADY LIVE (fi+gb+nl+ua) so both of the source's countries are already covered there and no evidence goes dark; ua is additionally retained under scania by bus/scania/k124, /k400, /k450, /l94 and /omni
+# ── Land Rover models registered under make ROVER (wave-4 JLR batch) ─────────
+# The Land Rover began in 1948 as a Rover Company product and the Range Rover
+# launched in 1970 under British Leyland; "In 1978, British Leyland created a
+# new subsidiary known as Land Rover Limited which encompassed much of the
+# original assets of the Rover Company"
+# (https://en.wikipedia.org/wiki/Rover_Company), and the Range Rover has been a
+# Land Rover product for 48 of its 56 years
+# (https://en.wikipedia.org/wiki/Range_Rover). National registers still derive
+# `make` from the type-approval holder, which for these vehicles was Rover
+# Group — the same mechanism that files every German Cupra under SEAT.
+# Land Rover's own current range lists RANGE ROVER / DISCOVERY / DEFENDER
+# (https://www.landrover.co.uk/vehicles/index.html); Rover lists nothing.
+# Each target already exists on the Land Rover side, so these are pure
+# re-attachments — no id is created and no country is lost.
+#
+# ★ NOT MOVED, DELIBERATELY: `car/rover/90` and `car/rover/110`. A slug-shape
+# check flagged them as Land Rover wheelbases; the raws refute it —
+# "ROVER | 90 SEDAN", "ROVER | ROVER 90 SALOON LHD", "ROVER | 110 SALOON",
+# plus 392 uk_dft "ROVER 90" rows sitting alongside the published P4 range
+# (rover/60, /75, /80, /95, /100). They are Rover P4 saloons (1953-59 and
+# 1962-64, https://en.wikipedia.org/wiki/Rover_P4), and the DVLA files 392
+# ROVER 90 cars under make ROVER while filing 2,082 LAND ROVER 90 cars and
+# 13,306 LAND ROVER 90 vans separately in the same table. Moving them would
+# have destroyed 534 vehicles of Rover evidence and left the P4 range with two
+# holes in it.
+#
+# ★ ALSO NOT MOVED, AND FOR THE SAME REASON: `car/rover/109` (2 vehicles,
+# nl 1 + nz 1, both raws a bare "109"). It is tempting — 109in is the Land
+# Rover long-wheelbase (1956-85, https://en.wikipedia.org/wiki/Land_Rover_series)
+# and the Rover P4 range was 60/75/80/90/95/100/105/110, which contains no 109
+# (https://en.wikipedia.org/wiki/Rover_P4). But that argument is ABSENCE of
+# evidence: "no Rover 109 appears in a closed list, therefore it is a Land
+# Rover". Every other move in this block rests on POSITIVE row evidence —
+# ROVER | ROVER RANGE ROVER x7,227, two genmodels under two makes in one DVLA
+# table, landrover.co.uk listing the nameplate. The 90/110 verdict two
+# paragraphs up is what a slug-shaped inference costs when it is wrong: it
+# would have destroyed 534 vehicles of P4 evidence. `109` is the same shape of
+# argument with a smaller number attached, and the number is not what makes it
+# wrong. HELD until someone finds a "ROVER 109" row that names a body, or
+# proves none exists. Failed routes, both tried: (1) raw re-parse — both raws
+# are literally "109", nothing left to recover; (2) body word — neither row
+# carries one, so the SEDAN/SALOON vs STATION WAGON discriminator that settled
+# 90 and 110 is unavailable here. Confidence in the Land Rover reading would
+# be MEDIUM at best, and skipped beats assumed.
+#
+# ORDERING: `Range` and `Ranger Rover` are renamed to `Range Rover` under the
+# `Rover:` block in the SAME change (moves.yml rule 1 — keys are POST-rename),
+# and rule 2 (a null rename beats a move) is satisfied: no model named here is
+# nulled in this change.
+"Rover|Range Rover": "Land Rover|Range Rover"   # 8,427 car + 659 van + 6 truck. uk_dft genmodel "ROVER RANGE ROVER" x7,227 car / x508 van; nl_rdw "RANGE ROVER" x984; nz_nzta x146. Target car/land-rover/range-rover carries 14 countries / 140,744 vehicles, so this is a re-attachment onto a far larger record (https://en.wikipedia.org/wiki/Range_Rover)
+"Rover|Defender": "Land Rover|Defender"         # van 6 (fi 2, nl 4) + car 5 (nl, candidate). The Defender name dates from the 1991 model year, thirteen years after Land Rover Limited was created — it was NEVER a Rover-marque product (https://en.wikipedia.org/wiki/Land_Rover_Defender). FIRES IN car AND van
+"Rover|Discovery": "Land Rover|Discovery"       # 1 vehicle (nz, candidate) — raw "DISCOVERY TDI 5 DOOR". The Discovery launched in 1989 under Land Rover Limited (https://en.wikipedia.org/wiki/Land_Rover_Discovery)
+# ── Jaguar rows that are Land Rovers (the shared JAGUAR LAND ROVER registrant)
+# normalizer.rb#split_compound_make already routes raw make "JAGUAR LAND ROVER"
+# by nameplate (normalizer.rb:67-79) and the corpus confirms it works; these two
+# rows arrive under a BARE "JAGUAR" make string instead, so the split never
+# sees them.
+"Jaguar|Range Rover Evoque": "Land Rover|Range Rover Evoque"  # 4 vehicles (es 1, nl 3). Target car/land-rover/range-rover-evoque carries 14 countries / 252,900 vehicles (https://www.landrover.co.uk/vehicles/index.html)
+"Jaguar|Defender": "Land Rover|Defender"                      # 3 vehicles (es, nl), van kind. Target van/land-rover/defender carries es,fi,gb,lu,nl / 126,728 vehicles (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+# ── MG models registered under make ROVER ────────────────────────────────────
+# MG was a Rover Group marque 1986-2000 and an MG Rover marque 2000-2005, so the
+# registers file MG-badged cars under ROVER. Both targets already exist.
+# NB the Rover MINI is deliberately NOT in this class: the Mini was badged and
+# sold as a "Rover Mini" 1988-2000 and the DVLA genmodel is literally
+# ROVER | ROVER MINI (29,832 registrations), so it stays under Rover
+# (https://en.wikipedia.org/wiki/Mini).
+"Rover|Mgf": "MG|Mgf"                            # 489 vehicles (fi 2, lu 1, nl 27, nz 459). The MGF is an MG (1995-2002, https://en.wikipedia.org/wiki/MG_F); target car/mg/mgf carries fi,gb,lu,nl,nz
+"Rover|MG Zt": "MG|Zt"                           # 2 vehicles (fi 1, nl 1). The MG ZT is an MG (2001-05, https://en.wikipedia.org/wiki/MG_ZT); target car/mg/zt carries gb,nl and GAINS fi

--- a/overrides/models/removals.yml
+++ b/overrides/models/removals.yml
@@ -877,3 +877,38 @@
 # former_ids.yml; the string names the marque, so no successor is honest.
 "car/chevrolet/chev": "dropped by an explicit null rename (Chevrolet: \"Chev\") — the make's NICKNAME written into the model column, the identical class the settled `Chevrolet: null` line already covers. MEASURED POPULATION: 2 registrations (nl_rdw 1, nz_nzta 1), 2 countries, decile 10. No alias target is honest: the string denotes the marque, not a model."
 
+
+# ── wave-4 JLR fold batch (Jaguar · Rover · Land Rover), dossier §A ──────────
+# 24 ids with NO honest successor: body-style words, equipment grades, engine
+# designations and OTHER MARQUES written into the model column. Each names a
+# class of vehicles rather than one vehicle, so every alias target would be a
+# guess; populations and country lists are measured (gen_review_pack against
+# pipeline origin/main, 2026-08-01) and recorded here because the gate stores
+# nothing else. The marque-in-model-column rows are drops, NOT moves, for one
+# reason each time: the row names no MODEL of the other marque, so moves.yml
+# has no target — the SEAT `Cupra: null` precedent.
+"car/jaguar/convertible": "body-style word in the model column (nl_rdw 1, nz_nzta 2 = 3 vehicles, nl+nz, measured 2026-08-01 via gen_review_pack); unresolvable across ninety years of Jaguar convertibles, so no alias target is honest."
+"car/jaguar/roadster": "body-style word in the model column (6 vehicles, nl+nz, measured 2026-08-01); unresolvable to one nameplate."
+"car/jaguar/saloon": "body-style word in the model column (8 vehicles, nl+nz, measured 2026-08-01); unresolvable to one nameplate."
+"car/jaguar/executive": "equipment level, not a model (2 vehicles, fi+nl, measured 2026-08-01); Executive was a trim of the XJ, XJ8, S-Type and X-Type simultaneously."
+"car/jaguar/v12": "engine designation (10 vehicles, nl+nz, measured 2026-08-01); shared by the E-type Series 3, XJ12, XJ-S, Double Six and Sovereign V12 — unresolvable."
+"car/jaguar/daimler": "a different MARQUE written into the model column (49 vehicles, fi+nl+nz, measured 2026-08-01). Daimler is a live make here (41 records) but the row names no Daimler MODEL, so moves.yml has no target — the SEAT `Cupra: null` precedent."
+"car/jaguar/daimler-8": "as car/jaguar/daimler, plus a truncated model fragment (2 vehicles, nl+nz, measured 2026-08-01)."
+"car/rover/cabriolet": "body-style word in the model column (7 vehicles, nl+nz, measured 2026-08-01 via gen_review_pack); unresolvable to one Rover nameplate."
+"car/rover/coupe": "body-style word in the model column (62 vehicles, gb+nl+nz, measured 2026-08-01); the DVLA genmodel ROVER COUPE pools the 200 Coupe, 800 Coupe and SD1 — unresolvable."
+"car/rover/estate": "body-style word in the model column (9 vehicles, nl+nz, measured 2026-08-01)."
+"car/rover/saloon": "body-style word in the model column (11 vehicles, nl+nz, measured 2026-08-01)."
+"car/rover/v8": "engine designation (43 vehicles, gb+nz, measured 2026-08-01); the Rover V8 was fitted to the P5B, P6B, SD1 and 800 — unresolvable to one nameplate."
+"car/rover/mg": "the MG MARQUE written into the model column (284 vehicles, nl+nz, measured 2026-08-01). MG is a live make here but the row names no MG MODEL, so moves.yml has no target. NB the two Rover rows that DO name an MG model (Mgf, MG Zt) are MOVES in this same change, not drops."
+"car/rover/land-rover": "the Land Rover MARQUE written into the model column (15 vehicles, fi+nl+nz, measured 2026-08-01); raws LAND ROVER / LANDROVER / 'LAND ROVER, 88' / 'LAND ROVER STATION WAGON/2180' name no Land Rover MODEL, so moves.yml has no target. Same class as the shipped `Land Rover: Landrover: null`."
+"car/land-rover/hard-top": "body-style word in the model column (6 vehicles, nl+nz, measured 2026-08-01 via gen_review_pack); every Series and Defender wheelbase had a Hard Top — unresolvable."
+"car/land-rover/pick-up": "body-style word in the model column (10 vehicles, nl+nz, measured 2026-08-01)."
+"van/land-rover/pick-up": "body-style word in the model column (5 vehicles, fi+nl, measured 2026-08-01); same word, same reasoning, van kind."
+"car/land-rover/station-wagon": "body-style word in the model column (4 vehicles, fi+nl+nz, measured 2026-08-01)."
+"car/land-rover/truck": "body-style word in the model column (9 vehicles, nl+nz, measured 2026-08-01)."
+"car/land-rover/hse": "equipment grade, not a model (2 vehicles, nl+nz, measured 2026-08-01); HSE spans Discovery, Range Rover and Freelander."
+"car/land-rover/regular": "fi_traficom body descriptor 'REGULAR STATION WAGON 4X4/2235' truncated to a word (21 vehicles, fi+nl+nz, measured 2026-08-01); never a Land Rover name."
+"car/land-rover/dormobile": "Dormobile was a camper CONVERTER, not a Land Rover nameplate (3 vehicles, nl+nz, measured 2026-08-01); the row names no base model to fold onto."
+"car/land-rover/jeep": "the generic Dutch/NZ word for a 4x4 in the model column (22 vehicles, fi+nl+nz, measured 2026-08-01); not the Chrysler marque — the sibling raw '86 JEEP CABRIOLET' resolves to land-rover/86."
+"car/land-rover/rover": "the marque in the model column, reached two ways: raws 'LAND ROVER' under make LAND ROVER where the normalizer's first-token make-fragment strip leaves 'ROVER' (30 of 39 vehicles), and bare 'ROVER' (9). 39 vehicles, fi+lu+nl+nz, measured 2026-08-01. INTERIM: the normalizer half is DEBT hygiene-2 'make-fragment strips LAND/MICRO/HD' (normalizer.rb:316-323)."
+"car/rover/landrover": "the fused register spelling LANDROVER under make ROVER, previously aliased to car/rover/land-rover. The wave-4 JLR batch drops that target (a marque written into the model column that names no Land Rover MODEL), so this id has no successor either and its former_ids alias would have redirected consumers into a 404 — the id-contract liveness gate caught exactly that. Re-disposed here as a removal; the alias line in former_ids.yml is retired with a pointer to this entry (lint_curation rule 1g forbids both). Not live in the catalog since the earlier spelling fold; nl 2 + nz 7 at the time of measurement."

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1970,15 +1970,15 @@ Jaguar:
   Mk 7: MK7                                   # spelling variant of "MK7" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Ss 100: SS100                               # spelling variant of "SS100" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Xj 12: XJ12                                 # spelling variant of "XJ12" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
-  Xj 12 L: XJ12L                              # spelling variant of "XJ12L" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+  Xj 12 L: XJ12                               # REPOINT (was -> XJ12L): XJ12L is now folded into XJ12 as a long-wheelbase BODY variant, so the old target is a dead id. Renames are SINGLE-PASS — left alone this line would misroute every matching raw row (https://en.wikipedia.org/wiki/Jaguar_XJ)
   Xj 40: XJ40                                 # spelling variant of "XJ40" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Xj 6: XJ6                                   # spelling variant of "XJ6" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Xj 8: XJ8                                   # spelling variant of "XJ8" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
-  XJ6-L: XJ6L                                 # spelling variant of "XJ6L" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+  XJ6-L: XJ6                                  # REPOINT (was -> XJ6L): XJ6L is now folded into XJ6 as a long-wheelbase BODY variant; EPA baseModel agrees (cache/us_vehicles.csv col 66). Renames are SINGLE-PASS (https://en.wikipedia.org/wiki/Jaguar_XJ)
   Xk 120: XK120                               # spelling variant of "XK120" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Xk 140: XK140                               # spelling variant of "XK140" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Xk 150: XK150                               # spelling variant of "XK150" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
-  Xk 150 S: XK150S                            # spelling variant of "XK150S" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+  Xk 150 S: XK150                             # REPOINT (was -> XK150S): S is the triple-carburettor ENGINE grade of the XK150 and XK150S is now folded into it. Renames are SINGLE-PASS (https://en.wikipedia.org/wiki/Jaguar_XK150)
   Xk 8: XK8                                   # spelling variant of "XK8" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   Xj-S: XJ-S                              # XJ-S is the launch name (1975); the hyphen was dropped from the badge only at the 1991 facelift, and Jaguar heritage still writes XJ-S. Engine/trim suffixes (HE, V12, Auto) and the XJ-SC cabriolet body fold into the nameplate (https://www.jaguarheritage.com/jaguar-world-may-2018-jaguar-convertible-at-30/)
   Xj-S He: XJ-S                           # XJ-S is the launch name (1975); the hyphen was dropped from the badge only at the 1991 facelift, and Jaguar heritage still writes XJ-S. Engine/trim suffixes (HE, V12, Auto) and the XJ-SC cabriolet body fold into the nameplate (https://www.jaguarheritage.com/jaguar-world-may-2018-jaguar-convertible-at-30/)
@@ -1993,6 +1993,110 @@ Jaguar:
   Xjs Auto: XJ-S                          # XJ-S is the launch name (1975); the hyphen was dropped from the badge only at the 1991 facelift, and Jaguar heritage still writes XJ-S. Engine/trim suffixes (HE, V12, Auto) and the XJ-SC cabriolet body fold into the nameplate (https://www.jaguarheritage.com/jaguar-world-may-2018-jaguar-convertible-at-30/)
   Xjs He Auto: XJ-S                       # XJ-S is the launch name (1975); the hyphen was dropped from the badge only at the 1991 facelift, and Jaguar heritage still writes XJ-S. Engine/trim suffixes (HE, V12, Auto) and the XJ-SC cabriolet body fold into the nameplate (https://www.jaguarheritage.com/jaguar-world-may-2018-jaguar-convertible-at-30/)
   Xjs V12: XJ-S                           # XJ-S is the launch name (1975); the hyphen was dropped from the badge only at the 1991 facelift, and Jaguar heritage still writes XJ-S. Engine/trim suffixes (HE, V12, Auto) and the XJ-SC cabriolet body fold into the nameplate (https://www.jaguarheritage.com/jaguar-world-may-2018-jaguar-convertible-at-30/)
+  # ── wave-4 JLR fold batch (dossier §A-J). Every key below was measured with a
+  # recording proxy at the `renames&.key?(nameplate)` probe (normalizer.rb:178)
+  # against pipeline origin/main: all are strings the normalizer DID produce on
+  # this corpus, so none can land dead. Blast radius per key checked in all six
+  # kinds; the two that fire in more than one kind say so on their line. ──
+  Xe Series:  Xe            # uk_dft VEH0120 genmodel "JAGUAR XE SERIES" x43,700 — a DVLA range label, not a nameplate; Jaguar sells one XE (https://www.jaguar.co.uk/jaguar-range/xe/index.html). ADDS gb to jaguar/xe, which has no UK evidence today
+  XF Series:  XF            # uk_dft "JAGUAR XF SERIES" x94,120 — same class; ADDS gb to jaguar/xf (https://www.jaguar.co.uk/jaguar-range/xf/index.html)
+  Xk Series:  Xk            # uk_dft "JAGUAR XK SERIES" x28,729 car + x5 van — same class; ADDS gb to jaguar/xk (https://en.wikipedia.org/wiki/Jaguar_XK_(X150)). FIRES IN car AND van — the twin van/jaguar/xk-series is a candidate row, same fold, intended
+  E:                        E-Type   # raws "E COUPE"/"E CABRIOLET"/"E SPORTS-COUPE"/"JAGUAR E" (lu,nl,nz x34) — the bare launch badge of the E-type, 1961-75 (https://www.jaguarheritage.com/vehicles/e-type/)
+  Xke:                      E-Type   # XK-E is the US-market name of the same car (ar,fi,nl,nz x12) — https://en.wikipedia.org/wiki/Jaguar_E-Type
+  Xke E Type:               E-Type   # US name + UK name in one register string (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  Xke E-Type:               E-Type   # same string, hyphenated register spelling — SAME SLUG as the line above, so both keys are required or the id republishes under the other display form (the BMW "3 C"/"3. C" gotcha)
+  Xke V12:                  E-Type   # US name + engine badge; the Series 3 V12, 1971-75 (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  Xke-V12:                  E-Type   # hyphenated spelling of the same, SAME SLUG (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  "2+2 E Type":             E-Type   # 2+2 is the long-wheelbase COUPE BODY of the Series 1/2, not a model — https://en.wikipedia.org/wiki/Jaguar_E-Type
+  "E Type 2+2":             E-Type   # word-order variant of the same body string (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  "E-Type 2+2":             E-Type   # hyphenated spelling, SAME SLUG as the two above (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  E Type 2-2:               E-Type   # the register wrote the plus as a hyphen; same 2+2 body (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  E Type Roadster:          E-Type   # Roadster = the open two-seater BODY (OTS) — https://www.jaguarheritage.com/vehicles/e-type/
+  E-Type Roadster:          E-Type   # hyphenated spelling, SAME SLUG (https://www.jaguarheritage.com/vehicles/e-type/)
+  E-Type Series:            E-Type   # bare "Series" residue of a Series 1/2/3 string (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  E-Type Series 2:          E-Type   # Series 2 is a GENERATION (1968-71), not a nameplate — https://en.wikipedia.org/wiki/Jaguar_E-Type
+  E-Type Series 2 4:        E-Type   # generation + a truncated 4.2-litre displacement (the comma-decimal generator, DEBT hygiene-2) — https://en.wikipedia.org/wiki/Jaguar_E-Type
+  E-Type Series 3 Roadster: E-Type   # generation + body (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  E Type Series 3 Roadster: E-Type   # unhyphenated spelling, SAME SLUG (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  E-Type Series 3 V12:      E-Type   # generation + engine (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  E Type V12:               E-Type   # engine badge; the Series 3 is the only V12 E-type — https://en.wikipedia.org/wiki/Jaguar_E-Type
+  E-Type V12:               E-Type   # hyphenated spelling, SAME SLUG (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  E-Type V12 Roadster:      E-Type   # engine + body (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  E-Type-V12 Roadster:      E-Type   # double-hyphen register spelling, SAME SLUG (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  E Type V12 Roadster:      E-Type   # unhyphenated spelling, SAME SLUG (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  E V12 Roadster:           E-Type   # bare-E badge + engine + body (https://en.wikipedia.org/wiki/Jaguar_E-Type)
+  Series Three E-Type V12:  E-Type   # generation spelled in words (an fi_traficom habit) + engine — https://en.wikipedia.org/wiki/Jaguar_E-Type
+  Xk 120 Roadster:   XK120    # OTS/Roadster is the open two-seater BODY of the XK120 (1948-54) — https://www.jaguarheritage.com/vehicles/xk120/
+  Xk 120 Se:         XK120    # SE = the Special Equipment engine/equipment grade, not a model (https://www.jaguarheritage.com/vehicles/xk120/)
+  Xk 140 Fhc:        XK140    # FHC = fixed-head coupe BODY of the XK140 (1954-57) — https://en.wikipedia.org/wiki/Jaguar_XK140
+  Xk 140 Fixed Head: XK140    # the same body, spelled out (https://en.wikipedia.org/wiki/Jaguar_XK140)
+  Xk 140 Ots:        XK140    # OTS = open two-seater BODY (https://en.wikipedia.org/wiki/Jaguar_XK140)
+  XK140 Dhc:         XK140    # DHC = drophead coupe BODY (https://en.wikipedia.org/wiki/Jaguar_XK140)
+  Xk 150 Roadster:   XK150    # Roadster BODY of the XK150 (1957-61) — https://en.wikipedia.org/wiki/Jaguar_XK150
+  "Xk-150 Drop Head": XK150   # drophead coupe BODY, hyphenated register spelling (https://en.wikipedia.org/wiki/Jaguar_XK150)
+  Xk 150 Drop Head:  XK150    # unhyphenated spelling — SAME SLUG (xk-150-drop-head), so both keys are required (https://en.wikipedia.org/wiki/Jaguar_XK150)
+  XK150S:            XK150    # S = the triple-carburettor engine grade (XK150 S), an equipment grade of the XK150 — https://en.wikipedia.org/wiki/Jaguar_XK150
+  XK120C:            C-Type   # XK120C IS the C-type — the factory designation of the 1951-53 Le Mans car — https://www.jaguarheritage.com/vehicles/c-type/
+  C Type:            C-Type   # display fix: Jaguar heritage writes "C-type" and the corpus also produces "C-Type" (nl x1) for the SAME slug, so pinning stops the display flapping by row count — https://www.jaguarheritage.com/vehicles/c-type/
+  D Type:            D-Type   # same display fix for the 1954-57 D-type (the corpus also produces "D-Type" x1) — https://www.jaguarheritage.com/vehicles/d-type/
+  Xj Executive:      Xj       # Executive is an XJ TRIM LEVEL (fi,nl x188) — https://en.wikipedia.org/wiki/Jaguar_XJ
+  Xjl:               Xj       # XJL = the long-wheelbase XJ BODY; the EPA/DOE baseModel column maps "XJL"/"XJL AWD" to XJ (cache/us_vehicles.csv col 66) — https://en.wikipedia.org/wiki/Jaguar_XJ
+  Xjl Supercharged:  Xj       # LWB body + supercharged engine badge; EPA baseModel "XJL FFV" to XJ (cache/us_vehicles.csv col 66)
+  "Xj 220":          XJ220    # SPELLING: Jaguar writes the supercar fused, XJ220 (1992-94, 275 built) — https://www.jaguarheritage.com/vehicles/xj220/ . This key MINTS the correct nameplate (the Cee D precedent)
+  XJ12 Auto:         XJ12     # automatic transmission is not a model (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  XJ12 He:           XJ12     # HE = "High Efficiency" (May-head) V12, an ENGINE spec from 1981 — https://en.wikipedia.org/wiki/Jaguar_XJ
+  XJ12C:             XJ12     # the two-door COUPE body of the Series 2 (1975-77) — https://en.wikipedia.org/wiki/Jaguar_XJ
+  XJ12L:             XJ12     # L = long-wheelbase BODY; EPA baseModel folds the same shape (XJ6L to XJ, cache/us_vehicles.csv col 66)
+  XJ6 2:             XJ6      # truncated displacement: raws "XJ6 - 2,7 TD" / "XJ6/2" — the COMMA-decimal generator (DEBT hygiene-2), not a variant (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  XJ6 4:             XJ6      # truncated displacement: raws "XJ6 4,2 SERIES 2" x22, "XJ6 4,2 SERIES 2 AUTOMATIC" x21 — same generator (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  XJ6 Auto:          XJ6      # automatic transmission is not a model (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  XJ6 Series:        XJ6      # bare "Series" residue of a Series 1/2/3 string (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  XJ6 Series 1:      XJ6      # Series 1 is a GENERATION (1968-73) — https://en.wikipedia.org/wiki/Jaguar_XJ
+  XJ6 Sovereign:     XJ6      # Sovereign is the TOP TRIM of the XJ6 from 1983 — https://en.wikipedia.org/wiki/Jaguar_XJ
+  XJ6C:              XJ6      # the two-door COUPE body of the Series 2 (1975-77) — https://en.wikipedia.org/wiki/Jaguar_XJ
+  XJ6L:              XJ6      # L = long-wheelbase BODY; EPA baseModel "XJ6L" to XJ (cache/us_vehicles.csv col 66)
+  XJ8 Executive:     XJ8      # Executive TRIM (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  XJ8L:              XJ8      # long-wheelbase BODY; EPA baseModel "XJ8L"/"XJ8l" to XJ (cache/us_vehicles.csv col 66)
+  Sovereign Auto:    Sovereign  # automatic transmission is not a model (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  Sovereign He:      Sovereign  # HE = High Efficiency V12 ENGINE spec (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  Sovereign V12:     Sovereign  # engine badge, not a model (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  Xj Sc:             XJ-S     # the SPACED twin of the settled "Xj-Sc": XJ-S line above. Raws nl_rdw "JAGUAR XJ SC"/"XJ SC" and nz_nzta "XJ SC" reach the SAME SLUG (xj-sc) and kept the record alive under the display "Xj Sc" — which is what propose_former_ids reported as a dead key. It is NOT dead: "Xj-Sc" fires on fi/nl/us rows and gen_review_pack reports no dead override keys for this make (dossier §E-3). XJ-SC is the 1983-88 targa/cabriolet BODY of the XJ-S (https://www.jaguarheritage.com/jaguar-world-may-2018-jaguar-convertible-at-30/)
+  S-Type 4:          S-Type     # truncated displacement from raw "S-TYPE 4,2 V8" (the comma-decimal generator) — https://en.wikipedia.org/wiki/Jaguar_S-Type
+  S-Type Executive:  S-Type     # Executive TRIM (https://en.wikipedia.org/wiki/Jaguar_S-Type)
+  S-Type R:          S-Type     # the EPA/DOE baseModel column says "S-Type R" to "S-type" (cache/us_vehicles.csv col 66); R is the supercharged performance TRIM, 2002-08 (https://en.wikipedia.org/wiki/Jaguar_S-Type)
+  X-Type 2:          X-Type     # truncated displacement from raws "X-TYPE 2,0 D I4 EXECUTIVE"/"X-TYPE 2,5 V6" — https://en.wikipedia.org/wiki/Jaguar_X-Type
+  X-Type Sport Brake: X-Type    # Sport Brake = the ESTATE BODY; EPA baseModel "X-Type Sport Brake" to "X-Type" (cache/us_vehicles.csv col 66)
+  XF S:              XF         # S = an engine/equipment grade, not a model (https://en.wikipedia.org/wiki/Jaguar_XF)
+  XF-S:              XF         # hyphenated register spelling — SAME SLUG (xf-s), so both keys are required (https://en.wikipedia.org/wiki/Jaguar_XF)
+  XF 30T:            XF         # 30t = a POWER/engine badge; EPA baseModel "XF 30t" to "XF" (cache/us_vehicles.csv col 66)
+  XF P250:           XF         # P250 = a power badge (250 PS); EPA baseModel to "XF" (cache/us_vehicles.csv col 66)
+  XF P300:           XF         # P300 power badge; EPA baseModel to "XF" (cache/us_vehicles.csv col 66)
+  XF Supercharged:   XF         # engine badge; EPA baseModel "XF Supercharged" to "XF" (cache/us_vehicles.csv col 66)
+  XF Sportbrake:     XF         # Sportbrake = the ESTATE BODY; EPA baseModel "XF Sportbrake AWD" to "XF" (cache/us_vehicles.csv col 66). FIRES IN car AND van — the twin van/jaguar/xf-sportbrake is a candidate row, same fold, intended
+  Xe 25T:            Xe         # 25t = a POWER/engine badge (https://en.wikipedia.org/wiki/Jaguar_XE)
+  Xe P250:           Xe         # P250 power badge; EPA baseModel "XE P250"/"XE P250 AWD" to "XE" (cache/us_vehicles.csv col 66)
+  Xe P300:           Xe         # P300 power badge; EPA baseModel to "XE" (cache/us_vehicles.csv col 66)
+  F-Pace 25T:        F-Pace     # 25t power badge (https://en.wikipedia.org/wiki/Jaguar_F-Pace)
+  F-Pace 30T:        F-Pace     # EPA baseModel "F-Pace 30t" to "F-Pace" (cache/us_vehicles.csv col 66)
+  F-Pace P340:       F-Pace     # EPA baseModel "F-Pace P340 MHEV" to "F-Pace" (cache/us_vehicles.csv col 66)
+  F-Pace P400:       F-Pace     # EPA baseModel "F-Pace P400 MHEV" to "F-Pace" (cache/us_vehicles.csv col 66)
+  F-Pace S:          F-Pace     # S equipment grade (https://en.wikipedia.org/wiki/Jaguar_F-Pace)
+  F-Pace Svr:        F-Pace     # EPA baseModel "F-Pace SVR" to "F-Pace" (cache/us_vehicles.csv col 66); SVR is the SV performance TRIM
+  F-Type P450:       F-Type     # EPA baseModel "F-Type P450 ..." to "F-Type" (cache/us_vehicles.csv col 66)
+  F-Type R:          F-Type     # EPA baseModel "F-Type R ..." to "F-Type" (cache/us_vehicles.csv col 66)
+  F-Type S:          F-Type     # EPA baseModel "F-Type S ..." to "F-Type" (cache/us_vehicles.csv col 66)
+  F-Type Svr:        F-Type     # EPA baseModel "F-Type SVR ..." to "F-Type" (cache/us_vehicles.csv col 66)
+  F-Type V8 S:       F-Type     # EPA baseModel "F-Type V8 S Convertible" to "F-Type" (cache/us_vehicles.csv col 66)
+  E-Pace P250:       E-Pace     # EPA baseModel "E-Pace P250" to "E-Pace" (cache/us_vehicles.csv col 66)
+  E-Pace P300:       E-Pace     # EPA baseModel "E-Pace P300" to "E-Pace" (cache/us_vehicles.csv col 66)
+  I-Pace EV400:      I-Pace     # EV400 is a POWER designation, not a model; EPA baseModel "I-Pace EV400" to "I-Pace" (cache/us_vehicles.csv col 66), and NAMING's own "Leaf 40KWH to Leaf" precedent
+  Convertible: null   # body style written into the model column (nl_rdw x1, nz_nzta x2) — unresolvable across ninety years of Jaguar convertibles (E-type, XJ-S, XK8), so no alias target is honest (https://en.wikipedia.org/wiki/Jaguar_Cars)
+  Roadster:    null   # body style in the model column (nl x1, nz x5) — same class, same reason (https://en.wikipedia.org/wiki/Jaguar_Cars)
+  Saloon:      null   # body style in the model column (nl x5, nz x3) — could be any of forty Jaguar saloons (https://en.wikipedia.org/wiki/Jaguar_Cars)
+  Executive:   null   # equipment level (fi x1, nl x1) — a TRIM shared by the XJ, XJ8, S-Type and X-Type simultaneously; unresolvable (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  V12:         null   # ENGINE designation (nl x3, nz x7; raws "JAGUAR V12"/"V12 COUPE"/"V12 CONVERTIBLE") — shared by the E-type S3, XJ12, XJ-S, Double Six and Sovereign V12; unresolvable (https://en.wikipedia.org/wiki/Jaguar_XJ)
+  Daimler:     null   # a different MARQUE written into the model column (fi x1, nl x6, nz x42). Daimler is a live make in this catalog (41 records) but the row names no Daimler MODEL, so moves.yml has no target and a move is impossible — the SEAT `Cupra: null` precedent exactly (https://en.wikipedia.org/wiki/Daimler_Company)
+  Daimler 8:   null   # same class, plus a truncated "Double Six"/"Eight" fragment; still no Daimler MODEL to move to (https://en.wikipedia.org/wiki/Daimler_Company)
 
 Jawa:
   Jawa: null                              # motorcycle fi|nl
@@ -2109,9 +2213,9 @@ Lancia:
   Montecarlo: Monte Carlo                     # spelling variant of "Monte Carlo" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Land Rover:
-  "109 Hardtop": "109 Hard Top"               # spelling variant of "109 Hard Top" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "88 Hardtop": "88 Hard Top"                 # spelling variant of "88 Hard Top" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "88 Wb": "88 W B"                           # spelling variant of "88 W B" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  "109 Hardtop": "109"                        # REPOINT (was -> "109 Hard Top"): the target is now folded into the 109 as a BODY variant. Renames are SINGLE-PASS, so a missed repoint silently misroutes rows to a dead id. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Hardtop": "88"                          # REPOINT (was -> "88 Hard Top"): same reason — the target is now a BODY variant of the 88. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Wb": "88"                               # REPOINT (was -> "88 W B"): same reason — WB is the wheel base the number already names. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
   Rangerover: Range Rover                     # spelling variant of "Range Rover" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Landrover: null                             # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   # ── REGISTER-LANGUAGE CONVENTION (issue #123, adjudicated in the issue
@@ -2127,6 +2231,67 @@ Land Rover:
   # key is probed there). ──
   "Serie I 80": Series I 80                   # raw "SERIE I 80 4X4/2235" fi_traficom 1 — the 80-inch Series I (the 1948 original, https://en.wikipedia.org/wiki/Land_Rover_series); continental spelling of a designation this make already publishes in English
   "Serie I-80": Series I 80                   # raw "SERIE I-80" nl_rdw 1 — hyphenated spelling of the SAME designation and the SAME slug (serie-i-80), so it must move WITH the key above or the record stays alive on this display form (the BMW "3 C"/"3. C" gotcha)
+  # ── wave-4 JLR fold batch (dossier §A-LR). Keys measured with a recording
+  # proxy at the `renames&.key?(nameplate)` probe (normalizer.rb:178) against
+  # pipeline origin/main. THE WHEELBASE NUMBERS 86/88/90/101/109/110/127 STAY
+  # AS NAMEPLATES — the inch figure WAS the model name for 37 years (the
+  # Series 80/86/88/107/109, then the "Land Rover Ninety" and "One Ten"), and
+  # the DVLA runs six separate genmodels for them beside LAND ROVER DEFENDER in
+  # one table. Only body/engine/registry-shorthand suffixes fold onto them. ──
+  Evoque:              Range Rover Evoque   # bare badge; Land Rover's own model name is "Range Rover Evoque" — https://www.landrover.co.uk/vehicles/index.html . lu,nl,nz,us are a strict subset of the survivor's 14 countries
+  Velar:               Range Rover Velar    # bare badge; the model name is "Range Rover Velar" — https://www.landrover.co.uk/vehicles/index.html
+  Sport:               Range Rover Sport    # raws "LAND ROVER SPORT" (fi 1, nl 2). TWO referents are possible — Range Rover Sport (186,186 vehicles) and Discovery Sport (7,332) — and the measured prior is 25:1; stated as a prior, not a certainty (https://www.landrover.co.uk/vehicles/index.html)
+  Vogue:               Range Rover          # Vogue is the Range Rover's flagship TRIM, not a model — the same corpus produces 30+ "RANGE ROVER VOGUE ..." strings that already resolve to range-rover (https://en.wikipedia.org/wiki/Range_Rover)
+  Rangerover Vogue:    Range Rover          # fused make-spelling + the Vogue trim (https://en.wikipedia.org/wiki/Range_Rover)
+  Ranger Rover:        Range Rover          # REGISTER TYPO, attested under BOTH makes: car/land-rover/ranger-rover (es 1, fi 1) sits beside car/land-rover/range-rover (140,744). Here the correct target already exists in-make, so a rename is the whole fix — https://www.landrover.co.uk/vehicles/index.html
+  Ranger Rover Sport:  Range Rover Sport    # the same typo on the Sport (es, nl, 4 vehicles) beside range-rover-sport (186,186) — https://www.landrover.co.uk/vehicles/index.html
+  "86 Wb":            "86"    # WB = wheel base — the register spelling out what the number already says (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Hard Top":      "88"    # Hard Top is a Land Rover BODY, built on every wheelbase (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Ht":            "88"    # HT = hard top, abbreviated by the register (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Pick Up":       "88"    # Pick Up BODY (https://en.wikipedia.org/wiki/Land_Rover_series). FIRES IN car AND van — van/land-rover/88-pick-up carries 312 vehicles and is the same body word, so the fold is load-bearing in both kinds
+  "88 Pick-Up":       "88"    # hyphenated spelling — SAME SLUG (88-pick-up), so both keys are required. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Series":        "88"    # bare "Series" residue of a Series II/III string. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Series 2A":     "88"    # Series 2A is a GENERATION (1961-71), not a nameplate. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Series 3":      "88"    # Series III generation (1971-85). FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Series Iia":    "88"    # the Roman spelling of Series 2A — a DIFFERENT slug from the line above, so both are needed. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Station":       "88"    # Station Wagon BODY, truncated by the register (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Sw":            "88"    # SW = station wagon (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Truck":         "88"    # Truck Cab BODY (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 Truck Cab":     "88"    # Truck Cab BODY, written out. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "88 W B":           "88"    # WB = wheel base, spaced (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "Series I 88":      "88"    # generation + wheelbase; the wheelbase is the nameplate (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "Series 88":        "88"    # the same with the generation word dropped — van kind only, and it ADDS fi to van/land-rover/88 (https://en.wikipedia.org/wiki/Land_Rover_series)
+  LR88:               "88"    # LR = LandRover, a registry abbreviation prefix (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "90 County":        "90"    # County is the Land Rover station-wagon TRIM, from 1982 (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+  "90 Defender":      "90"    # raws "90 DEFENDER TDI" (nl+nz). Folded to the NUMBER, not to Defender: the number is what the row leads with, land-rover/90 is a live four-country nameplate with 2,202 car registrations, and the DVLA keeps LAND ROVER 90 and LAND ROVER DEFENDER as separate genmodels over the same years — https://en.wikipedia.org/wiki/Land_Rover_Defender . The deeper 90/110/130-into-Defender question is HELD for the owner (dossier §E-6). FIRES IN car AND van
+  LR90:               "90"    # LR abbreviation prefix. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+  Ninety:             "90"    # "in 1984 the 'Land Rover Ninety' was added" — the launch name of the same vehicle, spelled as a word — https://en.wikipedia.org/wiki/Land_Rover_Defender
+  "109 Hard Top":     "109"   # Hard Top BODY. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "109 Lwb":          "109"   # LWB = long wheel base, i.e. the 109 itself. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "109 Pick Up":      "109"   # Pick Up BODY. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "109 Pick-Up":      "109"   # hyphenated spelling — SAME SLUG (109-pick-up). FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "109 / Pick Up":    "109"   # the RDW slash spelling — SAME SLUG again; all three keys are required or the id republishes under whichever form has the most rows (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "109 V8":           "109"   # the 3.5 V8 ENGINE (Stage 1 V8, 1979-85, 109in only). FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "Lr 109":           "109"   # LR abbreviation prefix — ADDS fi to car/land-rover/109. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "Series 3 109":     "109"   # generation + wheelbase. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  "110 4C":           "110"   # 4C = four-cylinder ENGINE (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+  "110 Hardtop":      "110"   # Hard Top BODY. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+  "110 V8":           "110"   # V8 ENGINE (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+  "110 Defender":     "110"   # raws "110 DEFENDER TDI"/"110 DEFENDER ESTATE"/"110 DEFENDER 4X4" (nl+nz). Folded to the NUMBER for the same reason as "90 Defender" above — land-rover/110 carries 3,549 car registrations and the DVLA keeps both genmodels — https://en.wikipedia.org/wiki/Land_Rover_Defender . FIRES IN car AND van
+  "One Ten":          "110"   # "The coil-sprung Land Rover was introduced in 1983 as 'Land Rover One Ten'" — the launch name of the 110, spelled as words — https://en.wikipedia.org/wiki/Land_Rover_Defender . FIRES IN car AND van
+  "One-Ten":          "110"   # hyphenated spelling — SAME SLUG (one-ten) (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+  "Ld Defender":      Defender  # LD is a Traficom/RDW body-code prefix; the nameplate is Defender (https://en.wikipedia.org/wiki/Land_Rover_Defender)
+  Hard Top:      null   # a BODY word alone (nl x2, nz x4; +1 van) — every Series and Defender wheelbase had a Hard Top, so the row names no one vehicle. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  Pick Up:       null   # a BODY word alone (nl x3, nz x5; +3 van). FIRES IN car AND van — intended, both are the same word (https://en.wikipedia.org/wiki/Land_Rover_series)
+  Pick-Up:       null   # hyphenated spelling — SAME SLUG (pick-up), so both keys are required. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  Station Wagon: null   # a BODY word alone (fi x1, nl x1, nz x2; +1 van). FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  Truck:         null   # a BODY word alone (nl x1, nz x8) (https://en.wikipedia.org/wiki/Land_Rover_series)
+  Hse:           null   # HSE is Land Rover's TOP EQUIPMENT GRADE across the whole range (Discovery, Range Rover, Freelander) — unresolvable to one nameplate (https://www.landrover.co.uk/vehicles/index.html)
+  Regular:       null   # the fi_traficom body/variant string "REGULAR STATION WAGON 4X4/2235" truncated to a word (fi x16, nl x3, nz x1) — never a Land Rover name (https://en.wikipedia.org/wiki/Land_Rover_series)
+  Dormobile:     null   # Dormobile was a British CAMPER CONVERTER; a "Land Rover Dormobile" is a converted Series, not a Land Rover model, and the row carries no base nameplate to fold onto (nl x1, nz x2; +2 van). FIRES IN car AND van (https://en.wikipedia.org/wiki/Dormobile)
+  Jeep:          null   # the generic Dutch/NZ word for a 4x4 written into the model column (fi x1, nl x18, nz x3; +3 van). NOT the Chrysler marque: the raws are "JEEP"/"JEEP 4X4" under make LAND ROVER and the sibling raw "86 JEEP CABRIOLET" resolves to land-rover/86. Kind-blind risk is nil — this key can only fire under Land Rover. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
+  Rover:         null   # INTERIM — superseded by the make-fragment normalizer fix (DEBT hygiene-2 "make-fragment strips LAND/MICRO/HD"). TWO causes, one string: (a) raws "LAND ROVER"/"LAND ROVER, SERIES III" under make LAND ROVER, where strip_make_prefix takes raw_make.split.first = "LAND" and leaves "ROVER" (normalizer.rb:316-323) — 30 of 39 vehicles; (b) bare "ROVER" in the model column (lu x1, nl x5, nz x2). The same class as the shipped `Landrover: null` line above. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover)
+  Fc: FC   # Forward Control — raws "FC6-109-4X4" (fi) and "FC-110" (nl), the 1962-72 forward-control Land Rovers; the caser Title-cases the initialism and this pins it. Blast radius 1 (truck kind only — the only kind that produces "Fc" for this make) — https://en.wikipedia.org/wiki/Land_Rover_series
 
 Leike:
   Leike: null                             # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
@@ -3661,13 +3826,67 @@ Rolls-Royce:
   Silvershadow: Silver Shadow                 # spelling variant of "Silver Shadow" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Rover:
-  "2300S": "2300 S"                           # spelling variant of "2300 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "2600S": "2600 S"                           # spelling variant of "2600 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "3500S": "3500 S"                           # spelling variant of "3500 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "3500 Vanden Plas": "3500 Van Den Plas"     # spelling variant of "3500 Van Den Plas" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Landrover: Land Rover                       # spelling variant of "Land Rover" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  "2300S": "2300"                             # REPOINT (was -> "2300 S"): S is an SD1 trim/engine grade and "2300 S" is now folded into 2300, so the old target is a dead id. Renames are SINGLE-PASS (https://en.wikipedia.org/wiki/Rover_SD1)
+  "2600S": "2600"                             # REPOINT (was -> "2600 S"): same reason (https://en.wikipedia.org/wiki/Rover_SD1)
+  "3500S": "3500"                             # REPOINT (was -> "3500 S"): same reason (https://en.wikipedia.org/wiki/Rover_P6)
+  "3500 Vanden Plas": "3500"                  # REPOINT (was -> "3500 Van Den Plas"): Vanden Plas is a luxury TRIM and "3500 Van Den Plas" is now folded into 3500 (https://en.wikipedia.org/wiki/Rover_SD1)
+  Landrover: null                             # REPOINT (was -> "Land Rover"): raws "LANDROVER" (nl x2, nz x7) are a Land Rover filed under make ROVER that names no Land Rover MODEL, so there is nothing to move to and the target is now itself null — the same class as the shipped `Land Rover: Landrover: null` line (https://en.wikipedia.org/wiki/Land_Rover)
   Rangerover: Range Rover                     # spelling variant of "Range Rover" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Vanden Plas: Van Den Plas                   # spelling variant of "Van Den Plas" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  # ── wave-4 JLR fold batch (dossier §A-R). Keys measured with a recording
+  # proxy at the `renames&.key?(nameplate)` probe (normalizer.rb:178) against
+  # pipeline origin/main — every one is a string the normalizer DID produce on
+  # this corpus. `90` and `110` are DELIBERATELY ABSENT: they are Rover P4
+  # saloons (raws "ROVER | 90 SEDAN", "ROVER | 110 SALOON", 392 uk_dft
+  # "ROVER 90"), not Land Rover wheelbases, and folding or moving them would
+  # have destroyed 534 vehicles of Rover evidence — see the moves section. ──
+  100 Series:  "100"    # uk_dft VEH0120 genmodel "ROVER 100 SERIES" x4,218 — a DVLA range label, not a nameplate; Rover sold the "Rover 100" (1994-98) — https://en.wikipedia.org/wiki/Rover_100 . ADDS gb to rover/100. FIRES IN car AND van (van/rover/100-series, same fold, intended)
+  200 Series:  "200"    # "ROVER 200 SERIES" x9,588 uk_dft + nl/fi — range label; the car is the Rover 200 (1984-2005) — https://en.wikipedia.org/wiki/Rover_200 . ADDS fi+gb to rover/200. FIRES IN car AND van (van/rover/200-series, same fold, intended)
+  400 Series:  "400"    # "ROVER 400 SERIES" x4,246 — range label; the car is the Rover 400 (1990-99) — https://en.wikipedia.org/wiki/Rover_400 . ADDS fi+gb to rover/400
+  600 Series:  "600"    # "ROVER 600 SERIES" x2,135 — range label; the car is the Rover 600 (1993-99) — https://en.wikipedia.org/wiki/Rover_600 . ADDS gb+nl to rover/600
+  800 Series:  "800"    # "ROVER 800 SERIES" x1,603 — range label; the car is the Rover 800 (1986-99) — https://en.wikipedia.org/wiki/Rover_800 . MINTS rover/800 (the Cee D precedent); the 820/825/827 engine-variant records already publish beneath it. FIRES IN car AND van (van/rover/800-series, same fold, intended)
+  2000 Series: "2000"   # "ROVER 2000 SERIES" x2,152 — range label for the P6 2000 (1963-77) — https://en.wikipedia.org/wiki/Rover_P6 . ADDS gb to rover/2000. FIRES IN car AND van; the bus-kind row series-collapses to "2000" and is NOT probed with this key
+  10 Hp:              "10"     # HP is the RAC horsepower TAX RATING, not part of the name; Rover sold the "Rover Ten" — https://en.wikipedia.org/wiki/Rover_10
+  12HP:               "12"     # the same rating suffix on the Rover Twelve — https://en.wikipedia.org/wiki/Rover_12
+  P4 75:              "75"     # P4 is the internal SERIES code; the model is the Rover 75 (P4, 1949-59) — https://en.wikipedia.org/wiki/Rover_P4
+  P4-75:              "75"     # hyphenated register spelling — SAME SLUG (p4-75), so both keys are required (https://en.wikipedia.org/wiki/Rover_P4)
+  2000 Sc:            "2000"   # SC = the single-carburettor ENGINE spec of the P6 2000 — https://en.wikipedia.org/wiki/Rover_P6
+  2000 Tc:            "2000"   # TC = the twin-carburettor ENGINE spec of the P6 2000 — https://en.wikipedia.org/wiki/Rover_P6
+  Tc-2000:            "2000"   # word-order variant of the same string (https://en.wikipedia.org/wiki/Rover_P6)
+  Tc 2000:            "2000"   # spaced spelling — SAME SLUG (tc-2000), so both keys are required (https://en.wikipedia.org/wiki/Rover_P6)
+  2200 Tc:            "2200"   # TC engine spec; MINTS rover/2200 — the P6 2200 (1973-77) is its own model, a 2.2-litre that replaced the 2000 — https://en.wikipedia.org/wiki/Rover_P6
+  2300 S:             "2300"   # S = a trim/engine grade of the SD1 2300 — https://en.wikipedia.org/wiki/Rover_SD1
+  2600 S:             "2600"   # S grade of the SD1 2600 — https://en.wikipedia.org/wiki/Rover_SD1
+  2600 Automatic:     "2600"   # transmission is not a model (https://en.wikipedia.org/wiki/Rover_SD1)
+  2600 Van Den Plas:  "2600"   # Vanden Plas = the luxury TRIM (a British Leyland coachbuilder name used as a trim level) — https://en.wikipedia.org/wiki/Rover_SD1
+  2600SE:             "2600"   # SE equipment grade (https://en.wikipedia.org/wiki/Rover_SD1)
+  3500 Auto:          "3500"   # transmission is not a model (https://en.wikipedia.org/wiki/Rover_SD1)
+  3500 S:             "3500"   # S grade of the P6B/SD1 3500 — https://en.wikipedia.org/wiki/Rover_P6
+  3500 Sdi:           "3500"   # engine/injection badge (https://en.wikipedia.org/wiki/Rover_SD1)
+  3500 Van Den Plas:  "3500"   # Vanden Plas TRIM (https://en.wikipedia.org/wiki/Rover_SD1)
+  3500 Vitesse:       "3500"   # Vitesse = the SD1 performance TRIM — https://en.wikipedia.org/wiki/Rover_SD1
+  214 I:              "214"    # i = fuel injection, an engine spec (https://en.wikipedia.org/wiki/Rover_200)
+  216 Sli:            "216"    # SLi equipment grade (https://en.wikipedia.org/wiki/Rover_200)
+  220 Turbo:          "220"    # a forced-induction ENGINE badge (https://en.wikipedia.org/wiki/Rover_200)
+  416 Si:             "416"    # Si equipment grade (https://en.wikipedia.org/wiki/Rover_400)
+  416 Sli:            "416"    # SLi equipment grade (https://en.wikipedia.org/wiki/Rover_400)
+  420 D:              "420"    # D = diesel ENGINE (https://en.wikipedia.org/wiki/Rover_400)
+  620 Si:             "620"    # Si equipment grade — ADDS fi to rover/620 (https://en.wikipedia.org/wiki/Rover_600)
+  825I:               "825"    # i = fuel injection (https://en.wikipedia.org/wiki/Rover_800)
+  827 Sterling:       "827"    # Sterling = the top TRIM of the 800 (and the US marque name); car/rover/sterling stays live for rows that carry ONLY that word — https://en.wikipedia.org/wiki/Rover_800
+  Mini Cooper 1.3I:   Mini Cooper  # 1.3i is the displacement + injection ENGINE spec, not a model — https://en.wikipedia.org/wiki/Mini
+  Cabriolet: null   # body style written into the model column (nl x5, nz x2) — unresolvable to one Rover nameplate (https://en.wikipedia.org/wiki/Rover_(marque))
+  Coupe:     null   # body style (uk_dft genmodel "ROVER COUPE" x49, nl x1, nz x12) — the 200, 800 and SD1 all had coupes, so the row names no one car (https://en.wikipedia.org/wiki/Rover_(marque))
+  Estate:    null   # body style (nl x7, nz x2) — same class (https://en.wikipedia.org/wiki/Rover_(marque))
+  Saloon:    null   # body style (nl x2, nz x9) — same class (https://en.wikipedia.org/wiki/Rover_(marque))
+  V8:        null   # ENGINE designation (uk_dft "ROVER V8" x34, nz x9) — the Buick-derived 3.5/3.9 V8 was fitted to the P5B, P6B, SD1 and 800; unresolvable to one nameplate, the same class as Jaguar's V12 (https://en.wikipedia.org/wiki/Rover_V8_engine)
+  MG:        null   # a different MARQUE in the model column (nl x6, nz x278). MG is a live make here (105 records) but the row names no MG MODEL, so moves.yml has no target — the SEAT `Cupra: null` precedent. The two rows that DO name a model (MGF, MG ZT) are MOVES, not drops — see moves.yml (https://en.wikipedia.org/wiki/MG_Cars)
+  Land Rover: null  # raws "LAND ROVER" (fi 1, nl 1, nz 2), "LAND ROVER STATION WAGON/2180" (fi 1), "LAND ROVER, 88" (nl 1) filed under make ROVER. A Land Rover that names no Land Rover MODEL, so moves.yml has no target — the same class as the shipped `Land Rover: Landrover: null` line (https://en.wikipedia.org/wiki/Land_Rover)
+  Range:        Range Rover   # nz_nzta truncates the genmodel to "RANGE" (x59) and "RANGE ESTATE" (x2); nl_rdw x2. The same NZ register also carries the full "RANGE ROVER" x146, so this is a field-width truncation of one string, not a name — https://en.wikipedia.org/wiki/Range_Rover . PRE-MOVE NORMALISATION: the resulting "Rover|Range Rover" is then moved to Land Rover by moves.yml in this same change. FIRES IN car AND truck (truck/rover/range is uk_dft "ROVER RANGE ROVER" after series_collapse — same vehicle, intended)
+  Ranger Rover: Range Rover   # REGISTER TYPO: nl_rdw x2 against nl_rdw "RANGE ROVER" x984 in the same table (2,809:1 across nl+nz), and the same typo appears independently under make LAND ROVER beside the correct spelling. There has never been a vehicle called a "Ranger Rover" — https://www.landrover.co.uk/vehicles/index.html . PRE-MOVE NORMALISATION, then moved by moves.yml
+  "Ranger/Rover": Range Rover # nz_nzta x1, slash spelling — SAME SLUG (ranger-rover) as the key above, so both are required or the id simply republishes under this display form (https://www.landrover.co.uk/vehicles/index.html)
+  "Range-Rover": Range Rover  # hyphenated spelling (nl x10 car/x3 van, nz x1) — SAME SLUG as Range Rover already; pinned so the display cannot flap by row count (the Scania G-Series precedent). FIRES IN car AND van (https://en.wikipedia.org/wiki/Range_Rover)
+  "3.5 Litre": "3.5 Litre"   # INTERIM — superseded by the junk? dot-decimal rule fix (DEBT hygiene-2 "comma-decimal + 2.0T junk rules"). Renames are consulted BEFORE junk? (normalizer.rb:178-186), so this identity key RESCUES 1,272 vehicles in fi+gb+nl+nz that the rule currently deletes outright: the Rover P5B 3.5-Litre (1967-73), the V8 sibling of the published car/rover/3-litre — https://en.wikipedia.org/wiki/Rover_P5 . Scoped to this ONE real nameplate; the other 6,713 vehicles of the same class stay filed as the rule defect they are (dossier §E-7)
 
 Ryuka:
   "Save-II S Fi":                            Save-II S FI             # FI is fuel injection, an initialism in every marque that uses it. Two tokens fixed in one record.


### PR DESCRIPTION
# Wave-4 JLR fold batch — Jaguar · Rover · Land Rover: **348 records → 168, 0 country evidence lost**

Pairs with **vehiclesdb-pipeline `s4w/jlr-enrich`** (three new `enrich/*.yml`). Merge the pipeline PR first or within minutes — data CI runs pipeline main's suite.

A **second, separate data PR (#138)** carries the `Xj Series` inversion held out of this one (see §9 / ruling 6); it is rebased onto this branch's current tip. **Do not merge either without a fresh CI pass.**

---

## 0. What this is, in one paragraph

Every published record under `make_id ∈ {jaguar, rover, land-rover}` — 348 of them across car/van/truck/bus — was measured against the pipeline's own `classify`, using recording proxies at the exact `renames&.key?(nameplate)` consultation point (`normalizer.rb:178`), never a disable seam. 53% of the slice is not a vehicle name: DVLA range labels, body abbreviations, engine grades, transmission words, register typos, and *other marques* written into the model column. This PR folds, drops or re-attributes them, and the hard contract — **no country's evidence for a nameplate may disappear** — is verified by a diff of two full builds, not asserted.

---

## 1. Verified numbers (control build vs treatment build, same frozen cache)

| | claimed by the dossier | **measured here** |
|---|---|---|
| records in slice, before | 348 | **348** ✔ |
| folds | 151 | **151** ✔ |
| drops | 24 | **24** ✔ |
| cross-make moves | 10 | **9** — the dossier proposed 10; `car/rover/109` is **HELD** on the owner ruling, see §2 and §9.2 |
| survivors | 163 | **164** (163 + the held `car/rover/109`) |
| minted ids | 4 | **4** ✔ (but not the same four — see §3) |
| records after | 167 | **168** (167 + the held `car/rover/109`) |
| net published-id change, catalog-wide | −181 | **−180** (15,845 → 15,665) |
| rename keys | "203" | **207 proposed in the dossier's own YAML blocks** → 200 new keys + 7 of them applied as repoints of existing keys. The prose figure was an undercount of its own tables. |
| dead rename keys | 0 | **0** — every one of the 200 keys is present in the recording-proxy probe index, and `propose_former_ids` reports no dead key for any of the three makes |
| country evidence lost | 0 | **0** ✔ |
| survivors strictly enlarged | "14" | **15** — the dossier's §D.2 *table* lists 15 rows; its prose said 14. All 15 reproduce. |
| vehicles re-attributed across makes | 9,670 | **9,656 on published records** (+12 on candidate rows: 6 truck `Range`, 5 car `Defender`, 1 `Discovery`; −2 for the held `109`) |

Per make: jaguar 156 → 69, rover 103 → **59**, land-rover 89 → **40**. The dossier predicted 69/57/41; the deviations are the held `car/rover/109` (§2), the INTERIM `3.5 Litre` mint and the un-mintable `van/land-rover/range-rover` (both §3), each measured.

**Disposition audit is exhaustive: `UNEXPLAINED: 0`.** Every one of the 184 ids that leaves the slice is accounted for by a `former_ids` alias (160) or a `removals.yml` entry (24).

---

## 2. ★ The best catch in the slice: `car/rover/90`, `/110` — and `/109` — stay under **Rover**

The cross-make companion worklist that seeded this slice flagged five `car/rover/*` slugs as Land Rovers on the shape of the number. **Three of the five do not survive contact with the rows.**

| id | vehicles | raw registry strings, verbatim | verdict |
|---|---:|---|---|
| `car/rover/90` | 478 car + 4 van | `ROVER \| 90 SEDAN`, `ROVER \| ROVER 90 SALOON LHD`, `ROVER \| ROVER 90` ×392 (uk_dft), ×65 (nz), ×16 (nl) | **ROVER. KEPT.** |
| `car/rover/110` | 56 | `ROVER \| 110 SALOON`, `ROVER \| 110` ×16 (nl) ×39 (nz) | **ROVER. KEPT.** |

Three independent reasons, in the order they decide it:

1. **The Rover P4 range was numbered 60, 75, 80, 90, 95, 100, 105, 110** (https://en.wikipedia.org/wiki/Rover_P4). This catalog *already publishes* `rover/60`, `/75`, `/80`, `/95`, `/100`. 90 and 110 are two members of a range whose siblings are right there.
2. **The body words decide it.** The Dutch and NZ registers attached `SEDAN` and `SALOON`. A Land Rover 90/109 row in the *same* registers reads `STATION WAGON`, `PICK UP`, `HARD TOP`, `4X4`, `CABRIOLET`.
3. **The DVLA files both, separately, in one table**: 392 `ROVER 90` cars under make ROVER, alongside 2,082 `LAND ROVER 90` cars and 13,306 `LAND ROVER 90` vans under make LAND ROVER.

**Moving them would have destroyed 534 vehicles of real Rover evidence** and left the published P4 range with two holes in it. The reasoning is written into `moves.yml` at the point of decision, so the next automated companion worklist cannot re-propose it silently.

**`car/rover/109` is HELD too, and it is the more interesting of the two decisions.** There was never a Rover P4 109, and 109 inches *is* the Land Rover long wheelbase — so the move looks obvious. It is not taken, because the argument for it is **absence of evidence**: "no Rover 109 appears in a closed list, therefore it is a Land Rover." Every other move in this PR rests on *positive row evidence* — `ROVER | ROVER RANGE ROVER` ×7,227, two genmodels under two makes in one DVLA table, landrover.co.uk listing the nameplate. The 90/110 verdict directly above is exactly what a slug-shaped inference costs when it turns out wrong: 534 vehicles of P4 evidence. `109` is the same shape of argument with a smaller number attached, and the number is not what makes it wrong.

Both failed routes are recorded in `moves.yml` at the point of decision, so the next automated worklist meets the reasoning before it re-proposes the move: **(1)** raw re-parse — both raws are literally `109`, nothing left to recover; **(2)** body word — neither row carries one, so the `SEDAN`/`SALOON` vs `STATION WAGON` discriminator that settled 90 and 110 is unavailable. `car/land-rover/109` carries the matching note from the other side in the enrich PR. Held until someone finds a `ROVER 109` row that names a body, or proves none exists.

---

## 3. The four minted ids — and the two deviations from the dossier's prediction

| minted | from | carrying |
|---|---|---|
| `car/jaguar/xj220` | `car/jaguar/xj-220` (spaced spelling) | fi, nl — 4 vehicles |
| `car/rover/2200` | `car/rover/2200-tc` | fi, nl, nz — 78 vehicles |
| `car/rover/800` | `car/rover/800-series` + an nz candidate | gb, nl, nz — 1,613 vehicles |
| **`car/rover/3-5-litre`** | the INTERIM `junk?` rescue (§9, ruling 7) | **fi, gb, nl, nz — 1,271 vehicles** |

**Deviation 1 — `van/land-rover/range-rover` is NOT minted, and the build is right.** The dossier predicted it as the fourth mint. It does not appear, and the mechanism is `Reconciler.cross_kind_prune!` (`reconciler.rb:105-130`): when one kind holds ≥97% of an id's total count, the other kinds' copies are pruned as mis-kinded. *Before* the move, `rover/range-rover` was car 8,427 / van 659 — 92.7%, under the bar, so the van record lived. *After* it, every Range Rover row consolidates onto `land-rover/range-rover` at car ~149,000 vs van ~1,200 (>99%), so the van twin is pruned. That is the pruner working: the Range Rover is a car.

So `van/rover/range-rover` is aliased **cross-kind** to `car/land-rover/range-rover` — the same shape as the already-shipped `van/land-rover/90-defender → car/land-rover/90-defender`. **This is a real consequence a reviewer should see**: a 659-vehicle van record ceases to exist. No *country* evidence is lost (the car record publishes gb and nl), and no consumer 404s; but those 659 UK/Dutch van registrations are no longer counted on any published record. The alternative would be to suppress the pruner, which is a pipeline change and out of scope here. Flagged, not worked around.

**Deviation 2 — `car/rover/3-5-litre` is minted instead**, by the one INTERIM line this PR carries. Net: still 4 mints.

---

## 4. The move: 9,656 vehicles off a marque that stopped owning the product in 1978

`overrides/models/moves.yml`, **7 keys, 9 published records** (the dossier proposed 8 and 10; `Rover|109` is held — §2).

**Why the Range Rover is a Land Rover, sourced:**

* *"In 1978, British Leyland created a new subsidiary known as Land Rover Limited which encompassed much of the original assets of the Rover Company"* — https://en.wikipedia.org/wiki/Rover_Company
* The Range Rover launched in 1970 under British Leyland and *"is a 4x4 luxury marque and sub-brand of Jaguar Land Rover"* — https://en.wikipedia.org/wiki/Range_Rover. It has been a Land Rover product for 48 of its 56 years.
* **Land Rover's own current vehicle index lists exactly three families — RANGE ROVER, DISCOVERY, DEFENDER** (https://www.landrover.co.uk/vehicles/index.html). Rover lists nothing; the marque has been dormant since 2005.
* `NAMING.md §1`: *"The make is the marque, not the registrant."* The DVLA's `ROVER | ROVER RANGE ROVER` genmodel is a **registrant** fact — the type-approval holder was Rover Group — and it is the artifact being corrected, not evidence against the correction. This is the `SEAT|Formentor → Cupra|Formentor` shape exactly.

**Ordering constraint, verified in the build and not assumed.** `Range` (nz field-width truncation, ×59) and `Ranger Rover`/`Ranger/Rover` (the typo) are renamed to `Range Rover` under the `Rover:` block, and only then moved — `moves.yml` rule 1 keys are POST-rename. Both live in this single commit. The build confirms the ordering holds: `car/rover/range` and `car/rover/ranger-rover` both disappear and both land on `car/land-rover/range-rover`, and neither is left published under Rover.

**Evidence transfer — the destination gains exactly what the source loses.** Measured per move; `missing` is empty in all ten:

| moved record | countries | destination | destination countries after | carried | missing |
|---|---|---|---|---|---|
| `car/rover/range-rover` (8,427 veh) | gb,nl,nz | `car/land-rover/range-rover` | ar,ca,de,es,fi,gb,ie,lu,my,nl,nz,th,ua,us | gb,nl,nz | — |
| `van/rover/range-rover` (659) | gb,nl | `car/land-rover/range-rover` (cross-kind, §3) | ″ | gb,nl | — |
| `car/rover/range` (63) | nl,nz | `car/land-rover/range-rover` | ″ | nl,nz | — |
| `car/rover/ranger-rover` (3) | nl,nz | `car/land-rover/range-rover` | ″ | nl,nz | — |
| `van/rover/defender` (6) | fi,nl | `van/land-rover/defender` | es,fi,gb,lu,nl | fi,nl | — |
| `car/rover/mgf` (489) | fi,lu,nl,nz | `car/mg/mgf` | fi,gb,lu,nl,nz | fi,lu,nl,nz | — |
| `car/rover/mg-zt` (2) | fi,nl | `car/mg/zt` | **fi**,gb,nl | fi,nl | — |
| `car/jaguar/range-rover-evoque` (4) | es,nl | `car/land-rover/range-rover-evoque` | 14 countries | es,nl | — |
| `van/jaguar/defender` (3) | es,nl | `van/land-rover/defender` | es,fi,gb,lu,nl | es,nl | — |

Destination count gains: `car/land-rover/range-rover` **+8,502**, `car/land-rover/109` +104 (all from the in-make `Lr 109`/`109 Lwb`/`109 V8` folds — nothing from Rover), `van/land-rover/defender` +13, `car/mg/mgf` +489, `car/mg/zt` +2, `car/land-rover/range-rover-evoque` +146. `car/mg/zt` **gains `fi`** — the only enlargement outside the three makes.

**The `ranger-rover` typo fix**, proven three ways: both spellings live under the same make in the same registers and the correct one outnumbers the typo **2,809 : 1** (`nl_rdw RANGE ROVER` ×984 vs `RANGER ROVER` ×2; `nz_nzta` ×146 vs ×1); the same typo appears independently under make LAND ROVER next to the correct spelling; and there has never been a vehicle called a "Ranger Rover". Both spellings that reach the slug `ranger-rover` are keyed (`Ranger Rover` **and** `Ranger/Rover`) — the BMW `3 C`/`3. C` gotcha — with rename+move under Rover and rename-only under Land Rover, where the correct target already exists in-make.

**NOT moved, deliberately:** `car/rover/mini` and `car/rover/mini-cooper`, 30,305 vehicles. The Mini was *badged and sold* as a **Rover Mini** 1988-2000 and the DVLA genmodel is literally `ROVER | ROVER MINI` (29,832 registrations). Unlike the Range Rover, whose marque changed in 1978 and never changed back, "Rover Mini" was the marketed name of the car.

---

## 5. Availability: **0 lost, 15 strictly enlarged**

`country evidence LOST by folding + moving: 0`, and `survivors that lost a country, any make, whole catalog: 0`.

| survivor | gains | why it matters |
|---|---|---|
| `car/jaguar/xf` | **+gb** | 94,120 UK vehicles were parked on the DVLA range label `JAGUAR XF SERIES`; the nameplate carried no UK evidence at all. 5,348 → 99,858 vehicles. |
| `car/jaguar/xe` | **+ca, +gb** | 43,700 UK + the ca-only P250/P300 rows. 2,330 → 46,032. |
| `car/jaguar/xk` | **+gb** | 28,729 UK. 875 → 29,604. |
| `car/jaguar/f-pace` | **+ca** | six ca-carrying power/trim ids, none of them on the base record |
| `car/jaguar/e-pace` | **+ca** | ditto |
| `car/rover/200` | **+fi, +gb** | 9,681 vehicles on the label vs 27 on the nameplate → 9,708 |
| `car/rover/400` | **+fi, +gb** | 20 → 4,336 |
| `car/rover/100` | **+gb** | 109 → 4,329 |
| `car/rover/600` | **+gb, +nl** | 5 → 2,210 |
| `car/rover/2000` | **+gb** | 113 → 2,321 |
| `car/rover/2600` | **+fi** | from `2600 Automatic` |
| `car/rover/620` | **+fi** | from `620 Si` |
| `car/land-rover/109` | **+fi** | from the in-make `Lr 109` fold — this gain does **not** depend on the held `car/rover/109` |
| `van/land-rover/88` | **+fi** | from `Series 88` |
| `car/mg/zt` | **+fi** | via the cross-make move |

Read the Rover rows again: **five nameplates whose UK evidence was sitting on a label record while the nameplate itself showed nl/nz only.** That is the largest coverage defect in the slice and it is invisible without decoding the DVLA genmodel column. `car/rover/800` did not exist at all; it is minted by the fold and publishes 1,613 vehicles in gb+nl+nz.

The 24 dropped ids take **56 (id, country) pairs** with them. That is a deliberate, ledgered trade, not an accident: each entry in `removals.yml` carries its measured population and country list inside the reason string, because the gate stores nothing else.

---

## 6. Repoints — 11, not the 7 the dossier listed

Renames are **single-pass**: the value is final and never re-looked-up. A live key whose target is a name this pass retires would silently misroute every matching raw row to a dead id. The dossier named 7; walking each block's own targets against this pass's folds found **4 more under `Rover:`**, all of which `lint_curation`'s direction-war rule fails on.

| block | key | was → | now → |
|---|---|---|---|
| Jaguar | `Xj 12 L` | `XJ12L` | `XJ12` |
| Jaguar | `XJ6-L` | `XJ6L` | `XJ6` |
| Jaguar | `Xk 150 S` | `XK150S` | `XK150` |
| Land Rover | `109 Hardtop` | `109 Hard Top` | `109` |
| Land Rover | `88 Hardtop` | `88 Hard Top` | `88` |
| Land Rover | `88 Wb` | `88 W B` | `88` |
| Rover | `Landrover` | `Land Rover` | `null` |
| **Rover** | **`2300S`** | `2300 S` | **`2300`** ← not in the dossier |
| **Rover** | **`2600S`** | `2600 S` | **`2600`** ← not in the dossier |
| **Rover** | **`3500S`** | `3500 S` | **`3500`** ← not in the dossier |
| **Rover** | **`3500 Vanden Plas`** | `3500 Van Den Plas` | **`3500`** ← not in the dossier |

## 7. `former_ids` chain pre-flight — 12 inbound aliases flattened, 2 dangling targets caught by the gate

Nothing may alias INTO a retired id. **12 existing aliases pointed at ids this pass retires** and were flattened in place, each stating what it was:

`car/jaguar/{xj-12-l, xj6-l, xk-150-s}` · `car/land-rover/{109-hardtop, 88-hardtop, 88-wb}` · `car/rover/{2300s, 2600s, 3500s, 3500-vanden-plas, rangerover}` · `van/land-rover/90-defender` (the one cross-**kind** inbound alias).

`car/rover/rangerover` is the interesting one: it had to follow the Range Rover **across the make**, to `car/land-rover/range-rover`.

Two more were caught by the id-contract gate on the first treatment build and fixed:

* **`van/rover/range-rover`** → target not live (§3) → repointed cross-kind to `car/land-rover/range-rover`.
* **`car/rover/landrover`** → its target `car/rover/land-rover` is one of this pass's 24 drops, so the alias pointed into a 404. Re-disposed as a **removal**, with the alias line retired and a pointer left in its place. `lint_curation` rule **1g** forbids carrying both dispositions, so this is the rule-1g remedy applied in the other direction: the reasoning moves, it is not deleted.

Also checked and clean: no target is itself an alias source; no self-references; no id appears in both `removals.yml` and `former_ids.yml`. Four dossier alias lines were **dropped** rather than written — `van/rover/{100,200,800,2000}-series` — because those ids are candidate rows that were never published and their targets would not be live: gate 7b (alias liveness) fails on a dangling target regardless of whether the source ever shipped.

## 8. Blast radius — every key checked in all six kinds

`renames.yml` is keyed `Make → nameplate` with **no kind dimension**, so every key fires in every kind of that make. All 200 keys were looked up in the per-kind probe index:

* **0 keys absent from the probe index** — every one is a string the normalizer demonstrably produced on this corpus, so none can land dead.
* **37 keys fire in more than one kind.** All 37 are intended, each says `FIRES IN …` on its own line, and each names its twin. **Each is written exactly ONCE.** The load-bearing ones are Land Rover `88 Pick Up`/`88 Pick-Up` (`van/land-rover/88-pick-up`, 312 vehicles) and Rover `Range` (car **and truck** — the truck rows are uk_dft `ROVER RANGE ROVER` after `series_collapse`, the same vehicle).
* **0 keys fire in `motorcycle`, `moped` or `bus`.**

The one key worth a second look is Land Rover `Rover: null`: it fires in car and van, and the van side (10 vehicles, nl) is an unpublished candidate — so the `null` also suppresses a row that never reached the catalog. That is correct, and it is marked **INTERIM** because 30 of its 39 car vehicles come from a normalizer defect, not from the register: `strip_make_prefix` takes `raw_make.split.first` = `"LAND"` for make `LAND ROVER`, so the raw row `LAND ROVER | LAND ROVER` produces the nameplate `Rover` (`normalizer.rb:316-323`). That is the filed DEBT hygiene-2 item *"make-fragment strips LAND/MICRO/HD"*, now with a price attached.

---

## 9. The nine rulings, and how each was applied

1. **`car/rover/90` and `car/rover/110` stay Rover.** Applied — §2. Neither appears in `moves.yml` or in any rename key; both are among the 164 survivors; the reasoning is written into `moves.yml` so the flawed companion worklist cannot re-propose it. The enrich PR puts a ★ note on both records saying the same thing in the data itself.
2. **`car/rover/109` is HELD, not moved.** **Applied.** The first cut of this PR moved it and said so loudly; the owner held the ruling and was right, and the reasoning is worth recording because it generalises: the case for the move is *absence* of evidence (no Rover 109 in a closed P4 list), while every other move here rests on positive row evidence. The same slug-shaped inference is what put `rover/90` and `/110` on the worklist, where it would have destroyed 534 vehicles; the smaller number attached to `109` is not what makes it safer. Held, with both failed routes recorded in `moves.yml` at the point of decision and the matching note on `car/land-rover/109` in the enrich PR — see §2. `car/rover/109` publishes unchanged (2 vehicles, nl+nz), and the `car/land-rover/109` **+fi** enlargement in §5 does not depend on it (that comes from the in-make `Lr 109` fold).
3. **Apply the `rover/range-rover` → land-rover move.** Applied — §4. `moves.yml` PLUS the pre-move `Range: Range Rover` rename in the same commit, and the ordering is **verified in the build**, not assumed: both `car/rover/range` and `car/rover/ranger-rover` vanish and land on the Land Rover record.
4. **Apply the `ranger-rover` typo fix, both spellings keyed.** Applied — §4. `Ranger Rover` + `Ranger/Rover` under Rover (rename → move), `Ranger Rover` + `Ranger Rover Sport` under Land Rover (rename only).
5. **Apply `"Xj Sc": XJ-S` and correct the record.** Applied. **DEBT.md line 69 is wrong about `Xj-Sc`**: that key is LIVE, firing on fi/nl/us rows, and `gen_review_pack` reports *no* dead override keys for any of these three makes. What `propose_former_ids` actually detected is a different and more useful thing — a **second raw spelling reaching the same slug** (`nl_rdw JAGUAR XJ SC` / `XJ SC`, `nz_nzta XJ SC`) keeping `car/jaguar/xj-sc` alive under the display `"Xj Sc"`, so the tool's rule-(b) branch reported "the rename never applied". It did apply — to the hyphenated string. One key closes it. **Confirmed empirically in this run:** `propose_former_ids` on control-vs-treatment now reports **1** dead key, and it is `car/chrysler/town-country-touring` — the *same signature*, one of the other two names on that DEBT line. The jaguar entry is gone from the list. The prediction that chrysler `Town&country Touring` and hyundai `Atos-Prime` are the same false class is now half-confirmed by direct observation; one `gen_review_pack chrysler hyundai` run settles the rest. (Owner is filing this.)
6. **`Xj Series: XJ-S` held out → its own PR.** Held. That line puts 42,896 UK XJ *saloons* — 97% of the record — onto the XJ-S *coupé*, and reversing it is a direction reversal of four settled lines. It is **not** in this diff. The separate PR uses the dossier's paste-ready inversion block, titles the number, and leads with the evidence and the "this reverses a settled line" statement.
7. **The dot-decimal `junk?` INTERIM line is allowed for `3.5 Litre`.** Applied, marked INTERIM against the filed rule defect. Renames are consulted BEFORE `junk?` (`normalizer.rb:178-186`), so the identity key `"3.5 Litre": "3.5 Litre"` **rescues 1,271 vehicles in fi+gb+nl+nz that the rule currently deletes outright** — the Rover P5B 3.5-Litre (1967-73), the V8 sibling of the published `car/rover/3-litre`, attested in four registers with no catalog record at all. Scoped to this one real nameplate. **No rule fix attempted** and **no interim lines added for the other ~6,714 vehicles of the same class**; they stay filed as the rule defect they are. (Measured cost of the rule in this slice alone: 846 raw rows / 7,985 vehicles.)
8. **U7 (`car/jaguar/mk` = 1,604 vehicles that are five different cars) is REPORTED, never patched.** Honoured. Not one key in this PR touches the `Mk`/`Mark` family, and the enrich files omit it deliberately with the reason in the file header. The information — `MK II` 1,317 · `MK VII` 166 · `MK VIII` 76 · `MK V` 8 · `MK IV` 6 — is destroyed by `VARIANT_SUFFIXES`' Roman-numeral strip (`normalizer.rb:47`, which strips II-VIII but not I, IX or X) **before renames are consulted**, so no override can recover it. Slice total for U7: 1,876 vehicles on 5 truncated ids spanning at least 13 distinct products.
9. **Wheelbase numbers stay; the Defender-merge question stays HELD; the EPA overrule stands.** Applied. `86/88/90/101/109/110/127` are kept as nameplates and only body/engine/registry-shorthand suffixes fold onto them — the inch figure *was* the model name for 37 years (the Series 80/86/88/107/109, then the **Ninety** and **One Ten**, spelled as words), and the DVLA runs six separate genmodels for them beside `LAND ROVER DEFENDER` in one table. `90 Defender`/`110 Defender` fold to the **number**, and their comments say the 90/110/130-into-Defender question is the owner's, not a curation pass's. The EPA `baseModel` overrule on the Range Rover family stands: that column folds Sport, Evoque and Velar all onto "Range Rover", but it also maps Discovery Sport **both ways in the same CSV**, so it is a fuel-economy grouping key here, not a taxonomy — landrover.co.uk's own family/model split wins.

## 10. Adaptations, each with its reason

All nine rulings are applied as written. Besides the four extra repoints (§6):

* **4 dossier `former_ids` lines dropped** — `van/rover/{100,200,800,2000}-series` — never-published candidate ids with targets that would dangle (§7).
* **`van/rover/range-rover` aliased cross-kind** to the car record after the cross-kind pruner removed the van twin (§3).
* **`car/rover/landrover` re-disposed** from alias to removal (§7).
* **2 enrich ids corrected for liveness**: the dossier's `car/rover/105` does not exist (fact kept in a comment, not written), and `car/rover/maestro` is really `van/rover/maestro`.
* **The `note:`-only loader bug — now CLOSED, and no workaround ships.** The first cut of this pair held `car/land-rover/santana-88` back because `Enrich.load` raised "empty entry" on a note-only entry, and reported that `lint_enrich.rb:123` rejected it too (verified by probe: `LINT FAIL: … expected runs:, links: and/or variants:`, exit 1) — so pipeline **#94** had fixed only the loader half. **#101 fixed the gate half.** The enrich branch is rebased onto both and `santana-88` ships as a real note-only entry, verified by running the lint against the actual entry. `car/jaguar/d-type` keeps its note alongside an attested `D Type` spelling variant, which is a genuine folded register string and belongs there either way.
* **One unintended display change, kept**: `car/jaguar/e-pace` publishes as **"E-Pace"** instead of "E Pace", because the `E-Pace P250`/`P300` folds pin the hyphenated target. It resolves an intra-make casing contradiction (`f-pace` and `i-pace` were already hyphenated) and matches Jaguar's own E-PACE. The other three display changes are intended pins: `C Type`→`C-Type`, `D Type`→`D-Type`, `Fc`→`FC`.

## 11. Filed, not fixed — what the next pass should pick up

* **Five Range Rover siblings are still under Rover.** `car/rover/range-rover-{auto, efi, efi-auto, hse, vogue}` (nl+nz each, deciles 7-10) survive this pass because the dossier neither measured nor proposed them. They are the same product with a transmission / injection / trim suffix, and the same 1978 argument applies — but inventing four folds the dossier never measured is exactly the drive-by this program does not do. **This is the most obvious follow-up in the slice.**
* `van/land-rover/range` and `truck/land-rover/range` sit in the candidate queue: the DVLA's own `LAND ROVER RANGE ROVER` rows `series_collapse` to `Range` under Land Rover, splitting them from `range-rover`. Not proposed here for the same reason.
* `car/jaguar/eagle` — a uk_dft candidate carrying **980 gb vehicles** under genmodel `JAGUAR EAGLE`. Unresolved; 980 vehicles is not nothing.
* `car/jaguar/fp-rd` (1,680 gb, almost certainly `F-PACE R-DYNAMIC`), `car/jaguar/24`, `car/jaguar/385`, `car/rover/35l` — each with two named failed routes in the dossier; none guessed.
* The comma-decimal half of the dot-decimal defect: 140 surviving rows / 207 vehicles carry a truncated displacement into their id.

---

## 12. Verification — every command run bare, every exit code

**The baseline was re-measured from scratch after the rebase, in dedicated pristine worktrees (data `origin/main` + pipeline `origin/main`) at the same frozen cache. It is 74 gate failures, not 2 and not 7** — the coordinator's "2" and my earlier "7" were both taken before **pipeline#100 (G-1) landed ahead of its data companion, data#129**. Current pristine composition: **2 × `car/chevrolet/{tudor,van}`** (awaiting data#132) + **72 × `motorcycle/*`** across aprilia, lexmoto, yamaha, sym, honda, kawasaki, royal-enfield and others, all created by G-1 reading the uk_dft Model column for two-wheelers while the 37 aliases + 35 removals that dispose of them sit unmerged in data#129. That is the coupling NEGOTIATION Turn 217 records — not a defect, and not mine.

| check | exit | result |
|---|---|---|
| `scripts/lint_curation.rb --base=origin/main` | **0** | OK (109 files; duplicate-key + shape + make-key + provenance + direction-war + rule 1g) |
| `scripts/lint_overrides.rb` | **0** | OK |
| `scripts/reorg_make_blocks.rb` | **0** | already alphabetical |
| `scripts/reorg_make_blocks.rb --check` | **0** | already alphabetical |
| `pipeline/tools/lint_enrich.rb` | **0** | 56 files, 839 ids, OK — includes the note-only `santana-88` |
| `pipeline/tests/test_override_key_reachability.rb` | **0** | 5 runs, 10 assertions, 0 failures |
| `pipeline/tests/test_enrich.rb` | **0** | 19 runs, 46 assertions, 0 failures |
| `rake test` (pipeline, full suite) | **0** | 11 suites, 0 failures, 0 errors |
| `ruby pipeline/run.rb` (full, all six kinds) | 1 | **74 gate failures — the FAIL set is BYTE-IDENTICAL to the pristine control. Zero are mine.** |
| `scripts/propose_former_ids.rb <control> <treatment>` | **0** | see below |

**Judged by diff-against-control, never by exit code**, and the diff is literally empty:

```
control fails:     74
treatment fails:   74
diff <control-fails> <treatment-fails>   ->   no output, exit 0
```

An earlier treatment build had **3** extra failures, all mine, all real, all fixed: the two dangling aliases in §7 and `van/rover/range-rover`'s missing target in §3.

### `propose_former_ids` output, investigated line by line

```
intents=11847 proposed=0 dead_keys=1 evidence_loss=0 unexplained=24
# ---- PROPOSED (0 new; 175 already in former_ids.yml) ----
# ---- !! DEAD OVERRIDE KEYS (1) ----
#   car/chrysler/town-country-touring  published as "Town & Country Touring"
#      <- renames.yml Chrysler: Town&country Touring -> Town & Country
# ---- UNEXPLAINED DISAPPEARANCES (24) ----   [the 24 `null` drops, listed]
```

* **`proposed=0`, 175 already covered** — every rename/move intent that actually changed an id is already aliased. Nothing was missed.
* **`evidence_loss=0`** — the script's own independent country check agrees with the build diff.
* **`dead_keys=1`, and it is not mine.** `car/chrysler/town-country-touring` is one of the other two names on DEBT.md line 69, with exactly the signature ruling 5 predicts (key fires; a sibling spelling keeps the slug alive). The jaguar `Xj-Sc` entry that used to appear here is **gone**, because this PR's `"Xj Sc": XJ-S` key retires the id — the empirical proof that the §E-3 diagnosis was right.
* **`unexplained=24`** — exactly the 24 deliberate `null` drops. `propose_former_ids` does not read `removals.yml`, so a null-rename disappearance always lands in this bucket; each of the 24 has a reviewed `removals.yml` entry and the id-contract gate is green on all of them. Reporting shape, not a defect.

---

*Companion pipeline PR: `s4w/jlr-enrich` (3 enrich files, 75 model ids, 3 make entries). Held-out inversion: the separate `Xj Series` PR (#138), rebased onto this branch's new tip. **Do not merge any of the three without a fresh CI pass.***