### PR TITLE
New-guard: the three UK gaps (datsun/sunny, datsun/cherry, nissan/urvan)

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1842,6 +1842,9 @@ Datsun:
   "260Z": "260 Z"                             # spelling variant of "260 Z" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   "280Z": "280 Z"                             # spelling variant of "280 Z" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
+  "New Sunny":           Sunny        # New-guard pre-positioning, UK replay (S2W handover): pipeline#111 rescued `NEW <x>` from junk? and this make already publishes the stripped nameplate, so without this key the next build MINTS A DUPLICATE. classify-derived both ways — classify(raw)="New X", classify(stripped)=the live nameplate. — uk_dft n=39; car/datsun/sunny is live
+  "New Cherry":          Cherry       # New-guard pre-positioning, UK replay (S2W handover): pipeline#111 rescued `NEW <x>` from junk? and this make already publishes the stripped nameplate, so without this key the next build MINTS A DUPLICATE. classify-derived both ways — classify(raw)="New X", classify(stripped)=the live nameplate. — uk_dft n=20; car/datsun/cherry is live
+
 De Soto:
   Desoto: null                                # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
@@ -5510,6 +5513,8 @@ Nissan:
   "Z Nismo": "Z"  # us_fueleconomy: model "Z NISMO" baseModel "Z" — https://www.fueleconomy.gov/feg/download.shtml
   "Z33": "350 Z"  # Z33 is the 350Z chassis code — https://en.wikipedia.org/wiki/Nissan_350Z
   "Z350": "350 Z"  # TOKEN INVERSION of 350Z in fi/nl free text — https://en.wikipedia.org/wiki/Nissan_350Z
+
+  "New Urvan":           Urvan        # New-guard pre-positioning, UK replay (S2W handover): pipeline#111 rescued `NEW <x>` from junk? and this make already publishes the stripped nameplate, so without this key the next build MINTS A DUPLICATE. classify-derived both ways — classify(raw)="New X", classify(stripped)=the live nameplate. — uk_dft n=4; car/nissan/urvan and bus/nissan/urvan are both live
 
 Norton:
   Norton: null                            # motorcycle nl|nz


### PR DESCRIPTION
The three S2W's UK replay handed over. classify-derived both directions; build clean.

**Blind spot in my own sweep, stated because it is now the adopted acceptance test**: none of these three reaches the candidate queue (0 `new-` datsun/nissan rows), and my sweep reads published + candidates — so a duplicate below that floor is invisible to it. The classify replay is the discovery instrument; the sweep is the acceptance test. My earlier claim that the sweep superseded the NL method was too strong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)