### PR TITLE
wave-7/8 review follow-ups: AMV8+Am V8 retarget, Vintage V8 disposition, Bentayga re-cite, WRX-STI unfold refuted, Libero E12 restated

### DIFF
--- a/overrides/body_types/body_types.yml
+++ b/overrides/body_types/body_types.yml
@@ -13,6 +13,24 @@
 
 overrides:
   Alfa Romeo|GT: coupe
+  # PINNED BECAUSE THE SIGNAL IS A TIE, NOT BECAUSE THE SIGNAL IS WRONG.
+  # car/aston-martin/v8 is the 1969-89 V8 family. Its nl_rdw body distribution
+  # (the only registry body signal the pipeline has) reads convertible 22 /
+  # coupe 20 on origin/main and convertible 21 / coupe 21 once `AMV8` is
+  # retargeted onto this record — an EXACT TIE, which `body_type_for`'s
+  # `registry_dist.max_by { |_t, c| c }` (normalizer.rb:361) would resolve by
+  # Ruby Hash insertion order. A published field must not be decided that way,
+  # and the 2-vehicle margin it replaces was barely better. Measured by
+  # replaying the real normalizer over every Aston Martin `inrichting` row
+  # under both override trees, 2026-08-02.
+  # COUPE IS ALSO THE RIGHT ANSWER ON THE MERITS: the convertibles are on this
+  # record only because `Volante` and the V8 Volante spellings FOLD here, and
+  # the DVLA itself keeps them apart — GenModel `ASTON MARTIN V8` 571 vs
+  # `ASTON MARTIN VOLANTE` 351 (uk_veh0120_uk.csv, 2026 Q1, measured). The
+  # convertible is already carried as a VARIANT of this record in
+  # enrich/aston-martin.yml (`{name: "Volante (convertible)", type: body}`),
+  # which is where a derivative body belongs; body_types names the primary.
+  Aston Martin|V8: coupe
   Opel|GT: roadster
   Opel|Manta: coupe
   Opel|Tigra: coupe

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -6236,7 +6236,21 @@
 "car/subaru/outback-2-5i":            "car/subaru/outback"                   # renames.yml Subaru: Outback 2.5I -> Outback  [ar,ca,de,es,fi,gb,lu,my,nl,nz,ua,us]
 "car/subaru/outback-3-0r":            "car/subaru/outback"                   # renames.yml Subaru: Outback 3.0R -> Outback  [ar,ca,de,es,fi,gb,lu,my,nl,nz,ua,us]
 "car/subaru/outback-3-6r":            "car/subaru/outback"                   # renames.yml Subaru: Outback 3.6R -> Outback  [ar,ca,de,es,fi,gb,lu,my,nl,nz,ua,us]
-"car/subaru/outback-pzev":            "car/subaru/outback"                   # renames.yml Subaru: Outback Pzev -> Outback  [ar,ca,de,es,fi,gb,lu,my,nl,nz,ua,us]intents=16773 proposed=115 dead_keys=0 evidence_loss=0 unexplained=0  [ar,ca,de,es,fi,gb,lu,my,nl,nz,ua,us]
+"car/subaru/outback-pzev":            "car/subaru/outback"                   # renames.yml Subaru: Outback Pzev -> Outback  [ar,ca,de,es,fi,gb,lu,my,nl,nz,ua,us]
+# ^ GENERATOR-STDOUT ARTIFACT REMOVED 2026-08-02 (wave-7 review, "cosmetic
+# defect"). The line above used to carry propose_former_ids.rb's own summary
+# line spliced into the comment, followed by a duplicated country list:
+# "…,us]intents=16773 proposed=115 dead_keys=0 evidence_loss=0 unexplained=0
+# [ar,…,us]". SAFE TO DELETE HERE, AND ONLY HERE, because that run's counters
+# are all zero — dead_keys=0 evidence_loss=0 unexplained=0 — so nothing was
+# swallowed. TWO OLDER INSTANCES ARE DELIBERATELY LEFT IN PLACE at
+# car/maserati/grecale-folgore and car/skoda/felica: theirs read dead_keys=1
+# … unexplained=9 and dead_keys=1 … unexplained=1, i.e. real unadjudicated
+# findings. Deleting those would destroy the only surviving trace of them, and
+# adjudicating them needs the builds those runs diffed, which are gone. They
+# are reported, not touched. The generator writing its stdout into the data
+# file at all is a scripts/propose_former_ids.rb defect and is filed as such —
+# not fixed here, because a tool change does not belong in a curation change.
 "car/subaru/outback-sport":           "car/subaru/impreza"                   # renames.yml Subaru: Outback Sport / Outback-Sport -> impreza (2 spellings, same slug)  [ca,de,es,fi,gb,lu,my,nl,nz,ua,us]
 "car/subaru/outback-touring":         "car/subaru/outback"                   # renames.yml Subaru: Outback Touring -> Outback  [ar,ca,de,es,fi,gb,lu,my,nl,nz,ua,us]
 "car/subaru/outback-wagon":           "car/subaru/outback"                   # renames.yml Subaru: Outback Wagon -> Outback  [ar,ca,de,es,fi,gb,lu,my,nl,nz,ua,us]

--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -6456,7 +6456,7 @@
 # manifest entry instead of an alias. Two PRE-EXISTING entries were REPOINTED
 # in place rather than appended (car/pontiac/transam, car/pontiac/firebird-
 # transam) because this fold retires their old targets — see their lines above.
