### PR TITLE
Chevrolet wave-4 CLEAN: 174 records fold onto 47 nameplates (393 → 219), 0 availability lost

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1227,13 +1227,13 @@
 "car/cadillac/lasalle": "car/cadillac/la-salle"
 "car/cadillac/sedan-deville": "car/cadillac/sedan-de-ville"
 "car/chevrolet/belair": "car/chevrolet/bel-air"
-"car/chevrolet/bellair": "car/chevrolet/bell-air"
-"car/chevrolet/camaro-z28": "car/chevrolet/camaro-z-28"
-"car/chevrolet/corvette-stingray": "car/chevrolet/corvette-sting-ray"
-"car/chevrolet/corvette-zr1": "car/chevrolet/corvette-zr-1"
+"car/chevrolet/bellair": "car/chevrolet/bel-air" # FLATTENED 2026-08-01 (was -> car/chevrolet/bell-air, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
+"car/chevrolet/camaro-z28": "car/chevrolet/camaro" # FLATTENED 2026-08-01 (was -> car/chevrolet/camaro-z-28, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
+"car/chevrolet/corvette-stingray": "car/chevrolet/corvette" # FLATTENED 2026-08-01 (was -> car/chevrolet/corvette-sting-ray, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
+"car/chevrolet/corvette-zr1": "car/chevrolet/corvette" # FLATTENED 2026-08-01 (was -> car/chevrolet/corvette-zr-1, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
 "car/chevrolet/deluxe": "car/chevrolet/de-luxe"
-"car/chevrolet/stingray": "car/chevrolet/sting-ray"
-"car/chevrolet/styleline-deluxe": "car/chevrolet/styleline-de-luxe"
+"car/chevrolet/stingray": "car/chevrolet/corvette" # FLATTENED 2026-08-01 (was -> car/chevrolet/sting-ray, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
+"car/chevrolet/styleline-deluxe": "car/chevrolet/styleline" # FLATTENED 2026-08-01 (was -> car/chevrolet/styleline-de-luxe, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
 "car/chevrolet/trailblazer": "car/chevrolet/trail-blazer"
 "car/chrysler/300c": "car/chrysler/300-c"
 "car/chrysler/300m": "car/chrysler/300-m"
@@ -2018,9 +2018,9 @@
 "truck/mercedes-benz/l508": "truck/mercedes-benz/l-508"
 "truck/mercedes-benz/l608": "truck/mercedes-benz/l-608"
 "truck/toyota/landcruiser": "truck/toyota/land-cruiser"
-"van/chevrolet/3100-pickup": "van/chevrolet/3100-pick-up"
-"van/chevrolet/c10-custom-deluxe": "van/chevrolet/c-10-custom-deluxe"
-"van/chevrolet/c10-pick-up": "van/chevrolet/c-10-pick-up"
+"van/chevrolet/3100-pickup": "van/chevrolet/3100" # FLATTENED 2026-08-01 (was -> van/chevrolet/3100-pick-up, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
+"van/chevrolet/c10-custom-deluxe": "van/chevrolet/c-10" # FLATTENED 2026-08-01 (was -> van/chevrolet/c-10-custom-deluxe, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
+"van/chevrolet/c10-pick-up": "van/chevrolet/c-10" # FLATTENED 2026-08-01 (was -> van/chevrolet/c-10-pick-up, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
 "van/chevrolet/fleetside-pickup": "van/chevrolet/fleetside-pick-up"
 "van/chevrolet/k-1500": "van/chevrolet/k1500"
 "van/chevrolet/pickup": "van/chevrolet/pick-up"
@@ -2686,7 +2686,7 @@
 # reversed on jeep.com; the two pre-existing willys chains edited above.
 "van/chevrolet/c10": "van/chevrolet/c-10"
 "car/chevrolet/c10": "car/chevrolet/c-10"
-"car/chevrolet/impala-s-s": "car/chevrolet/impala-ss"
+"car/chevrolet/impala-s-s": "car/chevrolet/impala" # FLATTENED 2026-08-01 (was -> car/chevrolet/impala-ss, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
 "van/chevrolet/s10-pick-up": "van/chevrolet/s10-pickup"
 "car/jeep/cj5": "car/jeep/cj-5"
 "car/jeep/cj7": "car/jeep/cj-7"
@@ -4585,3 +4585,199 @@
 "truck/scania/p92m":                       "truck/scania/p92"                     # FOLD onto a MINTED survivor (fi+nl); P92M => P92, 5 vehicles. inbound 0 — nothing chains through this id
 "truck/scania/sba":                        "truck/scania/sba111"                  # FOLD onto a MINTED survivor (fi+nl); Sba => SBA111, 4 vehicles. inbound 0 — nothing chains through this id
 "bus/scania/tdx":                          "bus/van-hool/tdx"                     # moves.yml Scania|Tdx -> Van Hool|Tdx (dossier §A-S6): the TDX27 Astromega is Van Hool's coach; target is LIVE at fi+gb+nl+ua, a strict superset of the source's nl+ua. Cross-make by the shipped moves precedent (car/toyota/scion-tc -> car/scion/tc). inbound 0 — nothing chains through this id
