### PR TITLE
harley-davidson: fold the Softtail misspelling onto Harley's Softail

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2877,6 +2877,8 @@
 "motorcycle/honda/cbr900": "motorcycle/honda/cbr900rr-fireblade" # Honda cluster fold: Honda publishes one nameplate and the register spellings are truncations of it.
 "motorcycle/honda/cbr900-fireblade": "motorcycle/honda/cbr900rr-fireblade" # Honda cluster fold: Honda publishes one nameplate and the register spellings are truncations of it.
 "motorcycle/honda/cbr900rr": "motorcycle/honda/cbr900rr-fireblade" # Honda cluster fold: Honda publishes one nameplate and the register spellings are truncations of it.
+"motorcycle/harley-davidson/softtail": "motorcycle/harley-davidson/softail" # misspelling folded onto Harley's own spelling
+"motorcycle/harley-davidson/softtail-custom": "motorcycle/harley-davidson/softail-custom" # same
 
 # ── A NOTE ON CHAINS, after three in one session (S2W 2026-07-26) ───────────
 # Every one had the identical shape: I retire an id X (rename/fold), and

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1830,6 +1830,8 @@ Govecs:
   Go! T2.4: GO! T2.4                        # T-series sibling of the above
 
 Harley-Davidson:
+  "Softtail": "Softail"                    # MISSPELLING. Harley spells it Softail — https://www.harley-davidson.com/us/en/motorcycles/softail.html and the model pages (softail-standard, softail-custom, softail-deluxe). Both spellings publish today; folding the typo onto the correct form is not a naming CHOICE, it is a correction.
+  "Softtail Custom": "Softail Custom"      # same misspelling, same source; "Softail Custom" is a published Harley model page
   # H-D CONVENTION DOSSIER (§11.2). Two rules, both from Harley's own pages,
   # and rows routinely need both at once ("FLSTF Fat Boy"):
   #


### PR DESCRIPTION
Both spellings publish today, and one of them is a typo:

    Softail          fi,gb,lu,nl,nz,ua
    Softtail         nl,nz               <- typo
    Softail Custom   fi,nl,nz
    Softtail Custom  nl,nz               <- typo

Harley spells it **Softail** — [the family page](https://www.harley-davidson.com/us/en/motorcycles/softail.html) and every model page (`softail-standard`, `softail-custom`, `softail-deluxe`). This is a **correction, not a naming choice**; there is no argument for the other spelling.

Build: **exit 0, zero gate failures.** Both typos folded, survivors keep their availability, 0 chains across 4,111 aliases.

### Context — this is the small piece of a larger finding

A read-only dossier over Harley's 633 records produced three results I am deliberately **not** acting on tonight (written up in NEGOTIATION Turn 218):

1. **My one-child filter has good precision and bad recall.** Six of the 65 bases have children the regex cannot see, and the 51 many-child bases I skipped hold *more* genuine duplicate mass than the 65 I kept.
2. **`flstc` is thirteen records for one motorcycle** — `flstc`, `flstc-heritage`, `flstc-heritage-classic`, `flstc-heritage-softail`, `flstc-heritage-softail-cl`, `flstc-heritage-softail-classic`, `flstc-softail-classic`, `flstci`, … That is the real prize and it needs a cluster pass, not a pair pass.
3. **The disjoint-availability signal is dead on this make.** It identified exactly the right pairs on Honda; here `nl_rdw` covers 622 of 633 records, so all 65 pairs intersect and it fired **zero** times. A heuristic's usefulness depends on source coverage, not just on the make.

All three verified against the catalog before being written down.
