### PR TITLE
MG + Austin wave-4: 281 records → 131, 515 registrations rescued, 0 countries lost

### DIFF
--- a/data/name_shapes.yml
+++ b/data/name_shapes.yml
@@ -290,6 +290,34 @@ debt:
       (PALFINGER_P200TXE-L_F24P_E6, fi/nl) that needs the coachbuilder
       treatment, not a rename.
 
+  - id: bare-body-word-nameplates-4w
+    owner: s4w
+    category: body_word
+    id_list: ["car/mg/roadster"]
+    count: 1
+    why: >-
+      HELD, NOT DELETED. car/mg/roadster is 1,561 registrations across fi, gb,
+      nl and nz and asserts that MG sells a model called "Roadster", which is
+      false: DVLA's GenModel AND its Model column both read only ROADSTER
+      (uk_veh0120_uk.csv, OGL v3, measured 2026-08-01) and nl/nz/fi write the
+      bare body word. The wave-4 MG dossier proposed nulling it with a
+      removals.yml ledger line; that was overruled, because nulling deletes
+      1,561 real registrations with no honest target — the same reason Ford's
+      ~45 bare body-style records were deliberately kept. So the shape is
+      COUNTED here instead of deleted, and the resolution is the pipeline
+      change filed alongside this entry: uk_dft.rb aggregates on
+      (Make, GenModel) and never reads DVLA's finer, regulator-authored `Model`
+      column, which is the only source in the corpus that could split this
+      record. The same choice applies at 1/50th the scale to car/austin/tourer
+      (25 registrations) and car/mg/sports (34), which WERE nulled with ledger
+      lines in the same pass — flagged here so a maintainer can extend or
+      reverse the line consistently rather than rediscover it.
+      KNOWN INERT: lint_dataset.rb has no body-word detector (its shapes are
+      placeholder / table_artifact / make_as_model / embedded_make /
+      numeric_only / spec_token / code_string), so nothing currently matches
+      this entry and it will report 0 records rather than 1. It is a declared
+      ledger line, not a working allowlist, until such a detector exists.
+
   # ── 2W half (S2W) — seeded from their measurement so the counter exists;
   #    they own the entries and the remedy (NEGOTIATION.md Turn 8 §4/§5) ──────
   - id: normalizer-space-collapse-display-names

--- a/overrides/makes/aliases.yml
+++ b/overrides/makes/aliases.yml
@@ -162,6 +162,7 @@ LANDROVER: Land Rover                # IE CSO TEM20 writes it as one word (measu
 MERCEDES-BENZS: Mercedes-Benz
 QUATTRO: Audi                        # RDW registers some Audi Quattros with merk=QUATTRO (quirk, audit 2026-07-05)
 MG ROEWE: MG                         # FI compound label; Roewe models sold as MG in EU
+"MG,ROEWE": MG                       # COMMA form of the same FI/ES compound label — the space form one line up already routes de_kba's 16,143 registrations, but es_dgt and fi_traficom write the comma and it matched nothing, falling through to smart_case and MINTING a make called "Mg,roewe". Measured 2026-08-01: es_dgt "MG,ROEWE | MG EHS PLUG-IN HYBRID" (1), fi_traficom "MG,ROEWE | MG EHS Plug-in Hybrid" (1), plus a sub-threshold "MG,ROEWE | MG HS" (es 1). Retires the make mg-roewe entirely — its one record's evidence lands on car/mg/ehs, which already carries both countries, so nothing is lost
 BAIC: BAIC
 DS AUTOMOBILES ONE: DS
 DAF TRUCKS: DAF

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1207,7 +1207,7 @@
 "car/audi/q-5": "car/audi/q5"
 "car/austin/a-35": "car/austin/a35"
 "car/austin/a-50": "car/austin/a50"
-"car/austin/healey3000": "car/austin/healey-3000"
+"car/austin/healey3000": "car/austin-healey/3000"
 "car/auto-union/1000s": "car/auto-union/1000-s"
 "car/barkas/b-1000": "car/barkas/b1000"
 "car/bentley/s-1": "car/bentley/s1"
@@ -1686,10 +1686,10 @@
 "car/mercedes-benz/600sl": "car/mercedes-benz/600-sl"
 "car/mercedes-benz/609d": "car/mercedes-benz/609-d"
 "car/mercury/montclair": "car/mercury/mont-clair"
-"car/mg/bgt": "car/mg/b-gt"
-"car/mg/cgt": "car/mg/c-gt"
+"car/mg/bgt": "car/mg/mgb"
+"car/mg/cgt": "car/mg/mgc"
 "car/mg/mg-b": "car/mg/mgb"
-"car/mg/mgbgt": "car/mg/mgb-gt"
+"car/mg/mgbgt": "car/mg/mgb"
 "car/mg/rx6": "car/mg/hs"
 "car/mg/s9": "car/mg/mgs9-phev"
 "car/mg/tf": "car/mg/t-f"
@@ -2636,15 +2636,15 @@
 # 2026-07-26 — MG lane-A (swarm dossier): the shipped stop-split artifacts
 # reversed. car/mg/mgb RESURRECTS as the live id (its old alias deleted —
 # the tvr/c70/austin precedent, 5th instance); artifacts fold in.
-"car/mg/b-g-t":        "car/mg/b-gt"
-"car/mg/bgt-v8":       "car/mg/b-gt-v8"
-"car/mg/bgtv8":        "car/mg/b-gt-v8"
+"car/mg/b-g-t":        "car/mg/mgb"
+"car/mg/bgt-v8":       "car/mg/mgb"
+"car/mg/bgtv8":        "car/mg/mgb"
 "car/mg/m-g-a":        "car/mg/mga"
 "car/mg/m-g-b":        "car/mg/mgb"      # the reversal — the artifact id folds into the resurrected closed-token id
-"car/mg/midget-mk-3":  "car/mg/midget-mkiii"
-"car/mg/midget-mk3":   "car/mg/midget-mkiii"
-"car/mg/t-d-roadster": "car/mg/td-roadster"
-"car/mg/tf-1500":      "car/mg/tf1500"
+"car/mg/midget-mk-3":  "car/mg/midget"
+"car/mg/midget-mk3":   "car/mg/midget"
+"car/mg/t-d-roadster": "car/mg/td"
+"car/mg/tf-1500":      "car/mg/tf-midget"
 # ---------------------------------------------------------------------------
 # 2026-07-26 — swarm-dossier batch: toyota/nissan/mitsubishi (9 groups → 0;
 # the detector canonical refuted in 8 of 9 — it fought settled curation).
@@ -2676,10 +2676,10 @@
 # 2026-07-26 — swarm-dossier batch: british small makes (saab/austin/jaguar/
 # daimler/morris/morgan; 14 groups → 0, 16 ids retired, 0 minted).
 "car/austin/a-30": "car/austin/a30"
-"car/austin/healey-3000-mk-111": "car/austin/healey-3000-mkiii"
-"car/austin/healey-3000-mk111": "car/austin/healey-3000-mkiii"
-"car/austin/mini-mk-2": "car/austin/mini-mkii"
-"car/austin/mini-mk2": "car/austin/mini-mkii"
+"car/austin/healey-3000-mk-111": "car/austin-healey/3000"
+"car/austin/healey-3000-mk111": "car/austin-healey/3000"
+"car/austin/mini-mk-2": "car/austin/mini"
+"car/austin/mini-mk2": "car/austin/mini"
 "car/daimler/250v8": "car/daimler/250-v8"
 "car/daimler/v8-250": "car/daimler/v8250"
 "car/jaguar/38s": "car/jaguar/3-8s"
@@ -2748,8 +2748,8 @@
 # Every alias is paired with its rename FOLD (the #67 rule). AR "TUCSON IX35"
 # raw re-verified by the maintainer before the hyundai fold.
 "car/aston-martin/dbx-707":    "car/aston-martin/dbx707"
-"car/austin-healey/3000-mk-2": "car/austin-healey/3000-mkii"
-"car/austin-healey/3000-mk2":  "car/austin-healey/3000-mkii"
+"car/austin-healey/3000-mk-2": "car/austin-healey/3000"
+"car/austin-healey/3000-mk2":  "car/austin-healey/3000"
 "car/chrysler/300c-srt-8":     "car/chrysler/300c-srt8"
 "car/datsun/280-zx":           "car/datsun/280zx"
 "car/faw/ehs9":                "car/faw/e-hs9"
@@ -5539,3 +5539,173 @@
 "bus/volvo/b10m-55":                       "bus/volvo/b10m" # FOLD. produced key/s "B10M-55". chassis length/axle sub-variant of the B-series chassis. countries fi,nl are already on the survivor (fi,nl,nz) — a strict subset, nothing is lost. inbound 0 — nothing chains through this id https://en.wikipedia.org/wiki/Volvo_B10M
 "bus/volvo/b10m-60":                       "bus/volvo/b10m" # FOLD. produced key/s "B10M-60". chassis length/axle sub-variant of the B-series chassis. countries fi,nl are already on the survivor (fi,nl,nz) — a strict subset, nothing is lost. inbound 0 — nothing chains through this id https://en.wikipedia.org/wiki/Volvo_B10M
 "bus/volvo/b58-60":                        "bus/volvo/b58" # FOLD. produced key/s "B58-60". chassis length/axle sub-variant of the B-series chassis. the survivor GAINS nl (had fi,nz), post-fold fi,nl,nz. inbound 0 — nothing chains through this id https://en.wikipedia.org/wiki/Volvo_B10M