+# ── Chevrolet wave-4 CLEAN pass (2026-08-01): 178 records fold onto 48 live
+# nameplates, one of them MINTED by the fold (truck/chevrolet/chevy-van, which
+# has no parent in its kind and receives 767 fi registrations currently
+# published as FI type codes). Every line below is a record that ceases to
+# exist because it denoted a trim, engine or package badge, a drivetrain
+# marker, a cab or bed configuration, a payload class, a chassis or generation
+# code, a body word or a registry misspelling of a nameplate that survives.
+# Zero (country, source) availability pairs are lost: a rename re-attributes
+# the child's evidence rows, it does not discard them, and 13 survivors gain
+# coverage they did not have (corvette +th, cruze +ar, sonic +es/fi, corvair
+# +es, k1500 +us, national +nl, nomad +fi, sportvan +ca, car/chevy-van +nz,
+# van/chevy-van +lu, van/s10 +lu, van/silverado +es, truck/chevy-van +fi).
+#
+# CHAIN PRE-FLIGHT, run before appending and asserted in the applier, not
+# assumed: no line below self-references; no target is itself one of the 178
+# retiring ids; no target is an existing alias KEY; none of the 178 is already
+# present in this file. ELEVEN existing aliases pointed INTO an id this batch
+# retires and were FLATTENED IN PLACE onto the final destination (each marked
+# "FLATTENED 2026-08-01" on its own line above). Rule 1g: the one id this pass
+# nulls (car/chevrolet/chev) is in removals.yml and is deliberately NOT
+# aliased — the string names the marque, so no successor is honest.
+# Dossier: wave-4 Chevrolet CLEAN+ENRICH. ──
+"car/chevrolet/camaro-1lt": "car/chevrolet/camaro" # (es+fi+nl) 1LT is the base Camaro trim (1LT/2LT/1SS/2SS ladder) — https://en.wikipedia.org/wiki/Chevrolet_Camaro ; us_fueleconomy baseModel: every Camaro row bases at "Camaro" (https://www.fueleconomy.gov/feg/download.shtml)
+"car/chevrolet/camaro-228": "car/chevrolet/camaro" # (nl+nz) registry mis-key of Z28 (no Chevrolet "Camaro 228" exists); raws "CAMARO 228" ×13 nz+nl sit beside "CAMARO Z28" ×130 — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+"car/chevrolet/camaro-2ss": "car/chevrolet/camaro" # (fi+nl) 2SS is the upper SS trim of the 5th/6th-gen Camaro — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+"car/chevrolet/camaro-berlinetta": "car/chevrolet/camaro" # (nl+nz) Berlinetta was the 1979-86 luxury trim replacing the Type LT — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+"car/chevrolet/camaro-iroc-z": "car/chevrolet/camaro" # (fi+nl+nz) IROC-Z was an option package on the Camaro Z28 (1985-90) — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+"car/chevrolet/camaro-iroc-z28": "car/chevrolet/camaro" # (fi+nz) same package, written with the Z28 base — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+"car/chevrolet/camaro-ls": "car/chevrolet/camaro" # (es+nl) LS is the base equipment level — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+"car/chevrolet/camaro-lt": "car/chevrolet/camaro" # (es+fi+nl+nz) LT is an equipment level; folding retires this record, so the open Lt-casing DEBT line is not touched
+"car/chevrolet/camaro-r-s": "car/chevrolet/camaro" # (nl+nz) RS = Rally Sport appearance package — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+"car/chevrolet/camaro-rally-sport": "car/chevrolet/camaro" # (fi+nl) the package written out in full; fi raws are "CAMARO RALLY SPORT COUPE-FP21E-K/2570" type-code rows
+"car/chevrolet/camaro-sport": "car/chevrolet/camaro" # (es+fi+nl+nz) "Sport Coupe" is the Camaro's body designation in the fi/nl rows, not a nameplate
+"car/chevrolet/camaro-ss": "car/chevrolet/camaro" # (ca+es+fi+lu+nl+nz) REPOINT (was -> Camaro SS): SS is the Super Sport package, one altitude below the nameplate — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport . The SS CASING decision is untouched; the record simply ceases to exist
+"car/chevrolet/camaro-z-28": "car/chevrolet/camaro" # (ca+es+fi+nl+nz) REPOINT (was -> Camaro Z/28): Z28 is RPO Z28, an option package — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+"car/chevrolet/camaro-z28-iroc": "car/chevrolet/camaro" # (fi+nz) two stacked packages
+"car/chevrolet/camaro-zl1": "car/chevrolet/camaro" # (ca+nl) ZL1 is the supercharged performance package; ca_nrcan writes "Camaro ZL1" while us_fueleconomy has no ZL1 row at all - it certifies every Camaro as "Camaro"
+"car/chevrolet/z28": "car/chevrolet/camaro" # (fi+nl) bare option code under make CHEVROLET (fi+nl); the vehicle is a Camaro Z28 — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+"car/chevrolet/corvett": "car/chevrolet/corvette" # (nl+nz) registry misspelling of Corvette (nz ×2, nl ×1)
+"car/chevrolet/corvette-427": "car/chevrolet/corvette" # (fi+nl) 427 is the 7.0 L big-block displacement, a spec in the car kind (NAMING.md 6) — https://en.wikipedia.org/wiki/Chevrolet_Corvette
+"car/chevrolet/corvette-c3": "car/chevrolet/corvette" # (es+fi+nl) C3 is the third-generation code, not a marketed nameplate — https://en.wikipedia.org/wiki/Chevrolet_Corvette
+"car/chevrolet/corvette-c4": "car/chevrolet/corvette" # (fi+nl) C4 generation code — same source
+"car/chevrolet/corvette-c5": "car/chevrolet/corvette" # (fi+nl) C5 generation code — same source
+"car/chevrolet/corvette-c6": "car/chevrolet/corvette" # (fi+nl) C6 generation code — same source
+"car/chevrolet/c6": "car/chevrolet/corvette" # (gb+nl) uk_dft files these under make CORVETTE, so strip_make_prefix leaves a bare "C6" (raws "CORVETTE | CORVETTE C6" ×32 gb, ×1 nl) — the vehicle is a C6 Corvette
+"car/chevrolet/corvette-e-ray": "car/chevrolet/corvette" # (ca+us) us_fueleconomy baseModel: "Corvette E-Ray" -> Corvette (https://www.fueleconomy.gov/feg/download.shtml)
+"car/chevrolet/corvette-lt4": "car/chevrolet/corvette" # (es+nl) LT4 is the engine RPO (1996 LT4, 2015- supercharged LT4) — https://en.wikipedia.org/wiki/Chevrolet_Corvette
+"car/chevrolet/corvette-roadster": "car/chevrolet/corvette" # (es+fi+nl) Roadster is the body style; us_fueleconomy's own "Corvette Convertible" rows base at "Corvette"
+"car/chevrolet/corvette-sting-ray": "car/chevrolet/corvette" # (es+fi+nl+nz+th) Sting Ray/Stingray is a model-name badge carried by the C2/C3/C7/C8, never a separate product; us_fueleconomy certifies all of them as model "Corvette", baseModel "Corvette" — https://en.wikipedia.org/wiki/Chevrolet_Corvette
+"car/chevrolet/corvette-stingray-454": "car/chevrolet/corvette" # (fi+nl) 454 is the big-block displacement (a spec in the car kind)
+"car/chevrolet/corvette-z06": "car/chevrolet/corvette" # (ca+fi+nl+th+us) us_fueleconomy baseModel: "Corvette Z06" -> Corvette. CARRIES th INTO the survivor
+"car/chevrolet/corvette-z06-carbon-aero": "car/chevrolet/corvette" # (ca+us) us_fueleconomy baseModel: "Corvette Z06 Carbon Aero" -> Corvette
+"car/chevrolet/corvette-z51": "car/chevrolet/corvette" # (fi+nl) Z51 is the performance handling package (RPO Z51), never a separate model
+"car/chevrolet/corvette-zr-1": "car/chevrolet/corvette" # (ca+es+fi+nl+us) us_fueleconomy baseModel: "Corvette ZR1" -> Corvette
+"car/chevrolet/corvette-zr1x": "car/chevrolet/corvette" # (ca+us) us_fueleconomy baseModel: "Corvette ZR1X" and "Corvette ZR1X Hybrid" -> Corvette
+"car/chevrolet/z06": "car/chevrolet/corvette" # (gb) uk_dft files it under make CORVETTE ("CORVETTE | CORVETTE Z06" ×12 gb), leaving a bare package code
+"car/chevrolet/sting-ray": "car/chevrolet/corvette" # (fi+nl) bare badge under make CHEVROLET; the only Chevrolet Sting Ray is the Corvette — https://en.wikipedia.org/wiki/Chevrolet_Corvette
+"car/chevrolet/silverado-1500": "car/chevrolet/silverado" # (nl+ua+us) us_fueleconomy baseModel: "Silverado 1500 2WD/4WD/AWD" -> Silverado (https://www.fueleconomy.gov/feg/download.shtml)
+"car/chevrolet/silverado-20": "car/chevrolet/silverado" # (nl+nz) GVW class 20 (three-quarter ton) written as a suffix; us_fueleconomy bases every Silverado NNNN row at "Silverado"
+"van/chevrolet/silverado-10": "van/chevrolet/silverado" # (fi+nl) half-ton class suffix. NB the bare "10" could also be read as the C10 chassis; folding to the Silverado nameplate is the conservative reading (no C token in the raw) — see E.9
+"van/chevrolet/silverado-1500-lt": "van/chevrolet/silverado" # (fi+nl) LT is the equipment level on the 1500 series
+"van/chevrolet/silverado-crew-cab": "van/chevrolet/silverado" # (es+nl) Crew Cab is the four-door cab configuration, a body style — https://en.wikipedia.org/wiki/Chevrolet_C/K_(fourth_generation) ("For 1992 ... a four-door crew cab was introduced")
+"van/chevrolet/silverado-lt-trail-boss": "van/chevrolet/silverado" # (lu+nl) us_fueleconomy baseModel: "Silverado 4WD TrailBoss" -> Silverado
+"van/chevrolet/silverado-pick-up": "van/chevrolet/silverado" # (fi+nl) body word on the nameplate
+"truck/chevrolet/siverado": "truck/chevrolet/silverado" # (fi+nl) registry misspelling (fi ×2, nl ×1)
+"truck/chevrolet/2500hd": "truck/chevrolet/silverado" # (fi+nl) all six raws behind this id are "2500HD SILVERADO..." (fi ×5, nl ×1) — the vehicle is a Silverado 2500HD; us_fueleconomy baseModel "Silverado 2500 HD 2WD" -> Silverado
+"van/chevrolet/silverado-1500": "van/chevrolet/silverado" # (fi+nl) us_fueleconomy baseModel: "Silverado 1500 2WD/4WD/AWD" -> Silverado (https://www.fueleconomy.gov/feg/download.shtml)
+"car/chevrolet/suburban-1500": "car/chevrolet/suburban" # (fi+us) us_fueleconomy baseModel: "Suburban 1500 2WD/4WD/AWD" -> Suburban
+"car/chevrolet/suburban-2wd": "car/chevrolet/suburban" # (nl+us) drivetrain marker; us_fueleconomy baseModel "Suburban 2WD" -> Suburban
+"car/chevrolet/suburban-ffv": "car/chevrolet/suburban" # (ca+fi) FFV = flexible-fuel certification marker, not a nameplate
+"car/chevrolet/suburban-k1500": "car/chevrolet/suburban" # (fi+nl+us) us_fueleconomy baseModel: "Suburban K1500 4WD" -> Suburban. DECISIVE
+"car/chevrolet/suburban-silverado": "car/chevrolet/suburban" # (fi+nl+nz) Silverado was the TOP TRIM LEVEL of the C/K trucks 1975-1998 — https://en.wikipedia.org/wiki/Chevrolet_Silverado ("The Silverado nameplate made its debut for the 1975 model year, becoming the top trim level on all Chevrolet C/K trucks")
+"car/chevrolet/surburban": "car/chevrolet/suburban" # (nl+nz) registry misspelling, 27 registrations (nl ×26, nz ×1)
+"car/chevrolet/k2500-suburban": "car/chevrolet/suburban" # (fi+nz) us_fueleconomy baseModel: "Suburban K10 4WD"/"Suburban K1500 4WD" -> Suburban; the chassis code is a variant of the nameplate
+"car/chevrolet/c10-suburban": "car/chevrolet/suburban" # (fi+nl) us_fueleconomy baseModel: "Suburban C10 2WD" -> Suburban. DECISIVE
+"car/chevrolet/tahoe-4": "car/chevrolet/tahoe" # (fi+nl) truncation of "TAHOE 4 DOOR"/"TAHOE 4-DOOR" — a body word, not a nameplate (60 registrations car + 13 van)
+"car/chevrolet/tahoe-k1500": "car/chevrolet/tahoe" # (fi+us) us_fueleconomy baseModel: "Tahoe K1500 4WD" -> Tahoe. DECISIVE
+"van/chevrolet/tahoe-4": "van/chevrolet/tahoe" # (fi+nl) truncation of "TAHOE 4 DOOR"/"TAHOE 4-DOOR" — a body word, not a nameplate (60 registrations car + 13 van)
+"car/chevrolet/blazer-1500": "car/chevrolet/blazer" # (fi+us) us_fueleconomy baseModel: "Blazer 1500 4WD" -> Blazer. DECISIVE
+"car/chevrolet/blazer-k5": "car/chevrolet/blazer" # (nl+nz) K5 is the full-size Blazer's chassis code — https://en.wikipedia.org/wiki/Chevrolet_Blazer ; us_fueleconomy bases "Blazer V1500 4WD" at Blazer
+"car/chevrolet/k5-blazer": "car/chevrolet/blazer" # (nl+nz) K5 is the full-size Blazer's chassis code, token order inverted — https://en.wikipedia.org/wiki/Chevrolet_Blazer
+"car/chevrolet/blazer-s10": "car/chevrolet/blazer" # (nl+nz) us_fueleconomy baseModel: "S10 Blazer 2WD/4WD" -> Blazer. DECISIVE
+"car/chevrolet/s10-blazer": "car/chevrolet/blazer" # (nl+nz) us_fueleconomy baseModel: "S10 Blazer 4WD" -> Blazer. DECISIVE
+"car/chevrolet/k10-blazer": "car/chevrolet/blazer" # (nl+us) us_fueleconomy baseModel: "K10 Blazer 4WD" -> Blazer. DECISIVE
+"car/chevrolet/blazer-silverado": "car/chevrolet/blazer" # (fi+nz) Silverado was the C/K top trim 1975-1998 and was applied to the K5 Blazer — https://en.wikipedia.org/wiki/Chevrolet_Silverado
+"car/chevrolet/blazer-ev-rwd": "car/chevrolet/blazer-ev" # (ca+us) drivetrain marker on the Blazer EV; ca_nrcan/us_fueleconomy both write "Blazer EV RWD" beside "Blazer EV AWD". (The EV/ICE split itself is a KEEP — see 3 and E.3)
+"car/chevrolet/impala-custom": "car/chevrolet/impala" # (fi+nl) Custom was an Impala trim (Impala Custom Coupe 1967-76) — https://en.wikipedia.org/wiki/Chevrolet_Impala
+"car/chevrolet/impala-hardtop": "car/chevrolet/impala" # (fi+nl) Hardtop Coupe is the body style
+"car/chevrolet/impala-sport": "car/chevrolet/impala" # (es+fi+nl+nz) "Sport Coupe"/"Sport Sedan" body designations
+"car/chevrolet/impala-ss": "car/chevrolet/impala" # (fi+nl+nz) REPOINT (was -> Impala SS): SS is the Super Sport package; us_fueleconomy certifies every Impala as model "Impala", baseModel "Impala" — the SS casing decision (#63) is preserved in spirit, the record simply rises one altitude
+"car/chevrolet/impala-ss-sport": "car/chevrolet/impala" # (fi+nl) REPOINT (was -> Impala SS Sport): package + body word stacked
+"car/chevrolet/impalla": "car/chevrolet/impala" # (nl+nz) registry misspelling (nz ×3, nl ×1)
+"car/chevrolet/malibu-classic": "car/chevrolet/malibu" # (fi+nl) Classic was the Malibu's upper trim; us_fueleconomy baseModel for every Malibu row is "Malibu"
+"car/chevrolet/malibu-limited": "car/chevrolet/malibu" # (ca+us) us_fueleconomy baseModel: "Malibu Limited" -> Malibu. DECISIVE
+"car/chevrolet/malibu-maxx": "car/chevrolet/malibu" # (ca+us) us_fueleconomy baseModel: "Malibu Maxx" -> Malibu. DECISIVE (Maxx is the 2004-07 five-door body)
+"car/chevrolet/chevelle-malibu": "car/chevrolet/chevelle" # (fi+nl+nz) Malibu was the Chevelle's top TRIM 1964-72 before becoming a nameplate in 1978 — https://en.wikipedia.org/wiki/Chevrolet_Chevelle
+"car/chevrolet/chevelle-malibu-classic": "car/chevrolet/chevelle" # (fi+nl) trim-on-trim (Malibu Classic, 1973-77 Chevelle)
+"car/chevrolet/chevelle-malibu-ss": "car/chevrolet/chevelle" # (fi+nl) REPOINT (was -> Chevelle Malibu SS): Super Sport package on the Chevelle Malibu
+"car/chevrolet/chevelle-ss": "car/chevrolet/chevelle" # (fi+nl) REPOINT (was -> Chevelle SS): Super Sport package — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport
+"car/chevrolet/nova-2": "car/chevrolet/nova" # (nl+nz) truncation of "NOVA 2 DOOR COUPE" — a body word
+"car/chevrolet/nova-concours": "car/chevrolet/nova" # (fi+nl) Concours was the Nova's luxury trim (1976-79) — https://en.wikipedia.org/wiki/Chevrolet_Chevy_II_/_Nova
+"car/chevrolet/nova-custom": "car/chevrolet/nova" # (fi+nl) Custom was a Nova trim level
+"car/chevrolet/nova-ss": "car/chevrolet/nova" # (nl+nz) REPOINT (was -> Nova SS): Super Sport package
+"car/chevrolet/monte-carlo-ss": "car/chevrolet/monte-carlo" # (fi+nl+nz) REPOINT (was -> Monte Carlo SS): us_fueleconomy certifies every Monte Carlo as baseModel "Monte Carlo" — no SS row exists in the EPA file
+"car/chevrolet/caprice-classic": "car/chevrolet/caprice" # (fi+nl+nz) Classic was the Caprice's trim/series name; us_fueleconomy's model strings are "Caprice", "Caprice Wagon", "Caprice/Impala" — "Caprice Classic" appears nowhere, and all base at "Caprice"
+"car/chevrolet/caprice-classic-wagon": "car/chevrolet/caprice" # (fi+nl) us_fueleconomy baseModel: "Caprice Wagon" -> Caprice. DECISIVE
+"car/chevrolet/caprice-wagon": "car/chevrolet/caprice" # (ca+nl+us) us_fueleconomy baseModel: "Caprice Wagon" -> Caprice. DECISIVE
+"car/chevrolet/caprice-hearse": "car/chevrolet/caprice" # (nl+nz) a hearse is a coachbuilt body on the Caprice chassis, not a Chevrolet nameplate
+"car/chevrolet/cavalier-wagon": "car/chevrolet/cavalier" # (nl+us) us_fueleconomy baseModel: "Cavalier Wagon" -> Cavalier. DECISIVE
+"car/chevrolet/chevette-cs": "car/chevrolet/chevette" # (nl+us) us_fueleconomy baseModel: "Chevette CS" -> Chevette. DECISIVE
+"car/chevrolet/cobalt-ss": "car/chevrolet/cobalt" # (ca+us) REPOINT (was -> Cobalt SS): us_fueleconomy baseModel "Cobalt SS Coupe" -> Cobalt. DECISIVE
+"car/chevrolet/cobalt-xfe": "car/chevrolet/cobalt" # (ca+us) us_fueleconomy baseModel: "Cobalt XFE"/"Cobalt XFE Coupe"/"Cobalt XFE Sedan" -> Cobalt. DECISIVE (XFE = eXtra Fuel Economy package)
+"car/chevrolet/colorado-crew-cab": "car/chevrolet/colorado" # (ca+us) us_fueleconomy baseModel: "Colorado Crew Cab 2WD/4WD" -> Colorado. DECISIVE
+"car/chevrolet/colorado-zr2": "car/chevrolet/colorado" # (ca+us) us_fueleconomy baseModel: "Colorado ZR2 4WD" -> Colorado. DECISIVE
+"car/chevrolet/colorado-zr2-bison": "car/chevrolet/colorado" # (ca+us) us_fueleconomy baseModel: "Colorado ZR2 Bison 4WD" -> Colorado. DECISIVE
+"car/chevrolet/cruze-eco": "car/chevrolet/cruze" # (ca+us) us_fueleconomy baseModel: "Cruze Eco" -> Cruze. DECISIVE
+"car/chevrolet/cruze-limited": "car/chevrolet/cruze" # (ca+us) us_fueleconomy baseModel: "Cruze Limited" -> Cruze. DECISIVE
+"car/chevrolet/cruze-limited-eco": "car/chevrolet/cruze" # (ca+us) us_fueleconomy baseModel: "Cruze Limited  Eco" -> Cruze. DECISIVE
+"car/chevrolet/cruze-lt": "car/chevrolet/cruze" # (es+fi+nl) LT equipment level (es/fi/nl rows)
+"car/chevrolet/cruze-premier": "car/chevrolet/cruze" # (ar+ca+us) us_fueleconomy baseModel: "Cruze Premier"/"Cruze Premier Hatchback" -> Cruze. DECISIVE. CARRIES ar INTO the survivor
+"car/chevrolet/aveo-5": "car/chevrolet/aveo" # (ca+us) us_fueleconomy baseModel: "Aveo 5" -> Aveo. DECISIVE (the 5 is the five-door body)
+"car/chevrolet/aveo-ls": "car/chevrolet/aveo" # (fi+nl) LS equipment level
+"car/chevrolet/sonic-5": "car/chevrolet/sonic" # (ca+us) us_fueleconomy baseModel: "Sonic 5"/"Sonic 5 RS" -> Sonic. DECISIVE
+"car/chevrolet/sonic-lt": "car/chevrolet/sonic" # (es+fi+nl) LT equipment level. CARRIES es+fi INTO the survivor
+"car/chevrolet/optra-wagon": "car/chevrolet/optra" # (ca+us) us_fueleconomy baseModel: "Optra Wagon" -> Optra. DECISIVE
+"car/chevrolet/traverse-limited": "car/chevrolet/traverse" # (ca+us) us_fueleconomy baseModel: "Traverse Limited AWD/FWD" -> Traverse. DECISIVE
+"car/chevrolet/trailblazer-ext": "car/chevrolet/trail-blazer" # (ca+fi+us) us_fueleconomy baseModel: "TrailBlazer Ext 2WD/4WD" -> TrailBlazer. DECISIVE. Target display is the SETTLED "Trail Blazer" form; the TrailBlazer-vs-Trail Blazer direction is filed DEBT and is NOT touched here
+"car/chevrolet/trailblazer-ss": "car/chevrolet/trail-blazer" # (fi+nl) REPOINT (was -> Trailblazer SS): SS package. Direction question untouched - target is the live "Trail Blazer" display
+"car/chevrolet/trail-blazer-ltz": "car/chevrolet/trail-blazer" # (fi+nl) LTZ equipment level (the Lt/Ltz casing DEBT line is not touched: folding retires the record)
+"car/chevrolet/t15506-trailblazer": "car/chevrolet/trail-blazer" # (fi+nl) RDW type-code prefix glued to the nameplate; raw "T15506-TRAILBLAZER 4WD 4-DOOR UTILITY" ×46 nl + fi ×1
+"car/chevrolet/equinox-lt": "car/chevrolet/equinox" # (fi+nl+ua) LT equipment level
+"car/chevrolet/hhr-ls": "car/chevrolet/hhr" # (fi+nl) REPOINT (was -> HHR LS): LS equipment level. NB this pass RETIRES the "Hhr Lt was deliberately half-done" DEBT line by folding the whole family
+"car/chevrolet/hhr-lt": "car/chevrolet/hhr" # (fi+nl) REPOINT (was -> HHR Lt): LT equipment level - see above
+"car/chevrolet/hhr-ss": "car/chevrolet/hhr" # (ca+nl) REPOINT (was -> HHR SS): SS package
+"car/chevrolet/astro-van": "car/chevrolet/astro" # (fi+nl) "Van" is the Astro's body word; us_fueleconomy splits Astro Cargo/Astro Passenger but both are the Astro — https://en.wikipedia.org/wiki/Chevrolet_Astro
+"car/chevrolet/astro-starcraft": "car/chevrolet/astro" # (fi+nl) Starcraft is a US conversion-van builder, not a Chevrolet nameplate; the row is a converted Astro (Ford Transit Tecnocar precedent)
+"van/chevrolet/astro-van": "van/chevrolet/astro" # (fi+nl) "Van" is the Astro's body word; us_fueleconomy splits Astro Cargo/Astro Passenger but both are the Astro — https://en.wikipedia.org/wiki/Chevrolet_Astro
+"car/chevrolet/corvair-500": "car/chevrolet/corvair" # (es+nl) 500 was the base Corvair series (500/700/900 Monza) — https://en.wikipedia.org/wiki/Chevrolet_Corvair . CARRIES es INTO the survivor
+"car/chevrolet/corvair-corsa": "car/chevrolet/corvair" # (fi+nl) Corsa was the 1965-66 top Corvair series — same source
+"car/chevrolet/corvair-monza": "car/chevrolet/corvair" # (fi+nl) Monza was the Corvair's sporty series — same source (distinct from the 1975-80 Chevrolet Monza, which stays live)
+"car/chevrolet/bel-air-4": "car/chevrolet/bel-air" # (fi+nl) truncation of "BEL AIR 4 DOOR SEDAN"/"Bel Air 4-D Sedan" - a body word
+"car/chevrolet/bel-air-4d": "car/chevrolet/bel-air" # (fi+nl) the "4 DOOR SEDAN" body word in its fused form — https://en.wikipedia.org/wiki/Chevrolet_Bel_Air
+"car/chevrolet/bel-air-sport": "car/chevrolet/bel-air" # (nl+nz) "Sport Sedan"/"Sport Coupe" body designations
+"car/chevrolet/bell-air": "car/chevrolet/bel-air" # (nl+nz) registry misspelling of Bel Air (nl ×7, nz ×3) — https://en.wikipedia.org/wiki/Chevrolet_Bel_Air
+"car/chevrolet/belair-nomad": "car/chevrolet/nomad" # (fi+nl) the 1955-57 Nomad was sold as the Bel Air Nomad; the Nomad is the product — https://en.wikipedia.org/wiki/Chevrolet_Nomad . CARRIES fi INTO the survivor
+"car/chevrolet/fleetline-aerosedan": "car/chevrolet/fleetline" # (fi+nl) Aerosedan is the Fleetline's fastback body style — https://en.wikipedia.org/wiki/Chevrolet_Fleetline
+"car/chevrolet/fleetline-deluxe": "car/chevrolet/fleetline" # (fi+nl) DeLuxe was the upper of the two Fleetline series (Special/DeLuxe) — https://en.wikipedia.org/wiki/Chevrolet_Fleetline
+"car/chevrolet/styleline-de-luxe": "car/chevrolet/styleline" # (fi+nl+nz) De Luxe was the upper of the two Styleline series; "the old nameplates - Special and Deluxe - were retired" in 1952 — https://en.wikipedia.org/wiki/Chevrolet_Styleline
+"car/chevrolet/stylemaster-sport": "car/chevrolet/stylemaster" # (fi+nl) "Sport Coupe"/"Sport Sedan" body designations — https://en.wikipedia.org/wiki/Chevrolet_Stylemaster
+"car/chevrolet/capitol-aa": "car/chevrolet/capitol" # (nl+nz) AA is the GM series code of the 1927 Capitol — https://en.wikipedia.org/wiki/Chevrolet_Series_AA_Capitol ("The Chevrolet Series AA Capitol was an American vehicle manufactured by Chevrolet in 1927")
+"car/chevrolet/capital": "car/chevrolet/capitol" # (nl+nz) registry misspelling of Capitol (nl ×2, nz ×1)
+"car/chevrolet/national-ab": "car/chevrolet/national" # (nl+nz) AB is the GM series code of the 1928 National — https://en.wikipedia.org/wiki/Chevrolet_Series_AB_National
+"car/chevrolet/ab": "car/chevrolet/national" # (nl+nz) bare GM series code; Series AB IS the 1928 National — https://en.wikipedia.org/wiki/Chevrolet_Series_AB_National . CARRIES nl INTO the survivor
+"car/chevrolet/ac-international": "car/chevrolet/international" # (nl+nz) AC is the GM series code of the 1929 International — https://en.wikipedia.org/wiki/Chevrolet_Series_AC_International
+"car/chevrolet/ac": "car/chevrolet/international" # (nl+nz) bare GM series code; Series AC IS the 1929 International — https://en.wikipedia.org/wiki/Chevrolet_Series_AC_International
+"car/chevrolet/k1500-pickup": "car/chevrolet/k1500" # (ca+us) "Pickup" is the body word on the K1500. FLAG: us_fueleconomy gives "K1500 Pickup" its OWN baseModel - see E.4. CARRIES us INTO the survivor
+"car/chevrolet/k1500-silverado": "car/chevrolet/k1500" # (ca+nz) Silverado was the C/K top TRIM 1975-1998 — https://en.wikipedia.org/wiki/Chevrolet_Silverado ; the K-series direction is settled FUSED (#63 Option A)
+"car/chevrolet/k2500-silverado": "car/chevrolet/k2500" # (ca+nz) same trim, K2500 series
+"van/chevrolet/c-10-custom-deluxe": "van/chevrolet/c-10" # (fi+nl) Custom Deluxe was the C/K base trim from 1975 — https://en.wikipedia.org/wiki/Chevrolet_C/K_(third_generation) ; C-series direction settled HYPHENATED (#63 Option A)
+"van/chevrolet/c-10-stepside": "van/chevrolet/c-10" # (fi+nl) Stepside is a BED/BODY style, not a trim — https://en.wikipedia.org/wiki/Chevrolet_C/K_(second_generation)
+"van/chevrolet/c-10-pick-up": "van/chevrolet/c-10" # (fi+nl) body word on the C-10
+"van/chevrolet/c10-apache": "van/chevrolet/c-10" # (fi+nl) the Apache series name ended in 1959 and the C-series began in 1960; the raw stacks both - the vehicle is a C-10
+"van/chevrolet/c10-custom": "van/chevrolet/c-10" # (fi+nl) Custom was a C/K trim — https://en.wikipedia.org/wiki/Chevrolet_C/K_(second_generation)
+"van/chevrolet/silverado-c10": "van/chevrolet/c-10" # (fi+nl) Silverado was the C/K top trim 1975-98; token order inverted in the raw
+"van/chevrolet/cheyenne-c10": "van/chevrolet/c-10" # (fi+nl) Cheyenne was a C/K trim level (1971-74, then base trim from 1988) — https://en.wikipedia.org/wiki/Chevrolet_C/K_(fourth_generation)
+"van/chevrolet/c20-pick-up": "van/chevrolet/c-20" # (fi+nl) body word on the C-20
+"van/chevrolet/c1500-silverado": "van/chevrolet/c1500" # (fi+nl) Silverado was the C/K top trim 1975-98 — https://en.wikipedia.org/wiki/Chevrolet_Silverado
+"van/chevrolet/apache-10": "van/chevrolet/apache" # (fi+nl) 10 = half-ton payload class of the 1958-59 Apache — https://en.wikipedia.org/wiki/Chevrolet_Task_Force ("From 1958 all light-duty trucks were called 'Apache'")
+"van/chevrolet/apache-32": "van/chevrolet/apache" # (fi+nl) 32 = one-ton payload class of the same series
+"van/chevrolet/apache-32-pick-up": "van/chevrolet/apache" # (fi+nl) payload class + body word
+"van/chevrolet/apache-pick-up": "van/chevrolet/apache" # (fi+nl) body word on the Apache
+"van/chevrolet/3100-apache": "van/chevrolet/3100" # (fi+nl) the 1955-57 Advance-Design/Task-Force half-ton was the 3100; "Apache" is the 1958-59 name for the same light-duty line — https://en.wikipedia.org/wiki/Chevrolet_Advance_Design ("3100 on 1/2 ton")
+"van/chevrolet/3100-pick-up": "van/chevrolet/3100" # (fi+nl) body word on the 3100 half-ton
+"van/chevrolet/3100-step-side": "van/chevrolet/3100" # (fi+nl) Stepside is a bed/body style — https://en.wikipedia.org/wiki/Chevrolet_C/K_(second_generation)
+"van/chevrolet/panel-3100": "van/chevrolet/3100" # (fi+nl) Panel is the closed-body variant of the 3100
+"van/chevrolet/pick-up-3100": "van/chevrolet/3100" # (fi+nl) body word + model number, token order inverted — https://en.wikipedia.org/wiki/Chevrolet_Advance_Design
+"van/chevrolet/el-camino-ss": "van/chevrolet/el-camino" # (fi+nl) REPOINT (was -> El Camino SS): Super Sport package — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport
+"van/chevrolet/el-camino-super-sport": "van/chevrolet/el-camino" # (fi+nl) the package written out in full
+"van/chevrolet/cheyenne-pickup": "van/chevrolet/cheyenne" # (fi+nl) body word on the Cheyenne rows (the Cheyenne altitude question itself is deferred to E.6)
+"van/chevrolet/express-van": "van/chevrolet/express" # (fi+nl) "Van" is the body word — https://en.wikipedia.org/wiki/Chevrolet_Express
+"van/chevrolet/express-g1500": "van/chevrolet/express" # (fi+nl) G1500 is the payload/series code of the Express — same source
+"van/chevrolet/chevy-van-20": "van/chevrolet/chevy-van" # (fi+nl) 20 is the GVW payload class (three-quarter ton) of the Chevy Van — https://en.wikipedia.org/wiki/Chevrolet_Van ("base cargo model marketed as Chevy Van", G10/G20/G30 payload series)
+"van/chevrolet/chevy-van-20-starcraft": "van/chevrolet/chevy-van" # (fi+nl) payload class + Starcraft conversion (a US van converter, not a Chevrolet nameplate)
+"car/chevrolet/chevy-van-30": "car/chevrolet/chevy-van" # (fi+nl+nz) 30 is the one-ton GVW payload class. CARRIES nz INTO the survivor
+"car/chevrolet/chevy-van-g20": "car/chevrolet/chevy-van" # (fi+nl) G-series payload code
+"car/chevrolet/van-20": "car/chevrolet/chevy-van" # (fi+nl) the Chevy Van 20 with the make nickname dropped by the register (raws "VAN 20"/"CHEVROLET VAN 20")
+"car/chevrolet/van-g10": "car/chevrolet/chevy-van" # (fi+nl) the Chevy Van G10 (raws "VAN G10"/"CHEVROLET VAN G10")
+"van/chevrolet/van-g20": "van/chevrolet/chevy-van" # (fi+nl) the Chevy Van G20 (raws "VAN G20"/"CHEVROLET VAN G20")
+"car/chevrolet/g-20-van": "car/chevrolet/chevy-van" # (fi+nl) G-series payload code + body word — https://en.wikipedia.org/wiki/Chevrolet_Van
+"van/chevrolet/g20-van": "van/chevrolet/chevy-van" # (fi+nl) fused twin of the same string in the van kind — https://en.wikipedia.org/wiki/Chevrolet_Van
+"truck/chevrolet/20-3-9t-fg25f": "truck/chevrolet/chevy-van" # (fi) INTERIM. The raw is "CHEVY VAN 20-3.9T-FG25F/343" (fi, 154 registrations): series_collapse strips CHEVY *and* VAN as make-word fragments (VAN is a token of the make alias VAN HOOL), leaving an FI type code as the published nameplate. The vehicle is a Chevy Van 20 — https://en.wikipedia.org/wiki/Chevrolet_Van . Superseded by the series_collapse make-fragment fix (DEBT: hygiene-2 normalizer queue)
+"truck/chevrolet/20-starcraft-3-9t-fg25f": "truck/chevrolet/chevy-van" # (fi) INTERIM, same defect: raw "CHEVY VAN 20-STARCRAFT-3.9T-FG25F/343" (fi, 613 registrations - the largest Chevrolet truck record). Starcraft is the conversion-van builder. Superseded by the series_collapse make-fragment fix
+"car/chevrolet/chevy-van-20": "car/chevrolet/chevy-van" # (fi+nl) 20 is the GVW payload class (three-quarter ton) of the Chevy Van — https://en.wikipedia.org/wiki/Chevrolet_Van
+"van/chevrolet/van-20": "van/chevrolet/chevy-van" # (fi+nl) the Chevy Van 20 with the make nickname dropped by the register (raws "VAN 20"/"CHEVROLET VAN 20")
+"car/chevrolet/chevy-van-g20-sportvan": "car/chevrolet/sportvan" # (fi+nl) the SPORTVAN is the passenger configuration and is a live Chevrolet nameplate — https://en.wikipedia.org/wiki/Chevrolet_Van ; the G20 is the payload class
+"car/chevrolet/g20-sportvan": "car/chevrolet/sportvan" # (ca+nl) same: payload class on the Sportvan. CARRIES ca INTO the survivor

