### PR TITLE
renames: rescue 8 nameplates junk? was deleting (115,809 vehicles measured)

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -5,6 +5,13 @@ Aixam:
   Aixam: null                             # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Alfa Romeo:
+  # ── junk?-rescue (2026-08-01, per-row replay of classify). junk?'s
+  # platform-code rule /\A\d[A-Z]\b/ — written for "8D Audi A4" — also matches
+  # a real nameplate that happens to be digit+letter, and deleted every 4C row
+  # in the corpus: 447 vehicles across ca+es+gb+lu+nl+nz+us, 7 sources, no
+  # published record anywhere in the catalog. IDENTITY form: Alfa's canonical
+  # IS "4C" (the block's house form for alphanumeric badges). ──
+  "4C": "4C"                        # https://en.wikipedia.org/wiki/Alfa_Romeo_4C — Maserati-built mid-engine sports car marketed by Alfa Romeo 2013-2020 (coupé 2013-19, Spider 2015-20); raws "ALFA ROMEO 4C" (316), "4C" (131), "4C Coupe"
   # ── casing-contradiction batch (2026-07-26): finish the GTV family the
   # 1750/2000 GTV caps fixes started — the detector reads the seam of
   # half-fixed families. ──
@@ -1231,6 +1238,17 @@ DS:
   No 8: DS N°8                            # registry rendering of N°8
   "3": DS 3                               # "Crossback" was dropped at the 2022-09-26 facelift, marketed as "New DS 3" (https://en.wikipedia.org/wiki/DS_3). The marque word is part of the name and bare "3" is not self-identifying (NAMING.md §1). NB not the fused "DS3": DS writes its models spaced.
   "7": DS 7                               # still the on-sale car; the DS N°7 successor was unveiled 2026-03 and goes on sale 2026-10, so expect KBA to merge this row later
+  # THE SAME OMISSION AS MAZDA "5", found by the same per-row replay
+  # (2026-08-01). The ORDER FIX comment in normalizer.rb names DS "3"/"4"/"7"/"8"
+  # and those four are curated above — but the register also writes the bare
+  # numeral for the 5 and the 9, and those two were never added. Both TARGETS
+  # ALREADY PUBLISH (car/ds/ds-5 on gb+lu+nl, car/ds/ds-9 on fi+gb+lu, off the
+  # fused "DS5"/"DS9" forms keyed below), so this is starving a live record,
+  # not minting one. Measured: "5" = 302 vehicles across es+fi+nl, "9" = 132
+  # across fi+nl. Raws are literally "DS 5" and "DS 9" — the marque token is
+  # stripped by the make-prefix rule, leaving a bare digit for junk? to eat.
+  "5": DS 5                               # https://en.wikipedia.org/wiki/DS_5 — the spaced marque form this block uses throughout; matches the fused DS5 key below and the published car/ds/ds-5
+  "9": DS 9                               # https://en.wikipedia.org/wiki/DS_9 — same; matches the fused DS9 key below and the published car/ds/ds-9
   DS3: DS 3                               # registry form with the marque fused; official spelling is spaced
   DS7: DS 7                               # fused registry form; official spelling is spaced
   DS5: DS 5                               # fused registry form
@@ -3040,6 +3058,8 @@ Mazda:
   "6": MAZDA6                             # same stripping. NB the 2026 car is the electric Mazda6e, but this KBA row also carries the discontinued ICE Mazda6, so it stays on the historic nameplate rather than attributing ICE volume to an EV.
   "2": MAZDA2                             # same stripping (https://www.mazda.de/modelle/)
   "323F": "323"                               # REPOINT (was → "323 F"), NOT a reversal: the settled statement "323F and 323 F are the same car" survives and now lands one altitude higher, on the nameplate, because "323 F" is itself folded by this pass. us_fueleconomy baseModel `323 Wagon` → `323`; the F suffix is the five-door fastback BODY of the same 323 — https://www.fueleconomy.gov/feg/download.shtml · corpus: 1643 vehicles on raws "323F", "MAZDA 323F", "MAZDA 323F,SPORTY"