+
+# ══ wave-4 MG + AUSTIN folds (2026-08-01) ═══════════════════════════════════
+# Chain pre-flight run before this append: 0 keys already present, 0 outbound
+# chains (no target below is itself an alias key), 0 self-references, 0 ids in
+# both removals.yml and this file (rule 1g), and every key below is LIVE in the
+# control build. 17 INBOUND chains were found and FLATTENED in place above
+# (car/mg/bgt, cgt, mgbgt, b-g-t, bgt-v8, bgtv8, midget-mk-3, midget-mk3,
+#  t-d-roadster, tf-1500; car/austin/healey3000, healey-3000-mk-111,
+#  healey-3000-mk111, mini-mk-2, mini-mk2; car/austin-healey/3000-mk-2,
+#  3000-mk2) so no consumer follows two redirects.
+# Five targets are minted or promoted by these folds and were not live in the
+# previous release: car/mg/mgs5-ev (from four losing ids, 11 countries),
+# car/mg/mgs6-ev (promoted from the candidate queue), car/mg/im5,
+# car/austin/14, car/austin-healey/100-6.
+
+# ── MG: the letter-shorthand folds. The marque's own names are MGA/MGB/MGC/MGF
+#    (closed, no space) and the registers state the relation themselves: nl_rdw
+#    writes both "B" (2,490) and "MGB" (65) for one car, and DVLA's Model column
+#    reads "A"/"B"/"B GT"/"B GT V8" under GenModel "MG MGA"/"MG MGB".
+"car/mg/a":                  "car/mg/mga"
+"car/mg/a-mk-2":             "car/mg/mga"
+"car/mg/a-roadster":         "car/mg/mga"
+"car/mg/a-twin-cam":         "car/mg/mga"
+"car/mg/a1600":              "car/mg/mga"
+"car/mg/1600":               "car/mg/mga"
+"car/mg/1600-mk":            "car/mg/mga"
+"car/mg/1600-mkii":          "car/mg/mga"
+"car/mg/mga-1500-roadster":  "car/mg/mga"
+"car/mg/mga-1600":           "car/mg/mga"
+"car/mg/mga-1600-mk":        "car/mg/mga"
+"car/mg/mga-roadster":       "car/mg/mga"
+"car/mg/mga-twin-cam":       "car/mg/mga"
+"car/mg/b":                  "car/mg/mgb"
+"car/mg/b-gt":               "car/mg/mgb"
+"car/mg/b-gt-v8":            "car/mg/mgb"
+"car/mg/b-roadstar":         "car/mg/mgb"
+"car/mg/b-roadster":         "car/mg/mgb"
+"car/mg/b-v8":               "car/mg/mgb"
+"car/mg/bgt-sport":          "car/mg/mgb"
+"car/mg/1800":               "car/mg/mgb"
+"car/mg/mgb-1800":           "car/mg/mgb"
+"car/mg/mgb-b":              "car/mg/mgb"
+"car/mg/mgb-gt":             "car/mg/mgb"
+"car/mg/mgb-gt-v8":          "car/mg/mgb"
+"car/mg/mgb-roadster":       "car/mg/mgb"
+"car/mg/c":                  "car/mg/mgc"
+"car/mg/c-gt":               "car/mg/mgc"
+"car/mg/c-roadster":         "car/mg/mgc"
+"car/mg/mgc-gt":             "car/mg/mgc"
+"car/mg/f":                  "car/mg/mgf"
+"car/mg/mgf-1-8i":           "car/mg/mgf"
+# ── MG: Midget, the T-series that was ALSO called Midget, the two TFs, saloons ──
+"car/mg/midget-1500":        "car/mg/midget"
+"car/mg/midget-mark":        "car/mg/midget"
+"car/mg/midget-mk":          "car/mg/midget"
+"car/mg/midget-mk-11":       "car/mg/midget"
+"car/mg/midget-mk2":         "car/mg/midget"
+"car/mg/midget-mkii":        "car/mg/midget"
+"car/mg/midget-mkiii":       "car/mg/midget"
+"car/mg/midget-sport":       "car/mg/midget"
+"car/mg/midget-td":          "car/mg/td"
+"car/mg/td-roadster":        "car/mg/td"
+"car/mg/m-midget":           "car/mg/m"
+"car/mg/mgtf":               "car/mg/t-f"
+"car/mg/tf-roadster":        "car/mg/t-f"
+"car/mg/midget-tf":          "car/mg/tf-midget"
+"car/mg/tf-1250":            "car/mg/tf-midget"
+"car/mg/tf1500":             "car/mg/tf-midget"
+"car/mg/y":                  "car/mg/ya"
+"car/mg/magnette-za":        "car/mg/magnette"
+"car/mg/magnette-zb":        "car/mg/magnette"
+"car/mg/za-magnette":        "car/mg/magnette"
+"car/mg/zb":                 "car/mg/magnette"
+"car/mg/l2-magna":           "car/mg/magna"
+"car/mg/metro-1300":         "car/mg/metro"
+"car/mg/metro-turbo":        "car/mg/metro"
+"car/mg/montego-efi":        "car/mg/montego"
+"car/mg/montego-turbo":      "car/mg/montego"
+"car/mg/zt-t":               "car/mg/zt"
+"car/mg/zs1":                "car/mg/zs"
+"car/mg/roewe-zs-ev":        "car/mg/zs-ev"
+# ── MG: the modern range. One car published at four ids becomes one id. ──
+"car/mg/s5-ev":              "car/mg/mgs5-ev"
+"car/mg/s5":                 "car/mg/mgs5-ev"
+"car/mg/mgs5":               "car/mg/mgs5-ev"
+"car/mg/mg-s5-se-ev":        "car/mg/mgs5-ev"
+"car/mg/s6-ev":              "car/mg/mgs6-ev"
+"car/mg/im5-long-range":     "car/mg/im5"
+# ── the mg-roewe make does not exist: the raw string is "MG,ROEWE" (comma). ──
+"car/mg-roewe/mg-ehs":       "car/mg/ehs"
+
+# ── Austin: pre-war coachwork names on a numbered chassis. Every body name here
+#    appears on EXACTLY ONE chassis; the six that were reused (Ascot, Clifton,
+#    Harley, Windsor, Cambridge, pre-war Westminster) are deliberately NOT folded.
+"car/austin/chummy":            "car/austin/seven"
+"car/austin/ruby":              "car/austin/seven"
+"car/austin/ruby-7":            "car/austin/seven"
+"car/austin/seven-ruby":        "car/austin/seven"
+"car/austin/seven-opal":        "car/austin/seven"
+"car/austin/seven-1935":        "car/austin/seven"
+"car/austin/nippy":             "car/austin/seven"
+"car/austin/ulster":            "car/austin/seven"
+"car/austin/box":               "car/austin/seven"
+"car/austin/a7":                "car/austin/seven"
+"car/austin/ten":               "car/austin/10"
+"car/austin/ten-four":          "car/austin/10"
+"car/austin/10-lichfield":      "car/austin/10"
+"car/austin/10-sherborne":      "car/austin/10"
+"car/austin/sixteen":           "car/austin/16"
+"car/austin/york":              "car/austin/16"
+"car/austin/goodwood":          "car/austin/14"
+# ── Austin: the Westminster series, the A-series, trim/displacement badges ──
+"car/austin/a95":               "car/austin/westminster"
+"car/austin/a99":               "car/austin/westminster"
+"car/austin/a105":              "car/austin/westminster"
+"car/austin/a110":              "car/austin/westminster"
+"car/austin/six":               "car/austin/westminster"
+"car/austin/a40-devon":         "car/austin/a40"
+"car/austin/a40-somerset":      "car/austin/a40"
+"car/austin/devon":             "car/austin/a40"
+"car/austin/a30-seven":         "car/austin/a30"
+"car/austin/a50-cambridge":     "car/austin/a50"
+"car/austin/allegro-1300":      "car/austin/allegro"
+"car/austin/allegro-1500":      "car/austin/allegro"
+"car/austin/1300-gt":           "car/austin/1300"
+# ── Austin: Mini strings INSIDE austin. No make boundary is crossed here — the
+#    cross-make Mini marque question is filed, not settled.
+"car/austin/mini-1000":         "car/austin/mini"
+"car/austin/mini-850":          "car/austin/mini"
+"car/austin/850":               "car/austin/mini"
+"car/austin/mini-mayfair":      "car/austin/mini"
+"car/austin/mini-mk":           "car/austin/mini"
+"car/austin/mini-mkii":         "car/austin/mini"
+"car/austin/cooper":            "car/austin/mini-cooper"
+"car/austin/cooper-s":          "car/austin/mini-cooper-s"
+"car/austin/clubman":           "car/austin/mini-clubman"
+"car/austin/moke":              "car/austin/mini-moke"
+# ── Austin: Metropolitan and the FX4 taxi ──
+"car/austin/nash":              "car/austin/metropolitan"
+"car/austin/taxi":              "car/austin/fx4"
+"car/austin/london-taxi":       "car/austin/fx4"
+"car/austin/taxi-hire-car-a":   "car/austin/fx4"
+# ── the ids that leave the make entirely (targets are the moves.yml destinations) ──
+"car/austin/healey-100":        "car/austin-healey/100"
+"car/austin/healey-100-4":      "car/austin-healey/100"
+"car/austin/healey-100-6":      "car/austin-healey/100-6"
+"car/austin/healey-3000":       "car/austin-healey/3000"
+"car/austin/healey-3000-mk":    "car/austin-healey/3000"
+"car/austin/healey-3000-mk-i":  "car/austin-healey/3000"
+"car/austin/healey-3000-mkiii": "car/austin-healey/3000"
+"car/austin/healy-3000-mark":   "car/austin-healey/3000"
+"car/austin/healey-mk":         "car/austin-healey/3000"
+"car/austin/healy-mk3":         "car/austin-healey/3000"
+"car/austin/mark":              "car/austin-healey/3000"
+"car/austin/3000":              "car/austin-healey/3000"
+"car/austin/healey-sprite":     "car/austin-healey/sprite"
+"car/austin/healey-sprite-mark": "car/austin-healey/sprite"
+"car/austin/healey-sprite-mk1": "car/austin-healey/sprite"
+"car/austin/healy-sprite":      "car/austin-healey/sprite"
+
+# ── Austin-Healey internal Mk/Mark folds (12 records -> 4) ──
+"car/austin-healey/3000-mark":  "car/austin-healey/3000"
+"car/austin-healey/3000-mk":    "car/austin-healey/3000"
+"car/austin-healey/3000-mk1":   "car/austin-healey/3000"
+"car/austin-healey/3000-mkii":  "car/austin-healey/3000"
+"car/austin-healey/mk":         "car/austin-healey/3000"
+"car/austin-healey/sprite-mark-1": "car/austin-healey/sprite"
+"car/austin-healey/sprite-mk":  "car/austin-healey/sprite"
+"car/austin-healey/sprite-mk-i": "car/austin-healey/sprite"
+"car/austin-healey/healey-sprite": "car/austin-healey/sprite"

--- a/overrides/models/moves.yml
+++ b/overrides/models/moves.yml
@@ -343,5 +343,29 @@
 # sold as a "Rover Mini" 1988-2000 and the DVLA genmodel is literally
 # ROVER | ROVER MINI (29,832 registrations), so it stays under Rover
 # (https://en.wikipedia.org/wiki/Mini).
-"Rover|Mgf": "MG|Mgf"                            # 489 vehicles (fi 2, lu 1, nl 27, nz 459). The MGF is an MG (1995-2002, https://en.wikipedia.org/wiki/MG_F); target car/mg/mgf carries fi,gb,lu,nl,nz
-"Rover|MG Zt": "MG|Zt"                           # 2 vehicles (fi 1, nl 1). The MG ZT is an MG (2001-05, https://en.wikipedia.org/wiki/MG_ZT); target car/mg/zt carries gb,nl and GAINS fi
+"Rover|Mgf": "MG|MGF"                            # 489 vehicles (fi 2, lu 1, nl 27, nz 459). The MGF is an MG (1995-2002, https://en.wikipedia.org/wiki/MG_F); target car/mg/mgf carries fi,gb,lu,nl,nz
+"Rover|MG Zt": "MG|ZT"                           # 2 vehicles (fi 1, nl 1). The MG ZT is an MG (2001-05, https://en.wikipedia.org/wiki/MG_ZT); target car/mg/zt carries gb,nl and GAINS fi
+# ── Austin-Healeys filed under make AUSTIN (wave-4 MG+Austin dossier, 2026-08-01) ──
+# DVLA files them as Make=AUSTIN with GenModel="AUSTIN HEALEY"/"AUSTIN SPRITE"
+# while ALSO carrying a separate Make="AUSTIN HEALEY" whose 5,139 GB rows are
+# 100% "MODEL MISSING" (uk_veh0120_uk.csv, OGL v3, measured 2026-08-01). nl_rdw
+# and nz_nzta write "HEALEY 3000", "HEALEY SPRITE", "HEALY SPRITE" etc. under
+# merk=AUSTIN. Austin-Healey is its own marque — "The Austin-Healey marque was
+# established through an arrangement set up in 1952 between Leonard Lord of the
+# Austin division of the British Motor Corporation (BMC) and Donald Healey"
+# (https://www.healey.org/about-the-marque) — so this is NAMING §1's "the make
+# is the marque, not the registrant".
+# CORROBORATES identity-austin.yml's four `make_boundary: austin-healey`
+# nominations (car/austin/healey-100 Q432387, healey-100-6 Q4822933,
+# healey-3000 Q780854, healey-sprite Q780868) — all four checked, all correct.
+# Rule 1: every key below is the canonical string produced by the Austin block's
+# renames above (renames run BEFORE moves), which is why four move lines replace
+# twenty. Rule 3: each string names ONE marque's model outright, so none pools.
+# NOT moved, deliberately: car/austin/sprite (the 1971 Austin Sprite is a real
+# Austin nameplate — "the final 1,022 Sprites built were simply Austin Sprites",
+# https://austinsprite.co.uk/, and DVLA gives it its own GenModel AUSTIN SPRITE);
+# car/austin/healey and car/austin/healy (they carry no nameplate at all).
+"Austin|Healey 100":    "Austin-Healey|100"     # Austin-Healey 100 (BN1/BN2) 1953-1956 — https://en.wikipedia.org/wiki/Austin-Healey_100
+"Austin|Healey 100-6":  "Austin-Healey|100-6"   # Austin-Healey 100-6 (BN4/BN6) 1956-1959 — https://en.wikipedia.org/wiki/Austin-Healey_100-6
+"Austin|Healey 3000":   "Austin-Healey|3000"    # Austin-Healey 3000 Mk I-III 1959-1967 — https://en.wikipedia.org/wiki/Austin-Healey_3000
+"Austin|Healey Sprite": "Austin-Healey|Sprite"  # Austin-Healey Sprite Mk I-IV 1958-1971 — https://en.wikipedia.org/wiki/Austin-Healey_Sprite

--- a/overrides/models/removals.yml
+++ b/overrides/models/removals.yml
@@ -935,3 +935,31 @@
 "car/volvo/estate": "bare body word; measured population 3 registrations across [nl, nz] in the wave-4 corpus replay (origin/main classify, 2026-08-01). Never a nameplate at any altitude, so no alias target is honest."
 "bus/volvo/matalalattiainen": "Finnish for 'low-floor'; the whole raw is a body description ('Matalalattiainen yksikerroksinen (CE) 3ov 7146cm3'); measured population 77 registrations across [fi] in the wave-4 corpus replay (origin/main classify, 2026-08-01). Never a nameplate at any altitude, so no alias target is honest."
 "truck/volvo/vvn": "3-letter registry stub, no resolvable nameplate; measured population 2 registrations across [fi, nl] in the wave-4 corpus replay (origin/main classify, 2026-08-01). Never a nameplate at any altitude, so no alias target is honest."
