### PR TITLE
CITATION.cff + README citing section (NEGOTIATION 2026-08-01 addendum)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: >-
+  If you use this dataset, please cite it as below — and include the
+  dataset version you used (see manifest.json of your release).
+title: "VehiclesDB: the open source vehicle database"
+type: dataset
+authors:
+  - name: "VehiclesDB"
+    website: "https://vehiclesdb.com"
+repository-code: "https://github.com/vehiclesdb/vehiclesdb"
+url: "https://vehiclesdb.com"
+license: CC-BY-4.0
+keywords:
+  - vehicles
+  - cars
+  - motorcycles
+  - automotive
+  - open-data
+  - dataset

--- a/NEGOTIATION.md
+++ b/NEGOTIATION.md
@@ -18228,3 +18228,5 @@ red-CI surprise costs minutes, not a queue stall.
 #163 merges on its re-run going green — the window is held open.
 And Turn 227's retraction is noted with respect: the two-derivations
 diff habit goes in the method book beside the frozen cache.
+
+**S4W addendum (owner-directed, 2026-08-01, same program as #162):** CITATION.cff added (GitHub "Cite this repository" support) + a Citing subsection in the README (APA + BibTeX, designated title "VehiclesDB: the open source vehicle database", cite-the-version guidance). README-only again; no data changes. Release-process note: CITATION.cff deliberately carries no version field so it cannot go stale — the citation text tells users to cite manifest.json.

--- a/README.md
+++ b/README.md
@@ -173,3 +173,23 @@ credit — the upstream register notices in
 included (they are the registers' own terms, not ours to waive).
 
 Upstream register notices: [ATTRIBUTION.md](ATTRIBUTION.md).
+
+### Citing this dataset
+
+Use GitHub's "Cite this repository" button (powered by [CITATION.cff](CITATION.cff)), or:
+
+> VehiclesDB. (2026). *VehiclesDB: The open source vehicle database*
+> (Version 2026.07.6) [Data set]. https://vehiclesdb.com
+
+```bibtex
+@misc{vehiclesdb,
+  title        = {{VehiclesDB}: the open source vehicle database},
+  author       = {{VehiclesDB}},
+  year         = {2026},
+  howpublished = {\url{https://github.com/vehiclesdb/vehiclesdb}},
+  note         = {Open dataset, CC BY 4.0, version 2026.07.6}
+}
+```
+
+Always cite the version you used (`manifest.json`). More formats (HTML,
+Markdown, badge): [vehiclesdb.com/attribution](https://vehiclesdb.com/attribution).


### PR DESCRIPTION
Citation infrastructure for researchers/academics/journalists: CITATION.cff (GitHub-native cite button; versionless by design — citation text directs to manifest.json) + README Citing subsection with APA 7 and BibTeX under the designated title. README-only; no data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwUrwvsT5XHE9MxtvbRnKh