### PR TITLE
DAF: the LF and CF power suffixes were publishing as nameplates — 26 ids fold onto 2

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -4581,7 +4581,7 @@
 "truck/daf/xf480f":                        "truck/daf/xf"                         # FLATTENED 2026-08-01 by the power-suffix fold (renames.yml DAF §X-1): was -> truck/daf/xf480, which is now itself an alias; XF480F => XF480, 16 vehicles. inbound 0 — nothing chains through this id
 "truck/daf/xf510f":                        "truck/daf/xf"                         # FLATTENED 2026-08-01 by the power-suffix fold (renames.yml DAF §X-1): was -> truck/daf/xf510, which is now itself an alias; XF510F => XF510, 3 vehicles. inbound 0 — nothing chains through this id
 "truck/daf/xf530f":                        "truck/daf/xf"                         # FLATTENED 2026-08-01 by the power-suffix fold (renames.yml DAF §X-1): was -> truck/daf/xf530, which is now itself an alias; XF530F => XF530, 5 vehicles. inbound 0 — nothing chains through this id
-"truck/daf/lf260f":                        "truck/daf/lf260"                      # FOLD onto a LIVE survivor (es+fi+nl, already covers the child's fi+nl); LF260F => LF260, 8 vehicles. inbound 0 — nothing chains through this id
+"truck/daf/lf260f":                        "truck/daf/lf"                         # FLATTENED 2026-08-02 by the LF/CF power-suffix fold (renames.yml DAF §X-2): was -> truck/daf/lf260, which is now itself an alias; LF260F => LF260, 8 vehicles. inbound 0 — nothing chains through this id
 "truck/daf/fa45":                          "truck/daf/45"                         # FOLD onto a MINTED survivor (fi+gb+nl); FA45 => 45, 1911 vehicles. inbound 0 — nothing chains through this id
 "truck/daf/fa55":                          "truck/daf/55"                         # FOLD onto a LIVE survivor, which GAINS es+fi (gb+nl -> es+fi+gb+nl); FA55 => 55, 317 vehicles. inbound 0 — nothing chains through this id
 "truck/daf/ad85":                          "truck/daf/85"                         # FOLD onto a MINTED survivor (fi+nl); AD85 => 85, 12 vehicles. inbound 0 — nothing chains through this id
@@ -6671,3 +6671,41 @@
 "moped/yamaha/ns50f": "moped/yamaha/aerox"  # fi,nl
 "moped/yamaha/ns50n": "moped/yamaha/aerox"  # fi,nl
 "motorcycle/yamaha/yp250ra": "motorcycle/yamaha/xmax-250"  # fi,lu,nl,ua
