### PR TITLE
renames: door-count rescue (safe slice) — 1,011 keys / 11,169 vehicles, zero new nameplates

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -5,6 +5,23 @@ Aixam:
   Aixam: null                             # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Alfa Romeo:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 147": "147"                                   # 1 veh/1 rows (fi, fi_traficom) -> live alfa-romeo/147; raw "2D 147 HATCHBACK 1.6-937AXA1A00/255"
+  "2D Spider": Spider                               # 1 veh/1 rows (fi, fi_traficom) -> live alfa-romeo/spider; raw "2D SPIDER CABRIOLET 2.0 16V-916S2B00/254"
+  "4D 156": "156"                                   # 4 veh/3 rows (fi, fi_traficom) -> live alfa-romeo/156; raw "4D 156 SEDAN 2.5 V6-932A110026D/260"
+  "4D 166": "166"                                   # 1 veh/1 rows (fi, fi_traficom) -> live alfa-romeo/166; raw "4D 166 SEDAN"
+  "5D 156": "156"                                   # 1 veh/1 rows (fi, fi_traficom) -> live alfa-romeo/156; raw "5D 156 SPORTWAGON 3,2 V6 GTA-923BXBOO47/260"
   # ── junk?-rescue (2026-08-01, per-row replay of classify). junk?'s
   # platform-code rule /\A\d[A-Z]\b/ — written for "8D Audi A4" — also matches
   # a real nameplate that happens to be digit+letter, and deleted every 4C row
@@ -484,6 +501,42 @@ Aston Martin:
   Dbx V8:                           Dbx                     # trim/engine/body designation of the Dbx — 0v 2r ca,us/ca_nrcan,us_fueleconomy
 
 Audi:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 90": "90"                                     # 1 veh/1 rows (fi, fi_traficom) -> live audi/90; raw "2D 90 QUATTRO-89Q-4X4/254"
+  "2D A3": A3                                       # 92 veh/19 rows (fi, fi_traficom) -> live audi/a3; raw "2D A3 HATCHBACK 1.8T-8L/250"
+  "2D A3 Hatcback 2.0TDI-8P/258": A3                # 1 veh/1 rows (fi, fi_traficom) -> live audi/a3; raw "2D A3 HATCBACK 2.0TDI-8P/258"
+  "2D A4": A4                                       # 6 veh/3 rows (fi, fi_traficom) -> live audi/a4; raw "2D A4 CABRIOLET 2.4-8H/266"
+  "2D S3": S3                                       # 1 veh/1 rows (fi, fi_traficom) -> live audi/s3; raw "2D S3 HATCHBACK QUATTRO 2.0T FSI"
+  "2D S4": S4                                       # 1 veh/1 rows (fi, fi_traficom) -> live audi/s4; raw "2D S4 CABRIOLET AUTOMATIC-QB6-4X4/266"
+  "2D TT": TT                                       # 7 veh/3 rows (fi, fi_traficom) -> live audi/tt; raw "2D TT COUPE QUATTRO 1.8T-8N-4X4/242"
+  "4D A2": A2                                       # 30 veh/6 rows (fi, fi_traficom) -> live audi/a2; raw "4D A2 HATCHBACK 1.4-8Z/240"
+  "4D A4": A4                                       # 350 veh/64 rows (fi, fi_traficom) -> live audi/a4; raw "4D A4 SEDAN 1.8T-8E/266"
+  "4D A4 SEDAN1.8T-8E": A4                          # 1 veh/1 rows (fi, fi_traficom) -> live audi/a4; raw "4D A4 SEDAN1.8T-8E"
+  "4D A6": A6                                       # 107 veh/43 rows (fi, fi_traficom) -> live audi/a6; raw "4D A6 SEDAN QUATTRO 2.4-4B-4X4/276"
+  "4D A8": A8                                       # 22 veh/10 rows (fi, fi_traficom) -> live audi/a8; raw "4D A8 SEDAN QUATTRO 4.2 AUTOMATIC-D2-4X4/289"
+  "4D A8L": A8                                      # 4 veh/3 rows (fi, fi_traficom) -> live audi/a8; raw "4D A8L SEDAN QUATTRO 4.0TDI AUTOMATIC-4E-4X4"
+  "4D Q7": Q7                                       # 2 veh/1 rows (fi, fi_traficom) -> live audi/q7; raw "4D Q7 QUATTRO 3.6FSI AUTOMATIC-4L-4X4/301"
+  "4D S4": S4                                       # 1 veh/1 rows (fi, fi_traficom) -> live audi/s4; raw "4D S4 QUATTRO 2.6-8E/266"
+  "5D A3": A3                                       # 1 veh/1 rows (fi, fi_traficom) -> live audi/a3; raw "5D A3 HATCHBACK QUATTRO 1.8T-8L-4X4/251"
+  "5D A4": A4                                       # 313 veh/80 rows (fi, fi_traficom) -> live audi/a4; raw "5D A4 AVANT 1.8T-8E/266"
+  "5D A4 2.0 Cvt-8E/266": A4                        # 1 veh/1 rows (fi, fi_traficom) -> live audi/a4; raw "5D A4 2.0 CVT-8E/266"
+  "5D A4 RS4": A4                                   # 1 veh/1 rows (fi, fi_traficom) -> live audi/a4; raw "5D A4 RS4 AVANT QUATTRO 2.7T-B5-4X4/261"
+  "5D A4 S4": A4                                    # 8 veh/1 rows (fi, fi_traficom) -> live audi/a4; raw "5D A4 S4 AVANT QUATTRO 2.7T-B5-4X4/261"
+  "5D A4 S4 Farmari": A4                            # 1 veh/1 rows (fi, fi_traficom) -> live audi/a4; raw "5D A4 S4 Farmari"
+  "5D A6": A6                                       # 157 veh/59 rows (fi, fi_traficom) -> live audi/a6; raw "5D A6 AVANT 1.9TDI-4B/275"
+  "5D Q7": Q7                                       # 7 veh/5 rows (fi, fi_traficom) -> live audi/q7; raw "5D Q7 QUATTRO 3.0TDI AUTOMATIC-4L-4X4/301"
+  "5D S4": S4                                       # 1 veh/1 rows (fi, fi_traficom) -> live audi/s4; raw "5D S4 AVANT QUATTRO 2.7 4X4/261"
   "5000S": "5000"                             # RETARGET (2026-07-26 trim-fold dossier), was "5000 S" — S is a US trim-ladder rung on the 5000 (the US-market C2/C3 100/200); the earlier consolidation intent is preserved and now lands on the nameplate. Renames are single-pass, so this key moves WITH the "5000 S" key below (dossier §7)
   Audi: null                                  # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   AUDIA6: A6                                  # es_dgt/nl_rdw glue artifact ("AUDIA6") — the make fused onto the nameplate; merges into the 14-source A6 id
@@ -527,6 +580,21 @@ Audi:
   "RS E-Tron GT Performance": RS E-Tron GT   # raw "RS E-TRON GT PERFORMANCE" nl 17, "RS e-tron GT performance" fi 5, "RS e-tron GT Performance" us — "the new variants of the e-tron GT series", one rung above the RS: https://www.audi.com/en/press-releases/audis-most-powerful-production-vehicle-the-new-rs-e-tron-gt-performance-16222
 
 Austin:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D A 30": A30                                    # 1 veh/1 rows (fi, fi_traficom) -> live austin/a30; raw "2D A 30 SALOON/201"
+  "2D Mini": Mini                                   # 1 veh/1 rows (fi, fi_traficom) -> live austin/mini; raw "2D MINI"
+  "3D Mini Clubman": Mini Clubman                   # 1 veh/1 rows (fi, fi_traficom) -> live austin/mini-clubman; raw "3D MINI CLUBMAN ESTATE-XA2W2/2140"
   # ── swarm-dossier batch: Mk goes FUSED ROMAN here — Austin registers EMIT
   # Roman (healey-3000-mkiii, mini-mkii live in-catalog), so the MG Midget
   # MkIII conditional applies, NOT the Triumph Mk-arabic one. No styling.yml
@@ -690,6 +758,19 @@ Barkas:
   B 1000: B1000                               # spelling variant of "B1000" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 Bentley:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D S 1": S1                                      # 1 veh/1 rows (fi, fi_traficom) -> live bentley/s1; raw "4D S 1 SALOON/3120"
   # ── BENTLEY'S OWN RANGE PAGE IS THE EVIDENCE (wave 7, 2026-08-01). The range
   # page lists the products — "Bentayga Extended Wheelbase · Bentayga · Flying
   # Spur · Continental GT · Continental GTC" (plus Supersports),
@@ -787,6 +868,189 @@ Bertone:
   X 1/9: X1/9                                 # spelling variant of "X1/9" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 BMW:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 316I Compact-CS11/273": "3 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 316I COMPACT-CS11/273"
+  "2D 316TI Compact Automatic-AT51/273": "3 Series"  # 3 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 316TI COMPACT AUTOMATIC-AT51/273"
+  "2D 316TI Compact-AT51": "3 Series"               # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 316TI COMPACT-AT51"
+  "2D 316TI Compact-AT51/273": "3 Series"           # 9 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 316TI COMPACT-AT51/273"
+  "2D 316TI Compact-EZ51/273": "3 Series"           # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 316TI COMPACT-EZ51/273"
+  "2D 318TD Compact-AT91/273": "3 Series"           # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 318TD COMPACT-AT91/273"
+  "2D 320TD Compact Automatic-AT71/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 320TD COMPACT AUTOMATIC-AT71/273"
+  "2D 323CI": "3 Series"                            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 323CI CABRIO 2.5 AUTOMATIC-BR33/273"
+  "2D 323I": "3 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 323I CABRIO 2.5"
+  "2D 325CI": "3 Series"                            # 6 veh/4 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 325CI CABRIO-BS31/273"
+  "2D 325TI Compact-AT31/273": "3 Series"           # 2 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 325TI COMPACT-AT31/273"
+  "2D 330CI": "3 Series"                            # 2 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 330CI CABRIO-BS51/272"
+  "2D 335I": "3 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D 335I CABRIO"
+  "2D 645CI": "6 Series"                            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/6-series; raw "2D 645CI CABRIO 4.4 AUTOMATIC-EK71/278"
+  "2D Compact": "3 Series"                          # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "2D COMPACT"
+  "2D M3": M3                                       # 1 veh/1 rows (fi, fi_traficom) -> live bmw/m3; raw "2D M3 CABRIO-BR91/273"
+  "4D 116I": "1 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/1-series; raw "4D 116I HATCHBACK-UF11/266"
+  "4D 120D": "1 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/1-series; raw "4D 120D HATCHBACK-UG51"
+  "4D 120I": "1 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/1-series; raw "4D 120I HATCHBACK AUTOMATIC-UF51/266"
+  "4D 316I": "3 Series"                             # 16 veh/4 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 316I SEDAN-AY31/273"
+  "4D 318D": "3 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 318D SEDAN-VC11"
+  "4D 318I": "3 Series"                             # 8 veh/5 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 318I SEDAN-AY71/273"
+  "4D 320D": "3 Series"                             # 14 veh/6 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 320D SEDAN-AS71/273"
+  "4D 320I": "3 Series"                             # 19 veh/9 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 320I SEDAN-AV11/273"
+  "4D 320IA": "3 Series"                            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 320iA sedan"
+  "4D 325I": "3 Series"                             # 18 veh/11 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 325I SEDAN-EV31/273"
+  "4D 325XI": "3 Series"                            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 325XI SEDAN AUTOMATIC-EU31-4X4/273"
+  "4D 328I": "3 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 328i"
+  "4D 328IA AM53": "3 Series"                       # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 328IA AM53"
+  "4D 330D": "3 Series"                             # 6 veh/4 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 330D SEDAN-ER91/273"
+  "4D 330I": "3 Series"                             # 12 veh/8 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 330I SEDAN AUTOMATIC-VB33/276"
+  "4D 330XD": "3 Series"                            # 3 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 330XD SEDAN AUTOMATIC-EV91-4X4/273"
+  "4D 330XI": "3 Series"                            # 5 veh/4 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 330XI SEDAN-AV51-4X4/273"
+  "4D 335D": "3 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "4D 335D"
+  "4D 520D": "5 Series"                             # 3 veh/3 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 520D SEDAN-DM71/283"
+  "4D 520I": "5 Series"                             # 15 veh/5 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 520I SEDAN-DT11/283"
+  "4D 523IA": "5 Series"                            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 523IA SEDAN"
+  "4D 525D": "5 Series"                             # 9 veh/4 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 525D SEDAN-DL91/283"
+  "4D 525I": "5 Series"                             # 25 veh/8 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 525I SEDAN AUTOMATIC-DT41/283"
+  "4D 530 D": "5 Series"                            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 530 D SEDAN AUTOMATIC-NC71/289"
+  "4D 530D": "5 Series"                             # 48 veh/8 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 530D SEDAN AUTOMATIC-DL81/283"
+  "4D 530DA": "5 Series"                            # 2 veh/2 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 530DA SEDAN"
+  "4D 530I": "5 Series"                             # 15 veh/6 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 530I SEDAN AUTOMATIC-DT61/283"
+  "4D 535D": "5 Series"                             # 2 veh/2 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 535D SEDAN AUTOMATIC-NC91/289"
+  "4D 535I": "5 Series"                             # 3 veh/2 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 535I SEDAN-DN11/283"
+  "4D 540I": "5 Series"                             # 4 veh/2 rows (fi, fi_traficom) -> live bmw/5-series; raw "4D 540I SEDAN AUTOMATIC-DE61/283"
+  "4D 730D": "7 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/7-series; raw "4D 730D SEDAN AUTOMATIC-GM21/299"
+  "4D 735I": "7 Series"                             # 4 veh/1 rows (fi, fi_traficom) -> live bmw/7-series; raw "4D 735I SEDAN AUTOMATIC-GL41/299"
+  "4D 740D": "7 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/7-series; raw "4D 740D SEDAN AUTOMATIC-GE81/293"
+  "4D 745I": "7 Series"                             # 1 veh/1 rows (fi, fi_traficom) -> live bmw/7-series; raw "4D 745I SEDAN AUTOMATIC-GL61/299"
+  "4D 760LI": "7 Series"                            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/7-series; raw "4D 760LI SEDAN AUTOMATIC-GN81/313"
+  "5D 316I Touring Automatic-AX31/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 316I TOURING AUTOMATIC-AX31/273"
+  "5D 316I Touring-AX31/273": "3 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 316I TOURING-AX31/273"
+  "5D 318I Touring": "3 Series"                     # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 318I TOURING"
+  "5D 318I Touring Automatic-AP31/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 318I TOURING AUTOMATIC-AP31/273"
+  "5D 318I Touring-AP31/273": "3 Series"            # 7 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 318I TOURING-AP31/273"
+  "5D 318I Touring-AX51/273": "3 Series"            # 2 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 318I TOURING-AX51/273"
+  "5D 318I Touring-EX51/273": "3 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 318I TOURING-EX51/273"
+  "5D 318I Touring-VR51/276": "3 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 318i TOURING-VR51/276"
+  "5D 320D Touring -AP71/273": "3 Series"           # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320D TOURING -AP71/273"
+  "5D 320D Touring Automatic-AP71/273": "3 Series"  # 2 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320D TOURING AUTOMATIC-AP71/273"
+  "5D 320D Touring Automatic-AX71/273": "3 Series"  # 3 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320D TOURING AUTOMATIC-AX71/273"
+  "5D 320D Touring Automatic-VU31": "3 Series"      # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320D TOURING AUTOMATIC-VU31"
+  "5D 320D Touring Automatic-VU31/276": "3 Series"  # 5 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320D TOURING AUTOMATIC-VU31/276"
+  "5D 320D Touring-AP71/273": "3 Series"            # 3 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320D TOURING-AP71/273"
+  "5D 320D Touring-AX71/273": "3 Series"            # 7 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320D TOURING-AX71/273"
+  "5D 320D Touring-VU31/276": "3 Series"            # 4 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320D TOURING-VU31/276"
+  "5D 320I Touring Automatic-AR11/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320I TOURING AUTOMATIC-AR11/273"
+  "5D 320I Touring Automatic-AW11/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320I TOURING AUTOMATIC-AW11/273"
+  "5D 320I Touring-AR11": "3 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320I TOURING-AR11"
+  "5D 320I Touring-AR11/273": "3 Series"            # 2 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320I TOURING-AR11/273"
+  "5D 320I Touring-AW11/273": "3 Series"            # 2 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320I TOURING-AW11/273"
+  "5D 320I Touring-EN11/273": "3 Series"            # 3 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 320I TOURING-EN11/273"
+  "5D 323I Touring Automatic-AR33/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 323I TOURING AUTOMATIC-AR33/273"
+  "5D 325D Touring Automatic": "3 Series"           # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 325D TOURING AUTOMATIC"
+  "5D 325I Touring Automatic": "3 Series"           # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 325I TOURING AUTOMATIC"
+  "5D 325I Touring Automatic-EN33/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 325I TOURING AUTOMATIC-EN33/273"
+  "5D 325I Touring-AW31/273": "3 Series"            # 2 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 325I TOURING-AW31/273"
+  "5D 325I Touring-EN31/273": "3 Series"            # 3 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 325I TOURING-EN31/273"
+  "5D 325XI Touring Automatic-EP33-4X4/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 325XI TOURING AUTOMATIC-EP33-4X4/273"
+  "5D 325XI Touring Automatic-VT13-4X4/276": "3 Series"  # 2 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 325XI TOURING AUTOMATIC-VT13-4X4/276"
+  "5D 325XI Touring-EP31-4X4/273": "3 Series"       # 3 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 325XI TOURING-EP31-4X4/273"
+  "5D 328I Touring Automatic-AR51/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 328I TOURING AUTOMATIC-AR51/273"
+  "5D 328I Touring-AR51": "3 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 328I TOURING-AR51"
+  "5D 328I Touring-AR51/273": "3 Series"            # 3 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 328I TOURING-AR51/273"
+  "5D 330 XD Touring -EP71-4X4/273": "3 Series"     # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330 XD TOURING -EP71-4X4/273"
+  "5D 330D Touring Automatic-AP91/273": "3 Series"  # 2 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330D TOURING AUTOMATIC-AP91/273"
+  "5D 330D Touring Automatic-EL91": "3 Series"      # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330D TOURING AUTOMATIC-EL91"
+  "5D 330D Touring Automatic-EX91/273": "3 Series"  # 2 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330D TOURING AUTOMATIC-EX91/273"
+  "5D 330D Touring-AP91/273": "3 Series"            # 2 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330D TOURING-AP91/273"
+  "5D 330D Touring-EL91/273": "3 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330D TOURING-EL91/273"
+  "5D 330D Touring-EX91/273": "3 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330D TOURING-EX91/273"
+  "5D 330D Touring-VU91": "3 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330D TOURING-VU91"
+  "5D 330D Touring-VU91/276": "3 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330D TOURING-VU91/276"
+  "5D 330I Touring Automatic-AW51/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330I TOURING AUTOMATIC-AW51/273"
+  "5D 330I Touring-AW51/273": "3 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330I TOURING-AW51/273"
+  "5D 330XD Touring": "3 Series"                    # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330XD TOURING"
+  "5D 330XD Touring Automatic-EP71-4X4/273": "3 Series"  # 2 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330XD TOURING AUTOMATIC-EP71-4X4/273"
+  "5D 330XD Touring Automatic-EX71-4X4/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330XD TOURING AUTOMATIC-EX71-4X4/273"
+  "5D 330XD Touring Automatic-VT91-4X4/276": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330XD TOURING AUTOMATIC-VT91-4X4/276"
+  "5D 330XD Touring-AP91-4X4/273": "3 Series"       # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330XD TOURING-AP91-4X4/273"
+  "5D 330XD Touring-EP71-4X4/273": "3 Series"       # 2 veh/2 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330XD TOURING-EP71-4X4/273"
+  "5D 330XI Touring Automatic-EP51-4X4/273": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330XI TOURING AUTOMATIC-EP51-4X4/273"
+  "5D 330XI Touring-EP51-4X4/273": "3 Series"       # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330XI TOURING-EP51-4X4/273"
+  "5D 330XIA Touring Automatic-AW51-4X4": "3 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/3-series; raw "5D 330XIA TOURING AUTOMATIC-AW51-4X4"
+  "5D 520D Touring": "5 Series"                     # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 520D TOURING"
+  "5D 520D Touring NJ31": "5 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 520d TOURING NJ31"
+  "5D 520D Touring-DR71/283": "5 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 520D TOURING-DR71/283"
+  "5D 520D Touring-NJ31": "5 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 520D TOURING-NJ31"
+  "5D 520D Touring-PX31": "5 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 520D TOURING-PX31"
+  "5D 520I Touring Automatic-DS21/283": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 520I TOURING AUTOMATIC-DS21/283"
+  "5D 520I Touring-DS11/283": "5 Series"            # 6 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 520I TOURING-DS11/283"
+  "5D 523I Touring Automatic-DR61/283": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 523I TOURING AUTOMATIC-DR61/283"
+  "5D 525D Touring Automatic-DP01/283": "5 Series"  # 6 veh/2 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525D TOURING AUTOMATIC-DP01/283"
+  "5D 525D Touring Automatic-NJ51": "5 Series"      # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525D TOURING AUTOMATIC-NJ51"
+  "5D 525D Touring Automatic-NJ51/289": "5 Series"  # 2 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525D TOURING AUTOMATIC-NJ51/289"
+  "5D 525D Touring Automatic-PX51/289": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525D TOURING AUTOMATIC-PX51/289"
+  "5D 525D Touring-DP91": "5 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525D TOURING-DP91"
+  "5D 525D Touring-DP91/283": "5 Series"            # 2 veh/2 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525D TOURING-DP91/283"
+  "5D 525D Touring-NJ51/289": "5 Series"            # 2 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525D TOURING-NJ51/289"
+  "5D 525DA Touring Automatic-DP01/283": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525DA TOURING AUTOMATIC-DP01/283"
+  "5D 525I Touring": "5 Series"                     # 2 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525I TOURING"
+  "5D 525I Touring Automatic-DS41/283": "5 Series"  # 2 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525I TOURING AUTOMATIC-DS41/283"
+  "5D 525I Touring Automatic-NG51/289": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525I TOURING AUTOMATIC-NG51/289"
+  "5D 525I Touring-DS31": "5 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525I TOURING-DS31"
+  "5D 525I Touring-DS31/283": "5 Series"            # 2 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525I TOURING-DS31/283"
+  "5D 525I Touring-DS531/283": "5 Series"           # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525I TOURING-DS531/283"
+  "5D 525I Touring-NG51/289": "5 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 525I TOURING-NG51/289"
+  "5D 530 Xi Touring Automatic-NN73/289": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530 XI TOURING AUTOMATIC-NN73/289"
+  "5D 530D Touring Auto": "5 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530D TOURING AUTO"
+  "5D 530D Touring Automatic-DP81/283": "5 Series"  # 44 veh/2 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530D TOURING AUTOMATIC-DP81/283"
+  "5D 530D Touring Automatic-DP81/289": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530D TOURING AUTOMATIC-DP81/289"
+  "5D 530D Touring Automatic-NJ71/289": "5 Series"  # 2 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530D TOURING AUTOMATIC-NJ71/289"
+  "5D 530D Touring Automatic-NS71": "5 Series"      # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530D TOURING AUTOMATIC-NS71"
+  "5D 530D Touring Automatic-NS71/289": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530D TOURING AUTOMATIC-NS71/289"
+  "5D 530D Touring-DP71": "5 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530D TOURING-DP71"
+  "5D 530D Touring-DP71/283": "5 Series"            # 6 veh/2 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530D TOURING-DP71/283"
+  "5D 530D Touring-NJ71": "5 Series"                # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530D TOURING-NJ71"
+  "5D 530D Touring-NJ71/289": "5 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530d TOURING-NJ71/289"
+  "5D 530DA Touring Automatic": "5 Series"          # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530dA Touring Automatic"
+  "5D 530DA Touring Automatic-DP81/283": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D  530dA TOURING AUTOMATIC-DP81/283"
+  "5D 530I Touring Automatic-DS61/283": "5 Series"  # 3 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530I TOURING AUTOMATIC-DS61/283"
+  "5D 530I Touring-DS51/283": "5 Series"            # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530I TOURING-DS51/283"
+  "5D 530I Touring-NL71/2890": "5 Series"           # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530I TOURING-NL71/2890"
+  "5D 530XD Touring Automatic-NP71-4X4": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530XD TOURING AUTOMATIC-NP71-4X4"
+  "5D 530XD Touring Automatic-NP71/289": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530XD TOURING AUTOMATIC-NP71/289"
+  "5D 530XI Touring Automatic-NN73-4X4/289": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 530XI TOURING AUTOMATIC-NN73-4X4/289"
+  "5D 535D Touring Automatic-NJ91/289": "5 Series"  # 4 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 535D TOURING AUTOMATIC-NJ91/289"
+  "5D 540I Touring Automatic-DR61/283": "5 Series"  # 3 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 540I TOURING AUTOMATIC-DR61/283"
+  "5D 545I Touring Automatic-NH31/289": "5 Series"  # 1 veh/1 rows (fi, fi_traficom) -> live bmw/5-series; raw "5D 545I TOURING AUTOMATIC-NH31/289"
+  "5D X3 Stw 2.5I Automatic-PA73-4X4/280": X3       # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 2.5i AUTOMATIC-PA73-4X4/280"
+  "5D X3 Stw 2.5I-PA73-4X4/280": X3                 # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 2.5I-PA73-4X4/280"
+  "5D X3 Stw 3.0D Automatic-PB51-4X4": X3           # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 3.0D AUTOMATIC-PB51-4X4"
+  "5D X3 Stw 3.0D Automatic-PD51-4X4": X3           # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 3.0D AUTOMATIC-PD51-4X4"
+  "5D X3 Stw 3.0D-PB51-4X4": X3                     # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 3.0D-PB51-4X4"
+  "5D X3 Stw 3.0I Automatic": X3                    # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 3.0I AUTOMATIC"
+  "5D X3 Stw 3.0I Automatic-PA91-4X4/280": X3       # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 3.0I AUTOMATIC-PA91-4X4/280"
+  "5D X3 Stw 3.0I Automatic-PA93-4X4/280": X3       # 2 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 3.0I AUTOMATIC-PA93-4X4/280"
+  "5D X3 Stw 3.0I-PA91-4X4/280": X3                 # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 3.0I-PA91-4X4/280"
+  "5D X3 Stw 3.0I-PA93-4X4": X3                     # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 3.0I-PA93-4X4"
+  "5D X3 Stw 3.0SI Automatic-PC93-4X4/280": X3      # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x3; raw "5D X3 STW 3.0SI AUTOMATIC-PC93-4X4/280"
+  "5D X5 Stw 3.0D": X5                              # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x5; raw "5D X5 STW 3.0D"
+  "5D X5 Stw 3.0D Automatic-FA71-4X4/282": X5       # 6 veh/2 rows (fi, fi_traficom) -> live bmw/x5; raw "5D X5 STW 3.0D AUTOMATIC-FA71-4X4/282"
+  "5D X5 Stw 3.0D Automatic-FB71-4X4/282": X5       # 9 veh/2 rows (fi, fi_traficom) -> live bmw/x5; raw "5D X5 STW 3.0D AUTOMATIC-FB71-4X4/282"
+  "5D X5 Stw 3.0D Automatic-FF41-4X4/293": X5       # 3 veh/1 rows (fi, fi_traficom) -> live bmw/x5; raw "5D X5 STW 3.0D AUTOMATIC-FF41-4X4/293"
+  "5D X5 Stw 3.0D-FA71-4X4/282": X5                 # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x5; raw "5D X5 STW 3.0D-FA71-4X4/282"
+  "5D X5 Stw 3.0I Automatic-FA13-4X4": X5           # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x5; raw "5D X5 STW 3.0I AUTOMATIC-FA13-4X4"
+  "5D X5 Stw 3.0I Automatic-FA13-4X4/282": X5       # 1 veh/1 rows (fi, fi_traficom) -> live bmw/x5; raw "5D X5 STW 3.0I AUTOMATIC-FA13-4X4/282"
+  "5D X5 Stw 3.0I Automatic-FA51-4X4/282": X5       # 2 veh/1 rows (fi, fi_traficom) -> live bmw/x5; raw "5D X5 STW 3.0I AUTOMATIC-FA51-4X4/282"
+  "5D X5 Stw 3.0I Automatic-FA53-4X4/282": X5       # 5 veh/1 rows (fi, fi_traficom) -> live bmw/x5; raw "5D X5 STW 3.0I AUTOMATIC-FA53-4X4/282"
+  "5D X5 Stw 4.4I Automatic-FB31-4X4/282": X5       # 3 veh/1 rows (fi, fi_traficom) -> live bmw/x5; raw "5D X5 STW 4.4I AUTOMATIC-FB31-4X4/282"
   Bmw: null                               # motorcycle nl|nz
   "K100RS Abs":               K100RS               # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); the non-ABS sibling is published from the same countries
   "K1100RS-Abs":               K1100RS              # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); the non-ABS sibling is published from the same countries