-"car/aston-martin/amv8":                        "car/aston-martin/vantage"                 # renames.yml Aston Martin: AMV8 -> Vantage  [ca,es,fi,gb,lu,my,nl,nz,th,ua,us]
+"car/aston-martin/amv8":                        "car/aston-martin/v8"                      # renames.yml Aston Martin: AMV8 -> V8  [fi,gb,nl,nz,us] — REPOINTED IN PLACE 2026-08-02, was -> car/aston-martin/vantage. Follows the renames.yml retarget (wave-8 review S-1); the retired id's own countries are nl+nz and car/aston-martin/v8 already publishes both, so no availability moves either way. Repointed rather than added because the id is already retired — a second alias key would be a duplicate
 "car/aston-martin/db-2-4-mark":                 "car/aston-martin/db2-4"                   # renames.yml Aston Martin: Db 2/4 Mark -> DB2/4  [fi,gb,nl]
 "car/aston-martin/db11-amr":                    "car/aston-martin/db11"                    # renames.yml Aston Martin: DB11 Amr -> DB11  [ca,es,fi,gb,lu,my,nl,nz,ua,us]
 "car/aston-martin/db11-v12":                    "car/aston-martin/db11"                    # renames.yml Aston Martin: DB11 V12 -> DB11  [ca,es,fi,gb,lu,my,nl,nz,ua,us]

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -292,7 +292,11 @@ Aston Martin:
   # at. Absence of a base row is not evidence of separateness. Only
   # "Dbx V8 S Auto" is keyed — to Dbx S, where the DVLA's own Model string
   # (89 gb vehicles) puts it. ──
-# Vantage · 39 keys, 554 vehicles, 73 rows
+# Vantage · 38 keys, 550 vehicles, 71 rows
+  # WAVE-8 REVIEW S-1/S-2 CORRECTION (2026-08-02). `AMV8` and `Am V8` LEFT this
+  # cluster for the V8 cluster below, and `Vintage V8` ARRIVED here from it.
+  # Counts above are restated for the moves: -2 keys/-5 veh/-3 rows out,
+  # +1 key/+1 veh/+1 row in. Evidence is on each moved line.
   V8 Vantage:                       Vantage                 # trim/engine/body designation of the Vantage — 219v 8r ca,fi,nl,us/ca_nrcan,fi_traficom,nl_rdw,us_fueleconomy
   V8 Vantage Roadster:              Vantage                 # trim/engine/body designation of the Vantage — 105v 2r nl/nl_rdw
   Vantage S V8 Auto:                Vantage                 # trim/engine/body designation of the Vantage — 53v 1r gb/uk_dft
@@ -308,9 +312,7 @@ Aston Martin:
   Vantage V8:                       Vantage                 # trim/engine/body designation of the Vantage — 5v 4r ca,nl,us/ca_nrcan,nl_rdw,us_fueleconomy
   V12 Vantage S Roadster:           Vantage                 # trim/engine/body designation of the Vantage — 4v 2r es,nl/es_dgt,nl_rdw
   V8 Vantage Amr:                   Vantage                 # trim/engine/body designation of the Vantage — 4v 2r lu,nl/lu_snca,nl_rdw
-  AMV8:                             Vantage                 # model line / alternate badge of the Vantage — see the cluster header — 3v 2r nl,nz/nl_rdw,nz_nzta
   Vantage S Roadster:               Vantage                 # trim/engine/body designation of the Vantage — 3v 1r nl/nl_rdw
-  Am V8:                            Vantage                 # model line / alternate badge of the Vantage — see the cluster header — 2v 1r nz/nz_nzta
   H V12 Vantage S:                  Vantage                 # trim/engine/body designation of the Vantage — 2v 1r nl/nl_rdw
   V8 Vantage R:                     Vantage                 # trim/engine/body designation of the Vantage — 2v 1r nl/nl_rdw
   Vantage N430:                     Vantage                 # trim/engine/body designation of the Vantage — 2v 1r nl/nl_rdw
@@ -328,6 +330,7 @@ Aston Martin:
   Vantage N430 Roadster:            Vantage                 # trim/engine/body designation of the Vantage — 1v 1r nl/nl_rdw
   Vantage R:                        Vantage                 # trim/engine/body designation of the Vantage — 1v 1r nl/nl_rdw
   Vantages:                         Vantage                 # trim/engine/body designation of the Vantage — 1v 1r nl/nl_rdw
+  Vintage V8:                       Vantage                 # RETARGETED FROM V8 (wave-8 review S-2). "Vintage" is this make's recurring misspelling of "Vantage" — this file already keys `DB2 Vintage: DB2` on that reading — and the two spellings must not answer the same question two ways: `Vantage V8` folds here, so `Vintage V8` folds here. Decided on the DATE, not the resemblance: nl_rdw by-year puts this single vehicle at y=2008, and y is first admission to traffic anywhere (pipeline/sources/nl_rdw.rb:136). The Aston Martin V8 ended production in 1989, so a 2008 first admission cannot be one; nl_rdw's own `VANTAGE V8` rows are 2006:1 2007:1 2008:2, the same window. Retiring nothing: no car/aston-martin/vintage-v8 id exists in former_ids.yml or the catalog (1 vehicle never met the publish floor) — 1v 1r nl/nl_rdw
   V8 Vantage Asm:                   Vantage                 # trim/engine/body designation of the Vantage — 0v 1r us/us_fueleconomy
   Vantage GT:                       Vantage                 # trim/engine/body designation of the Vantage — 0v 2r ca,us/ca_nrcan,us_fueleconomy
   Vantage Manual:                   Vantage                 # trim/engine/body designation of the Vantage — 0v 1r us/us_fueleconomy
