### PR TITLE
former_ids: correct a miscited AMG string in permanent documentation

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2093,7 +2093,10 @@
 # van-kind G-Class — the car record held >=97% of the registrations, i.e. the pipeline's own
 # verdict was "this IS the car, misfiled by body type". The AMG fix moves 92 van
 # registrations off the (unpublished) `van/mercedes-benz/amg` stub onto the van G-Class
-# ("AMG G 63", "AMG G 63 4X42", "AMG G 63 SUV" — fi|gb|lu|nl), and dominance now reads
+# ("AMG G 63", "AMG G 63 4X42" — nl only; CORRECTED 2026-08-02, this line first
+# read "fi|gb|lu|nl" and also listed "AMG G 63 SUV", which is NOT a van registration
+# at all: it appears only in the ca_* fuel-consumption ratings, a Canadian CAR
+# approval source, and in no registration file), and dominance now reads
 # 11,866 / (11,866 + 399) = 96.75%, BELOW the 97% bar, so the van record survives the prune
 # and PUBLISHES. Measured: control vs treatment build, both from pipeline 2511322 against
 # this repo's main. An alias may never name a live id (validate.rb:441) and the id is no


### PR DESCRIPTION
Follow-up (1) from the owner-swarm batch audit of the AMG pair.

The retained `van/mercedes-benz/g-class` ledger comment listed the van-side strings as `"AMG G 63", "AMG G 63 4X42", "AMG G 63 SUV"` across `fi|gb|lu|nl`.

**Verified against the raw cache before correcting:**

| string | where it actually appears |
|---|---|
| `AMG G 63 SUV` | **only** `ca_*-fuel-consumption-ratings*.csv` — a Canadian CAR approval source. **In no registration file at all.** |
| `AMG G 63 4X42` | `nl_rdw` only (personenauto + bedrijfsauto) |
| `AMG G 63` | nl_rdw, plus th/lu/ca — but the van-kind source is `nl_rdw_bedrijfsauto` |

So `AMG G 63 SUV` is not a van registration and never was, and the van-side country list is `nl`, not `fi|gb|lu|nl`.

I recorded the wrong claim in the correction rather than quietly deleting it. A ledger comment is precisely what a future reader trusts when the build no longer reproduces the state it describes — a silent edit would leave them unable to tell a corrected line from an original one.

The surrounding reasoning (the cross-kind prune arithmetic, 96.75% dominance, the van record surviving and publishing) is untouched and unaffected: those numbers came from the control-vs-treatment build, not from this string list.