### PR TITLE
lexus: missed-spelling sweep + the TX nameplate (dossier §A.2 L1-L4, §C.4)

### DIFF
--- a/overrides/body_types/body_types.yml
+++ b/overrides/body_types/body_types.yml
@@ -60,6 +60,8 @@ overrides:
   EBRO|S700: suv                 # mid-size SUV (Chery Tiggo 7 platform, built ex-Nissan Barcelona) — DGT-only rows were default-typed hatchback
   EBRO|S800: suv                 # 7-seat SUV (Chery Tiggo 8 platform), same revival family
   EBRO|S400: suv                 # compact SUV (Chery Tiggo 4 Pro base) — key is the post-rename nameplate (S400 Hev → S400)
+  # --- Lexus TX (2026-08-02, S4W; dossier §A.2 L1 mints car/lexus/tx) ---
+  Lexus|TX: suv                  # "This three-row SUV provides seating for up to seven passengers" — https://pressroom.lexus.com/a-new-era-of-three-row-luxury-the-first-ever-lexus-tx/ (fetched 2026-08-02). REQUIRED, not cosmetic: normalizer.rb's Lexus family rule tests /\A(NX|RX|UX|GX|LX|RZ|LBX)/ for :suv and has no TX arm, the TX has no nl_rdw rows so the registry-signal layer never fires, and the record therefore falls to the default :hatchback — which is what car/lexus/tx-350 and car/lexus/tx-500h publish TODAY (measured, dist/vehicles.csv v2026.08.0). Curated here rather than in the Ruby family rule per AGENTS.md ("string FACTS are overrides"); layer 1 outranks the family rule either way
 
 keywords:                        # [type, ruby-regex] — checked before the sets
   - [suv, '\b(Aircross|Crossback|Cross)\b']   # *Cross / Aircross / Crossback crossovers

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -1521,6 +1521,7 @@
 "car/lexus/rx350h": "car/lexus/rx"
 "car/lexus/rx400h": "car/lexus/rx"
 "car/lexus/rx450": "car/lexus/rx"
+"car/lexus/rx450-h": "car/lexus/rx" # retired 2026-08-02 by renames.yml `RX450 H: RX` (dossier §A.2 L2). Held es:es_dgt + nl:nl_rdw, both of which car/lexus/rx already carries — availability union unchanged (measured, control vs treatment build)
 "car/lexus/rx450h": "car/lexus/rx"
 "car/lexus/rx450hl": "car/lexus/rx"
 "car/lexus/rx500h": "car/lexus/rx"
@@ -1537,6 +1538,8 @@
 "car/lexus/sc-430": "car/lexus/sc"
 "car/lexus/sc400": "car/lexus/sc"
 "car/lexus/sc430": "car/lexus/sc"
+"car/lexus/tx-350": "car/lexus/tx"   # retired 2026-08-02 by renames.yml `Tx 350: TX` (dossier §A.2 L1) — TX 350 is a powertrain grade of the TX, per Lexus's own launch release. Held ca:ca_nrcan ua:ua_mvs us:us_fueleconomy; car/lexus/tx is MINTED by the same fold and carries all three
+"car/lexus/tx-500h": "car/lexus/tx"  # retired 2026-08-02 by renames.yml `Tx 500H: TX` (same cluster). Held ca:ca_nrcan ua:ua_mvs us:us_fueleconomy — identical member set, so the union is lossless by construction
 "car/lexus/ux-200": "car/lexus/ux"
 "car/lexus/ux-250": "car/lexus/ux"
 "car/lexus/ux-250h": "car/lexus/ux"

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -5118,6 +5118,62 @@ Lexus:
   UX250H: UX                              # engine/powertrain variant of the UX line — the nameplate is the line, not the engine (lexus.co.uk/car-models)
   UX300E: UX                              # engine/powertrain variant of the UX line — the nameplate is the line, not the engine (lexus.co.uk/car-models)
   UX300H: UX                              # engine/powertrain variant of the UX line — the nameplate is the line, not the engine (lexus.co.uk/car-models)