@@ -348,16 +351,29 @@ Aston Martin:
   Vanquish Zagato:                  Vanquish                # trim/engine/body designation of the Vanquish — 1v 2r ca,nl/ca_nrcan,nl_rdw
   Vanquish S Zagato:                Vanquish                # trim/engine/body designation of the Vanquish — 0v 1r us/us_fueleconomy
 
-  # V8 · 13 keys, 386 vehicles, 18 rows
+  # V8 · 14 keys, 390 vehicles, 20 rows
+  # WAVE-8 REVIEW S-1 CORRECTION (2026-08-02). `AMV8` and `Am V8` ARRIVED here
+  # from the Vantage cluster (+2 keys/+5 veh/+3 rows) and `Vintage V8` LEFT for
+  # it (-1 key/-1 veh/-1 row). THE RULE THE CORRECTION RESTS ON: "AM" is the
+  # marque abbreviation, not part of a nameplate, so an `Am <x>` string resolves
+  # to `<x>`. This file ALREADY applies that rule once — `Am Vantage: Vantage`
+  # in the Vantage cluster above — and applying it to `Am V8` gives V8, not
+  # Vantage. Wikipedia (locator only) states it outright: "in 1972 the DBS V8
+  # became just the Aston Martin V8 … The V8 became known as the AM V8" —
+  # https://en.wikipedia.org/wiki/Aston_Martin_V8 . NOT FIRST-PARTY-CONFIRMED:
+  # astonmartin.com/en/our-world/heritage is HTTP 404 and astonmartinworks.com
+  # /en/heritage renders no model text, so there is no marque page to cite; the
+  # case is two dated registers plus this file's own internal rule. ──
   Volante:                          V8                      # model line / alternate badge of the V8 — see the cluster header — 357v 3r gb,nl,nz/nl_rdw,nz_nzta,uk_dft
   V8 Volante:                       V8                      # trim/engine/body designation of the V8 — 11v 3r fi,nl/fi_traficom,nl_rdw
   V 8:                              V8                      # misspelling of V8 — 7v 1r nl/nl_rdw
+  AMV8:                             V8                      # RETARGETED FROM VANTAGE (wave-8 review S-1): the 1972-89 Aston Martin V8, not the 2005 Vantage. nl_rdw by-year dates the one Dutch AMV8 to y=1974 — first admission to traffic anywhere (pipeline/sources/nl_rdw.rb:136) — which no 2005 car can carry. nz_nzta writes the modern car as bare VANTAGE (348 vehicles) and holds NO "V8 VANTAGE" string at all, so its AMV8 2 / AM V8 2 / V8 5 / V8 COUPE 2 are one 1970s-80s cluster. enrich/aston-martin.yml already describes this record's run as "The DBS V8 / AM V8 / V8 Saloon family" — 3v 2r nl,nz/nl_rdw,nz_nzta
+  Am V8:                            V8                      # RETARGETED FROM VANTAGE (wave-8 review S-1): the same car, spaced. See the cluster header for the "AM = marque abbreviation" rule and `Am Vantage: Vantage` for this file's own prior use of it — 2v 1r nz/nz_nzta
   V8 Vantage Volante:               V8                      # trim/engine/body designation of the V8 — 2v 1r nl/nl_rdw
   Volante Aut. E2:                  V8                      # nl_rdw type-approval/emission-class suffix on a V8 row — 2v 1r nl/nl_rdw
   V8 Mark:                          V8                      # trim/engine/body designation of the V8 — 1v 1r fi/fi_traficom
   V8 Series:                        V8                      # trim/engine/body designation of the V8 — 1v 1r nl/nl_rdw
   V8 Volante Zagato:                V8                      # trim/engine/body designation of the V8 — 1v 1r nl/nl_rdw
-  Vintage V8:                       V8                      # trim/engine/body designation of the V8 — 1v 1r nl/nl_rdw
   Volante Aut. U9:                  V8                      # nl_rdw type-approval/emission-class suffix on a V8 row — 1v 1r nl/nl_rdw
   Volante V8:                       V8                      # trim/engine/body designation of the V8 — 1v 1r nl/nl_rdw
   Volante Vantage:                  V8                      # model line / alternate badge of the V8 — see the cluster header — 1v 1r nl/nl_rdw
@@ -846,7 +862,21 @@ Bentley:
   "Bentayga S V8": "Bentayga"        # S + engine; 25 veh, lu+nl (GAINS lu)
   "Bentayga W12": "Bentayga"         # engine; 19 veh, lu+nl (GAINS lu)
   "Bentayga Speed": "Bentayga"       # Speed specification; 15 veh, ca+es+lu+nl+us (GAINS lu)