--- a/overrides/models/removals.yml
+++ b/overrides/models/removals.yml
@@ -867,3 +867,13 @@
 "truck/leyland-daf/fa": "Bare AXLE CODE with no model token anywhere in the row: the single raw is \"LEYLAND DAF FA\" and FA is DAF's 4x2 rigid axle configuration (https://www.daf.com/-/media/files/document-library/infosheets/ngd/axles/axle-configuration-model-overview-hq-en-def.pdf). Measured 2026-08-01: 382 vehicles (gb), 1 raw spelling. It could be a 45, 50, 55, 60, 65 or 80 and nothing in the row says which, so NAMING §8.1 (unidentifiable → drop) applies and no pipeline change can recover it — unlike DAF's own FA stubs, whose raws DO carry the series and which are therefore deliberately kept. gb is retained at make level by truck/leyland-daf/45 (6,878 vehicles), /50, /55, /60, /65, /80 and the 200/400 vans."
 "truck/leyland-daf/ft": "Same class, tractor side: the single raw is \"LEYLAND DAF FT\", FT being DAF's 4x2 tractor axle configuration. Measured 2026-08-01: 500 vehicles (gb) — 499 truck plus 1 van, the van row sub-threshold. No model token in any row. gb retained at make level by truck/leyland-daf/45 and the 200/400 vans."
 "truck/leyland-daf/fat": "Same class, 6x4 rigid: raws \"LEYLAND DAF FAT\" x136, \"FAT 80\" x13 and \"FAT 70\" x1. Measured 2026-08-01: 150 vehicles (gb). MIXED as well as bare — two different models appear under it — so no single survivor is honest even for the 14 rows that do carry a number. gb retained at make level by truck/leyland-daf/45 and the 200/400 vans."