+  "5": MAZDA5                             # THE MISSING FOURTH SIBLING. Same stripping as 2/3/6 above; those three were rescued by the junk?-ordering fix (normalizer.rb ORDER FIX 2026-07-25) and "5" was missed. Measured cost of the omission on a per-row replay of origin/main classify (2026-08-01): junk?'s letterless test drops 17,158 vehicles across es+fi+gb+lu+my+nl+nz+ua+us / 9 sources, while car/mazda/mazda5 publishes on the 3 countries (ca,fi,lu) whose registers happen to write the fused "MAZDA5". The nameplate is the Premacy's export name, "Mazda5" (2004-2018) — https://en.wikipedia.org/wiki/Mazda_Premacy
+  "6E": MAZDA6e                           # the electric Mazda6e, killed by junk?'s platform-code rule (/\A\d[A-Z]\b/, written for "8D Audi A4"). MINTS car/mazda/mazda6e carrying 1,369 measured vehicles across nl+es+fi+lu. Deliberately NOT pooled onto MAZDA6: the "6" line above already made that call ("it stays on the historic nameplate rather than attributing ICE volume to an EV") and this line completes it rather than reversing it. Lowercase-e suffix follows the block's settled CX-6e — https://www.mazda.de/modelle/
   CX3: CX-3                                   # spelling variant of "CX-3" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   CX30: CX-30                                 # spelling variant of "CX-30" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   CX5: CX-5                                   # spelling variant of "CX-5" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -4551,6 +4571,23 @@ Ryuka:
   "Classic Fi":                                "Classic FI"                               # resolves an intra-make casing contradiction: FI attested x1 in-make (ryuka/classic-fi)
 
 Saab:
+  # ── THE RESCUE (2 lines), 2026-08-01. The 2026-07-26 note below says the
+  # 9-3/9-5 boundary was "checked, untouched — no key here can reach them".
+  # That was true and it was the wrong conclusion to stop at: nothing could
+  # reach them because junk? was DELETING them before any key was consulted.
+  # `name !~ /[A-Za-z]/ && name !~ /\A\d{2,4}\+?\z/` — "9-3" has no letters and
+  # the hyphen disqualifies it from "2-4 digits", so Saab's two best-known
+  # nameplates died on their shape. Measured on a per-row replay of classify
+  # (2026-08-01): 9-3 = 70,404 vehicles / 9 countries / 9 sources, 9-5 = 20,193
+  # / 8 / 8 — thrown away, while the catalog published 15 "9-3 <trim>" and 11
+  # "9-5 <trim>" records off the SAME registers. The trims survived only
+  # because a trim word supplies the letter the bare nameplate lacks; that is
+  # the whole difference, and it is an artefact of the heuristic, not a fact
+  # about Saab. IDENTITY form (the Renault "4"/"5"/"8"/"9" precedent in this
+  # file): Saab's canonical IS the bare numeral pair, unlike Mazda's
+  # "3": MAZDA3 where the canonical embeds the marque word. ──
+  "9-3": "9-3"               # https://en.wikipedia.org/wiki/Saab_9-3 — one nameplate 1998-2014; raws "SAAB 9-3" (62,220), "9-3" (8,099), "9-3 CABRIOLET", "Saab 9-3"
+  "9-5": "9-5"               # https://en.wikipedia.org/wiki/Saab_9-5 — one nameplate 1997-2012; raws "SAAB 9-5" (15,443), "9-5" (4,712), "9-5 ESTATE", "Saab 9-5"
   # ── swarm-dossier batch (2026-07-26): 93/95 vs 9-3/9-5 boundary checked,
   # untouched — no key here can reach them. ──
   "900I 16V": "900 I 16V"    # 900i 16-valve, same nameplate; follows this block's own "900I": "900 I" (en.wikipedia Saab_900)