-  "Bentayga Ewb": "Bentayga"         # Extended Wheelbase — a wheelbase, nested under Bentayga on https://www.bentleymotors.com/en/models.html ; 0 veh (ca+us catalogue rows), both pairs kept
+  # ── CITATION CORRECTED, 2026-08-02 (wave-7 review S-1). The line below used
+  # to cite https://www.bentleymotors.com/en/models.html for "the range page
+  # nests Bentayga Extended Wheelbase and Bentayga under ONE Bentayga heading".
+  # THAT PAGE DOES NOT SAY THAT and the claim is withdrawn: re-fetched
+  # 2026-08-02, models.html carries `<h3 class="bm-h4">Bentayga Extended
+  # Wheelbase` and `<h3 class="bm-h4">Bentayga` as SIBLING sections, at the same
+  # class as Flying Spur, Continental GT and Continental GTC, and its
+  # og:description reads "The complete Bentley Motors range, including the
+  # Bentayga Extended Wheelbase, Bentayga, Flying Spur, Continental GT and
+  # Continental GTC" — five peers. The fold is still right; the evidence is one
+  # level down and is cited on the line itself. The same corrected test also
+  # VINDICATES the neighbouring call it appeared to contradict: Supersports
+  # keeps model status because /en/models/supersports.html is a top-level page
+  # that returns 200 and does NOT redirect, whereas the EWB URL does. ──
+  "Bentayga Ewb": "Bentayga"         # Extended Wheelbase — a wheelbase, not a model line. Verified 2026-08-02 by direct fetch: /en/models/bentayga.html is `<h1 class="bm-h1--large">Bentayga Range</h1>` carrying `<h2 class="bm-desc--large">Standard Wheelbase</h2>` and `<h2 class="bm-desc--large">Extended Wheelbase</h2>` as the two sections of that ONE range, and Bentley's own routing agrees — https://www.bentleymotors.com/en/models/bentayga-ewb.html answers HTTP 301 to /en/models/bentayga.html, while every EWB product page (bentayga-ewb.html, -ewb-azure.html, -ewb-mulliner.html) is a child of /en/models/bentayga/. NEGATIVE CONTROL RUN so the 301 is not read as a catch-all: /en/models/zzz-not-a-model.html returns 404 — https://www.bentleymotors.com/en/models/bentayga.html ; 0 veh (ca+us catalogue rows), both pairs kept
   # ── Flying Spur, Arnage, Brooklands, Mulsanne, Turbo R, Eight, R Type
   # (wave 7). Same ladder, same source for the current cars; the historic
   # letters are wheelbase and equipment grades of one car. ──
@@ -8710,7 +8740,11 @@ Subaru:
   Forester Wilderness: Forester   # EPA "Forester Wilderness AWD" → baseModel `Forester`
   Forrester:           Forester   # SPELLING — doubled-R misspelling (fi+nl)
   # — Impreza: trims, door counts, comma-decimal displacements, and the pre-2014
-  # WRX versions. `Wrx`/`Wrx Sti` remain SEPARATE ids — see the header. —
+  # WRX versions. The post-2014 standalone `Wrx` keeps its OWN id and does not
+  # fold into Impreza — see the header. (This line used to read "`Wrx`/`Wrx Sti`
+  # remain SEPARATE ids", which contradicted both the header and the
+  # `Wrx Sti: Wrx` key below; corrected 2026-08-02. `Wrx Sti` is separate from
+  # IMPREZA, not from WRX.) —
   "Impreza 2":                Impreza   # truncated comma-decimal displacement (raws "IMPREZA 2,0 GT TURBO AWD", "IMPREZA 2,5T WRX S")
   Impreza 2.0GT:            Impreza   # displacement + GT trim
   "Impreza 4":                Impreza   # DOOR COUNT — raws "Impreza 4-Door AWD" (ca_nrcan) / "Impreza 4-Door" (us_fueleconomy)
@@ -8752,9 +8786,74 @@ Subaru:
   B9 Tribeca: Tribeca   # EPA "B9 Tribeca AWD" → baseModel `Tribeca`; Subaru dropped the B9 prefix at the 2007 facelift
   Brz Ts:     Brz       # EPA "BRZ tS" → baseModel `BRZ`; tS = Tecnica Sports, a trim
   Justy G3X:  Justy     # G3X is the 2003-07 Justy generation designation (a rebadged Suzuki Ignis) — https://en.wikipedia.org/wiki/Subaru_Justy