+
+# ── Chevrolet wave-4 CLEAN pass (2026-08-01). ONE null, and only one: every
+# other removal candidate in this marque is a bare body-style / bare trim-word /
+# bare model-year record with real registrations behind it and NO unambiguous
+# fold target (a 1935 "TUDOR" is a Standard Six, a 1953 "TUDOR" is a One-Fifty),
+# so nulling them would delete 1,200+ real registrations — they are filed as
+# UNCERTAIN in the dossier instead. Rule 1g: this id is deliberately NOT in
+# former_ids.yml; the string names the marque, so no successor is honest.
+"car/chevrolet/chev": "dropped by an explicit null rename (Chevrolet: \"Chev\") — the make's NICKNAME written into the model column, the identical class the settled `Chevrolet: null` line already covers. MEASURED POPULATION: 2 registrations (nl_rdw 1, nz_nzta 1), 2 countries, decile 10. No alias target is honest: the string denotes the marque, not a model."
+

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -341,47 +341,278 @@ Chevrolet:
   # ── casing-contradiction batch: the SS badge family finished (Impala SS
   # was fixed in #63, ten siblings weren't). Hhr Lt keeps Lt lowercase ON
   # PURPOSE — 8 sibling chevrolet Lt records; capitalising one mints a new
-  # contradiction (dossier §4.4). ──
-  Camaro Ss: Camaro SS              # SS = Super Sport badge — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport ; raw "CAMARO SS COUPE"
-  Chevelle Malibu Ss: Chevelle Malibu SS # mixed-case raw writes it caps: "Chevelle Malibu SS Convertible" (ca_nrcan)
-  Chevelle Ss: Chevelle SS          # same badge — same source
-  Cobalt Ss: Cobalt SS              # mixed-case raw "Cobalt SS Coupe" (ca_nrcan)
-  El Camino Ss: El Camino SS        # van kind; same badge ("El Camino SS 1968-1987")
+  # contradiction (dossier §4.4).
+  # SUPERSEDED 2026-08-01: the whole Hhr family now FOLDS to HHR, so this
+  # pass RETIRES those records rather than casing them; the Lt-casing
+  # question stands untouched for the Lt records that survive it. ──
+  Camaro Ss: Camaro  # REPOINT (was -> Camaro SS): SS is the Super Sport package, one altitude below the nameplate — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport . The SS CASING decision is untouched; the record simply ceases to exist
+  Chevelle Malibu Ss: Chevelle  # REPOINT (was -> Chevelle Malibu SS): Super Sport package on the Chevelle Malibu
+  Chevelle Ss: Chevelle  # REPOINT (was -> Chevelle SS): Super Sport package — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport
+  Cobalt Ss: Cobalt  # REPOINT (was -> Cobalt SS): us_fueleconomy baseModel "Cobalt SS Coupe" -> Cobalt. DECISIVE
+  El Camino Ss: El Camino  # REPOINT (was -> El Camino SS): Super Sport package — https://en.wikipedia.org/wiki/Chevrolet_Super_Sport
   Hhr: HHR                          # FLAP insurance — HHR = Heritage High Roof initialism; hits car+van, both intended — https://en.wikipedia.org/wiki/Chevrolet_HHR
-  Hhr LS: HHR LS                    # FLAP — LS already caps; only the nameplate token moves
-  Hhr Lt: HHR Lt                    # FLAP — Lt deliberately LEFT lowercase (8 sibling Lt records; §6.4 owns that family)
-  Hhr Ss: HHR SS                    # both tokens initialisms — "HHR SS" verbatim in the Super Sport article
-  Impala Ss Sport: Impala SS Sport  # raw "Impala SS Sport Coupe"; matches the curated Impala SS
-  Monte Carlo Ss: Monte Carlo SS    # mixed-case raw "Chevrolet Monte Carlo SS" (ca_nrcan)
-  Nova Ss: Nova SS                  # same badge — Super Sport article
+  Hhr LS: HHR  # REPOINT (was -> HHR LS): LS equipment level. NB this pass RETIRES the "Hhr Lt was deliberately half-done" DEBT line by folding the whole family
+  Hhr Lt: HHR  # REPOINT (was -> HHR Lt): LT equipment level - see above
+  Hhr Ss: HHR  # REPOINT (was -> HHR SS): SS package
+  Impala Ss Sport: Impala  # REPOINT (was -> Impala SS Sport): package + body word stacked
+  Monte Carlo Ss: Monte Carlo  # REPOINT (was -> Monte Carlo SS): us_fueleconomy certifies every Monte Carlo as baseModel "Monte Carlo" — no SS row exists in the EPA file
+  Nova Ss: Nova  # REPOINT (was -> Nova SS): Super Sport package
   Ss: SS                            # the 2014-17 sedan IS named SS — https://en.wikipedia.org/wiki/Chevrolet_SS
-  Trailblazer Ss: Trailblazer SS    # SS only; the TrailBlazer-vs-Trail Blazer direction question is filed (dossier §6.5), deliberately not settled here
+  Trailblazer Ss: Trail Blazer  # REPOINT (was -> Trailblazer SS): SS package. Direction question untouched - target is the live "Trail Blazer" display
   # ── swarm-dossier batch (2026-07-26): C-10 direction reversed on GM's own
   # prose (Option A of the dossier's maintainer call); SS is a badge, not a
   # word; "Pickup" one-word fix limited to the collision (S-10 family pass
-  # deferred — no live GM page to cite). ──
+  # deferred — no live GM page to cite;
+  # SUPERSEDED 2026-08-01 by a live REGULATOR citation instead: us_fueleconomy's
+  # own baseModel string is "T10 (S10) Pickup"). ──
   C10: C-10         # fused registry spelling of the same truck; folds van/chevrolet/c10 + moves the car bystander — https://www.gm.com/heritage/collection/chevrolet-trucks/1971-chevrolet-c-10-pickup
   C/10: C-10        # RDW slash spelling — same source
-  Impala S.s: Impala SS   # RDW punctuates the Super Sport badge; Chevrolet's badge is SS (https://en.wikipedia.org/wiki/Chevrolet_Impala; GM collection titles "1963 Chevy Nova SS")
-  Impala Ss: Impala SS    # caser Title-cases the badge — same sources; slug unchanged (impala-ss survives)
-  S10 Pick Up: S10 Pickup # GM writes the body style one word ("1971 Chevy C-10 Pickup", https://www.gm.com/heritage/collection); same truck as the ca/us "S10 Pickup" record
+  Impala S.s: Impala  # REPOINT (was -> Impala SS): RDW/NZTA punctuate the badge ("IMPALA S.S."); same slug impala-ss
+  Impala Ss: Impala  # REPOINT (was -> Impala SS): SS is the Super Sport package; us_fueleconomy certifies every Impala as model "Impala", baseModel "Impala" — the SS casing decision (#63) is preserved in spirit, the record simply rises one altitude
+  S10 Pick Up: S10 Pickup # GM writes the body style one word ("1971 Chevy C-10 Pickup", https://www.gm.com/heritage/collection); same truck as the ca/us "S10 Pickup" record. NB the wave-4 fold pass DELIBERATELY did not repoint this to the bare nameplate — see the S10 note in the wave-4 block below
   Belair: Bel Air                             # spelling variant of "Bel Air" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Bellair: Bell Air                           # spelling variant of "Bell Air" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Camaro Z28: Camaro Z/28                     # spelling variant of "Camaro Z/28" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Corvette Stingray: Corvette Sting Ray       # spelling variant of "Corvette Sting Ray" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Corvette ZR1: Corvette ZR-1                 # spelling variant of "Corvette ZR-1" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  Bellair: Bel Air  # REPOINT (was -> Bell Air): the fused misspelling, now folded onto the real nameplate
