### PR TITLE
cadillac + chrysler + buick: fold 97 trim/body/series records into 45 nameplates

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1216,16 +1216,16 @@
 "car/bertone/x-1-9": "car/bertone/x1-9"
 "car/bmw/x-1": "car/bmw/x1"
 "car/bricklin/sv-1": "car/bricklin/sv1"
-"car/buick/gs-350": "car/buick/gs350"
+"car/buick/gs-350": "car/buick/gs" # FLATTENED 2026-08-01 (was -> car/buick/gs350, which the American wave-6 fold retires into car/buick/gs): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
 "car/buick/lesabre": "car/buick/le-sabre"
-"car/buick/lesabre-custom": "car/buick/le-sabre-custom"
+"car/buick/lesabre-custom": "car/buick/le-sabre" # FLATTENED 2026-08-01 (was -> car/buick/le-sabre-custom, which the American wave-6 fold retires into car/buick/le-sabre): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
 "car/buick/sportwagon": "car/buick/sport-wagon"
 "car/buick/wildcat": "car/buick/wild-cat"
-"car/cadillac/coupe-deville": "car/cadillac/coupe-de-ville"
+"car/cadillac/coupe-deville": "car/cadillac/de-ville" # FLATTENED 2026-08-01 (was -> car/cadillac/coupe-de-ville, which the American wave-6 fold retires into car/cadillac/de-ville): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
 "car/cadillac/deville": "car/cadillac/de-ville"
 "car/cadillac/eldorado": "car/cadillac/el-dorado"
 "car/cadillac/lasalle": "car/cadillac/la-salle"
-"car/cadillac/sedan-deville": "car/cadillac/sedan-de-ville"
+"car/cadillac/sedan-deville": "car/cadillac/de-ville" # FLATTENED 2026-08-01 (was -> car/cadillac/sedan-de-ville, which the American wave-6 fold retires into car/cadillac/de-ville): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
 "car/chevrolet/belair": "car/chevrolet/bel-air"
 "car/chevrolet/bellair": "car/chevrolet/bel-air" # FLATTENED 2026-08-01 (was -> car/chevrolet/bell-air, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
 "car/chevrolet/camaro-z28": "car/chevrolet/camaro" # FLATTENED 2026-08-01 (was -> car/chevrolet/camaro-z-28, which the Chevrolet wave-4 fold retires): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
@@ -1237,7 +1237,7 @@
 "car/chevrolet/trailblazer": "car/chevrolet/trail-blazer"
 "car/chrysler/300c": "car/chrysler/300-c"
 "car/chrysler/300m": "car/chrysler/300-m"
-"car/chrysler/300s": "car/chrysler/300-s"
+"car/chrysler/300s": "car/chrysler/300" # FLATTENED 2026-08-01 (was -> car/chrysler/300-s, which the American wave-6 fold retires into car/chrysler/300): the alias now points straight at the final destination, so a consumer following one redirect lands on a LIVE id.
 "car/chrysler/lebaron": "car/chrysler/le-baron"
 "car/citroen/b-11": "car/citroen/b11"
 "car/citroen/c-1": "car/citroen/c1"
@@ -5982,3 +5982,113 @@
 "car/skoda/s110l":                             "car/skoda/110-l"                              # renames.yml Škoda: S110L -> 110 L  [fi,nl,nz]
 "car/skoda/spaceback":                         "car/skoda/rapid"                              # renames.yml Škoda: Spaceback -> Rapid  [es,fi,gb,lu,nl,nz,ua]
 "car/skoda/suberb":                            "car/skoda/superb"                             # renames.yml Škoda: Suberb -> Superb  [de,es,fi,gb,ie,lu,nl,nz,ua]