-  Wrx Sti:    Wrx       # EPA "WRX STI Type RA" → baseModel `WRX`; STI is Subaru Tecnica International's performance version of the WRX, discontinued 2021
+  # ── `Wrx Sti` — AN UNFOLD WAS PROPOSED AND IS REFUTED. The wave-7 owner-swarm
+  # review (S-2) called this fold a suspect on the grounds that it used an
+  # oracle the block header itself calls unreliable for Subaru. Re-checked
+  # 2026-08-02; the objection does not survive, for four measured reasons.
+  #  1. THE HEADER'S CAVEAT DOES NOT REACH THIS KEY. It is scoped, in its own
+  #     words, to Legacy vs Outback ("is NOT used to adjudicate Legacy vs
+  #     Outback"). Nothing about WRX is mixed.
+  #  2. THE ORACLE IS UNAMBIGUOUS HERE, at the level the oracle operates on.
+  #     The review's counter-example — the EPA menu listing "WRX STI Type RA" as
+  #     a distinct MODEL — is a model-STRING fact, and baseModel is precisely
+  #     the column that pools model strings. In cache/us_vehicles.csv the only
+  #     STI-named row, `WRX STI Type RA` MY2018 (id 39792), carries
+  #     baseModel `WRX`; and the STI drivetrain is otherwise filed under the
+  #     model string `WRX` itself — the 2.5-litre manual-only row present every
+  #     year MY2015-2021 (id 43630 for 2021) beside the 2.0 SIDI base rows, and
+  #     absent from MY2022 on, matching the STI's 2021 discontinuation.
+  #  3. A SECOND REGULATOR AGREES, INDEPENDENTLY. UK DfT VEH0120 (2026 Q1,
+  #     cache/uk_veh0120_uk.csv) has NO "SUBARU WRX STI" GenModel. It has two:
+  #     `SUBARU IMPREZA` (29,668) and `SUBARU WRX` (1,911) — and the STI Model
+  #     strings `WRX STI TYPE UK SYMETRICAL AWD` (1,291), `WRX STI-TP UK SYM-CAL
+  #     AWD` (480) and `WRX STI TYPE UK FINAL EDITION` (140) all sit inside
+  #     GenModel `SUBARU WRX`. The DVLA splits Impreza from WRX and does not
+  #     split STI from WRX. That is the same two-regulator agreement the wave-8
+  #     Firebird ruling was accepted on.
+  #  4. STI IS A BADGE ACROSS NAMEPLATES, so making it a nameplate on exactly
+  #     one host is the internal inconsistency, not folding it. The corpus
+  #     carries FORESTER STI and `Levorg STI` (fi_traficom kaupallinenNimi),
+  #     IMPREZA STI and SUBARU LEGACY STI (nl_rdw) — and this block already
+  #     folds `Forester Sti`, `Impreza Sti` and `Brz Ts` (tS = Tecnica Sports,
+  #     STI's own trim badge) on exactly that reading.
+  # WHAT COULD NOT BE RE-VERIFIED, STATED RATHER THAN GLOSSED: the review's
+  # first-party counter-evidence was media.subaru.com/pressrelease/1674/ (the
+  # "2021 WRX AND WRX STI" pricing headline) and /1699/ (an STI press kit).
+  # Both URLs today return Subaru's own "Page Not Found" body, and the Wayback
+  # Machine holds NO snapshot of either, so the marketing claim could be
+  # neither confirmed nor refuted — the fold rests on the two registers above.
+  # NOT LITIGATED HERE: whether Subaru marketed the two as separate cars. The
+  # catalog's altitude is the nameplate as the regulators file it. ──
+  Wrx Sti:    Wrx       # STI is Subaru Tecnica International's performance version of the WRX, discontinued 2021. us_fueleconomy baseModel `WRX` and UK DfT GenModel `SUBARU WRX` both — see the block immediately above for the full measurement and for the refuted unfold
   Subaru: null          # registry row where the make was written into the MODEL column (nl_rdw "SUBARU | SUBARU") — not a nameplate. The settled class: `Opel: null`, `Jeep: null`. Nothing published is retired — car/subaru/subaru has never met the publish predicate, so no removals.yml entry is owed
-  Libero E12: E12       # RESOLVED, not guessed (NAMING §7.5): the enlarged export Sambar "was also called the Subaru E10 and Subaru E12 respectively in some places, the names referring to the size of the engines" and carried Libero/Sumo/Domingo/Columbuss/Combi badges by market. `E12` is the majority register spelling here (fi+nl) and `LIBERO E12` the compound — a badge PREFIX on the same nameplate, the Kia "Picanto Morning → Picanto" shape — https://en.wikipedia.org/wiki/Subaru_Libero
+  # ── `Libero E12` — THE §7.5 CLAIM ON THIS LINE WAS OVERSTATED AND IS
+  # WITHDRAWN (wave-7 review S-3, re-checked 2026-08-02). The line used to claim
+  # the code was "RESOLVED, not guessed (NAMING §7.5)". §7.5 asks for the
+  # register to be queried for the approval number and capacity behind a code;
+  # that was not what happened. The E10/E12-are-the-Libero equation rests on ONE
+  # Wikipedia sentence, and no Subaru first-party page attesting `E12` as a
+  # model name was found. So the honest grounding is register-majority, and it
+  # is strong — but it is a different claim and it is now the one being made.
+  # MEASURED, 2026-08-02: fi_traficom carries 13 Subaru rows whose type
+  # designation is an E12 code (`E12-KJ8-VAN-4X4/1810`, `5D WAGON
+  # E12-SDX-KJ8-4X4/181`), 9 of them with the register's own COMMERCIAL-NAME
+  # column `kaupallinenNimi` set to exactly "E12" — and ZERO Finnish Subaru rows
+  # containing "LIBERO". nl_rdw carries 25 E12-prefixed vehicles (`E12 MINIBUS
+  # 4WD K6` 12, bare `E12` 8, `E12 MINIBUS 4WD` 2, `E12 4WD DX` 1, `E12 MINIBUS
+  # 4WD K9` 1, `SUBARU E12 KJ8 WAGON 4WD` 1) against exactly 1 `SUBARU LIBERO
+  # E12`. 25:1 and 13:0.
+  # THE DIRECTION IS ALSO FORCED, NOT CHOSEN: there is no car/subaru/libero id
+  # anywhere in the catalog, so `Libero E12 -> Libero` would be a MINT with a
+  # 1-vehicle evidence base, not a fold.
+  # THE MARQUE EVIDENCE RUNS THE OTHER WAY AND IS NOT DISMISSED. The wave-7
+  # review reports Subaru's own European material using "Libero" (a subaru.jp
+  # trivia article and a Subaru Deutschland MJ1987 "Libero 1200 Allrad"
+  # brochure). NEITHER WAS RE-VERIFIED HERE — no working URL was given and
+  # direct fetches of the obvious subaru.jp / subaru.de paths returned 404, and
+  # this session's web-search budget was spent. Treat the marque attestation as
+  # reported-not-verified. If a car/subaru/libero record is ever minted on
+  # first-party evidence, this line is the one to revisit. ──
+  Libero E12: E12       # `LIBERO E12` is the badge-prefixed compound of the same nameplate — the Kia "Picanto Morning → Picanto" shape. Survivor chosen on register majority (fi 13:0, nl 25:1 — see the block above), NOT on marque attestation, which is absent for `E12` and reported-but-unverified for `Libero` — https://en.wikipedia.org/wiki/Subaru_Libero
 
 Sunbeam:
   Sunbeam: null                               # registry rows where the make was written into the model column (car kind) — not a nameplate. Multi-source, but corroboration does not clear this class: several registers share the same fallback habit.