@@ -946,6 +1210,34 @@ Buell:
   "Lightning XB12S":                         "XB12S Lightning"              # PERMUTATION FOLD (verified batch, tier A): Code-first 289 vs name-first 4 (72:1).
 
 Buick:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Centurion": Centurion                         # 1 veh/1 rows (fi, fi_traficom) -> live buick/centurion; raw "2D CENTURION CONVERTIBLE"
+  "2D Electra 225": Electra                         # 5 veh/5 rows (fi, fi_traficom) -> live buick/electra; raw "2D ELECTRA 225 CONVERTIBLE 4867"
+  "2D Electra Limited": Electra                     # 1 veh/1 rows (fi, fi_traficom) -> live buick/electra; raw "2D Electra Limited"
+  "2D Riviera": Riviera                             # 4 veh/3 rows (fi, fi_traficom) -> live buick/riviera; raw "2D RIVIERA"
+  "2D Riviera GS": Riviera                          # 1 veh/1 rows (fi, fi_traficom) -> live buick/riviera; raw "2D RIVIERA GS"
+  "2D Skylark": Skylark                             # 5 veh/5 rows (fi, fi_traficom) -> live buick/skylark; raw "2D SKYLARK CABRIOLET/2920"
+  "2D Skylark Custom": Skylark                      # 2 veh/2 rows (fi, fi_traficom) -> live buick/skylark; raw "2D SKYLARK CUSTOM CONVERTIBLE 44467/"
+  "2D Special": Special                             # 4 veh/4 rows (fi, fi_traficom) -> live buick/special; raw "2D SPECIAL CONVERTIBLE 65-43467/2920-65"
+  "2D Wildcat": Wild Cat                            # 2 veh/2 rows (fi, fi_traficom) -> live buick/wild-cat; raw "2D WILDCAT CONVERTIBLE-46667/3200"
+  "4D Century": Century                             # 2 veh/2 rows (fi, fi_traficom) -> live buick/century; raw "4D CENTURY"
+  "4D Electra 225": Electra                         # 1 veh/1 rows (fi, fi_traficom) -> live buick/electra; raw "4D ELECTRA 225"
+  "4D Le Sabre": Le Sabre                           # 2 veh/1 rows (fi, fi_traficom) -> live buick/le-sabre; raw "4D LE SABRE"
+  "4D Roadmaster": Roadmaster                       # 1 veh/1 rows (fi, fi_traficom) -> live buick/roadmaster; raw "4D ROADMASTER CONVERTIBLE SEDAN"
+  "4D Special": Special                             # 3 veh/3 rows (fi, fi_traficom) -> live buick/special; raw "4D SPECIAL"
+  "5D Century": Century                             # 1 veh/1 rows (fi, fi_traficom) -> live buick/century; raw "5D CENTURY ESTATE WAGON-AL353-G/2660"
+  "5D Roadmaster": Roadmaster                       # 4 veh/3 rows (fi, fi_traficom) -> live buick/roadmaster; raw "5D ROADMASTER ESTATE WAGON-8-BR82P-R/295"
   Lesabre: Le Sabre                           # spelling variant of "Le Sabre" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Sportwagon: Sport Wagon                     # spelling variant of "Sport Wagon" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Wildcat: Wild Cat                           # spelling variant of "Wild Cat" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1122,6 +1414,43 @@ BYD:
   "Tang Dm-P":                      Tang                    # trim/engine/body designation of the Tang — 2v 1r ua/ua_mvs
 
 Cadillac:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 62": Series 62                                # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/series-62; raw "2D 62 Coupe"
+  "2D Allante": Allante                             # 3 veh/3 rows (fi, fi_traficom) -> live cadillac/allante; raw "2D ALLANTE CONVERTIBLE-VR3-7/253"
+  "2D Calais": Calais                               # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/calais; raw "2D CALAIS COUPE"
+  "2D De Ville": De Ville                           # 12 veh/7 rows (fi, fi_traficom) -> live cadillac/de-ville; raw "2D DE VILLE CONVERTIBLE"
+  "2D Deville": De Ville                            # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/de-ville; raw "2D DEVILLE CABRIOLET 65-68367"
+  "2D Eldorado": El Dorado                          # 21 veh/18 rows (fi, fi_traficom) -> live cadillac/el-dorado; raw "2D ELDORADO COUPE"
+  "2D Eldorado Biarritz": El Dorado                 # 4 veh/4 rows (fi, fi_traficom) -> live cadillac/el-dorado; raw "2D ELDORADO BIARRITZ CONVERTIBLE 59E1/330"
+  "2D Eldorado Touring": El Dorado                  # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/el-dorado; raw "2D ELDORADO TOURING COUPE/275"
+  "2D Fleetwood": Fleetwood                         # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/fleetwood; raw "2D FLEETWOOD COUPE/3290"
+  "2D Fleetwood Brougham": Fleetwood Brougham       # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/fleetwood-brougham; raw "2D FLEETWOOD BROUGHAM"
+  "2D Fleetwood Eldorado": El Dorado                # 2 veh/2 rows (fi, fi_traficom) -> live cadillac/el-dorado; raw "2D FLEETWOOD ELDORADO COUPE 68-69347"
+  "2D Hardtop": Hardtop                             # 7 veh/5 rows (fi, fi_traficom) -> live cadillac/hardtop; raw "2D HARDTOP COUPE DE VILLE/3290"
+  "2D Series 62": Series 62                         # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/series-62; raw "2D SERIES 62 CONVERTIBLE-55-6267/328"
+  "2D Sixty-Two": Series 62                         # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/series-62; raw "2D SIXTY-TWO COUPE"
+  "4D Bls": Bls                                     # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/bls; raw "4D BLS SEDAN 2.0 AUTOMATIC-CFD49S/268"
+  "4D Brougham": Brougham                           # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/brougham; raw "4d Brougham"
+  "4D Cts": Cts                                     # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/cts; raw "4D CTS SEDAN 2.6 AUTOMATIC-D-57M/288"
+  "4D Fleetwood": Fleetwood                         # 13 veh/13 rows (fi, fi_traficom) -> live cadillac/fleetwood; raw "4D FLEETWOOD LIMOUSINE 81/3800"
+  "4D Fleetwood 75": Fleetwood 75                   # 4 veh/3 rows (fi, fi_traficom) -> live cadillac/fleetwood-75; raw "4D FLEETWOOD 75 LIMOUSINE 6733/3800"
+  "4D Fleetwood Brougham": Fleetwood Brougham       # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/fleetwood-brougham; raw "4D FLEETWOOD BROUGHAM"
+  "4D Hardtop": Hardtop                             # 3 veh/3 rows (fi+nl, fi_traficom+nl_rdw) -> live cadillac/hardtop; raw "4D HARDTOP SEDAN DE VILLE/3300"
+  "4D Seville": Seville                             # 8 veh/4 rows (fi, fi_traficom) -> live cadillac/seville; raw "4D SEVILLE SEDAN STS-KY5-Y/285"
+  "4D Seville Sts": Seville                         # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/seville; raw "4D SEVILLE STS SEDAN/295"
+  "4D Sixty-Two": Series 62                         # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/series-62; raw "4D SIXTY-TWO SEDAN 60-6239/3330"
+  "6D Fleetwood": Fleetwood                         # 1 veh/1 rows (fi, fi_traficom) -> live cadillac/fleetwood; raw "6D FLEETWOOD LIMOUSINE DW52/425"
   Deville: De Ville                           # spelling variant of "De Ville" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Eldorado: El Dorado                         # spelling variant of "El Dorado" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Lasalle: La Salle                           # spelling variant of "La Salle" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -1212,6 +1541,49 @@ Chery:
   Icaur 03: iCAUR 03                      # official styling of Chery's off-road EV sub-brand is iCAUR (https://www.icaur.com/); the default caser yields "Icaur"
 
 Chevrolet:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Bel Air": Bel Air                             # 3 veh/2 rows (fi, fi_traficom) -> live chevrolet/bel-air; raw "2D BEL AIR CONVERTIBLE"
+  "2D Bel Air Sport": Bel Air                       # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/bel-air; raw "2D BEL AIR SPORT COUPE-57-10370/292"
+  "2D Camaro": Camaro                               # 15 veh/12 rows (fi, fi_traficom) -> live chevrolet/camaro; raw "2D CAMARO CONVERTIBLE 67-12467/2750"
+  "2D Camaro Sport": Camaro                         # 8 veh/7 rows (fi, fi_traficom) -> live chevrolet/camaro; raw "2D CAMARO SPORT COUPE 327-67-12437/2750"
+  "2D Camaro Ss": Camaro                            # 11 veh/7 rows (fi, fi_traficom) -> live chevrolet/camaro; raw "2D CAMARO SS COUPE 350-67-12437/2750"
+  "2D Camaro Z28": Camaro                           # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/camaro; raw "2D CAMARO Z28 COUPE 305-12487/275"
+  "2D Caprice Classic": Caprice                     # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/caprice; raw "2D CAPRICE CLASSIC CONVERTIBLE-1N67R3/3090"
+  "2D Chevelle": Chevelle                           # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/chevelle; raw "2D Chevelle Coupe"
+  "2D Chevelle Malibu": Chevelle                    # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/chevelle; raw "2D CHEVELLE MALIBU CONVERTIBLE 64-5667/2920"
+  "2D Chevy": Chevy                                 # 2 veh/2 rows (fi, fi_traficom) -> live chevrolet/chevy; raw "2D CHEVY II NOVA SS COUPE 63"
+  "2D Coach": Coach                                 # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/coach; raw "2D Coach"
+  "2D Corvair Monza": Corvair                       # 3 veh/3 rows (fi, fi_traficom) -> live chevrolet/corvair; raw "2D CORVAIR MONZA CONVERTIBLE 65-10567/2740"
+  "2D Corvette": Corvette                           # 26 veh/17 rows (fi, fi_traficom) -> live chevrolet/corvette; raw "2D CORVETTE HATCHBACK-YY2-G/266"
+  "2D Corvette Sting Ray": Corvette                 # 5 veh/3 rows (fi, fi_traficom) -> live chevrolet/corvette; raw "2D CORVETTE STING RAY COUPE"
+  "2D Corvette Stingray": Corvette                  # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/corvette; raw "2D CORVETTE STINGRAY CONVERTIBLE"
+  "2D Impala": Impala                               # 7 veh/6 rows (fi, fi_traficom) -> live chevrolet/impala; raw "2D Impala Convertible"
+  "2D Impala Sport": Impala                         # 4 veh/3 rows (fi, fi_traficom) -> live chevrolet/impala; raw "2D IMPALA SPORT COUPE-59-1837/3020"
+  "2D Impala Ss": Impala                            # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/impala; raw "2D IMPALA SS CONVERTIBLE"
+  "2D Sport": Sport                                 # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/sport; raw "2D SPORT COUPE/2920"
+  "3D Blazer": Blazer                               # 2 veh/2 rows (fi, fi_traficom) -> live chevrolet/blazer; raw "3D BLAZER 4X4"
+  "4D 210": "210"                                   # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/210; raw "4D 210 Sedan"
+  "4D Alero": Alero                                 # 9 veh/2 rows (fi, fi_traficom) -> live chevrolet/alero; raw "4D ALERO SEDAN 2.4 AUTOMATIC-NL52T/272"
+  "4D Astro": Astro                                 # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/astro; raw "4D Astro RS-DM"
+  "4D Aveo": Aveo                                   # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/aveo; raw "4D AVEO SEDAN 1.4-SF697/248"
+  "4D Bel-Air": Bel Air                             # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/bel-air; raw "4D BEL-AIR"
+  "4D Biscayne": Biscayne                           # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/biscayne; raw "4D BISCAYNE"
+  "4D Chevy": Chevy                                 # 10 veh/6 rows (fi, fi_traficom) -> live chevrolet/chevy; raw "4D CHEVY II-65-11369/2790-65"
+  "4D Epica": Epica                                 # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/epica; raw "4D EPICA SEDAN 2.0-LF69K/270"
+  "4D Impala": Impala                               # 2 veh/1 rows (fi, fi_traficom) -> live chevrolet/impala; raw "4D IMPALA"
+  "4D Impala Sport": Impala                         # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/impala; raw "4D IMPALA SPORT SEDAN 1839/3020"
+  "4D Kalos": Kalos                                 # 1 veh/1 rows (fi, fi_traficom) -> live chevrolet/kalos; raw "4D KALOS HATCHBACK 1.2-SF48T/248"
   C20: C-20                                   # series-collapse now surfaces the spaced C-series raws fused; the settled family direction is HYPHENATED (GM heritage prose, #63 Option A) — born-form key so the id publishes hyphenated from day one
   C30: C-30                                   # ditto
   C50: C-50                                   # ditto
@@ -1493,6 +1865,37 @@ Chevrolet:
   Chev:                      null  # the make's NICKNAME written into the model column — the identical class the settled `Chevrolet: null` line already covers. Raws: nl_rdw "CHEV" ×1, nz_nzta "CHEV" ×1 (car); truck rows "CHEV K2500", "CHEV-FLEETWOOD JAMBAREE" carry a model that this key cannot reach and are separately noted in §E.2. No honest survivor: the string names the marque, not a vehicle.
 
 Chrysler:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 300": "300"                                   # 4 veh/2 rows (fi, fi_traficom) -> live chrysler/300; raw "2D 300"
+  "2D Imperial": Imperial                           # 1 veh/1 rows (fi, fi_traficom) -> live chrysler/imperial; raw "2D IMPERIAL CONVERTIBLE/3280"
+  "2D Imperial Crown": Imperial                     # 1 veh/1 rows (fi, fi_traficom) -> live chrysler/imperial; raw "2D Imperial Crown Coupe-YM23K8"
+  "2D Lebaron": Le Baron                            # 13 veh/7 rows (fi, fi_traficom) -> live chrysler/le-baron; raw "2D LEBARON CABRIOLET 3.0-BJ453/255"
+  "2D New Yorker": New Yorker                       # 1 veh/1 rows (fi, fi_traficom) -> live chrysler/new-yorker; raw "2D NEW YORKER CABRIOLET 61-831"
+  "2D Newport": Newport                             # 5 veh/4 rows (fi, fi_traficom) -> live chrysler/newport; raw "2D NEWPORT"
+  "2D Pt Cruiser": Pt Cruiser                       # 1 veh/1 rows (fi, fi_traficom) -> live chrysler/pt-cruiser; raw "2D PT CRUISER CABRIO 2.4GT/262"
+  "2D Royal": Royal                                 # 1 veh/1 rows (fi, fi_traficom) -> live chrysler/royal; raw "2D ROYAL CONVERTIBLE COUPE"
+  "2D Sebring": Sebring                             # 8 veh/7 rows (fi, fi_traficom) -> live chrysler/sebring; raw "2D SEBRING CONVERTIBLE JXI-2.5/269"
+  "4D Cirrus": Cirrus                               # 1 veh/1 rows (fi, fi_traficom) -> live chrysler/cirrus; raw "4D CIRRUS SEDAN AUTOMATIC-EJ56H"
+  "4D Imperial Crown": Imperial                     # 1 veh/1 rows (fi, fi_traficom) -> live chrysler/imperial; raw "4D IMPERIAL CROWN"
+  "4D Intrepid": Intrepid                           # 1 veh/1 rows (fi, fi_traficom) -> live chrysler/intrepid; raw "4D INTREPID SEDAN 2.7-AUTOMATIC-H56U/287"
+  "4D Neon": Neon                                   # 12 veh/4 rows (fi, fi_traficom) -> live chrysler/neon; raw "4D NEON SEDAN 2.0-SM6C/267"
+  "4D New Yorker": New Yorker                       # 2 veh/2 rows (fi, fi_traficom) -> live chrysler/new-yorker; raw "4D NEW YORKER LIMOUSINE 64-833/3800-64"
+  "4D Newport": Newport                             # 2 veh/2 rows (fi, fi_traficom) -> live chrysler/newport; raw "4D NEWPORT"
+  "4D Pt Cruiser": Pt Cruiser                       # 36 veh/19 rows (fi, fi_traficom) -> live chrysler/pt-cruiser; raw "4D PT CRUISER HATCHBACK 2.0-YNB9/262"
+  "4D Saratoga": Saratoga                           # 1 veh/1 rows (fi, fi_traficom) -> live chrysler/saratoga; raw "4D SARATOGA SEDAN-27800/320"
+  "4D Sebring": Sebring                             # 18 veh/9 rows (fi, fi_traficom) -> live chrysler/sebring; raw "4D SEBRING SEDAN 2.7-LB6U/274"
+  "4D Windsor": Windsor                             # 1 veh/1 rows (fi, fi_traficom) -> live chrysler/windsor; raw "4D WINDSOR SEDAN/319"
   300C Srt-8: 300C SRT8                       # the badge is the unhyphenated SRT8 (https://en.wikipedia.org/wiki/Chrysler_300, first-gen LX 2005-2010); nl_rdw "300C SRT8" n=42 vs "300C SRT-8" n=4
   300C-Srt-8: 300C SRT8                       # fully hyphenated register shape, same car ("CHRYSLER 300C-SRT-8")
   "300C/SRT-8": 300C SRT8                     # slash shape, same car — third produced form. NB the existing "300C": "300 C" line contradicts the source cited above; filed as debt, not repointed here (9-country id)
@@ -1562,6 +1965,28 @@ Chrysler:
 
 Citroën:
   "Saloon":      null   # body word exposed by the C-1 parenthetical strip: raw "(II CV BL) SALOON" nl 1 (+ nz) — stripping the bracket leaves the BODY, not a nameplate. "SALOON" appears across Aston Martin, Bentley, Bristol, Cadillac, Crossley and Daimler in the same column the same way, so it is a register habit rather than a Citroen model (removals.yml carries the ledger line)
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D C2": C2                                       # 4 veh/3 rows (fi, fi_traficom) -> live citroen/c2; raw "2D C2 HATCHBACK 1.4I-JMKFVB/232"
+  "2D Saxo": Saxo                                   # 4 veh/3 rows (fi, fi_traficom) -> live citroen/saxo; raw "2D SAXO HATCHBACK 1.4I-S0KFWB/239"
+  "2D Xsara": Xsara                                 # 2 veh/1 rows (fi, fi_traficom) -> live citroen/xsara; raw "2D XSARA HATCHBACK 1.6I AUTOMATIC-N0NFUN/254"
+  "4D C3": C3                                       # 11 veh/4 rows (fi, fi_traficom) -> live citroen/c3; raw "4D C3 HATCHBACK 1.4I-FCKFVB/246"
+  "4D C4": C4                                       # 1 veh/1 rows (fi, fi_traficom) -> live citroen/c4; raw "4D C4 HATCHBACK 1.6 HDI FAP-LC9HXC/261"
+  "4D C5": C5                                       # 18 veh/8 rows (fi, fi_traficom) -> live citroen/c5; raw "4D C5 HATCHBACK 2.0I-DCRFNC/275"
+  "4D C6": C6                                       # 1 veh/1 rows (fi, fi_traficom) -> live citroen/c6; raw "4D C6 SEDAN 2.7 HDI V6 AUTOMATIC-TDUHZJ/290"
+  "4D Dyane": Dyane                                 # 1 veh/1 rows (fi, fi_traficom) -> live citroen/dyane; raw "4D DYANE"
+  "4D Traction": Traction                           # 1 veh/1 rows (fi, fi_traficom) -> live citroen/traction; raw "4D TRACTION AVANT B11"
+  "4D Xsara": Xsara                                 # 7 veh/4 rows (fi, fi_traficom) -> live citroen/xsara; raw "4D XSARA HATCHBACK 1.6I-N1NFUB/254"
   # ── casing-contradiction batch: the BX family finished (BX 16/19 TRS were
   # fixed earlier, nine siblings weren't). VALUES superseded 2026-07-26 by the
   # trim-fold dossier (aux/research/trims-2026-07/dossier-citroen-opel.md,
@@ -1859,6 +2284,19 @@ Datsun:
   "New Cherry":          Cherry       # New-guard pre-positioning, UK replay (S2W handover): pipeline#111 rescued `NEW <x>` from junk? and this make already publishes the stripped nameplate, so without this key the next build MINTS A DUPLICATE. classify-derived both ways — classify(raw)="New X", classify(stripped)=the live nameplate. — uk_dft n=20; car/datsun/cherry is live
 
 De Soto:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D Custom": Custom                               # 1 veh/1 rows (fi, fi_traficom) -> live de-soto/custom; raw "4D CUSTOM"
   Desoto: null                                # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Derbi:
