### PR TITLE
QUALITY + overnight report: final wave numbers and the third defect generator

### DIFF
--- a/OVERNIGHT-2026-08-01.md
+++ b/OVERNIGHT-2026-08-01.md
@@ -3,10 +3,10 @@
 ## The headline
 
 **You were right about the noise, and it was worse than you thought.** Across
-nine makes measured tonight, between 23% and 82% of records were not models —
-they were trims, axle codes, payload classes, body words, engine markers and
-misspellings. All of it is now folded onto real nameplates with **zero country
-evidence lost**, verified per fold.
+twenty-plus makes measured, between 23% and 82% of records were not models —
+they were trims, axle codes, payload classes, body words, engine markers,
+generation codes and misspellings. All of it is folded onto real nameplates
+with **zero country evidence lost**, verified per fold.
 
 **And the bigger finding was the opposite problem: 115,809 vehicles were being
 DELETED on every build**, before they ever reached a record.
@@ -15,15 +15,22 @@ DELETED on every build**, before they ever reached a record.
 
 | slice | records | noise folded |
 |---|---|---|
+| Saab + Porsche + Bentley | 210 → 73 | **67%** (saab alone 77%) |
 | Iveco + Dodge | 430 → 170 | **82%** / 37% |
 | Volvo | 428 → 157 | **63%** |
 | MG + Austin | 281 → 131 | **53%** |
 | Jaguar / Rover / Land Rover | 348 → 168 | **53%** |
+| Vauxhall + Subaru + Jeep | 233 → 126 | **47%** |
 | Chevrolet | 393 → 219 | **45%** |
+| Ferrari / Alfa / Maserati | 304 → 233 | 23% (Ferrari held at both altitudes) |
+| Kia + Škoda | 151 → 96 | 40% each |
+| Cadillac + Chrysler + Buick | 270 → 173 | 36% |
 | Mitsubishi + Mazda | 211 → 149 | 35% |
-| Scania + DAF | 420 → 313 | 23% net (+28 real models minted) |
+| Scania + DAF | 420 → 313 | 23% net, +28 real models recovered |
 
-4W catalog: **8,613 → 7,765 published ids**, and van *grew* (742 → 907) because
+4W catalog: **8,613 → 6,946 published ids** (car 5,026 · van 616 · truck 914 ·
+bus 390), and van/truck grew in places because real models were freed from
+pooled axle codes before the later waves trimmed them again.
 real models were recovered out of pooled axle codes.
 
 ## The three things worth your attention

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -22,26 +22,34 @@ are part of the product.*
   themselves. Make ~96%, kind ~97%. The defect mass is names and
   id-canonicality, concentrated in two structural generators (truncation
   stubs; trim-granularity ids) now being fixed at the generator.
-- **Both generators have since been attacked at scale (2026-07-26,
-  post-baseline)**: the truncation-stub fix retired 36 stubs and
-  recovered ~370 real models; the trim-granularity fold wave measured
-  seven common makes (35–53% of their ids were trims/codes, not models —
-  per-make dossiers in the pipeline repo, `aux/research/trims-2026-07/`)
-  and folded ~690 records onto their real nameplates with **zero
-  availability evidence lost** (verified per fold, source drift
-  adjudicated against pristine builds) and every retired string preserved
-  as alias + typed variant. These fixes land AFTER the baseline above —
-  the next audit round measures their effect; this dashboard does not
-  claim it in advance.
+- **Both generators have since been attacked at scale (2026-07-26 → 08-01,
+  post-baseline)**: the truncation-stub fix retired 36 stubs and recovered
+  ~370 real models; the trim-granularity fold programme then measured
+  twenty-plus makes (23%–82% of their ids were trims, codes or body words
+  rather than models — per-make dossiers in the pipeline repo under
+  `aux/research/`) and folded them onto their real nameplates with **zero
+  availability evidence lost**, verified per fold. The 4W catalog went
+  8,613 → 6,946 published ids.
+- **A third generator was found that no detector could see: DELETION.**
+  `junk?` was discarding real nameplates before they ever reached a record —
+  a bare numeral cannot be a model, and a platform-code rule fires after the
+  make token is stripped. Measured by a per-row replay logging nil returns:
+  **125,650 vehicles recovered** so far (Saab 9-3 alone was 70,404 across 9
+  countries, while its own trim records published normally). A dropped row
+  leaves no record, so every catalog-side check is structurally blind to it;
+  `rake report:junk_drops` now stands watch. The largest known remaining
+  instance (a door-count prefix, ~26,700 recoverable vehicles) is filed
+  UNFIXED in DEBT because the same rule shape is a real platform code.
+- These land AFTER the baseline above — the next audit round measures their
+  effect; this dashboard does not claim it in advance.
 - **Wave 3 (2026-07-27, post-baseline)**: nine more makes measured and
   organized (Seat/Renault/Peugeot/VW/Dacia/Hyundai/Mercedes-Benz/Fiat/
   Tesla — 14–70% of ids per make were not models). ~719 records folded
   with zero unauthored evidence loss, and the reverse defect class fixed
   at scale: real nameplates the pipeline was DELETING or mislabeling
   (Renault 4/5/6/8/9, VW New Beetle, the 11,768-registration urban→Fox
-  re-landing, the 7,793-registration i80 phantom). Sixteen popular makes
-  now measured across the two waves; per-make dossiers in the pipeline
-  repo. Effect on the claim-level rates: measured by the NEXT round, not
+  re-landing, the 7,793-registration i80 phantom). Per-make dossiers in the pipeline repo. (Superseded as a COUNT by the
+  line above: the programme ran to twenty-plus makes across waves 4-7.) Effect on the claim-level rates: measured by the NEXT round, not
   asserted here.
 - **The audit's own error rates, published**: researcher miss rate on
   spot-checked corrects 7% (CI 2.9–13.9%); defect-verdict confirmation


### PR DESCRIPTION
The dashboard's post-baseline note listed two structural generators. A third turned up tonight and it is the one no detector could see — deletion. `junk?` was discarding real nameplates before they reached a record; 125,650 vehicles recovered, with the largest remaining instance stated as filed-unfixed rather than omitted.

The overnight report is refreshed with the full slice table and final catalog counts; the mid-run version predated four waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)