### PR DESCRIPTION
Closes the five items the owner-swarm **wave-7** and **wave-8** reviews left as SUSPECTS rather than confirmed, plus one item their follow-up lists missed. Unresolved suspects rot — the next reader assumes they were checked — so each one gets a verdict, and the two that were *already shipped on a false or overstated citation* are corrected **in the file, visibly**, not quietly replaced.

Sources: `aux/research/2026-08-owner-swarm/review-wave7.md`, `review-wave8.md` (pipeline repo).

**Pairs with vehiclesdb-pipeline#137. Merge this one FIRST.**

---

## Verdicts

| # | item | review | verdict |
|---|---|---|---|
| 1 | `AMV8` / `Am V8` → Vantage | w8 S-1 | **CONFIRMED — retargeted to `V8`** |
| 2 | `Vintage V8` → V8 | w8 S-2 | **CONFIRMED — retargeted to `Vantage`** |
| 3 | `Bentayga Ewb` → Bentayga citation | w7 S-1 | **CITATION REFUTED, FOLD CONFIRMED — re-cited** |
| 4 | `Wrx Sti` → Wrx (proposed unfold) | w7 S-2 | **REFUTED — fold stands, evidence recorded** |
| 5 | `Libero E12` → E12 justification | w7 S-3 | **CLAIM OVERSTATED — withdrawn and restated** |
| 6 | generator stdout in `former_ids.yml` | w7 "cosmetic defect" | **1 of 3 fixed, 2 deliberately left + reported** |

---

### 1 + 2 — Aston Martin: the AM-prefix rule, applied consistently

The wave-8 review was right, and the rule underneath it is **already in this file**.

`Am Vantage: Vantage` (line unchanged) treats `AM` as the *marque abbreviation*, not part of a nameplate. Apply the same strip to `Am V8` and you get **V8**, not Vantage. The wave-8 pass applied the rule once and missed it twice.

Dated register evidence, measured 2026-08-02:

* `nl_rdw` by-year: the only Dutch `AMV8` is **y=1974**. `y` is first admission to traffic *anywhere* (`pipeline/sources/nl_rdw.rb:136`). A 2005 car cannot carry it.
* `nz_nzta`: writes the modern car as bare `VANTAGE` (**348** vehicles) and has **no `V8 VANTAGE` string at all**. Its `AMV8` 2 / `AM V8` 2 / `V8` 5 / `V8 COUPE` 2 are one coherent 1970s–80s cluster.
* `enrich/aston-martin.yml` already described this record's run as *"The DBS V8 / **AM V8** / V8 Saloon family"* — the pair of repos disagreed with itself in two files.

`Vintage V8` is the mirror image and is decided on the **date, not the resemblance**: `nl_rdw` puts its single vehicle at **y=2008**, and the Aston Martin V8 ended production in 1989. `nl_rdw`'s own `VANTAGE V8` rows are 2006:1 2007:1 2008:2 — the same window. It now agrees with `Vantage V8: Vantage` instead of contradicting it.

**Not first-party-confirmed, stated plainly:** `astonmartin.com/en/our-world/heritage` is **HTTP 404** and `astonmartinworks.com/en/heritage` renders no model text. There is no marque page to cite. The case is two dated registers plus this file's own internal rule; Wikipedia is cited as a locator only.

### 3 — Bentayga EWB: the shipped citation does not say what it was quoted as saying

The line claimed *"the range page nests Bentayga Extended Wheelbase and Bentayga under ONE Bentayga heading"*, citing `models.html`. **Re-fetched 2026-08-02 — that page does not do that**, exactly as the review found:

* `<h3 class="bm-h4">Bentayga Extended Wheelbase` and `<h3 class="bm-h4">Bentayga` are **siblings**, same level as Flying Spur / Continental GT / GTC.
* `og:description` names five peers verbatim: *"The complete Bentley Motors range, including the Bentayga Extended Wheelbase, Bentayga, Flying Spur, Continental GT and Continental GTC"*.

The claim is **withdrawn in the file**, not swapped out silently. The fold is still right, and the real evidence is one level down:

* `/en/models/bentayga.html` is `<h1>Bentayga Range</h1>` carrying `<h2>Standard Wheelbase</h2>` **and** `<h2>Extended Wheelbase</h2>` as the two sections of that one range.
* **Bentley's own routing settles it**: `GET /en/models/bentayga-ewb.html` → **HTTP 301** → `/en/models/bentayga.html`.
* **Negative control run**, so the 301 is not read as a catch-all: `/en/models/zzz-not-a-model.html` → **404**.