+
+# ── wave-4 MG + AUSTIN: strings with NO honest survivor (2026-08-01) ─────────
+# Every line carries its MEASURED population (registrations from the 2026-08-01
+# replay, countries from the control catalog) — nothing here is a silent drop,
+# and every folded string that DOES have a survivor is in former_ids.yml
+# instead. NOTE the one big body-word record this pass deliberately does NOT
+# null: car/mg/roadster (1,561 registrations, fi+gb+nl+nz). Nulling it would
+# delete real registrations with no honest target, the same reason Ford's bare
+# body-style records were kept; it is held as declared debt in
+# data/name_shapes.yml instead.
+"car/mg/roadstar": "body-class misspelling, not a nameplate: the registrar's spelling of 'Roadster' (nl+nz, 6 registrations). MG has never sold a model called Roadstar or Roadster; there is no nameplate here to fold onto, and unlike car/mg/roadster this record is 6 vehicles rather than 1,561. NAMING §7.6 (the BMW letter-only range-label precedent)."
+"car/mg/sports": "body class, not a nameplate: nz_nzta writes the bare body word 'SPORTS' 29 times (nl+nz, 34 registrations). No MG model is called Sports. NAMING §7.6."
+"car/mg/saloon": "body class, not a nameplate (nl+nz, 4 registrations). NAMING §7.6."
+"car/mg/coupe": "body class, not a nameplate (nl+nz, 6 registrations). NAMING §7.6."
+"car/mg/convertible": "body class, not a nameplate (nl+nz, 5 registrations). NAMING §7.6."
+"car/mg/mk": "U7 ROMAN-NUMERAL TRUNCATION ARTIFACT (nl+nz, 5 registrations). The raws are 'MK II', 'MK III', 'MK II 1.6 A': normalizer.rb VARIANT_SUFFIXES[5] (/ (II|III|IV|VI{0,3})\\b.*/) strips the spaced Roman numeral BEFORE the rename lookup, so no nameplate token remains and no rename key can ever see the numeral. Curation cannot fix it — DEBT.md 'U7 variant-strip Roman collapse'. If U7 is repaired these rows resolve themselves onto real MG nameplates."
+"car/mg/rover": "company name in the model column, not a model (fi+nl, 4 registrations): 'MG ROVER' is the MG Rover Group 2000-2005 — https://en.wikipedia.org/wiki/MG_Rover_Group . No nameplate is asserted, so no alias target is honest."
+"car/mg/mg1": "INTERIM, and a NORMALIZER defect rather than a curation verdict (nl+nz, 8 registrations). normalizer.rb#mg's second branch `return \"MG#{$1}\" if m =~ /\\A(\\d)\\b/` matches at a decimal point, so 'MGF 1.8i' (nl 2), 'MG Metro 1.3 GS' (nz 2) and three litre-only strings all become a fabricated 'MG1'. MG has never built an MG1. Reported as a pipeline finding; this entry is superseded the moment that branch is scoped, and the destroyed rows then land on MGF/Metro."
+"car/mg/mg2": "INTERIM, same normalizer defect (fi+nl+nz, 9 registrations): '2.0'/'2.0I'/'2.0 SL'/'2.0 TURBO' (nz 6), a 2-door cabriolet body code '2 D CABRIOLET-GHN3/2310' (fi — GHN3 is the MGB body code) and two RDW '2 AXLE- RIGID BODY' strings all become a fabricated 'MG2'. MG has never built an MG2. Reported as a pipeline finding, not patched here."
+"car/austin/saloon": "body class, not a nameplate (nl+nz, 16 registrations). NAMING §7.6."
+"car/austin/sedan": "body class, not a nameplate: nz_nzta writes 'SEDAN' 9 times (nl+nz, 10 registrations). NAMING §7.6."
+"car/austin/sports": "body class, not a nameplate (nl+nz, 13 registrations). NAMING §7.6."
+"car/austin/tourer": "body class, not a nameplate (nl 'TOURER' 2, nz 'TOURER' 22 and 'TOURER 7HP' 1 — nl+nz, 25 registrations). NAMING §7.6."
+"car/austin/roadster": "body class, not a nameplate (nl+nz, 5 registrations). NAMING §7.6."
+"car/austin/pick-up": "body class, not a nameplate (nl+nz, 5 registrations). The key also fires in the van kind on nl_rdw 'PICK UP' (n=1, sub-threshold, so it publishes nothing there). NAMING §7.6."
+"car/austin/morris": "the SIBLING MARQUE's name in the model column with no nameplate attached (nl 1, nz 1). Austin and Morris were both BMC marques and the registrar wrote the wrong one; nothing here says WHICH Morris, so no alias target is honest."
+"car/austin/rover": "company name in the model column, not a model (fi+nz+ua, 3 registrations): 'AUSTIN ROVER' is the Austin Rover Group 1982-1988 — https://en.wikipedia.org/wiki/Austin_Rover_Group ."
+"car/austin/mk": "U7 ROMAN-NUMERAL TRUNCATION ARTIFACT **with mixed content** (nl+nz, 17 registrations). Same VARIANT_SUFFIXES[5] strip as car/mg/mk, but here the swallowed raws span two marques and two cars: 'MK III 3000' and 'MK II HEALEY 3000' are Austin-Healeys, 'MK III 1300' is an Austin 1300 Mk III, 'MK III 3 LITER' is an Austin 3-Litre. No single honest survivor exists, which is why this one is nulled where the Austin-Healey block's own `Mk` key could be folded. DEBT.md 'U7 variant-strip Roman collapse'."

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -110,13 +110,116 @@ Austin:
   # pin (stylings run before renames and would kill these keys). ──
   "A-30": A30                # third raw shape (hyphenated) — Austin badged the A30 closed, 1952-56 (en.wikipedia Austin_A30); completes A 30/A-40/A 40
   "A/30": A30                # fourth raw shape (slash) — same nameplate
-  Healey 3000 Mk 111: Healey 3000 MkIII   # "111" is three ones typed for Roman III — the car is the 3000 Mk III (BJ8, 1964-67; en.wikipedia Austin-Healey_3000)
-  Healey 3000 MK111: Healey 3000 MkIII    # all-caps register variant of the same typo
-  Healey 3000 Mkiii: Healey 3000 MkIII    # same id already — display fix from the caser's "Mkiii"
-  Mini Mk 2: Mini MkII                    # classic Mini Mark II, 1967-70 (en.wikipedia Mini); same Roman conditional as the Healey
-  Mini MK2: Mini MkII                     # fused arabic register variant
-  Mini Mkii: Mini MkII                    # same id already — display fix
+  Healey 3000 Mk 111: Healey 3000         # REPOINT (was "Healey 3000 MkIII"): "111" is three ones typed for Roman III; Mk numbering is a generation of one nameplate — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Healey 3000 MK111: Healey 3000          # REPOINT (was "Healey 3000 MkIII"): all-caps register variant of the same typo — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Healey 3000 Mkiii: Healey 3000          # REPOINT (was "Healey 3000 MkIII"): Mk III 1964-1967 (BJ8) is a generation, not a nameplate — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Mini Mk 2: Mini                         # REPOINT (was "Mini MkII"): classic Mini Mark II 1967-70 is a generation of the Mini — https://en.wikipedia.org/wiki/Mini
+  Mini MK2: Mini                          # REPOINT (was "Mini MkII"): fused arabic register variant — https://en.wikipedia.org/wiki/Mini
+  Mini Mkii: Mini                         # REPOINT (was "Mini MkII"): caser output of "MINI MKII" — https://en.wikipedia.org/wiki/Mini
   HEALEY3000: Healey 3000                     # spelling variant of "Healey 3000" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+