+
+# ── DAF LF/CF power-suffix fold (2026-08-02, renames.yml DAF §X-2): the sibling
+#    families the §X-1 pass missed. The three-digit run after a bare LF/CF badge
+#    is the HORSEPOWER — es_dgt states it a second time as an explicit kW spec
+#    (CF 530 -> 390.0 kW = 530.3 hp; LF 230 -> 172.0 kW = 233.9 hp), and nl_rdw
+#    carries the <series>.<power> form ("LF45.180", "FT CF 85.460") whose power
+#    halves reappear as bare badges ("LF 180 FA", "CF 460 FT").
+#    NOT aliased, because NOT folded: truck/daf/lf45, /lf55, /cf65, /cf75, /cf85
+#    are real SERIES designations (the same kW instrument answers 247 hp for
+#    LF45 and 428 hp for CF85 — not 45, not 85) and stay live.
+#    Every alias below is a strict SUBSET of its target at (country,SOURCE)
+#    level — measured control-vs-treatment, evidence lost: NONE.
+"truck/daf/cf260":  "truck/daf/cf"   # renames.yml DAF §X-2: CF260 -> CF  [es,nl] — power rating, not a designation
+"truck/daf/cf290":  "truck/daf/cf"   # renames.yml DAF §X-2: CF290 -> CF  [es,fi,nl]
+"truck/daf/cf300":  "truck/daf/cf"   # renames.yml DAF §X-2: CF300 -> CF  [fi,nl]
+"truck/daf/cf320":  "truck/daf/cf"   # renames.yml DAF §X-2: CF320 -> CF  [es,nl]
+"truck/daf/cf330":  "truck/daf/cf"   # renames.yml DAF §X-2: CF330 -> CF  [es,fi,nl]
+"truck/daf/cf340":  "truck/daf/cf"   # renames.yml DAF §X-2: CF340 -> CF  [es,fi,nl]
+"truck/daf/cf370":  "truck/daf/cf"   # renames.yml DAF §X-2: CF370 -> CF  [es,fi,nl]
+"truck/daf/cf400":  "truck/daf/cf"   # renames.yml DAF §X-2: CF400 -> CF  [es,nl]
+"truck/daf/cf410":  "truck/daf/cf"   # renames.yml DAF §X-2: CF410 -> CF  [es,fi,nl]
+"truck/daf/cf430":  "truck/daf/cf"   # renames.yml DAF §X-2: CF430 -> CF  [es,nl]
+"truck/daf/cf440":  "truck/daf/cf"   # renames.yml DAF §X-2: CF440 -> CF  [es,fi,nl]
+"truck/daf/cf450":  "truck/daf/cf"   # renames.yml DAF §X-2: CF450 -> CF  [es,fi,lu,nl]
+"truck/daf/cf460":  "truck/daf/cf"   # renames.yml DAF §X-2: CF460 -> CF  [es,fi,nl]
+"truck/daf/cf480":  "truck/daf/cf"   # renames.yml DAF §X-2: CF480 -> CF  [es,fi,lu,nl]
+"truck/daf/cf510":  "truck/daf/cf"   # renames.yml DAF §X-2: CF510 -> CF  [fi,nl]
+"truck/daf/cf530":  "truck/daf/cf"   # renames.yml DAF §X-2: CF530 -> CF  [fi,lu,nl]
+"truck/daf/lf180":  "truck/daf/lf"   # renames.yml DAF §X-2: LF180 -> LF  [es,fi,nl] — power rating, not a designation
+"truck/daf/lf210":  "truck/daf/lf"   # renames.yml DAF §X-2: LF210 -> LF  [es,fi,nl]
+"truck/daf/lf220":  "truck/daf/lf"   # renames.yml DAF §X-2: LF220 -> LF  [es,fi,nl]
+"truck/daf/lf230":  "truck/daf/lf"   # renames.yml DAF §X-2: LF230 -> LF  [es,fi,nl]
+"truck/daf/lf250":  "truck/daf/lf"   # renames.yml DAF §X-2: LF250 -> LF  [es,fi,nl]
+"truck/daf/lf260":  "truck/daf/lf"   # renames.yml DAF §X-2: LF260 -> LF  [es,fi,nl] — truck/daf/lf260f is repointed to truck/daf/lf for this reason (rule 1f)
+"truck/daf/lf280":  "truck/daf/lf"   # renames.yml DAF §X-2: LF280 -> LF  [es,nl]
+"truck/daf/lf290":  "truck/daf/lf"   # renames.yml DAF §X-2: LF290 -> LF  [es,fi,nl]
+"truck/daf/lf310":  "truck/daf/lf"   # renames.yml DAF §X-2: LF310 -> LF  [es,nl]
+"truck/daf/lf320":  "truck/daf/lf"   # renames.yml DAF §X-2: LF320 -> LF  [es,fi,nl]

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -2283,7 +2283,7 @@ DAF:
   XF480F:     XF     # same
   XF510F:     XF     # same
   XF530F:     XF     # same
-  LF260F:     LF260     # same (LF 260FA…)
+  LF260F:     LF        # FLATTENED 2026-08-02 by §X-2 below: was -> LF260, which §X-2 makes a fold key, and renames are NOT transitive — left pointing at LF260 this key would land on an intermediate and stop. Trailing "F" is still the one-letter axle-code fusion (LF 260FA…)
   # ── §A-D2: DAF's pre-1997 ranges exist in the corpus only INSIDE axle codes.
   # Only truck/daf/55 (3 vehicles) and /95 (12) are published today; these folds
   # recover the rest. ──
@@ -2339,6 +2339,87 @@ DAF:
   XG450:   XG        # as XG430. fi,nl
   XG480:   XG        # as XG430. es,fi,lu,nl
   XG530:   XG        # as XG430. es,fi,lu,nl