+
+# ── American wave-6 marque CLEAN: cadillac + chrysler + buick, 97 folds (2026-08-01) ──────────
+# 97 of 270 records in the slice were trims, engine badges, series numbers, body styles,
+# coachbuilt conversions, GM order codes and registry typos hanging off 45 live nameplates.
+# Every fold has an honest survivor, so removals.yml gets NOTHING. Measured against a control
+# build: 0 (country,source) pairs lost, 1 strict gain (car/chrysler/town-country += us).
+# Trailing comment = the renames.yml key that retires the id + the countries the id carried.
+#
+# Cadillac — 39 folds
+"car/cadillac/62":                      "car/cadillac/series-62"           # renames.yml Cadillac: 62 -> Series 62  [fi,nl,nz]
+"car/cadillac/62-series":               "car/cadillac/series-62"           # renames.yml Cadillac: 62 Series -> Series 62  [fi,nl,nz]
+"car/cadillac/sixty-two":               "car/cadillac/series-62"           # renames.yml Cadillac: Sixty-Two -> Series 62  [fi,nl]
+"car/cadillac/series-6200":             "car/cadillac/series-62"           # renames.yml Cadillac: Series 6200 -> Series 62  [nl,nz]
+"car/cadillac/type-61":                 "car/cadillac/series-61"           # renames.yml Cadillac: Type 61 -> Series 61  [nl,nz]
+"car/cadillac/coupe-de-ville":          "car/cadillac/de-ville"            # renames.yml Cadillac: Coupe De Ville -> De Ville  [fi,nl,nz]
+"car/cadillac/sedan-de-ville":          "car/cadillac/de-ville"            # renames.yml Cadillac: Sedan De Ville -> De Ville  [fi,nl,nz]
+"car/cadillac/de-ville-62":             "car/cadillac/de-ville"            # renames.yml Cadillac: De Ville 62 -> De Ville  [fi,nl]
+"car/cadillac/de-ville-fleetwood":      "car/cadillac/de-ville"            # renames.yml Cadillac: De Ville Fleetwood -> De Ville  [es,nl]
+"car/cadillac/deville-concours":        "car/cadillac/de-ville"            # renames.yml Cadillac: Deville Concours -> De Ville  [fi,nl]
+"car/cadillac/deville-dts":             "car/cadillac/de-ville"            # renames.yml Cadillac: Deville Dts -> De Ville  [fi,nl]
+"car/cadillac/armored-deville":         "car/cadillac/de-ville"            # renames.yml Cadillac: Armored Deville -> De Ville  [ca,us]
+"car/cadillac/eldorado-biarritz":       "car/cadillac/el-dorado"           # renames.yml Cadillac: Eldorado Biarritz -> El Dorado  [fi,nl,nz]
+"car/cadillac/eldorado-biarriz":        "car/cadillac/el-dorado"           # renames.yml Cadillac: Eldorado Biarriz -> El Dorado  [fi,nl]
+"car/cadillac/eldorado-seville":        "car/cadillac/el-dorado"           # renames.yml Cadillac: Eldorado Seville -> El Dorado  [fi,nl,nz]
+"car/cadillac/eldorado-touring":        "car/cadillac/el-dorado"           # renames.yml Cadillac: Eldorado Touring -> El Dorado  [fi,nl]
+"car/cadillac/fleetwood-eldorado":      "car/cadillac/el-dorado"           # renames.yml Cadillac: Fleetwood Eldorado -> El Dorado  [fi,nl]
+"car/cadillac/fleetwood-broughan":      "car/cadillac/fleetwood-brougham"  # renames.yml Cadillac: Fleetwood Broughan -> Fleetwood Brougham  [nl,nz]
+"car/cadillac/fleetwood-seventy-five":  "car/cadillac/fleetwood-75"        # renames.yml Cadillac: Fleetwood Seventy Five -> Fleetwood 75  [fi,nl]
+"car/cadillac/fleetwood-60-special":    "car/cadillac/sixty-special"       # renames.yml Cadillac: Fleetwood 60 Special -> Sixty Special  [fi,nl]
+"car/cadillac/fleetwood-60s":           "car/cadillac/sixty-special"       # renames.yml Cadillac: Fleetwood 60S -> Sixty Special  [fi,nl]
+"car/cadillac/fleetwood-sixty-special": "car/cadillac/sixty-special"       # renames.yml Cadillac: Fleetwood Sixty Special -> Sixty Special  [fi,nl]
+"car/cadillac/seville-sls":             "car/cadillac/seville"             # renames.yml Cadillac: Seville Sls -> Seville  [fi,nl,ua]
+"car/cadillac/seville-sts":             "car/cadillac/seville"             # renames.yml Cadillac: Seville Sts -> Seville  [fi,nl]
+"car/cadillac/cts-4":                   "car/cadillac/cts"                 # renames.yml Cadillac: Cts 4 -> Cts  [es,fi]
+"car/cadillac/cts-v":                   "car/cadillac/cts"                 # renames.yml Cadillac: Cts-V -> Cts  [ca,fi,nl,us]
+"car/cadillac/ats-v":                   "car/cadillac/ats"                 # renames.yml Cadillac: Ats-V -> Ats  [ca,nl,us]
+"car/cadillac/sts-v":                   "car/cadillac/sts"                 # renames.yml Cadillac: Sts-V -> Sts  [nl,us]
+"car/cadillac/6eb26-srx":               "car/cadillac/srx"                 # renames.yml Cadillac: 6EB26 Srx -> Srx  [fi,nl]
+"car/cadillac/6rb26-srx":               "car/cadillac/srx"                 # renames.yml Cadillac: 6RB26 Srx -> Srx  [fi,nl]
+"car/cadillac/6yv67-xlr":               "car/cadillac/xlr"                 # renames.yml Cadillac: 6YV67 Xlr -> Xlr  [fi,nl]
+"car/cadillac/escalade-esv":            "car/cadillac/escalade"            # renames.yml Cadillac: Escalade Esv -> Escalade  [ca,es,fi,lu,nl,us]
+"car/cadillac/escalade-esv-sport":      "car/cadillac/escalade"            # renames.yml Cadillac: Escalade Esv Sport -> Escalade  [nl,ua]
+"car/cadillac/escalade-ext":            "car/cadillac/escalade"            # renames.yml Cadillac: Escalade Ext -> Escalade  [ca,fi,us]
+"van/cadillac/escalade-ext":            "van/cadillac/escalade"            # renames.yml Cadillac: Escalade Ext -> Escalade  [fi,nl]
+"car/cadillac/k10706-escalade":         "car/cadillac/escalade"            # renames.yml Cadillac: K10706-Escalade -> Escalade  [fi,nl]
+"car/cadillac/dts-hearse":              "car/cadillac/dts"                 # renames.yml Cadillac: Dts Hearse -> Dts  [fi,nl]
+"car/cadillac/xts-hearse":              "car/cadillac/xts"                 # renames.yml Cadillac: Xts Hearse -> Xts  [nl,us]
+"car/cadillac/limosine":                "car/cadillac/limousine"           # renames.yml Cadillac: Limosine -> Limousine  [nl,nz]
+#
+# Chrysler — 20 folds
+"car/chrysler/300-s":                "car/chrysler/300"           # renames.yml Chrysler: 300 S -> 300  [fi,nl,ua]
+"car/chrysler/300-touring":          "car/chrysler/300"           # renames.yml Chrysler: 300 Touring -> 300  [nl,ua]
+"car/chrysler/300-hurst":            "car/chrysler/300"           # renames.yml Chrysler: 300 Hurst -> 300  [fi,nl]
+"car/chrysler/three-hundred":        "car/chrysler/300"           # renames.yml Chrysler: Three Hundred -> 300  [fi,nl]
+"car/chrysler/town-and-country":     "car/chrysler/town-country"  # renames.yml Chrysler: Town And Country -> Town & Country  [fi,nl,us]
+"car/chrysler/town-country-touring": "car/chrysler/town-country"  # renames.yml Chrysler: Town&country Touring -> Town & Country  [fi,nl]
+"car/chrysler/crossfire-roadster":   "car/chrysler/crossfire"     # renames.yml Chrysler: Crossfire Roadster -> Crossfire  [ca,fi,us]
+"car/chrysler/crossfire-srt6":       "car/chrysler/crossfire"     # renames.yml Chrysler: Crossfire SRT6 -> Crossfire  [ca,nl]
+"car/chrysler/sebring-lx":           "car/chrysler/sebring"       # renames.yml Chrysler: Sebring LX -> Sebring  [fi,nl]
+"car/chrysler/pacifica-limited":     "car/chrysler/pacifica"      # renames.yml Chrysler: Pacifica Limited -> Pacifica  [nl,ua]
+"car/chrysler/pacifica-touring-l":   "car/chrysler/pacifica"      # renames.yml Chrysler: Pacifica Touring L -> Pacifica  [fi,nl]
+"car/chrysler/newport-custom":       "car/chrysler/newport"       # renames.yml Chrysler: Newport Custom -> Newport  [fi,nl]
+"car/chrysler/newport-royal":        "car/chrysler/newport"       # renames.yml Chrysler: Newport Royal -> Newport  [fi,nl]
+"car/chrysler/windsor-deluxe":       "car/chrysler/windsor"       # renames.yml Chrysler: Windsor Deluxe -> Windsor  [fi,nl]
+"car/chrysler/windsor-nassau":       "car/chrysler/windsor"       # renames.yml Chrysler: Windsor Nassau -> Windsor  [fi,nl]
+"car/chrysler/royal-eight":          "car/chrysler/royal"         # renames.yml Chrysler: Royal Eight -> Royal  [nl,nz]
+"car/chrysler/imperial-crown":       "car/chrysler/imperial"      # renames.yml Chrysler: Imperial Crown -> Imperial  [fi,nl,nz]
+"car/chrysler/crown-imperial":       "car/chrysler/imperial"      # renames.yml Chrysler: Crown Imperial -> Imperial  [fi,nl]
+"car/chrysler/imperial-le-baron":    "car/chrysler/imperial"      # renames.yml Chrysler: Imperial Le Baron -> Imperial  [fi,nl]
+"car/chrysler/charger-r-t":          "car/chrysler/charger"       # renames.yml Chrysler: Charger R/T -> Charger  [nl,nz]
+#
+# Buick — 38 folds
+"car/buick/le-sabre-400":        "car/buick/le-sabre"    # renames.yml Buick: Le Sabre 400 -> Le Sabre  [fi,nl]
+"car/buick/le-sabre-custom":     "car/buick/le-sabre"    # renames.yml Buick: Le Sabre Custom -> Le Sabre  [fi,nl]
+"car/buick/le-sabre-limited":    "car/buick/le-sabre"    # renames.yml Buick: Le Sabre Limited -> Le Sabre  [fi,nl]
+"car/buick/electra-225":         "car/buick/electra"     # renames.yml Buick: Electra 225 -> Electra  [fi,nl,nz]
+"car/buick/electra-225-custom":  "car/buick/electra"     # renames.yml Buick: Electra 225 Custom -> Electra  [fi,nl]
+"car/buick/electra-custom-225":  "car/buick/electra"     # renames.yml Buick: Electra Custom 225 -> Electra  [fi,nl]
+"car/buick/electra-limited":     "car/buick/electra"     # renames.yml Buick: Electra Limited -> Electra  [fi,nl,nz]
+"car/buick/electra-park-avenue": "car/buick/electra"     # renames.yml Buick: Electra Park Avenue -> Electra  [nl,us]
+"car/buick/century-caballero":   "car/buick/century"     # renames.yml Buick: Century Caballero -> Century  [fi,nl]
+"car/buick/century-wagon":       "car/buick/century"     # renames.yml Buick: Century Wagon -> Century  [ca,us]
+"car/buick/skylark-350":         "car/buick/skylark"     # renames.yml Buick: Skylark 350 -> Skylark  [nl,nz]
+"car/buick/skylark-custom":      "car/buick/skylark"     # renames.yml Buick: Skylark Custom -> Skylark  [fi,nl]
+"car/buick/skylark-gs":          "car/buick/skylark"     # renames.yml Buick: Skylark GS -> Skylark  [fi,nl]
+"car/buick/gs-400":              "car/buick/gs"          # renames.yml Buick: GS 400 -> GS  [fi,nl,nz]
+"car/buick/gs-455-stage-1":      "car/buick/gs"          # renames.yml Buick: GS 455 Stage 1 -> GS  [fi,nl]
+"car/buick/gs350":               "car/buick/gs"          # renames.yml Buick: GS350 -> GS  [fi,nl]
+"car/buick/gran-sport":          "car/buick/gs"          # renames.yml Buick: Gran Sport -> GS  [fi,nl]
+"car/buick/california-gs":       "car/buick/gs"          # renames.yml Buick: California GS -> GS  [fi,nl]
+"car/buick/rivera":              "car/buick/riviera"     # renames.yml Buick: Rivera -> Riviera  [nl,nz]
+"car/buick/riviera-2":           "car/buick/riviera"     # renames.yml Buick: Riviera 2 -> Riviera  [fi,nl]
+"car/buick/riviera-gs":          "car/buick/riviera"     # renames.yml Buick: Riviera GS -> Riviera  [fi,nl,nz]
+"car/buick/special-40":          "car/buick/special"     # renames.yml Buick: Special 40 -> Special  [nl,nz]
+"car/buick/special-series-40":   "car/buick/special"     # renames.yml Buick: Special Series 40 -> Special  [nl,nz]
+"car/buick/series-40-special":   "car/buick/special"     # renames.yml Buick: Series 40 Special -> Special  [nl,nz]
+"car/buick/special-riviera":     "car/buick/special"     # renames.yml Buick: Special Riviera -> Special  [fi,nl]
+"car/buick/super-8":             "car/buick/super"       # renames.yml Buick: Super 8 -> Super  [nl,nz]
+"car/buick/super-dynaflow":      "car/buick/super"       # renames.yml Buick: Super Dynaflow -> Super  [fi,nl]
+"car/buick/super-eight":         "car/buick/super"       # renames.yml Buick: Super Eight -> Super  [fi,nl]
+"car/buick/super-series-50":     "car/buick/super"       # renames.yml Buick: Super Series 50 -> Super  [nl,nz]
+"car/buick/super-riviera":       "car/buick/super"       # renames.yml Buick: Super Riviera -> Super  [fi,nl,nz]
+"car/buick/eight-super":         "car/buick/super"       # renames.yml Buick: Eight Super -> Super  [fi,nl]
+"car/buick/roadmaster-72":       "car/buick/roadmaster"  # renames.yml Buick: Roadmaster 72 -> Roadmaster  [nl,nz]
+"car/buick/roadmaster-wagon":    "car/buick/roadmaster"  # renames.yml Buick: Roadmaster Wagon -> Roadmaster  [ca,fi,us]
+"car/buick/regal-eassist":       "car/buick/regal"       # renames.yml Buick: Regal Eassist -> Regal  [ca,us]
+"car/buick/regal-ltd":           "car/buick/regal"       # renames.yml Buick: Regal Ltd -> Regal  [nl,nz]
+"car/buick/regal-tourx":         "car/buick/regal"       # renames.yml Buick: Regal Tourx -> Regal  [fi,us]
+"car/buick/lacrosse-eassist":    "car/buick/lacrosse"    # renames.yml Buick: Lacrosse Eassist -> Lacrosse  [ca,us]
+"car/buick/wildcat-custom":      "car/buick/wild-cat"    # renames.yml Buick: Wildcat Custom -> Wild Cat  [fi,nl]

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -572,23 +572,158 @@ Buell:
 
 Buick:
   Lesabre: Le Sabre                           # spelling variant of "Le Sabre" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Lesabre Custom: Le Sabre Custom             # spelling variant of "Le Sabre Custom" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Sportwagon: Sport Wagon                     # spelling variant of "Sport Wagon" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Wildcat: Wild Cat                           # spelling variant of "Wild Cat" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "120L": "120 L"                             # spelling variant of "120 L" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Buick: null                                 # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
