### PR TITLE
PRE-POSITIONING: New-guard gap (kymco + riese) + the five G-1 suzuki keys

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -3909,6 +3909,9 @@ KTM:
   "Duke 2":                                  "Duke II"                      # PERMUTATION FOLD (verified batch, tier A): AGAINST THE RAW TOTAL (276 Arabic vs 91 Roman), on a rank-4 register-corroboration argument plus the manufacturer's own filed type designation.
 
 Kymco:
+  "New Grand Dink": "Grand Dink"  # NEW-GUARD gap (owner review report 1): Kymco badges facelifts "New <name>" and #151 folded New Like/People S/Sento on that basis. These four meet the identical test on the identical register and were missed — each has a LIVE record at the stripped name, so without the key the next build mints a duplicate.
+  "New Agility City 125": "Agility City 125"  # same
+  "New Agility City 50": "Agility City 50"  # same
   # ── "New <nameplate>" batch (2026-08-01) — see the Chrysler block header for
   # the measurement and the test. Kymco's European price lists badge the
   # facelifted generation "New <name>" (New Like, New People S, New Sento), and
@@ -6450,6 +6453,9 @@ Rieju:
   NKD125: NKD 125                # official "NKD 125" naked, NKD stays caps (https://rieju.com/us/naked/130/524/nkd-125)
   Rally 307: Aventura Rally 307   # official product name incl. family prefix (https://rieju.com/us/off-road/121/522/aventura-rally-307); registry drops "AVENTURA" and the space
 
+Riese Und Mueller:
+  "New Charger": "Charger"  # NEW-GUARD gap: moped/riese-und-mueller/charger is live (nl); "NEW CHARGER" (170) would duplicate it.
+
 Riley:
   Rma: R M A                                  # spelling variant of "R M A" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
@@ -7114,6 +7120,11 @@ Super Soco:
   Ts Street Hunter: TS Street Hunter        # TS is Super Soco's model line (3rd-gen TS), caps at the marque and in press: https://www.motorcyclenews.com/news/new-bikes/super-soco-tc-wanderer-ts-street-hunter/
 
 Suzuki:
+  "Gsxr 1000": "GSX-R1000"  # G-1 PRE-POSITIONING (suzuki dossier C-1): G-1 splits SUZUKI GSX by displacement and the caser produces "Gsxr 1000"/"Gsxs 1000" etc. Without these the build MINTS FIVE NEW IDS. Siblings "Gsxr 750"/"Gsxr 600" already exist in this block. Hyphenation per Suzuki's own product list https://www.globalsuzuki.com/motorcycle/smgs/products/ (GSX-R1000R, GSX-R125, GSX-S1000, GSX-S125, GSX-S750).
+  "Gsxr 125": "GSX-R125"  # same
+  "Gsxs 1000": "GSX-S1000"  # same
+  "Gsxs 125": "GSX-S125"  # same
+  "Gsxs 750": "GSX-S750"  # same
   Wagon-R: Wagon R                          # hyphenation variant of Suzuki Wagon R (global-suzuki.com) — spacing, not a different model
   Suzuki: null                              # registry row where the make was written into the model column (motorcycle+moped) — not a nameplate; restored from a flow-style entry
   # The R sportbike line hyphenates — GSX-R750 (suzukicycles.com) — while the


### PR DESCRIPTION
PRE-POSITIONING: New-guard gap (kymco + riese) and the five G-1 suzuki keys

Owner dispatch S2W item 1. Full-corpus New-guard replay done; my half of the
gap lines landed; the five G-1 keys pre-positioned before the split mints ids.

FULL-CORPUS REPLAY (the dispatch asked for fi + uk; NL was already done)

  NL   93 NEW <x> pairs · 21 with a live record · #151 covers 7 · 14 uncovered
  UK   36 pairs · 3 uncovered:  datsun/sunny 39 · datsun/cherry 20 ·
                                nissan/urvan 4        <- ALL S4W's makes
  FI  221 pairs · 0 uncovered   <- genuinely clean; FI's NEW strings are
                                   Dethleffs caravans, Fordson tractors and
                                   VW New Beetle (correctly distinct)

METHOD NOTE, because my first pass was wrong. A naive "strip NEW, compare to
live names" over UK reported SIX, including piaggio/skipper, kymco/like and
mash/seventy — all three ALREADY covered by #151. Running the pipeline's own
`Normalizer#classify` on both the raw and the stripped string drops them
correctly, because classify applies the renames. FI's naive pass reported zero
for the opposite reason: its model strings carry spec suffixes
("NEW BEETLE Viistoper? (AB) 2ov 1980cm3"), so nothing matched. Both numbers
above are classify-derived.

MY LINES (S2W)
  Kymco  New Grand Dink -> Grand Dink · New Agility City 125 -> Agility City 125
         New Agility City 50 -> Agility City 50
  Riese Und Mueller  New Charger -> Charger

THE FIVE SUZUKI G-1 KEYS (dossier §C-1), verified absent from the Suzuki block:
  Gsxr 1000 -> GSX-R1000 · Gsxr 125 -> GSX-R125 · Gsxs 1000 -> GSX-S1000
  Gsxs 125 -> GSX-S125 · Gsxs 750 -> GSX-S750
Siblings "Gsxr 750" and "Gsxr 600" already exist, confirming the produced shape.
Hyphenation per https://www.globalsuzuki.com/motorcycle/smgs/products/

I DID NOT LAND `like-ii` — the dispatch names it, and it is NOT a New-guard case.
There is no `NEW LIKE II` raw anywhere in the corpus, so the key would be DEAD.
What exists is a different defect: `kymco/like-ii125i` publishes as
**"Like II125I"** — the spacing rule failed between "II" and "125I" — with
unpublished misspellings `LIKEII 125I` -> "Likeii 125I" and `LIKELL 125I` ->
"Likell 125I" alongside. That is a spacing/casing cluster needing its own
verdict, not a "New" strip. Raised in NEGOTIATION rather than guessed.

Verified: build exit 0, zero gate failures; all four guarded ids publish as
single records with no `new-` twin; 0 rename chains in every touched block;
lint_curation OK; reorg_make_blocks alphabetical.