@@ -1899,6 +2337,32 @@ DFSK:
 
 Dodge:
   "Chrysler":    null   # MAKE NAME in the model column: raw "CHRYSLER (CDN)" nl 3, "CHRYSLER" nz 2 — the bracket is the COUNTRY (Canada), and the head is the parent marque, so neither half names a Dodge model. Exposed by the C-1 parenthetical strip; same class as car/volkswagen/volkswagen-vw, but unlike that one this id never published, so no removals.yml line is owed
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Challenger": Challenger                       # 4 veh/3 rows (fi, fi_traficom) -> live dodge/challenger; raw "2D CHALLENGER CONVERTIBLE"
+  "2D Charger": Charger                             # 3 veh/2 rows (fi, fi_traficom) -> live dodge/charger; raw "2D CHARGER"
+  "2D Charger R/T": Charger                         # 1 veh/1 rows (fi, fi_traficom) -> live dodge/charger; raw "2D CHARGER R/T"
+  "2D Coronet 500": Coronet                         # 2 veh/2 rows (fi, fi_traficom) -> live dodge/coronet; raw "2D CORONET 500 CONVERTIBLE-318-68-WP27/2970"
+  "2D Dart": Dart                                   # 2 veh/1 rows (fi, fi_traficom) -> live dodge/dart; raw "2D DART"
+  "2D Polara": Polara                               # 3 veh/3 rows (fi, fi_traficom) -> live dodge/polara; raw "2D POLARA CONVERTIBLE/3070"
+  "2D Wayfarer": Wayfarer                           # 1 veh/1 rows (fi, fi_traficom) -> live dodge/wayfarer; raw "2D WAYFARER COUPE/293"
+  "4D Caliber": Caliber                             # 2 veh/2 rows (fi, fi_traficom) -> live dodge/caliber; raw "4D CALIBER HATCHBACK 1.8-BBN8C/264"
+  "4D Coronet": Coronet                             # 1 veh/1 rows (fi, fi_traficom) -> live dodge/coronet; raw "4D CORONET"
+  "4D Coronet 440": Coronet                         # 2 veh/1 rows (fi, fi_traficom) -> live dodge/coronet; raw "4D CORONET 440"
+  "4D Custom": Custom                               # 1 veh/1 rows (fi, fi_traficom) -> live dodge/custom; raw "4d Custom sedan"
+  "4D Dart": Dart                                   # 3 veh/2 rows (fi, fi_traficom) -> live dodge/dart; raw "4D DART"
+  "4D Neon": Neon                                   # 2 veh/2 rows (fi, fi_traficom) -> live dodge/neon; raw "4D NEON SEDAN 2.0-ES46C/267"
+  "4D Pioneer": Pioneer                             # 1 veh/1 rows (fi, fi_traficom) -> live dodge/pioneer; raw "4D PIONEER"
   # ── collision batch: Dodge performance suffixes (2026-07-26). The marque
   # convention dossier, per Dodge press materials + dodge.com heritage:
   # R/T and T/A carry the SLASH (Road/Track; Trans Am — 1970 and the 2017
@@ -2132,6 +2596,21 @@ EBRO:
   S400 Hev: S400         # HEV is the powertrain badge, not the nameplate — official lineup is s400/s700/s800 (sold as "s400 HEV"; sibling records are already powertrain-bare); folds like Leaf 40KWH (https://www.ebroauto.com/)
   S400 HEV: S400         # same fold — key form that applies once HEV joins styling.yml acronyms (the caser runs before renames; cf. the "Town&country LX" key, LX being an acronym)
 
+Edsel:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Ranger": Ranger                               # 1 veh/1 rows (fi, fi_traficom) -> live edsel/ranger; raw "2D RANGER"
+
 Edwards:
   Sc-153: SC-153                            # raw "SC-153"; SC is a type-code prefix (siblings SC-151, SC-154 in the same register), not a word
 
@@ -2293,6 +2772,30 @@ Ferrari:
   "Ferrari": null                       # 2 vehicles (nl) → car/ferrari/ferrari
 
 Fiat:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Bravo": Bravo                                 # 1 veh/1 rows (fi, fi_traficom) -> live fiat/bravo; raw "2D BRAVO HATCHBACK 1.6-182AB1AA01/254"
+  "2D Panda": Panda                                 # 1 veh/1 rows (fi, fi_traficom) -> live fiat/panda; raw "2D PANDA 4X4-141AE5313"
+  "2D Punto": Punto                                 # 6 veh/5 rows (fi, fi_traficom) -> live fiat/punto; raw "2D PUNTO HATCHBACK 1.2 8V-188AXA1A00M/246"
+  "2D Punto 60 S": Punto                            # 1 veh/1 rows (fi, fi_traficom) -> live fiat/punto; raw "2D PUNTO 60 S CABRIO-176AR52C/245"
+  "2D Sport": "124"                                 # 2 veh/1 rows (fi, fi_traficom) -> live fiat/124; raw "2D SPORT COUPE 124AC/2420"
+  "2D Stilo": Stilo                                 # 1 veh/1 rows (fi, fi_traficom) -> live fiat/stilo; raw "2D STILO HATCHBACK 1.2-192AXA1B00E/260"
+  "4D Brava": Brava                                 # 4 veh/4 rows (fi, fi_traficom) -> live fiat/brava; raw "4D BRAVA FASTBACK 1.2-182BP1AA20B/254"
+  "4D Linea": Linea                                 # 1 veh/1 rows (fi, fi_traficom) -> live fiat/linea; raw "4D LINEA SEDAN 77 1.4-323AXA1A00/260"
+  "4D Marea": Marea                                 # 1 veh/1 rows (fi, fi_traficom) -> live fiat/marea; raw "4D MAREA SEDAN 2.0-185AXM1A19/254"
+  "4D Punto": Punto                                 # 12 veh/6 rows (fi, fi_traficom) -> live fiat/punto; raw "4D PUNTO HATCHBACK 1.2 16V-188BXB1A03F/246"
+  "4D Stilo": Stilo                                 # 1 veh/1 rows (fi, fi_traficom) -> live fiat/stilo; raw "4D STILO HATCHBACK 1.2 ACTIVE-192BXA1B01/260"
+  "5D Multipla": Multipla                           # 1 veh/1 rows (fi, fi_traficom) -> live fiat/multipla; raw "5D MULTIPLA"
   FIAT500: "500"                              # es_dgt/nl_rdw glue artifact — make fused onto the nameplate; merges into the corroborated 500 id. Value QUOTED: a bare 500 parses as Integer and crashes slugify (lint_curation catches this, but don't rely on it)
   "126P": "126"  # repointed (was → "126 P"): "126 P" folds into "126" this pass, and renames apply ONCE with the value used verbatim — a value that is itself folded would strand this key (Gas Gas Cg-EC300 precedent; dossier-trims-fiat-tesla §9.3). The settled two-spellings statement survives, one altitude higher.
   "2300S": "2300"  # repointed (was → "2300 S"): "2300 S" folds into "2300" this pass, and renames apply ONCE with the value used verbatim — a value that is itself folded would strand this key (Gas Gas Cg-EC300 precedent; dossier-trims-fiat-tesla §9.3). The settled two-spellings statement survives, one altitude higher.
@@ -2396,6 +2899,78 @@ Fiat:
   "Uno Turbo I.e": "Uno"  # enrich/fiat.yml car/fiat/uno variant "Turbo i.e." — https://en.wikipedia.org/wiki/Fiat_Uno
 
 Ford:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Anglia": Anglia                               # 3 veh/1 rows (fi, fi_traficom) -> live ford/anglia; raw "2D ANGLIA"
+  "2D Capri": Capri                                 # 6 veh/5 rows (fi, fi_traficom) -> live ford/capri; raw "2D CAPRI II-S-2.0-GECP/2560"
+  "2D Capri 3000 GT": Capri                         # 3 veh/1 rows (fi, fi_traficom) -> live ford/capri; raw "2D CAPRI 3000 GT XL-EC/2560"
+  "2D Cortina": Cortina                             # 1 veh/1 rows (fi, fi_traficom) -> live ford/cortina; raw "2D CORTINA"
+  "2D Escort": Escort                               # 35 veh/18 rows (fi+nl, fi_traficom+nl_rdw) -> live ford/escort; raw "2D ESCORT RS COSWORTH-ABLC4-4X4/255"
+  "2D Escort 1100": Escort                          # 1 veh/1 rows (fi, fi_traficom) -> live ford/escort; raw "2D ESCORT 1100"
+  "2D Escort 1300": Escort                          # 3 veh/2 rows (fi, fi_traficom) -> live ford/escort; raw "2D ESCORT 1300"
+  "2D Escort 1300 Sport": Escort                    # 1 veh/1 rows (fi, fi_traficom) -> live ford/escort; raw "2D Escort 1300 Sport"
+  "2D Escort Mexico 1600 GT": Escort                # 1 veh/1 rows (fi, fi_traficom) -> live ford/escort; raw "2D ESCORT MEXICO 1600 GT"
+  "2D Escort XR3I": Escort                          # 2 veh/1 rows (fi, fi_traficom) -> live ford/escort; raw "2D ESCORT XR3I CABRIOLET-ALL/253"
+  "2D Fairlane": Fairlane                           # 1 veh/1 rows (fi, fi_traficom) -> live ford/fairlane; raw "2D FAIRLANE XL-390-67-63C/2950"
+  "2D Falcon": Falcon                               # 1 veh/1 rows (fi, fi_traficom) -> live ford/falcon; raw "2D Falcon Convertible"
+  "2D Fiesta": Fiesta                               # 79 veh/9 rows (fi, fi_traficom) -> live ford/fiesta; raw "2D FIESTA HATCHBACK 1.3-JBS/245"
+  "2D Focus": Focus                                 # 31 veh/12 rows (fi, fi_traficom) -> live ford/focus; raw "2D FOCUS HATCHBACK 1.6 AUTOMATIC-DBW/262"
+  "2D Galaxie": Galaxie                             # 2 veh/2 rows (fi, fi_traficom) -> live ford/galaxie; raw "2D GALAXIE XL CABRIOLET/3040"
+  "2D Galaxie 500": Galaxie                         # 7 veh/7 rows (fi, fi_traficom) -> live ford/galaxie; raw "2D GALAXIE 500 CONVERTIBLE-76A"
+  "2D Granada": Granada                             # 1 veh/1 rows (fi, fi_traficom) -> live ford/granada; raw "2D GRANADA COUPE GXL-3000-AUTOMATIC-GC/2770"
+  "2D Ka": Ka                                       # 7 veh/1 rows (fi, fi_traficom) -> live ford/ka; raw "2D KA HATCHBACK 1.3-RBT/245"
+  "2D Ltd": L T D                                   # 1 veh/1 rows (fi, fi_traficom) -> live ford/l-t-d; raw "2D LTD"
+  "2D Mustang": Mustang                             # 133 veh/64 rows (fi+nl, fi_traficom+nl_rdw) -> live ford/mustang; raw "2D MUSTANG CONVERTIBLE 65-76A/2740"
+  "2D Mustang GT": Mustang                          # 1 veh/1 rows (fi, fi_traficom) -> live ford/mustang; raw "2D MUSTANG GT CONVERTIBLE/2550"
+  "2D Mustang LX": Mustang                          # 1 veh/1 rows (fi, fi_traficom) -> live ford/mustang; raw "2D MUSTANG LX HATCHBACK-BP28A-F/2550"
+  "2D Mustang Mach 1": Mustang                      # 2 veh/2 rows (fi, fi_traficom) -> live ford/mustang; raw "2D MUSTANG MACH 1"
+  "2D Mustang Mach I": Mustang                      # 3 veh/1 rows (fi, fi_traficom) -> live ford/mustang; raw "2D MUSTANG MACH I"
+  "2D Taunus": Taunus                               # 7 veh/2 rows (fi, fi_traficom) -> live ford/taunus; raw "2D TAUNUS XL-1600-GBTK/2580"
+  "2D Taunus 12M": Taunus 12M                       # 1 veh/1 rows (fi, fi_traficom) -> live ford/taunus-12m; raw "2D TAUNUS 12M KOMBI P4KOS/2530-65"
+  "2D Taunus 17M": Taunus 17M                       # 4 veh/3 rows (fi, fi_traficom) -> live ford/taunus-17m; raw "2D TAUNUS 17M"
+  "2D Thunderbird": Thunderbird                     # 10 veh/7 rows (fi, fi_traficom) -> live ford/thunderbird; raw "2D THUNDERBIRD"
+  "2D Torino": Torino                               # 1 veh/1 rows (fi, fi_traficom) -> live ford/torino; raw "2D TORINO FASTBACK"
+  "2D Tudor": Tudor                                 # 2 veh/2 rows (fi, fi_traficom) -> live ford/tudor; raw "2D TUDOR SEDAN/2620"
+  "2D Tunderbird": Thunderbird                      # 1 veh/1 rows (fi, fi_traficom) -> live ford/thunderbird; raw "2D TUNDERBIRD"
+  "3D Bronco": Bronco                               # 2 veh/2 rows (fi, fi_traficom) -> live ford/bronco; raw "3D BRONCO II XLT-U140-CU14T-K-4X4/2390"
+  "3D Escort": Escort                               # 3 veh/3 rows (fi, fi_traficom) -> live ford/escort; raw "3D ESCORT KOMBI 1.3-BADR/2410"
+  "3D Escort 1300": Escort                          # 1 veh/1 rows (fi, fi_traficom) -> live ford/escort; raw "3D ESCORT 1300 ESTATE ADH/2390"
+  "3D Maverick": Maverick                           # 1 veh/1 rows (fi, fi_traficom) -> live ford/maverick; raw "3D MAVERICK 4X4/245"
+  "3D Taunus 15M": Taunus 15M                       # 1 veh/1 rows (fi, fi_traficom) -> live ford/taunus-15m; raw "3D TAUNUS 15M KOMBI 25G/2530"
+  "3D Taunus 17M": Taunus 17M                       # 4 veh/1 rows (fi, fi_traficom) -> live ford/taunus-17m; raw "3D TAUNUS 17M KOMBI 215S/2700"
+  "4D A Town": Model A                              # 1 veh/1 rows (fi, fi_traficom) -> live ford/model-a; raw "4D A TOWN SEDAN 160B/2630"
+  "4D Consul Cortina": Cortina                      # 2 veh/2 rows (fi, fi_traficom) -> live ford/cortina; raw "4D CONSUL CORTINA ESTATE CAR 114E/2490-64"
+  "4D Cortina": Cortina                             # 3 veh/2 rows (fi, fi_traficom) -> live ford/cortina; raw "4D CORTINA XL 1600-BF/2580"
+  "4D Country": Country                             # 1 veh/1 rows (fi, fi_traficom) -> live ford/country; raw "4D COUNTRY SEDAN 63-71C/3020"
+  "4D Deluxe": De Luxe                              # 1 veh/1 rows (fi, fi_traficom) -> live ford/de-luxe; raw "4D DELUXE"
+  "4D Escort 1300": Escort                          # 1 veh/1 rows (fi, fi_traficom) -> live ford/escort; raw "4D ESCORT 1300 XL-AUTOMATIC-AFH/2390"
+  "4D Fiesta": Fiesta                               # 12 veh/6 rows (fi, fi_traficom) -> live ford/fiesta; raw "4D FIESTA HATCHBACK 1.4-JH1/249"
+  "4D Focus": Focus                                 # 104 veh/21 rows (fi, fi_traficom) -> live ford/focus; raw "4D FOCUS HATCHBACK 1.6-DAW/262"
+  "4D Focus C-Max": C-Max                           # 1 veh/1 rows (fi, fi_traficom) -> live ford/c-max; raw "4D FOCUS C-MAX"
+  "4D Ltd Landau": L T D                            # 1 veh/1 rows (fi, fi_traficom) -> live ford/l-t-d; raw "4D LTD LANDAU"
+  "4D Mondeo": Mondeo                               # 120 veh/37 rows (fi, fi_traficom) -> live ford/mondeo; raw "4D MONDEO SEDAN 1.8-BFP/270"
+  "4D T Touring": Model T                           # 1 veh/1 rows (fi, fi_traficom) -> live ford/model-t; raw "4D T TOURING"
+  "4D Taunus": Taunus                               # 3 veh/2 rows (fi, fi_traficom) -> live ford/taunus; raw "4D TAUNUS XL-1600-GBFK/2580"
+  "4D Taunus 17M": Taunus 17M                       # 1 veh/1 rows (fi, fi_traficom) -> live ford/taunus-17m; raw "4D TAUNUS 17M"
+  "4D Touring": Touring                             # 1 veh/1 rows (fi, fi_traficom) -> live ford/touring; raw "4d Touring"
+  "4D Town": Town                                   # 1 veh/1 rows (fi, fi_traficom) -> live ford/town; raw "4D TOWN SEDAN/2640"
+  "4D Transit": Transit                             # 5 veh/5 rows (fi, fi_traficom) -> live ford/transit; raw "4D TRANSIT KOMBI 300S-2.0D55-9-FDEY/293"
+  "5D Explorer Limited": Explorer                   # 2 veh/1 rows (fi, fi_traficom) -> live ford/explorer; raw "5D EXPLORER LIMITED 4X4/284"
+  "5D Focus": Focus                                 # 1 veh/1 rows (fi, fi_traficom) -> live ford/focus; raw "5D FOCUS"
+  "5D Mondeo": Mondeo                               # 2 veh/2 rows (fi, fi_traficom) -> live ford/mondeo; raw "5D MONDEO ST 200 2.5-V6-STW-BNP/270"
+  "5D Taunus 20M": Taunus 20M                       # 1 veh/1 rows (fi, fi_traficom) -> live ford/taunus-20m; raw "5D TAUNUS 20M KOMBI 226/2700"
+  "5D Torino": Torino                               # 1 veh/1 rows (fi, fi_traficom) -> live ford/torino; raw "5D Torino"
+  "5D Tourneo Connect": Tourneo Connect             # 5 veh/3 rows (fi, fi_traficom) -> live ford/tourneo-connect; raw "5D TOURNEO CONNECT KOMBI 1.8TDCI-PJ2/291"
   # ── swarm-dossier batch: residuals only — F-Series direction untouched. ──
   Ecosport: EcoSport      # Ford styles it camel-case, one word (https://en.wikipedia.org/wiki/Ford_EcoSport); the us_fueleconomy raw is literally "EcoSport AWD" — display-only, slug stays ecosport
   Eco Sport: EcoSport     # es_dgt/RDW split spelling of the same car — same source
@@ -2740,6 +3315,21 @@ Gas Gas:
   Cg-EC300: EC 300       # registry compound "type code + commercial name"; 299cc on e9*168/2013*30006 = the EC 300 (targets the respaced canonical directly — rename chaining is not assumed)
   ES700:                     ES 700               # Gas Gas ES 700 — space before the displacement. THIS KEY is why the ES acronym token was rejected: adding it would have orphaned this line (S4W Turn 56)
 
+GAZ:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D Volga": Volga                                 # 1 veh/1 rows (fi, fi_traficom) -> live gaz/volga; raw "4D Volga"
+
 Geely:
   Starray: Starray EM-i                   # KBA truncation; the model sold in Germany is the Starray EM-i PHEV (https://www.geely.com/en/news/2026/geely-e5-starray-em-i-debut-five-european-countries)
   Starray Em-I: Starray EM-i              # registry-derived casing of the same car folds into the official form
@@ -2748,6 +3338,20 @@ Gilera:
   Runner 45KM/H: Runner      # L1e class marker folds (NAMING.md §6); the Runner nameplate covers it
 
 GMC:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "3D Safari": Safari                               # 1 veh/1 rows (fi, fi_traficom) -> live gmc/safari; raw "3D SAFARI AWD"
+  "4D Sierra 1500": Sierra 1500                     # 1 veh/1 rows (fi, fi_traficom) -> live gmc/sierra-1500; raw "4D SIERRA 1500"
   "Hummer EV SUV 3X": Hummer EV     # drift-adoption fold: 3X is a trim of the Hummer EV SUV (leaf-30-kwh precedent)
   Pickup: Pick-Up                             # spelling variant of "Pick-Up" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
@@ -2932,7 +3536,48 @@ Harley-Davidson:
   "Softail Springer":                        "Springer Softail"             # PERMUTATION FOLD (verified batch, tier A): Springer-first 10 vs Softail-first 7, AND H-D's code page writes 'FXSTS: Springer™ Softail®'.
   "Road Glide Special Fltrxs":               "Fltrxs Road Glide Special"    # PERMUTATION FOLD (verified batch, tier A): Code-first 7 vs name-first 2, and H-D's code page pairs FLTRXS with Road Glide Special.
 
+Hillman:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D Minx": Minx                                   # 5 veh/4 rows (fi, fi_traficom) -> live hillman/minx; raw "4D MINX III A/2440"
+  "4D Super Minx": Super Minx                       # 1 veh/1 rows (fi, fi_traficom) -> live hillman/super-minx; raw "4D SUPER MINX III/2560-65"
+
 Honda:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Accord": Accord                               # 5 veh/4 rows (fi, fi_traficom) -> live honda/accord; raw "2D ACCORD COUPE 2.2IES-CD714/272"
+  "2D Civic": Civic                                 # 18 veh/8 rows (fi, fi_traficom) -> live honda/civic; raw "2D CIVIC HATCHBACK 1.6-EP23/258"
+  "4D Accord": Accord                               # 21 veh/15 rows (fi, fi_traficom) -> live honda/accord; raw "4D ACCORD SEDAN 2.0-CL75/268"
+  "4D Accord LX": Accord LX                         # 1 veh/1 rows (fi, fi_traficom) -> live honda/accord-lx; raw "4D ACCORD LX SEDAN 2.4 AUTOMATIC-CM56/274"
+  "4D Civic": Civic                                 # 54 veh/18 rows (fi, fi_traficom) -> live honda/civic; raw "4D CIVIC SEDAN 1.6-ES55/263"
+  "4D Cr-V": CR-V                                   # 81 veh/16 rows (fi, fi_traficom) -> live honda/cr-v; raw "4D CR-V HATCHBACK-RD17-4X4/262"
+  "4D Fit": Fit                                     # 1 veh/1 rows (fi, fi_traficom) -> live honda/fit; raw "4D FIT HATCHBACK 1.5-GD37/245"
+  "4D HR-V": HR-V                                   # 21 veh/6 rows (fi, fi_traficom) -> live honda/hr-v; raw "4D HR-V HATCHBACK 1.6-GH47-4X4/245"
+  "4D Jazz": Jazz                                   # 6 veh/2 rows (fi, fi_traficom) -> live honda/jazz; raw "4D JAZZ HATCHBACK 1.4-GD17/245"
+  "5D Accord": Accord                               # 6 veh/2 rows (fi, fi_traficom) -> live honda/accord; raw "5D ACCORD TOURER 2.0 AUTOMATIC-CM18/272"
+  "5D Accord 2": Accord 2                           # 1 veh/1 rows (fi, fi_traficom) -> live honda/accord-2; raw "5D ACCORD 2,0IES AERODECK AUTOMATIC CE2/272"
+  "5D Cr-V": CR-V                                   # 1 veh/1 rows (fi, fi_traficom) -> live honda/cr-v; raw "5D CR-V"
+  "5D Odyssey EX L": Odyssey EX-L                   # 1 veh/1 rows (fi, fi_traficom) -> live honda/odyssey-ex-l; raw "5D ODYSSEY EX L 4DR  MVAN"
   "CB600": "CB600F Hornet"                 # HONDA CLUSTER FOLD: Honda's page heading is "1998 HORNET 600/CB600F HORNET" (https://global.honda/en/CB/models/1998_hornet-600/) and Honda publishes NO bare CB600 — "CB600", "CB600F" and "CB600 Hornet" are register truncations of one machine.
   "CB600 Hornet": "CB600F Hornet"          # same cluster, same source
   "CB600F": "CB600F Hornet"                # same cluster, same source
@@ -2982,6 +3627,19 @@ Honda:
   "Z50 Monkey":                      "Monkey Z50"             # PERMUTATION FOLD (tier B, direction settled by sibling consistency): name-first 7v5 is thin, but Monkey Z50A shipped in tier A on its own count and a third Monkey sibling agrees — three members, one order
 
 Humber:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D Hawk": Hawk                                   # 1 veh/1 rows (fi, fi_traficom) -> live humber/hawk; raw "4D HAWK SALOON 2800"
   Humber: null                                # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Hummer:
@@ -2994,6 +3652,22 @@ Husqvarna:
   "901 Norden":                              "Norden 901"                   # PERMUTATION FOLD (verified batch, tier A): MARQUE ORDER, AGAINST THE COUNT (222 vs 25 the other way).
 
 Hyundai:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Accent": Accent                               # 1 veh/1 rows (fi, fi_traficom) -> live hyundai/accent; raw "2D ACCENT HATCHBACK 1.5 AUTOMATIC-C"