+  Camaro Z28: Camaro  # REPOINT (was -> Camaro Z/28): Z28 is RPO Z28, an option package — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+  Corvette Stingray: Corvette  # REPOINT (was -> Corvette Sting Ray): the fused spelling is 599+34 raws vs 118 spaced; both now land on the nameplate
+  Corvette ZR1: Corvette  # REPOINT (was -> Corvette ZR-1): the unhyphenated form is the majority raw (10+1+1 vs 3+2); both now land one level up
   Deluxe: De Luxe                             # spelling variant of "De Luxe" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Stingray: Sting Ray                         # spelling variant of "Sting Ray" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Styleline Deluxe: Styleline De Luxe         # spelling variant of "Styleline De Luxe" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  Stingray: Corvette  # REPOINT (was -> Sting Ray): fused spelling of the same bare badge
+  Styleline Deluxe: Styleline  # REPOINT (was -> Styleline De Luxe): the fused spelling of the same trim, now folded one level up
   Trailblazer: Trail Blazer                   # spelling variant of "Trail Blazer" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "3100 Pickup": "3100 Pick-Up"               # spelling variant of "3100 Pick-Up" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  C10 Custom Deluxe: C-10 Custom Deluxe     # display-only coherence with the C-10 repoint (same slug either way)
-  C10 Pick Up: C-10 Pick Up                 # display-only coherence with the C-10 repoint (same slug either way); GM titles write "Pickup" one word but that family pass is deferred
+  "3100 Pickup": "3100"  # REPOINT (was -> 3100 Pick-Up): fused twin, now folded one level up
+  C10 Custom Deluxe: C-10  # REPOINT (was -> C-10 Custom Deluxe): fused twin, same slug, now folded one level up
+  C10 Pick Up: C-10  # REPOINT (was -> C-10 Pick Up): fused twin, now folded one level up
   Fleetside Pickup: Fleetside Pick-Up         # spelling variant of "Fleetside Pick-Up" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Pickup: Pick Up                             # spelling variant of "Pick Up" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Chevrolet: null                             # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   C 10: C-10                                # REPOINT (was → C10). GM's own heritage prose writes the pickup C-10, 15x on one page (https://www.gm.com/heritage/collection/chevrolet-trucks/1971-chevrolet-c-10-pickup); the rest of the family already publishes hyphenated (c-10-cheyenne, c-20, k-10)
   K 1500: K1500                               # spelling variant of "K1500" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+