+  # ══ wave-4 MG+Austin dossier (2026-08-01) ═══════════════════════════════════
+  # Austin's 1920s-30s cars are a NUMBERED CHASSIS + a NAMED BODY, so the
+  # chassis number is the nameplate and the body name is a variant ("the
+  # four-seater saloon being the Ruby, the two-seater tourer the Opal and the
+  # cabriolet saloon the Pearl" — https://a7ca.org/austin-seven/models/).
+  # Six further body names (Ascot, Clifton, Harley, Windsor, Cambridge,
+  # Westminster-pre-war) were REUSED across chassis and are deliberately NOT
+  # folded — the measured collision table is in the dossier §E-7.
+  Chummy: Seven              # Seven "Chummy" Models B (1923-24) and C (1924-26) — https://a7ca.org/austin-seven/models/
+  Ruby: Seven                # Seven Ruby (ARQ) Aug 1934-Aug 1936 and Ruby Mk2 (ARR) Aug 1936-Jan 1939 — https://a7ca.org/austin-seven/models/
+  Ruby 7: Seven              # the registrar wrote the chassis and the body together — https://a7ca.org/austin-seven/models/
+  Seven Ruby: Seven          # ditto, words reversed — https://a7ca.org/austin-seven/models/
+  Seven Opal: Seven          # Seven Opal (APD) from July 1934, the two-seat tourer — https://a7ca.org/austin-seven/models/
+  Seven 1935: Seven          # a model YEAR in the model column — https://a7ca.org/austin-seven/models/
+  Nippy: Seven               # Seven Nippy (AEB) from Jan 1934, the sports two-seater — https://a7ca.org/austin-seven/models/
+  Ulster: Seven              # Seven "Sports/Super Sports 2 seater 'Ulster'" (EA) from Feb 1930 — https://a7ca.org/austin-seven/models/
+  Box: Seven                 # Seven Box saloon (RN Oct 1931-Oct 1932, RP Oct 1932-Aug 1934); raws are "BOX SALOON"/"BOX SEDAN" — https://a7ca.org/austin-seven/models/
+  A7: Seven                  # registrar shorthand for the Austin Seven (nz 7, nl 1, fi 1); Austin never designated a post-war "A7" — https://en.wikipedia.org/wiki/Austin_7
+  Ten: "10"                  # SAME CAR: Wikidata Q780947 "Austin 10" is nominated for BOTH car/austin/10 and car/austin/ten (identity-austin.yml shared_with) — https://en.wikipedia.org/wiki/Austin_10
+  Ten Four: "10"             # "Ten-Four" is the Austin Ten's own designation — https://en.wikipedia.org/wiki/Austin_10
+  10 Lichfield: "10"         # "The saloon was given the name Lichfield…", Ten only, 1934-1937 — https://en.wikipedia.org/wiki/Austin_10
+  10 Sherborne: "10"         # "A new six light … Sherborne body style was added in January 1936", Ten only, 1936-1937 — https://en.wikipedia.org/wiki/Austin_10
+  Sixteen: "16"              # word form of the digit id already in the catalog — https://en.wikipedia.org/wiki/Austin_16
+  York: "16"                 # York 5-seater saloon, one of the four bodies the Sixteen range was cut to in 1935 — https://en.wikipedia.org/wiki/Austin_16
+  Goodwood: "14"             # "available as a Goodwood saloon—with a fixed or sliding head—or as a Goodwood cabriolet"; the Fourteen offered no other body, so the fold is exact — https://en.wikipedia.org/wiki/Austin_14 (MINTS car/austin/14)
+  # OVERTURNS identity-austin.yml's Q781039 "Morris Marshal" nomination on
+  # car/austin/a95, which b2-report.md §4.2 already flagged as "1 clear error"
+  # naming Q690875 "Austin Westminster" as the right anchor. The Marshal is the
+  # AUSTRALIAN Morris-badged A95 — a rebadge relation, never an identity.
+  A95: Westminster           # A95 Westminster 1956-1959 — "The Westminster line was produced as the A90, A95, A99, A105, and A110 until 1968" — https://en.wikipedia.org/wiki/Austin_Westminster
+  A105: Westminster          # A105 Westminster 1956-1959 — https://en.wikipedia.org/wiki/Austin_Westminster
+  A99: Westminster           # A99 Westminster 1959-1961 (factory name) — https://en.wikipedia.org/wiki/Austin_Westminster
+  A110: Westminster          # A110 Westminster 1961-1968 (factory name; DVLA's Model column literally reads "A110 WESTMINSTER") — https://en.wikipedia.org/wiki/Austin_Westminster
+  Six: Westminster           # DVLA resolves this in its own Model column: GenModel "AUSTIN SIX" has Model "SIX WESTMINSTER" for 26 of 31 vehicles — the A90 Six Westminster, "introduced at the 1954 London Motor Show" (uk_veh0120_uk.csv, OGL v3) — https://en.wikipedia.org/wiki/Austin_Westminster
+  A40 Devon: A40             # A40 Devon 1947-1952 — https://en.wikipedia.org/wiki/Austin_A40_Devon
+  A40 Somerset: A40          # A40 Somerset 1952-1954 — https://en.wikipedia.org/wiki/Austin_A40_Somerset
+  Devon: A40                 # bare body name; Devon appears on no other Austin chassis — https://en.wikipedia.org/wiki/Austin_A40_Devon
+  A30 Seven: A30             # "It was launched at the 1951 Earls Court Motor Show as the 'New Austin Seven'"; DVLA's Model column for GenModel "AUSTIN A30" reads "A30 SEVEN" (1,253 vehicles) — https://en.wikipedia.org/wiki/Austin_A30
+  A50 Cambridge: A50         # A50 Cambridge 1954-1957 — https://en.wikipedia.org/wiki/Austin_Cambridge
+  Allegro 1300: Allegro      # 1,275 cc A-series — an engine variant, not a nameplate — https://en.wikipedia.org/wiki/Austin_Allegro
+  Allegro 1500: Allegro      # 1,485 cc E-series — ditto — https://en.wikipedia.org/wiki/Austin_Allegro
+  1300 GT: "1300"            # "GT" is a trim badge on the ADO16 Austin 1300 — https://en.wikipedia.org/wiki/BMC_ADO16
+  #      cross-make Mini marque question is deliberately NOT settled here. ----
+  Mini 1000: Mini            # 998 cc A-series — displacement, NAMING §6 — https://en.wikipedia.org/wiki/Mini
+  Mini 850: Mini             # 848 cc A-series — displacement — https://en.wikipedia.org/wiki/Mini
+  "850": Mini                # bare 848 cc badge under make Austin (nz 5, nl 1) — the Mini 850 — https://en.wikipedia.org/wiki/Mini
+  Mini Mayfair: Mini         # "The Mayfair first appeared in 1982, continuing in production until 1996" — a TRIM level; DVLA's Model column shows it beside MINI CITY / MINI THIRTY / MINI PICCADILLY — https://en.wikipedia.org/wiki/List_of_Mini_limited_editions
+  Mini Mk: Mini              # U7 truncation of "MINI MK II/III" — generation, numeral eaten by VARIANT_SUFFIXES — https://en.wikipedia.org/wiki/Mini
+  Cooper: Mini Cooper        # bare "COOPER" under Austin is the Mini Cooper — https://en.wikipedia.org/wiki/Mini
+  Mini-Cooper: Mini Cooper   # hyphen spelling — https://en.wikipedia.org/wiki/Mini
+  Cooper S: Mini Cooper S    # bare "COOPER S" is the Mini Cooper S — https://en.wikipedia.org/wiki/Mini
+  "Mini Cooper 's": Mini Cooper S   # nl_rdw apostrophe spelling "MINI COOPER 'S" — https://en.wikipedia.org/wiki/Mini
+  Clubman: Mini Clubman      # "The restyled version was called the Mini Clubman", 1969-1980; bare "CLUBMAN" under Austin is that car — https://en.wikipedia.org/wiki/Mini
+  Moke: Mini Moke            # "BMC's Cowley plant started building Mokes in January 1964"; bare "MOKE" is the Mini Moke — https://en.wikipedia.org/wiki/Mini_Moke
+  Nash: Metropolitan         # DVLA GenModel "AUSTIN NASH" (gb 83) — the Austin-built Nash Metropolitan, sold in the UK as an Austin from April 1957. CORROBORATES identity-austin.yml's rebadge_of: nash (Q1965741), and a rebadge stays under Austin — https://en.wikipedia.org/wiki/Nash_Metropolitan
+  Taxi: FX4                  # identity-austin.yml nominates the SAME QID (Q781084 "Austin FX4") for car/austin/taxi and car/austin/fx4 — corroborated. "sold by Austin from 1958 until 1982" — https://en.wikipedia.org/wiki/Austin_FX4
+  London Taxi: FX4           # the FX4 IS the London taxi — https://en.wikipedia.org/wiki/Austin_FX4
+  Taxi Hire Car A: FX4       # DVLA's own Model strings are "TAXI/HIRE CAR" and "TAXI/HIRE CAR A" (uk_veh0120_uk.csv) — a licensing class, not a model — https://en.wikipedia.org/wiki/Austin_FX4
+  "Taxi/Hire Car A": FX4     # slash spelling of the same produced string — https://en.wikipedia.org/wiki/Austin_FX4
+  #      string per model here, then relocate with FOUR moves.yml lines.
+  #      renames run BEFORE moves, so this is four move lines instead of twenty.
+  Healey 100 4: Healey 100        # Austin-Healey 100 BN1/BN2, "100/4" = the four-cylinder — https://en.wikipedia.org/wiki/Austin-Healey_100
+  Healey 100-4: Healey 100        # hyphen spelling of the same raw — https://en.wikipedia.org/wiki/Austin-Healey_100
+  "Healey 100/4": Healey 100      # slash spelling of the same raw — https://en.wikipedia.org/wiki/Austin-Healey_100
+  Healey 100 6: Healey 100-6      # Austin-Healey 100-6, "produced from 1956 until 1959" — a DIFFERENT car from the 100 (2,639 cc six vs 2,660 cc four) — https://en.wikipedia.org/wiki/Austin-Healey_100-6
+  "Healey 100/6": Healey 100-6    # slash spelling — https://en.wikipedia.org/wiki/Austin-Healey_100-6
+  Healey 3000 Mk: Healey 3000     # U7 truncation of "HEALEY 3000 MK II/III" — generation — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Healey 3000-Mk: Healey 3000     # hyphen spelling of the same U7 stub — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Healey 3000 Mk I: Healey 3000   # a bare "I" survives U7 (the regex alternation has no lone I) — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Healy 3000 Mark: Healey 3000    # registrar misspelling "HEALY" — SPELLING variant — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  "3000": Healey 3000             # bare "3000" under make Austin: Austin never sold a model called 3000, the Austin-Healey 3000 is the only candidate — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Healey Mk: Healey 3000          # U7 stub; raws are "HEALEY MK III" 13(+1 fi), "HEALEY MK II 3000" 2, "HEALEY MK II A" — Big-Healey Mk numbering, never a Sprite (Sprites are written "SPRITE MK") — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Healy MK3: Healey 3000          # "HEALY MK3" (nl 2, nz 1) — Mk III, misspelt marque — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Mark: Healey 3000               # U7 stub; raws "MARK II 3000", "MARK II BT 7" (BT7 IS the 3000 2+2 body code), "MARK II" — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Healey Sprite Mark: Healey Sprite  # U7 stub of "HEALEY SPRITE MARK II/IV" — https://en.wikipedia.org/wiki/Austin-Healey_Sprite
+  Healey Sprite MK1: Healey Sprite   # Sprite Mk I "frogeye" 1958-61 — https://en.wikipedia.org/wiki/Austin-Healey_Sprite
+  Healy Sprite: Healey Sprite        # registrar misspelling — SPELLING variant — https://en.wikipedia.org/wiki/Austin-Healey_Sprite
+  Healy-Sprite: Healey Sprite        # hyphen + misspelling — https://en.wikipedia.org/wiki/Austin-Healey_Sprite
+  Healey-Sprite: Healey Sprite       # hyphen spelling — https://en.wikipedia.org/wiki/Austin-Healey_Sprite
+  #      FIX): "an explicit rename entry is an AUTHOR'S STATEMENT that a string
+  #      is meaningful; junk? is a HEURISTIC. The statement wins." junk? rejects
+  #      any letter-free name that is not 2-4 bare digits, which is currently
+  #      deleting the Austin Seven. 516 registrations across this file.
+  "7": Seven                 # RESCUE, 360 registrations (nl_rdw + nz_nzta; raws "7", "7 SPORTS", "7 TOURER", "7 SALOON", "'7'", "AUSTIN 7") — two sources, two countries, i.e. above the publish floor — https://en.wikipedia.org/wiki/Austin_7
+  "8": Eight                 # RESCUE, 53 registrations — the Austin Eight (1939-1948). DECLARED BLAST RADIUS: also fires on one truck row (nl_rdw "8 KDF", n=1, sub-threshold) — https://en.wikipedia.org/wiki/Austin_8
+  "10/4": "10"               # RESCUE, 7 registrations — the Austin Ten-Four — https://en.wikipedia.org/wiki/Austin_10
+  "16/6": "16"               # RESCUE, 19 registrations (nz) — "The first name for this car was Austin Sixteen Light Six" — https://en.wikipedia.org/wiki/Austin_16
+  "14/6": "14"               # RESCUE, 5 registrations (nz) — the Austin Fourteen; lands on the id the Goodwood fold mints, which is mutual corroboration — https://en.wikipedia.org/wiki/Austin_14
+  "100/4": Healey 100        # RESCUE, 3 registrations — Austin-Healey 100 BN1/BN2 — then MOVES with the rest — https://en.wikipedia.org/wiki/Austin-Healey_100
+  "100-4": Healey 100        # RESCUE, 2 registrations — https://en.wikipedia.org/wiki/Austin-Healey_100
+  "100/6": Healey 100-6      # RESCUE, 5 registrations — https://en.wikipedia.org/wiki/Austin-Healey_100-6
+  "100-6": Healey 100-6      # RESCUE, 10 registrations — https://en.wikipedia.org/wiki/Austin-Healey_100-6
+  Fg: FG                     # display fix only, same slug (truck/austin/fg) — the Austin FG (1960-68) — https://en.wikipedia.org/wiki/BMC_FG
+  Saloon: null               # body class, not a nameplate — NAMING §7.6
+  Sedan: null                # body class (nz "SEDAN" 9) — NAMING §7.6
+  Sports: null               # body class — NAMING §7.6
+  Tourer: null               # body class (nl "TOURER" 2, nz "TOURER" 22, "TOURER 7HP" 1) — NAMING §7.6
+  Roadster: null             # body class — NAMING §7.6
+  Pick Up: null              # body class; fires in car AND van (nl_rdw "PICK UP", van n=1 sub-threshold) — NAMING §7.6
+  Morris: null               # the sibling MARQUE's name in the model column, no nameplate attached (nl 1, nz 1)
+  Rover: null                # "AUSTIN ROVER" = the Austin Rover Group (1982-1988), a company, not a model — https://en.wikipedia.org/wiki/Austin_Rover_Group
+  Mk: null                   # U7 TRUNCATION ARTIFACT and the content is MIXED: raws include "MK III 3000" and "MK II HEALEY 3000" (Austin-Healeys) AND "MK III 1300" (an Austin 1300 Mk III). No single honest survivor exists — DEBT.md "U7 variant-strip Roman collapse"
   Austin: null                                # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   A 30: A30                                   # spelling variant of "A30" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   A 35: A35                                   # spelling variant of "A35" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -130,9 +233,29 @@ Austin-Healey:
   # so fused Roman wins and no styling pin is used (stylings run before renames).
   # Keys reachable only for hyphenated raw makes — the unhyphenated "AUSTIN
   # HEALEY" (es_dgt n=4) is fixed by the makes/aliases.yml companion line. ──
-  3000 Mk 2: 3000 MkII                        # Austin-Healey 3000 Mark II, 1961-62 (https://en.wikipedia.org/wiki/Austin-Healey_3000); register-Roman conditional, same as austin/healey-3000-mkiii
-  3000 MK2: 3000 MkII                         # fused-arabic register variant (nl_rdw n=3)
-  3000 Mkii: 3000 MkII                        # same id already (slug 3000-mkii) — display fix from the caser's "Mkii"
+  3000 Mk 2: "3000"                           # REPOINT (was "3000 MkII"): Mark II 1961-62 is a GENERATION of the 3000 nameplate, not its own model — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  3000 MK2: "3000"                            # REPOINT (was "3000 MkII"): fused-arabic register variant (nl_rdw n=3) — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  3000 Mkii: "3000"                           # REPOINT (was "3000 MkII"): caser output of "3000 MKII" — https://en.wikipedia.org/wiki/Austin-Healey_3000
+
+  # ══ wave-4 MG+Austin dossier (2026-08-01) ═══════════════════════════════════
+  # Austin-Healey IS a separate marque and stays one: "The Austin-Healey marque
+  # was established through an arrangement set up in 1952 between Leonard Lord
+  # of the Austin division of the British Motor Corporation (BMC) and Donald
+  # Healey" (https://www.healey.org/about-the-marque). Nothing is folded across
+  # the Austin <-> Austin-Healey boundary; the Austin-side rows are MOVED.
+  3000 Mark: "3000"          # U7 stub of "3000 MARK II/III" (nl 19, fi 1) — generation — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  3000 Mk: "3000"            # U7 stub of "3000 MK II/III" (nl, fi, es) — generation — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  3000 MK1: "3000"           # Mk I 1959-1961 (BN7/BT7) — generation — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Mk: "3000"                 # U7 stub; raws "MK III 3000", "MK III 3000 GT", "MK III", "MK II", "MK II A" — three of five name the 3000 outright and Big-Healey Mk numbering is what "MK n" means with no SPRITE token. FLAGGED (dossier §E-13), 5 registrations — https://en.wikipedia.org/wiki/Austin-Healey_3000
+  Sprite Mark 1: Sprite      # Sprite Mk I "frogeye" 1958-1961 — https://en.wikipedia.org/wiki/Austin-Healey_Sprite
+  Sprite Mk: Sprite          # U7 stub of "SPRITE MK III/IV" (es, nl) — generation — https://en.wikipedia.org/wiki/Austin-Healey_Sprite
+  Sprite Mk I: Sprite        # a bare "I" survives U7 — https://en.wikipedia.org/wiki/Austin-Healey_Sprite
+  Healey Sprite: Sprite      # the marque name repeated in the model column ("AUSTIN-HEALEY | HEALEY SPRITE") — https://en.wikipedia.org/wiki/Austin-Healey_Sprite
+  #      and renames are consulted FIRST by design. 52 registrations.
+  "100-6": 100-6             # RESCUE, 24 registrations (nl_rdw "100-6", "AUSTIN-HEALEY 100-6") — the Austin-Healey 100-6, 1956-1959 — https://en.wikipedia.org/wiki/Austin-Healey_100-6
+  "100/6": 100-6             # RESCUE, 17 registrations (fi, nl, nz) — slash spelling — https://en.wikipedia.org/wiki/Austin-Healey_100-6
+  "100/4": "100"             # RESCUE, 10 registrations (es 1, nl 9) — the four-cylinder 100 — https://en.wikipedia.org/wiki/Austin-Healey_100
+  "100-4": "100"             # RESCUE, 1 registration — hyphen spelling — https://en.wikipedia.org/wiki/Austin-Healey_100
 
 Auto Union:
   "1000S": "1000-S"                           # spelling variant of "1000-S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -3325,23 +3448,23 @@ MG:
   # ── casing-contradiction batch: MGA/MGB closed tokens finished; the TD
   # fix forces the TF family in the same commit (flap insurance) or a new
   # contradiction ships. ──
