### PR TITLE
New-guard pre-positioning (S4W half): 11 keys, swept corpus-wide

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -781,6 +781,8 @@ Bentley:
   S 2: S2                                     # spelling variant of "S2" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   S 3: S3                                     # spelling variant of "S3" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
+  "New Flying Spur":               Flying Spur            # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate n=1, dup of car/bentley/flying-spur
+
 Bertone:
   X 1/9: X1/9                                 # spelling variant of "X1/9" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
@@ -1876,6 +1878,9 @@ Derbi:
   Mulhacen 125: Mulhacén 125  # official accented name (after the Mulhacén peak), scrambler 2007-2013 (https://www.autoevolution.com/moto/derbi/mulhacen/)
   Mulhacen 659: Mulhacén 659  # official accented name; 659cc Yamaha-engined single (2006-2013)
 
+DFSK:
+  "New Seres 3":                   Seres 3                # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate n=1, dup of car/dfsk/seres-3
+
 Dodge:
   # ── collision batch: Dodge performance suffixes (2026-07-26). The marque
   # convention dossier, per Dodge press materials + dodge.com heritage:
@@ -2694,6 +2699,9 @@ Ford:
   "Transit /Tourneo":                        Tourneo       # ditto
   "Transit Tourneo":                         Tourneo       # ditto
   "Transit/ Tourneo":                        Tourneo       # ditto
+
+  "New Anglia":                    Anglia                 # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate n=2, dup of car/ford/anglia
+  "New Prefect":                   Prefect                # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate n=1, dup of car/ford/prefect
 
 Gas Gas:
   Enducross: EC          # same nameplate: EC is short for Enducross — shared TAN e9*92/61*0062*09 with gas-gas/ec (https://en.wikipedia.org/wiki/Gas_Gas)
@@ -3664,6 +3672,7 @@ Kia:
   Cee D: Ceed            # RDW writes "CEE D" / "CEE'D"; official spelling since 2018 is Ceed
   Cee'd: Ceed                               # Kia dropped the apostrophe with the 3rd gen in 2018 (ceed.kia.com); old spelling folds
 
+  "New Picanto":                   Picanto                # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate n=1, dup of car/kia/picanto
 # Final per-make nameplate corrections, applied AFTER the pipeline's
 # normalization. `null` drops the entry; a string renames/merges it into
 # another nameplate. Keys are canonical make display names; sub-keys are the
@@ -4018,6 +4027,9 @@ Land Rover:
   # → Range Rover; it just cannot see through the leading "New". ──
   New Range Rover P400: Range Rover           # https://www.landrover.co.uk/range-rover/index.html — P400 is the engine badge; the same catalogues also list the un-prefixed "Range Rover"
   New Range Rover P400 Lwb: Range Rover       # LWB is the long-wheelbase body of the same nameplate (the shipped "One Ten"/"110" precedent above: wheelbase ≠ nameplate)
+
+  "New Range Rover":         Range Rover            # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate, dup of car/land-rover/range-rover. produced string verified against the build: the model half is "New Range Rover". (My first draft keyed "Rover New Range Rover" — an artifact of splitting the record name on its FIRST space when the make display is two words, "Land Rover". That key was inert; the duplicate sweep caught it)
+  "New Range Rover Sport":   Range Rover Sport      # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate, dup of car/land-rover/range-rover-sport; same two-word-make note as above
 
 Leike:
   Leike: null                             # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
@@ -5271,6 +5283,8 @@ MG:
   MG1: null                  # INTERIM — a NORMALIZER defect, not curation: normalizer.rb#mg's `\A(\d)\b` branch turns "1.5", "1,5 L", "1 1/4 LTR", "MG 1.8I" and "1.3 GS METRO" into a fabricated "MG1". MG has never made an MG1; reported as a pipeline finding
   MG2: null                  # INTERIM — same defect: "2.0", "2.0 TURBO", "2.0SL", "2 AXLE- RIGID BODY SALOON", "2 D CABRIOLET-GHN3/2310" all become "MG2". MG has never made an MG2; reported as a pipeline finding
 
+  "New MG3":                       MG3                    # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate n=4, dup of car/mg/mg3
+
 Microcar:
   M.go:                      M.Go                 # Microcar writes M.GO with the period; title form M.Go
   Mgo:                       M.Go                 # Microcar writes M.GO with the period; title form M.Go
@@ -6442,6 +6456,8 @@ Renault:
   Velsatis: Vel Satis                         # spelling variant of "Vel Satis" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Renault: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
+  "New Twingo":                    Twingo                 # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate n=2, dup of car/renault/twingo
+
 Rewaco:
   Rewaco: null                            # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
@@ -6455,6 +6471,8 @@ Riley:
 
 Rolls-Royce:
   Silvershadow: Silver Shadow                 # spelling variant of "Silver Shadow" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
+
+  "New Silver Spur":               Silver Spur            # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate n=1, dup of car/rolls-royce/silver-spur
 
 Rover:
   "2300S": "2300"                             # REPOINT (was -> "2300 S"): S is an SD1 trim/engine grade and "2300 S" is now folded into 2300, so the old target is a dead id. Renames are SINGLE-PASS (https://en.wikipedia.org/wiki/Rover_SD1)
@@ -8392,6 +8410,8 @@ Volvo:
   Estate:                            null  # bare body word
   Matalalattiainen:                  null  # Finnish for 'low-floor'; the whole raw is a body description ("Matalalattiainen yksikerroksinen (CE) 3ov 7146cm3")
   Vvn:                               null  # 3-letter registry stub, no resolvable nameplate
+
+  "New C70":                       C70                    # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate, dup of car/volvo/c70 (native "New C70 Convertible")
 
 Wartburg:
   "353W": "353 W"                             # spelling variant of "353 W" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence


### PR DESCRIPTION
Owner dispatch §S4W-1. `pipeline#111` is merged, so every `NEW <x>` row that duplicates a live record mints a duplicate on the next build — this closes the 4W half of that gap.

Swept the whole corpus rather than the NL subset the review used: **19 duplicate-risk pairs**, five of which NL could not see (bentley, land-rover ×2, mg, volvo).

Two deliberate non-folds: **volkswagen/new-beetle** (a genuinely distinct product — minting it is correct, and the review checked this specifically) and **piaggio ×2** (S2W's make, handed over).

One self-caught error worth the note: I first keyed `"Rover New Range Rover"`, having split the record name on its first space when the make display is two words. Those keys were inert, the reachability test passed anyway, and the duplicate sweep caught them — because it asks whether the duplicate is still there rather than whether the key parses.

Build exit 0, zero gate failures, sweep 19 → 3 remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)