+  # ── Chevrolet wave-4 CLEAN pass (2026-08-01). 198 new keys here + the 24
+  # REPOINTS marked above; together they fold 178 records onto 48 live
+  # nameplates and mint one truck id. The altitude rule: a key denotes a
+  # distinct PRODUCT; a trim / engine / drivetrain / cab-or-bed configuration
+  # / payload class / chassis or generation code / body word / registry
+  # misspelling of a live nameplate FOLDS. Primary oracle is us_fueleconomy's
+  # baseModel column (cache/us_vehicles.csv col 66; 401 Chevrolet tuples over
+  # 83 baseModels), cited inline wherever it is decisive. Every key was
+  # replay-verified against a recording proxy on the real classify path
+  # (gen_review_pack.rb's RecordingRenameBlock mechanism) — 0 inert keys.
+  # Settled directions are untouched: C-series hyphenated / K-series fused
+  # (#63 Option A); the SS casing decision (every SS line is a REPOINT of an
+  # existing casing line, so the decision survives and only the altitude
+  # changes); and Trail Blazer vs TrailBlazer (every fold targets the live
+  # "Trail Blazer" display). Two lines are marked INTERIM against the
+  # series_collapse make-fragment defect and must be pruned when it lands.
+  # Dossier: wave-4 Chevrolet CLEAN+ENRICH. ──
+  Camaro 1LT:                Camaro  # 1LT is the base Camaro trim (1LT/2LT/1SS/2SS ladder) — https://en.wikipedia.org/wiki/Chevrolet_Camaro ; us_fueleconomy baseModel: every Camaro row bases at "Camaro" (https://www.fueleconomy.gov/feg/download.shtml)
+  Camaro 228:                Camaro  # registry mis-key of Z28 (no Chevrolet "Camaro 228" exists); raws "CAMARO 228" ×13 nz+nl sit beside "CAMARO Z28" ×130 — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+  Camaro 2SS:                Camaro  # 2SS is the upper SS trim of the 5th/6th-gen Camaro — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+  Camaro Berlinetta:         Camaro  # Berlinetta was the 1979-86 luxury trim replacing the Type LT — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+  Camaro Iroc-Z:             Camaro  # IROC-Z was an option package on the Camaro Z28 (1985-90) — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+  Camaro Iroc Z:             Camaro  # unspaced/spaced twin of the same raw; both reach slug camaro-iroc-z (observed_model_names)
+  Camaro Iroc-Z28:           Camaro  # same package, written with the Z28 base — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+  Camaro Iroc Z28:           Camaro  # spacing twin of the same raw (observed_model_names)
+  Camaro LS:                 Camaro  # LS is the base equipment level — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+  Camaro Lt:                 Camaro  # LT is an equipment level; folding retires this record, so the open Lt-casing DEBT line is not touched
+  Camaro R S:                Camaro  # RS = Rally Sport appearance package — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+  Camaro R.s:                Camaro  # RDW punctuates the badge "CAMARO R.S." ×18; same slug camaro-r-s (observed_model_names)
+  Camaro R/S:                Camaro  # NZTA slash spelling of the same package; same slug
+  Camaro Rally Sport:        Camaro  # the package written out in full; fi raws are "CAMARO RALLY SPORT COUPE-FP21E-K/2570" type-code rows
+  Camaro Sport:              Camaro  # "Sport Coupe" is the Camaro's body designation in the fi/nl rows, not a nameplate
+  Camaro Z 28:               Camaro  # spaced twin, same slug camaro-z-28 (observed_model_names)
+  Camaro Z-28:               Camaro  # hyphen twin, same slug
+  Camaro Z/28:               Camaro  # the settled display form, now folded one level up
+  Camaro Z28 Iroc:           Camaro  # two stacked packages
+  Camaro ZL1:                Camaro  # ZL1 is the supercharged performance package; ca_nrcan writes "Camaro ZL1" while us_fueleconomy has no ZL1 row at all - it certifies every Camaro as "Camaro"
+  Z28:                       Camaro  # bare option code under make CHEVROLET (fi+nl); the vehicle is a Camaro Z28 — https://en.wikipedia.org/wiki/Chevrolet_Camaro
+  Corvett:                   Corvette  # registry misspelling of Corvette (nz ×2, nl ×1)
+  Corvette 427:              Corvette  # 427 is the 7.0 L big-block displacement, a spec in the car kind (NAMING.md 6) — https://en.wikipedia.org/wiki/Chevrolet_Corvette
+  Corvette -427:             Corvette  # leading-dash twin of the same raw "CORVETTE -427-"; same slug corvette-427 (observed_model_names)
+  Corvette C3:               Corvette  # C3 is the third-generation code, not a marketed nameplate — https://en.wikipedia.org/wiki/Chevrolet_Corvette
+  Corvette C4:               Corvette  # C4 generation code — same source
+  Corvette C5:               Corvette  # C5 generation code — same source
+  Corvette C6:               Corvette  # C6 generation code — same source
+  C6:                        Corvette  # uk_dft files these under make CORVETTE, so strip_make_prefix leaves a bare "C6" (raws "CORVETTE | CORVETTE C6" ×32 gb, ×1 nl) — the vehicle is a C6 Corvette
+  Corvette E-Ray:            Corvette  # us_fueleconomy baseModel: "Corvette E-Ray" -> Corvette (https://www.fueleconomy.gov/feg/download.shtml)
+  Corvette LT4:              Corvette  # LT4 is the engine RPO (1996 LT4, 2015- supercharged LT4) — https://en.wikipedia.org/wiki/Chevrolet_Corvette
+  Corvette Roadster:         Corvette  # Roadster is the body style; us_fueleconomy's own "Corvette Convertible" rows base at "Corvette"
+  Corvette Sting Ray:        Corvette  # Sting Ray/Stingray is a model-name badge carried by the C2/C3/C7/C8, never a separate product; us_fueleconomy certifies all of them as model "Corvette", baseModel "Corvette" — https://en.wikipedia.org/wiki/Chevrolet_Corvette
+  Corvette Sting-Ray:        Corvette  # hyphen twin, same slug corvette-sting-ray (observed_model_names)
+  Corvette Stingray 454:     Corvette  # 454 is the big-block displacement (a spec in the car kind)
+  Corvette Z06:              Corvette  # us_fueleconomy baseModel: "Corvette Z06" -> Corvette. CARRIES th INTO the survivor
+  Corvette Z06 Carbon Aero:  Corvette  # us_fueleconomy baseModel: "Corvette Z06 Carbon Aero" -> Corvette
+  Corvette Z51:              Corvette  # Z51 is the performance handling package (RPO Z51), never a separate model
+  Corvette ZR-1:             Corvette  # us_fueleconomy baseModel: "Corvette ZR1" -> Corvette
+  Corvette ZR 1:             Corvette  # spaced twin, same slug corvette-zr-1 (observed_model_names)
+  Corvette ZR1X:             Corvette  # us_fueleconomy baseModel: "Corvette ZR1X" and "Corvette ZR1X Hybrid" -> Corvette
+  Z06:                       Corvette  # uk_dft files it under make CORVETTE ("CORVETTE | CORVETTE Z06" ×12 gb), leaving a bare package code
+  Sting Ray:                 Corvette  # bare badge under make CHEVROLET; the only Chevrolet Sting Ray is the Corvette — https://en.wikipedia.org/wiki/Chevrolet_Corvette
+  Silverado 1500:            Silverado  # us_fueleconomy baseModel: "Silverado 1500 2WD/4WD/AWD" -> Silverado (https://www.fueleconomy.gov/feg/download.shtml) — KIND-BLIND, both intended: this ONE key folds car/chevrolet/silverado-1500 and van/chevrolet/silverado-1500
+  Silverado 20:              Silverado  # GVW class 20 (three-quarter ton) written as a suffix; us_fueleconomy bases every Silverado NNNN row at "Silverado"
+  Silverado 10:              Silverado  # half-ton class suffix. NB the bare "10" could also be read as the C10 chassis; folding to the Silverado nameplate is the conservative reading (no C token in the raw) — see E.9
+  Silverado 1500 Lt:         Silverado  # LT is the equipment level on the 1500 series
+  Silverado Crew Cab:        Silverado  # Crew Cab is the four-door cab configuration, a body style — https://en.wikipedia.org/wiki/Chevrolet_C/K_(fourth_generation) ("For 1992 ... a four-door crew cab was introduced")
+  Silverado Lt Trail Boss:   Silverado  # us_fueleconomy baseModel: "Silverado 4WD TrailBoss" -> Silverado
+  Silverado Pick Up:         Silverado  # body word on the nameplate
+  Silverado Pick-Up:         Silverado  # hyphen twin, same slug silverado-pick-up (observed_model_names)
+  Siverado:                  Silverado  # registry misspelling (fi ×2, nl ×1)
+  2500HD:                    Silverado  # all six raws behind this id are "2500HD SILVERADO..." (fi ×5, nl ×1) — the vehicle is a Silverado 2500HD; us_fueleconomy baseModel "Silverado 2500 HD 2WD" -> Silverado
+  Suburban 1500:             Suburban  # us_fueleconomy baseModel: "Suburban 1500 2WD/4WD/AWD" -> Suburban
+  Suburban 2WD:              Suburban  # drivetrain marker; us_fueleconomy baseModel "Suburban 2WD" -> Suburban
+  Suburban Ffv:              Suburban  # FFV = flexible-fuel certification marker, not a nameplate
+  Suburban K1500:            Suburban  # us_fueleconomy baseModel: "Suburban K1500 4WD" -> Suburban. DECISIVE
+  Suburban Silverado:        Suburban  # Silverado was the TOP TRIM LEVEL of the C/K trucks 1975-1998 — https://en.wikipedia.org/wiki/Chevrolet_Silverado ("The Silverado nameplate made its debut for the 1975 model year, becoming the top trim level on all Chevrolet C/K trucks")
+  Surburban:                 Suburban  # registry misspelling, 27 registrations (nl ×26, nz ×1)
+  K2500 Suburban:            Suburban  # us_fueleconomy baseModel: "Suburban K10 4WD"/"Suburban K1500 4WD" -> Suburban; the chassis code is a variant of the nameplate
+  C10 Suburban:              Suburban  # us_fueleconomy baseModel: "Suburban C10 2WD" -> Suburban. DECISIVE
+  Tahoe 4:                   Tahoe  # truncation of "TAHOE 4 DOOR"/"TAHOE 4-DOOR" — a body word, not a nameplate (60 registrations car + 13 van) — KIND-BLIND, both intended: this ONE key folds car/chevrolet/tahoe-4 and van/chevrolet/tahoe-4
+  Tahoe K1500:               Tahoe  # us_fueleconomy baseModel: "Tahoe K1500 4WD" -> Tahoe. DECISIVE
+  Blazer 1500:               Blazer  # us_fueleconomy baseModel: "Blazer 1500 4WD" -> Blazer. DECISIVE
+  Blazer K5:                 Blazer  # K5 is the full-size Blazer's chassis code — https://en.wikipedia.org/wiki/Chevrolet_Blazer ; us_fueleconomy bases "Blazer V1500 4WD" at Blazer
+  K5 Blazer:                 Blazer  # same code, token order inverted
+  Blazer S10:                Blazer  # us_fueleconomy baseModel: "S10 Blazer 2WD/4WD" -> Blazer. DECISIVE
+  S10 Blazer:                Blazer  # us_fueleconomy baseModel: "S10 Blazer 4WD" -> Blazer. DECISIVE
+  K10 Blazer:                Blazer  # us_fueleconomy baseModel: "K10 Blazer 4WD" -> Blazer. DECISIVE
+  Blazer Silverado:          Blazer  # Silverado was the C/K top trim 1975-1998 and was applied to the K5 Blazer — https://en.wikipedia.org/wiki/Chevrolet_Silverado
+  Blazer EV Rwd:             Blazer EV  # drivetrain marker on the Blazer EV; ca_nrcan/us_fueleconomy both write "Blazer EV RWD" beside "Blazer EV AWD". (The EV/ICE split itself is a KEEP — see 3 and E.3)
+  Impala Custom:             Impala  # Custom was an Impala trim (Impala Custom Coupe 1967-76) — https://en.wikipedia.org/wiki/Chevrolet_Impala
+  Impala Hardtop:            Impala  # Hardtop Coupe is the body style
+  Impala Sport:              Impala  # "Sport Coupe"/"Sport Sedan" body designations
+  Impalla:                   Impala  # registry misspelling (nz ×3, nl ×1)
+  Malibu Classic:            Malibu  # Classic was the Malibu's upper trim; us_fueleconomy baseModel for every Malibu row is "Malibu"
+  Malibu-Classic:            Malibu  # hyphen twin, same slug malibu-classic (observed_model_names)
+  Malibu Limited:            Malibu  # us_fueleconomy baseModel: "Malibu Limited" -> Malibu. DECISIVE
+  Malibu Maxx:               Malibu  # us_fueleconomy baseModel: "Malibu Maxx" -> Malibu. DECISIVE (Maxx is the 2004-07 five-door body)
+  Chevelle Malibu:           Chevelle  # Malibu was the Chevelle's top TRIM 1964-72 before becoming a nameplate in 1978 — https://en.wikipedia.org/wiki/Chevrolet_Chevelle
+  Chevelle Malibu Classic:   Chevelle  # trim-on-trim (Malibu Classic, 1973-77 Chevelle)
+  Nova 2:                    Nova  # truncation of "NOVA 2 DOOR COUPE" — a body word
+  Nova Concours:             Nova  # Concours was the Nova's luxury trim (1976-79) — https://en.wikipedia.org/wiki/Chevrolet_Chevy_II_/_Nova
+  Nova-Concours:             Nova  # hyphen twin, same slug nova-concours (observed_model_names)
+  Nova Custom:               Nova  # Custom was a Nova trim level
+  Caprice Classic:           Caprice  # Classic was the Caprice's trim/series name; us_fueleconomy's model strings are "Caprice", "Caprice Wagon", "Caprice/Impala" — "Caprice Classic" appears nowhere, and all base at "Caprice"
+  Caprice Classic Wagon:     Caprice  # us_fueleconomy baseModel: "Caprice Wagon" -> Caprice. DECISIVE
+  Caprice Wagon:             Caprice  # us_fueleconomy baseModel: "Caprice Wagon" -> Caprice. DECISIVE
+  Caprice Hearse:            Caprice  # a hearse is a coachbuilt body on the Caprice chassis, not a Chevrolet nameplate
+  Cavalier Wagon:            Cavalier  # us_fueleconomy baseModel: "Cavalier Wagon" -> Cavalier. DECISIVE
+  Chevette Cs:               Chevette  # us_fueleconomy baseModel: "Chevette CS" -> Chevette. DECISIVE
+  Cobalt Xfe:                Cobalt  # us_fueleconomy baseModel: "Cobalt XFE"/"Cobalt XFE Coupe"/"Cobalt XFE Sedan" -> Cobalt. DECISIVE (XFE = eXtra Fuel Economy package)
+  Colorado Crew Cab:         Colorado  # us_fueleconomy baseModel: "Colorado Crew Cab 2WD/4WD" -> Colorado. DECISIVE
+  Colorado ZR2:              Colorado  # us_fueleconomy baseModel: "Colorado ZR2 4WD" -> Colorado. DECISIVE
+  Colorado ZR2 Bison:        Colorado  # us_fueleconomy baseModel: "Colorado ZR2 Bison 4WD" -> Colorado. DECISIVE
+  Cruze Eco:                 Cruze  # us_fueleconomy baseModel: "Cruze Eco" -> Cruze. DECISIVE
+  Cruze Limited:             Cruze  # us_fueleconomy baseModel: "Cruze Limited" -> Cruze. DECISIVE
+  Cruze Limited Eco:         Cruze  # us_fueleconomy baseModel: "Cruze Limited  Eco" -> Cruze. DECISIVE
+  Cruze Lt:                  Cruze  # LT equipment level (es/fi/nl rows)
+  Cruze Premier:             Cruze  # us_fueleconomy baseModel: "Cruze Premier"/"Cruze Premier Hatchback" -> Cruze. DECISIVE. CARRIES ar INTO the survivor
+  Aveo 5:                    Aveo  # us_fueleconomy baseModel: "Aveo 5" -> Aveo. DECISIVE (the 5 is the five-door body)
+  Aveo LS:                   Aveo  # LS equipment level
+  Sonic 5:                   Sonic  # us_fueleconomy baseModel: "Sonic 5"/"Sonic 5 RS" -> Sonic. DECISIVE
+  Sonic Lt:                  Sonic  # LT equipment level. CARRIES es+fi INTO the survivor
+  Optra Wagon:               Optra  # us_fueleconomy baseModel: "Optra Wagon" -> Optra. DECISIVE
+  Traverse Limited:          Traverse  # us_fueleconomy baseModel: "Traverse Limited AWD/FWD" -> Traverse. DECISIVE
+  Trailblazer Ext:           Trail Blazer  # us_fueleconomy baseModel: "TrailBlazer Ext 2WD/4WD" -> TrailBlazer. DECISIVE. Target display is the SETTLED "Trail Blazer" form; the TrailBlazer-vs-Trail Blazer direction is filed DEBT and is NOT touched here
+  Trail Blazer Ltz:          Trail Blazer  # LTZ equipment level (the Lt/Ltz casing DEBT line is not touched: folding retires the record)
+  T15506-Trailblazer:        Trail Blazer  # RDW type-code prefix glued to the nameplate; raw "T15506-TRAILBLAZER 4WD 4-DOOR UTILITY" ×46 nl + fi ×1
+  Equinox Lt:                Equinox  # LT equipment level
+  Astro Van:                 Astro  # "Van" is the Astro's body word; us_fueleconomy splits Astro Cargo/Astro Passenger but both are the Astro — https://en.wikipedia.org/wiki/Chevrolet_Astro — KIND-BLIND, both intended: this ONE key folds car/chevrolet/astro-van and van/chevrolet/astro-van
+  Astro Starcraft:           Astro  # Starcraft is a US conversion-van builder, not a Chevrolet nameplate; the row is a converted Astro (Ford Transit Tecnocar precedent)
+  Corvair 500:               Corvair  # 500 was the base Corvair series (500/700/900 Monza) — https://en.wikipedia.org/wiki/Chevrolet_Corvair . CARRIES es INTO the survivor
+  Corvair Corsa:             Corvair  # Corsa was the 1965-66 top Corvair series — same source
+  Corvair Monza:             Corvair  # Monza was the Corvair's sporty series — same source (distinct from the 1975-80 Chevrolet Monza, which stays live)
+  Bel Air 4:                 Bel Air  # truncation of "BEL AIR 4 DOOR SEDAN"/"Bel Air 4-D Sedan" - a body word
+  Bel Air 4D:                Bel Air  # same body word, fused form
+  Bel Air Sport:             Bel Air  # "Sport Sedan"/"Sport Coupe" body designations
+  Bel-Air:                   Bel Air  # DISPLAY-ONLY: the hyphenated raw reaches the SAME slug bel-air and the published display flaps between three forms (observed_model_names: "Bel Air | Bel-Air | Bel/Air"). No id moves
+  Bel/Air:                   Bel Air  # DISPLAY-ONLY: RDW slash spelling, same slug bel-air. No id moves
+  Bell Air:                  Bel Air  # registry misspelling of Bel Air (nl ×7, nz ×3) — https://en.wikipedia.org/wiki/Chevrolet_Bel_Air
+  Belair Nomad:              Nomad  # the 1955-57 Nomad was sold as the Bel Air Nomad; the Nomad is the product — https://en.wikipedia.org/wiki/Chevrolet_Nomad . CARRIES fi INTO the survivor
+  Fleetline Aerosedan:       Fleetline  # Aerosedan is the Fleetline's fastback body style — https://en.wikipedia.org/wiki/Chevrolet_Fleetline
+  Fleetline Deluxe:          Fleetline  # DeLuxe was the upper of the two Fleetline series (Special/DeLuxe) — https://en.wikipedia.org/wiki/Chevrolet_Fleetline
+  Styleline De Luxe:         Styleline  # De Luxe was the upper of the two Styleline series; "the old nameplates - Special and Deluxe - were retired" in 1952 — https://en.wikipedia.org/wiki/Chevrolet_Styleline
+  Stylemaster Sport:         Stylemaster  # "Sport Coupe"/"Sport Sedan" body designations — https://en.wikipedia.org/wiki/Chevrolet_Stylemaster
+  Capitol Aa:                Capitol  # AA is the GM series code of the 1927 Capitol — https://en.wikipedia.org/wiki/Chevrolet_Series_AA_Capitol ("The Chevrolet Series AA Capitol was an American vehicle manufactured by Chevrolet in 1927")
+  Capital:                   Capitol  # registry misspelling of Capitol (nl ×2, nz ×1)
+  National Ab:               National  # AB is the GM series code of the 1928 National — https://en.wikipedia.org/wiki/Chevrolet_Series_AB_National
+  Ab:                        National  # bare GM series code; Series AB IS the 1928 National — https://en.wikipedia.org/wiki/Chevrolet_Series_AB_National ("The Chevrolet Series AB National was manufactured by Chevrolet in 1928 ... successor to Series AA Capitol"). CARRIES nl INTO the survivor
+  Ac International:          International  # AC is the GM series code of the 1929 International — https://en.wikipedia.org/wiki/Chevrolet_Series_AC_International
+  Ac:                        International  # bare GM series code; Series AC IS the 1929 International — https://en.wikipedia.org/wiki/Chevrolet_Series_AC_International ("a car made only for the 1929 model year")
+  K1500 Pickup:              K1500  # "Pickup" is the body word on the K1500. FLAG: us_fueleconomy gives "K1500 Pickup" its OWN baseModel - see E.4. CARRIES us INTO the survivor
+  K1500 Silverado:           K1500  # Silverado was the C/K top TRIM 1975-1998 — https://en.wikipedia.org/wiki/Chevrolet_Silverado ; the K-series direction is settled FUSED (#63 Option A)
+  K2500 Silverado:           K2500  # same trim, K2500 series
+  # ── S10: the ONE fold group this pass measured and then REFUSED. Folding
+  # `S10 Pickup` / `S-10 LS` / `S 10 LS` / `T10 Pick Up` onto `S10` is correct
+  # on the evidence (us_fueleconomy's own baseModel string is literally
+  # "T10 (S10) Pickup" — a US regulator stating the T10 IS the S10), and it was
+  # BUILT: it moves ~fi/lu/nl registration mass onto van/chevrolet/s10, whose
+  # kind share then crosses cross_kind_prune!'s 97% dominance ratio and DELETES
+  # car/chevrolet/s10 — a live published id carrying ca+nl+nz+us. The dominance
+  # ratio is computed over REGISTRATION COUNTS, and ca_nrcan/us_fueleconomy are
+  # catalog sources with no counts, so the car record contributes 0 to its own
+  # kind and cannot defend itself. Measured on this batch's own build:
+  # no-vanish gate FAIL car/chevrolet/s10 + a dangling migration. Zero-evidence-
+  # loss is the standing contract for a fold wave, so the group is NOT SHIPPED
+  # and the pipeline defect is filed instead. Restore this group in the same PR
+  # as the fix, never before it. ──
+  C 10 Custom Deluxe:        C-10  # Custom Deluxe was the C/K base trim from 1975 — https://en.wikipedia.org/wiki/Chevrolet_C/K_(third_generation) ; C-series direction settled HYPHENATED (#63 Option A)
+  C 10 Stepside:             C-10  # Stepside is a BED/BODY style, not a trim — https://en.wikipedia.org/wiki/Chevrolet_C/K_(second_generation)
+  C-10 Pick Up:              C-10  # body word on the C-10
+  C 10 Pick Up:              C-10  # spaced twin, same slug c-10-pick-up (observed_model_names)
+  C 10 Pick-Up:              C-10  # spaced+hyphen twin, same slug
+  C/10 Pick Up:              C-10  # RDW slash spelling, same slug
+  C10 Apache:                C-10  # the Apache series name ended in 1959 and the C-series began in 1960; the raw stacks both - the vehicle is a C-10
+  C10 Custom:                C-10  # Custom was a C/K trim — https://en.wikipedia.org/wiki/Chevrolet_C/K_(second_generation)
+  Silverado C10:             C-10  # Silverado was the C/K top trim 1975-98; token order inverted in the raw
+  Cheyenne C10:              C-10  # Cheyenne was a C/K trim level (1971-74, then base trim from 1988) — https://en.wikipedia.org/wiki/Chevrolet_C/K_(fourth_generation)
+  C20 Pick Up:               C-20  # body word on the C-20
+  C20 Pick-Up:               C-20  # hyphen twin, same slug c20-pick-up (observed_model_names)
+  C1500 Silverado:           C1500  # Silverado was the C/K top trim 1975-98 — https://en.wikipedia.org/wiki/Chevrolet_Silverado
+  Apache 10:                 Apache  # 10 = half-ton payload class of the 1958-59 Apache — https://en.wikipedia.org/wiki/Chevrolet_Task_Force ("From 1958 all light-duty trucks were called 'Apache'")
+  Apache 32:                 Apache  # 32 = one-ton payload class of the same series
+  Apache-32:                 Apache  # hyphen twin, same slug apache-32 (observed_model_names)
+  Apache 32 Pick Up:         Apache  # payload class + body word
+  Apache 32 Pick-Up:         Apache  # hyphen twin, same slug
+  Apache Pick Up:            Apache  # body word on the Apache
+  Apache Pick-Up:            Apache  # hyphen twin, same slug
+  3100 Apache:               "3100"  # the 1955-57 Advance-Design/Task-Force half-ton was the 3100; "Apache" is the 1958-59 name for the same light-duty line — https://en.wikipedia.org/wiki/Chevrolet_Advance_Design ("3100 on 1/2 ton")
+  3100 Pick-Up:              "3100"  # body word on the 3100 half-ton
+  3100 Pick Up:              "3100"  # spaced twin, same slug 3100-pick-up (observed_model_names)
+  3100 Step Side:            "3100"  # Stepside is a bed/body style — https://en.wikipedia.org/wiki/Chevrolet_C/K_(second_generation)
+  3100 Step-Side:            "3100"  # hyphen twin, same slug 3100-step-side (observed_model_names)
+  Panel 3100:                "3100"  # Panel is the closed-body variant of the 3100
+  Pick Up 3100:              "3100"  # body word + model number, token order inverted
+  Pick-Up 3100:              "3100"  # hyphen twin, same slug pick-up-3100
+  Pick Up. 3100:             "3100"  # stray-period twin, same slug
+  El-Camino Ss:              El Camino  # hyphen twin, same slug el-camino-ss (observed_model_names)
+  El Camino Super Sport:     El Camino  # the package written out in full
+  El-Camino:                 El Camino  # DISPLAY-ONLY: hyphenated twin reaching the SAME slug el-camino in both car and van (observed_model_names). No id moves
+  Cheyenne Pickup:           Cheyenne  # body word on the Cheyenne rows (the Cheyenne altitude question itself is deferred to E.6)
+  Express Van:               Express  # "Van" is the body word — https://en.wikipedia.org/wiki/Chevrolet_Express
+  Express G1500:             Express  # G1500 is the payload/series code of the Express — same source
+  Chevy Van 20:              Chevy Van  # 20 is the GVW payload class (three-quarter ton) of the Chevy Van — https://en.wikipedia.org/wiki/Chevrolet_Van ("base cargo model marketed as Chevy Van", G10/G20/G30 payload series) — KIND-BLIND, both intended: this ONE key folds van/chevrolet/chevy-van-20 and car/chevrolet/chevy-van-20
+  Chevy-Van 20:              Chevy Van  # hyphen twin, same slug chevy-van-20 (observed_model_names)
+  Chevy Van 20 Starcraft:    Chevy Van  # payload class + Starcraft conversion (a US van converter, not a Chevrolet nameplate)
+  Chevy Van 30:              Chevy Van  # 30 is the one-ton GVW payload class. CARRIES nz INTO the survivor
+  Chevy Van G20:             Chevy Van  # G-series payload code
+  Van 20:                    Chevy Van  # the Chevy Van 20 with the make nickname dropped by the register (raws "VAN 20"/"CHEVROLET VAN 20") — KIND-BLIND, both intended: this ONE key folds car/chevrolet/van-20 and van/chevrolet/van-20
+  Van G10:                   Chevy Van  # the Chevy Van G10 (raws "VAN G10"/"CHEVROLET VAN G10")
+  Van G20:                   Chevy Van  # the Chevy Van G20 (raws "VAN G20"/"CHEVROLET VAN G20")
+  G-20 Van:                  Chevy Van  # payload code + body word
+  G 20 Van:                  Chevy Van  # spaced twin, same slug g-20-van (observed_model_names)
+  G20 Van:                   Chevy Van  # fused twin of the same string in the van kind
+  20-3.9T-FG25F:             Chevy Van  # INTERIM. The raw is "CHEVY VAN 20-3.9T-FG25F/343" (fi, 154 registrations): series_collapse strips CHEVY *and* VAN as make-word fragments (VAN is a token of the make alias VAN HOOL), leaving an FI type code as the published nameplate. The vehicle is a Chevy Van 20 — https://en.wikipedia.org/wiki/Chevrolet_Van . Superseded by the series_collapse make-fragment fix (DEBT: hygiene-2 normalizer queue)
+  20-Starcraft-3.9T-FG25F:   Chevy Van  # INTERIM, same defect: raw "CHEVY VAN 20-STARCRAFT-3.9T-FG25F/343" (fi, 613 registrations - the largest Chevrolet truck record). Starcraft is the conversion-van builder. Superseded by the series_collapse make-fragment fix
+  Chevy Van G20 Sportvan:    Sportvan  # the SPORTVAN is the passenger configuration and is a live Chevrolet nameplate — https://en.wikipedia.org/wiki/Chevrolet_Van ; the G20 is the payload class
+  G20 Sportvan:              Sportvan  # same: payload class on the Sportvan. CARRIES ca INTO the survivor
+  C 20:                      C-20  # DISPLAY-ONLY: observed_model_names car/chevrolet/c-20 = "C 20 | C-20", van/chevrolet/c-20 = "C 20 | C-20 | C/20" — one slug, three published forms. Settled direction is HYPHENATED (#63 Option A)
+  C/20:                      C-20  # DISPLAY-ONLY: RDW slash spelling of the same slug — same source
+  C 2500:                    C-2500  # DISPLAY-ONLY: observed_model_names van/chevrolet/c-2500 = "C 2500 | C-2500"; the hyphenated form is what the record publishes today
+  Impàla:                    Impala  # DISPLAY-ONLY: observed_model_names car/chevrolet/impala = "Impala | Impàla" — a stray combining accent in one RDW row; the slug is unchanged (NFKD folds it)
+  Pick-Up:                   Pick Up  # DISPLAY-ONLY: observed_model_names car+van /pick-up = "Pick Up | Pick-Up"; the existing `Pickup: Pick Up` line already pins the third spelling. (The ALTITUDE of `Pick Up` is a separate question — §E.2)
+  Two Ten:                   Two-Ten  # DISPLAY-ONLY: observed_model_names car/chevrolet/two-ten = "Two Ten | Two-Ten"; Chevrolet's own name is the Two-Ten — https://en.wikipedia.org/wiki/Chevrolet_210
+  Trans-Sport:               Trans Sport  # DISPLAY-ONLY: observed_model_names car/chevrolet/trans-sport = "Trans Sport | Trans-Sport"
+  Fleetside Pick Up:         Fleetside Pick-Up  # DISPLAY-ONLY: observed_model_names van/chevrolet/fleetside-pick-up = "Fleetside Pick Up | Fleetside Pick-Up | Fleetside Pickup"; the existing `Fleetside Pickup:` line pins only one of the two twins
+  Chev:                      null  # the make's NICKNAME written into the model column — the identical class the settled `Chevrolet: null` line already covers. Raws: nl_rdw "CHEV" ×1, nz_nzta "CHEV" ×1 (car); truck rows "CHEV K2500", "CHEV-FLEETWOOD JAMBAREE" carry a model that this key cannot reach and are separately noted in §E.2. No honest survivor: the string names the marque, not a vehicle.
 
 Chrysler:
   300C Srt-8: 300C SRT8                       # the badge is the unhyphenated SRT8 (https://en.wikipedia.org/wiki/Chrysler_300, first-gen LX 2005-2010); nl_rdw "300C SRT8" n=42 vs "300C SRT-8" n=4