-  GS 350: GS350                               # spelling variant of "GS350" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
+  # NB `"120L": "120 L"` was DELETED here on 2026-08-01: neither the key nor the target "120 L" is
+  # produced by any raw row (measured over 1,310 buick raws, all six kinds, pipeline origin/main).
+  # The only genuinely dead key found by sweeping all 23 keys in the Cadillac/Chrysler/Buick blocks —
+  # every other one FIRES. Reachability counted in ROWS, never vehicles (american wave-6 dossier §A.5.1).
+  #
+  # NOT folded: `Encore Gx` — a separate marketed product. us_fueleconomy bases every "Encore GX" row
+  # at `Encore` and is NOT followed: its own year ranges certify the two CONCURRENTLY (Encore 2013-2022
+  # vs Encore GX 2020-2026), so one baseModel is covering two vehicles sold side by side, and
+  # https://www.buick.com lists `Encore GX` as a current model and does not list `Encore` at all.
+
+  # LeSabre (1959-2005) trims — https://en.wikipedia.org/wiki/Buick_LeSabre
+  Le Sabre 400: Le Sabre                      # "400" was a LeSabre trim/engine designation (fi/nl) — a spec, not a nameplate
+  Le Sabre Custom: Le Sabre                   # Custom is a LeSabre trim level; us_fueleconomy bases every LeSabre row at LeSabre — https://www.fueleconomy.gov/feg/download.shtml
+  Lesabre Custom: Le Sabre                    # REPOINT (was → "Le Sabre Custom"): unspaced registry spelling of the same trim; the settled "same car" statement survives one altitude up
+  Le Sabre Limited: Le Sabre                  # Limited is a LeSabre trim level — https://en.wikipedia.org/wiki/Buick_LeSabre
+
+  # Electra (1959-1990). "225" is the car's OVERALL LENGTH IN INCHES, used as the senior
+  #     Electra's designation — https://en.wikipedia.org/wiki/Buick_Electra
+  Electra 225: Electra                        # length-derived series designation ("a nod to the car's overall length of over 225 in"), not a separate nameplate
+  Electra 225 Custom: Electra                 # the 225 designation + the Custom trim
+  Electra Custom 225: Electra                 # the same two tokens inverted by the register
+  Electra Limited: Electra                    # Limited is an Electra trim level — https://en.wikipedia.org/wiki/Buick_Electra
+  Electra Park Avenue: Electra                # Park Avenue began as the Electra's top TRIM (1975-1990); the separate 1991-2005 `Park Avenue` record SURVIVES — us_fueleconomy carries both "Electra/Park Avenue" (to 1990) and "Park Avenue" (1991+) as bases
+  Electra/Park Avenue: Electra                # us_fueleconomy's own slash-joined string for the same 1984-90 car — SAME SLUG as the line above, so both must be keyed or the record republishes
+
+  # Century — https://en.wikipedia.org/wiki/Buick_Century
+  Century Caballero: Century                  # the 1957-58 Century Caballero was the four-door hardtop WAGON body
+  Century Wagon: Century                      # the station-wagon body of the Century. us_fueleconomy REFUTES (own baseModel "Century Wagon") while folding "Roadmaster Wagon" and "Skyhawk Wagon" into their parents — followed the majority; reversible in one line
+
+  # Skylark — https://en.wikipedia.org/wiki/Buick_Skylark
+  Skylark 350: Skylark                        # 350 = the 350 cu in engine; in the car kind engine size is a spec, not part of the nameplate (NAMING §6)
+  Skylark Custom: Skylark                     # Custom is a Skylark trim level
+  Skylark GS: Skylark                         # "a Gran Sport option became available in mid-1965" ON THE SKYLARK — an option package, not the standalone 1968-72 GS; the raw leads with SKYLARK
+
+  # GS / Gran Sport (the standalone 1968-72 model) — https://en.wikipedia.org/wiki/Buick_Gran_Sport
+  GS 400: GS                                  # 400 = the 400 cu in engine
+  GS 455 Stage 1: GS                          # 455 cu in + the Stage 1 performance package
+  GS350: GS                                   # 350 cu in
+  GS 350: GS                                  # REPOINT (was → "GS350"): the spaced spelling of the same engine variant; the settled "same car" statement survives one altitude up
+  Gran Sport: GS                              # what "GS" abbreviates — https://en.wikipedia.org/wiki/Buick_Gran_Sport
+  California GS: GS                           # the California GS was a regional appearance package (fi/nl)
+
+  # Riviera (1963-1999), the personal-luxury car — https://en.wikipedia.org/wiki/Buick_Riviera
+  Rivera: Riviera                             # registry misspelling (nl/nz)
+  Riviera 2: Riviera                          # door count, not a model: raws "Riviera 2-dr Sport Coupe", "RIVIERA 2 DOOR HARDTOP BOATTAIL"
+  Riviera GS: Riviera                         # Gran Sport was a Riviera option package
+
+  # Special (Series 40) and Super (Series 50). NB "Riviera" was ALSO Buick's 1949-58 HARDTOP-COUPE
+  #     BODY NAME on the Special/Super/Roadmaster — "The name Riviera … first entered the Buick line in
+  #     1949, as the designation for the new two-door pillarless hardtop" — a completely different thing
+  #     from the 1963 Riviera model, which is why the two lines below fold HERE and not to Riviera.
+  Special 40: Special                         # Series 40 IS the Special — https://en.wikipedia.org/wiki/Buick_Special
+  Special Series 40: Special                  # the same designation written out
+  Series 40 Special: Special                  # the same two tokens inverted by the register
+  Special Riviera: Special                    # the Special with the Riviera hardtop-coupe BODY — https://en.wikipedia.org/wiki/Buick_Riviera
+  Super 8: Super                              # the straight-eight engine on the Super — https://en.wikipedia.org/wiki/Buick_Super
+  Super Dynaflow: Super                       # Dynaflow is Buick's TRANSMISSION ("an optional automatic transmission") — https://en.wikipedia.org/wiki/Buick_Super
+  Super Eight: Super                          # the same engine, spelled out
+  Super Series 50: Super                      # Series 50 IS the Super
+  Super Riviera: Super                        # the Super with the Riviera hardtop-coupe BODY — https://en.wikipedia.org/wiki/Buick_Riviera
+  Eight Super: Super                          # the same two tokens inverted by the register
+
+  # Roadmaster / Regal / LaCrosse / Wildcat
+  Roadmaster 72: Roadmaster                   # Model 72 was the Roadmaster's four-door body code — https://en.wikipedia.org/wiki/Buick_Roadmaster
+  Roadmaster Wagon: Roadmaster                # us_fueleconomy bases "Roadmaster Wagon" at Roadmaster — https://www.fueleconomy.gov/feg/download.shtml
+  Regal Eassist: Regal                        # us_fueleconomy bases "Regal eAssist" at Regal — eAssist is GM's belt-alternator-starter mild-hybrid SYSTEM, not a model
+  Regal Ltd: Regal                            # Limited is a Regal trim level
+  Regal Tourx: Regal                          # us_fueleconomy bases "Regal TourX AWD" at Regal — TourX is the wagon body
+  Lacrosse Eassist: Lacrosse                  # us_fueleconomy bases "LaCrosse eAssist" at LaCrosse — https://www.fueleconomy.gov/feg/download.shtml
+  Wildcat Custom: Wild Cat                    # Custom is a Wildcat trim level. NB the fold target keeps the SETTLED spelling `Wild Cat`; Buick's own spelling is "Wildcat" and that DIRECTION question is FILED, not reversed here (reversing is a 4-country repoint)
 
 Bultaco:
   Brinco C: Brinco  # C/S/R are same-2kW equipment trims of the one Brinco e-moped platform (2015 revival); rename CREATES the Brinco nameplate (https://newatlas.com/bultaco-brinco-street-bikes/43202/)
 
 Cadillac:
-  Coupe Deville: Coupe De Ville               # spelling variant of "Coupe De Ville" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Deville: De Ville                           # spelling variant of "De Ville" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Eldorado: El Dorado                         # spelling variant of "El Dorado" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Lasalle: La Salle                           # spelling variant of "La Salle" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  Sedan Deville: Sedan De Ville               # spelling variant of "Sedan De Ville" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Cadillac: null                              # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
+
+  # Series 62 (1940-42, 1946-64) — the series NUMBER, in five registry spellings.
+  #     "The Series 62 (née 6200) designation was dropped after 1964" — https://en.wikipedia.org/wiki/Cadillac_Series_62
+  "62": Series 62                             # bare series number; raws "62", "62 CONVERTIBLE", "62 SEDAN DE VILLE" (fi/nl/nz) — https://en.wikipedia.org/wiki/Cadillac_Series_62
+  62 Series: Series 62                        # token order inverted; raw "62 SERIES" ×8 — SAME SLUG as the key below, so BOTH must be keyed
+  62-Series: Series 62                        # hyphenated form of the same string, lands on the same slug (`62-series`)
+  Sixty-Two: Series 62                        # the series number spelled out; raws "SIXTY-TWO COUPE", "SIXTY-TWO SEDAN 6-WINDOW" (fi/nl)
+  Sixty Two: Series 62                        # unhyphenated spelling of the same, SAME SLUG
+  Series 6200: Series 62                      # Cadillac's own internal designation for the 1959-64 Series 62 — "née 6200" — https://en.wikipedia.org/wiki/Cadillac_Series_62
+  Type 61: Series 61                          # raw "TYPE 61 COUPE DE VILLE" (nl) dates this to the 1949-51 Series 61, not the 1922 Type 61 — Coupe de Ville is a 1949+ Cadillac name (https://en.wikipedia.org/wiki/Cadillac_de_Ville_series). An INFERENCE from the raw; moves 2 vehicles and no countries
+
+  # De Ville (1958-2005). Coupe/Sedan de Ville are BODY STYLES: "The Cadillac Series 62 Coupe de
+  #     Ville was introduced late in the 1949 model year"; they "were moved to their own separate
+  #     series in 1959" — https://en.wikipedia.org/wiki/Cadillac_de_Ville_series
+  Coupe De Ville: De Ville                    # two-door body style of the de Ville — https://en.wikipedia.org/wiki/Cadillac_de_Ville_series
+  Sedan De Ville: De Ville                    # four-door body style of the de Ville — https://en.wikipedia.org/wiki/Cadillac_de_Ville_series
+  Coupe Deville: De Ville                     # REPOINT (was → "Coupe De Ville"): unspaced registry spelling of the same body style; the settled "same car" statement survives, one altitude higher
+  Sedan Deville: De Ville                     # REPOINT (was → "Sedan De Ville"): unspaced registry spelling of the same body style
+  De Ville 62: De Ville                       # the de Ville on the Series 62 chassis; raws "DE VILLE 62", "DE VILLE 62 CONVERTIBLE" (fi/nl) — a series number, not a nameplate
+  De Ville Fleetwood: De Ville                # Fleetwood was Cadillac's coachwork house, not a separate product here; raw "DE VILLE FLEETWOOD" (es/nl)
+  Deville Concours: De Ville                  # Concours was a DeVille trim level (1994-99); raw "DEVILLE CONCOURS" (fi/nl). us_fueleconomy REFUTES (own baseModel "DeVille/Concourse") — that string is a slash-joined certification grouping, not a product name
+  Deville Dts: De Ville                       # DTS = DeVille Touring Sedan, a DeVille TRIM until 2005: "For 2006, the DeVille nameplate was retired, when the model line was carried forward … as the Cadillac DTS" — https://en.wikipedia.org/wiki/Cadillac_de_Ville_series ; the 2006-11 `Dts` record stays separate
+  Armored Deville: De Ville                   # an armouring conversion of the DeVille, not a Cadillac product line. us_fueleconomy REFUTES (own baseModel); zero registrations either way, so the fold is evidence-neutral
+
+  # Eldorado (1952-2002) — https://en.wikipedia.org/wiki/Cadillac_Eldorado
+  Eldorado Biarritz: El Dorado                # Biarritz = the Eldorado convertible/cabriolet trim ("Biarritz returned as an up level trim package for the Eldorado for 1976 until 1991"); raws "ELDORADO BIARRITZ" (fi/nl/nz)
+  Eldorado Biarriz: El Dorado                 # registry misspelling of Biarritz, same car
+  Eldorado Seville: El Dorado                 # the 1956-60 Eldorado Seville was the Eldorado's HARDTOP COUPE body (the convertible was the Biarritz) — unrelated to the 1975-2004 Seville; raw "ELDORADO SEVILLE COUPE"
+  Eldorado Touring: El Dorado                 # Eldorado Touring Coupe = the ETC trim; raw "ELDORADO TOURING COUPE-EL1-9/274" (fi) carries the Finnish type code too
+  Fleetwood Eldorado: El Dorado               # 1965-78 the Eldorado was marketed inside the Fleetwood series; the product is the Eldorado — raws "FLEETWOOD ELDORADO CONVERTIBLE"
+
+  # Fleetwood family — https://en.wikipedia.org/wiki/Cadillac_Fleetwood
+  Fleetwood Broughan: Fleetwood Brougham      # registry misspelling of Brougham (nl/nz); the Fleetwood Brougham record SURVIVES — us_fueleconomy gives it its own baseModel
+  Fleetwood Seventy Five: Fleetwood 75        # the Series 75 limousine, series number spelled out (fi/nl)
+  Fleetwood Seventy-Five: Fleetwood 75        # hyphenated spelling of the same string — SAME SLUG, so both must be keyed
+  Fleetwood 60 Special: Sixty Special         # Series 60 Special; Cadillac's own name is "Sixty Special" (1938-1993) — https://en.wikipedia.org/wiki/Cadillac_Sixty_Special
+  Fleetwood 60S: Sixty Special                # "60S" = Sixty Special, glued registry form
+  Fleetwood Sixty Special: Sixty Special      # the Fleetwood prefix is the coachwork house; the product is the Sixty Special
+
+  # Seville (1975-2004): SLS and STS are its two trim levels — https://en.wikipedia.org/wiki/Cadillac_Seville
+  Seville Sls: Seville                        # SLS = Seville Luxury Sedan, a trim
+  Seville Sts: Seville                        # STS = Seville Touring Sedan, a trim. The separate 2005-11 `Sts` record is a DIFFERENT car and SURVIVES (own us_fueleconomy baseModel)
+
+  # V-Series and drivetrain suffixes. us_fueleconomy bases "CT4 V"→CT4, "CT5 V"→CT5,
+  #     "Escalade V AWD"→Escalade and "CTS V"→CTS, but SELF-CONTRADICTS on the hyphenated forms.
+  Cts 4: Cts                                  # "CTS4" is Cadillac's AWD designation, not a model — us_fueleconomy bases every "CTS AWD" row at CTS
+  Cts-V: Cts                                  # V-Series performance trim; us_fueleconomy files "CTS-V" under BOTH CTS (9 rows) and CTS-V (1) — folded on the majority plus the uncontradicted CT4 V / CT5 V / Escalade V treatment
+  Ats-V: Ats                                  # V-Series performance trim; us_fueleconomy files "ATS-V" under BOTH ATS (2 rows) and ATS-V (6) — the opposite majority; the weakest of the three V-Series folds, taken on the same rule
+  Sts-V: Sts                                  # V-Series performance trim. us_fueleconomy REFUTES cleanly here (STS-V has its own baseModel, 4 rows, no contradiction) — folded on the marque's own V-Series-is-a-trim usage; reversible in one line
+
+  # GM order / Finnish type codes prefixed to the nameplate
+  6EB26 Srx: Srx                              # GM body/order code prefixed to the nameplate; raw "6EB26 SRX" ×72 (fi/nl) — the code is not part of any Cadillac name
+  6RB26 Srx: Srx                              # same shape, second code (raw "6RB26 SRX" ×34)
+  6YV67 Xlr: Xlr                              # same shape on the XLR
+  K10706-Escalade: Escalade                   # same shape on the Escalade; raw "K10706-ESCALADE" (fi/nl)
+  K10706 Escalade: Escalade                   # the spaced spelling of the same code, raw "K10706 - ESCALADE" — SAME SLUG, both must be keyed
+
+  # Escalade wheelbase/body variants. us_fueleconomy bases "Escalade ESV 2WD/4WD/AWD",
+  #     "Escalade Ext AWD", "Escalade Hybrid" and "Escalade V AWD" ALL at Escalade —
+  #     https://www.fueleconomy.gov/feg/download.shtml
+  Escalade Esv: Escalade                      # ESV = the long-wheelbase body; us_fueleconomy baseModel Escalade
+  Escalade Esv Sport: Escalade                # the ESV body + the Sport trim
+  Escalade Ext: Escalade                      # EXT = the 2002-13 pickup body; us_fueleconomy baseModel Escalade. FIRES IN car AND van — intended, both are EXT records. A pickup body folded into an SUV is arguable and is flagged, not hidden
+  # NOT folded: `Escalade Iq` — a distinct BEV product with its own Wikipedia article, listed as its
+  # own model on https://www.cadillac.com (ESCALADE IQ / ESCALADE IQL alongside ESCALADE / ESCALADE ESV)
+
+  # Coachbuilt bodies and one typo
+  Dts Hearse: Dts                             # a funeral-coach body on the DTS chassis; us_fueleconomy bases "XT5 Hearse AWD" at XT5 — https://www.fueleconomy.gov/feg/download.shtml
+  Xts Hearse: Xts                             # same, on the XTS. us_fueleconomy REFUTES here specifically (own baseModel "XTS Hearse", 7 rows) while folding the XT5 hearse — the two treatments cannot both be right; followed the XT5 precedent
+  Limosine: Limousine                         # registry misspelling of Limousine (nl/nz). NB the target is itself a bare body word and is deliberately KEPT, not nulled: us_fueleconomy gives `Limousine` its own baseModel across 16 rows (MY1984-2011) — Cadillac's professional-car chassis were a separately-certified product line
 
 Cagiva:
   "125 Mito":                                "Mito 125"                     # PERMUTATION FOLD (verified batch, tier A): AGAINST THE RAW TOTAL (359 vs 224), because the 359 is one register contradicting itself while the manufacturer's own type designation and three other registers agree on Mito-first.