+  "2D Getz": Getz                                   # 1 veh/1 rows (fi, fi_traficom) -> live hyundai/getz; raw "2D GETZ HATCHBACK 1.3 AUTOMATIC-B-31HP/246"
+  "4D Accent": Accent                               # 1 veh/1 rows (fi, fi_traficom) -> live hyundai/accent; raw "4D ACCENT HATCHBACK 1.3-C-51FP/244"
+  "4D Sonata": Sonata                               # 4 veh/4 rows (fi, fi_traficom) -> live hyundai/sonata; raw "4D SONATA SEDAN 2.4-E-41CP/273"
   # ── singleton-tail dossier: the LM-generation (2009-15) Tucson was sold as
   # the ix35 in every market these records evidence (https://en.wikipedia.org/wiki/Hyundai_Tucson);
   # registers wrote both names on one row. AR raw re-verified by the maintainer:
@@ -3062,6 +3736,21 @@ I-Goo:
   Lt-019: LT019                             # closed, to match the I-Coco LT018 block above: i-coco/LT-018 and i-goo/LT-019 are consecutive type codes from one OEM and the register writes both open and closed. Neither form is manufacturer-attested; sibling consistency is the only argument available, and it is the reason stated.
 
 Imperial:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Crown": Crown                                 # 2 veh/2 rows (fi, fi_traficom) -> live imperial/crown; raw "2D CROWN COUPE-Y22/328"
+  "4D Crown": Crown                                 # 2 veh/2 rows (fi, fi_traficom) -> live imperial/crown; raw "4D CROWN SEDAN HT"
+  "4D Le Baron": Le Baron                           # 1 veh/1 rows (fi, fi_traficom) -> live imperial/le-baron; raw "4D LE BARON SEDAN/3280"
   Lebaron: Le Baron                           # spelling variant of "Le Baron" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Indian:
@@ -3081,6 +3770,19 @@ Irizar:
   "16": i6               # digit-1 typo of I6 — RDW merk IRIZAR carries "16 14.07.37 EFFICIENT" beside "I6 14.07.37 EFFICIENT"; Irizar's range has no "16" (https://www.irizar.com/en/products-technologies/all-models); target is the post-styling lowercase i6
 
 Isuzu:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D Bellett": Bellett                             # 1 veh/1 rows (fi, fi_traficom) -> live isuzu/bellett; raw "4D BELLETT"
   Dmax: D-Max                                 # spelling variant of "D-Max" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Isuzu: null                                 # registry rows where the make was written into the model column (van kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
   NLR85EXXXB: N-Series                    # NLR85 is a CHASSIS code, not a nameplate — Isuzu's light truck line is the N-Series (sold as Elf in Japan). The trailing EXXXB is a body/spec suffix. https://www.isuzu.co.jp/world/product/elf/
@@ -3340,6 +4042,21 @@ Jaecoo:
   JAECOO8: Jaecoo 8                       # marque fused; official spelling is spaced
 
 Jaguar:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D S-Type": S-Type                               # 58 veh/11 rows (fi, fi_traficom) -> live jaguar/s-type; raw "4D S-TYPE SALOON 3.0 AUTOMATIC-F/291"
+  "4D X-Type": X-Type                               # 19 veh/10 rows (fi, fi_traficom) -> live jaguar/x-type; raw "4D X-TYPE SALOON 2,0-B5Y/271"
+  "4D Xj": Xj                                       # 1 veh/1 rows (fi, fi_traficom) -> live jaguar/xj; raw "4D XJ SALOON 4.2 AUTOMATIC-A7"
   # ── swarm-dossier batch: X.J.S stop-split artifacts (the MG "M G B"
   # class) + the settled fused XJ6 direction completed. "Xj  6" has TWO
   # literal spaces (smart_case lone-hyphen defect; corpus-proven,
@@ -3497,6 +4214,24 @@ Jawa:
   Jawa: null                              # motorcycle fi|nl
 
 Jeep:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Wrangler": Wrangler                           # 1 veh/1 rows (fi, fi_traficom) -> live jeep/wrangler; raw "2D WRANGLER CONVERTIBLE 4.0 AUTOM-TJ-J4FAA-4"
+  "3D Wrangler": Wrangler                           # 2 veh/2 rows (fi, fi_traficom) -> live jeep/wrangler; raw "3D WRANGLER 4X4"
+  "5D Grand Cherokee": Grand Cherokee               # 4 veh/2 rows (fi, fi_traficom) -> live jeep/grand-cherokee; raw "5D GRAND CHEROKEE"
+  "5D Grand Cherokee Laredo": Grand Cherokee        # 1 veh/1 rows (fi, fi_traficom) -> live jeep/grand-cherokee; raw "5D GRAND CHEROKEE LAREDO 4X4"
+  "5D Grand Cherokee Limited": Grand Cherokee       # 1 veh/1 rows (fi, fi_traficom) -> live jeep/grand-cherokee; raw "5D GRAND CHEROKEE LIMITED"
+  "5D Liberty": Liberty                             # 1 veh/1 rows (fi, fi_traficom) -> live jeep/liberty; raw "5D LIBERTY 4WD"
   # ── swarm-dossier batch: CJ direction reversed on jeep.com's own history
   # pages (marque-official hyphenation beats the fused-prefix heuristic —
   # the settled F-150 shape). ──
@@ -3954,12 +4689,74 @@ Kymco:
   New Sento: Sento                            # 938 vehicles (nl) — same scooter as moped/kymco/sento (live: nl_rdw, the same register that writes both forms) — https://www.kymco.eu/scooters/
 
 Lada:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D Samara": Samara                               # 65 veh/1 rows (fi, fi_traficom) -> live lada/samara; raw "4D SAMARA HATCHBACK 1.5I-210930/246"
   "1200S": "1200 S"                           # spelling variant of "1200 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Lancia:
   Montecarlo: Monte Carlo                     # spelling variant of "Monte Carlo" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Land Rover:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "3D Defender 90 Stw 2.5TD5-LDVB5-4X4/236": Defender  # 2 veh/1 rows (fi, fi_traficom) -> live land-rover/defender; raw "3D DEFENDER 90 STW 2.5TD5-LDVB5-4X4/236"
+  "3D Defender 90 Stw 2.5TD5-LDVB6-4X4/236": Defender  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/defender; raw "3D DEFENDER 90 STW 2.5TD5-LDVB6-4X4/236"
+  "3D Defender 90 Stw 2.5TD5-LDVB8-4X4/236": Defender  # 3 veh/2 rows (fi, fi_traficom) -> live land-rover/defender; raw "3D DEFENDER 90 STW 2.5TD5-LDVB8-4X4/236"
+  "3D Defender 90 Stw 2.5TDI-LDVB8-4X4/236": Defender  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/defender; raw "3D DEFENDER 90 STW 2.5TDI-LDVB8-4X4/236"
+  "3D Discovery": Discovery                         # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/discovery; raw "3D DISCOVERY"
+  "3D Discovery-LJGB7-4X4/254": Discovery           # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/discovery; raw "3D DISCOVERY-LJGB7-4X4/254"
+  "3D Discovery-Ljgbf-4X4/254": Discovery           # 8 veh/2 rows (fi, fi_traficom) -> live land-rover/discovery; raw "3D DISCOVERY-LJGBF-4X4/254"
+  "3D Discovery-Ljgbm-4X4/254": Discovery           # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/discovery; raw "3D DISCOVERY-LJGBM-4X4/254"
+  "3D Freelander Stw 1.8-Lnaaa-4X4/256": Freelander  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/freelander; raw "3D FREELANDER STW 1.8-LNAAA-4X4/256"
+  "5D Defender 110": Defender                       # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/defender; raw "5D DEFENDER 110"
+  "5D Defender 110 Stw 2.5TD5-LDHM5-4X4/279": Defender  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/defender; raw "5D DEFENDER 110 STW 2.5TD5-LDHM5-4X4/279"
+  "5D Defender 110 Stw 2.5TD5-LDHM8-4X4/279": Defender  # 7 veh/2 rows (fi, fi_traficom) -> live land-rover/defender; raw "5D DEFENDER 110 STW 2.5TD5-LDHM8-4X4/279"
+  "5D Discovery": Discovery                         # 27 veh/17 rows (fi, fi_traficom) -> live land-rover/discovery; raw "5D DISCOVERY II STW 2.5TD-LTGM98-4X4/254"
+  "5D Discovery 2.5TDI-4X4": Discovery              # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/discovery; raw "5D DISCOVERY 2.5TDI-4X4"
+  "5D Discovery Ll Stw 4.0 Automatic-7-LTGM24-4X4/254": Discovery  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/discovery; raw "5D DISCOVERY ll STW 4.0 AUTOMATIC-7-LTGM24-4"
+  "5D Discovery-Automatic-JY124-4X4": Discovery     # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/discovery; raw "5D DISCOVERY-AUTOMATIC-JY124-4X4"
+  "5D Discovery-Automatic-LJGM7-4X4/254": Discovery  # 5 veh/1 rows (fi, fi_traficom) -> live land-rover/discovery; raw "5D DISCOVERY-AUTOMATIC-LJGM7-4X4/254"
+  "5D Discovery-Automatic-LJY12-4X4/254": Discovery  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/discovery; raw "5D DISCOVERY-AUTOMATIC-LJY12-4X4/254"
+  "5D Discovery-Ljgbf-4X4/254": Discovery           # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/discovery; raw "5D DISCOVERY-LJGBF-4X4/254"
+  "5D Discovery-Ljgmf-4X4/254": Discovery           # 15 veh/3 rows (fi, fi_traficom) -> live land-rover/discovery; raw "5D DISCOVERY-LJGMF-4X4/254"
+  "5D Discovery-Ljgmm-4X4/254": Discovery           # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/discovery; raw "5D DISCOVERY-LJGMM-4X4/254"
+  "5D Freelander Sport Stw 2.0 TD4 Autom-LNFBE2-4X4/256": Freelander  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER SPORT STW 2.0 TD4 AUTOM-LNFBE2"
+  "5D Freelander Stw": Freelander                   # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW"
+  "5D Freelander Stw 1.8-Lnaba-4X4/256": Freelander  # 6 veh/1 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW 1.8-LNABA-4X4/256"
+  "5D Freelander Stw 1.8-LNABA8-4X4/256": Freelander  # 6 veh/1 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW 1.8-LNABA8-4X4/256"
+  "5D Freelander Stw 1.8-Lnba": Freelander          # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW 1.8-LNBA"
+  "5D Freelander Stw 2.0 TD4-LNABE8-4X4/256": Freelander  # 2 veh/2 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW 2.0 TD4-LNABE8-4X4/256"
+  "5D Freelander Stw 2.0D Automatic-LNABE2-4X4/256": Freelander  # 3 veh/2 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW 2.0D AUTOMATIC-LNABE2-4X4/"
+  "5D Freelander Stw 2.0D-LNABE8-4X4/256": Freelander  # 2 veh/2 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW 2.0D-LNABE8-4X4/256"
+  "5D Freelander Stw 2.0TDI-Lnabb-4X4": Freelander  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW 2.0TDI-LNABB-4X4"
+  "5D Freelander Stw 2.5 Automatic-LNABG2-4X4/256": Freelander  # 2 veh/1 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW 2.5 AUTOMATIC-LNABG2-4X4/2"
+  "5D Freelander Stw 2.5 Automatic-NE2227-4X4/256": Freelander  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW 2.5 AUTOMATIC-NE2227-4X4/2"
+  "5D Freelander Stw 2.5 V6 Autom-NY222-Se-4X4/256": Freelander  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/freelander; raw "5D FREELANDER STW 2.5 V6 AUTOM-NY222-SE-4X4/"
+  "5D Range Rover Sport": Range Rover Sport         # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/range-rover-sport; raw "5D RANGE ROVER SPORT"
+  "5D Range Rover Sport Stw 2.7TDV6 Autom. LSAAA14-4X": Range Rover Sport  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/range-rover-sport; raw "5D RANGE ROVER SPORT STW 2.7TDV6 AUTOM. LSAA"
+  "5D Range Rover Stw 3.0 TD6 Automatic-LMAMC4-4X4/288": Range Rover  # 1 veh/1 rows (fi, fi_traficom) -> live land-rover/range-rover; raw "5D RANGE ROVER STW 3.0 TD6 AUTOMATIC-LMAMC4-"
+  "5D Range Rover Stw 4.4 V8 Automatic-LMAMA4-4X4/288": Range Rover  # 2 veh/1 rows (fi, fi_traficom) -> live land-rover/range-rover; raw "5D RANGE ROVER STW 4.4 V8 AUTOMATIC-LMAMA4-4"
   "109 Hardtop": "109"                        # REPOINT (was -> "109 Hard Top"): the target is now folded into the 109 as a BODY variant. Renames are SINGLE-PASS, so a missed repoint silently misroutes rows to a dead id. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
   "88 Hardtop": "88"                          # REPOINT (was -> "88 Hard Top"): same reason — the target is now a BODY variant of the 88. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
   "88 Wb": "88"                               # REPOINT (was -> "88 W B"): same reason — WB is the wheel base the number already names. FIRES IN car AND van (https://en.wikipedia.org/wiki/Land_Rover_series)
@@ -4055,6 +4852,22 @@ Leike:
   Leike: null                             # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Lexus:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D GS300": GS                                    # 1 veh/1 rows (fi, fi_traficom) -> live lexus/gs; raw "4D GS300 SEDAN 3.0 AUTOMATIC/280"
+  "4D GS430": GS                                    # 1 veh/1 rows (fi, fi_traficom) -> live lexus/gs; raw "4D GS430 SEDAN 4.3 AUTOMATIC-UZS190L-BETQKW/"
+  "4D IS200": IS                                    # 14 veh/4 rows (fi, fi_traficom) -> live lexus/is; raw "4D IS200 SEDAN 2.0-GXE10L-AEFVKW/267"
+  "4D IS250": IS                                    # 1 veh/1 rows (fi, fi_traficom) -> live lexus/is; raw "4D IS250 SEDAN 2.5 AUTOMATIC-GSE20L-AETLHW/2"
   Rc F: RC F                        # mixed-case raw writes it caps: "Lexus RC F" (ca_nrcan); "RC F" spaced — https://en.wikipedia.org/wiki/Lexus_RC
   IS 250C: IS                             # engine/powertrain variant of the IS line — Lexus writes "IS 450h" style and the NAMEPLATE is the line (lexus.co.uk/car-models); folds per the trim policy
   IS 350C: IS                             # engine/powertrain variant of the IS line — Lexus writes "IS 450h" style and the NAMEPLATE is the line (lexus.co.uk/car-models); folds per the trim policy
@@ -4286,6 +5099,29 @@ Ligier:
   "Xtoo RS Dci":                 Xtoo RS                # dCi is Renault's diesel ENGINE badge, not part of the nameplate — folds like any engine variant
 
 Lincoln:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Continental": Continental                     # 3 veh/2 rows (fi, fi_traficom) -> live lincoln/continental; raw "2D CONTINENTAL"
+  "2D Continental Mark": Continental Mark           # 38 veh/28 rows (fi, fi_traficom) -> live lincoln/continental-mark; raw "2D CONTINENTAL MARK V HT-77-89S/3060"
+  "2D Continental Mk": Continental Mk               # 3 veh/2 rows (fi, fi_traficom) -> live lincoln/continental-mk; raw "2D CONTINENTAL MK IV"
+  "2D Continental Town": Continental Town           # 5 veh/3 rows (fi, fi_traficom) -> live lincoln/continental-town; raw "2D CONTINENTAL TOWN COUPE"
+  "2D Continental-Mark 4": Continental Mark 4       # 1 veh/1 rows (fi, fi_traficom) -> live lincoln/continental-mark-4; raw "2D CONTINENTAL-MARK 4"
+  "2D Mark": Mark                                   # 4 veh/4 rows (fi, fi_traficom) -> live lincoln/mark; raw "2D MARK V-89A/3060"
+  "4D Continental": Continental                     # 8 veh/6 rows (fi, fi_traficom) -> live lincoln/continental; raw "4D CONTINENTAL"
+  "4D Continental Mark": Continental Mark           # 1 veh/1 rows (fi, fi_traficom) -> live lincoln/continental-mark; raw "4D CONTINENTAL MARK VI BP96F-B"
+  "4D Continental Town": Continental Town           # 1 veh/1 rows (fi, fi_traficom) -> live lincoln/continental-town; raw "4D CONTINENTAL TOWN"
+  "4D Town Car": Town Car                           # 3 veh/2 rows (fi, fi_traficom) -> live lincoln/town-car; raw "4D TOWN CAR LIMOUSINE"
+  "4D Towncar": Town Car                            # 1 veh/1 rows (fi, fi_traficom) -> live lincoln/town-car; raw "4D TOWNCAR LIMOUSINE"
   Towncar: Town Car                           # spelling variant of "Town Car" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Lincoln: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
@@ -4654,6 +5490,24 @@ Maybach:
   "57S": "57 S"                               # spelling variant of "57 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Mazda:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D MX-5": MX-5                                   # 2 veh/2 rows (fi, fi_traficom) -> live mazda/mx-5; raw "2D MX-5 CONVERTIBLE 1.8"
+  "4D 323": "323"                                   # 4 veh/1 rows (fi, fi_traficom) -> live mazda/323; raw "4D 323 SEDAN 1.6-BJ-12M5/261"
+  "4D 323F": "323"                                  # 2 veh/2 rows (fi, fi_traficom) -> live mazda/323; raw "4D 323F HATCHBACK SPORT 2.0-BJ-14S2/261"
+  "4D 626": "626"                                   # 11 veh/7 rows (fi, fi_traficom) -> live mazda/626; raw "4D 626 SEDAN 1.8-GF-12P-2E/261"
+  "4D MAZDA3": MAZDA3                               # 6 veh/4 rows (fi, fi_traficom) -> live mazda/mazda3; raw "4D MAZDA3 HATCHBACK 2.0-BK14F2/264"
+  "4D MAZDA6": MAZDA6                               # 15 veh/11 rows (fi, fi_traficom) -> live mazda/mazda6; raw "4D MAZDA6 SEDAN 2.0-GG12F2/268"
   # ── WITHHELD: the B-series displacement pooling (`B2000`/`B2500`/`B2600`/
   # `B3000`/`B3000 Ffv`/`B4000` → `B Series`) is NOT taken by this pass, and
   # the six ids stay live. It was proposed on strong evidence (us_fueleconomy
@@ -4724,6 +5578,152 @@ Mazda:
   Coupe:      null                   # bare body word; the single RDW row is a 1,300 cc coupe first registered 1992 (a 323 coupe), and the NZ half carries no further token
 
 Mercedes-Benz:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 108": "108"                                   # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/108; raw "2D 108 CDI-638194/300"