+  # ── LEXUS MISSED-SPELLING SWEEP + the TX nameplate (2026-08-02, S4W; owner
+  # dossier aux/research/2026-08-owner-swarm/mini-lexus-smart.md §A.2 L1-L4 and
+  # §C.4). Two classes only:
+  #   (a) NAMING §7.6 rule 2 — a spelling of a line that is ALREADY published
+  #       and that the 165-key powertrain fold above missed. Every value below
+  #       is a live record's own name, so this batch can mint no new spelling.
+  #   (b) ONE new nameplate, TX, whose three powertrain grades post-date that
+  #       fold. It mints car/lexus/tx; car/lexus/tx-350 and car/lexus/tx-500h
+  #       retire into it via former_ids.yml.
+  # KEYS ARE THE PRODUCED STRINGS, MEASURED, NOT GUESSED. classify() was
+  # replayed for every raw below (pipeline 6101c2c, frozen cache); five of the
+  # dossier's draft keys were written in the wrong case and WOULD HAVE BEEN
+  # INERT — the corrected forms are here. The difference is overrides/styling.yml
+  # `acronyms:`, which pins IS/GS/LS/LC/RX/NX/UX/LX/RZ/LBX/HS to caps but has no
+  # token for ES/RC/CT/SC/GX/LM/TX, so "Rc 200" and "Es 500E" are title-case
+  # while "RX 200" and "IS350 Sport" are not.
+  # Rename VALUES are used verbatim (normalizer.rb `nameplate = repl`), which is
+  # why writing the target as `TX`/`GS F`/`LFA`/`LM` fixes the published casing
+  # in the same line — the Rc F: RC F precedent above. §C.4 explicitly rules out
+  # an acronyms: token for these (NAMING §9 sweep; the Volvo "480 ES" comment
+  # records a token un-folding this very make's ES family).
+  # KIND-BLIND, checked: the only non-car Lexus strings in the corpus are
+  # van/lexus/{gx,is,lx,lx450d} (nl 8+2+1, gb 0) — none of them is a key below,
+  # so the van blast radius of this batch is zero (measured on the control
+  # build, all six kinds). ──
+  #
+  # (b) TX — one nameplate, three powertrain grades, per Lexus's own launch
+  # release: "Lexus has ushered in a new era of luxury with the global reveal of
+  # the first-ever TX, a vehicle made specifically for the North American
+  # market" … "The 2024 TX will be offered in four grades: Standard, Premium,
+  # Luxury and F SPORT Performance" — https://pressroom.lexus.com/a-new-era-of-three-row-luxury-the-first-ever-lexus-tx/ (fetched 2026-08-02)
+  Tx 350: TX                              # published car/lexus/tx-350 (ca:ca_nrcan ua:ua_mvs us:us_fueleconomy) — the 2.4L turbo grade, not a model; raw "TX 350 AWD" (ca_nrcan/us_fueleconomy)
+  Tx 500H: TX                             # published car/lexus/tx-500h (ca:ca_nrcan ua:ua_mvs us:us_fueleconomy) — the turbo-hybrid grade; raw "TX 500h AWD"
+  Tx 550H Plus: TX                        # candidate lexus/tx-550h-plus (us:us_fueleconomy) — the 3.5L V6 plug-in grade; raw "TX 550h Plus AWD" (us_fueleconomy)
+  TX350 Executive: TX                     # candidate lexus/tx350-executive (ua=1, ua_mvs) — raw "TX350 EXECUTIVE"; a fourth TX spelling the dossier did not list, folded here so no TX row is left outside the new record. "Executive" is a re-export-market trim label; the vehicle is a TX 350
+  #
+  # (a) missed spellings of already-published lines
+  RX450 H: RX                             # published car/lexus/rx450-h (es:es_dgt nl:nl_rdw) — the block already keys "RX 450 H", "RX 450H", "RX450H" and "RX450HL" but NOT this spacing; raws "LEXUS RX450 H" (nl_rdw n=1, es_dgt 2026-06 n=1). Union unchanged: car/lexus/rx already holds es:es_dgt + nl:nl_rdw
+  Gsf: GS F                               # candidate lexus/gsf (gb=65, uk_dft). THE REGISTER CORROBORATES ITSELF INSIDE ONE ROW: uk_veh0120_uk.csv writes GenModel "LEXUS GSF" with Model "GS F AUTO" on the same statutory line, i.e. the source spells the model "GS F" while pooling it under a spaceless GenModel. (The dossier said this sits "beside LEXUS GS F"; it does not — `grep -c 'LEXUS GS F'` on that file is 0. GSF is GB's ONLY spelling, which makes this a spelling fold, not a merge of two GB families.) Mirror of the shipped `Isf: IS F`; F is a grade marker, not a nameplate — "The F in RC F denotes our high-performance, sports models" — https://mag.lexus.co.uk/lexus-model-names/ (fetched 2026-08-02). ADDS gb:uk_dft to car/lexus/gs-f
+  RX 500: RX                              # candidate lexus/rx-500 (gb=634, uk_dft) — "RX 500H" is keyed above, the bare truncated form is not; GB writes the GenModel without the h
+  RX500: RX                               # candidate lexus/rx500 (nl=1, nl_rdw, raw "RX500") — the un-spaced twin of the line above; "RX500H" is already keyed
+  Rc 200: RC                              # candidate lexus/rc-200 (gb=97, uk_dft) — "Rc 200T" is keyed above; GB truncates the T
+  RX 200: RX                              # candidate lexus/rx-200 (gb=56, uk_dft) — "RX 200T"/"RX200T" are keyed above; bare form is not
+  LBX Vibrant: LBX                        # candidate lexus/lbx-vibrant (gb=137, uk_dft) — "Vibrant Edition" is a TRIM of the LBX, not a model — https://media.lexus.co.uk/lexus-lbx-offers-more-choice-and-style-with-new-vibrant-edition/
+  RX 450H Plus: RX                        # candidate lexus/rx-450h-plus (us:us_fueleconomy, raw "RX 450h Plus AWD") — 450h+ is the plug-in hybrid grade of the RX line; "RX 450H L"/"RX450HL" are already keyed
+  NX 450H Plus: NX                        # candidate lexus/nx-450h-plus (us:us_fueleconomy, raw "NX 450h Plus AWD") — same grade shape on the NX; "NX 450H"/"NX450H" are already keyed
+  Es 500E: ES                             # candidate lexus/es-500e (us:us_fueleconomy, raws "ES 500e AWD (19 inch Wheels)"/"(21 inch Wheels)") — "ES500E" is keyed above, the spaced form is not
+  IS 300H F Sport: IS                     # candidate lexus/is-300h-f-sport (fi=1, fi_traficom, raw "LEXUS IS 300h F Sport") — F SPORT is a trim; "Es 350 F Sport"/"GS 350 F Sport" are already keyed the same way. NB the dossier attributed this string to NL/GB; the corpus puts it in fi_traficom
+  IS350 Sport: IS                         # candidate lexus/is350-sport (nl=1, nl_rdw, raw "LEXUS IS350 SPORT") — same class; "IS350" is keyed above
+  #
+  # (c) §C.4 CASING — two published records whose display name is wrong today,
+  # both because they have no rename key and so fall through to smart_case.
+  # Whole-string pins, blast radius 1 each, slug unchanged (slugify("LFA") ==
+  # slugify("Lfa") == "lfa"). NOT styling.yml entries, per §C.4.
+  Lfa: LFA                                # published car/lexus/lfa displays "Lfa" (dist/vehicles.csv v2026.08.0) — measured classify("LEXUS","LFA") -> ["Lexus","Lfa"]. Register attestation, not just marque styling: uk_veh0120_uk.csv writes GenModel "LEXUS LFA" with Model "LFA F S-A" — both halves caps. Every other Lexus record in the catalog is all-caps
+  Lm: LM                                  # published car/lexus/lm displays "Lm" (dist/vehicles.csv v2026.08.0) — build/observed_model_names.json flags car/lexus/lm as flapping ["LM","Lm"], i.e. the published name is decided by SOURCE ITERATION ORDER (reconciler.rb:246 keeps the first spelling to arrive). The keyed raws ("LM350H", "LM500H", "Lm 350H") already emit LM; bare "LEXUS LM" does not. This pin makes it deterministic. The dossier §C.4 states LM "is already fixed" — the released catalog refutes that
 
 Leyland Daf:
   # ── wave-4 heavy-vehicle clean (2026-08-01; Scania+DAF dossier §A-L1/§A-L2).