+
+  # ── §X-2 the POWER SUFFIX, LF and CF (2026-08-02): the sibling families §X-1
+  # missed. Same defect, same shape, same target discipline — but LF and CF have
+  # far longer histories than XD/XG, so the series-vs-rating call was re-derived
+  # from scratch here rather than inherited.
+  #
+  # THE MEASUREMENT that settles it, and it is per-record in our OWN corpus, not
+  # a caption: es_dgt's fixed-width microdata carries engine power in kW as an
+  # explicit spec field (offset 224). Converting kW->hp (x1.35962) reproduces the
+  # badge number on the LF/CF rows:
+  #   CF 530 FA  390.0 kW -> 530.3 hp     LF 230 FA  172.0 kW -> 233.9 hp
+  #   CF 480 FT  355.0 kW -> 482.7 hp     LF 260 FA  194.0 kW -> 263.8 hp
+  #   CF 450 FT  330.0 kW -> 448.7 hp     LF 320 FA  239.0 kW -> 324.9 hp
+  # 26 of 30 distinct LF/CF model strings in es_dgt 2026-03 match their badge
+  # within +-8 hp; the register states the number twice, once as a spec.
+  #
+  # SECOND, INDEPENDENT corpus proof (nl_rdw, same register, same download):
+  # the historic caption form is <series>.<power> and BOTH halves are present —
+  # "FA LF 45.180" x3, "LF45.180" x2, "LF 55.250" x2, "FT CF 85.460" x6,
+  # "FTCF85.410T" x9, "FANCF75.360U" x3. The very same numbers then appear
+  # directly after the BARE badge: "LF 180 FA" (472 vehicles), "LF 250 FA",
+  # "CF 460 FT", "CF 410 FT" (1,928). A number that is the power of an LF45
+  # cannot be a designation when it follows a bare LF.
+  # Wikipedia lists the ranges as line items ("LF series" / "CF series") —
+  # https://en.wikipedia.org/wiki/DAF_Trucks
+  #
+  # KEPT, DELIBERATELY — the LF/CF equivalent of §X-1's xf105 trap, and there
+  # are FIVE of them, not one. LF45/LF55 and CF65/CF75/CF85 are real SERIES
+  # designations, not ratings, and folding them would destroy live nameplates:
+  #   - The kW instrument above is a known-answer test and it answers NO on all
+  #     five: "FA LF 45"/"FA LF55" measure 181.6 kW = 247 hp (not 45 or 55),
+  #     "DAF CF85" 315.0 kW = 428 hp, "FACF65" 218.7 kW = 297 hp. The digits are
+  #     not the power of these units, so they are not a rating.
+  #   - They carry their OWN power suffix: "LF45.180", "CF 85.410" — a series
+  #     cannot be the rating and take a rating at the same time.
+  #   - en.wikipedia.org/wiki/DAF_CF: "Originally launched as the 65, 75, and 85
+  #     series (from 1992 through 1997)", "renamed the CF range in 1998", and
+  #     "DAF 65, 75 & 85 CF (1998-2000)" — 65/75/85 are the series.
+  #   - en.wikipedia.org/wiki/DAF_LF: "The LF45 and LF55 are powered by Cummins B
+  #     Series engines... all LF55s use the 6 cylinder due to their increased
+  #     size and weight" — LF45/LF55 are distinct models, not power steps.
+  #   - Lineage corroborates: they succeed the Leyland-DAF 45/55, which this file
+  #     already publishes as truck/leyland-daf/45 and /55 (§A-D2).
+  # Untouched here and verified untouched in the control-vs-treatment id diff.
+  #
+  # AVAILABILITY UNION verified at (country,SOURCE) level, not country: both
+  # parents already carry es:es_dgt fi:fi_traficom gb:uk_dft lu:lu_snca
+  # nl:nl_rdw, and every id below is a strict SUBSET of that. No child carries a
+  # (country,source) pair its parent lacks, so nothing ARRIVES and nothing is
+  # lost. Evidence lost by these folds: NONE.
+  #
+  # CHAIN: LF260F above was `-> LF260` and is repointed to LF, because LF260
+  # becomes a fold key here and renames do not apply transitively. Fascf/Fatcf
+  # `-> CF85` need NO change precisely because CF85 is kept — the trap and the
+  # chain are the same fact seen twice.
+  CF260:   CF        # power rating, not a designation — target truck/daf/cf is LIVE (es,fi,gb,lu,nl). es,nl
+  CF290:   CF        # as CF260. es,fi,nl
+  CF300:   CF        # as CF260. fi,nl
+  CF320:   CF        # as CF260. es,nl
+  CF330:   CF        # as CF260. es,fi,nl
+  CF340:   CF        # as CF260. es,fi,nl
+  CF370:   CF        # as CF260. es,fi,nl
+  CF400:   CF        # as CF260. es,nl
+  CF410:   CF        # as CF260. es,fi,nl
+  CF430:   CF        # as CF260. es,nl
+  CF440:   CF        # as CF260. es,fi,nl
+  CF450:   CF        # as CF260. es,fi,lu,nl
+  CF460:   CF        # as CF260. es,fi,nl
+  CF480:   CF        # as CF260. es,fi,lu,nl
+  CF510:   CF        # as CF260. fi,nl
+  CF530:   CF        # as CF260. fi,lu,nl
+  LF180:   LF        # power rating, not a designation — target truck/daf/lf is LIVE (es,fi,gb,lu,nl). es,fi,nl
+  LF210:   LF        # as LF180. es,fi,nl
+  LF220:   LF        # as LF180. es,fi,nl
+  LF230:   LF        # as LF180. es,fi,nl
+  LF250:   LF        # as LF180. es,fi,nl
+  LF260:   LF        # as LF180; LF260F above is repointed to LF for this reason. es,fi,nl
+  LF280:   LF        # as LF180. es,nl
+  LF290:   LF        # as LF180. es,fi,nl
+  LF310:   LF        # as LF180. es,nl
+  LF320:   LF        # as LF180. es,fi,nl
 
 Daihatsu:
   Hijet: Hi-Jet                               # spelling variant of "Hi-Jet" — same nameplate, different spacing/casing; merging keeps one id and one set of evidence