-  Mga 1500 Roadster: MGA 1500 Roadster # MGA one closed all-caps token — https://en.wikipedia.org/wiki/MG_MGA ; raws "MG MGA", "MGA CABRIOLET 1500"
-  Mga 1600 Mk: MGA 1600 Mk          # raw "MGA 1600 MK II"; Mk stays British title-case (MK deliberately unpinned)
-  Mga Roadster: MGA Roadster        # same closed token
-  Mga Twin Cam: MGA Twin Cam        # raw "MGA TWIN-CAM COUPE"
-  Mga-1600: MGA 1600                # FLAP — hyphen-joined so the detector cannot see it; raw "MGA-1600 COUPE/2390"; slug mga-1600 unchanged
-  Mgb B: MGB B                      # raws "MGB B SPORTS", "MGB B TOURER" — https://en.wikipedia.org/wiki/MG_MGB
-  Mgb GT: MGB GT                    # raws "MG MGB GT", "MGB GT COUPE"
-  Mgb GT V8: MGB GT V8              # same family — same article
-  Mgb Roadster: MGB Roadster        # same closed token
-  Mgb-1800: MGB 1800                # FLAP — hyphen-joined, detector-invisible; raw "MGB-1800 COUPE GT"; slug mgb-1800 unchanged
-  Midget Td: Midget TD              # T-types all-caps; the TD IS a Midget ("TD Midget") — https://en.wikipedia.org/wiki/MG_T-type
-  Midget Tf: Midget TF              # FLAP — same family, same source ("TF Midget")
+  Mga 1500 Roadster: MGA            # REPOINT (was "MGA 1500 Roadster"): 1,489 cc B-series 1955-59, an ENGINE series of the MGA — https://en.wikipedia.org/wiki/MG_MGA
+  Mga 1600 Mk: MGA                  # REPOINT (was "MGA 1600 Mk"): U7 stub of raw "MGA 1600 MK II", a generation — https://en.wikipedia.org/wiki/MG_MGA
+  Mga Roadster: MGA                 # REPOINT (was "MGA Roadster"): body style; the MGA was sold as roadster and coupé from launch — https://en.wikipedia.org/wiki/MG_MGA
+  Mga Twin Cam: MGA                 # REPOINT (was "MGA Twin Cam"): the 1,588 cc DOHC ENGINE option, 1958-60 — https://en.wikipedia.org/wiki/MG_MGA
+  Mga-1600: MGA                     # REPOINT (was "MGA 1600"): displacement badge, NAMING §6 — https://en.wikipedia.org/wiki/MG_MGA
+  Mgb B: MGB                        # REPOINT (was "MGB B"): doubled badge, raws "MGB B SPORTS", "MGB B TOURER" — https://en.wikipedia.org/wiki/MG_MGB
+  Mgb GT: MGB                       # REPOINT (was "MGB GT"): "The fixed-roof MGB GT was introduced in October 1965" — a BODY of the MGB — https://en.wikipedia.org/wiki/MG_MGB
+  Mgb GT V8: MGB                    # REPOINT (was "MGB GT V8"): the Rover 3.5 V8 ENGINE in the GT body, 1973-76 — https://en.wikipedia.org/wiki/MG_MGB
+  Mgb Roadster: MGB                 # REPOINT (was "MGB Roadster"): "The roadster was the first of the MGB range to be produced" — body — https://en.wikipedia.org/wiki/MG_MGB
+  Mgb-1800: MGB                     # REPOINT (was "MGB 1800"): 1,798 cc B-series displacement, NAMING §6 — https://en.wikipedia.org/wiki/MG_MGB
+  Midget Td: TD                     # REPOINT (was "Midget TD"): the TD *was* the MG Midget of 1950-53, so this string names the TD — https://en.wikipedia.org/wiki/MG_T-type
+  Midget Tf: TF Midget              # REPOINT (was "Midget TF"): "The TF Midget, launched on 15 October 1953" — https://www.mgownersclub.co.uk/mg-guides/t-types/mg-tf-1500
   Td: TD                            # raws "MG TD", "TD SPORTS", "TD II" — all-caps in every one
   "Td/Tf": TD/TF                    # POST-#36 KEY (pre-#36 Td/tf would be inert). Raw "MG TD/TF" — both halves caps
-  Tf 1250: TF 1250                  # FLAP — https://en.wikipedia.org/wiki/MG_T-type
+  Tf 1250: TF Midget                # REPOINT (was "TF 1250"): the 1,250 cc XPAG is the original TF engine; displacement, NAMING §6 — https://www.mgownersclub.co.uk/mg-guides/t-types/mg-tf-1500
   Tf Midget: TF Midget              # FLAP, same source
-  Tf Roadster: TF Roadster          # FLAP, same source
+  Tf Roadster: T F                  # REPOINT (was "TF Roadster"): body word on the bare designation of the MODERN TF — https://www.mgownersclub.co.uk/mg-guides/mgtf/rover-mg-tf
   "M.g. B": MGB                     # tenth one-id-many-names instance: residual stop-form raw "M.G. B." (nl_rdw, 1 row) survived the lane-A pass and resurrected the retired m-g-b id under publication hysteresis — found by the alias-source exclusion (pipeline #32). Same MGB target as the whole family.
   RX6: HS                                 # NOT a model name: KBA's internal type code for the MG HS/EHS. FZ 6.1 HSN 2180 Handelsname reads 'MG RX6;-HS;-EHS;-EHS PHEV' (https://dewiki.de/Lexikon/MG_HS)
   S6: MGS6 EV                             # official German name is the fused MGS6 EV (https://www.mgmotor.de/model/mgs6); KBA's make string "MG ROEWE" is SAIC's dual-brand label for HSN 2180 and there is no Roewe S6 — no Roewe is sold in Germany at all
@@ -3351,30 +3474,157 @@ MG:
   # writes GT fused on the MGB GT and MGB/MGA as closed tokens (en.wikipedia
   # MG_MGB / MG_MGA; the block itself pinned Cgt: C GT one line up — the
   # internal contradiction that exposed this). ──
-  "B G T": B GT                              # fold the artifact display back to the sourced form
-  "B.g.t": B GT                              # stop-form raw, uncased tail
-  "B. GT": B GT                              # leading stop survives as a token boundary
-  "B.gt": B GT                               # fused stop form
-  Bgt: B GT                                   # register shorthand for the MGB GT
-  "Bgt V8": B GT V8                          # MGB GT V8 (1973-76, Rover 3.5 V8 — en.wikipedia MGB_GT_V8); Bgt is shorthand, never a badge
-  BGTV8: B GT V8                              # fully fused register form
-  Cgt: C GT                                   # spelling variant of "C GT" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+  "B G T": MGB                               # REPOINT (was "B GT"): nl_rdw spaced-initials spelling of the MGB GT body — https://en.wikipedia.org/wiki/MG_MGB
+  "B.g.t": MGB                               # REPOINT (was "B GT"): period-joined token, smart_case lowercases its tail — https://en.wikipedia.org/wiki/MG_MGB
+  "B. GT": MGB                               # REPOINT (was "B GT"): leading stop survives as a token boundary — https://en.wikipedia.org/wiki/MG_MGB
+  "B.gt": MGB                                # REPOINT (was "B GT"): nl_rdw "B.GT." 139 — https://en.wikipedia.org/wiki/MG_MGB
+  Bgt: MGB                                    # REPOINT (was "B GT"): nl_rdw "BGT" 439 — https://en.wikipedia.org/wiki/MG_MGB
+  "Bgt V8": MGB                              # REPOINT (was "B GT V8"): MGB GT V8 1973-76, a Rover 3.5 V8 ENGINE in the GT body — https://en.wikipedia.org/wiki/MG_MGB
+  BGTV8: MGB                                  # REPOINT (was "B GT V8"): fully fused register form — https://en.wikipedia.org/wiki/MG_MGB
+  Cgt: MGC                                    # REPOINT (was "C GT"): nz "CGT" 10 — the GT body on the MGC — https://en.wikipedia.org/wiki/MG_MGB
   MG B: MGB                                   # MGB is one closed token (en.wikipedia MG_MGB); the old pin propagated the stop-split artifact
   Mgb: MGB                                    # register shorthand, same closed token
   "M G B": MGB                               # fold the shipped artifact display back
   "M.g.b": MGB                               # stop-form raw
   "M G A": MGA                               # same artifact class on the MGA (en.wikipedia MG_MGA); the styling pin MGA: MGA carries the casing — do NOT also key Mga (ordering hazard: the pin recases before renames run)
   "M.g.a": MGA                               # stop-form raw
-  Midget Mk 3: Midget MkIII                   # MG registers EMIT Roman (Midget Mkii/Mkiii live in-catalog), so Roman is not a minted third form here — diverges from the Triumph Mk-arabic precedent DELIBERATELY, per its own conditional
-  Midget Mk3: Midget MkIII                    # arabic register variant folds
-  Midget MK3: Midget MkIII                    # all-caps register variant — the actual produced form (found by the liveness gate)
-  T D Roadster: TD Roadster                   # stop-split of the TD; canonical slugs to the existing td-roadster (casing fix + fi evidence gained)
-  T.d.roadster: TD Roadster                   # fused stop-form — the actual produced display (liveness gate find); the dot survives the caser as a token boundary
-  Tf 1500: TF1500                             # the factory designation is TF1500 fused (T-type source); the generator would have made the EXISTING value a key — the direction-war trap avoided
-  Mgbgt: MGB GT                               # REPOINT with the MGB casing fix: its target is the string being re-cased (casing-contradiction dossier)
+  Midget Mk 3: Midget                         # REPOINT (was "Midget MkIII"): Mk III 1966-74 is a generation of the 1961-79 Midget — https://en.wikipedia.org/wiki/MG_Midget
+  Midget Mk3: Midget                          # REPOINT (was "Midget MkIII"): arabic register variant of the same generation — https://en.wikipedia.org/wiki/MG_Midget
+  Midget MK3: Midget                          # REPOINT (was "Midget MkIII"): all-caps register variant — https://en.wikipedia.org/wiki/MG_Midget
+  T D Roadster: TD                            # REPOINT (was "TD Roadster"): stop-split of the TD plus a body word — https://en.wikipedia.org/wiki/MG_T-type
+  T.d.roadster: TD                            # REPOINT (was "TD Roadster"): nl_rdw "T.D.ROADSTER"; the dot survives the caser as a token boundary — https://en.wikipedia.org/wiki/MG_T-type
+  Tf 1500: TF Midget                          # REPOINT (was "TF1500"): "The TF 1500 variant launched in mid-1954" with the 1,466 cc XPEG — a displacement series of the classic TF — https://en.wikipedia.org/wiki/MG_T-type
+  Mgbgt: MGB                                  # REPOINT (was "MGB GT"): nz_nzta "MGBGT" 51 — the GT is a BODY of the MGB — https://en.wikipedia.org/wiki/MG_MGB
   Tf: T F                                     # spelling variant of "T F" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   MG: null                                    # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