### PR DESCRIPTION
Applies the **LEXUS** portion of `aux/research/2026-08-owner-swarm/mini-lexus-smart.md` — §A.2 clusters L1–L4 plus the §C.4 casing pins. **18 rename keys, 3 `former_ids`, 1 body-type override.** Sibling PRs cover the MINI and smart portions; nothing here touches either.

## Measurement setup

Frozen cache (`find cache -type f ! -name 'license_*.txt' -exec touch {} +` — the licence exclusion matters, a blanket touch silently disables the licence gate). **Control and treatment built from base `f9d5637` (this branch's parent) in a private, pristine detached worktree, with the pipeline held IDENTICAL** across both runs, so the data change is the only variable.

**Both builds exit 0 with ZERO gate failures.** (An earlier revision of this PR was based on `8204669` and showed 16 red `id-contract` gates on `motorcycle/yamaha/*` — those were **main's**, fixed by #190 four commits later, and identical in that revision's control. Rebased; they are gone from both sides.)

**Everything below was re-derived from scratch after the scratchpad-collision warning.** My first-pass helper `iddiff.rb` had been written to the shared scratchpad root and **was in fact overwritten by a sibling delegate** (verified: different header, my marker string absent). The re-derivation, under a private namespace with tagged filenames and fresh builds at the newer base, **reproduces the original id/candidate/dist diffs exactly**.

## Control vs treatment — all six kinds

```
control 13936 ids | treatment 13934 ids | delta -2

REMOVED car/lexus/rx450-h   RX450 H   suv         es:es_dgt nl:nl_rdw
REMOVED car/lexus/tx-350    Tx 350    hatchback   ca:ca_nrcan ua:ua_mvs us:us_fueleconomy
REMOVED car/lexus/tx-500h   Tx 500H   hatchback   ca:ca_nrcan ua:ua_mvs us:us_fueleconomy
ADDED   car/lexus/tx        TX        suv         ca:ca_nrcan ua:ua_mvs us:us_fueleconomy
CHANGED car/lexus/gs-f  avail  ca:ca_nrcan nl:nl_rdw nz:nz_nzta us:us_fueleconomy
                            ->  ca:ca_nrcan gb:uk_dft nl:nl_rdw nz:nz_nzta us:us_fueleconomy
CHANGED car/lexus/lfa   name   Lfa -> LFA
CHANGED car/lexus/lm    name   Lm  -> LM

kinds touched: car        makes touched: lexus
gate-FAIL parity: control 0 | treatment 0 | identical
```

**Nothing changes in `van`, `truck`, `bus`, `motorcycle` or `moped`.** Renames are make-scoped but kind-blind, so that was checked, not assumed: the only non-car Lexus strings in the corpus are `van/lexus/{gx,is,lx,lx450d}` (nl 8+2+1, gb 0) and none of them is a key in this batch.

Whole-`dist` field-level diff outside make `lexus`: **three popularity deciles and nothing else** — `car/datsun/120` 9→8, `car/hyundai/grand-starex` 7→8, `car/renault/rodeo` 8→9. Rank-boundary collateral of the net −2 record count (the known popularity-determinism item); zero ids, names, bodies or countries move.

## Availability union per fold, at (country, SOURCE) level

| cluster | key(s) | folded pairs | survivor | verdict |
|---|---|---|---|---|
| **L1** | `Tx 350`, `Tx 500H`, `Tx 550H Plus`, `TX350 Executive` → `TX` | `ca:ca_nrcan ua:ua_mvs us:us_fueleconomy` (×2 published) + `us:us_fueleconomy` (tx-550h-plus) + `ua:ua_mvs` (tx350-executive) | **`car/lexus/tx` — MINTED**, carries exactly `ca:ca_nrcan ua:ua_mvs us:us_fueleconomy` | **LOSSLESS** (read off the treatment build, not inferred) |
| **L2** | `RX450 H` → `RX` | `es:es_dgt nl:nl_rdw` | `car/lexus/rx` — absent from the CHANGED list, i.e. it already held both | **LOSSLESS** |
| **L3** | `Gsf` → `GS F` | `gb:uk_dft` (65) | `car/lexus/gs-f` | **ADDITIVE — gains `gb:uk_dft`** |
| **L4** | 10 keys (below) | 10 candidate pairs | `rx`/`rc`/`nx`/`es`/`is`/`lbx` — **none appears in the CHANGED list** | **LOSSLESS** |
| **§C.4** | `Lfa`→`LFA`, `Lm`→`LM` | — | same ids (`slugify("LFA") == slugify("Lfa")`) | name only |

## The dossier's draft keys were wrong in five places — corrected here

`classify()` was replayed for every raw (twice, on two pristine checkouts, identical results). The rename lookup is an **exact whole-string match on the produced nameplate**, so a mis-cased key is silently inert:

| dossier draft | actual produced string | |
|---|---|---|
| `Lbx Vibrant` | **`LBX Vibrant`** | would have been inert |
| `Rx 450H Plus` | **`RX 450H Plus`** | would have been inert |
| `Nx 450H Plus` | **`NX 450H Plus`** | would have been inert |
| `Is 300H F Sport` | **`IS 300H F Sport`** | would have been inert |
| `Is350 Sport` | **`IS350 Sport`** | would have been inert |

The mechanism is `overrides/styling.yml` `acronyms:`, which pins `IS GS LS LC RX NX UX LX RZ LBX HS` to caps but has no token for `ES RC CT SC GX LM TX` — which is why `Rc 200` and `Es 500E` are title-case in the same batch and `RX 200` is not.

Two keys are **additions to the dossier**, both the same string family as a key it did list, both measured: `RX500: RX` (nl=1, the un-spaced twin of `RX 500`) and `TX350 Executive: TX` (ua=1, a fourth TX spelling, folded so no TX row is left outside the record this PR mints).

## Dead-curation audit

The failure mode is a change that alters a matched produced string and silently kills a key — green build, no lint. Audited in three directions:

* **Forward (do the new keys fire?).** Candidate-side diff: **13 Lexus candidates disappear, 0 appear, 0 non-Lexus candidate churn.** With the 3 removed published ids and the 2 name changes, all 18 keys are individually accounted for. **Zero inert lines.**
* **Reverse (does anything die?).** No new key's *value* is an existing Lexus key (checked programmatically — empty set), so nothing chains or is shadowed; 169 → 187 Lexus keys, 0 case-variant collisions. `grep` over `overrides/**` + `spotchecks.yml` for the retiring ids and changed names: the only pre-existing references are the three `car/lexus/lm-*` aliases, unaffected (slug `lm` unchanged). `spotchecks.yml` has **zero** Lexus entries.
* **RENAME-VALUE LIVENESS** — the third silent class, raised in NEGOTIATION Turn 242 / `data#197` and **explicitly aimed at this PR**. Run both halves:
  * No rename in **any** make uses `RX450 H`, `Tx 350`, `Tx 500H`, `Lfa` or `Lm` as a **VALUE** → **0 hits**, so this batch resurrects nothing.
  * Whole-Lexus-block sweep of all 187 values against the treatment catalog → **every value resolves to a live record, 0 findings.** Against the *control* catalog the sweep flags exactly one value (`TX`), correctly, as a `former_ids` target not yet live — the expected signature of a mint, not a defect.
* `test_override_key_reachability` passes — but per the standing warning it is kind-blind and would not have caught this class anyway, so the candidate-side diff is the real evidence.

## Why `Lexus|TX: suv` is in this PR and not cosmetic

`normalizer.rb#car_body_rule` tests `/\A(NX|RX|UX|GX|LX|RZ|LBX)/` for `:suv` and has **no TX arm**; the TX has no `nl_rdw` rows so the registry-signal layer never fires; the record therefore falls to the default `:hatchback` — which is exactly what `car/lexus/tx-350` and `car/lexus/tx-500h` publish today. First-party: *"This three-row SUV provides seating for up to seven passengers"* — https://pressroom.lexus.com/a-new-era-of-three-row-luxury-the-first-ever-lexus-tx/ (fetched 2026-08-02). Curated in `body_types.yml` layer 1 rather than in the Ruby family rule, per AGENTS.md ("string FACTS are overrides"); layer 1 outranks the family rule either way.

## Lexus regex-collision check (the `/ACEMAN/`-in-`PACEMAN` analogue)

Asked for explicitly. **The class exists structurally but has no live instance in this make:**

1. **`family_nameplate` has no `Lexus` arm at all** (`normalizer.rb:704-716` — BMW, Mercedes-Benz, Audi, Mini, Volkswagen, Hyundai, Porsche, MG, Land Rover, Tesla). The `mini()` defect class — an unanchored family regex matching a shorter nameplate inside a longer one — **cannot exist for Lexus**.
2. **`case_token` is whole-token equality, not a regex**: `return w if @o.acronyms.include?(w)` (`normalizer.rb:418`). `IS` cannot fire inside `ISUZU` or `VISION`. Tokenisation splits on space, `-` and `/` (digit-free tokens only), so a pin can only ever match a whole token.
3. **The one unanchored-tail shape is `car_body_rule`'s Lexus arm** — `/\A(NX|RX|UX|GX|LX|RZ|LBX)/`, `/\A(IS|ES|GS|LS)/`, `/\A(LC|RC)/` are `\A`-anchored with **no trailing boundary**, structurally the same hazard as `/ACEMAN/`. Swept **every** Lexus string in the corpus — every rename key, every rename value, every published name, every candidate across all six kinds — flagging any string whose matched prefix is not its whole letter-head, or which matches two arms:

   ```
   control build:    360 distinct Lexus strings | prefix!=head 0 | multi-arm 0
   treatment build:  362 distinct Lexus strings | prefix!=head 0 | multi-arm 0
   ```

   `Gsf` is a near miss only because the regexes are case-sensitive; after this PR it is `GS F` and correctly `:sedan`.

## Corpus vs dossier — five gaps, reported not papered over

* **`Gsf` — the dossier's stated reason is wrong.** It says GB writes `LEXUS GSF` "beside `LEXUS GS F`". It does not: `grep -c 'LEXUS GS F' cache/uk_veh0120_uk.csv` is **0**. GSF is GB's only spelling. The real evidence is **better** and self-corroborating inside one statutory row — `Cars,LEXUS,LEXUS GSF,GS F AUTO,Petrol,Licensed,…`: the register pools it under a spaceless `GenModel` while its own `Model` column writes `GS F`. The fold is a spelling fold, not a merge of two GB families.
* Counts drift: `lexus/gsf` is **gb 65** not 58; `lexus/rx-500` **634** not 592; `lexus/rc-200` **97** not 92; `lexus/rx-200` **56** not 50. The dossier counted `2026 Q1 Licensed` GB `GenModel` rows; these are the pipeline's own counts on the same frozen cache. `lbx-vibrant` matches exactly (137).
* `Is 300H F Sport` is attributed to "NL/GB strings". The corpus puts it in **`fi_traficom`** (fi=1, raw `LEXUS IS 300h F Sport`) and nowhere else.
* The dossier lists `van/lexus/{gx,is,lx,rx}`. The corpus has `van/lexus/{gx,is,lx,lx450d}` — **no `rx` van candidate**, and an `lx450d` it does not mention.
* **§C.4 says "`Lm` is already fixed and nobody noticed". The released catalog refutes it**: `dist/vehicles.csv` v2026.08.0 line `car,lexus,lm,Lm`. `build/observed_model_names.json` flags `car/lexus/lm` as flapping `["LM","Lm"]`, and `reconciler.rb:246` keeps the **first** spelling to arrive (`entities[key] ||= Entity.new(...)`) — so the published name is decided by source iteration order. `Lm: LM` makes it deterministic. Same mechanism for `Lfa`, which also gets register attestation, not just marque styling: `Cars,LEXUS,LEXUS LFA,LFA F S-A,…` — both halves caps.

## Declined

* **The other five flapping ids.** `ct`, `es`, `gx`, `rc`, `sc` flap too — but all five currently publish the **correct** caps form. Latent, not broken; a determinism pass for them is a separate, wider change, and widening a batch the reviewer did not ask for is how these pins rot (the XFC/XB precedent in `styling.yml`).
* **`Lexus|LM: mpv`.** `car/lexus/lm` publishes `hatchback`; the LM is a luxury MPV. Real defect, pre-existing, discovered not caused here. Reported, not shipped.
* **The `F Sport` tail family beyond the two dossier keys** — `RX 500H F Sport` (ua=5), `RX 500H F-SPORT+ ML` (ar=1). Same class, but the dossier deliberately bucketed the remainder as "triage rather than apply blind". Measured and left.
* **§D.4 (Lexus F models vs the Porsche-911 precedent).** `is-f`/`rc-f`/`gs-f`/`lfa` stay separate. Reversing a shipped decision needs the owner; not touched.
* **§D.5 strings** (`ls-300h`, `lh-470`, `rx450x`, `sc43`, `xe2`). NAMING §7.5 says resolve, do not guess, and the RDW aggregate carries no approval number — unresolvable from `cache/`.
* The `stylings: TX: TX` comment says LEVC TX and Van Hool TX are "the only other whole-string matches". After this PR `car/lexus/tx` also displays `TX` — but from the rename *value* (used verbatim), not from that pin, so the pin's own claim stays accurate. Flagged, another owner's line, not edited.

## Lints

`lint_overrides` OK · `lint_curation --base=origin/main` OK (109 files) · `reorg_make_blocks --check` OK · `lint_plates` OK · `lint_dataset --report` unchanged (escapes 0) · `gen_ownership.rb` regen is a no-op · `rake test` 25/25, `test_override_key_reachability` 5/5, `test_normalizer` 34/34, `test_normalizer_families` 19/19, `test_id_contract_gate` 14/14, `test_enrich` 19/19. Lexus is `s4w` in OWNERSHIP.yml.

## Merge order

**Not a coupled pair.** The companion pipeline PR (vehiclesdb/vehiclesdb-pipeline#136, `enrich/lexus.yml`) is independent in **either** direction, and that is measured rather than asserted: `lint_enrich` is OK against the **pristine** data repo *and* against this branch, because the one id this PR mints (`car/lexus/tx`) ships **commented out under a HELD header** there. Uncomment it in the cycle after the release that publishes `car/lexus/tx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