### PR DESCRIPTION
DAF writes the horsepower rating after the series badge, and the registers file
the whole string as the model. `data#176` fixed that for XF/XG/XD/XB and stopped
there. `LF` and `CF` carry the identical defect.

    FOLD  lf180 lf210 lf220 lf230 lf250 lf260 lf280 lf290 lf310 lf320   -> daf/lf  (live)
    FOLD  cf260 cf290 cf300 cf320 cf330 cf340 cf370 cf400 cf410 cf430
          cf440 cf450 cf460 cf480 cf510 cf530                           -> daf/cf  (live)
    KEEP  lf45 lf55 cf65 cf75 cf85 — real series designations

Measured today against the audit's expectation of 10 + 16: **exactly 10 and 16.**

## The evidence is per-record in our own corpus, not a caption

`data#176` argued from a DAF marketing page and a photo caption. For LF/CF I could
re-derive it from the registers themselves, which is stronger.

**es_dgt states the number twice.** The Spanish microdata is fixed-width and
carries engine power in kW as an explicit spec field (offset 224). Converting
kW->hp (x1.35962) reproduces the badge:

| raw model | kW (register) | -> hp | badge |
|---|---|---|---|
| `CF 530 FA`  | 390.0 | 530.3 | 530 |
| `CF 480 FT`  | 355.0 | 482.7 | 480 |
| `CF 450 FT`  | 330.0 | 448.7 | 450 |
| `LF 230 FA`  | 172.0 | 233.9 | 230 |
| `LF 260 FA`  | 194.0 | 263.8 | 260 |
| `LF 320 FA`  | 239.0 | 324.9 | 320 |

26 of 30 distinct LF/CF model strings in `es_dgt_202603` match their own badge
within ±8 hp.

**nl_rdw carries the `<series>.<power>` form, and both halves are present.**
`"FA LF 45.180"` x3, `"LF45.180"` x2, `"LF 55.250"` x2, `"FT CF 85.460"` x6,
`"FTCF85.410T"` x9, `"FANCF75.360U"` x3 — and the very same numbers reappear
directly after the *bare* badge: `"LF 180 FA"` (472 vehicles), `"CF 460 FT"`,
`"CF 410 FT"` (1,928). A number that is the power of an LF45 cannot be a
designation when it follows a bare LF.

## The trap: there are FIVE real series here, not one

`data#176` kept `xf105` because XF105/XF106 are genuine generations. The LF/CF
equivalent is bigger, and getting it wrong would have destroyed five live
nameplates. **The kW instrument above doubles as a known-answer test, and it
answers NO on all five:**