@@ -6239,6 +6276,17 @@ Yamaha:
   "Xj":                                  "XJ"                                   # uniformly-wrong casing (invisible to the contradiction detector): Yamaha XJ6, XJR1300 — the XJ line is always caps (yamaha/xj)
   "Virago XV535":                            "XV535 Virago"                 # PERMUTATION FOLD (verified batch, tier A): XV-first 17 vs Virago-first 3.
   "Virago XV750":                            "XV750 Virago"                 # PERMUTATION FOLD (verified batch, tier A): XV-first 493 vs Virago-first 2.
+
+Zeekr:
+  # ── NEW BLOCK, junk?-rescue (2026-08-01, per-row replay of classify). Same
+  # platform-code rule as Alfa Romeo "4C" (/\A\d[A-Z]\b/, written for "8D Audi
+  # A4"), and here it produces a self-refuting result: the rule needs a WORD
+  # BOUNDARY after the letter, so Zeekr's "7GT" publishes (car/zeekr/7gt) while
+  # its sibling "7X" — same marque, same naming grammar, one letter shorter —
+  # is deleted. 5,804 vehicles across de+es+my+nl+nz+th+ua, 7 sources, no
+  # record anywhere. IDENTITY form: the catalog already publishes this make's
+  # alphanumeric badges bare (001, 009, 7GT, X). ──
+  "7X": "7X"                # https://en.wikipedia.org/wiki/Zeekr_7X — battery-electric mid-size crossover SUV, in production since 2024-09-17; raws "7X" (5,453), "ZEEKR 7X" (344), "7X 100KW 4WD"
 
 Zero Motorcycles:
   # Residue of a SINGULAR/PLURAL mismatch between the two columns, not a naming


### PR DESCRIPTION
## 115,809 vehicles were being deleted before they could become a record

A row that dies in `junk?` returns `nil` from `classify` and **never becomes a record**. There is nothing in `catalog/`, nothing in `build/out`, nothing in `observed_model_names.json` (a feed of what *published*) and nothing in a review pack for a checker to look at.

**You cannot detect the absence of a record you never created by inspecting the records you did create.** Every catalog-side check is structurally blind to this class — by construction, not by oversight. That is the reusable lesson, and it is why this went unmeasured while looking perfectly healthy from the catalog.

The only thing that sees it is a **per-row replay that logs `classify`'s nil returns**. That is what produced everything below.

This PR pairs with the other half (pipeline ↔ data); neither works alone.

---

## 1. Reproduction, per-row, before any edit

Replayed **378,261 rows / 76,943,060 vehicles** across every source and all six kinds through the real `Normalizer#classify`, on an mtime-frozen cache.

Instrumentation is provably behaviour-neutral. `normalizer.rb:178` is the only consumer of `@o.model_renames`, and `classify` does:

```ruby
renames = @o.model_renames[make]
curated = renames&.key?(nameplate)
return nil if !curated && junk?(nameplate, kind)
```

The real map yields `nil` for a make with no rename block (`curated` → `nil`, falsy). The probe returns `false` for that case — also falsy, and `if curated` is skipped identically. Wrapping **every** make rather than only curated ones is what lets it observe uncurated makes at all: `gen_review_pack.rb`'s recorder wraps only real blocks, so a make with **no** block probes no key and is invisible to it. That gap is exactly where Zeekr `7X` and Alfa Romeo `4C` were hiding.

**Both brief numbers reproduced exactly.** I measured one country more than the dossier on `MAZDA 5` (it lists 8 "+us"; the replay resolves 9 including `us`), same 17,158 total.

| make | key | vehicles | countries | sources |
|---|---|---:|---:|---:|
| Mazda | `5` | **17,158** | 9 (es,fi,gb,lu,my,nl,nz,ua,us) | 9 |
| Mazda | `6E` | **1,369** | 4 (es,fi,lu,nl) | 4 |

Baseline: **478,918** vehicles across **25,735** distinct `(make, key)` pairs die in `junk?`. Most of that is correct — the honest denominator matters, and this defect is a small, specific slice of it.

## 2. …and the replay immediately found something 5× larger