@@ -889,13 +1024,59 @@ Chrysler:
   300C Srt-8: 300C SRT8                       # the badge is the unhyphenated SRT8 (https://en.wikipedia.org/wiki/Chrysler_300, first-gen LX 2005-2010); nl_rdw "300C SRT8" n=42 vs "300C SRT-8" n=4
   300C-Srt-8: 300C SRT8                       # fully hyphenated register shape, same car ("CHRYSLER 300C-SRT-8")
   "300C/SRT-8": 300C SRT8                     # slash shape, same car — third produced form. NB the existing "300C": "300 C" line contradicts the source cited above; filed as debt, not repointed here (9-country id)
-  Town&country LX: Town & Country       # fueleconomy.gov spells it without spaces + trim; official name has them
-  Town&country Touring: Town & Country  # same, Touring trim
+  Town&country LX: Town & Country       # fueleconomy.gov spells it without spaces + trim; official name has them. KEPT — it FIRES (1 row); deleting it would re-mint a record
+  Town&country Touring: Town & Country  # same, Touring trim. KEPT — NOT a dead key: it FIRES on 4 vehicles (nl_rdw ×3, fi_traficom ×1), measured with the pipeline's own key? probe. DEBT.md's "dead key" line was a FALSE DIAGNOSIS, corrected 2026-08-01 (data#147): the slug stayed alive through the UNKEYED sibling `Town & Country Touring` (15 veh), which is now keyed below
   "300C": "300 C"                             # spelling variant of "300 C" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "300M": "300 M"                             # spelling variant of "300 M" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