-  Tf-1500: TF1500                             # spelling variant of "TF1500" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+  Tf-1500: TF Midget                          # REPOINT (was "TF1500"): hyphen spelling of the same 1,466 cc XPEG car — https://en.wikipedia.org/wiki/MG_T-type
+
+  # ══ wave-4 MG+Austin dossier (2026-08-01) ═══════════════════════════════════
+  # THE RULE for the letter-shorthand block: the marque's own names are MGA,
+  # MGB, MGC, MGF (closed, no space). A bare A/B/C/F in a register is registry
+  # shorthand for them, and the registers prove it themselves — nl_rdw writes
+  # both "B" (2,490) and "MGB" (65) and "M.G.B." and "MG- B"; nz_nzta writes
+  # both "A" (60) and "MGA" (49); DVLA's GenModel is "MG MGA"/"MG MGB" with
+  # the Model column reading "A", "B", "B GT", "B GT V8" (uk_veh0120_uk.csv,
+  # OGL v3, measured 2026-08-01) — two columns of one regulator stating the
+  # shorthand relation outright.
+  A: MGA                     # registry shorthand for MGA; nl_rdw writes "A" and "MGA" for the same car — https://www.mgcars.org.uk/mga/
+  A Mk 2: MGA                # MGA 1600 Mk II (1960-62), a generation not a nameplate — https://en.wikipedia.org/wiki/MG_MGA
+  A Roadster: MGA            # body style; the MGA was sold as roadster and coupé from launch — https://en.wikipedia.org/wiki/MG_MGA
+  A Twin Cam: MGA            # MGA Twin-Cam 1958-60, a 1,588 cc DOHC ENGINE option of the MGA — https://en.wikipedia.org/wiki/MG_MGA
+  A Twin-Cam: MGA            # hyphen spelling of the same raw (nl_rdw "A TWIN-CAM") — https://en.wikipedia.org/wiki/MG_MGA
+  A1600: MGA                 # fused displacement badge; 1,588 cc B-series — NAMING §6 (car-kind displacement is a spec) — https://en.wikipedia.org/wiki/MG_MGA
+  "1600": MGA                # bare displacement under MG = MGA 1600; every sibling raw spells it "A 1600"/"MGA 1600". WEAKER INFERENCE, declared in the dossier §E-2 — https://en.wikipedia.org/wiki/MG_MGA
+  1600 Mk: MGA               # U7 truncation of "1600 MK II" (nl_rdw 7, fi 1) — MGA 1600 Mk II — https://en.wikipedia.org/wiki/MG_MGA
+  1600 Mkii: MGA             # unspaced Roman numeral survives U7; same car — https://en.wikipedia.org/wiki/MG_MGA
+  Mga 1600: MGA              # displacement badge on the closed token — NAMING §6 — https://en.wikipedia.org/wiki/MG_MGA
+  MGA.1600: MGA              # nl_rdw period spelling "MGA.1600" — https://en.wikipedia.org/wiki/MG_MGA
+  Mga Twin-Cam: MGA          # hyphen spelling of the Twin Cam engine option — https://en.wikipedia.org/wiki/MG_MGA
+  B: MGB                     # registry shorthand; nl_rdw "B" 2,490 + "MGB" 65 + "M.G.B." for one car; DVLA's Model column literally reads "B" under GenModel "MG MGB" — uk_veh0120_uk.csv (OGL v3)
+  B GT: MGB                  # "The fixed-roof MGB GT was introduced in October 1965" — a BODY of the MGB — https://en.wikipedia.org/wiki/MG_MGB
+  B -GT: MGB                 # nl_rdw stray-space spelling — https://en.wikipedia.org/wiki/MG_MGB
+  "B'gt": MGB                # nz_nzta apostrophe spelling — https://en.wikipedia.org/wiki/MG_MGB
+  B-GT: MGB                  # nl_rdw/nz hyphen spelling (12/1) — https://en.wikipedia.org/wiki/MG_MGB
+  B GT V8: MGB               # "MG began offering the MGB GT V8 in 1973 … production ending in 1976" — a Rover 3.5 V8 ENGINE in the GT body — https://en.wikipedia.org/wiki/MG_MGB
+  B GT-V8: MGB               # hyphen spelling of the GT V8 — https://en.wikipedia.org/wiki/MG_MGB
+  B-GT-V8: MGB               # fully hyphenated spelling of the GT V8 — https://en.wikipedia.org/wiki/MG_MGB
+  B Roadster: MGB            # "The roadster was the first of the MGB range to be produced" — body — https://en.wikipedia.org/wiki/MG_MGB
+  B-Roadster: MGB            # hyphen spelling — https://en.wikipedia.org/wiki/MG_MGB
+  B. Roadster: MGB           # nz_nzta period spelling — https://en.wikipedia.org/wiki/MG_MGB
+  B Roadstar: MGB            # registrar misspelling of Roadster (nl 6, nz 1) — SPELLING variant — https://en.wikipedia.org/wiki/MG_MGB
+  B V8: MGB                  # engine designation without the GT body word — https://en.wikipedia.org/wiki/MG_MGB
+  Bgt Sport: MGB             # "BGT SPORT" (nl 1, nz 1) — body plus a registrar body-class word — https://en.wikipedia.org/wiki/MG_MGB
+  "1800": MGB                # bare 1,798 cc B-series displacement under MG; every sibling raw spells it "MGB 1800"/"B 1800". WEAKER INFERENCE, declared in §E-2 — https://en.wikipedia.org/wiki/MG_MGB
+  Mgb 1800: MGB              # displacement badge — NAMING §6 — https://en.wikipedia.org/wiki/MG_MGB
+  Mgb-GT: MGB                # hyphen spelling of the GT body — https://en.wikipedia.org/wiki/MG_MGB
+  Mgc: MGC                   # display fix only, same slug: "MGC" is the marque's spelling; case_token gives "Mgc" because MGC is not in styling.yml acronyms — https://en.wikipedia.org/wiki/MG_MGB
+  C: MGC                     # registry shorthand; "The MGC was a 2,912 cc, straight-six version of the MGB sold from 1967 and produced until August 1969" — https://en.wikipedia.org/wiki/MG_MGB
+  C GT: MGC                  # MGC GT — the GT body on the MGC — https://en.wikipedia.org/wiki/MG_MGB
+  C-GT: MGC                  # nl_rdw "C-GT" 74 — https://en.wikipedia.org/wiki/MG_MGB
+  C.gt: MGC                  # nl_rdw "C.GT" — https://en.wikipedia.org/wiki/MG_MGB
+  C Roadster: MGC            # body — https://en.wikipedia.org/wiki/MG_MGB
+  C-Roadster: MGC            # es_dgt "MG C-ROADSTER" — https://en.wikipedia.org/wiki/MG_MGB
+  Mgc GT: MGC                # the GT body on the MGC, closed-token spelling — https://en.wikipedia.org/wiki/MG_MGB
+  Mgf: MGF                   # display fix only, same slug — "The MG F was finally unveiled on 8 March 1995" — https://en.wikipedia.org/wiki/MG_F_/_MG_TF
+  F: MGF                     # registry shorthand (nz "F" 77, nl "F" 15 + "MG F" 9). WEAKER INFERENCE — the pre-war F-type Magna is also written "F"; declared in §E-2 — https://en.wikipedia.org/wiki/MG_F_/_MG_TF
+  Mgf 1.8I: MGF              # engine/trim badge; DVLA's Model column shows "MGF", "MGF SE", "MGF 1.8I VVC" all under GenModel "MG MGF" — uk_veh0120_uk.csv (OGL v3)
+  #      were all badged MG Midget ("Known as the Midget, the series included the
+  #      TA, TB, TC, TD, and TF models" — https://en.wikipedia.org/wiki/MG_T-type),
+  #      so "Midget <T-letter>" is a T-type, NOT the 1961-79 Midget.
+  Midget 1500: Midget        # Midget 1500 (1974-80), the 1,493 cc Triumph-engined final series — https://en.wikipedia.org/wiki/MG_Midget
+  Midget Mark: Midget        # U7 stub of "MIDGET MARK II/III" — generation — https://en.wikipedia.org/wiki/MG_Midget
+  Midget Mk: Midget          # U7 stub of "MIDGET MK II/III/IV" (nl 133) — generation — https://en.wikipedia.org/wiki/MG_Midget
+  Midget Mk 11: Midget       # the registrar's "11" for "II" — Mk II 1964-66 — https://en.wikipedia.org/wiki/MG_Midget
+  Midget MK2: Midget         # Mk II 1964-66 — https://en.wikipedia.org/wiki/MG_Midget
+  Midget Mkii: Midget        # Mk II 1964-66, caser output of "MIDGET MKII" — https://en.wikipedia.org/wiki/MG_Midget
+  Midget Mkiii: Midget       # Mk III 1966-74, caser output of "MIDGET MKIII" — https://en.wikipedia.org/wiki/MG_Midget
+  Midget Sport: Midget       # registrar body-class word — https://en.wikipedia.org/wiki/MG_Midget
+  Td Roadster: TD            # body word on the TD — https://en.wikipedia.org/wiki/MG_T-type
+  Td-Roadster: TD            # hyphen spelling of the same — https://en.wikipedia.org/wiki/MG_T-type
+  M Midget: M                # M-type Midget (1929-32) — the string names its own nameplate — https://en.wikipedia.org/wiki/MG_M-type
+  #      (T-type, XPAG/XPEG four) AND the MG TF 2002-2011 (MGF-derived). Every
+  #      MG heritage body files them in DIFFERENT registers with no cross-
+  #      reference (MG Car Club has a "T Register" and, separately, an "MGF
+  #      Register" covering MGF/TF — https://www.mgcc.co.uk/registers/), and
+  #      Wikipedia's hatnote agrees: "For the MG TF Midget 1953-1955, see MG
+  #      T-type". So: two survivors. The settled line `Tf: "T F"` above is NOT
+  #      reversed here — that spelling question is adjudicated separately.
+  TF1500: TF Midget          # REPOINT (was itself the target): fused spelling (es_dgt "TF1500", nl_rdw "TF1500") of the classic 1,466 cc car — https://en.wikipedia.org/wiki/MG_T-type
+  Mgtf: T F                  # "MGTF" (lu/nl/nz) — mg-cars.org.uk's own register is spelled "MGTF" and covers the MODERN car — https://www.mg-cars.org.uk/
+  Magnette Za: Magnette      # "The Magnette ZA was announced on 15 October 1953 … Production continued until 1956" — a series of the Magnette nameplate — https://en.wikipedia.org/wiki/MG_Magnette
+  Magnette Zb: Magnette      # "The ZA was replaced by the Magnette ZB … announced on 12 October 1956" — https://en.wikipedia.org/wiki/MG_Magnette
+  Magnette-Zb: Magnette      # hyphen spelling — https://en.wikipedia.org/wiki/MG_Magnette
+  Za Magnette: Magnette      # words reversed by the registrar — https://en.wikipedia.org/wiki/MG_Magnette
+  Zb: Magnette               # bare "ZB" under MG is the Magnette ZB (nl 1, nz 1); no other MG carries the code — https://en.wikipedia.org/wiki/MG_Magnette
+  L2 Magna: Magna            # L2 is the L-type Magna two-seater; the string names its own nameplate — https://en.wikipedia.org/wiki/MG_L-type
+  Metro 1300: Metro          # displacement (A-series 1,275 cc) — NAMING §6 — https://en.wikipedia.org/wiki/MG_Metro
+  Metro Turbo: Metro         # MG Metro Turbo, a performance version of the MG Metro — https://en.wikipedia.org/wiki/MG_Metro
+  Montego Efi: Montego       # "EFi" = electronic fuel injection, an engine badge — https://en.wikipedia.org/wiki/Austin_Montego
+  Montego Turbo: Montego     # MG Montego Turbo, a performance version — https://en.wikipedia.org/wiki/Austin_Montego
+  Zt: ZT                     # display fix only, same slug — "The MG ZT is a car which was produced by MG Rover from 2001 to 2005" — https://en.wikipedia.org/wiki/MG_ZT
+  Zt-T: ZT                   # "It was offered in saloon and estate versions, the latter designated as the MG ZT-T" — a BODY of the ZT — https://en.wikipedia.org/wiki/MG_ZT
+  ZS1: ZS                    # nl 1 + th 1; MG has never sold a "ZS1" — a registrar suffix on the ZS — https://en.wikipedia.org/wiki/MG_ZS
+  #      vehicle: DVLA proves it in its own two columns (GenModel "MG MG S5 SE
+  #      EV" has Model values "MG S5 SE EV" 1,462 and "MG S5 TROPHY EV" 5,774,
+  #      so SE and Trophy are trims and DVLA baked one into the GenModel);
+  #      KBA's series is the bare "S5", my_jpj and nz_nzta write "S5", ie_cso
+  #      writes "MGS5". The canonical spelling is MG's own and it is CLOSED.
+  S5 EV: MGS5 EV             # "The new MGS5 EV has now secured the highest possible safety rating from Euro NCAP" — https://news.mgmotor.eu/press/new-mgs5-ev-achieves-highest-safety-rating/
+  S5: MGS5 EV                # de_kba "S5" 1,405 · my_jpj "S5" 532 · nz "S5" 311 — all the MGS5 EV; MG sells no ICE S5 in any of the three — https://news.mgmotor.eu/press/new-mgs5-ev-achieves-highest-safety-rating/
+  MGS5: MGS5 EV              # ie_cso label "MGS5" 551 — same car — https://news.mgmotor.eu/press/new-mgs5-ev-achieves-highest-safety-rating/
+  MG S5 Se EV: MGS5 EV       # uk_dft GenModel "MG MG S5 SE EV" 7,275; "SE" is a TRIM (DVLA's own Model column also carries "MG S5 TROPHY EV") — uk_veh0120_uk.csv (OGL v3)
+  S6 EV: MGS6 EV             # aligns the es/fi/lu/nl/ua record with the EXISTING settled line `S6: MGS6 EV`, which routes de_kba's registrations — https://news.mgmotor.eu/fr/press/nouveau-mgs6-ev-tarifs-et-ouverture-des-commandes/
+  IM5 Long Range: IM5        # "Long Range" is a battery grade, used identically on MGS5 EV and MG IM6 — https://news.mgmotor.eu/press/introducing-the-new-mg-im-range/
+  Roewe ZS EV: ZS EV         # nl/fi raw "ROEWE ZS EV" — Roewe is SAIC's domestic brand and does not retail in the EU; the vehicle registered is the MG ZS EV — https://www.mgownersclub.co.uk/mg-zs-and-mg-zs-ev
+  Ehs: EHS                   # display fix only, same slug — MG's own European release is titled "The MG EHS Plug-in Hybrid: the second model of the renewed MG brand" (capital E, not "eHS") — https://news.mgmotor.eu/press/
+  Ep: EP                     # display fix only, same slug — the Thai-market MG EP (the Roewe Ei5 estate), launched 26 Nov 2020 — https://paultan.org/2020/12/02/mg-ep-ev-launched-in-thailand-for-below-1m-baht-c-segment-wagon-380-km-electric-range-only-rm133k/
+  #      slugify collapses case). Deliberately renames and NOT styling.yml
+  #      acronyms: NAMING §9 — the caser runs BEFORE renames, so an acronym
+  #      token silently re-cases other makes' rename keys and orphans them.
+  #      A rename has blast radius 1 make. Precedent in this very block: Td/TD.
+  Sa: SA                     # MG SA (1936-39), a two-letter type code — https://en.wikipedia.org/wiki/MG_SA
+  Va: VA                     # MG VA (1937-39) — https://en.wikipedia.org/wiki/MG_VA
+  Ta: TA                     # TA Midget 1936-39, 3,003 built — https://en.wikipedia.org/wiki/MG_T-type
+  Tb: TB                     # TB Midget 1939-40, 379 built — https://en.wikipedia.org/wiki/MG_T-type
+  Tc: TC                     # "The TC Midget was the first postwar MG", 1945-49, 10,001 built — https://en.wikipedia.org/wiki/MG_T-type
+  Ya: YA                     # "the MG Y (1947 - 1951) — a four door, four seat, six window saloon later called the MG YA" — https://www.mg-cars.org.uk/imgytr/
+  Yb: YB                     # "the MG YB (1951 - 1953) - the updated version of the MG Y" — https://www.mg-cars.org.uk/imgytr/
+  Yt: YT                     # "the MG YT (1948 - 1950) - a two door four seat convertible" — https://www.mg-cars.org.uk/imgytr/
+  Y: YA                      # NOT just a casing fix: the Register states the plain "MG Y" IS the car "later called the MG YA" (nl 6, nz 2) — https://www.mg-cars.org.uk/imgytr/
+  Pb: PB                     # MG PB Midget; "Production of the PB finally ceased in February 1936" — https://www.mgownersclub.co.uk/mg-guides/pre-war/mg-pa-midget
+  #      NOTE car/mg/roadster (1,561 registrations) is deliberately NOT nulled —
+  #      it is held as declared debt instead (data/name_shapes.yml), because
+  #      nulling deletes real registrations with no honest target. Same class as
+  #      Ford's bare body-style records, which were kept for the same reason.
+  Roadstar: null             # registrar misspelling of a body class — nothing to fold onto, and no nameplate is asserted — NAMING §7.6
+  Sports: null               # body class (nz "SPORTS" 29) — NAMING §7.6
+  Saloon: null               # body class — NAMING §7.6
+  Coupe: null                # body class — NAMING §7.6
+  Convertible: null          # body class — NAMING §7.6
+  Mk: null                   # U7 TRUNCATION ARTIFACT: raws are "MK II", "MK III", "MK II 1.6 A" — the numeral is eaten by VARIANT_SUFFIXES and NO nameplate token remains — DEBT.md "U7 variant-strip Roman collapse"
+  Rover: null                # the COMPANY name in the model column ("MG ROVER" = MG Rover Group 2000-2005), not a model — https://en.wikipedia.org/wiki/MG_Rover_Group
+  MG1: null                  # INTERIM — a NORMALIZER defect, not curation: normalizer.rb#mg's `\A(\d)\b` branch turns "1.5", "1,5 L", "1 1/4 LTR", "MG 1.8I" and "1.3 GS METRO" into a fabricated "MG1". MG has never made an MG1; reported as a pipeline finding
+  MG2: null                  # INTERIM — same defect: "2.0", "2.0 TURBO", "2.0SL", "2 AXLE- RIGID BODY SALOON", "2 D CABRIOLET-GHN3/2310" all become "MG2". MG has never made an MG2; reported as a pipeline finding
 
 Microcar:
   M.go:                      M.Go                 # Microcar writes M.GO with the period; title form M.Go