+  "2D CLK 200": CLK                                 # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/clk; raw "2D CLK 200 KOMPRESSOR CABRIOLET-208445/269"
+  "2D CLK 240": CLK                                 # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/clk; raw "2D CLK 240 CABRIOLET AUTOMATIC-209461/272"
+  "2D CLK 320": CLK                                 # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/clk; raw "2D CLK 320 CABRIOLET AUTOMATIC-208465/269"
+  "2D Roadster 190SL/2400": Roadster                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/roadster; raw "2D ROADSTER 190SL/2400"
+  "2D Roadster 450 Automatic 107/245": Roadster     # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/roadster; raw "2D ROADSTER 450 AUTOMATIC 107/245"
+  "2D SL 500 Roadster Automatic-230475/256": SL     # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/sl; raw "2D SL 500 ROADSTER AUTOMATIC-230475/256"
+  "2D SL 500 Roadster-230475/256": SL               # 2 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/sl; raw "2D SL 500 ROADSTER-230475/256"
+  "2D SL 600 Roadster-230476/256": SL               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/sl; raw "2D SL 600 ROADSTER-230476/256"
+  "2D SLK 350 Roadster Automatic": SLK              # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/slk; raw "2D SLK 350 ROADSTER AUTOMATIC"
+  "2D SLK 350 Roadster Automatic-171456/243": SLK   # 2 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/slk; raw "2D SLK 350 ROADSTER AUTOMATIC-171456/243"
+  "3D 313": "313"                                   # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/313; raw "3D 313 CDI KOMBI-9036/355"
+  "3D A 170": A-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/a-class; raw "3D A 170 KOMBI-5-169332/257"
+  "3D C 180": C-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "3D C 180 KOMPRESSOR SPORTCOUPE-203746/272"
+  "3D C 200": C-Class                               # 3 veh/3 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "3D C 200 KOMPRESSOR SPORTCOUPE AUTOMATIC-203"
+  "3D C 220": C-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "3D C 220 CDI SPORTCOUPE-203708/272"
+  "3D C 230 Sportcoupe-203752/272": C-Class         # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "3D C 230 SPORTCOUPE-203752/272"
+  "3D C 320 Sportcoupe-203764/272": C-Class         # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "3D C 320 SPORTCOUPE-203764/272"
+  "3D E 270": E-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "3D E 270 CDI KOMBI AUTOMATIC-211616/360"
+  "3D E220": E-Class                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "3D E220 CDI AUTOMATIC-211F/360"
+  "3D E270": E-Class                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "3D E270 CDI AUTOMATIC-211F/360"
+  "3D G 270": G-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/g-class; raw "3D G 270 CDI-463322-4X4/240"
+  "3D V220CDI Bus-638-2/300": V-Class               # 4 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/v-class; raw "3D V220CDI BUS-638-2/300"
+  "3D V280-Automatic-638-2/300": V-Class            # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/v-class; raw "3D V280-AUTOMATIC-638-2/300"
+  "4D 211": "211"                                   # 2 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/211; raw "4D 211 CDI KOMBI-9026/355"
+  "4D 213": "213"                                   # 3 veh/3 rows (fi, fi_traficom) -> live mercedes-benz/213; raw "4D 213 CDI KOMBI HOCH-9026/355"
+  "4D 260E": "260 E"                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/260-e; raw "4D 260E"
+  "4D 300 Se": "300 SE"                             # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/300-se; raw "4D 300 SE"
+  "4D 313": "313"                                   # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/313; raw "4D 313 CDI KOMBI HOCH-9036/355"
+  "4D 316": "316"                                   # 3 veh/3 rows (fi, fi_traficom) -> live mercedes-benz/316; raw "4D 316 CDI-9036-3.5T-KASTEN/355"
+  "4D C 180": C-Class                               # 50 veh/7 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C 180 SEDAN-203035/272"
+  "4D C 200": C-Class                               # 141 veh/20 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C 200 KOMPRESSOR SEDAN AUTOMATIC-203045/2"
+  "4D C 220": C-Class                               # 43 veh/8 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C 220 CDI SEDAN AUTOMATIC-203006/272"
+  "4D C 230": C-Class                               # 5 veh/4 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C 230 KOMPRESSOR SEDAN AUTOMATIC-203040/2"
+  "4D C 240": C-Class                               # 20 veh/7 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C 240 SEDAN AUTOMATIC-203061/272"
+  "4D C 270": C-Class                               # 7 veh/3 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C 270 CDI SEDAN AUTOMATIC-203016/272"
+  "4D C 300": C-Class                               # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C 300 SEDAN 4-MATIC"
+  "4D C 320": C-Class                               # 5 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C 320 SEDAN AUTOMATIC-203064/272"
+  "4D C 350": C-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C 350 SEDAN AUTOMATIC"
+  "4D C180": C-Class                                # 3 veh/3 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C180 KOMPRESSOR SEDAN AUTOMATIC-203046/27"
+  "4D C240": C-Class                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "4D C240 SEDAN AUTOMATIC-RF61J8/272"
+  "4D CLS 320": CLS                                 # 3 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/cls; raw "4D CLS 320 CDI SEDAN AUTOMATIC-219322/285"
+  "4D CLS 350": CLS                                 # 5 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/cls; raw "4D CLS 350 SEDAN AUTOMATIC-219356/285"
+  "4D CLS 500": CLS                                 # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/cls; raw "4D CLS 500 SEDAN AUTOMATIC-219375/285"
+  "4D CLS 55 AMG": CLS                              # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/cls; raw "4D CLS 55 AMG SEDAN AUTOMATIC-219376/285"
+  "4D E 200": E-Class                               # 55 veh/15 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E 200 CDI SEDAN AUTOMATIC-211004/285"
+  "4D E 220": E-Class                               # 173 veh/10 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E 220 CDI SEDAN AUTOMATIC-211006/285"
+  "4D E 240": E-Class                               # 35 veh/8 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E 240 SEDAN AUTOMATIC-211061/285"
+  "4D E 270": E-Class                               # 88 veh/10 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E 270 CDI SEDAN AUTOMATIC-211016/285"
+  "4D E 280": E-Class                               # 20 veh/8 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E 280 CDI SEDAN AUTOMATIC-211023/285"
+  "4D E 320": E-Class                               # 66 veh/14 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E 320 CDI SEDAN AUTOMATIC-211026/285"
+  "4D E 400": E-Class                               # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E 400 CDI SEDAN AUTOMATIC-211028/285"
+  "4D E 430": E-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E 430 SEDAN AUTOMATIC-210070/283"
+  "4D E 500": E-Class                               # 8 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E 500 SEDAN AUTOMATIC-211070/285"
+  "4D E 55 AMG": E-Class                            # 5 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E 55 AMG SEDAN AUTOMATIC-210074/283"
+  "4D E200": E-Class                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "4D E200"
+  "4D S 320": S-Class                               # 21 veh/7 rows (fi, fi_traficom) -> live mercedes-benz/s-class; raw "4D S 320 CDI SEDAN AUTOMATIC-220026/296"
+  "4D S 350": S-Class                               # 5 veh/4 rows (fi, fi_traficom) -> live mercedes-benz/s-class; raw "4D S 350 SEDAN AUTOMATIC-220067/297"
+  "4D S 400": S-Class                               # 5 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/s-class; raw "4D S 400 CDI SEDAN AUTOMATIC-220028/296"
+  "4D S 430": S-Class                               # 3 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/s-class; raw "4D S 430 SEDAN AUTOMATIC-220070/296"
+  "4D S 500": S-Class                               # 9 veh/3 rows (fi, fi_traficom) -> live mercedes-benz/s-class; raw "4D S 500 SEDAN AUTOMATIC-220075/296"
+  "4D S 55AMG": S-Class                             # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/s-class; raw "4D S 55AMG SEDAN AUTOMATIC-"
+  "4D S 600": S-Class                               # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/s-class; raw "4D S 600 SEDAN-AUTOMATIC-220176/308"
+  "4D S320": S-Class                                # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/s-class; raw "4D S320 SEDAN AUTOMATIC-220065/296"
+  "4D S350 4-Matic-220187-4X4/309": S-Class         # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/s-class; raw "4D S350 4-MATIC-220187-4X4/309"
+  "4D SEDAN200/2750": Sedan                         # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/sedan; raw "4D SEDAN200/2750"
+  "4D V200CDI Bus-638-2/300": V-Class               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/v-class; raw "4D V200CDI BUS-638-2/300"
+  "4D Viano": Viano                                 # 2 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/viano; raw "4D VIANO KOMBI CDI 2.2 AUTOMATIC-639813/320"
+  "4D Vito": Vito                                   # 4 veh/4 rows (fi, fi_traficom) -> live mercedes-benz/vito; raw "4D VITO KOMBI 111 CDI-639703/320"
+  "4D Vito 112": Vito                               # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/vito; raw "4D VITO 112 CDI"
+  "4D Vito 115": Vito                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/vito; raw "4D VITO 115 CDI-639703/320"
+  "4D Vito-V230TD-638-2/300": Vito                  # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/vito; raw "4D VITO-V230TD-638-2/300"
+  "5D 180 C": "180 C"                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/180-c; raw "5D 180 C KOMBI-203235/272"
+  "5D 220": "220"                                   # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/220; raw "5D 220 CDI"
+  "5D 250TD": "250 TD"                              # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/250-td; raw "5D 250TD"
+  "5D 270": "270"                                   # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/270; raw "5D 270 CDI KOMBI AUTOMATIC 203216/272"
+  "5D 300GD": "300 GD"                              # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/300-gd; raw "5D 300GD"
+  "5D 320": "320"                                   # 8 veh/4 rows (fi, fi_traficom) -> live mercedes-benz/320; raw "5D 320 KOMBI AUTOMATIC-5-163154-4X4/282"
+  "5D 350": "350"                                   # 2 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/350; raw "5D 350 KOMBI AUTOMATIC-163157-4X4/282"
+  "5D A 140": A-Class                               # 12 veh/7 rows (fi, fi_traficom) -> live mercedes-benz/a-class; raw "5D A 140 KOMBI AUTOMATIC-5-168031/242"
+  "5D A 160": A-Class                               # 13 veh/7 rows (fi, fi_traficom) -> live mercedes-benz/a-class; raw "5D A 160 KOMBI-5-168133/259"
+  "5D A 170": A-Class                               # 10 veh/8 rows (fi, fi_traficom) -> live mercedes-benz/a-class; raw "5D A 170 CDI KOMBI AUTOMATIC-5-168109/259"
+  "5D A 190": A-Class                               # 9 veh/5 rows (fi, fi_traficom) -> live mercedes-benz/a-class; raw "5D A 190 KOMBI AUTOMATIC-5-168032/242"
+  "5D A 200": A-Class                               # 3 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/a-class; raw "5D A 200 CDI KOMBI AUTOMATIC-5-169008/257"
+  "5D A 210 Evolution": A-Class                     # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/a-class; raw "5D A 210 EVOLUTION KOMBI-5-168035/242"
+  "5D B 170": B-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/b-class; raw "5D B 170 KOMBI AUTOMATIC-245232/278"
+  "5D B 180": B-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/b-class; raw "5D B 180 CDI KOMBI AUTOMATIC-245207/278"
+  "5D B 200 Turbo": B-Class                         # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/b-class; raw "5D B 200 TURBO KOMBI AUTOMATIC-245234/278"
+  "5D C 180": C-Class                               # 22 veh/8 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 180 KOMPRESSOR KOMBI-203246/272"
+  "5D C 200": C-Class                               # 84 veh/28 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 200 CDI KOMBI AUTOMATIC-203204/272"
+  "5D C 220": C-Class                               # 68 veh/23 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 220 CDI KOMBI AUTOMATIC-203208/272"
+  "5D C 220CDI": C-Class                            # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 220CDI KOMBI AUTOMATIC 203208/272"
+  "5D C 240": C-Class                               # 7 veh/5 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 240 KOMBI AUTOMATIC-203261/272"
+  "5D C 240 S": C-Class                             # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 240 S KOMBI AUTOMATIC-RH61J1/272"
+  "5D C 250 Turbodiesel": C-Class                   # 19 veh/7 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 250 TURBODIESEL KOMBI AUTOMATIC-202188/"
+  "5D C 270": C-Class                               # 14 veh/7 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 270 CDI KOMBI AUTOMATIC-203216/272"
+  "5D C 270CDI": C-Class                            # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 270CDI KOMBI"
+  "5D C 30": C-Class                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 30 CDI AMG KOMBI AUTOMATIC-203218/272"
+  "5D C 32 AMG": C-Class                            # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 32 AMG KOMPRESSOR KOMBI AUTOMATIC-20326"
+  "5D C 320": C-Class                               # 5 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C 320 KOMBI AUTOMATIC-203264/272"
+  "5D C200": C-Class                                # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C200 KOMPRESSOR KOMBI AUTOMATIC-203242"
+  "5D C270": C-Class                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C270 CDI KOMBI"
+  "5D C320": C-Class                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/c-class; raw "5D C320 KOMBI AUTOMATIC/272"
+  "5D E 200": E-Class                               # 9 veh/7 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E 200 KOMPRESSOR KOMBI-210248/283"
+  "5D E 200 Automatic-211242/285": E-Class          # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E 200  AUTOMATIC-211242/285"
+  "5D E 220": E-Class                               # 75 veh/17 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E 220 CDI KOMBI AUTOMATIC-211206/285"
+  "5D E 240": E-Class                               # 13 veh/7 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E 240 KOMBI AUTOMATIC-5-210262/283"
+  "5D E 240KOMBI Automatic 211261/285": E-Class     # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E 240kombi automatic 211261/285"
+  "5D E 270": E-Class                               # 51 veh/6 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E 270 CDI KOMBI AUTOMATIC-211216/285"
+  "5D E 280": E-Class                               # 13 veh/6 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E 280 KOMBI 4-MATIC-5-210281-4X4/283"
+  "5D E 320": E-Class                               # 82 veh/21 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E 320 CDI KOMBI AUTOMATIC-211226/285"
+  "5D E 500": E-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E 500 KOMBI 4-MATIC"
+  "5D E 55 AMG": E-Class                            # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E 55 AMG KOMBI AUTOMATIC-5-210274/283"
+  "5D E200": E-Class                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E200 KOMPRESSOR"
+  "5D E280": E-Class                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/e-class; raw "5D E280 CDI"
+  "5D GL 420": GL                                   # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/gl; raw "5D GL 420 CDI KOMBI-7-164828-4X4/308"
+  "5D ML 280": ML                                   # 7 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML 280 CDI KOMBI AUTOMATIC-164120-4X4/292"
+  "5D ML 320": ML                                   # 14 veh/8 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML 320 CDI KOMBI AUTOMATIC-164122-4X4/292"
+  "5D ML 350": ML                                   # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML 350 KOMBI AUTOMATIC-4X4/292"
+  "5D ML270": ML                                    # 64 veh/12 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML270 KOMBI CDI AUTOMATIC-5-163113-4X4/28"
+  "5D ML320": ML                                    # 55 veh/9 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML320 KOMBI AUTOMATIC-5-163154-4X4/282"
+  "5D ML320 Automatic 163154-4X4": ML               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML320 AUTOMATIC 163154-4X4"
+  "5D ML320 Automatic-4X4": ML                      # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML320 AUTOMATIC-4X4"
+  "5D ML320 Automatic-5-4X4": ML                    # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML320 AUTOMATIC-5-4X4"
+  "5D ML320 Automatic-5-4X4/282": ML                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML320 AUTOMATIC-5-4X4/282"
+  "5D ML320-5-Automatic-4X4/282": ML                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML320-5-AUTOMATIC-4X4/282"
+  "5D ML350": ML                                    # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML350 KOMBI AUTOMATIC-5-AB57E0-4X4/282"
+  "5D ML430": ML                                    # 10 veh/6 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML430 KOMBI AUTOMATIC-5-163172-4X4/282"
+  "5D ML500": ML                                    # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML500 KOMBI AUTOMATIC-4X4/282"
+  "5D ML55AMG": ML                                  # 6 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/ml; raw "5D ML55AMG KOMBI AUTOMATIC-5-163174-4X4/282"
+  "5D R 320": R-Class                               # 8 veh/3 rows (fi, fi_traficom) -> live mercedes-benz/r-class; raw "5D R 320 CDI 4MATIC-251122-4X4/322"
+  "5D R 350": R-Class                               # 2 veh/2 rows (fi, fi_traficom) -> live mercedes-benz/r-class; raw "5D R 350 4MATIC-4X4/322"
+  "5D R 500": R-Class                               # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/r-class; raw "5D R 500 4MATIC"
+  "5D R320": R-Class                                # 1 veh/1 rows (fi, fi_traficom) -> live mercedes-benz/r-class; raw "5D R320 CDI 4MATIC"
   E Sprinter: eSprinter                   # truck/mercedes-benz/e-sprinter → esprinter: a TRUE DUPLICATE of truck/mercedes-benz/esprinter (same make, same kind, same product, two register spellings — raws "MERCEDES-BENZ | E SPRINTER" lu+nl n=2 vs "ESPRINTER"/"eSprinter" fi+nl n=959). Mercedes writes it eSprinter — https://www.mbvans.com/en/esprinter ("Prepare to experience the all-electric eSprinter"); the pure-casing half of the fix is styling.yml `ESPRINTER: eSprinter`. Fold gains lu on the survivor and loses no country
   # ── casing-contradiction batch: SEC/TD casing finished; Cdi dropped (not
   # a nameplate); the four 639 Vito lines above REPOINTED to folds. ──
@@ -5116,6 +6116,27 @@ Mercedes-Benz:
   Arcos: Arocs              # truck/mercedes-benz/arcos, raws "ARCOS" x5, "ARCOS 4642" x4, "ARCOS 4942 M" x3, "ARCOS 4745K" — 46xx/49xx/47xx are Arocs construction-range type numbers; a transposed-letter misspelling — https://en.wikipedia.org/wiki/Mercedes-Benz_Arocs
 
 Mercury:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Comet Caliente": Comet Caliente               # 1 veh/1 rows (fi, fi_traficom) -> live mercury/comet-caliente; raw "2D COMET CALIENTE"
+  "2D Cougar": Cougar                               # 6 veh/6 rows (fi, fi_traficom) -> live mercury/cougar; raw "2D COUGAR CONVERTIBLE-XR7-70-94H/282"
+  "2D Cougar Xr-7": Cougar XR-7                     # 1 veh/1 rows (fi, fi_traficom) -> live mercury/cougar-xr-7; raw "2D COUGAR XR-7"
+  "2D Cougar XR7": Cougar XR-7                      # 1 veh/1 rows (fi, fi_traficom) -> live mercury/cougar-xr-7; raw "2D COUGAR XR7"
+  "2D Park Lane": Park Lane                         # 2 veh/2 rows (fi, fi_traficom) -> live mercury/park-lane; raw "2D PARK LANE CONVERTIBLE 65M/3120"
+  "4D Comet": Comet                                 # 1 veh/1 rows (fi, fi_traficom) -> live mercury/comet; raw "4D COMET"
+  "4D Grand Marquis": Grand Marquis                 # 1 veh/1 rows (fi, fi_traficom) -> live mercury/grand-marquis; raw "4D GRAND MARQUIS"
+  "4D Grand Marquis LS": Grand Marquis LS           # 1 veh/1 rows (fi, fi_traficom) -> live mercury/grand-marquis-ls; raw "4D GRAND MARQUIS LS"
+  "4D Montclair Marauder": Montclair Marauder       # 1 veh/1 rows (fi, fi_traficom) -> live mercury/montclair-marauder; raw "4D MONTCLAIR MARAUDER"
   Cougar Xr 7: Cougar XR-7                    # Mercury's badge is the hyphenated XR-7 across all generations (https://en.wikipedia.org/wiki/Mercury_Cougar); corpus near three-way tie, marque decides
   Cougar Xr-7: Cougar XR-7                    # same id already — caser lower-cases the un-pinned XR token; display fix
   Cougar XR7: Cougar XR-7                     # fused register shape (nl_rdw n=28) folds in
@@ -5309,7 +6330,44 @@ Microcar:
   M.go:                      M.Go                 # Microcar writes M.GO with the period; title form M.Go
   Mgo:                       M.Go                 # Microcar writes M.GO with the period; title form M.Go
 
+Mini:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D One": Cooper                                  # 4 veh/1 rows (fi, fi_traficom) -> live mini/cooper; raw "2D ONE HATCHBACK 1.6-RA31/247"
+
 Mitsubishi:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Colt": Colt                                   # 3 veh/3 rows (fi, fi_traficom) -> live mitsubishi/colt; raw "2D COLT HATCHBACK 1.6-MNCJ4A/242"
+  "2D Eclipse": Eclipse                             # 19 veh/8 rows (fi, fi_traficom) -> live mitsubishi/eclipse; raw "2D ECLIPSE HATCHBACK 2.0 GS-16V-M-D22A/247"
+  "3D Pajero Pinin": Pajero Pinin                   # 1 veh/1 rows (fi, fi_traficom) -> live mitsubishi/pajero-pinin; raw "3D PAJERO PININ"
+  "4D Carisma": Carisma                             # 13 veh/8 rows (fi, fi_traficom) -> live mitsubishi/carisma; raw "4D CARISMA HATCHBACK 1.6 CLASSIC-LNDA1A/254"
+  "4D Colt": Colt                                   # 2 veh/2 rows (fi, fi_traficom) -> live mitsubishi/colt; raw "4D COLT HATCHBACK 1.3 AMT-XJZ34A/250"
+  "4D Galant": Galant                               # 8 veh/6 rows (fi, fi_traficom) -> live mitsubishi/galant; raw "4D GALANT SEDAN 2.4 AUTOMATIC-SREA3A/264"
+  "4D Lancer": Lancer                               # 2 veh/2 rows (fi, fi_traficom) -> live mitsubishi/lancer; raw "4D LANCER SEDAN 1.6 COMFORT AUTOMATIC-SRCS3A"
+  "4D Lancer Evolution": Lancer Evolution           # 5 veh/4 rows (fi, fi_traficom) -> live mitsubishi/lancer-evolution; raw "4D LANCER EVOLUTION SEDAN 2.0 GSR-SNCT9A-4X4"
+  "4D Space Star": Space Star                       # 7 veh/3 rows (fi, fi_traficom) -> live mitsubishi/space-star; raw "4D SPACE STAR HATCHBACK 1.8-LNDG5A/249"
+  "5D Pajero": Pajero                               # 1 veh/1 rows (fi, fi_traficom) -> live mitsubishi/pajero; raw "5D PAJERO"
   # ── swarm-dossier batch: VR-4 is a hyphenated suffix badge (Viscous
   # Realtime 4WD — en.wikipedia Galant VR-4), the Celica GT-4 class, NOT the
   # fusing letter-prefix class (L200/L300). ──
@@ -5395,6 +6453,24 @@ Morgan:
   PLUS8: "Plus 8"            # fused register shape; Morgan Plus 8, 1968-2004 + 2012-18 (en.wikipedia Morgan_Plus_8; "Plus Eight" never appears)
 
 Morris:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Mini 1000": Mini 1000                         # 1 veh/1 rows (fi, fi_traficom) -> live morris/mini-1000; raw "2D Mini 1000"
+  "2D Mini 1000-Mk": Mini 1000 Mk                   # 6 veh/3 rows (fi, fi_traficom) -> live morris/mini-1000-mk; raw "2D MINI 1000-MK II-A2S6/2030"
+  "2D Mini Clubman": Mini Clubman                   # 1 veh/1 rows (fi, fi_traficom) -> live morris/mini-clubman; raw "2D Mini Clubman"
+  "2D Minor": Minor                                 # 3 veh/2 rows (fi, fi_traficom) -> live morris/minor; raw "2D MINOR"
+  "2D Minor 1000": Minor 1000                       # 1 veh/1 rows (fi, fi_traficom) -> live morris/minor-1000; raw "2D MINOR 1000"
+  "4D Oxford Series": Oxford Series                 # 1 veh/1 rows (fi, fi_traficom) -> live morris/oxford-series; raw "4D OXFORD SERIES III/246"
   MINI1000: "Mini 1000"      # fused register shape of the Morris Mini 1000 (en.wikipedia Mini); matches morris/mini-850, austin/mini-1000. NOTE morris/mini-mk-2 left dangling (dossier U6)
   Coopers: Cooper S                           # spelling variant of "Cooper S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   # ── REGISTER-LANGUAGE CONVENTION (issue #123): English marketing form wins;
@@ -5418,6 +6494,19 @@ Mutt:
   GT-Sr: GT-SR                              # Mutt GT-SR: https://muttmotorcycles.com/products/gt-sr-matt-black-silver-125cc-motorcycle — raw "GT-SR". Note the first segment survived (GT is in `acronyms`) and the second did not, which is why the defect reads as a typo rather than a casing rule
 
 Nash:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Metropolitan": Metropolitan                   # 1 veh/1 rows (fi, fi_traficom) -> live nash/metropolitan; raw "2D METROPOLITAN CONVERTIBLE-Y2"
   Nash: null                                  # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Nilsson:
@@ -5430,6 +6519,35 @@ Nio:
   ES8: EL8                                # NIO renamed ES6→EL6 and ES8→EL8 for Europe; the German lineup is ET5 / ET5 Touring / EL6 / EL8 (https://www.chinaelektro.de/nio/). The catalog already carries EL6, so this keeps the family consistent.
 
 Nissan:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 200 Sx": "200SX"                              # 1 veh/1 rows (fi, fi_traficom) -> live nissan/200sx; raw "2D 200 SX COUPE/2430"
+  "2D Almera": Almera                               # 22 veh/3 rows (fi, fi_traficom) -> live nissan/almera; raw "2D ALMERA HATCHBACK 1.5-EAAN16/254"
+  "2D Micra": Micra                                 # 72 veh/16 rows (fi, fi_traficom) -> live nissan/micra; raw "2D MICRA HATCHBACK 1.0-EAAK11/236"
+  "2D Skyline": Skyline                             # 1 veh/1 rows (fi, fi_traficom) -> live nissan/skyline; raw "2D SKYLINE GTS-T-ECR33/270"
+  "2D Sunny": Sunny                                 # 1 veh/1 rows (fi, fi_traficom) -> live nissan/sunny; raw "2D SUNNY GTI HATCHBACK-RCLN13SFEQ/2430"
+  "3D Terrano": Terrano                             # 11 veh/3 rows (fi, fi_traficom) -> live nissan/terrano; raw "3D TERRANO II-KBNR20-4X4/245"
+  "4D Almera": Almera                               # 65 veh/13 rows (fi, fi_traficom) -> live nissan/almera; raw "4D ALMERA SEDAN 1.5-BAAN16/254"
+  "4D Cedric": Cedric                               # 1 veh/1 rows (fi, fi_traficom) -> live nissan/cedric; raw "4D CEDRIC V-30E SGL-PLY30JAEQ/2730"
+  "4D Maxima": Maxima                               # 2 veh/2 rows (fi, fi_traficom) -> live nissan/maxima; raw "4D MAXIMA  SEDAN 3.0 AUTOMATIC"
+  "4D Maxima Qx": Maxima                            # 14 veh/5 rows (fi, fi_traficom) -> live nissan/maxima; raw "4D MAXIMA QX SEDAN 3.0-CCUA33/275"
+  "4D Micra": Micra                                 # 22 veh/12 rows (fi, fi_traficom) -> live nissan/micra; raw "4D MICRA HATCHBACK 1.3-FBAK11/236"
+  "4D Primera": Primera                             # 19 veh/9 rows (fi, fi_traficom) -> live nissan/primera; raw "4D PRIMERA SEDAN 1.6-BAAP12/268"
+  "4D Sentra": Sentra                               # 1 veh/1 rows (fi, fi_traficom) -> live nissan/sentra; raw "4D SENTRA 4WDXE HATCHBACK 4X4/243"
+  "4D Skyline": Skyline                             # 1 veh/1 rows (fi, fi_traficom) -> live nissan/skyline; raw "4D SKYLINE GTS-T ECR33/270"
+  "4D Sunny": Sunny                                 # 1 veh/1 rows (fi, fi_traficom) -> live nissan/sunny; raw "4D SUNNY GTI-ELN13WFEQ/2430"
+  "5D Primera": Primera                             # 11 veh/5 rows (fi, fi_traficom) -> live nissan/primera; raw "5D PRIMERA HATCHBACK 1.8-FBAP12/268"
+  "5D Terrano": Terrano                             # 96 veh/20 rows (fi, fi_traficom) -> live nissan/terrano; raw "5D TERRANO II-TVUR20-4X4/265"
   # ── swarm-dossier batch: Silvia-derived export badges FUSE (en.wikipedia
   # 180SX/Silvia; corpus corroboration 6 registers vs 2); battery-capacity
   # suffixes dissolve per the in-block Leaf 40KWH precedent. LANE-A FLAGGED,
@@ -5542,6 +6660,26 @@ NSU:
   LUX200: Lux                     # NSU never used "Lux 200": the model is the Lux (1951-54, 198cc), upgraded as the Superlux. "produced from 1951-54 ... a capacity of 198cc" — https://www.motorcyclespecifications.com/nsu-lux-superlux-1951-54/ . LUX200 is a register artifact gluing a ROUNDED displacement (198 -> 200) onto the nameplate, so this is NOT the two-wheeler displacement-stays-separate case: dropping it is correct, "Lux 200" would be inventing a designation. Also unblocks the B2 identity match to Q927073 NSU Lux, unreachable from "lux200" because prefix containment is token-based (pipeline#54 finding f)
 
 Oldsmobile:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Business": Business                           # 1 veh/1 rows (fi, fi_traficom) -> live oldsmobile/business; raw "2D BUSINESS COUPE/293"
+  "2D Cutlass": Cutlass                             # 3 veh/3 rows (fi, fi_traficom) -> live oldsmobile/cutlass; raw "2D CUTLASS CONVERTIBLE 33867/2920"
+  "2D Cutlass Supreme": Cutlass Supreme             # 1 veh/1 rows (fi, fi_traficom) -> live oldsmobile/cutlass-supreme; raw "2D CUTLASS SUPREME COUPE DIESEL-5-3R47P9G/27"
+  "2D Delta 88 Royale Brougham": Delta 88 Royale Brougham  # 1 veh/1 rows (fi, fi_traficom) -> live oldsmobile/delta-88-royale-brougham; raw "2D DELTA 88 ROYALE BROUGHAM COUPE-AY37Y5/295"
+  "2D Dynamic 88": Dynamic 88                       # 2 veh/2 rows (fi, fi_traficom) -> live oldsmobile/dynamic-88; raw "2D DYNAMIC 88 COUPE"
+  "2D Ninety-Eight": Ninety-Eight                   # 2 veh/1 rows (fi, fi_traficom) -> live oldsmobile/ninety-eight; raw "2D NINETY-EIGHT CONVERTIBLE"
+  "2D Starfire": Starfire                           # 1 veh/1 rows (fi, fi_traficom) -> live oldsmobile/starfire; raw "2D STARFIRE CONVERTIBLE/3130"
+  "4D Ninety Eight": Ninety-Eight                   # 1 veh/1 rows (fi, fi_traficom) -> live oldsmobile/ninety-eight; raw "4D NINETY EIGHT"
   SUPER88: Super 88                           # spelling variant of "Super 88" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Omoda:
@@ -5563,6 +6701,35 @@ Omoda:
   E5 Comfort: Omoda E5                    # trim folds; the E5 is the electric sibling sold under its own name
 
 Opel:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Astra": Astra                                 # 61 veh/15 rows (fi, fi_traficom) -> live opel/astra; raw "2D ASTRA HATCHBACK 1.6-TGF08/261"
+  "2D Corsa": Corsa                                 # 11 veh/5 rows (fi, fi_traficom) -> live opel/corsa; raw "2D CORSA HATCHBACK 1.4-XCF08/249"
+  "2D Kadett": Kadett                               # 8 veh/3 rows (fi, fi_traficom) -> live opel/kadett; raw "2D KADETT"
+  "2D Kadett B": Kadett                             # 32 veh/9 rows (fi, fi_traficom) -> live opel/kadett; raw "2D KADETT B COUPE F-RALLYE 1900-92/2420"
+  "2D Kadett C": Kadett                             # 1 veh/1 rows (fi, fi_traficom) -> live opel/kadett; raw "2D KADETT C"
+  "2D Record": Rekord                               # 1 veh/1 rows (fi, fi_traficom) -> live opel/rekord; raw "2D Record"
+  "2D Speedster": Speedster                         # 1 veh/1 rows (fi, fi_traficom) -> live opel/speedster; raw "2D SPEEDSTER CONVERTIBLE 2.0 TURBO TARGA-EBR"
+  "4D Astra": Astra                                 # 95 veh/21 rows (fi, fi_traficom) -> live opel/astra; raw "4D ASTRA HATCHBACK 1.6-TGF48/261"
+  "4D Astra F": Astra                               # 1 veh/1 rows (fi, fi_traficom) -> live opel/astra; raw "4D ASTRA F CABRIO F-53/252"
+  "4D Corsa": Corsa                                 # 8 veh/3 rows (fi, fi_traficom) -> live opel/corsa; raw "4D CORSA HATCHBACK 1.2-XCF68/249"
+  "4D Diplomat": Diplomat                           # 1 veh/1 rows (fi, fi_traficom) -> live opel/diplomat; raw "4D DIPLOMAT"
+  "4D Olympia Rekord": Rekord                       # 1 veh/1 rows (fi, fi_traficom) -> live opel/rekord; raw "4D OLYMPIA REKORD"
+  "4D Omega": Omega                                 # 18 veh/9 rows (fi, fi_traficom) -> live opel/omega; raw "4D OMEGA SEDAN 2.2-VB-69/273"
+  "4D Vectra": Vectra                               # 31 veh/20 rows (fi, fi_traficom) -> live opel/vectra; raw "4D VECTRA HATCHBACK 2.0-JBF68/264"
+  "5D Astra": Astra                                 # 108 veh/30 rows (fi, fi_traficom) -> live opel/astra; raw "5D ASTRA CARAVAN 1.6-TGF35/261"
+  "5D Omega": Omega                                 # 32 veh/19 rows (fi, fi_traficom) -> live opel/omega; raw "5D OMEGA CARAVAN 2.0-VBF35/273"
+  "5D Vectra": Vectra                               # 19 veh/9 rows (fi, fi_traficom) -> live opel/vectra; raw "5D VECTRA CARAVAN 2.0DTI-JBF35/264"
   Karl / Viva: Karl      # RDW dual-market label
   "Karl/Viva": Karl                           # Opel Karl and its Vauxhall-badged twin Viva registered as one string; Karl is the Opel nameplate
   Karl Rocks / Viva Rocks: Karl             # same twin-string case for the raised "Rocks" trim — trim folds into the nameplate
@@ -5697,6 +6864,21 @@ Opel:
   "375": Blitz                          # Blitz PAYLOAD/type code: every raw says so ("375/6 BLITZ", "375 6/H", "375/3750-58"). QUOTES ARE LOAD-BEARING: unquoted, YAML parses this key as Integer 375 and renames.key?("375") never matches — a silently inert line — https://en.wikipedia.org/wiki/Opel_Blitz
   Rocks-E Cargo: Rocks-E                # "Cargo" is the load-box BODY of the Rocks-e quadricycle (moped kind) — https://en.wikipedia.org/wiki/Opel_Rocks-e
 
+Packard:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Caribbean": Caribbean                         # 1 veh/1 rows (fi, fi_traficom) -> live packard/caribbean; raw "2D CARIBBEAN CONVERTIBLE 2631-2678/3100-53"
+
 Panhard:
   Pl 17: PL17                                 # spelling variant of "PL17" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
@@ -5704,6 +6886,26 @@ Panther:
   Panther: null                           # registry row where the make was written into the model column — not a nameplate (restored from a flow-style entry)
 
 Peugeot:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 206": "206"                                   # 57 veh/22 rows (fi, fi_traficom) -> live peugeot/206; raw "2D 206 HATCHBACK 1.3I-2CKFWF/245"
+  "2D 307": "307"                                   # 9 veh/5 rows (fi, fi_traficom) -> live peugeot/307; raw "2D 307 HATCHBACK 1.6I-3ANFUB/261"
+  "4D 206": "206"                                   # 30 veh/8 rows (fi, fi_traficom) -> live peugeot/206; raw "4D 206 HATCHBACK 1.3I-2AKFWF/245"
+  "4D 306": "306"                                   # 4 veh/3 rows (fi, fi_traficom) -> live peugeot/306; raw "4D 306 SEDAN 2.0HDI-7BRHYE/258"
+  "4D 307": "307"                                   # 31 veh/8 rows (fi, fi_traficom) -> live peugeot/307; raw "4D 307 HATCHBACK 1.6I-3CNFUB/261"
+  "4D 406": "406"                                   # 21 veh/13 rows (fi, fi_traficom) -> live peugeot/406; raw "4D 406 SEDAN 2.0I 16V-8BRFRE/270"
+  "4D 407": "407"                                   # 1 veh/1 rows (fi, fi_traficom) -> live peugeot/407; raw "4D 407 SEDAN 2.0HDI-6DRHRH/273"
+  "4D 607": "607"                                   # 8 veh/5 rows (fi, fi_traficom) -> live peugeot/607; raw "4D 607 SEDAN 2.2I 16V AUTOMATIC-9D3FZE/280"
   # ── wave-3 trim-fold batch (2026-07-26, dossier-trims-peugeot-hyundai): 92
   # Peugeot ids fold onto 26 nameplates — trim badges, engine/displacement
   # suffixes, body designations, Sevel chassis type codes, GVW/payload strings,
@@ -5873,6 +7075,38 @@ Piaggio:
   New Skipper: Skipper                        # 516 vehicles (gb) — the facelifted Skipper; motorcycle/piaggio/skipper is live off uk_dft + nl_rdw + nz_nzta, and uk_dft writes BOTH forms. Generation marker, not a nameplate (same ruling as the Kymco block) — https://en.wikipedia.org/wiki/Piaggio_Skipper
 
 Plymouth:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Barracuda": Barracuda                         # 4 veh/4 rows (fi, fi_traficom) -> live plymouth/barracuda; raw "2D BARRACUDA CONVERTIBLE -BH27N1/2740"
+  "2D Barracuda Gran": Barracuda Gran               # 4 veh/3 rows (fi, fi_traficom) -> live plymouth/barracuda-gran; raw "2D BARRACUDA GRAN COUPE HT-BP23GO/2740"
+  "2D Belvedere": Belvedere                         # 1 veh/1 rows (fi, fi_traficom) -> live plymouth/belvedere; raw "2D Belvedere Convertible"
+  "2D Cuda": Cuda                                   # 3 veh/3 rows (fi, fi_traficom) -> live plymouth/cuda; raw "2D CUDA CONVERTIBLE-BS27N1/2740"
+  "2D Fury": Fury                                   # 4 veh/4 rows (fi, fi_traficom) -> live plymouth/fury; raw "2D FURY III-PM27H9/3050"
+  "2D Road Runner": Road Runner                     # 3 veh/2 rows (fi, fi_traficom) -> live plymouth/road-runner; raw "2D ROAD RUNNER"
+  "2D Roadrunner": Road Runner                      # 2 veh/2 rows (fi, fi_traficom) -> live plymouth/road-runner; raw "2D ROADRUNNER"
+  "2D Satellite": Satellite                         # 1 veh/1 rows (fi, fi_traficom) -> live plymouth/satellite; raw "2D SATELLITE"
+  "2D Savoy": Savoy                                 # 2 veh/2 rows (fi, fi_traficom) -> live plymouth/savoy; raw "2D SAVOY COUPE-M133"
+  "2D Special De Luxe": Special De Luxe             # 1 veh/1 rows (fi, fi_traficom) -> live plymouth/special-de-luxe; raw "2D SPECIAL DE LUXE"
+  "2D Valiant 100": Valiant 100                     # 1 veh/1 rows (fi, fi_traficom) -> live plymouth/valiant-100; raw "2D VALIANT 100"
+  "2D Valiant Signet": Valiant Signet               # 1 veh/1 rows (fi, fi_traficom) -> live plymouth/valiant-signet; raw "2D Valiant Signet"
+  "4D Belvedere": Belvedere                         # 3 veh/3 rows (fi, fi_traficom) -> live plymouth/belvedere; raw "4D BELVEDERE II-273-67-RH-41/2950"
+  "4D Breeze": Breeze                               # 1 veh/1 rows (fi, fi_traficom) -> live plymouth/breeze; raw "4D BREEZE SEDAN 2.0-EJ46C/275"
+  "4D Fury": Fury                                   # 20 veh/14 rows (fi, fi_traficom) -> live plymouth/fury; raw "4D FURY III-PM41L0/3050"
+  "4D Fury Gran": Fury Gran                         # 1 veh/1 rows (fi, fi_traficom) -> live plymouth/fury-gran; raw "4D FURY GRAN SEDAN HT-PP43M3/3050"
+  "4D Neon": Neon                                   # 2 veh/2 rows (fi, fi_traficom) -> live plymouth/neon; raw "4D NEON SEDAN 2.0 AUTOMATIC-S47C/267"
+  "4D Satellite": Satellite                         # 1 veh/1 rows (fi, fi_traficom) -> live plymouth/satellite; raw "4D SATELLITE"
+  "4D Valiant": Valiant                             # 1 veh/1 rows (fi, fi_traficom) -> live plymouth/valiant; raw "4D VALIANT"
+  "5D Belvedere": Belvedere                         # 1 veh/1 rows (fi, fi_traficom) -> live plymouth/belvedere; raw "5D BELVEDERE II-STW-225-66-RH46"
   Roadrunner: Road Runner                     # spelling variant of "Road Runner" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Special Deluxe: Special De Luxe             # spelling variant of "Special De Luxe" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Plymouth: null                              # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
@@ -5899,6 +7133,36 @@ Polestar:
   "4 Long Range Dual Motor Performance": Polestar 4 # trim string folds
 
 Pontiac:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Bonneville": Bonneville                       # 3 veh/3 rows (fi, fi_traficom) -> live pontiac/bonneville; raw "2D BONNEVILLE"
+  "2D Bonneville Brougham": Bonneville              # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/bonneville; raw "2D BONNEVILLE BROUGHAM"
+  "2D Catalina": Catalina                           # 4 veh/4 rows (fi, fi_traficom) -> live pontiac/catalina; raw "2D CATALINA CONVERTIBLE 25267"
+  "2D Firebird": Fire Bird                          # 4 veh/4 rows (fi, fi_traficom) -> live pontiac/fire-bird; raw "2D FIREBIRD CONVERTIBLE"
+  "2D Firebird 400": Fire Bird                      # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/fire-bird; raw "2D FIREBIRD 400   COUPE"
+  "2D Firebird Se": Fire Bird                       # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/fire-bird; raw "2D FIREBIRD SE COUPE-FX87H/2570"
+  "2D Firebird Sport": Fire Bird                    # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/fire-bird; raw "2D FIREBIRD  SPORT COUPE 67-22337/2750"
+  "2D Firebird Trans Am": Fire Bird                 # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/fire-bird; raw "2D FIREBIRD TRANS AM CONVERTIBLE-FV32/257"
+  "2D Grand Ville": Grand Ville                     # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/grand-ville; raw "2D GRAND VILLE CONVERTIBLE 2P67Y3"
+  "2D Grand Ville Brougham": Grand Ville            # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/grand-ville; raw "2D GRAND VILLE BROUGHAM CONVERTIBLE/314"
+  "2D Grandville": Grand Ville                      # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/grand-ville; raw "2D GRANDVILLE CONVERTIBLE"
+  "2D Gto Judge": Gto                               # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/gto; raw "2D GTO JUDGE CONVERTIBLE"
+  "2D Le Mans": Le Mans                             # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/le-mans; raw "2D LE MANS CONVERTIBLE 62-2167"
+  "2D Le Mans Ht": Le Mans                          # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/le-mans; raw "2D LE MANS HT COUPE 66-23767"
+  "2D Le Mans Sport": Le Mans                       # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/le-mans; raw "2D LE MANS SPORT CONVERTIBLE 71-23767/2845"
+  "2D Silverstreak": Silver Streak                  # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/silver-streak; raw "2D Silverstreak"
+  "2D Trans Am": Fire Bird                          # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/fire-bird; raw "2D TRANS AM COUPE"
+  "4D Vibe": Vibe                                   # 1 veh/1 rows (fi, fi_traficom) -> live pontiac/vibe; raw "4D VIBE AWD"
   Firebird: Fire Bird                         # spelling variant of "Fire Bird" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Grandville: Grand Ville                     # spelling variant of "Grand Ville" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   Lemans: Le Mans                             # spelling variant of "Le Mans" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
@@ -6293,7 +7557,46 @@ Ram:
   RAM1500: "1500"                        # lu_snca fused-marque form; Ram's nameplate is the bare 1500 (ramtrucks.com). Value QUOTED: bare 1500 parses as Integer
   Ram: null                                   # registry rows where the make was written into the model column (truck kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
+Rambler:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D American": American                           # 1 veh/1 rows (fi, fi_traficom) -> live rambler/american; raw "2D AMERICAN CONVERTIBLE/269"
+  "2D American 220": American 220                   # 1 veh/1 rows (fi, fi_traficom) -> live rambler/american-220; raw "2d American 220"
+  "4D American": American                           # 1 veh/1 rows (fi, fi_traficom) -> live rambler/american; raw "4D AMERICAN"
+  "4D American 220": American 220                   # 1 veh/1 rows (fi, fi_traficom) -> live rambler/american-220; raw "4D AMERICAN 220"
+  "5D Ambassador": Ambassador                       # 1 veh/1 rows (fi, fi_traficom) -> live rambler/ambassador; raw "5D AMBASSADOR"
+
 Renault:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Alpine": Alpine                               # 2 veh/2 rows (fi, fi_traficom) -> live renault/alpine; raw "2D ALPINE COUPE"
+  "2D Clio": Clio                                   # 21 veh/10 rows (fi, fi_traficom) -> live renault/clio; raw "2D CLIO HATCHBACK 1.4-CBEB0F/247"
+  "2D Megane": Megane                               # 4 veh/3 rows (fi, fi_traficom) -> live renault/megane; raw "2D MEGANE CABRIOLET 1.6-EA0F0G/246"
+  "2D Twingo": Twingo                               # 4 veh/3 rows (fi, fi_traficom) -> live renault/twingo; raw "2D TWINGO HATCHBACK 1.2 16V-C06D05/234"
+  "4D Clio": Clio                                   # 33 veh/15 rows (fi, fi_traficom) -> live renault/clio; raw "4D CLIO HATCHBACK 1.4-BB0S0F/247"
+  "4D Laguna": Laguna                               # 3 veh/3 rows (fi, fi_traficom) -> live renault/laguna; raw "4D LAGUNA HATCHBACK 3.0 V6 24V AUTOMATIC-BG0"
+  "4D Megane": Megane                               # 16 veh/13 rows (fi, fi_traficom) -> live renault/megane; raw "4D MEGANE HATCHBACK 1.6 16V-BA0405/257"
+  "4D Safrane": Safrane                             # 3 veh/2 rows (fi, fi_traficom) -> live renault/safrane; raw "4D SAFRANE HATCHBACK 2.4-B54F05/278"
   # ── trim-fold batch (2026-07-26, wave 3 apply; evidence per line in the
   # pipeline repo's aux/research/trims-2026-07/dossier-trims-renault-dacia.md):
   # 101 Renault records fold across six kinds (renames are kind-blind; the
@@ -6492,14 +7795,60 @@ Riese Und Mueller:
   "New Charger": "Charger"  # NEW-GUARD gap: moped/riese-und-mueller/charger is live (nl); "NEW CHARGER" (170) would duplicate it.
 
 Riley:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Elf-Mk": Elf Mk                               # 1 veh/1 rows (fi, fi_traficom) -> live riley/elf-mk; raw "2D ELF-MK II/2030"
   Rma: R M A                                  # spelling variant of "R M A" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Rolls-Royce:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Corniche": Corniche                           # 2 veh/2 rows (fi, fi_traficom) -> live rolls-royce/corniche; raw "2D CORNICHE CONVERTIBLE-H2505"
+  "4D Silver Cloud": Silver Cloud                   # 1 veh/1 rows (fi, fi_traficom) -> live rolls-royce/silver-cloud; raw "4D SILVER CLOUD"
+  "4D Silver Shadow": Silver Shadow                 # 4 veh/3 rows (fi, fi_traficom) -> live rolls-royce/silver-shadow; raw "4D SILVER SHADOW"
+  "4D Silver Shadow I": Silver Shadow I             # 2 veh/1 rows (fi, fi_traficom) -> live rolls-royce/silver-shadow-i; raw "4D SILVER SHADOW I"
+  "4D Silver Spirit": Silver Spirit                 # 1 veh/1 rows (fi, fi_traficom) -> live rolls-royce/silver-spirit; raw "4D SILVER SPIRIT II ZS02"
+  "4D Wraith": Wraith                               # 1 veh/1 rows (fi, fi_traficom) -> live rolls-royce/wraith; raw "4D WRAITH LIMOUSINE/3460"
   Silvershadow: Silver Shadow                 # spelling variant of "Silver Shadow" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
   "New Silver Spur":               Silver Spur            # New-guard pre-positioning (owner dispatch): pipeline#111 rescued `NEW <x>` rows from junk?, and this make already publishes the stripped nameplate — without this key the next build MINTS A DUPLICATE. Test per data#151: same make, live record at the stripped name, same registers. — candidate n=1, dup of car/rolls-royce/silver-spur
 
 Rover:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Mini Mk": Mini Mk                             # 2 veh/2 rows (fi, fi_traficom) -> live rover/mini-mk; raw "2D MINI MK II/2040"
+  "4D 75": "75"                                     # 16 veh/8 rows (fi, fi_traficom) -> live rover/75; raw "4D 75 SALOON 2.5 AUTOMATIC-RJ-LLZ/275"
+  "5D 75": "75"                                     # 3 veh/3 rows (fi, fi_traficom) -> live rover/75; raw "5D 75 ESTATE 2.5 AUTOMATIC-RJ-TLZ/275"
   "2300S": "2300"                             # REPOINT (was -> "2300 S"): S is an SD1 trim/engine grade and "2300 S" is now folded into 2300, so the old target is a dead id. Renames are SINGLE-PASS (https://en.wikipedia.org/wiki/Rover_SD1)
   "2600S": "2600"                             # REPOINT (was -> "2600 S"): same reason (https://en.wikipedia.org/wiki/Rover_SD1)
   "3500S": "3500"                             # REPOINT (was -> "3500 S"): same reason (https://en.wikipedia.org/wiki/Rover_P6)
@@ -6567,6 +7916,24 @@ Ryuka:
   "Classic Fi":                                "Classic FI"                               # resolves an intra-make casing contradiction: FI attested x1 in-make (ryuka/classic-fi)
 
 Saab:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 9-3": "9-3"                                   # 13 veh/8 rows (fi, fi_traficom) -> live saab/9-3; raw "2D 9-3 CONVERTIBLE 2.0"
+  "2D 900": "900"                                   # 1 veh/1 rows (fi, fi_traficom) -> live saab/900; raw "2D 900"
+  "4D 9-3": "9-3"                                   # 79 veh/22 rows (fi, fi_traficom) -> live saab/9-3; raw "4D 9-3 HATCHBACK 2.0-D-55C/261"
+  "4D 9-5": "9-5"                                   # 57 veh/21 rows (fi, fi_traficom) -> live saab/9-5; raw "4D 9-5 SEDAN 2.0-E-45C/270"
+  "5D 9-3": "9-3"                                   # 1 veh/1 rows (fi, fi_traficom) -> live saab/9-3; raw "5D 9-3 HATCHBACK 2.0-D-55C/261"
+  "5D 9-5": "9-5"                                   # 56 veh/19 rows (fi, fi_traficom) -> live saab/9-5; raw "5D 9-5 ESTATE 2.0-E-55C/270"
   # ── THE RESCUE (2 lines), 2026-08-01. The 2026-07-26 note below says the
   # 9-3/9-5 boundary was "checked, untouched — no key here can reach them".
   # That was true and it was the wrong conclusion to stop at: nothing could
@@ -6945,6 +8312,26 @@ Sea:
   P 200: P200                                 # spelling variant of "P200" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
 
 SEAT:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Arosa": Arosa                                 # 3 veh/2 rows (fi, fi_traficom) -> live seat/arosa; raw "2D AROSA HATCHBACK 1.4-6H/232"
+  "2D Cordoba": Cordoba                             # 2 veh/2 rows (fi, fi_traficom) -> live seat/cordoba; raw "2D CORDOBA SEDAN 1.8T-6K/244"
+  "2D Ibiza": Ibiza                                 # 9 veh/6 rows (fi, fi_traficom) -> live seat/ibiza; raw "2D IBIZA HATCHBACK 1.4-6L/246"
+  "3D Marbella": Marbella                           # 1 veh/1 rows (fi, fi_traficom) -> live seat/marbella; raw "3D MARBELLA"
+  "4D Cordoba": Cordoba                             # 4 veh/3 rows (fi, fi_traficom) -> live seat/cordoba; raw "4D CORDOBA SEDAN 1.4-6K/244"
+  "4D Ibiza": Ibiza                                 # 2 veh/2 rows (fi, fi_traficom) -> live seat/ibiza; raw "4D IBIZA HATCHBACK 1.9TDI-6L/246"
+  "4D Leon": Leon                                   # 16 veh/11 rows (fi, fi_traficom) -> live seat/leon; raw "4D LEON HATCHBACK 4 1.8T-1M-4X4/252"
+  "4D Toledo": Toledo                               # 10 veh/5 rows (fi, fi_traficom) -> live seat/toledo; raw "4D TOLEDO SEDAN 1.9TDI-1M/251"
   # Cupra split (brand standalone since 2018; pre-2018 Cupra = SEAT trim).
   #
   # 2026-07-25: the three `null` drops here were REPLACED BY MOVES (see
@@ -7041,10 +8428,38 @@ Silence:
   S02LS: S02             # "S02 LS" = the L1e speed variant; kind=moped already encodes the class — RDW writes both strings for the same scooter (681 S02LS vs 104 S02 bromfiets rows; Silence's manual says "S02 LS")
   S01LS: S01             # L1e (45 km/h, 4 kW) version of the S01 — same nameplate, kind captures the class; intentionally CREATES the moped-kind S01 beside the L3e motorcycle record
 
+Simca:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D Aronde": Aronde                               # 1 veh/1 rows (fi, fi_traficom) -> live simca/aronde; raw "4D Aronde"
+
 Simson:
   Awo: AWO                                  # AWO = Awtowelo, the Soviet-era trade name under which Simson (Suhl) built the 425; never a word. Variants AWO 425 S (Sport) and 425 T (Touren). https://en.wikipedia.org/wiki/Simson_(company) — NOTE the register also holds "AW0 425" with a DIGIT ZERO for the letter O, which is registry noise and correctly stayed below threshold
 
 Smart:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D MC01": MC01                                   # 1 veh/1 rows (fi, fi_traficom) -> live smart/mc01; raw "2D MC01"
   For Two: Fortwo   # smart writes the nameplate as ONE word — "smart fortwo" (https://www.smart.com/en/models/); the es_dgt/RDW "SMART FOR TWO" rows are the same car. Display stays Title-case while the make does (deliberate — CPx/GTi covers internal case, not the initial)
   "1": "#1"                              # smart official model names carry the hash: de.smart.com/de/models renders "smart #1". KBA strips both the marque token and the symbol. NB the block key is the catalog display name "Smart"; the marque is officially lowercase "smart" (de.smart.com) but changing the display name is a makes/aliases.yml identity pin and a separate change.
   "3": "#3"                              # as above