-  "300S": "300 S"                             # spelling variant of "300 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Lebaron: Le Baron                           # spelling variant of "Le Baron" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Chrysler: null                              # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
+
+  # The modern 300 (LX/LD, 2005-2023). `300 C`, `300 M`, `300 H`, `300L`, `C300` and `300C SRT8`
+  #     are DIFFERENT CARS and all SURVIVE. us_fueleconomy's baseModel is REFUTED here and NOT
+  #     followed: it bases `300 M` (MY1999-2004) and `300C AWD` (MY2005-06) at `300`, which would
+  #     merge the 1999 LH-platform FWD 300M, the LX 300C and the LX/LD 300 — three different cars —
+  #     while promoting `300 SRT8` to its own baseModel two rows away. https://en.wikipedia.org/wiki/Chrysler_300
+  #     NOT folded either: `300C SRT8` and its three settled keys (`300C Srt-8`, `300C-Srt-8`,
+  #     `300C/SRT-8`) — all three FIRE, and `300C/SRT-8` is reachable through exactly ONE
+  #     us_fueleconomy row carrying count 0. A fold there would repoint settled curation on an
+  #     oracle that contradicts itself two rows away. Reachability is counted in ROWS, never vehicles.
+  300 S: "300"                                # 300S is a trim level of the modern 300 (2012+); raws "300 S" (fi/nl/ua)
+  "300S": "300"                               # REPOINT (was → "300 S"): the same trim, unspaced registry form; the settled statement survives one altitude up
+  300 Touring: "300"                          # Touring is a 300 trim level; raws "300 TOURING" (nl/ua)
+  300 Hurst: "300"                            # the 1970 Chrysler 300 Hurst was a limited appearance/performance package on the 300 — https://en.wikipedia.org/wiki/Chrysler_300 ; raw "300 HURST" (fi/nl)
+  Three Hundred: "300"                        # the designation spelled out; raws "THREE HUNDRED", "THREE HUNDRED COUPE" (fi/nl)
+
+  # Town & Country. The marque writes it with the ampersand. SEVEN produced display spellings
+  #     land on the one slug and ALL of them are keyed or display-pinned below — keying only the
+  #     obvious one would have let the record republish under another form and the retirement would
+  #     have silently failed. https://en.wikipedia.org/wiki/Chrysler_Town_%26_Country
+  Town And Country: Town & Country            # the ampersand spelled out — the EPA's own spelling ("Town and Country" baseModel, https://www.fueleconomy.gov/feg/download.shtml). THIS FOLD CARRIES `us` ONTO THE SURVIVOR, which is a North American minivan that carries no US availability today
+  Town & Country Touring: Town & Country      # Touring is a T&C trim level; raws "TOWN & COUNTRY TOURING" (nl_rdw 11 + fi_traficom 4 = 15 vehicles). THIS is the unkeyed sibling that kept `car/chrysler/town-country-touring` alive and made the existing `Town&country Touring` key look dead
+  Town Country Touring: Town & Country        # ampersand dropped by the register; SAME SLUG as the line above
+  Town&country-Touring: Town & Country        # ampersand glued + hyphen; SAME SLUG again — raw "TOWN&COUNTRY-TOURING" (nl)
+  Town Country: Town & Country                # DISPLAY PIN: 47 vehicles publish this form on the survivor's own slug (nl 23, ua 18, fi 4) — without the pin the display flaps by row count (NAMING §7.6 rule 3)
+  Town&country: Town & Country                # DISPLAY PIN: 46 vehicles (nl 22, fi 22, lu 1, nz 1)
+  Town+country: Town & Country                # DISPLAY PIN: 5 vehicles (nl) — the register wrote "+" for "&"
+  Town-Country: Town & Country                # DISPLAY PIN: 3 vehicles (fi/nl)
+  Town &country: Town & Country               # DISPLAY PIN: 2 vehicles (fi/nl)
+  Town& Country: Town & Country               # DISPLAY PIN: 2 vehicles (fi/nl)
+
+  # Trims and bodies of live nameplates
+  Crossfire Roadster: Crossfire               # us_fueleconomy bases "Crossfire Coupe" AND "Crossfire Roadster" at Crossfire — the body split is not a product split — https://www.fueleconomy.gov/feg/download.shtml
+  Crossfire SRT6: Crossfire                   # SRT-6 is the supercharged trim of the Crossfire
+  Sebring LX: Sebring                         # LX is a Sebring trim; us_fueleconomy bases "Sebring 4 Door"/"Convertible"/"AWD" at Sebring
+  Pacifica Limited: Pacifica                  # Limited is a Pacifica trim; us_fueleconomy bases every Pacifica row (2WD/AWD/FWD/Hybrid) at Pacifica
+  Pacifica Touring L: Pacifica                # Touring-L is a Pacifica trim
+  Pacifica Touring-L: Pacifica                # hyphenated spelling — SAME SLUG, both must be keyed
+  Newport Custom: Newport                     # Custom was a Newport trim level — https://en.wikipedia.org/wiki/Chrysler_Newport
+  Newport Royal: Newport                      # Royal was a Newport trim level (1970s)
+  Windsor Deluxe: Windsor                     # De Luxe was a Windsor trim level — https://en.wikipedia.org/wiki/Chrysler_Windsor
+  Windsor Nassau: Windsor                     # Nassau was the Windsor's two-door hardtop BODY name
+  Royal Eight: Royal                          # the straight-eight engine variant of the Chrysler Royal — an engine, not a nameplate — https://en.wikipedia.org/wiki/Chrysler_Royal
+  Imperial Crown: Imperial                    # Crown was the Imperial's senior trim level (by 1967 "the Imperial Division, offering three ranges (Custom, Crown, and LeBaron)") — https://en.wikipedia.org/wiki/Chrysler_Imperial
+  Crown Imperial: Imperial                    # the same designation with the tokens inverted (the limousine)
+  Imperial Le Baron: Imperial                 # LeBaron was the Imperial's TOP TRIM (and a coachbuilder name), NOT the separate 1977-95 Chrysler LeBaron — the `Le Baron` record SURVIVES
+  Charger R/T: Charger                        # R/T is the performance trim of the Australian Chrysler Valiant Charger; raws "CHARGER R/T" (nl/nz) beside "CHARGER XL" — https://en.wikipedia.org/wiki/Chrysler_Valiant_Charger
 
 Citroën:
   # ── casing-contradiction batch: the BX family finished (BX 16/19 TRS were


### PR DESCRIPTION
**97 of 270 records (35.9%) under `cadillac`, `chrysler`, `buick` were not models.** They are trims, engine badges, series numbers, body styles, coachbuilt conversions, GM order codes and registry typos hanging off 45 live nameplates. This folds them: **115 rename keys** (110 new + 5 repoints), **97 `former_ids` aliases**, **zero `removals.yml` entries** — every fold has an honest survivor.

**Merge order: this PR FIRST, then the pipeline enrich PR — vehiclesdb/vehiclesdb-pipeline#110.** The enrich side declares 110 model ids that must be live *after* these folds; it was linted against the post-fold build and passes either way, but data-first is the measured order.

---

## Everything here was re-measured, not inherited

The dossier that proposed this batch was written against data HEAD `0bfd291`; several of tonight's slices found dossier numbers wrong, so **every number below is from my own control-vs-treatment build pair** (pipeline `origin/main` @ `1134cd2`, data `origin/main` @ `966dc20`, same cache, both builds exit 0, `validate: ALL GATES GREEN`). Comparing against the shipped `catalog/` would have been wrong — it is a monthly build output and other waves have landed since.

| claim | dossier | measured here | verdict |
|---|---|---|---|
| records in slice | 270 (cad 95 / chr 89 / bui 86) | 270 (95 / 89 / 86) | **verified** |
| records retiring | 97 (39 / 20 / 38) | 97 (39 / 20 / 38) | **verified** |
| survivors | 173 (56 / 69 / 48) | 173 (56 / 69 / 48) | **verified** |
| rename keys | 115 = 110 new + 5 repoints | 115; blocks 6→48, 10→39, 7→45 | **verified** |
| `former_ids` appended | 97 | 97 (5,288 → 5,385) | **verified** |
| `removals.yml` | 0 | 0 | **verified** |
| `(country,source)` pairs lost | 0 | **0** | **verified** |
| strict gains | 1 | **1**, identical | **verified** |
| cross-kind casualties | 0 | **0** | **verified (stronger, see below)** |
| slice availability rows | 834 → 615 | 834 → **616** | **corrected** |
| `cadillac/srx` van shadow | "pruned at share 0.9932" | never published, so never pruned | **corrected (mechanism)** |
| EPA `baseModel` triples | 246 (cad 114 / chr 75 / bui 57) | 246 (114 / 75 / 57) | **verified** |
| EPA coverage floor | MY1984 | min year = **1984** in all three makes | **verified** |
| Cadillac self-contradictions | "4, every one a V-Series **or a hearse**" | **2, both V-Series** | **corrected** |

**The two corrections, stated plainly.**

1. **834 → 616, not 615.** The dossier subtracted the 219 deduplicated rows but did not add back the row the one gain creates: 834 − 219 + 1 = 616. Arithmetic, not a defect.
2. **`cadillac/srx` does acquire a van shadow, but it is never pruned.** The dossier said the van rows behind `6EB26 Srx`/`6RB26 Srx` merge into a 2-vehicle `van/cadillac/srx` which `cross_kind_prune!` then prunes at 0.9932. Measured: they merge into a van **candidate** (`build/candidates/van.jsonl`: `{"id":"cadillac/srx","counts":{"nl":2}}`), which never reaches publication — and `cross_kind_prune!` only ever sees published models. So it is never pruned and the prune counts do not move. The conclusion the dossier drew (nothing is lost) holds; the mechanism it named does not.
3. **Cadillac's `baseModel` self-contradicts TWICE, not four times, and no hearse is involved.** Re-derived from `cache/us_vehicles.csv` col 66 (819 Cadillac rows / 114 triples), counting a self-contradiction as *one `model` string filed under two different `baseModel`s*:
   ```
   "CTS-V" -> CTS x9 | CTS-V x1
   "ATS-V" -> ATS-V x6 | ATS x2
   ```
   Both are V-Series; there is no hearse contradiction. The dossier's per-string evidence (9-vs-1, 6-vs-2) is exactly right — only the headline count and the "or a hearse" are wrong. The hearse case is a different defect: the EPA treats `XTS Hearse` (own baseModel) and `XT5 Hearse AWD` (bases at XT5) *inconsistently across two nameplates*, which is inconsistent **treatment**, not self-contradiction on one string. Chrysler and Buick have **zero** self-contradictions.

Two dossier measurements have simply **drifted with the corpus**, recorded so the next reader does not think something broke: review-pack raw rows are now buick 1,310 (unchanged, fingerprint `d8e70cd12f2a…` **identical**), cadillac 1,848 (was 1,846), chrysler 2,077 (was 2,093), with correspondingly new cadillac/chrysler fingerprints. The fold set is unaffected — all 97 sources and all 40 targets were re-confirmed live in my own control build.

---

## The blast-radius result

```
control build   14,542 published ids
treatment build 14,445 published ids
ids REMOVED     97
ids ADDED        0
```

**The 97 removed ids are byte-for-byte the 97 fold sources** (`diff` of the two sorted lists is empty). Zero collateral in any make, any kind.

## Availability: 0 lost, 1 gain

Replayed over both **built catalogs**, not over the override files:

```
1. (country,source) pairs LOST by the 97 folds ............ 0
2. surviving records that lost a pair, CATALOG-WIDE ....... 0
3. records that GAINED a pair ............................. 1
     car/chrysler/town-country += [["us","us_fueleconomy"]]
```