| make | key | vehicles | countries | sources | catalog says |
|---|---|---:|---:|---:|---|
| **Saab** | `9-3` | **70,404** | 9 | 9 | 15 `9-3 <trim>` records publish; bare `9-3` absent |
| **Saab** | `9-5` | **20,193** | 8 | 8 | 11 `9-5 <trim>` records publish; bare `9-5` absent |
| Mazda | `5` | 17,158 | 9 | 9 | `car/mazda/mazda5` publishes on 3 countries |
| **Zeekr** | `7X` | **5,804** | 7 | 7 | sibling `car/zeekr/7gt` publishes; `7x` absent |
| Mazda | `6E` | 1,369 | 4 | 4 | absent |
| **Alfa Romeo** | `4C` | **447** | 7 | 7 | absent |
| **DS** | `5` | **302** | 3 | 3 | `car/ds/ds-5` publishes on 3 countries |
| **DS** | `9` | **132** | 2 | 2 | `car/ds/ds-9` publishes on 3 countries |

**Two `junk?` rules did all of it, and both are heuristics colliding with a real name:**

- **letterless** — `name !~ /[A-Za-z]/ && name !~ /\A\d{2,4}\+?\z/` kills `5`, `9`, `9-3`, `9-5`. Saab's trims survived *only because a trim word supplies the letter the bare nameplate lacks*. That is the entire difference between `9-3 Aero` publishing and `9-3` being deleted, and it is an artefact of the heuristic, not a fact about Saab.
- **platform code** — `name =~ /\A\d[A-Z]\b/`, written for `"8D Audi A4"`, kills `6E`, `7X`, `4C`. It needs a **word boundary** after the letter, so Zeekr's own `7GT` publishes while its one-letter-shorter sibling `7X` dies. The rule refutes itself inside a single make.

## 3. The whole class, re-measured — the part that matters

The 2026-07-25 ORDER FIX comment names the makes it rescued. I re-measured **every name on that list**, digit by digit, against both the corpus and `renames.yml`:

| make | listed digits | verdict |
|---|---|---|
| SMART | 1, 3, 5 | **complete** — all curated, 0 vehicles dropped |
| POLESTAR | 2, 3, 4 | **complete** — all curated, 0 dropped |
| JAECOO | 7 | **complete** — 0 dropped |
| OMODA | 5, 9 | **complete** — 0 dropped |
| MAZDA | 2, 3, 6 | **incomplete** — `5` missing (17,158) |
| DS | 3, 4, 7, 8 | **incomplete** — `5` and `9` missing (434), *both targets already published* |

So the dossier's worry was right but narrower than feared: the named list was applied completely **except for MAZDA and DS**. The larger finding is that the same *shapes* were eating nameplates nobody had listed at all — which is why the fix here is a detector, not a longer list.

### Fixed (8 lines) — unambiguous