| raw | kW | -> hp | badge digits | verdict |
|---|---|---|---|---|
| `FA LF 45` / `FA LF55` | 181.6 | 246.9 | 45 / 55 | **not a rating** |
| `DAF CF85` | 315.0 | 428.3 | 85 | **not a rating** |
| `FACF65`   | 218.7 | 297.3 | 65 | **not a rating** |

Corroborated three more ways: they take their *own* power suffix (`LF45.180`,
`CF 85.410`) and a series cannot be the rating and carry a rating at once;
[DAF CF](https://en.wikipedia.org/wiki/DAF_CF) — *"Originally launched as the 65,
75, and 85 series (from 1992 through 1997)"*, *"renamed the CF range in 1998"*,
*"DAF 65, 75 & 85 CF (1998–2000)"*; [DAF LF](https://en.wikipedia.org/wiki/DAF_LF) —
*"The LF45 and LF55 are powered by Cummins B Series engines... all LF55s use the 6
cylinder due to their increased size and weight"*. And the lineage: they succeed
the Leyland-DAF 45/55 this file already publishes as `truck/leyland-daf/45` and
`/55`.

All five verified untouched in the id diff.

## Availability union, at (country, SOURCE)

Both parents already carry `es:es_dgt fi:fi_traficom gb:uk_dft lu:lu_snca
nl:nl_rdw`. Every one of the 26 is a **strict subset** — the id diff reports
**0 availability changes anywhere in the catalog**, which is the same statement
measured rather than asserted. Nothing lost; unlike `daf/xb` in #176, nothing
arrives either.

## Control vs treatment — all six kinds

Same base (`aeccb6a`), same pipeline (`6bbd4ee`), and a **private APFS clone of
the cache** used for both runs, mtime-frozen except `license_*.txt` so the
licence gate stays honest. Cache manifest verified byte-identical before the
control, after the control, and after the treatment.

    CONTROL 13936 ids   TREATMENT 13910 ids   (-26)
    REMOVED 26 — exactly the intended ids
    ADDED 0 · AVAILABILITY/NAME CHANGED 0 · NON-DAF ids touched 0

    truck published 907 -> 881;  car/motorcycle/moped/van/bus IDENTICAL
    gate failures: 0 on BOTH sides (EXIT=0 both)

**Cross-kind spill: zero.** Make-scoped renames are kind-blind and DAF has van
and bus records; all 7 non-truck DAF/Leyland-DAF records are byte-identical
between the two builds.

## Key-fires proof, including a deliberate negative control

All 26 fold keys fire — each retires its id in the diff above. The 27th change is
the chain flatten, which retires nothing visible, so I proved it separately by
building a **negative control that differs from this branch by exactly two
lines** (the flatten reverted, nothing else):

    with the flatten      truck/daf/lf260  ABSENT
    without the flatten   truck/daf/lf260  SURVIVES  [fi, nl]

`LF260F -> LF260` was already in the DAF block. Renames are not transitive, so
the moment `LF260` became a fold key those rows landed on the intermediate and
stopped — and `daf/lf260` lives on as a *different, smaller* record (fi+nl
instead of es+fi+nl). That is nastier than #176's version: a check that only asks
"did the id list shrink?" passes while the id survives.

`Fascf`/`Fatcf -> CF85` needed **no** change, precisely because CF85 is kept. The
trap and the chain are the same fact seen twice.

## Correction to data#176's permanent documentation

`data#176`'s body states the rename-side chain shipped with *"green build, no
lint, no gate — caught only by diffing control-vs-treatment id lists"*. **That is
wrong, and it is wrong in permanent documentation.** I reconstructed #176's
pre-flatten state on current main and ran the lint:

    10 failure(s) — 5x former_ids CHAIN, 5x renames DIRECTION WAR

`lint_curation`'s direction-war rule landed in `data#26` on 2026-07-26, **six days
before #176**. Both halves were always catchable pre-build. The id diff remains
necessary for what the lint genuinely cannot see — a key that fires on nothing,
and cross-kind spill — but it is not the only instrument, and the next reader
should not skip the cheaper one.

## Gates

`lint_overrides`, `lint_curation --base=origin/main`, `reorg_make_blocks --check`,
`lint_plates`: all green. 26 `former_ids` aliases added, 1 repointed; no-vanish
clean, 0 id-contract failures. `daf/cf` now carries 19 aliases, `daf/lf` 13.

## Not coupled

Data-only. No pipeline change, no merge-order constraint.