--- a/scripts/lint_curation.rb
+++ b/scripts/lint_curation.rb
@@ -304,6 +304,17 @@ if File.exist?(moves_path)
     next unless renames[t_make]&.key?(t_model)
     canon = renames[t_make][t_model]
     next if canon.nil? # a null target is check 1d's problem, not this one
+    # A CONVERGED IDENTITY TARGET is not a non-canonical target. The sibling
+    # DIRECTION-WAR check below already carries this exemption and for the same
+    # reason: `"100-6": 100-6` is an IDENTITY rename, the junk?-override rescue
+    # class (normalizer ORDER FIX 2026-07-25 — an explicit rename entry beats
+    # the letter-free junk heuristic, which would otherwise delete every
+    # Austin-Healey 100-6). A fixed point cannot produce the divergence this
+    # rule hunts: the moved row arrives carrying "100-6" un-renormalized and the
+    # destination make's own rows renormalize to "100-6" too, so both land on
+    # ONE record. Without this exemption a sanctioned rescue and a sanctioned
+    # move are mutually exclusive. (wave-4 MG+Austin, 2026-08-01.)
+    next if canon.to_s == t_model
     fail! "overrides/models/moves.yml: #{from.inspect} targets #{to.inspect}, but #{t_make.inspect} " \
           "renames #{t_model.inspect} -> #{canon.inspect}. Renames run BEFORE moves, so the move target " \
           "is NOT re-normalized and this publishes a non-canonical record beside the canonical one. " \


### PR DESCRIPTION
### CI status — the `build` check is red **by construction** until pipeline#103 merges

`.github/workflows/monthly-build.yml` checks out `vehiclesdb/vehiclesdb-pipeline`
with **no `ref:`**, i.e. the pipeline's **default branch**. The harness fix this
change depends on lives in **pipeline#103**, which is not merged yet, so the data
build runs the *old* `test_override_key_reachability.rb` against the new keys and
fails on exactly the two it fixes:

```
Austin-Healey "100/6" would be produced as ["100"]
Austin-Healey "100/4" would be produced as ["100"]
```

Nothing else in that run is red — the other six pipeline test files report
`0 failures, 0 errors`, and the `lint` check **passes**.

Those two keys are demonstrably live, three ways: `classify("AUSTIN-HEALEY",
"100/6", kind: :car)` returns `["Austin-Healey", "100-6"]` with renames on; an
ablation build shows the rescue keys are worth **515 registrations** and one
country; and without them Austin-Healey **100-6 cars land on the 100 record**.
The harness measures keys with renames *disabled*, which is precisely the rule an
ORDER-FIX rescue key depends on — the blind spot pipeline#103 documents and fixes.

**This is the same coupling as data#129 / pipeline#91 tonight** (NEGOTIATION Turn
217: *"data#129's CI red is the pipeline#91 coupling, not a defect"*).
**Merge order: pipeline#103 → this PR.**

---

The MG/Austin slice was **281 published records** across six makes, and **53.4 %
of them were not nameplates**: body words (Roadster, Saloon, Tourer),
displacement badges (MGA 1600, Allegro 1300), generation numerals eaten by the
known U7 Roman-numeral strip (`Mk`, `Sprite Mk`, `Healey 3000 Mk`), registry
shorthand for the marque's own name (`B` → MGB, `A` → MGA, `Ten` → 10), coachwork
names on a numbered chassis (Ruby, Nippy, Ulster), company names in the model
column (MG Rover, Austin Rover), and two nameplates the normalizer **invented**
(`car/mg/mg1`, `car/mg/mg2`).

Requires **vehiclesdb/vehiclesdb-pipeline#103** — merge that one **first**.

---

## Measured, control-vs-treatment, never by exit code

| | before | after |
|---|---:|---:|
| **records** | **281** | **131**  (−53.4 %) |
| `mg` | 130 | 57 |
| `austin` | 134 | 66 |
| `austin-healey` | 12 | 4 |
| `austin-morris` | 2 | 2 (filed, not folded) |
| `leyland-cars` | 2 | 2 (filed, not folded) |
| **`mg-roewe`** | 1 | **0 — make retired** |

* **155 ids retired**, every one disposed: **137** `former_ids` aliases + **18**
  `removals.yml` manifest lines. Zero unexplained.
* **5 minted or promoted**: `car/mg/mgs5-ev`, `car/mg/mgs6-ev`, `car/mg/im5`,
  `car/austin/14`, `car/austin-healey/100-6`.
* **COUNTRIES LOST: 0.** Verified per fold and per move, not asserted.
* **19 records gain a country.**
* **515 registrations rescued** that publish nothing today (ablation-measured).
* **Collateral outside the six makes: none** — no id appeared or disappeared, no
  availability changed, no display name changed.

> The dossier counted 282 → 131 against release 2026.08.0. `car/mg/rx5` has since
> fallen below the publish floor on pristine main (it already carries a
> `removals.yml` demotion), so the honest before-figure on tonight's base is
> **281**, and `car/mg/roadster` is **held** rather than nulled (below), which
> puts the after-figure back on **131**.

### Availability gains — every one verified individually

| survivor | before | after | gained |
|---|---:|---:|---|
| `car/mg/mgs5-ev` | (new) | **11** | de, es, fi, gb, ie, lu, my, nl, nz, th, ua |
| `car/mg/mgs6-ev` | (new) | **6** | de, es, fi, lu, nl, ua |
| `car/mg/im5` | (new) | **2** | de, gb |
| `car/austin-healey/100-6` | (new) | **3** | fi, nl, nz |
| `car/austin/14` | (new) | **2** | nl, nz |
| `car/mg/zt` | 2 | 4 | fi, nz |
| `car/mg/tf-midget` | 2 | 4 | es, fi |
| `car/mg/mgb` | 6 | 7 | my |
| `car/mg/mgc` | 3 | 4 | es |
| `car/mg/metro` | 3 | 4 | nl |
| `car/mg/montego` | 2 | 3 | nl |
| `car/mg/t-f` | 5 | 6 | lu |
| `car/austin/westminster` | 2 | 3 | gb |
| `car/austin/fx4` | 3 | 4 | gb |
| `car/austin/metropolitan` | 2 | 3 | gb |
| `car/austin/mini-moke` | 2 | 3 | lu |
| `car/austin-healey/3000` | 5 | 6 | es |
| `car/austin-healey/sprite` | 4 | 5 | es |
| `car/austin-healey/100` | 4 | 5 | es |

`car/austin-healey/100` (+es) and `car/austin-healey/100-6` were **not**
predicted by the dossier; both are byproducts of the rescues below.