@@ -7059,9 +8474,38 @@ Smc:
   Smc: null      # moped es|fi. Make survives on motorcycle/ram. Raws are karts and ATVs ("F KART", "M KART", "CRS170") — not road vehicles in any kind we publish
 
 Studebaker:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D President": President                         # 1 veh/1 rows (fi, fi_traficom) -> live studebaker/president; raw "2D PRESIDENT"
+  "4D Lark": Lark                                   # 1 veh/1 rows (fi, fi_traficom) -> live studebaker/lark; raw "4D LARK VI/2755-60"
   Studebaker: null                            # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Subaru:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "4D Impreza": Impreza                             # 40 veh/17 rows (fi+ca, fi_traficom+ca_nrcan) -> live subaru/impreza; raw "4D IMPREZA SEDAN 2.0 WRX-GDA-4X4/253"
+  "4D Legacy": Legacy                               # 4 veh/7 rows (fi+ca, fi_traficom+ca_nrcan) -> live subaru/legacy; raw "4D LEGACY SEDAN 2.5 GX AUTOMATIC-BE9-4X4/265"
+  "4D Outback": Outback                             # 0 veh/1 rows (ca, ca_nrcan) -> live subaru/outback; raw "4D Outback AWD H6-3.0"
   # ── wave-7 CLEAN batch (2026-08-01). NEW BLOCK: Subaru had NO rename block at
   # all — 85 published records, zero curation lines — which is also why
   # gen_review_pack.rb's recorder is structurally blind to this make (it wraps
@@ -7157,6 +8601,24 @@ Super Soco:
   Ts Street Hunter: TS Street Hunter        # TS is Super Soco's model line (3rd-gen TS), caps at the marque and in press: https://www.motorcyclenews.com/news/new-bikes/super-soco-tc-wanderer-ts-street-hunter/
 
 Suzuki:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Swift": Swift                                 # 2 veh/1 rows (fi, fi_traficom) -> live suzuki/swift; raw "2D SWIFT HATCHBACK 1.3-MAA35S/227"
+  "3D Vitara": Vitara                               # 2 veh/1 rows (fi, fi_traficom) -> live suzuki/vitara; raw "3D VITARA"
+  "4D Liana": Liana                                 # 3 veh/3 rows (fi, fi_traficom) -> live suzuki/liana; raw "4D LIANA HATCHBACK 1.6-ERD31S-4X4/248"
+  "4D Swift": Swift                                 # 1 veh/1 rows (fi, fi_traficom) -> live suzuki/swift; raw "4D SWIFT HATCHBACK 1.3-MAB35S/237"
+  "5D Grand Vitara": Grand Vitara                   # 3 veh/2 rows (fi, fi_traficom) -> live suzuki/grand-vitara; raw "5D GRAND VITARA XL-7 STW 2.7 V6-HTX92V-4X4/2"
+  "5D Grand Vitara V6": Grand Vitara V6             # 1 veh/1 rows (fi, fi_traficom) -> live suzuki/grand-vitara-v6; raw "5D GRAND VITARA V6"
   "Gsxr 1000": "GSX-R1000"  # G-1 PRE-POSITIONING (suzuki dossier C-1): G-1 splits SUZUKI GSX by displacement and the caser produces "Gsxr 1000"/"Gsxs 1000" etc. Without these the build MINTS FIVE NEW IDS. Siblings "Gsxr 750"/"Gsxr 600" already exist in this block. Hyphenation per Suzuki's own product list https://www.globalsuzuki.com/motorcycle/smgs/products/ (GSX-R1000R, GSX-R125, GSX-S1000, GSX-S125, GSX-S750).
   "Gsxr 125": "GSX-R125"  # same
   "Gsxs 1000": "GSX-S1000"  # same
@@ -7218,6 +8680,47 @@ Tol:
   "TOL1500":                   "1500"                 # embedded make prefix — strip_make_prefix needs [\s,]+ after the prefix, so a hyphenated or fused badge survives (the IVA pilot's diagnosis)
 
 Toyota:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Carina": Carina                               # 1 veh/1 rows (fi, fi_traficom) -> live toyota/carina; raw "2D CARINA"
+  "2D Celica": Celica                               # 15 veh/5 rows (fi, fi_traficom) -> live toyota/celica; raw "2D CELICA ST-TA22L-MZ-NN/2430"
+  "2D Celica Liftback": Celica                      # 2 veh/2 rows (fi, fi_traficom) -> live toyota/celica; raw "2D CELICA LIFTBACK ST 2000"
+  "2D Celica Lt": Celica                            # 2 veh/2 rows (fi, fi_traficom) -> live toyota/celica; raw "2D Celica LT"
+  "2D Corolla": Corolla                             # 212 veh/39 rows (fi, fi_traficom) -> live toyota/corolla; raw "2D COROLLA HATCHBACK XLI-EE101L-AGMDKW/247"
+  "2D Corolla 1200": Corolla                        # 1 veh/1 rows (fi, fi_traficom) -> live toyota/corolla; raw "2D COROLLA 1200"
+  "2D Corolla GT": Corolla                          # 1 veh/1 rows (fi, fi_traficom) -> live toyota/corolla; raw "2D COROLLA GT"
+  "2D MR2": MR2                                     # 5 veh/2 rows (fi, fi_traficom) -> live toyota/mr2; raw "2D MR2 CONVERTIBLE 1.8-ZZW30L-AKMQHW/245"
+  "2D Supra 3.0I Turbo": Supra                      # 1 veh/1 rows (fi, fi_traficom) -> live toyota/supra; raw "2D SUPRA 3.0I TURBO"
+  "2D Yaris": Yaris                                 # 54 veh/9 rows (fi, fi_traficom) -> live toyota/yaris; raw "2D YARIS HATCHBACK 1.3-NCP10L-AGMNKW/237"
+  "3D Land Cruiser": Land Cruiser                   # 3 veh/2 rows (fi, fi_traficom) -> live toyota/land-cruiser; raw "3D LAND CRUISER"
+  "3D Land Cruiser LX Turbo": Land Cruiser          # 2 veh/1 rows (fi, fi_traficom) -> live toyota/land-cruiser; raw "3D LAND CRUISER LX TURBO"
+  "4D Auris": Auris                                 # 1 veh/1 rows (fi, fi_traficom) -> live toyota/auris; raw "4D AURIS HATCHBACK 1.6-ZRE151L-DHGNKW/260"
+  "4D Avensis": Avensis                             # 123 veh/28 rows (fi, fi_traficom) -> live toyota/avensis; raw "4D AVENSIS SEDAN 1.6-ZZT220L-AEMNKW/263"
+  "4D Aygo": Aygo                                   # 1 veh/1 rows (fi, fi_traficom) -> live toyota/aygo; raw "4D AYGO HATCHBACK 1.0-KGB10L-AHMGKW/234"
+  "4D Camry": Camry                                 # 54 veh/36 rows (fi, fi_traficom) -> live toyota/camry; raw "4D CAMRY SEDAN 2.4 AUTOMATIC-ACV30L-AEPNKW/2"
+  "4D Carina": Carina                               # 45 veh/16 rows (fi, fi_traficom) -> live toyota/carina; raw "4D CARINA II-1.6 XLI-AT171L-AEMDKG/253"
+  "4D Corolla": Corolla                             # 229 veh/43 rows (fi, fi_traficom) -> live toyota/corolla; raw "4D COROLLA SEDAN 1.4-ZZE111L-AEMDKW/247"
+  "4D Corona Mk": Mark                              # 7 veh/2 rows (fi, fi_traficom) -> live toyota/mark; raw "4D CORONA MK II-RT60/2510"
+  "4D Crown": Crown                                 # 2 veh/2 rows (fi, fi_traficom) -> live toyota/crown; raw "4D Crown"
+  "4D Previa": Previa                               # 1 veh/1 rows (fi, fi_traficom) -> live toyota/previa; raw "4D PREVIA XL-8-TCR10L-RRMDKW/286"
+  "4D Prius": Prius                                 # 6 veh/5 rows (fi, fi_traficom) -> live toyota/prius; raw "4D PRIUS HATCHBACK 1.5 CVT-NHW20L-AHEEBW/270"
+  "4D Yaris": Yaris                                 # 78 veh/18 rows (fi, fi_traficom) -> live toyota/yaris; raw "4D YARIS HATCHBACK 1.3-NCP10L-AHMNKW/237"
+  "5D 4RUNNER": "4-Runner"                          # 2 veh/2 rows (fi, fi_traficom) -> live toyota/4-runner; raw "5D 4RUNNER                4X4/263"
+  "5D Avensis": Avensis                             # 18 veh/5 rows (fi, fi_traficom) -> live toyota/avensis; raw "5D AVENSIS VERSO STW 2.0-7-ACM20L-ARMDKW/283"
+  "5D Carina": Carina                               # 3 veh/3 rows (fi, fi_traficom) -> live toyota/carina; raw "5D CARINA II-1.6 XLI WAGON-AT190L/253"
+  "5D Corolla": Corolla                             # 21 veh/11 rows (fi, fi_traficom) -> live toyota/corolla; raw "5D COROLLA VERSO STW 1.6-ZZE121L-FWMDKW/260"
+  "5D Land Cruiser": Land Cruiser                   # 12 veh/4 rows (fi+nl, fi_traficom+nl_rdw) -> live toyota/land-cruiser; raw "5D LAND CRUISER"
+  "5D Yaris": Yaris                                 # 373 veh/23 rows (fi, fi_traficom) -> live toyota/yaris; raw "5D YARIS VERSO STW 1.3-NCP20L-CHMGKW/250"
   # ── swarm-dossier batch (2026-07-26): the detector canonical was wrong in
   # 8 of 9 groups here — it fought SETTLED in-repo decisions (Mr 2: MR2,
   # Hi Ace: Hiace, Landcruiser: Land Cruiser). Fused acronym badges are the
@@ -7386,6 +8889,19 @@ Toyota:
   "Yaris Ia": "Yaris"  # us_fueleconomy: model "Yaris iA" baseModel "Yaris" — https://www.fueleconomy.gov/feg/download.shtml
 
 Trabant:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D P 601 LS": P 601 LS                           # 1 veh/1 rows (fi, fi_traficom) -> live trabant/p-601-ls; raw "2D P 601 LS"
   "601S": "601 S"                             # spelling variant of "601 S" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
   P601 L: P601L                               # spelling variant of "P601L" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical, not the spaced one
   P 60: P60                                   # spelling variant of "P60" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
@@ -7396,6 +8912,26 @@ Trigano:
   Trigano: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.
 
 Triumph:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 1200 Herald": "1200 Herald"                   # 2 veh/1 rows (fi, fi_traficom) -> live triumph/1200-herald; raw "2D 1200 HERALD"
+  "2D Herald": Herald                               # 1 veh/1 rows (fi, fi_traficom) -> live triumph/herald; raw "2D HERALD CONVERTIBLE 13-60/2320"
+  "2D Herald 1200": Herald 1200                     # 10 veh/4 rows (fi, fi_traficom) -> live triumph/herald-1200; raw "2D HERALD 1200 SALOON/2320"
+  "2D Herald 13-60": Herald 13/60                   # 5 veh/1 rows (fi, fi_traficom) -> live triumph/herald-13-60; raw "2D HERALD 13-60"
+  "2D Spitfire": Spitfire                           # 1 veh/1 rows (fi, fi_traficom) -> live triumph/spitfire; raw "2D SPITFIRE CONVERTIBLE"
+  "2D Spitfire Mk": Spitfire Mk                     # 1 veh/1 rows (fi, fi_traficom) -> live triumph/spitfire-mk; raw "2D SPITFIRE MK II"
+  "2D Vitesse": Vitesse                             # 1 veh/1 rows (fi, fi_traficom) -> live triumph/vitesse; raw "2D VITESSE CONVERTIBLE 6/234"
+  "3D Herald": Herald                               # 1 veh/1 rows (fi, fi_traficom) -> live triumph/herald; raw "3D HERALD ESTATE CAR 13-60"
   2500 Pi: 2500 PI                  # PI = petrol injection — "the 2.5 PI (petrol injection)" https://en.wikipedia.org/wiki/Triumph_2000 ; raw "TRIUMPH 2500 PI"
   TR5 Pi: TR5 PI                    # same badge; observed all-caps "TR5/PI"; matches TR6 Pi: TR6 PI
   Tiger 800XC Abs: Tiger 800XC           # ABS is EQUIPMENT and folds into the nameplate (the batch-4 ABS class; this one surfaced only when the published catalog updated). Cross-owner add by S4W post-publish, flagged in NEGOTIATION Turn 71
@@ -7495,6 +9031,25 @@ Valiant:
   V200: V-200                                 # spelling variant of "V-200" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence
 
 Vauxhall:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Chevette L": Chevette                         # 1 veh/1 rows (fi, fi_traficom) -> live vauxhall/chevette; raw "2D CHEVETTE L HATCHBACK-9B 08DF/2400"
+  "2D Viva Deluxe": Viva                            # 1 veh/1 rows (fi, fi_traficom) -> live vauxhall/viva; raw "2D VIVA DELUXE"
+  "3D Viva": Viva                                   # 3 veh/3 rows (fi, fi_traficom) -> live vauxhall/viva; raw "3D VIVA ESTATE DELUXE-933151/2460"
+  "4D Ventora": Ventora                             # 1 veh/1 rows (fi, fi_traficom) -> live vauxhall/ventora; raw "4D VENTORA II 948690/2590"
+  "4D Victor": Victor                               # 1 veh/1 rows (fi, fi_traficom) -> live vauxhall/victor; raw "4D VICTOR ESTATE CAR FBW/2540-63"
+  "4D Victor 101 Super": Victor                     # 1 veh/1 rows (fi, fi_traficom) -> live vauxhall/victor; raw "4D Victor 101 Super"
+  "5D Victor": Victor                               # 1 veh/1 rows (fi, fi_traficom) -> live vauxhall/victor; raw "5D VICTOR ESTATE 2000 SUPER-943350/2590"
   Vx 220: VX220                               # spelling variant of "VX220" — a short letter prefix glued to digits IS the nameplate for this make (Audi A3, Citroën C1, Chevrolet C10), so the fused form is canonical
   # ── wave-7 CLEAN batch (2026-08-01). Vauxhall is the OPEL TWIN, and the
   # discipline here is to MIRROR the settled `Opel:` block rather than invent a
@@ -7593,6 +9148,175 @@ Vmoto:
   "N.a.": null   # 169 placeholder rows; make survives on CITI / F01 / CPX / VS1 / CU ECONOMY / CUMINI ECONOMY
 
 Volkswagen:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 1200": "1200"                                 # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/1200; raw "2D 1200"
+  "2D 1500": "1500"                                 # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/1500; raw "2D  1500 CONVERTIBLE"
+  "2D Derby": Derby                                 # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/derby; raw "2D DERBY"
+  "2D Eos": Eos                                     # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/eos; raw "2D EOS CABRIOLET 2.0TDI-1F/258"
+  "2D Golf": Golf                                   # 97 veh/41 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF HATCHBACK 1.8T-1J/250"
+  "2D Golf 1": Golf                                 # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1,6"
+  "2D Golf 1.4": Golf                               # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.4"
+  "2D Golf 1.4 Cl-1HXO": Golf                       # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.4 CL-1HXO"
+  "2D Golf 1.4 Cl-1HXO/248": Golf                   # 4 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.4 CL-1HXO-A/248"
+  "2D Golf 1.4-1J": Golf                            # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.4-1J"
+  "2D Golf 1.4-1J/250": Golf                        # 16 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.4-1J/250"
+  "2D Golf 1.6 -1HXO/248": Golf                     # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.6 -1HXO-A/248"
+  "2D Golf 1.6 Cl-1HXO/248": Golf                   # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.6 CL-1HXO-A/248"
+  "2D Golf 1.6 GL-1HXO/248": Golf                   # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.6 GL-1HXO-A/248"
+  "2D Golf 1.6 GT-1HXO/248": Golf                   # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.6 GT-1HXO-A/248"
+  "2D Golf 1.6-1J/250": Golf                        # 23 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.6-1J/250"
+  "2D Golf 1.6-Automatic-1J/250": Golf              # 11 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.6-AUTOMATIC-1J/250"
+  "2D Golf 1.8 -1HXO/248": Golf                     # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8 -1HXO-A/248"
+  "2D Golf 1.8 -Automatic-1HXO/248": Golf           # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8 -AUTOMATIC-1HXO-A/248"
+  "2D Golf 1.8 Cl-1H/248": Golf                     # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8 CL-1H/248"
+  "2D Golf 1.8 Cl-1HXO": Golf                       # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8 CL-1HXO-A"
+  "2D Golf 1.8 Cl-1HXO/248": Golf                   # 12 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8 CL-1HXO-A/248"
+  "2D Golf 1.8 Cl-Automatic-1HXO": Golf             # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8 CL-AUTOMATIC-1HXO"
+  "2D Golf 1.8 Cl-Automatic-1HXO/248": Golf         # 4 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8 CL-AUTOMATIC-1HXO-A/248"
+  "2D Golf 1.8 GL-1HXO/248": Golf                   # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8 GL-1HXO-A/248"
+  "2D Golf 1.8 GL-Automatic-1HXO/248": Golf         # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8 GL-AUTOMATIC-1HXO-A/248"
+  "2D Golf 1.8 GT/248": Golf                        # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8 GT/248"
+  "2D Golf 1.8-1HXO/248": Golf                      # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8-1HXO-A/248"
+  "2D Golf 1.8-1J/250": Golf                        # 5 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8-1J/250"
+  "2D Golf 1.8T-1J": Golf                           # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8T-1J"
+  "2D Golf 1.8T-1J/250": Golf                       # 40 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.8T-1J/250"
+  "2D Golf 1.9TD GL-1HXO/248": Golf                 # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.9TD GL-1HXO/248"
+  "2D Golf 1.9TDI-1J/250": Golf                     # 5 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.9TDI-1J/250"
+  "2D Golf 1.9TDI-Automatic-1J/250": Golf           # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1.9TDI-AUTOMATIC-1J/250"
+  "2D Golf 1600-Automatic-19E": Golf                # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 1600-AUTOMATIC-19E"
+  "2D Golf 2.0": Golf                               # 19 veh/5 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF 2.0 GTI-1HXO-A/248"
+  "2D Golf C-1300-19E/2470": Golf                   # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF C-1300-19E-G/2470"
+  "2D Golf C-1600-19": Golf                         # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF C-1600-19-E-G"
+  "2D Golf C-1600-19/2470": Golf                    # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF C-1600-19-E-G/2470"
+  "2D Golf C-17/2400": Golf                         # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF C-17/2400"
+  "2D Golf C-1800-19E/247": Golf                    # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF C-1800-19E-G/247"
+  "2D Golf C-Diesel-17/2400": Golf                  # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF C-DIESEL-17/2400"
+  "2D Golf Cl": Golf                                # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL"
+  "2D Golf Cl-1300-19/2470": Golf                   # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1300-19/2470"
+  "2D Golf Cl-1300-19E/247": Golf                   # 4 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1300-19E-G/247"
+  "2D Golf Cl-1300-19E/2470": Golf                  # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1300-19E-G/2470"
+  "2D Golf Cl-1600": Golf                           # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1600"
+  "2D Golf Cl-1600-19": Golf                        # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1600-19"
+  "2D Golf Cl-1600-19/2470": Golf                   # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1600-19/2470"
+  "2D Golf Cl-1600-19E/2470": Golf                  # 4 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1600-19E-G/2470"
+  "2D Golf Cl-1800-19": Golf                        # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1800-19"
+  "2D Golf Cl-1800-19E/247": Golf                   # 3 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1800-19E-G/247"
+  "2D Golf Cl-1800-Automatic-19E-H/247": Golf       # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1800-AUTOMATIC-19E-H/247"
+  "2D Golf Cl-1800-Automatic-19E/2470": Golf        # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-1800-AUTOMATIC-19E-G/2470"
+  "2D Golf Cl-Diesel-19/2470": Golf                 # 6 veh/2 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-DIESEL-19/2470"
+  "2D Golf Cl-Turbo-Diesel-19E/247": Golf           # 3 veh/2 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF CL-TURBO-DIESEL-19E-G/247"
+  "2D Golf D-17/2400": Golf                         # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF D-17/2400"
+  "2D Golf GL-1300-19/2470": Golf                   # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF GL-1300-19/2470"
+  "2D Golf GL-17/2400": Golf                        # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF GL-D-17/2400"
+  "2D Golf GL-1800-19E/2470": Golf                  # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF GL-1800-19E-G/2470"
+  "2D Golf GL-1800-Automatic-19E": Golf             # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF GL-1800-AUTOMATIC-19E-G"
+  "2D Golf GL-1800-Automatic-19E/247": Golf         # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF GL-1800-AUTOMATIC-19E-G/247"
+  "2D Golf GT-1800-19E": Golf                       # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF GT-1800-19E-G"
+  "2D Golf GT-1800-19E/2470": Golf                  # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF GT-1800-19E-G/2470"
+  "2D Golf L-17/2400": Golf                         # 7 veh/2 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF L-D-17/2400"
+  "2D Golf LS-17/2400": Golf                        # 3 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF LS-17/2400"
+  "2D Golf LX-Diesel-17/2400": Golf                 # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF LX-DIESEL-17/2400"
+  "2D Golf Rallye-1800-19E-299-R-4X4/247": Golf     # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF RALLYE-1800-19E-299-R-4X4/247"
+  "2D Golf S-17/2400": Golf                         # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF S-17/2400"
+  "2D Golf Syncro 1.8-1HX1-4X4/248": Golf           # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF SYNCRO 1.8-1HX1-4X4/248"
+  "2D Golf V5 Hb 2.3": Golf                         # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF V5 HB 2.3"
+  "2D Golf VR6-1HXO/248": Golf                      # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF VR6-1HXO-A/248"
+  "2D Golf VR6-Automatic-1HX0/248": Golf            # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF VR6-AUTOMATIC-1HX0-A/248"
+  "2D Golf-GTI-16V": Golf                           # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D GOLF-GTI-16V"
+  "2D Lupo": Lupo                                   # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/lupo; raw "2D LUPO HATCHBACK"
+  "2D Lupo 1": Lupo                                 # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/lupo; raw "2D LUPO 1,4/2340"
+  "2D New Beetle": Beetle                           # 41 veh/16 rows (fi, fi_traficom) -> live volkswagen/beetle; raw "2D NEW BEETLE HATCHBACK 2.0-9C/250"
+  "2D Polo": Polo                                   # 16 veh/9 rows (fi, fi_traficom) -> live volkswagen/polo; raw "2D POLO HATCHBACK 1.2-9N/245"
+  "2D R32": Golf                                    # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "2D  R32 HATCHBACK 4MOTION 3.2-1J-4X4/258"
+  "4D Bora": Bora                                   # 82 veh/15 rows (fi, fi_traficom) -> live volkswagen/bora; raw "4D BORA SEDAN 1.6-1J/250"
+  "4D Caddy": Caddy                                 # 2 veh/2 rows (fi, fi_traficom) -> live volkswagen/caddy; raw "4D CADDY KOMBI 1.9TDI-2K/268"
+  "4D Caravelle": Caravelle                         # 7 veh/4 rows (fi, fi_traficom) -> live volkswagen/caravelle; raw "4D CARAVELLE KOMBI-2.5TDI-9-7DB/332"
+  "4D Golf": Golf                                   # 204 veh/43 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF HATCHBACK 1.8T-1J/250"
+  "4D Golf -19E": Golf                              # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF -19E"
+  "4D Golf 1.4": Golf                               # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.4"
+  "4D Golf 1.4 Cl-1HXO/248": Golf                   # 4 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.4 CL-1HXO-A/248"
+  "4D Golf 1.4 Cl-1HZV/248": Golf                   # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.4 CL-1HZV-B/248"
+  "4D Golf 1.4-1J/250": Golf                        # 25 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.4-1J/250"
+  "4D Golf 1.6 Cl": Golf                            # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.6 CL"
+  "4D Golf 1.6 Cl-1HXO": Golf                       # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.6 CL-1HXO"
+  "4D Golf 1.6 Cl-1HXO/248": Golf                   # 8 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.6 CL-1HXO-A/248"
+  "4D Golf 1.6 GL-1HXO/248": Golf                   # 3 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.6 GL-1HXO-A/248"
+  "4D Golf 1.6-1HXO": Golf                          # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.6-1HXO"
+  "4D Golf 1.6-1J/250": Golf                        # 75 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.6-1J/250"
+  "4D Golf 1.6-Automatic-1J/250": Golf              # 19 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.6-AUTOMATIC-1J/250"
+  "4D Golf 1.8 -1HXO/248": Golf                     # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8 -1HXO-A/248"
+  "4D Golf 1.8 Automatic-1HXO/248": Golf            # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8 AUTOMATIC-1HXO/248"
+  "4D Golf 1.8 Cl-1HXO/248": Golf                   # 10 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8 CL-1HXO-A/248"
+  "4D Golf 1.8 Cl-Automatic-1HXO/248": Golf         # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8 CL-AUTOMATIC-1HXO-A/248"
+  "4D Golf 1.8 GL-1H13H4/248": Golf                 # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8 GL-1H13H4/248"
+  "4D Golf 1.8 GL-1HXO/248": Golf                   # 21 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8 GL-1HXO-A/248"
+  "4D Golf 1.8 GL-Automatic-1HXO/248": Golf         # 9 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8 GL-AUTOMATIC-1HXO-A/248"
+  "4D Golf 1.8 GT-1HXO/248": Golf                   # 3 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8 GT-1HXO-A/248"
+  "4D Golf 1.8-1J-4X4/251": Golf                    # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8-1J-4X4/251"
+  "4D Golf 1.8-1J/250": Golf                        # 12 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8-1J/250"
+  "4D Golf 1.8T-1J": Golf                           # 4 veh/2 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8T-1J"
+  "4D Golf 1.8T-1J/250": Golf                       # 56 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8T-1J/250"
+  "4D Golf 1.8T-GTI 1J/250": Golf                   # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.8T-GTI 1J/250"
+  "4D Golf 1.9SDI-1J/250": Golf                     # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.9SDI-1J/250"
+  "4D Golf 1.9TD -1H-GL": Golf                      # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.9TD -1H-GL"
+  "4D Golf 1.9TD -1H/248": Golf                     # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.9TD -1H/248"
+  "4D Golf 1.9TD Cl-1HXO/248": Golf                 # 4 veh/2 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.9TD CL-1HXO-A/248"
+  "4D Golf 1.9TDI-1J": Golf                         # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.9TDI-1J"
+  "4D Golf 1.9TDI-1J/250": Golf                     # 17 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.9TDI-1J/250"
+  "4D Golf 1.9TDI-Automatic-1J/250": Golf           # 3 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 1.9TDI-AUTOMATIC-1J/250"
+  "4D Golf 2.0": Golf                               # 17 veh/6 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 2.0 GTI-1HXO-A/248"
+  "4D Golf 2.0 Cl-1H13Q3/248": Golf                 # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 2.0 CL-1H13Q3/248"
+  "4D Golf 2.0 GL-Automatic-1HXO/248": Golf         # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 2.0 GL-AUTOMATIC-1HXO-A/248"
+  "4D Golf 2.0-1J": Golf                            # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 2.0-1J"
+  "4D Golf 2.0-1J/250": Golf                        # 6 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 2.0-1J/250"
+  "4D Golf 2.3 V5 1J/250": Golf                     # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 2.3 V5 1J/250"
+  "4D Golf 2.3-1J/250": Golf                        # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 2.3-1J/250"
+  "4D Golf 2.3V5-1J/250": Golf                      # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF 2.3V5-1J/250"
+  "4D Golf Cl-1600-19E/247": Golf                   # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF CL-1600-19E-G/247"
+  "4D Golf Cl-1600-19E/2470": Golf                  # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF CL-1600-19E-G/2470"
+  "4D Golf Cl-1800-19E/247": Golf                   # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF CL-1800-19E-G/247"
+  "4D Golf Cl-1800-Automatic-19E/247": Golf         # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF CL-1800-AUTOMATIC-19E-G/247"
+  "4D Golf Cl-1800-Automatic-19E/2470": Golf        # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF CL-1800-AUTOMATIC-19E-G/2470"
+  "4D Golf Country-1800": Golf                      # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF COUNTRY-1800"
+  "4D Golf Country-1800-19E-299-4X4": Golf          # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF COUNTRY-1800-19E-299-C-4X4"
+  "4D Golf Country-1800-19E-299-4X4/248": Golf      # 5 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF COUNTRY-1800-19E-299-C-4X4/248"
+  "4D Golf GL-1600-19E/2470": Golf                  # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF GL-1600-19E/2470"
+  "4D Golf Hactback 1.6-1K/258": Golf               # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF HACTBACK 1.6-1K/258"
+  "4D Golf Hatcback": Golf                          # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4d GOLF HATCBACK"
+  "4D Golf HATCHBACK1.6": Golf                      # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF HATCHBACK1.6"
+  "4D Golf Mpv 1.4-1KP/257": Golf                   # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF MPV 1.4-1KP/257"
+  "4D Golf Mpv 1.9TDI-1KP/257": Golf                # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF MPV 1.9TDI-1KP/257"
+  "4D Golf Plus 1KP/258": Golf                      # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF PLUS 1KP/258"
+  "4D Golf Plus Mpv 1.9TDI-1KP": Golf               # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF PLUS MPV 1.9TDI-1KP"
+  "4D Golf S-17/2400": Golf                         # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF S-17/2400"
+  "4D Golf Syncro-1800-19-4X4/2470": Golf           # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF SYNCRO-1800-19-4X4/2470"
+  "4D Golf Syncro-1800-19E-299-4X4": Golf           # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF SYNCRO-1800-19E-299-G-4X4"
+  "4D Golf Syncro-1800-19E-299-4X4/2470": Golf      # 2 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF SYNCRO-1800-19E-299-G-4X4/2470"
+  "4D Golf VR6-1HXO": Golf                          # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF VR6-1HXO-A"
+  "4D Golf VR6-1HXO/248": Golf                      # 10 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF VR6-1HXO-A/248"
+  "4D Golf VR6-Automatic-1HXO/248": Golf            # 3 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF VR6-AUTOMATIC-1HXO-A/248"
+  "4D Golf VR6-HXO/284": Golf                       # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF VR6-HXO/284"
+  "4D Golf-19E": Golf                               # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "4D GOLF-19E"
+  "4D Jetta": Jetta                                 # 13 veh/13 rows (fi, fi_traficom) -> live volkswagen/jetta; raw "4D JETTA SEDAN 2.0T FSI-1KM/258"
+  "4D Passat 2": Passat                             # 2 veh/2 rows (fi, fi_traficom) -> live volkswagen/passat; raw "4D PASSAT 2,0I-3A/271"
+  "4D Polo": Polo                                   # 29 veh/9 rows (fi, fi_traficom) -> live volkswagen/polo; raw "4D POLO HATCHBACK 1.4-9N/245"
+  "5D Bora": Bora                                   # 9 veh/8 rows (fi, fi_traficom) -> live volkswagen/bora; raw "5D BORA VARIANT 1.9"
+  "5D Golf": Golf                                   # 498 veh/58 rows (fi, fi_traficom) -> live volkswagen/golf; raw "5D GOLF VARIANT 1.9TDI-1J/250"
+  "5D Golf 1.8 -1H/248": Golf                       # 1 veh/1 rows (fi, fi_traficom) -> live volkswagen/golf; raw "5D GOLF 1.8 -1H/248"
+  "5D Passat": Passat                               # 844 veh/138 rows (fi, fi_traficom) -> live volkswagen/passat; raw "5D PASSAT VARIANT 1.9TDI-3B/271"
+  "5D Polo": Polo                                   # 3 veh/3 rows (fi, fi_traficom) -> live volkswagen/polo; raw "5D POLO VARIANT-1.6-6KV/244"
+  "5D Tiguan": Tiguan                               # 2 veh/2 rows (fi, fi_traficom) -> live volkswagen/tiguan; raw "5D TIGUAN VARIANT 4MOTION 1.4TSI-5N-4X4/261"
   Vw: null                                    # NOT A NAMEPLATE: make abbreviation left after VARIANT_SUFFIXES ate the body word — all 38 raws are "VW KOMBI/CABRIOLET/VARIANT/T5/SP-2"; zero model information remains, same class as the Volkswagen/Volkswagen-Vw/Kombi nulls. Kind-blind: retires car+van. Manifest: removals.yml
   "V.w": null                                 # punctuated shape of the same residue — sole raw "V.W. CABRIOLET" (nl_rdw n=2)
   "V W": null                                 # third produced shape (nz spacing) — flap insurance