All identity-form rescues follow the **Renault `"4"`/`"5"`/`"8"`/`"9"` precedent** already in `renames.yml` (and already blessed by `lint_curation.rb`'s direction-war exemption for fixed-point targets); Mazda/DS use the marque-word form their own blocks established.

```yaml
Mazda:       "5": MAZDA5      "6E": MAZDA6e
Saab:        "9-3": "9-3"     "9-5": "9-5"
DS:          "5": DS 5        "9": DS 9
Alfa Romeo:  "4C": "4C"
Zeekr:       "7X": "7X"       # new block
```

Each line carries its measured corpus attestation and a source. Zeekr 7X and Alfa Romeo 4C were verified against Wikipedia before minting (production 2024– and 2013–2020 respectively) rather than assumed from the string.

**`6E` is deliberately NOT pooled onto `MAZDA6`.** The existing `"6"` line already chose to keep ICE volume off the EV; this completes that call rather than reversing it. Verified: `car/mazda/mazda6`'s availability is byte-identical across control and treatment.

### Filed, not guessed — a rescue that mints a wrong nameplate is worse than a drop

| class | example | vehicles | why not fixed |
|---|---|---:|---|
| **`New` prefix rule** | Chrysler `New Yorker` (7 countries!), Kymco `New Like`, Suzuki `New SX4` | ~3.6k | `/\A(Buggy\|New\|…)\b/i` eats real nameplates. Needs a rule change, not a rename — out of scope for a curation PR |
| BMC `N/M` family | Wolseley `16/60`, `6/110`, `4/44`, `18/85`, `15/50`; Riley `4/72` | ~1.5k | real nameplates, but the family needs **one** consistent slug decision and the catalog has none of them today |
| Morgan `4/4` | | 2,882 | **two competing live ids** (`morgan/44` "44" and `morgan/4-4-series` "4/4 Series") — pure naming judgement |
| litre-displacement | Jaguar `3.8`/`3.4`, Daimler `4.2`/`3.6`, Riley `1.5`, Triumph `2.5`, Rover `3.5 Litre` | ~4.5k | **mixed** — Riley 1.5 is a real nameplate (already `riley/one-point-five`), Jaguar 3.8 is a Mk2 engine size. Cannot be split by shape |
| Lada VAZ codes | `21063`, `21061`, `21011`, `21043`, `21213`… | ~6k | the 5-digit VAZ number *is* the designation, but the VIN-ish rule kills it; needs a Lada-wide decision |
| parenthetical forms | Yamaha `XTZ690 (tenere 700)`, KTM `990 Supermoto (85KW)` | ~950 | record already publishes from the non-paren raw; this is *partial* evidence loss, a different defect |
| single digits | Austin `7`, Morris `8`, Piaggio `1`, Seres `3` | ~1.8k | real nameplates, but canonical form is a judgement (`7` vs `Seven`) and Seres has no records at all |
| Mazda `8` | | 5 | real nameplate, **1 country / 1 source** — under the two-source publication floor |

I did not guess on any of these.

## 4. Build verification — control vs treatment, one frozen cache

`find cache -type f -exec touch {} +` in my own worktree before the control; identical cache for both. Judged by **diff, not exit code** (both builds exit 1).

```
kind        control  treat  delta
car            6235   6240     +5
van             742    742     +0
truck          1224   1224     +0
bus             408    408     +0
motorcycle     5941   5941     +0
moped          1297   1297     +0
```

**Added (5), removed (0):** `car/saab/9-3`, `car/saab/9-5`, `car/zeekr/7x`, `car/mazda/mazda6e`, `car/alfa-romeo/4c`.

Records that were **starved and are now fed** (no new id — they gain countries):

| id | control | treatment |
|---|---|---|
| `car/mazda/mazda5` | ca,fi,lu (3) | ca,es,fi,gb,lu,my,nl,nz,ua,us (**10**) |
| `car/ds/ds-5` | gb,lu,nl (3) | es,fi,gb,lu,nl (**5**) |
| `car/ds/ds-9` | fi,gb,lu (3) | fi,gb,lu,nl (**4**) |
| `car/mazda/mazda6` | 12 countries | **12 countries — unchanged** (the EV did not leak onto the ICE car) |

### Gate and prune consequences — asked explicitly, answered explicitly

- **id-contract gates: nothing moved.** Control and treatment both fail the **same 72** no-vanish gates, on the **same ids**, all in `motorcycle`. Diffing the two sorted failure lists yields no difference (the only textual delta is a stderr traceback interleaving into stdout). **All 72 are inherited, none are mine** — my change touches `car`/`van` only.
  - *Note on the brief's baseline*: it predicted **2** failures (`car/chevrolet/tudor`, `car/chevrolet/van`). I measured **72**, all `motorcycle`, and **zero** chevrolet. Both repos' `main` moved tonight (pipeline `7bd13e5`, data `bb366ba`); the 72 look like the G-1 uk_dft 2W-nameplate change landing ahead of the data repo's `former_ids`/`removals`. Flagging it because it is a cross-repo coupling someone is presumably still holding, not something this PR should absorb.
- **`cross_kind_prune!`: `van -288 → -291` (+3), every other kind unchanged.** No pre-existing record was deleted anywhere — the removed-id set is **empty**. The 3 extra prunes are the *newly minted* van entries for the rescued nameplates being pruned by the 97 % dominance rule exactly as designed (car dominates; the van rows are grijs-kenteken noise). Confirmed `saab/9-3`, `saab/9-5`, `mazda/mazda5` are absent from `van` and `truck` in **both** builds.
- The knife-edge the brief warned about — *"the ratio is computed over registration counts, so a catalog-sourced record with no counts contributes 0 and cannot defend itself"* — was the real risk here, since `car/mazda/mazda5`'s pre-existing evidence is `ca` **approval** evidence with no counts. It did not fire: the rescue *adds* count-bearing car evidence, which moves the ratio toward the kind that was already dominant.
- `scripts/lint_overrides.rb` and `scripts/lint_curation.rb` both exit 0. No direction war: the identity targets are fixed points, which that check exempts by name.

## 5. Tests

Two new tests in `pipeline/tests/test_normalizer_families.rb`, in the style of the existing `test_curated_single_digit_names_are_rescuable`, one per broken rule. Full suite bare: **`rake test` exit 0**, 0 failures, 0 errors.

Negative cases use `LADA` keys (no rename entry) so they keep testing the **heuristic** rather than the curation — the fixture-rot lesson the existing test records in its own comment, where `MAZDA`/`3` stopped being an uncurated example the moment someone curated it. Positive cases use `stub_renames`, so they stay green regardless of what the data repo carries.

## 6. The detector

Built, because it was cheap and safe: `pipeline/tools/report_junk_drops.rb`, `rake report:junk_drops`.

- **Where it hooks:** the `renames&.key?(nameplate)` probe at `normalizer.rb:178` — the exact `junk?` decision point — via a proxy that records and delegates. Behaviour-neutral for the reason argued in §1.
- **What it emits:** `build/junk-drops.json` plus a ranked stdout summary. Candidates are `(make, key)` pairs dying in `junk?` with **≥200 vehicles, ≥2 sources, ≥2 countries** *and* a live sibling record under one of three joins: `R1` marque-prefix fusion (`5` ↔ `mazda5`), `R2` trim-orphan (`9-3 Aero` exists, `9-3` does not), `R3` exact slug already published but starving.
- **Why it cannot live on the catalog side:** §1. There is no record to flag.
- **Report-only by default**, exit 0. `VDB_JUNK_DROPS_FAIL=1` turns it into a gate once the standing list is at zero. It proposes *curation*, and a human must write the line with its source — so failing the build by default would be wrong.
- **Not in `rake test`**: the unit suite is hermetic and a worktree has no `cache/`; this replays every row of every source.
- **Specificity, measured:** 5 candidates out of 25,735 dropped pairs / 478,918 dropped vehicles before the fix; **2 after** (both the filed parenthetical class). The independent before/after delta in vehicles dying in `junk?` is **478,918 → 363,109 = 115,809** — matching the sum of the eight rescues **to the vehicle**.
- **Its own known gap, stated in the tool rather than hidden:** all three joins need a live sibling, so a rescue that would MINT the make's *first* record for a nameplate is invisible to it — `6E`, `7X` and `4C` all were. It therefore emits a second, deliberately noisier `unjoined_high_volume` list (26 entries, ≥3 sources and ≥3 countries) for a human to read. That list is where `New Yorker`, `4/4` and the Wolseley family surfaced.

## 7. The lesson, stated plainly

**Dropped rows are invisible to catalog-side detectors.** A check that reads `catalog/`, `build/out`, `observed_model_names.json` or a review pack can only ever audit what survived. An entire defect class — real nameplates deleted by a heuristic before they became records — lives in the complement of that set and cannot be reached from it at any level of effort. Detecting it requires replaying rows and logging what `classify` *refused*, which is a different shape of check and needs to exist as one.

The corollary this PR is evidence for: **a heuristic that silently deletes needs a standing measurement of what it deleted**, or its mistakes compound invisibly. `junk?` had none. The 2026-07-25 ORDER FIX correctly made the class *rescuable*, then hand-listed the rescues — and a hand-list with no detector behind it is exactly how `5` sat next to `2`, `3` and `6` for a month while 17,158 vehicles fell on the floor.

---

**DO NOT MERGE** — posted for review.