**`car/mg/mgs5-ev` is one car that was published at four ids** (`s5-ev`, `s5`,
`mgs5`, `mg-s5-se-ev`) carrying 13,683 registrations between them. DVLA proves
the identity in its own two columns: GenModel `MG MG S5 SE EV` carries `Model`
values `MG S5 SE EV` (1,462) and `MG S5 TROPHY EV` (5,774) — SE and Trophy are
trims, so DVLA baked one into the GenModel. KBA's series is the bare `S5`,
`my_jpj` and `nz_nzta` write `S5`, `ie_cso` writes `MGS5`. The canonical spelling
is MG's own and it is **closed**: *"The new MGS5 EV has now secured the highest
possible safety rating from Euro NCAP"*
(<https://news.mgmotor.eu/press/new-mgs5-ev-achieves-highest-safety-rating/>).
Adopting it also makes the three S-series records consistent with the already
settled `S6: MGS6 EV` and `S9: MGS9 PHEV` lines for the first time.

---

## The rescues — 515 registrations that publish **nothing** today

`junk?` rejects any name with **no letters** that is not 2–4 bare digits. Under
Austin that rule was deleting **the Austin Seven** outright. Renames are consulted
**before** `junk?` by design — the 2026-07-25 ORDER FIX, whose own comment reads
*"an explicit rename entry is an AUTHOR'S STATEMENT that a string is meaningful;
`junk?` is a HEURISTIC. The statement wins."* — so a curated key brings the car
back.

Isolated with an **ablation build** (the identical tree with only the 13 rescue
keys removed) rather than inferred:

| key | → | regs | evidence |
|---|---|---:|---|
| `"7"` | `Seven` | **360** | `nl_rdw` + `nz_nzta`; raws `7`, `7 SPORTS`, `7 TOURER`, `7 SALOON`, `'7'`, `AUSTIN 7` |
| `"8"` | `Eight` | 52 | the Austin Eight, 1939-1948 |
| `"16/6"` | `16` | 19 | *"The first name for this car was Austin Sixteen Light Six"* |
| `"10/4"` | `10` | 7 | the Austin Ten-Four |
| `"14/6"` | `14` | 5 | the Austin Fourteen — lands on the id the Goodwood fold mints, which is mutual corroboration from two independent register spellings |
| `100/4` `100-4` `100/6` `100-6` | Healey 100 / 100-6 | 72 | keyed on **both** sides of the make boundary |
| | | **515** | dossier predicted 516 |

Each rescued id was checked as **actually publishing in the build**, not assumed:

```
car/austin/seven          2,942 -> 3,392 regs   nz 96 -> 518
car/austin/eight              7 ->    59 regs   nz  2 ->  50
car/austin/10               125 ->   179 regs
car/austin/16                15 ->    39 regs
car/austin/14             (absent) ->  10 regs  MINTED, nl+nz
car/austin-healey/100        43 ->    95 regs   +es
car/austin-healey/100-6   (absent) -> 108 regs  MINTED, fi+nl+nz
car/austin-healey/3000       37 ->   396 regs   +es
car/austin-healey/sprite     34 ->   231 regs   +es
```

Two rescues buy a country nothing else reaches: `car/austin-healey/100` **+es**
and `car/austin-healey/100-6` **+fi**.

**Not rescued, deliberately:** `12/4` (38 regs), `12/6` (8), `12-4` (5), `6` (3).
There are **three** different pre-war Austin Twelves — the Heavy Twelve
(1921-1939), the Light Twelve-Four (1933-1939) and the Light Twelve-Six
(1931-1937) — and `car/austin/12` does not say which. Rescuing onto `12` would
pool three cars; minting `12/4`/`12/6` ids needs an adjudication a register
string cannot support.

---

## Austin-Healey: four moves, not a fold

Austin-Healey is a real marque — *"The Austin-Healey marque was established
through an arrangement set up in 1952 between Leonard Lord of the Austin division
of the British Motor Corporation (BMC) and Donald Healey"*
(<https://www.healey.org/about-the-marque>). So the Austin-side rows are
**MOVED**, which preserves the marque; folding them would erase it.

`renames.yml` runs **before** `moves.yml`, so the Austin block first collapses
every spelling to one canonical string and **four** move lines do the rest
instead of twenty:

```yaml
"Austin|Healey 100":    "Austin-Healey|100"
"Austin|Healey 100-6":  "Austin-Healey|100-6"
"Austin|Healey 3000":   "Austin-Healey|3000"
"Austin|Healey Sprite": "Austin-Healey|Sprite"
```

**The evidence.** DVLA files these cars as `Make=AUSTIN` with GenModel
`AUSTIN HEALEY`/`AUSTIN SPRITE`, while *also* carrying a separate
`Make="AUSTIN HEALEY"` whose 5,139 GB rows are **100 % `MODEL MISSING`**
(`uk_veh0120_uk.csv`, OGL v3, measured 2026-08-01). `nl_rdw` and `nz_nzta` write
`HEALEY 3000`, `HEALEY SPRITE`, `HEALY SPRITE` under `merk=AUSTIN`. That is
NAMING §1's *"the make is the marque, not the registrant"*.

The four moves **corroborate four independent Wikidata `make_boundary`
nominations**, all four checked and all four correct:

| id | QID | |
|---|---|---|
| `car/austin/healey-100` | Q432387 | Austin-Healey 100 (BN1/BN2) 1953-1956 |
| `car/austin/healey-100-6` | Q4822933 | Austin-Healey 100-6 (BN4/BN6) 1956-1959 |
| `car/austin/healey-3000` | Q780854 | Austin-Healey 3000 Mk I-III 1959-1967 |
| `car/austin/healey-sprite` | Q780868 | Austin-Healey Sprite Mk I-IV 1958-1971 |

**The destination gains exactly what the source loses** — verified per id, zero
countries dropped in the transfer.

### Not moved, deliberately

* **`car/austin/sprite` STAYS AUSTIN.** The 1971 Austin Sprite is a real Austin
  nameplate: *"Only 1,022 of these Austin Sprites rolled off the assembly line
  between January 27 and July 6 of 1971"* (<https://austinsprite.co.uk/>),
  because *"the Healey connection was discontinued in 1971, so the final 1,022
  Sprites built were simply Austin Sprites"*. DVLA agrees at column level: its own
  GenModel is `AUSTIN SPRITE` with Model `SPRITE`, distinct from `AUSTIN HEALEY`.
  Residual flagged: 604 GB registrations is a lot for a 1,022-car run, so this id
  certainly pools some Austin-Healey Sprites. The split is not guessed at.
* **`car/austin/healey` and `car/austin/healy`** carry no nameplate at all — the
  string is the second half of the marque name.
* **`austin-healey` does NOT gain `gb`, and that retraction stands.** DVLA's
  5,139 GB rows under make `AUSTIN HEALEY` are 100 % `AUSTIN HEALEY MODEL
  MISSING` and are correctly dropped by `junk?`. Reading DVLA's unread `Model`
  column is the single change that would give the marque its home market — filed
  in the pipeline PR, not built here.

---

## Mini is not folded across any make

Mini strings **inside** `austin` are folded (`Mini 1000`, `Mini 850`, `850`,
`Mini Mayfair`, `Mini Mk`, `Cooper`, `Cooper S`, `Clubman`, `Moke`) because **no
make boundary is crossed**. Nothing else.

`car/austin/mini` is legitimately an Austin for two of its three bands:
Austin Seven 1959-61 → Austin Mini 1962-Oct 1969 → **Mini marque** Oct 1969-1980 →
Austin Mini 1980-1988 → Mini 1988-2000. Moving it would be wrong for 1962-69 and
1980-88.

`car/austin-morris/mini` (gb 6,549) and `car/leyland-cars/mini` (gb 3,050) sit
under **British Leyland division names, not marques** — but their raw makes pool
several marques' models: `AUSTIN-MORRIS` also carries `MAXI`, `PRINCESS`,
`MORRIS MINOR 1000` and `AUSTIN-HEALEY SPRITE MK1`, and `moves.yml` **rule 3
forbids moving a row that pools two marques**. A per-*string* move is possible and
its target is precisely the unresolved question, so this is **filed as an explicit
marque-history decision**, not taken unilaterally — it would bind another
maintainer's make.

Measured fact for whoever takes it: neither division make has a rename block
today, and `renames.yml` **cannot reach them at all** until one is added under the
exact display names `Austin-Morris` and `Leyland Cars`.

---

## `car/mg/roadster` is held, not nulled

The dossier proposed nulling it — **1,561 registrations across fi, gb, nl, nz**,
the largest single line it contained. **Overruled.** Nulling deletes real
registrations with no honest target, the same reason Ford's bare body-style
records were kept.

It is now declared debt in `data/name_shapes.yml` with the measured population and
the resolution named (DVLA's `Model` column — the record's GenModel *and* its
`Model` both read only `ROADSTER`, so nothing else in the corpus can split it).

The entry states plainly that it is currently **inert**: `lint_dataset.rb` has no
body-word detector (its shapes are placeholder / table_artifact / make_as_model /
embedded_make / numeric_only / spec_token / code_string), so nothing matches it
and it reports 0 records rather than 1. It is a **ledger line, not a working
allowlist**, and the entry says so.

**Flagged for consistency rather than acted on:** the same argument applies at
1/50th the scale to `car/austin/tourer` (25 regs) and `car/mg/sports` (34), which
**were** nulled in this pass because the ruling scoped the hold to
`car/mg/roadster`. A maintainer may reasonably extend the line; it should be one
decision, not rediscovered per make.

---

## The `mg-roewe` make does not exist

The raw string is `MG,ROEWE` with a **comma**. The space form `MG ROEWE` was
already aliased to MG (routing `de_kba`'s 16,143 registrations); the comma form
matched nothing, fell through to `smart_case`, and **minted a make** carrying one
record. One alias line retires it: **1 → 0**. Its record's evidence lands on
`car/mg/ehs`, which already carried both `es` and `fi`, so nothing is lost.

**`OWNERSHIP.yml`:** `scripts/gen_ownership.rb` run — **exit 0, no new tie, and no
diff**, which is correct and required: CI regenerates it from `catalog/`, and
`catalog/` is a build output this PR does not touch. Previewed against the
post-fold catalog to prove the next release regenerates cleanly:

```
856 -> 855 makes, s4w 418 -> 417, mg-roewe drops out, 28 arbitrated (unchanged),
zero owner changes, exit 0
```

(The only other line that moves in that preview is `suzuki 79|425 -> 79|420`,
which is S2W's own pre-existing drift and does not change suzuki's owner.)

---

## One lint change, and why it was unavoidable

`lint_curation` **rule 1e** ("a move TARGET must already be canonical") failed on
`"Austin|Healey 100-6" -> "Austin-Healey|100-6"`, because Austin-Healey carries
the **identity** rename `"100-6": 100-6` — the `junk?`-override rescue without
which every Austin-Healey 100-6 is deleted.

A fixed point cannot produce the divergence rule 1e hunts: the moved row arrives
carrying `100-6` un-renormalized, and the destination make's own rows normalize to
`100-6` too, so both land on **one** record. Without the exemption a sanctioned
rescue and a sanctioned move are **mutually exclusive**.

The sibling DIRECTION-WAR check *in the same file* already carries this exact
exemption for this exact rescue class ("A CONVERGED IDENTITY TARGET is not a
war… the `junk?`-override rescue class"); 1e simply lacked it. Eleven lines,
commented with the reasoning and the precedent.

---

## Verification

Run bare, exit codes checked, judged by **diff against a control build**.

| check | exit | notes |
|---|---:|---|
| `scripts/lint_curation.rb` | **0** | 109 files |
| `scripts/lint_overrides.rb` | **0** | |
| `scripts/reorg_make_blocks.rb` | **0** | content verified identical |
| `scripts/reorg_make_blocks.rb --check` | **0** | |
| `scripts/gen_ownership.rb` | **0** | no tie, no diff (above) |
| `scripts/propose_former_ids.rb` | **0** | see below |
| `pipeline/tools/lint_enrich.rb` | **0** | 56 files, 864 ids — shipped catalog *and* fresh build |
| `pipeline/tests/test_override_key_reachability.rb` | **0** | with pipeline#103 |
| `rake test` (pipeline) | **0** | 11 files, 0 failures |
| `ruby pipeline/run.rb` (full, six kinds) | 1 | **5 gate failures, all `motorcycle/suzuki/*` — byte-identical to the control build on the same base. Zero new.** |
| `scripts/lint_dataset.rb` | 1 | **PRE-EXISTING** — reproduced on pristine `origin/main`: the same 7 unexplained shapes (`daf/xf410`, `daf/xg430`, `heuliez-bus/gx437`, `leyland-daf/fa45|fa50|fa55`, `chevrolet/3500`). **None is in this slice.** |

### `propose_former_ids.rb`

```
intents=11811  proposed=0  dead_keys=2  evidence_loss=0  unexplained=18
```

* **0 new aliases proposed** (145 intents already covered) → **nothing is
  missing** from `former_ids.yml`.
* **2 dead override keys**: `Chrysler: "Town&country Touring"` and
  `Jaguar: "Xj-Sc"`. Both **pre-existing**, neither appears in this diff —
  verified by grepping the diff. Reported for their owners.
* **18 "unexplained disappearances"** — an **exact 18/18 match** with the
  `removals.yml` manifest added here. That is expected and correct: a `null`
  rename has no successor, so there is no alias intent for the tool to find.
  Every one carries a reviewed manifest line with its measured population.

### Landing-slug check

Replaying a rename key proves it **fires**; it does not prove it is the only
string landing on the slug being retired (`NAMING.md` §7.6 rule 2 — two visibly
different spellings can collapse to one slug). The pipeline already groups by
landing slug, since every produced nameplate becomes either a published record or
a candidate. For **all 155 retired slugs**:

* **none is still LIVE** in the treatment build;
* **none is still fed as a CANDIDATE** — no retired slug receives any produced
  nameplate at all any more, so there are **no latent second spellings**;
* **no id is both aliased and live.**

(The check does surface three `motorcycle/yamaha/*` ids that are live *and* carry
`removals.yml` entries — `mtn850-a`, `mxt890d`, `xp530-a`. Confirmed **identical
in the control build**: pre-existing, S2W's makes, reported not touched.)

### `former_ids` chain pre-flight

Run **before** the append: 0 keys already present, 0 outbound chains (no target is
itself an alias key), 0 self-references, **0 ids in both `removals.yml` and
`former_ids.yml`** (rule 1g), and every new key is live in the control build.
**17 inbound chains** were found and **flattened in place**, so no consumer
follows two redirects:

```
car/mg/bgt · cgt · mgbgt · b-g-t · bgt-v8 · bgtv8 · midget-mk-3 · midget-mk3
car/mg/t-d-roadster · tf-1500
car/austin/healey3000 · healey-3000-mk-111 · healey-3000-mk111 · mini-mk-2 · mini-mk2
car/austin-healey/3000-mk-2 · 3000-mk2
```

---

## Three pipeline defects — filed, not patched

Full detail and the DVLA evidence table are in **pipeline#103**; the headline:

1. **`normalizer.rb#mg`'s `\A(\d)\b` branch fabricates nameplates.** `MGF 1.8i`
   and `MG Metro 1.3 GS` → **MG1**; `2.0 TURBO` and the MGB body code
   `2 D CABRIOLET-GHN3/2310` → **MG2**. MG has never built either. 17
   registrations, three different real cars. `car/mg/mg1` and `car/mg/mg2` are
   nulled here and their manifest lines are marked **INTERIM** — they are
   superseded the moment that branch is scoped.
2. **`collapse_variant`'s `-[A-G]\b` rule eats MG's model letter.** `MG-B` → `MG`,
   and the deliberate `MG: null` line then drops it. **29 real MGs die** and **no
   override can rescue them** — at the rename lookup the nameplate is literally
   `MG`, indistinguishable from the bare-make rows the null line is meant to kill.
3. **DVLA's `Model` column is never read** — `uk_dft.rb` aggregates on
   `(Make, GenModel)` only. **Third independent sighting.** The evidence from this
   slice is load-bearing: `AUSTIN`/`AUSTIN HEALEY` splits into Model
   **`HEALEY SPRITE` (1,858)** and **`HEALEY` (903)** — two thirds of
   `car/austin/healey`'s GB mass is *identifiable* and is being thrown away, and
   it is exactly what would give Austin-Healey its home market. Same class as
   `DEBT.md`'s "us_fueleconomy `baseModel` column, never read".

**Also reported, not touched:** `nz_nzta` motorcycle `AUSTIN | AJS` (n=1) is an
AJS motorcycle filed under make Austin — the two-wheel half's call, not this one.

---

## Untouched, on purpose

* **The Ascot / Clifton / Harley / Windsor / Cambridge / pre-war-Westminster
  group** stays published and flagged. Those six body names were **reused across
  chassis** and the measured collision table blocks the fold — Wikipedia states
  one outright: *"The Westminster name was previously used by the Austin Motor
  Company in the 1930s for a four light version of the 16/6 and the Heavy 12/4."*
  Only body names appearing on **exactly one** chassis were folded (Chummy, Ruby,
  Nippy, Opal, Ulster, Box → Seven; Lichfield, Sherborne → 10; York → 16;
  Goodwood → 14).
* **The settled `MG: Tf → "T F"` line is flagged and NOT reversed.**
  `car/mg/t-f` still publishes a display no MG source writes; that inversion needs
  its own reviewed pass, and folding onto the existing canonical shrinks it from
  many records to two lines.
* Every other §E item — the strings that could not be honestly resolved
  (`car/mg/13`, `car/mg/gt`, `car/mg/td-tf`, `car/austin/a-90`, `car/austin/jeep`,
  `car/austin/countryman`, the double-booked `car/austin/princess`) — stays
  published and flagged rather than guessed at.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)