`car/chrysler/town-country` goes `ca,fi,gb,lu,nl,nz,ua` → `ca,fi,gb,lu,nl,nz,ua,us`. It is a *North American* minivan that carried no US availability at all; folding `Town And Country` (the EPA's own spelling) carries `us` onto it. Strictly additive — every prior country retained.

## CHECK 1 — landing slugs, re-run not trusted

Enumerated with the pipeline's own recorder (`gen_review_pack.rb`, whose `RecordingRenameBlock#key?` is the reachability event `normalizer.rb` fires once per surviving row), on the pre-fold tree. **Seven retired slugs receive more than one produced display form, and every extra form is keyed in this PR:**

| retired slug | produced display forms landing on it |
|---|---|
| `car/cadillac/62-series` | `62 Series` · `62-Series` |
| `car/cadillac/sixty-two` | `Sixty Two` · `Sixty-Two` |
| `car/cadillac/fleetwood-seventy-five` | `Fleetwood Seventy Five` · `Fleetwood Seventy-Five` |
| `car/cadillac/k10706-escalade` | `K10706 Escalade` · `K10706-Escalade` |
| `car/chrysler/town-country-touring` | `Town & Country Touring` · `Town Country Touring` · `Town&country-Touring` |
| `car/chrysler/pacifica-touring-l` | `Pacifica Touring L` · `Pacifica Touring-L` |
| `car/buick/electra-park-avenue` | `Electra Park Avenue` · `Electra/Park Avenue` |

Had only the obvious spelling been keyed in any of these seven, the record would have republished under the other form and the retirement would have silently failed — the BMW `R-Serien` gotcha. The **`ids ADDED = 0`** line above is the empirical proof that none of them did.

**And the survivor result this slice was sent to find.** `car/chrysler/town-country` receives **SEVEN distinct produced display spellings**:

```
Town & Country · Town &country · Town Country · Town& Country
Town&country   · Town+country  · Town-Country
```

Six are keyed as display pins in this PR; the seventh **is** the canonical. Without the pins the published display flaps by row count between releases (NAMING §7.6 rule 3). The treatment build publishes `Town & Country`.

## CHECK 2 — cross-kind dominance, re-run not trusted

Rather than replay `reconciler.rb:105-130`'s arithmetic, I diffed the reconciler's **own prune output** across the two builds:

```
CONTROL                                    TREATMENT
cross-kind prune van:        -291    ==    -291
cross-kind prune motorcycle:  -26    ==     -26
cross-kind prune car:         -33    ==     -33
cross-kind prune truck:       -14    ==     -14
cross-kind prune bus:         -18    ==     -18
cross-kind prune moped:       -19    ==     -19
```

**Byte-identical in all six kinds.** This batch changes the prune set by exactly zero records. `van/cadillac/escalade` survives with `fi,gb,nl` intact (the dossier's gb 22 · fi 6 · nl 97), and `van/cadillac/escalade-ext` folds into it — the one fold that moves real mass between kinds, and it is safe.

## `propose_former_ids` — the before/after that settles DEBT line 74

Same two `dist/vehicles.csv` files, run once from each override set:

```
baseline overrides (origin/main):  intents=15172  proposed=1  dead_keys=0  evidence_loss=0  unexplained=96
this PR's overrides:               intents=15352  proposed=0  dead_keys=0  evidence_loss=0  unexplained=0
```

The single thing the **baseline** can explain is:

```
"car/chrysler/town-country-touring": "car/chrysler/town-country"
    # renames.yml Chrysler: Town&country Touring -> Town & Country
```

**The tool attributes the retirement to the very key three agents reported as dead.** It fires. It has always fired. This is the mechanism data#147 (landed by the owner while this was in flight) already records, reproduced independently here.

---

## The `Town & Country` work — the most valuable thing in the batch

**`Chrysler "Town&country Touring"` is NOT a dead key and is KEPT.** It fires on 4 vehicles (`nl_rdw` ×3, `fi_traficom` ×1). What was actually broken is that a **different, unkeyed spelling** — `Town & Country Touring`, 15 vehicles — reached the same slug and kept `car/chrysler/town-country-touring` alive, so a catalog-side tool saw the key change nothing. **The fix is an ADD of the unkeyed siblings, never a re-key or a delete.** This PR adds all three siblings and pins all six non-canonical survivor spellings.

`Chrysler "Town&country LX"` (1 row) and the three `300C SRT8` keys are KEPT for the same reason — all fire.

### Method finding for the next apply agent: **count reachability in ROWS, never in vehicles**

`Chrysler "300C/SRT-8"` is reachable through **exactly one `us_fueleconomy` row, and that row carries `count = 0`** — catalog sources carry no registration counts. Any reachability test that sums *vehicles* calls such a key dead and deletes it, and the next build re-mints the record it was suppressing. This is the **same zero-count hazard the brief flags for `cross_kind_prune!`, surfacing in a second, unrelated mechanism**, and it is a plausible contributor to the DEBT line-74 false positives. Every reachability number in this PR is a **row** count.

### The one genuinely dead key

`Buick "120L": "120 L"` is **deleted with a comment**. Zero producing rows, and its target `120 L` is not a live record either — generated boilerplate with no source and no destination. It is the only dead key among all 23 pre-existing keys across the three blocks; the other 22 fire.

---

## What is deliberately NOT here

**All 12 §E refusals stand.** Each is a separate evidence problem with a separate resolver.

* **22 bare body-style records / 422 vehicles** (`Coupe` 198+3, `Convertible`, `Hearse`, `Tourer` 28, `Roadster` 20, `Limousine`, `De Luxe`, `Six`, …). Ford's wave settled this class: these are unquestionably not models, they have **no unambiguous target**, and nulling them deletes real registrations with no honest target. **They stay live.** Resolves with the per-row NL RDW / NZ NZTA / FI Traficom first-registration year + body code + displacement. (`car/cadillac/limousine` and `commercial-chassis` are NOT in this class — each has its own `us_fueleconomy` baseModel.)
* **`300C SRT8`** and its three settled keys — see above.
* **Cross-make moves** (`car/chrysler/jeep` 717 veh, `cherokee`, `grand-cherokee`, `cj`, `plymouth`, `dodge`, `de-soto`, `truck/chrysler/ram`, `car/buick/marquette`, `car/cadillac/la-salle`). Reported only; `moves.yml` questions needing the make-boundary owner, and two would MINT a make. NB `car/chrysler/charger` (401 veh, the Australian Valiant Charger) and `car/chrysler/dodge-charger` are **different cars** — do not merge.
* **Numeric/short stubs** (`452` = the V-16's Series 452 from its own raws `452 V-16`/`452-A Sedan`, `Model K`, Chrysler `70`/`72`/`75`, Buick `10`, `Sd`, `Ch`, `Cm`, `G70`…). NAMING §2.1: a bare integer under an old marque is a **parser** suspect before it is a **data** suspect, and these are multi-source.
* **Five survivor display flaps** (§E.6) — `Pt Cruiser`/`Pt-Cruiser`, `Grand Voyager`/`Grand-Voyager`, `Grand Cherokee`/`Grand-Cherokee`, `Park Avenue`/`Park-Avenue`, `Estate Wagon`/`Estate-Wagon`. Re-confirmed still present and still unkeyed; a different change class from a fold.

### The `baseModel` oracle is THREE DIFFERENT ORACLES, per make

The filed "baseModel oracle" DEBT item needs this stated per make, so:

All figures below are **re-derived** from `cache/us_vehicles.csv` col 66, not inherited:

| make | rows / triples | self-contradictions | verdict | how it was used |
|---|---|---|---|---|
| **Buick** | 728 / 57 | **0** | **well-behaved** | followed |
| **Chrysler** | 768 / 75 | **0** | **trim-only** — clean on trims, **wrong about the 300 family** | followed for trims; **refuted** on `300`/`300 M`/`300C` |
| **Cadillac** | 819 / 114 | **2** (`CTS-V`, `ATS-V`) | **self-contradicting**, both on V-Series | tiebreak only, never alone |

Note the shape: Chrysler's failure is *not* self-contradiction — its baseModel is internally consistent and **substantively wrong**, which is the harder case to catch. Cadillac's is the opposite: visibly inconsistent, therefore safe to distrust.

It is also **blind to ~60% of the slice**: the minimum `year` in all three makes is **1984** (verified), and these marques date from 1899, 1902 and 1925 (cadillac 55/95 records pre-1984, buick 60/86, chrysler ~40/89). Every Series 62, Fleetwood, Newport, Windsor, Royal, Special, Super, Roadmaster, Invicta, Centurion, Imperial and Charger decision rests on Wikipedia + the raw strings.

**Refutations taken as reasoned, not followed mechanically:**

* **Chrysler `300` / `300 M` / `300C`** — the EPA bases `300 M` (MY1999-2004) and `300C AWD` (MY2005-06) at `300`. That merges **three different cars**: the 1999 LH-platform FWD 300M, the LX 300C, and the LX/LD 300 — while promoting `300 SRT8` to its own baseModel two rows away. **Not followed.** `300 C`, `300 M`, `300 H`, `300L`, `C300`, `300C SRT8` all keep their own records.
* **Cadillac V-Series** (`Cts-V`, `Ats-V`, `Sts-V`) — the oracle contradicts itself on exactly the hyphenated forms, and these two contradictions are the *only* two it has (re-derived above): `CTS-V` filed under both `CTS` ×9 and `CTS-V` ×1; `ATS-V` under both `ATS-V` ×6 and `ATS` ×2 — *opposite* majorities. Folded on the uncontradicted `CT4 V`→CT4 / `CT5 V`→CT5 / `Escalade V`→Escalade treatment plus the marque's own V-Series-is-a-trim usage. `Ats-V` therefore goes **against** its own majority and is the weaker of the two. **`Sts-V` is the most refutable line in the batch** — the EPA gives STS-V its own baseModel with no contradiction at all. Reversible in one line; it costs 1 vehicle and 2 countries the target already has.
* **Buick `Encore GX`** — the EPA bases every `Encore GX` row at `Encore`. **Not followed:** its own year ranges certify the two *concurrently* (Encore 2013-2022 vs Encore GX 2020-2026), so one baseModel covers two vehicles sold side by side, and buick.com lists `Encore GX` and no `Encore`.
* **Also refuted-but-folded, each reversible in one line:** `Century Wagon` (EPA gives it its own base while folding `Roadmaster Wagon` and `Skyhawk Wagon` — followed the majority), `XTS Hearse` (own base, while `XT5 Hearse AWD` bases at XT5), `Deville Concours`, `Armored Deville`.

### ⚠ TEN KEYS DEPEND ON TODAY'S TITLE CASE — do not "tidy" the casing

`Cts-V`, `Ats-V`, `Sts-V`, `Cts 4`, `6EB26 Srx`, `6RB26 Srx`, `6YV67 Xlr`, `Dts Hearse`, `Xts Hearse`, `Seville Sts` are written in the Title Case the caser produces **today**. Cadillac's letter-only designations publish `Cts` `Sts` `Srx` `Xlr` `Dts` `Ats` `Elr` `Bls` `Xts` while its digit-bearing ones publish correctly (`CT4` `CT5` `XT4` `XT5`), because `case_token` returns digit-bearing tokens unchanged.

**The caser runs BEFORE renames.** An `acronyms:` pin for any of those nine tokens **silently orphans every key above**. NAMING §9 already forbids shipping such a pin in the same PR as keys that depend on it; this is the concrete list to rewrite when that pass happens. Nine of the tokens are on NAMING §9's 4W-owned list. Same class: `Lyriq`/`Optiq`/`Vistiq`/`Celestiq` (marque writes them in caps) and Buick's `Lacrosse` (marque: `LaCrosse`).

**Direction questions flagged, never reversed:** `Wild Cat` vs Wildcat, `Le Sabre` vs LeSabre, `Le Baron` vs LeBaron, `El Dorado` vs Eldorado (**679 vehicles / 6 countries ride on the settled direction — do not drive-by reverse**), `Lacrosse` vs LaCrosse, `De Ville` vs de Ville. Four of the six exist because a settled rename already chose the spaced form, so the fix is a repoint of settled curation, not a new line.

### Pipeline findings: REPORTED, not patched

Neither is in this PR, and **no rename line here anticipates either rescue** (verified: zero keys match `/\ANew\b/i`, zero match `/\A\d[DdRr]\b/`). If a build shows those records changing, that is the other agent's change landing, not this one.

* **`junk?`'s `\ANew\b` clause destroys `Chrysler New Yorker`** — 241 vehicles, 7 countries, 7 sources, the marque's flagship 1940-1996, before it can become a record. Catalog-wide the clause costs 9,848 vehicles across 155 (make,key) pairs (Kymco `New Like` 2,981; Suzuki `New SX4` 299); the genuine placeholders it exists to catch total **2 vehicles** (VW `New`, Porsche `New`). Remedy is a one-line rule change (`\ANew\b` → `\ANew\z`), not 37 override lines — the family produces 37 distinct probe keys and NAMING §4 caps override-line workarounds at ~20.
* **`\A\d[A-Z]\b` eats door counts** — 1,178 vehicles in this slice (59% of everything it loses to `junk?`), 51,234 catalog-wide. `2D ELDORADO COUPE`, `4D PT CRUISER HATCHBACK`, `4D SEBRING SEDAN` — real nameplates with a body prefix.

---

## Verification run

| check | result |
|---|---|
| `scripts/lint_curation.rb` (and `--base=origin/main`) | **OK** — 109 files |
| `scripts/lint_overrides.rb` | **OK** |
| `scripts/reorg_make_blocks.rb --check` | **already alphabetical** |
| `scripts/lint_plates.rb` | **exit 0** |
| `scripts/gen_ownership.rb` | **no diff** |
| `scripts/lint_dataset.rb --report` | unexplained 7 · debt 322 · escapes 0 — **identical to baseline** |
| `pipeline/tests/test_override_key_reachability.rb` | **5 runs, 10 assertions, 0 failures** |
| `rake test` (pipeline) | **0 failures, 0 errors** |
| full `pipeline/run.rb` | **exit 0, `validate: ALL GATES GREEN`** |
| `scripts/propose_former_ids.rb` | `proposed=0 dead_keys=0 evidence_loss=0 unexplained=0` |
| `former_ids` chains / cycles | **0** |
| `lint_curation` rule 1g (aliased AND removed) | **0** |

### Adaptations made while applying, and why

1. **`former_ids` chain flattening was mandatory, not optional.** The dossier left it conditional on "check whether the loader follows chains". It does not — `lint_curation` rule 1f **fails** on them. The 5 pre-existing aliases whose targets this batch retires are repointed straight at the final target, using the `# FLATTENED` comment precedent already in the file: `car/buick/gs-350`, `car/buick/lesabre-custom`, `car/cadillac/coupe-deville`, `car/cadillac/sedan-deville`, `car/chrysler/300s`. A full sweep of all 5,288 existing aliases found exactly these 5 and no others; 0 of my 97 new keys already existed; 0 collide with `removals.yml` (rule 1g).
2. **`# ---` section banners had to go.** `reorg_make_blocks.rb` defines `BANNER = /\A\s*#\s*(={3,}|-{3,})/` and **strips such lines by design** (NEGOTIATION Turn 6 §5), which failed `--check`. The dossier's 20 section headers were rewritten without the dash run; no wording lost.
3. **Trailing block comments relocated.** Comments at the *end* of a make block are re-attached to the *next* block by `split_blocks`, also failing `--check`. The two "NOT folded" notes (Buick `Encore Gx`, Chrysler `300C SRT8`) now sit inside their own blocks above a key line.
4. **DEBT.md deliberately untouched.** The owner landed the correction as **data#147** while this was in flight; this branch is rebased onto it and cites it rather than re-editing. The `hyundai Atos-Prime` third was not measured here and must not be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### CI: both gates green — and a note on a red baseline that resolved mid-flight

```
lint   pass
build  pass   (Build & publish data, run 30695454304)
              → Run pipeline tests: "enrich lint: 75 files, 1847 ids / enrich lint: OK"
```

Recorded because it shaped my measurements: when I took my baseline, `rake test` was **red on clean main** with 7 `lint_enrich` liveness failures in `enrich/alfa-romeo.yml` and `enrich/maserati.yml` (`car/alfa-romeo/{4c,6c,8c,alfa-6}`, `car/maserati/{sebring,mc12,mcpura}`), from pipeline#107. I reproduced them on an untouched `origin/main` pair before editing anything, and they were failing the same check on other agents' PRs at the time (`s4w/kia-skoda-folds` run 30694929164, `s2w/harley-electra` run 30695075391). All 7 ids were live in a *fresh* build but absent from the committed `catalog/` that `lint_enrich` measures against by default.

**That has since been fixed by someone else** — pipeline#109 ("hold back 7 Italian entries whose ids the catalog does not carry yet — main's lint was red") removed those entries, and this PR's build is green on current main. Nothing in this batch was affected either way: it added zero `lint_enrich` failures under either measurement, before or after that fix.
