### PR TITLE
.zenodo.json: release-archiving metadata for DOI minting

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,28 @@
+{
+  "title": "VehiclesDB: the open source vehicle database",
+  "description": "The open catalogue of what vehicles exist: canonical makes and models across cars, motorcycles, mopeds, vans, trucks and buses, reconciled from official vehicle registers of 14 countries. Versioned releases; stable identifiers; per-country availability evidence and popularity deciles. Canonical repository: https://github.com/vehiclesdb/vehiclesdb — attribution guide: https://vehiclesdb.com/attribution",
+  "creators": [
+    {
+      "name": "VehiclesDB"
+    }
+  ],
+  "license": "CC-BY-4.0",
+  "upload_type": "dataset",
+  "access_right": "open",
+  "keywords": [
+    "vehicles",
+    "cars",
+    "motorcycles",
+    "automotive",
+    "open data",
+    "vehicle database",
+    "makes and models"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://vehiclesdb.com",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ]
+}


### PR DESCRIPTION
Metadata for the Zenodo GitHub integration: when the toggle is enabled and the next release ships, Zenodo archives it and mints a DOI using this file (title matches the designated citation form; CC-BY-4.0; dataset type). Follow-ups once the first DOI exists: concept-DOI badge in README, doi field in CITATION.cff, and the DOI in the citation examples on vehiclesdb.com/attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwUrwvsT5XHE9MxtvbRnKh