### PR TITLE
C-1: two null renames for junk the parenthetical strip exposes

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -518,7 +518,7 @@ Audi:
   "GT":          Coupe    # raw "GT" nz 5 nl 1, "GT COUPE" nz 4 — nz_nzta's truncation of Coupe GT; the "GT COUPE" rows carry the body word explicitly (dossier §8)
   "Cabriolet 2": Cabriolet  # raw "Cabriolet 2,3E" fi 1, "AUDI CABRIOLET 2,0 TFSI" nl 1 — an ENGINE code (2.3E / 2.0 TFSI) whose decimal comma the slugifier turned into a model number (dossier §8)
   "Ur":          Quattro  # raw "UR QUATTRO" fi 1 nl 1 — "Ur-quattro" is the enthusiasts' retronym for the original; Audi's own name is "Audi quattro", and car/audi/quattro is live (dossier §8)
-  "Avant":       null     # body suffix: raw "AUDI AVANT" uk_dft GenModel 31, "AVANT" nz 6 nl 3 fi 1 + "AVANT QUATTRO" and 4 engine-suffixed forms — Avant is Audi's estate BODY word spanning A4/A6/80/100/RS2/RS4/RS6; no single successor (removals.yml carries the ledger line)
+  "Avant":       null     # body suffix: raw "AUDI AVANT" uk_dft GenModel 31, "AVANT" nz 6 nl 3 fi 1 + "AVANT QUATTRO" and 4 engine-suffixed forms — Avant is Audi's estate BODY word spanning A4/A6/80/100/RS2/RS4/RS6; no single successor — NO removals.yml line: this id never published, so nothing ceases to exist and there is no consumer to inform; removals.yml is for ids that DIE, not strings that were never minted
   "C":           null     # register fragment: raw "AUDI C" uk_dft GenModel 155 + nl 5, "C" nl 1 — a bare letter with no Audi designation behind it; uk_dft GenModel truncation class, same shape as "BMW CI" (the VITO/MGA rule; removals.yml)
   # ── e-tron GT family (dossier §9): the RS trim rung folds into the RS
   # nameplate. NOTE the e-tron vs e-tron GT SPLIT itself (gap G-9: 1,619 GT
@@ -1561,6 +1561,7 @@ Chrysler:
   Charger R/T: Charger                        # R/T is the performance trim of the Australian Chrysler Valiant Charger; raws "CHARGER R/T" (nl/nz) beside "CHARGER XL" — https://en.wikipedia.org/wiki/Chrysler_Valiant_Charger
 
 Citroën:
+  "Saloon":      null   # body word exposed by the C-1 parenthetical strip: raw "(II CV BL) SALOON" nl 1 (+ nz) — stripping the bracket leaves the BODY, not a nameplate. "SALOON" appears across Aston Martin, Bentley, Bristol, Cadillac, Crossley and Daimler in the same column the same way, so it is a register habit rather than a Citroen model (removals.yml carries the ledger line)
   # ── casing-contradiction batch: the BX family finished (BX 16/19 TRS were
   # fixed earlier, nine siblings weren't). VALUES superseded 2026-07-26 by the
   # trim-fold dossier (aux/research/trims-2026-07/dossier-citroen-opel.md,
@@ -1897,6 +1898,7 @@ DFSK:
   "New Seres 3":                   Seres 3                # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate n=1, dup of car/dfsk/seres-3
 
 Dodge:
+  "Chrysler":    null   # MAKE NAME in the model column: raw "CHRYSLER (CDN)" nl 3, "CHRYSLER" nz 2 — the bracket is the COUNTRY (Canada), and the head is the parent marque, so neither half names a Dodge model. Exposed by the C-1 parenthetical strip; same class as car/volkswagen/volkswagen-vw, but unlike that one this id never published, so no removals.yml line is owed
   # ── collision batch: Dodge performance suffixes (2026-07-26). The marque
   # convention dossier, per Dodge press materials + dodge.com heritage:
   # R/T and T/A carry the SLASH (Road/Track; Trans Am — 1970 and the 2017


### PR DESCRIPTION
Data half of **vehiclesdb-pipeline#126**, which stops `junk?` discarding every model string containing a bracket (51,175 NL registrations).

Two strings reach the catalog as ids once the bracket comes off, and neither is a nameplate:

| key | raw | why |
|---|---|---|
| `Citroën "Saloon"` | `(II CV BL) SALOON` | stripping the bracket leaves the **body**. `SALOON` appears the same way under Aston Martin, Bentley, Bristol, Cadillac, Crossley and Daimler — a register habit, not a Citroën model |
| `Dodge "Chrysler"` | `CHRYSLER (CDN)` nl 3, `CHRYSLER` nz 2 | the bracket is the **country** (Canada) and the head is the **parent marque** — neither half names a Dodge model |

**No `removals.yml` lines are owed.** Neither id has ever published, so nothing ceases to exist and there is no consumer to inform — `removals.yml` is for ids that die, not strings that were never minted. The comments say that explicitly rather than pointing at a ledger line that does not exist, which is what my first draft did.

Two further cases from the same class — `car/jaguar/gb` and `car/peugeot/f`, both country codes — are fixed in the **rule** in #126 rather than here, because they are systematic: registers write `JAGUAR (GB)` and `strip_make_prefix` eats the make first, leaving the bracket to become the nameplate.

Merge after #126.