@@ -7996,6 +9720,32 @@ Volkswagen:
   Dune Buggy: null  # SPACED sibling of the Dune-Buggy null above, measured live in the verification build (nz raws `DUNE BUGGY`); same kit-car class — https://en.wikipedia.org/wiki/Dune_buggy
 
 Volvo:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D 1800 Es": "1800ES"                            # 1 veh/1 rows (fi, fi_traficom) -> live volvo/1800es; raw "2D 1800 ES"
+  "2D 1800ES": "1800ES"                             # 2 veh/1 rows (fi, fi_traficom) -> live volvo/1800es; raw "2D 1800ES"
+  "2D Amazon": Amazon                               # 10 veh/2 rows (fi, fi_traficom) -> live volvo/amazon; raw "2D AMAZON"
+  "2D C70": C70                                     # 10 veh/10 rows (fi, fi_traficom) -> live volvo/c70; raw "2D C70 CONVERTIBLE 2.5"
+  "4D Amazon": Amazon                               # 1 veh/1 rows (fi, fi_traficom) -> live volvo/amazon; raw "4D AMAZON"
+  "4D S40": S40                                     # 102 veh/40 rows (fi, fi_traficom) -> live volvo/s40; raw "4D S40 SEDAN 1.8-VS14K3/256"
+  "4D S60": S60                                     # 427 veh/96 rows (fi, fi_traficom) -> live volvo/s60; raw "4D S60 SEDAN 2.4-RS65P2/272"
+  "4D S60 R": S60                                   # 2 veh/2 rows (fi, fi_traficom) -> live volvo/s60; raw "4D S60 R SEDAN 2.5 TURBO AUTOMATIC-RS5246"
+  "4D S70": S70                                     # 44 veh/12 rows (fi, fi_traficom) -> live volvo/s70; raw "4D S70 SEDAN 2.4-LS65F2/266"
+  "4D S80": S80                                     # 172 veh/62 rows (fi, fi_traficom) -> live volvo/s80; raw "4D S80 SEDAN 2.4 AUTOMATIC-TS61P9/279"
+  "5D S60": S60                                     # 1 veh/1 rows (fi, fi_traficom) -> live volvo/s60; raw "5D S60 SEDAN 2.4-RS65P2"
+  "5D V70 2.4T": V70                                # 1 veh/1 rows (fi, fi_traficom) -> live volvo/v70; raw "5D V70 2.4T"
+  "5D V70 XC": V70 XC                               # 1 veh/1 rows (fi, fi_traficom) -> live volvo/v70-xc; raw "5D V70 XC AWDSTW 2.4 TURBO-AUTOMATIC-SZ58K7-"
+  "5D XC90": XC90                                   # 2 veh/2 rows (fi, fi_traficom) -> live volvo/xc90; raw "5D XC90 AWD 2.5T AUTOMATIC-7-CZ5928-4X4/286"
   # ── REGISTER-LANGUAGE CONVENTION (issue #123): "FH Serien"/"FM Serien"
   # (Swedish) and "FH Series"/"FM Series" (uk_dft GenModel) are the same range
   # label reaching two ids in one make — truck/volvo/fm-serien and
@@ -8618,6 +10368,25 @@ Zundapp Famel:
   Ks Super: KS Super                        # Famel KS Super, the Portuguese-built Zündapp-engined moped. KS is Zündapp's type prefix, never a word: https://zundapp.one/zundapp-models/9/zundapp-mebea-en-exoten/39/famel-ks-super
 
 Škoda:
+  # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
+  # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's
+  # kaupallinenNimi is "<door><BODY> <model> <engine>-<typecode>/<wheelbase>",
+  # so the nameplate arrives with a leading door count. junk?'s platform-code
+  # rule /\A\d[A-Z]\b/ — written for nl_rdw's "8D Audi A4" — matches that door
+  # count and deleted the row BEFORE it could become a record. Renames are
+  # consulted before junk? (normalizer.rb ORDER FIX), so a key on the produced
+  # string rescues it. SAFETY: every line below folds onto a record that is
+  # ALREADY PUBLISHED in this catalog — the value is that record's own name, so
+  # this batch can mint neither a new id nor a new spelling. Keys whose
+  # remainder was NOT already live (type-approval strings like "5D Felicia
+  # Combi 1.9D LX-EHH653/245") are deliberately NOT rescued. ──
+  "2D Octavia": Octavia                             # 1 veh/1 rows (fi, fi_traficom) -> live skoda/octavia; raw "2D OCTAVIA"
+  "2D Octavia Super": Octavia                       # 1 veh/1 rows (fi, fi_traficom) -> live skoda/octavia; raw "2D OCTAVIA SUPER"
+  "4D Fabia": Fabia                                 # 23 veh/14 rows (fi, fi_traficom) -> live skoda/fabia; raw "4D FABIA RS HATCHBACK 1.9TDI-96-U-6Y/246"
+  "4D Octavia": Octavia                             # 68 veh/26 rows (fi, fi_traficom) -> live skoda/octavia; raw "4D OCTAVIA HATCHBACK 1.6-1U/250"
+  "4D Suberb": Superb                               # 1 veh/1 rows (fi, fi_traficom) -> live skoda/superb; raw "4D SUBERB SEDAN 1.8-110-AUTOMATIC-B-3U/279"
+  "4D Superb": Superb                               # 7 veh/5 rows (fi, fi_traficom) -> live skoda/superb; raw "4D SUPERB SEDAN 1.8-110-B-3U/279"
+  "5D Felicia Combi": Felicia                       # 1 veh/1 rows (fi, fi_traficom) -> live skoda/felicia; raw "5D FELICIA COMBI"
   120L: 120 L       # Škoda spaces the trim letters across the range — 105 S / 105 L / 120 L / 120 LS / 120 GLS (https://en.wikipedia.org/wiki/%C5%A0koda_105/120)
   120-L: 120 L      # hyphenated registry spelling of the same trim — same source
   Enyaq 60: Enyaq        # battery-size registrations


### PR DESCRIPTION
**DATA-ONLY. No pipeline change — this is NOT a coupled pair.** Merge alone, any time.

## The defect

`fi_traficom`'s `kaupallinenNimi` is formatted `<door><BODY> <model> <engine>-<typecode>/<wheelbase>`, so the nameplate reaches the normalizer with a leading door count — `5D PASSAT VARIANT 1.9TDI-3B/271`. `junk?`'s platform-code rule `/\A\d[A-Z]\b/` (`pipeline/lib/normalizer.rb:503`), written for nl_rdw's `8D Audi A4`, matches that door count and returns `nil` from `classify` — the row **never becomes a record**, so no catalog-side check can see it.

Measured by a per-row replay of `classify` over the whole corpus (378,281 rows / 76,947,294 vehicles; the method of `pipeline/tools/report_junk_drops.rb`), the rule kills **8,577 (make,key) pairs / 51,087 vehicles**, decomposing as:

| class | pairs | vehicles | disposition |
|---|---:|---:|---|
| door-shaped (`5D Passat`, `4D S60`) | 8,015 | 33,607 | **this PR** |
| bare body codes `2D`/`4D`/`5D` | 177 | 13,178 | unrecoverable — `collapse_variant` already destroyed the nameplate upstream |
| real digit-letter nameplates (`8N`, `4L`, `1T`, `8H`) | 198 | 3,645 | out of scope |
| other | 187 | 657 | out of scope |

## MECHANISM — established empirically, not by reading

Renames are consulted **before** `junk?` (the ORDER FIX, `normalizer.rb:155-180`). I verified this directly rather than trusting the comment — probing the rename lookup and then injecting a rename:

```
BASELINE   "5D PASSAT VARIANT 1.9TDI-3B/271"       -> nil
PROBE      rename lookup receives ["Volkswagen", "5D Passat"]      MATCH
TREATMENT  with {"5D Passat" => "Passat"} injected  -> ["Volkswagen", "Passat"]   RESCUED
```

Same for `4D S60`→`S60`, `8D Audi A4`→`A4`, and `4D E 220`→`E-Class` (the last routed through the Mercedes family rule).

So the rescue needs **no pipeline change**: a make-scoped rename keyed on the produced string is enough, one auditable line per key with its evidence.

**Rejected alternative — an upstream prefix strip in the fi_traficom adapter.** One line of code, but it strips unconditionally and so rescues the type-approval garbage along with the nameplates: it is the "unsliced" version that mints thousands of junk pairs. It also cannot be scoped by whether the result is a real nameplate, because the adapter has no catalog knowledge, and giving it any would make the build depend on its own previous output. Renames keep the decision per-key, reviewable, and reversible.

**Why re-classify rather than hand-strip a body-word list.** For each candidate I strip `\A[2-9]D\s+` from the **raw** string and re-run `classify`, which lets the existing `collapse_variant` / family machinery resolve the remainder. Measured against the briefed rule (strip prefix + body word off the produced key), on the identical candidate set:

| rule | pairs | vehicles |
|---|---:|---:|
| re-classify the door-stripped raw | **1,014** | **11,181** |
| strip prefix + body word off the key | 443 | 8,514 |

The hand-strip cannot fold `330XD Touring Automatic-EX71-4X4/273` → `3-Series`; the family rules can.

## THE SAFETY PROPERTY

A key is rescued **only when the stripped remainder is already a live published record for that make**, and the value written is **that record's own published `name`** — so the batch can introduce neither a new id nor a new spelling. (6 keys folded onto a record whose published spelling differs from the derived one — `Herald 13-60` vs published `Herald 13/60` — and took the published form.)

Selection over the 8,015 door-shaped pairs:

| | pairs | vehicles |
|---|---:|---:|
| door-shaped candidates | 8,015 | 33,607 |
| − nl_rdw platform-code shape (2nd token IS the make word) | −36 | −1,914 |
| − stripped raw re-classifies to nothing | −1,720 | −6,199 |
| − rows under one key disagree on the target (ambiguous) | −4 | −305 |
| − **remainder NOT already live** (the garbage class) | −5,241 | −14,008 |
| − proven to mint on the control build (below) | −2 | −10 |
| − make is not a catalog display name (`Auto-Union`) | −1 | −2 |
| **= RESCUE SET** | **1,011** | **11,169** |

1,011 keys across **62 make blocks**, folding onto **397 already-published records**, 3,694 corpus rows. Volume is `fi` (11,169 vehicles); 183 vehicles' worth of keys are also seen by nl_rdw and 44 by ca_nrcan.

Top targets: `volkswagen/golf` 1,392 · `volkswagen/passat` 846 · `mercedes-benz/e-class` 706 · `audi/a4` 681 · `mercedes-benz/c-class` 513 · `toyota/yaris` 505 · `toyota/corolla` 464 · `volvo/s60` 430.

### Delta vs the briefed 579 pairs / ~19,002 vehicles

**I could not reproduce those figures and am reporting mine rather than forcing the number.** My set has *more* pairs (1,011 vs 579) and *fewer* vehicles (11,169 vs ~19,002). The briefed per-record figures exceed what their keys can supply:

- All Mercedes-Benz door-shaped keys together are **1,671 vehicles**, yet the brief quotes C-Class 1,997 + E-Class 1,674 = 3,671 from that class alone.
- All Audi door-shaped keys naming A4 total **2,063 vehicles** *including* the `8D Audi A4` platform shape the brief tells me to exclude, vs the quoted 2,702.

The whole door-shaped class is only 33,607 vehicles, and the subset whose remainder is already live is 11,169. Most likely the earlier simulation counted the resulting record's total corpus volume rather than the rescued increment, or attributed some of the bare body-code class (Mercedes-Benz `4D` alone is 4,719 vehicles) to the nameplate it would have belonged to — which the brief itself declares unrecoverable at this layer. Everything I report is per-key reproducible from the replay.

## THE FOUR VERIFICATIONS

Frozen cache (`find cache -type f ! -name 'license_*.txt' -exec touch {} +` — the licence exclusion matters, a blanket touch disables the licence gate), identical pipeline commit `e1e863d`, `VDB_VERSION=2026.08.99`. Control = this branch's base with renames.yml untouched; treatment = this branch.

**1. Frozen-cache control build.** Both builds exit 1 on the *same pre-existing* 16 `yamaha` id-contract stubs + summary (main is red for that reason at the base commit); both emit full output. Record counts identical in every kind.

**2. ZERO new nameplates.**
```
control ids: 13998    treatment ids: 13998
NEW in treatment:        0
DISAPPEARED from control: 0
display-name changes:     0
```
The only difference is **23 records gaining `fi` availability** — the intended effect (`car/opel/speedster` `es+gb+nl+nz` → `es+fi+gb+nl+nz`, `car/hillman/minx` `gb+nl+nz` → `fi+gb+nl+nz`, …).

**3. `rake report:junk_drops` before/after**, same 378,281-row / 76,947,294-vehicle replay:
```
BEFORE  25,492 distinct (make,key) dying in junk?, 330,700 vehicles
AFTER   24,481 distinct (make,key) dying in junk?, 319,531 vehicles
        = -1,011 pairs and -11,169 vehicles — exactly the set added, to the vehicle
```

**4. Dead-key sweep.** Replayed the corpus recording every rename key both probed and present: **1,011 fired / 0 dead.**

**Lints** (all on this branch): `lint_overrides.rb` OK · `lint_curation.rb --base=origin/main` OK (109 files) · `reorg_make_blocks.rb --check` alphabetical · `lint_dataset.rb --report` **byte-identical** control vs treatment (unexplained 15, debt 374, escapes 0 on both).

## DELIBERATELY NOT RESCUED

- **5,241 pairs / 14,008 vehicles whose remainder is not already published.** This is the garbage the unsliced fix would mint: `skoda/felicia-combi-1-9d-lx-ehh653-245` (165), `volvo/stw-940-94581-277` (159), `mitsubishi/pajero-stw-2-8td-0nv460-4x4-273` (154), `saab/combi` (93), `toyota/corolla-1-6xli-ae101l-aemdkw-247` (91). Rescuing these is what makes this the largest-garbage-minting change in the catalog's history; the live-record predicate is precisely what stops it.
- **The nl_rdw platform-code shape (36 pairs / 1,914 vehicles)** — where the token after the digit-letter is the make word. `8D AUDI A4` (1,381) is the B5 platform code, not a door count. Note `4D Audi A8` (286) is genuinely *both* simultaneously; excluded anyway, because the platform reading is the one nl_rdw intends.
- **The bare body-code class (177 pairs / 13,178 vehicles)** — `Mercedes-Benz "4D"` 4,719, `Volvo "4D"` 1,252. `collapse_variant` destroyed the nameplate upstream; nothing at this layer can recover it. Fixing it means changing `collapse_variant`, which is a different and much riskier change.
- **The real digit-letter nameplates (198 pairs / 3,645 vehicles)** — `Tomos "4L"` 1,306, `JCB "1T"` 368, `Audi "8N"` 241/`"8H"` 131. These are genuine nameplates/platform codes needing individual identity renames, not a door-count strip.
- **`Dodge "5D Grand"` / `"4D Grand"` (2 keys / 10 vehicles) — found by the control build, not by reasoning.** A rename key is make-scoped, not kind-scoped, so it fires on every kind. Where a key also hits a kind the target isn't published in, `Reconciler.cross_kind_prune!` (`reconciler.rb:105`) normally deletes the minority entry — control and treatment prune an *identical* 291 van / 26 motorcycle / 33 car / 14 truck / 18 bus ids, so for big nameplates (`audi/a4` is in that list) this rescue changes nothing. But the prune has a `next if grand < 100` guard: `dodge/grand-caravan` is published as a car only and is too small for the prune to reach, so its van rows minted `van/dodge/grand-caravan` on the first control build (van 616 → 617). Dropped, because a rename cannot take the car rows and leave the van ones.
- **`Auto-Union "2D Audi"` (2 vehicles)** — `classify` produces the make `Auto-Union` at the rename lookup but the catalog's display name is `Auto Union`, so the block would be inert (and `lint_curation.rb` rejects it). The underlying make-name mismatch is real but out of scope here; **unverified** whether it costs anything beyond these 2 vehicles.

## Notes for the reviewer

- 529 of the 1,011 keys rescue a single vehicle, and ~320 embed a full type-approval string (`5D Freelander Stw 2.0 TD4-LNABE8-4X4/256`). Each is individually justified and each fires today, but they are brittle by construction: they are pinned to exact registry strings and will go dead if fi_traficom reformats. They are the tail — the top 20 keys carry 5,600 of the 11,169 vehicles. I kept them because dropping them would be an arbitrary line, but a reviewer who wants a volume floor has a defensible case.
- Every line carries its own evidence comment: vehicle count, row count, countries, sources, the live target id, and a representative raw string.
