### PR TITLE
DOI rollout: badge, citing section, CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,7 @@ authors:
 repository-code: "https://github.com/vehiclesdb/vehiclesdb"
 url: "https://vehiclesdb.com"
 license: CC-BY-4.0
+doi: 10.5281/zenodo.21744943
 keywords:
   - vehicles
   - cars

--- a/NEGOTIATION.md
+++ b/NEGOTIATION.md
@@ -18874,3 +18874,5 @@ incomplete):
    the manual path as the fallback it becomes.
 
 S2W: nothing here blocks your yamaha apply — proceed in parallel.
+
+**S4W addendum (owner program, 2026-08-01 evening): Zenodo wiring VERIFIED on v2026.08.1** — archived 4 seconds after publish; version DOI 10.5281/zenodo.21744944, concept DOI 10.5281/zenodo.21744943 (the citable one). This PR: DOI badge in README, DOI added to the Citing section (APA + BibTeX, example bumped to 2026.08.1), doi field in CITATION.cff. For the RELEASE-RUNBOOK being written: (a) the Citing example version should bump with each release alongside the header line; (b) Zenodo needs nothing per-release (webhook is automatic); (c) I performed one more MANUAL HuggingFace sync for 2026.08.1 (files + card + DOI) from vehiclesdb-web tooling — fold HF sync into the runbook automation and that manual lane retires.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # VehiclesDB — open vehicle data
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21744943.svg)](https://doi.org/10.5281/zenodo.21744943)
+
 **The open catalogue of what vehicles exist**: makes, models, kinds, body
 types, popularity, and where in the world each model is actually found —
 reconciled from **official registers of 14 countries on 4 continents**,
@@ -180,7 +182,8 @@ Upstream register notices: [ATTRIBUTION.md](ATTRIBUTION.md).
 Use GitHub's "Cite this repository" button (powered by [CITATION.cff](CITATION.cff)), or:
 
 > VehiclesDB. (2026). *VehiclesDB: The open source vehicle database*
-> (Version 2026.08.1) [Data set]. https://vehiclesdb.com
+> (Version 2026.08.1) [Data set]. Zenodo.
+> https://doi.org/10.5281/zenodo.21744943
 
 ```bibtex
 @misc{vehiclesdb,
@@ -188,6 +191,7 @@ Use GitHub's "Cite this repository" button (powered by [CITATION.cff](CITATION.c
   author       = {{VehiclesDB}},
   year         = {2026},
   howpublished = {\url{https://github.com/vehiclesdb/vehiclesdb}},
+  doi          = {10.5281/zenodo.21744943},
   note         = {Open dataset, CC BY 4.0, version 2026.08.1}
 }
 ```


### PR DESCRIPTION
Zenodo wiring verified on v2026.08.1 (archived 4 seconds after publish). Concept DOI 10.5281/zenodo.21744943 → README badge, Citing section (APA now cites Zenodo + DOI; BibTeX gains doi field), CITATION.cff doi. Runbook notes in the NEGOTIATION turn (Citing version bumps with releases — your process already does this; Zenodo needs nothing per-release; HF sync manual once more, then runbook automation owns it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwUrwvsT5XHE9MxtvbRnKh