### PR TITLE
DECISIONS: the fold safeguard — check for a contradicting published record, not a pattern

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -34,6 +34,41 @@ altitude honestly; pretending to trim-level accuracy from it would be a lie.
 Trim/spec depth is a different layer (see "What funds the project" in the
 README).
 
+**Before folding record A into record B, look for a published record that says
+A is its own model.** Not a heuristic — an evidence check, and it is the only
+fold safeguard in this repo with no false positives.
+
+Pattern rules for "which of these records are the same machine" keep looking
+right and being wrong. Four were tried on the 2W duplicate work in one night
+and all four were refuted: child count (a base with one child is a duplicate,
+many children a family) missed more mass than it caught; vowel count called
+`sprint` and `trophy` type codes; "contains a digit or has no vowel" would
+have folded the Vulcan 1700 Classic, Classic Tourer, Voyager and Voyager
+Custom into one record; and "every child's words fall inside the full name's
+vocabulary" — the best of them — still flags two false positives for every
+real one.
+
+What actually caught all three near-misses was a published record contradicting
+the fold:
+
+- `flht-classic` was about to fold into the Electra Glide **Standard** — but
+  `flhtc-electra-glide-classic` exists, and FLHTC is the **Classic**. Two models.
+- `kawasaki/vn1700`'s children looked like spellings — but sixteen existing
+  `former_ids` aliases showed someone had already curated them as distinct
+  models with their ABS variants folded in.
+- `gl1500c` looked like a Gold Wing by slug — Honda lists the Valkyrie under
+  `street/cruiser/`, away from the tourers, and markets it as "Gold Wing
+  Valkyrie" so a NAME check agrees with the wrong answer.
+
+The pattern rules are still useful as a filter for *where to look*. They are
+never a licence to fold. A fold batch that cannot point at the evidence for
+each cluster is a batch that has not been checked.
+
+Corollary, learned the same night: **a heuristic's value depends on source
+coverage, not on the make.** Disjoint availability identified exactly the two
+Honda pairs that were genuinely different machines — and fired zero times on
+Harley, where `nl_rdw` covers 622 of 633 records so every pair intersects.
+
 ## Sources & evidence
 
 **A model is published when ≥2 independent sources agree, or when a single


### PR DESCRIPTION
DECISIONS: the fold safeguard — check for a contradicting published record, not a pattern

Writing this because it is the most reusable thing the 2W duplicate work
produced, and right now it exists only in a NEGOTIATION turn nobody will read
in six months.

FOUR pattern rules were tried in one night and all four were refuted:

  child count            missed more duplicate mass than it caught
  vowel count            called "sprint" and "trophy" type codes
  digit-or-no-vowel      would have folded four distinct Vulcans into one
  vocabulary subset      the best of them, still 2 false positives per real one

What caught all three near-misses was EVIDENCE, not pattern — a published record
contradicting the fold:

  flht-classic     about to fold into the Electra Glide STANDARD, but
                   flhtc-electra-glide-classic exists and FLHTC is the CLASSIC
  kawasaki/vn1700  children looked like spellings; 16 existing former_ids
                   aliases showed they were already curated as distinct models
  gl1500c          looked like a Gold Wing by slug; Honda lists the Valkyrie
                   under street/cruiser and markets it as "Gold Wing Valkyrie",
                   so a NAME check agrees with the wrong answer

Also records the corollary: a heuristic's value depends on SOURCE COVERAGE, not
on the make. Disjoint availability identified exactly the two honda pairs that
were genuinely different machines, and fired ZERO times on harley because
nl_rdw covers 622 of 633 records so every pair intersects.

Filed under "Taxonomy & identity". No code change; lint OK.