**This also dissolves the review's sharper charge** — that the same page was used to *keep* `continental-supersports` and *fold* EWB, "same test, opposite answers". On the heading test they do look identical. On Bentley's routing they are opposites: `/en/models/supersports.html` returns **200 with no redirect** as a top-level model page, while the EWB URL 301s into a parent. **Both calls stand, under one consistent test.** (Correction to the review: it said there is no top-level `bentayga-ewb.html`; the URL exists and redirects, which is stronger evidence, not weaker.)

### 4 — WRX STI: the proposed unfold is REFUTED

Comment-only; the fold is unchanged. Four measured reasons, in the file:

1. **The header caveat does not reach this key.** It is scoped in its own words to Legacy vs Outback.
2. **The oracle is unambiguous at the level it operates on.** The review's counter-example — the EPA menu listing `WRX STI Type RA` as a distinct *model* — is a model-**string** fact, and `baseModel` is precisely the column that pools model strings. In `cache/us_vehicles.csv` the only STI-named row (MY2018, id 39792) carries `baseModel: WRX`, and the STI drivetrain is otherwise filed under the model string `WRX` itself — the 2.5 L manual-only row present every year MY2015–2021 (id 43630 for 2021) beside the 2.0 SIDI base rows, and **gone from MY2022 on**, matching the STI's discontinuation.
3. **A second regulator agrees, independently.** UK DfT VEH0120 2026 Q1 has **no `SUBARU WRX STI` GenModel**. It has two — `SUBARU IMPREZA` (29,668) and `SUBARU WRX` (1,911) — and `WRX STI TYPE UK SYMETRICAL AWD` (1,291), `WRX STI-TP UK SYM-CAL AWD` (480) and `WRX STI TYPE UK FINAL EDITION` (140) all sit **inside** `SUBARU WRX`. The DVLA splits Impreza from WRX and does *not* split STI from WRX.
4. **STI is a badge across nameplates**, so making it a nameplate on exactly one host is the inconsistency. The corpus carries `FORESTER STI` and `Levorg STI` (fi_traficom), `IMPREZA STI` and `SUBARU LEGACY STI` (nl_rdw) — and this block already folds `Forester Sti`, `Impreza Sti` and `Brz Ts` (tS = Tecnica Sports, STI's own trim badge) on exactly that reading.

**What I could not re-verify, named rather than glossed:** the review's first-party counter-evidence was `media.subaru.com/pressrelease/1674/` and `/1699/`. **Both now return Subaru's own "Page Not Found" body, and the Wayback Machine holds no snapshot of either.** The marketing claim could be neither confirmed nor refuted. The fold rests on the two registers.

Also fixed: a stale comment reading *"`Wrx`/`Wrx Sti` remain SEPARATE ids"*, which contradicted both its own block header and the `Wrx Sti: Wrx` key twenty lines below it.

### 5 — Libero E12: the §7.5 claim was overstated and is withdrawn

Comment-only; direction unchanged. The line claimed the code was *"RESOLVED, not guessed (NAMING §7.5)"*. §7.5 asks for the register to be queried for the approval number and capacity behind a code — that is not what happened. The equation rests on **one Wikipedia sentence**.

The honest grounding is register-majority, and it is strong (measured 2026-08-02):

* `fi_traficom`: **13** Subaru rows carry an E12 type designation, **9** of them with the register's own commercial-name column `kaupallinenNimi` set to exactly `"E12"` — and **zero** Finnish Subaru rows contain `LIBERO`.
* `nl_rdw`: **25** E12-prefixed vehicles against exactly **1** `SUBARU LIBERO E12`.

The direction is also **forced, not chosen**: there is no `car/subaru/libero` id anywhere in the catalog, so `Libero E12 -> Libero` would be a **mint** on a 1-vehicle base, not a fold.

**The marque evidence runs the other way and is not dismissed.** The review reports Subaru's European material using "Libero". **Not re-verified here** — no working URL was given, direct fetches of the obvious `subaru.jp` / `subaru.de` paths 404'd, and the search budget was spent. Recorded as reported-not-verified, with a note to revisit if a Libero record is ever minted on first-party evidence.

### 6 — the generator-stdout defect (not on the follow-up list; found by re-reading the review)

`propose_former_ids.rb`'s summary line is spliced into three shipped comments. I fixed **one** — `car/subaru/outback-pzev`, my make, landed by wave 7 — because its counters are `dead_keys=0 evidence_loss=0 unexplained=0`, so nothing is lost.

I **deliberately left** `car/maserati/grecale-folgore` and `car/skoda/felica`: theirs read `dead_keys=1 … unexplained=9` and `dead_keys=1 … unexplained=1`. Those are **unadjudicated findings and the comment is their only surviving trace**; adjudicating them needs the builds those runs diffed, which are gone. Tidying them away would destroy the evidence the review wanted read. Reported, not touched.

The generator writing its own stdout into a data file is a `scripts/propose_former_ids.rb` defect. **Filed, not fixed here** — a tool change does not belong in a curation change.

---

## CONTROL vs TREATMENT

Frozen cache (`find cache -type f ! -name 'license_*.txt' -exec touch {} +` — 214 files touched, **14 licence files excluded**). Control is a **pristine detached worktree at the identical base commit**, verified by `git status --porcelain` returning empty. Full build, all six kinds, `VDB_VERSION` pinned identically, separate `VDB_BUILD_DIR` and `VDB_SNAPSHOT_STORE` per side.

```
CONTROL rows   : 14027
TREATMENT rows : 14027

IDS MINTED  : 0
IDS RETIRED : 0
RECORDS LOSING A COUNTRY : 0

ROWS WITH ANY FIELD CHANGED : 2
  car/aston-martin/v8
      body_types: 'convertible' -> 'coupe'
      former_ids: +['car/aston-martin/amv8']
  car/aston-martin/vantage
      former_ids: -['car/aston-martin/amv8']
```

**Availability union holds at (country, SOURCE) level.** The retired id's own countries are nl+nz; `car/aston-martin/v8` already publishes fi|gb|nl|nz|us, so nothing moves either way, and no record anywhere in the catalog loses a country.

**The whole measurement was run twice, the second time under a private namespace after a session-wide warning that shared-scratchpad artifacts were being clobbered. Both `dist/vehicles.csv` outputs reproduced BYTE-IDENTICALLY (control `ed628fb5c68d4bd7`, treatment `1bf19a5d050ea4ac`).**

### The one thing that was *not* clean — and why there is a third commit

`body_types` on `car/aston-martin/v8` flips `convertible` → `coupe`. I did not accept that at face value. Replaying the **real normalizer** over every Aston Martin `inrichting` row under both override trees:

```
CONTROL   aston-martin/v8: {"convertible" => 22, "coupe" => 20}  -> convertible
TREATMENT aston-martin/v8: {"coupe" => 21, "convertible" => 21}  -> EXACT TIE
```

The retarget moves one nl coupe **on** (`AMV8`) and one nl convertible **off** (`VINTAGE V8`), producing a **21–21 tie** that `body_type_for`'s `registry_dist.max_by { |_t, c| c }` (`normalizer.rb:361`) resolves by **Ruby Hash insertion order**. A published field must not be decided that way — and the 2-vehicle margin it replaced was barely better.

So it is **pinned** in `overrides/body_types/body_types.yml`, the file that exists for exactly this (`Opel|Manta`, `Ford|Capri`, …), to the value the evidence supports independently: the convertibles reach this record **only through the `Volante` fold**, and the DVLA keeps `ASTON MARTIN V8` (**571**) and `ASTON MARTIN VOLANTE` (**351**) as separate GenModels (measured). The convertible is already a declared *variant* of the record in enrich; `body_types` names the primary.

### Build-environment findings, disclosed — including one claim I got wrong

* **The frozen cache does not cover next-period probes.** Both runs made a live network call for a not-yet-published month and got *different failure text* for the same non-existent file (`de_kba_fz10 2026-07`: "non-xlsx payload (soft 404)" vs "fetch failed"). No count changed, but a "frozen-cache" build is **not hermetic**, and that is the shape a contaminated comparison would take.
* **RETRACTED — my error, caught by CI.** An earlier revision of this PR body claimed `origin/main` is red on a full build, on the strength of **16 `id-contract gate (no-vanish)` failures** (`motorcycle/yamaha/xc`, `/xvz`, `/cg`, `/tw`, …) appearing in my local run. That claim was **wrong**. CI's `build` job on this branch **passes (8m29s)**, as does a sibling branch's.

  The failures are an artifact of *my local cache*, not of `main`. They are all **1-vehicle motorcycle stubs sitting on the publish threshold** — the local cache holds exactly one NZ vehicle for most of them and none for `/cg`, `/tw`, `/vp`, `/yfm` — so whether they publish flips on small differences between a frozen local cache (13 of 36 `nz_motorcycle_*.json` shards are empty payloads; `es_dgt` resolved 2026-04…06 locally) and CI's fresh fetch.

  **This does not touch the comparison below it.** Control and treatment produced a **byte-identical** failure set, so the delta is unaffected — but the inference I drew from it was not supported, and it is corrected here rather than left standing. The general lesson is the one this repo already knows: *a local frozen-cache build is not equivalent to CI's fetch, and threshold-marginal records are exactly where the two diverge.*

## CI & lints

**CI on this branch: `lint` pass (14s), `build` pass (8m29s), `channels` skipped.** Paired pipeline PR: `test` pass (1m52s) — note the wave-8 review recorded `vehiclesdb-pipeline` as having 0 workflows; it now has one (`test`), so that observation is stale.

Local:

`lint_overrides` OK · `lint_curation --base=origin/main` OK (109 files) · `reorg_make_blocks --check` OK · `lint_plates` OK.

## Dead-curation audit

Required, because this alters a produced string. Every reference to the affected strings and ids across `overrides/`, `spotchecks.yml` and `scripts/` is confined to `renames.yml` + `former_ids.yml` — **no inert keys left behind anywhere else**. The one real dead-curation risk was the `AMV8` variant line on `car/aston-martin/vantage`, which `test_override_key_reachability` would *not* have caught; it is moved in the paired pipeline PR, which is why the two must land together.

## Merge order

**This PR first, then vehiclesdb-pipeline#137.** Order is not load-bearing — neither direction breaks anything, since both ids are live either way and `lint_enrich` passes on both — but the window in either direction leaves one inert variant string on one record, so land them close together. Data-first matches the wave-7/8 precedent.

## Overlap with concurrent delegates

Checked before editing. No line-level overlap with the Mercedes / Opel / Lexus / MINI / Hyundai work. Textual rebase conflicts in `renames.yml` / `former_ids.yml` are expected; this branch has already been rebased once.

**Cross-check offered to `s4w/gtc-token-data`** (the other Bentley branch, which cites the same `models.html`): its claims *are* supported by the page I fetched — `Continental GT` and `Continental GTC` are separate top-level `bm-h4` sections, and Azure/Mulliner/S/Speed are children of `/en/models/continental-gtc/`. No action needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)