### PR DESCRIPTION
# Chevrolet wave-4 CLEAN — 174 records fold onto 47 nameplates (393 → 219)

Pairs with **vehiclesdb-pipeline#98** (`enrich/chevrolet.yml`). **Merge order: pipeline first**,
then this — that file is keyed on the ids this PR leaves live, and its `variants:` blocks are the
"organize, not delete" half of the same batch. **Please do not merge either without a review.**

## Verified numbers — measured on THIS branch's build, not claimed

Method: a full `ruby pipeline/run.rb` from this branch, and a **pristine control build of
`origin/main` from the same frozen cache**, so every number below is a diff against a control that
shares my inputs exactly.

| | before (control) | folds | nulled | minted | after | net |
|---|---:|---:|---:|---:|---:|---:|
| **all Chevrolet** | **393** | **174** | **1** | **1** | **219** | **−174 (44.3%)** |
| car | 284 | 134 | 1 | 0 | 149 | −135 |
| van | 72 | 36 | 0 | 0 | 36 | −36 |
| truck | 37 | 4 | 0 | 1 | 34 | −3 |

Catalog-wide: **15,615 → 15,441 records. 175 ids gone, 1 added, and every single gone id is
Chevrolet — no other make moved by one record.**

| file | change |
|---|---|
| `overrides/models/renames.yml` | `Chevrolet:` block **40 → 234 keys**: **194 new** + **23 REPOINTED IN PLACE** |
| `overrides/models/former_ids.yml` | **+174** appended at EOF, **+11 existing lines flattened in place** |
| `overrides/models/removals.yml` | **+1** (`car/chevrolet/chev`) with its measured population |

### Where this diverges from the dossier it applies, and why

The dossier claimed 396 → 218 / 178 folds / 222 rename lines / 178 aliases. Three adaptations,
each measured:

1. **The baseline is 393, not 396.** `car/chevrolet/3500`, `car/chevrolet/tudor` and
   `car/chevrolet/van` have already fallen below the publication threshold from upstream drift and
   are absent from a pristine control build. Not my doing, not my count. (`3500` is manifested in
   `removals.yml` already; `tudor`/`van` are data#132's, and this branch deliberately leaves them
   alone — see the note at the end.)
2. **The S10 fold group is REFUSED**, −4 folds and −5 rename lines. See below; this is the most
   important thing in the PR.
3. `Impala S.s`'s comment gained the explicit `REPOINT (was -> Impala SS)` marker the dossier's
   §D listed but its §A line did not carry.

## THE CONTRACT: zero (country, source) availability pairs lost

Checked two ways against the control catalog, in `scratchpad/chev_diff.rb`:

* **per fold** — every `(country, source)` pair on each of the 174 folding children is present on
  its survivor after the build: **0 missing**;
* **make-wide** — the union of `(country, source)` pairs over all Chevrolet records: **0 lost**.

**Eleven survivors strictly ENLARGE**, plus the mint — all confirmed in the built catalog, not
inferred:

| survivor | gains | from |
|---|---|---|
| `car/chevrolet/corvette` | **th** | `Corvette Sting Ray`, `Corvette Z06` |
| `car/chevrolet/cruze` | **ar** | `Cruze Premier` |
| `car/chevrolet/sonic` | **es, fi** | `Sonic Lt` |
| `car/chevrolet/corvair` | **es** | `Corvair 500` |
| `car/chevrolet/k1500` | **us** | `K1500 Pickup` |
| `car/chevrolet/national` | **nl** | `Ab`, `National Ab` |
| `car/chevrolet/nomad` | **fi** | `Belair Nomad` |
| `car/chevrolet/sportvan` | **ca** | `G20 Sportvan` |
| `car/chevrolet/chevy-van` | **nz** | `Chevy Van 30` |
| `van/chevrolet/chevy-van` | **lu** | the `Van G20` group |
| `van/chevrolet/silverado` | **es** | `Silverado Crew Cab` |
| `truck/chevrolet/chevy-van` | **fi** | **MINTED** — see below |

`car/chevrolet/corvette` now publishes **ar, ca, es, fi, gb, lu, my, nl, nz, th, ua, us** with 22
migration aliases on it. The dossier's twelfth enlarging group was `van/chevrolet/s10 +lu`; it went
with the refused S10 fold.

### The mint

`truck/chevrolet/chevy-van` did not exist. It is created by the fold and publishes, verbatim from
the build:

```json
{"id":"chevrolet/chevy-van","kind":"truck","name":"Chevy Van",
 "availability":[{"country":"fi","evidence":"registration","source":"fi_traficom"}],
 "popularity":{"global_decile":1,"by_country":{"fi":{"rank":17,"decile":1}}},
 "former_ids":["truck/chevrolet/20-3-9t-fg25f","truck/chevrolet/20-starcraft-3-9t-fg25f"]}
```

Those two ids are the **decile-1** records of the entire Chevrolet truck kind — 613 + 154 = **767
Finnish registrations published as raw type codes**, because in the truck/bus path `series_collapse`
strips `CHEVY` *and* `VAN` off the front of `"CHEVY VAN 20-STARCRAFT-3.9T-FG25F/343"`. Evidence
moves onto a real nameplate; nothing is created from nothing. Both lines are marked **`# INTERIM`**
against the `search_aliases` token-eater defect that DEBT.md now carries as a root cause (data#130),
with the instruction to prune them when the one-line fix lands. **I have not attempted that fix** —
it changes produced strings and this batch is keyed on today's.

## THE ONE THING I MEASURED AND THEN REFUSED: the S10 group

Folding `S10 Pickup` / `S-10 LS` / `S 10 LS` / `T10 Pick Up` onto `S10` is **correct on the
evidence** — `us_fueleconomy`'s own baseModel string is literally **`T10 (S10) Pickup`**, a US
regulator stating in one field that the T10 *is* the S10, and it resolves the "S-10 family pass
deferred, no live GM page to cite" DEBT line with a citation that is not GM's.

I built it. It **deleted a live published id**:

* the fold moves fi/lu/nl registration mass onto `van/chevrolet/s10`;
* `Reconciler.cross_kind_prune!` then measures van at **≥97%** of that nameplate's grand total and
  prunes every other kind;
* `car/chevrolet/s10` — published, carrying **ca + nl + nz + us** — is deleted. Build output:
  `FAIL id-contract gate (no-vanish) car: car/chevrolet/s10` **and**
  `FAIL id-contract gate (liveness): car/chevrolet/s10-pickup -> car/chevrolet/s10: target is not
  live`.

**The mechanism is a pipeline defect and deserves its own line:** the dominance ratio is computed
over registration **counts**, and `ca_nrcan` / `us_fueleconomy` are *catalog* sources that carry no
counts. A record whose evidence is entirely catalog-sourced contributes **0** to its own kind's
total and is therefore **structurally unable to defend itself** — so a fold performed in a
*different kind* can silently delete it, and the only warning is a gate failure in a make the folder
may not be looking at. Filed here; not fixed here.

Because zero evidence loss is the standing contract for a fold wave, the group is **not shipped**.
`renames.yml` carries the whole reasoning as a block comment where the lines would have gone,
`S10 Pick Up: S10 Pickup` is left at its original target, and `enrich/chevrolet.yml` says the same
on both `s10` entries. **Restore the group in the same PR as the fix, never before it.**

## The four rulings, and how each was applied

**1 — The four `baseModel` disagreements: the dossier's calls STAND, both ways.** Two deliberate
divergences from the primary oracle, stated plainly:

* **KEEP `Blazer EV`, `Equinox EV`, `Silverado EV`, `Spark EV` as separate records**, although
  `us_fueleconomy` bases `Blazer EV AWD` at `Blazer`, `Equinox EV` at `Equinox`, and so on. An
  electric product with its own platform is a distinct product — this repo's settled position
  (`data/review/citroen-e-prefix-verdict.md`, the Opel Ampera-e split, the Audi e-tron GT split) —
  and EPA's `baseModel` is a **fuel-economy certification grouping, not a product taxonomy**. The
  source contradicts itself here anyway: it gives `Bolt EV` and `Bolt EUV` their own bases, so it is
  capable of the distinction and declined it only for the badge-shared EVs. Only
  `Blazer EV Rwd → Blazer EV` folds (a drivetrain marker).
* **FOLD the `Pickup` body word off `K1500 Pickup` and `S10 Pickup`**, although EPA gives each its
  own baseModel. NAMING.md §1 makes body and configuration words non-nameplates, and that outranks a
  regulator listing a body style inside its certification label. `car/chevrolet/k1500` and
  `car/chevrolet/s10` already publish the same truck. (The S10 half is refused for the unrelated
  cross-kind reason above; the K1500 half ships and carries **us** into the survivor.)

**2 — All six make-boundary items are REPORT-ONLY.** Nothing cross-make ships. Filed worklist, both
ids named per item:

| moves.yml / aliases work | ids |
|---|---|
| joint DVLA marque string; these are Chevrolets | `car/chevrolet-gmc/camaro` → `car/chevrolet/camaro` · `car/chevrolet-gmc/corvette` → `car/chevrolet/corvette` (2 records, **gb**) |
| three makes, one lineage — a three-way make merge, far outside a trim pass | `car/gm-daewoo/kalos` · `car/gm-daewoo/lacetti` · `car/gm-daewoo/matiz` vs their `chevrolet` and `daewoo` twins (3 records, **fi+nl**) |
| sub-brand written into the model column; NAMING.md §8.2 says MOVE, not drop | `car/chevrolet/gmc-jimmy` → `car/gmc/jimmy` · `car/chevrolet/gmc-safari` → `car/gmc/safari` |
| both raws name a GMC (`SIERRA 2500 HD` fi, `SIERRA CLASSIC 3+3` nl) | `truck/chevrolet/sierra` → `truck/gmc/sierra` |
| Oldsmobile nameplate; the Chevrolet badge is REAL for exactly the markets these rows sit in | `car/chevrolet/alero` (fi, lu, nl, ua — 109 regs, decile 6). Probably KEEP; reviewer's call. The run and the caveat are in `enrich/chevrolet.yml`, the record is untouched |
| Pontiac nameplate, but two registers in two countries both write Chevrolet; UNSOURCED | `car/chevrolet/trans-sport` (fi+nl, **268 regs, decile 2**). Failed routes: EPA has no Trans Sport row under Chevrolet at all; GM Europe material is 403. Resolves with a Chevrolet Europe 1997-2005 price list or the NL RDW type-approval holder |

**3 — Everything else in §E is untouched.** The ~45 bare body-style / trim-word / year records
(`Coupe` 262 regs, `Sedan` 194, `Pick Up`, `Fleetside` 165, `Tudor`, `Van`, `1934`, …) — **not
nulled**, because nulling them deletes 1,200+ real registrations and no single target is honest (a
1935 `TUDOR` is a Standard Six, a 1953 `TUDOR` is a One-Fifty). The 18 bare-number and G-series ids —
untouched, because they are mixed blocks one rename key cannot split, and because the G-series ids
are exactly what pipeline#42 rescued. `Cheyenne` / `Scottsdale` / `Custom` / `Fleetside` /
`Stepside` / `Sportside` — sourced as trims and bed styles, but with no resolvable target. The
U+200E scrub, `Chevy II`, and the TrailBlazer casing — pipeline problems, filed not fixed. **The C/K
direction is untouched** (C-series hyphenated, K-series fused, #63 Option A) and the
C-1500/C-2500 incoherence the dossier wrote out as NOT PROPOSED is **not** "fixed" here.

**4 — The two `# INTERIM` folds ship as INTERIM with their comments intact.** No attempt at the
`series_collapse` fix.

## Discipline notes for the reviewer

* **The 23 repoints are EDITS, not appends.** Every one changes an existing line's target in place;
  `lint_curation`'s duplicate-key rule is the reason, and none of them reverses a settled
  *decision* — the SS casing family, the `Sting Ray`/`Stingray` pin, the `C-10` direction and the
  `Styleline De Luxe` spelling all survive intact and simply land one altitude higher.
* **Chain pre-flight, asserted in the applier rather than assumed:** no line self-references; no
  target is itself one of the 174 retiring ids; no target is an existing alias KEY; none of the 174
  was already present. **Eleven existing aliases pointed INTO an id this batch retires and were
  FLATTENED IN PLACE** onto the final destination, each marked `FLATTENED 2026-08-01` with its old
  midpoint named: `bellair`, `camaro-z28`, `corvette-stingray`, `corvette-zr1`, `stingray`,
  `styleline-deluxe`, `impala-s-s`, `van/3100-pickup`, `van/c10-custom-deluxe`, `van/c10-pick-up`,
  `van/s10-pick-up` (the last one restored to its original target when the S10 group was refused).
  File-wide chain scan after the append: **0 chains, 0 cycles.**
* **Rule 1g:** `car/chevrolet/chev` is the one nulled id and is deliberately **NOT** in
  `former_ids.yml` — the string names the marque, so no successor is honest. No id in this PR is
  both aliased and manifested.
* **data#132 is untouched.** I independently measured `car/chevrolet/tudor` and `car/chevrolet/van`
  falling out on a pristine control and had drafted the same two demotion manifests; on the
  coordinator's note that #132 already disposes them, I removed mine so the two PRs cannot collide
  on a duplicate key. My dossier folds/aliases neither id, so there is no supersession to make.

## Every check, run bare, with its exit code

| check | exit | result |
|---|---:|---|
| `scripts/lint_curation.rb` | **0** | OK — 109 files, duplicate-key + shape + make-key + provenance |
| `scripts/lint_overrides.rb` | **0** | OK |
| `scripts/reorg_make_blocks.rb` | **0** | already alphabetical |
| `scripts/reorg_make_blocks.rb --check` | **0** | already alphabetical |
| `pipeline/tools/lint_enrich.rb` | **0** | 50 files, 896 ids, OK |
| `pipeline/tests/test_override_key_reachability.rb` | **0** | 5 runs, 10 assertions |
| every file in `pipeline/tests/` | **0** | 11/11 green |
| `pipeline/tools/lint_claims.rb` | **0** | OK |
| `ruby pipeline/run.rb` (full build) | 1 | **7 gate failures — byte-identical to the pristine control from the same cache. Zero are mine.** |
| `scripts/lint_dataset.rb` | 1 | **6 unexplained name-shape suspects — identical on the pristine control** (daf/xf410, daf/xg430, heuliez-bus/gx437, leyland-daf/fa45, /fa50, /fa55). This PR *reduces* tracked debt: `spec-token-4w` 17 → 16 |

**Which gate failures are mine: none.** The 7 are `motorcycle/suzuki/{gs1100,gs250,gs650,gsx1250,
gsx250}` (S2W's half, being handled there) plus `car/chevrolet/{tudor,van}` (upstream drift,
disposed by data#132). All seven reproduce on a pristine `origin/main` build from the same frozen
cache, with zero Chevrolet changes applied.

## `propose_former_ids.rb` — the verifier

```
intents=11974  proposed=0  dead_keys=2  evidence_loss=0  unexplained=12
```

* **`proposed=0`** — every rename intent in the whole repo already has its alias. **Nothing in this
  batch failed to take effect.**
* **`evidence_loss=0`** — the script's own successor-country check agrees with the diff above.
* **`dead_keys=2`** — `car/chrysler/town-country-touring` and `car/jaguar/xj-sc`. **Both pre-existing
  and in other makes**; independently, `gen_review_pack.rb chevrolet` reports
  `MANDATORY §B — dead override keys targeting this make: (none)`, so this batch adds **0 inert
  keys** on top of 217 lines.
* **`unexplained=12`** — investigated, every one: `car/chevrolet/chev` is **mine and intentional**
  (a null rename has no successor by design; its `removals.yml` line carries the reason and the
  measured population). The other eleven are the inherited drift set — `car/chevrolet/3500`,
  `car/chevrolet/tudor`, `car/chevrolet/van`, `car/ford/e-450`, `car/mg/rx5`,
  `bus/irisbus/eurorider` and the five suzuki — none of them touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
