### PR TITLE
mercedes-benz: the bus O-number boundary + the Marco Polo truncation (12 ids fold, 0 pairs lost)

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -6671,3 +6671,21 @@
 "moped/yamaha/ns50f": "moped/yamaha/aerox"  # fi,nl
 "moped/yamaha/ns50n": "moped/yamaha/aerox"  # fi,nl
 "motorcycle/yamaha/yp250ra": "motorcycle/yamaha/xmax-250"  # fi,lu,nl,ua
+# ── Mercedes-Benz residual, §A.1 + §A.4.1 (2026-08-02): the bus O-number ↔
+#    nameplate boundary, plus the Marco Polo respell. Every alias below was
+#    measured control-vs-treatment on a frozen-cache build from the same base
+#    commit; the bracketed list is the retiring id's (country,source) pairs, and
+#    every one of them is present on the successor after the fold. Evidence
+#    lost: NONE. Gains: tourino +nl:nl_rdw, o303 +nz:nz_nzta +ua:ua_mvs.
+"bus/mercedes-benz/o530":    "bus/mercedes-benz/citaro"     # renames.yml Mercedes-Benz: O530 -> Citaro  [es:es_dgt,nl:nl_rdw,ua:ua_mvs]
+"bus/mercedes-benz/o530g":   "bus/mercedes-benz/citaro"     # renames.yml Mercedes-Benz: O530G -> Citaro  [nl:nl_rdw,ua:ua_mvs]
+"bus/mercedes-benz/o530l":   "bus/mercedes-benz/citaro"     # renames.yml Mercedes-Benz: O530L -> Citaro  [nl:nl_rdw,ua:ua_mvs]
+"bus/mercedes-benz/o350":    "bus/mercedes-benz/tourismo"   # renames.yml Mercedes-Benz: O350 -> Tourismo  [fi:fi_traficom,nl:nl_rdw,ua:ua_mvs]
+"bus/mercedes-benz/o580":    "bus/mercedes-benz/travego"    # renames.yml Mercedes-Benz: O580 -> Travego  [nl:nl_rdw,ua:ua_mvs]
+"bus/mercedes-benz/o550":    "bus/mercedes-benz/integro"    # renames.yml Mercedes-Benz: O550 -> Integro  [fi:fi_traficom,nl:nl_rdw]
+"bus/mercedes-benz/o510":    "bus/mercedes-benz/tourino"    # renames.yml Mercedes-Benz: O510 -> Tourino  [fi:fi_traficom,nl:nl_rdw] — nl is the pair the fold ADDS to the survivor
+"bus/mercedes-benz/0303":    "bus/mercedes-benz/o303"       # renames.yml Mercedes-Benz: "0303" -> O303  [nz:nz_nzta,ua:ua_mvs] — both pairs are gains on the survivor
+"bus/mercedes-benz/303":     "bus/mercedes-benz/o303"       # renames.yml Mercedes-Benz: "303" -> O303  [nz:nz_nzta,ua:ua_mvs]
+"bus/mercedes-benz/transfer": "bus/mercedes-benz/sprinter"  # renames.yml Mercedes-Benz: Transfer -> Sprinter  [fi:fi_traficom,nl:nl_rdw,nz:nz_nzta]
+"bus/mercedes-benz/midcity": "bus/vdl/midcity"              # moves.yml Mercedes-Benz|Midcity -> VDL|Midcity  [fi:fi_traficom,nl:nl_rdw]. CROSS-MAKE alias for a cross-make MOVE — same shape as the 17 `moped/piaggio/vespa-*` -> `moped/vespa/*` lines above, where the source make also stays alive: the model IS relocated (rule 3's purpose), the alias only keeps the old id resolvable
+"car/mercedes-benz/marco":   "car/mercedes-benz/marco-polo" # renames.yml Mercedes-Benz: Marco -> Marco Polo  [es:es_dgt,fi:fi_traficom,lu:lu_snca,nl:nl_rdw] — target MINTED by the same change

--- a/overrides/models/moves.yml
+++ b/overrides/models/moves.yml
@@ -387,3 +387,25 @@
 "Austin|Healey 100-6":  "Austin-Healey|100-6"   # Austin-Healey 100-6 (BN4/BN6) 1956-1959 — https://en.wikipedia.org/wiki/Austin-Healey_100-6
 "Austin|Healey 3000":   "Austin-Healey|3000"    # Austin-Healey 3000 Mk I-III 1959-1967 — https://en.wikipedia.org/wiki/Austin-Healey_3000
 "Austin|Healey Sprite": "Austin-Healey|Sprite"  # Austin-Healey Sprite Mk I-IV 1958-1971 — https://en.wikipedia.org/wiki/Austin-Healey_Sprite
+
+# ── VDL MidCity filed under the chassis maker (Mercedes residual dossier §A.1.8,
+# applied 2026-08-02) ────────────────────────────────────────────────────────
+# NAMING §1: "in `bus`, the **bodybuilder** is the make (Plaxton/Caetano
+# precedent)". bus/mercedes-benz/midcity (fi|nl, d8) is the VDL MidCity, and one
+# of its two raws names the marque outright: fi_traficom writes
+# merk="Mercedes-Benz" handelsbenaming="VDL MidCity". Its other raw is bare
+# "MIDCITY" (nl_rdw x2, first reg 2020) — the SAME spelling nl_rdw uses under
+# make=VDL for the same product ("MIDCITY" x15, "MIDCITY ELECTRIC" x30). The
+# target already exists and is well-populated: bus/vdl/midcity carries
+# fi:fi_traficom, gb:uk_dft, nl:nl_rdw, so the move loses no (country,source)
+# pair — both of the Mercedes record's pairs are already on the survivor.
+#
+# ONLY THE FUSED SPELLING MOVES, and that is a measurement, not caution.
+# `Mercedes-Benz|Mid` — the dossier's second draft key — is REFUTED by the
+# corpus: the move vocabulary is kind-blind, and in the TRUCK kind the string
+# "Mid" is produced by nl_rdw's "MID-LIFT 10X8" (x2), a mid-lift-axle Mercedes
+# TRUCK. Shipping that key would file a Mercedes truck as a VDL bus. The bus-kind
+# "MID CITY" rows it would have rescued (fi x1, nl x2, first reg 2014) stay on
+# bus/mercedes-benz/mid, reported rather than mis-moved; nl_rdw also holds
+# "SPRINTER MID CITY" (2011), so the spaced form is not unambiguously VDL either.
+"Mercedes-Benz|Midcity": "VDL|Midcity"   # target is the CANONICAL DISPLAY (moves.yml rule "TARGET IS THE CANONICAL, not the raw form" — moves are not re-normalized against the destination make): bus/vdl/midcity publishes the name "Midcity", so "VDL|MidCity" would have minted a second record on the same slug

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -6230,6 +6230,65 @@ Mercedes-Benz:
   "300 SL 24V": 300 SL-24   # SPELLING of the already-curated valve-count form: raws "300SL 24V", "300 SL 24V" (nl+nz). The block's own convention hyphenates the valve count ("300 CE-24") — https://mercedes-benz-publicarchive.com/marsClassic/
   Ateco: Atego              # truck/mercedes-benz/ateco, raws "Ateco" x6, "ATECO" x4, "ATECO 818" x3, "ATECO 1224Lnr/4760", "Ateco 818" — the numbers are Atego type designations, so this is a one-letter misspelling of the series, not a product — https://en.wikipedia.org/wiki/Mercedes-Benz_Atego
   Arcos: Arocs              # truck/mercedes-benz/arcos, raws "ARCOS" x5, "ARCOS 4642" x4, "ARCOS 4942 M" x3, "ARCOS 4745K" — 46xx/49xx/47xx are Arocs construction-range type numbers; a transposed-letter misspelling — https://en.wikipedia.org/wiki/Mercedes-Benz_Arocs
+  # ── BUS: the O-number ↔ nameplate boundary (residual dossier §A.1), applied
+  # 2026-08-02 on a frozen-cache control-vs-treatment build from the same base
+  # commit. Mercedes states the rule AND dates it:
+  #   "The Mercedes-Benz Tourismo celebrated its premiere in 1994 under the name
+  #    O 350 Tourismo. … until that time, short designations such as O 303 or
+  #    O 404 were the norm."
+  #   https://www.mercedes-benz-bus.com/int/en/news-and-stories/mercedes-benz-tourismo-the-classic-coach-turns-30.html
+  # PRE-1994 the O-number IS the nameplate (o303, o404, o405 keep theirs — see
+  # the 0303/303 keys below, which MERGE INTO O303 rather than away from it);
+  # FROM 1994 the NAME is the nameplate and the O-number is the type code.
+  #
+  # THE BOUNDARY IS CORROBORATED BY THE REGISTER'S OWN CLOCK, not just by the
+  # marque. nl_rdw first-registration years (date_extract_y(datum_eerste_
+  # toelating_dt), measured 2026-08-02 over the frozen cache): O 530 2004-2011,
+  # O 530 G 2000-2010, O 530 LE 2006-2012, O 550 2000-2006, O 580 2003,
+  # O 350 2005-2006, O 510 2005 — every folding id is post-1994. O 303
+  # 1977-1988, O 305 1976-1982, O 405 1988-1997 — every id that KEEPS its
+  # number is pre-1994. Not one row crosses the line.
+  #
+  # KEY FORM: the produced string is the FUSED "O530", never "O 530" —
+  # series_collapse (bus/truck only) fuses a 1-2-letter head with its digits and
+  # one single-letter suffix (normalizer.rb#series_collapse), which is why the
+  # published display reads O530G. A spaced key would be inert.
+  #
+  # KIND-BLINDNESS, swept over the whole corpus (replay of classify, all six
+  # kinds): these keys reach BUS and TRUCK only. The truck kind holds the same
+  # coaches misfiled by nl_rdw — raws "O 530" x1 (2014), "O 550" x1 (2001),
+  # "0303" x1 (1982) + "0303/10R" x1 (1976) — so they fold to the same
+  # survivors there, all four sub-threshold. The CAR/VAN kinds are NOT reached:
+  # mercedes() returns the bare letter "O" for those rows, which is why they
+  # pool on car/mercedes-benz/o (dossier §C.1, rule-level, filed not fixed).
+  # Other makes are untouched — renames are make-scoped, and bus/setra "O530G"
+  # (nl x1) is the reason that matters here. ──
+  O530: Citaro     # bus/mercedes-benz/o530 (es|nl|ua) → citaro (es|fi|lu|nl|ua): the register says so in BOTH directions — o530 holds raw "O 530 CITARO" and citaro holds "CITARO O530 G". Marque: Citaro/K/G/LE/hybrid are variants of ONE model — https://www.mercedes-benz-bus.com/int/en/models/citaro.html . Union es|fi|lu|nl|ua, survivor already carries all 5 (country,source) pairs
+  O530G: Citaro    # bus/mercedes-benz/o530g (nl|ua) → citaro; raw "O 530G CITARO" (ua) names it outright; "O 530 G" nl x128 is the 18.13 m articulated Citaro G — https://www.mercedes-benz-bus.com/int/en/models/citaro.html
+  O530L: Citaro    # bus/mercedes-benz/o530l (nl|ua) → citaro; raws "O530L", "O 530 L" (nl), "O 530L" (ua) — L is the 3-axle length variant of the same model line, same page as above
+  O350: Tourismo   # bus/mercedes-benz/o350 (fi|nl|ua) → tourismo (fi|gb|nl|ua); raw "O 350-15R TOURISMO/625" (fi); Mercedes: "premiere in 1994 under the name O 350 Tourismo" — link in the header. Survivor already carries fi|nl|ua
+  O580: Travego    # bus/mercedes-benz/o580 (nl|ua) → travego (fi|nl|ua); raw "O 580-15RH TRAVEGO" (ua) names it outright; archive title "Mercedes-Benz Travego O 580" — https://mercedes-benz-publicarchive.com/marsClassic/ (oid=196153)
+  O550: Integro    # bus/mercedes-benz/o550 (fi|nl) → integro (fi|lu|nl); raws "O 550 INTEGRO" (nl), "Mercedes-Benz O 550" (fi); archive title "Mercedes-Benz Integro O 550" — https://mercedes-benz-publicarchive.com/marsClassic/ (oid=55520)
+  O510: Tourino    # bus/mercedes-benz/o510 (fi|nl) → tourino (fi|ua) — survivor GAINS nl:nl_rdw. Three independent register spellings name the coach: "O 510 TOURINO", "O 510 Tourino", "O 510 TOURINO-444203/468" (fi), plus bare "O 510" (nl, first reg 2005 = Tourino's 2004-2013 run). MARQUE CONFIRMATION NOT OBTAINED (mercedes-benz-bus.com is JS-rendered, marsClassic 403s, fetches attempted 2026-08-02) — this line rests on register evidence only, and is the lowest-confidence key in the block
+  "0303": O303     # bus/mercedes-benz/0303 (nz|ua) → o303 (fi|nl), survivor GAINS nz:nz_nzta + ua:ua_mvs. DIGIT-ZERO-FOR-LETTER-O: raw "BENZ 0303" (nz) is the same designation with a zero, and "0303/3 MAJESTIC" + "0303 DENNING" (nz) are Denning Majestic coaches on the O 303 chassis. Mercedes' whole bus type-number series in this corpus is O-prefixed (O 302/303/305/307/309/321/345/350/404/405/408/450/510/513/515/516/518/530/550/560/580/814/815/817) — there is no bare-number Mercedes bus line for these rows to belong to
+  "303": O303      # bus/mercedes-benz/303 (nz|ua) → o303. ADJUDICABLE NOW, unlike when the dossier filed it in §D.2: the dossier's oracle (build/observed_variants.json) only records raws whose fold DISCARDED tokens, so a bare "303" was structurally invisible to it and read as "0 raws". A whole-corpus replay shows the raw IS literally "303" — nz_nzta x1 + ua_mvs x1 — sitting inside the same two registers' 0303 cluster (ua also writes "0303" x4 and "303D"). Same make, same kind, same two (country,source) pairs as 0303, which the "BENZ 0303" raw proves is the O 303
+  Transfer: Sprinter # bus/mercedes-benz/transfer (fi|nl|nz) → bus/mercedes-benz/sprinter (es|fi|gb|lu|nl|nz|ua). THE REGISTER ITSELF WRITES THE FULL NAME: nl_rdw holds "SPRINTER TRANSFER 34" (2018), "SPRINTER TRANSFER 35" (2020), "SPRINTER TRANSFER 45" (2014, 2019), "SPRINTER TRANSFER 55" (2016, 2017), "316 CDI SPRINTER TRANSFER 34 B" and "O 516 CDI SPRINTER TRANSFER 45" — all of which already classify to Sprinter — while the bare "TRANSFER 35/45/45 LL/55" rows are the same product with the nameplate dropped. Marque: the minibus range runs "from the 5.9-metre-long Sprinter Transfer 23 to the 7.7-metre Sprinter Transfer 55" — https://www.mercedes-benz-bus.com/en_DE/models/minibuses.html . KIND-BLIND ×4 but verified inert elsewhere: no other Mercedes record in any kind produces "Transfer" (bus/tremonia-mobility/transfer is a DIFFERENT MAKE and renames are make-scoped). Survivor already carries fi|nl|nz
+  # ── CAR: `Marco` is the Mercedes-Benz MARCO POLO, truncated by the same
+  # mercedes() first-letter-run defect the AMG fix (pipeline#130) addressed —
+  # "MARCO POLO" → letters "MARCO" → not a class letter → returns "MARCO".
+  # Unlike AMG this one IS curable by curation, because ALL of it wants ONE
+  # target: a whole-corpus replay finds 1,044 registrations behind this string
+  # and EVERY raw is Marco Polo — "MARCO POLO" (es 893, lu 5, nl 6+), "Marco
+  # Polo" (fi 61, nl 70), "MERCEDES-BENZ MARCO POLO" (nl 2), "MARCO POLO 250 D"
+  # (nl 1), "Marco Polo V-Klasse" (fi 1). Zero contrary raws in any kind.
+  # KIND-BLIND ×2 (car+van); van/mercedes-benz/marco cross-kind-prunes into the
+  # car record today (11 of 1,044 regs) and will do the same after the fold.
+  # MINTS car/mercedes-benz/marco-polo and retires car/mercedes-benz/marco via
+  # former_ids. MARQUE PAGE NOT RETRIEVED (mercedes-benz.co.uk timed out,
+  # mercedes-benz.com 403, mbvans.com/en/marco-polo 404, all 2026-08-02) — the
+  # two-word name is corroborated register-side by two registers writing it in
+  # full and by the fi raw that appends the platform ("Marco Polo V-Klasse"). ──
+  Marco: Marco Polo # car/mercedes-benz/marco (es|fi|lu|nl) → car/mercedes-benz/marco-polo, same four (country,source) pairs; every one of the id's 16 raw rows reads MARCO POLO. NOT to be confused with car/mercedes-benz/112's raw "112 CDI M POLO" — an abbreviated Marco Polo ACTIVITY on a Vito chassis, which correctly stays with the Vito-band record
 
 Mercury:
   # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay

--- a/spotchecks.yml
+++ b/spotchecks.yml
@@ -693,3 +693,43 @@ checks:
     kind: motorcycle
     availability_includes: [gb, nl]
     reason: "The stub that SURVIVES, deliberately. 24,411 gb vehicles remain on it because 'YZF R125'/'YZF R6' write the index after a SPACE, which the designation rule does not cover (dossier C-3, filed). This row exists so the residual is visible: if it ever hits zero, someone widened the rule and owes yamaha/yzf a disposition."
+
+  # ── Mercedes-Benz residual §A.1 + §A.4.1 (S4W, 2026-08-02) ──────────────────
+  # The bus O-number folds cross a DATE BOUNDARY (pre-1994 O-numbers ARE the
+  # nameplate; from 1994 the name is), so both sides need a tripwire: the
+  # survivors that must GAIN, and the pre-1994 numbers that must STAY.
+  - id: mercedes-benz/citaro
+    kind: bus
+    availability_includes: [es, fi, lu, nl, ua]
+    reason: "O 530 / O 530 G / O 530 L fold here. The register attests it in both directions (o530 held 'O 530 CITARO', citaro holds 'CITARO O530 G') and Mercedes lists Citaro/K/G/LE/hybrid as variants of one model. es and ua arrive ONLY via the folded O-number ids — if either disappears, a key went inert or the fold regressed."
+  - id: mercedes-benz/tourino
+    kind: bus
+    availability_includes: [fi, nl, ua]
+    reason: "nl is the country the O 510 fold ADDS (it had fi+ua only). This is the block's lowest-confidence key — marque confirmation was never obtained, only three register spellings of 'O 510 TOURINO' — so it is the one most worth watching."
+  - id: mercedes-benz/o303
+    kind: bus
+    availability_includes: [fi, nl, nz, ua]
+    reason: "nz and ua arrive from the digit-zero spelling (bus/mercedes-benz/0303, raws 'BENZ 0303', '0303/3 MAJESTIC') and the bare '303'. O 303 is PRE-1994 and keeps its type number by Mercedes' own account — this row asserts both halves at once: the merge happened AND the number survived."
+  - id: mercedes-benz/o405
+    kind: bus
+    reason: "The control half of the date boundary. O 405 (nl first registrations 1988-1997) is pre-1994 and has no nameplate; it must NEVER be folded onto a named coach. If this record disappears, someone widened the O-number rule past 1994."
+  - id: mercedes-benz/o530
+    kind: bus
+    exists: false
+    reason: "The retired half of the Citaro fold. A new register spelling that reaches 'O530' is a curation gap to key, not a second product."
+  - id: mercedes-benz/sprinter
+    kind: van
+    availability_includes: [de, es, fi, gb, lu, nl, th]
+    reason: "KIND-BLIND TRIPWIRE for `Transfer: Sprinter`. That key fires in car+van+truck+bus; it is intended for the bus-kind minibus range only, and no other Mercedes record in any kind produces 'Transfer' today. If the van Sprinter's country set moves, the key reached a kind it was not measured against."
+  - id: mercedes-benz/marco-polo
+    kind: car
+    availability_includes: [es, fi, lu, nl]
+    reason: "The Marco Polo respell: mercedes() truncated 'MARCO POLO' to its first letter-run, exactly as it did for AMG (pipeline#130). All 1,044 registrations behind the old id read MARCO POLO, so all four countries must arrive intact on the minted id."
+  - id: mercedes-benz/marco
+    kind: car
+    exists: false
+    reason: "The truncation must never publish as a nameplate again. Presence here plus presence on marco-polo is the whole fix."
+  - id: vdl/midcity
+    kind: bus
+    availability_includes: [fi, gb, nl]
+    reason: "bus/mercedes-benz/midcity moves here (raw 'VDL MidCity' names the marque; NAMING §1 makes the bodybuilder the make in bus). Both of its pairs were already on this record, so the countries must not change — a change means the move landed somewhere else."


### PR DESCRIPTION
Applies the **Mercedes-Benz residual dossier** `aux/research/2026-08-owner-swarm/mercedes-residual.md`, §A.1 and §A.4.1.
**§A.0 (the AMG first-letter-run) is out of scope** — it shipped as pipeline#130 + data#182. Every number below was **re-derived on a post-AMG build**; nothing is carried over from the dossier's pre-AMG figures.

## Measurement layers

| what | how | when |
|---|---|---|
| control build | pristine detached worktree at `aeccb6a` (data) + `6bbd4ee` (pipeline), frozen cache | 2026-08-02 |
| treatment build | this branch + the **same** pipeline commit `6bbd4ee` | 2026-08-02 |
| cache freeze | `find cache -type f ! -name 'license_*.txt' -exec touch {} +` on a private APFS clone | licence gate left armed |
| raws / kind-blindness | whole-corpus replay of `classify`, all six kinds, 377,986 rows / 76.9 M registrations | 2026-08-02 |
| dead keys | `pipeline/tools/gen_review_pack.rb mercedes-benz vdl`, run on **both** builds | 2026-08-02 |

`origin/main` moved twice while I measured. Both deltas since the build commits are **documentation only** (`NEGOTIATION.md`; `aux/research/*.md`) — no override, no pipeline code — so the builds still describe this branch. The branch itself is rebased onto current main.

## What ships — 11 rename keys + 1 move; 12 ids retire, 1 is minted

### §A.1 — the bus O-number ↔ nameplate boundary (8 clusters)

Mercedes dates the rule itself: from 1994 a coach carries a **name** and the O-number becomes its type designation; before 1994 the **O-number is the nameplate**.

**The register's own clock confirms the boundary with zero overlap.** `nl_rdw` first-registration years (`date_extract_y(datum_eerste_toelating_dt)`), measured on the frozen cache:

| folds away (post-1994) | first-reg years | keeps its number (pre-1994) | first-reg years |
|---|---|---|---|
| `O 530` | 2004–2011 | `O 303` | 1977–1988 |
| `O 530 G` | 2000–2010 | `O 305` | 1976–1982 |
| `O 530 LE` | 2006–2012 | `O 405` | 1988–1997 |
| `O 550` | 2000–2006 | `O 302` | 1973–1975 |
| `O 580` | 2003 | | |
| `O 350` | 2005–2006 | | |
| `O 510` | 2005 | | |

Not one row crosses the line. `o303` is on the **keeping** side and is therefore a fold **target**, not a source.

| key | → | evidence |
|---|---|---|
| `O530` `O530G` `O530L` | Citaro | the register attests it **both ways**: `"O 530 CITARO"` / `"O 530G CITARO"` on the folding ids, `"CITARO O530 G"` on the survivor |
| `O350` | Tourismo | `"O 350-15R TOURISMO/625"` (fi) names both halves in one string |
| `O580` | Travego | `"O 580-15RH TRAVEGO"` (ua) |
| `O550` | Integro | `"O 550 INTEGRO"` (nl), `"Mercedes-Benz O 550"` (fi) |
| `O510` | Tourino | three independent spellings, `"O 510 TOURINO"` / `"O 510 Tourino"` / `"O 510 TOURINO-444203/468"` |
| `"0303"` `"303"` | O303 | see below |
| `Transfer` | Sprinter | see below |
| `Mercedes-Benz\|Midcity` | `VDL\|Midcity` (moves.yml) | see below |

**`"303"` was unblocked by re-measuring, not by guessing.** The dossier filed it in §D.2 as *"zero observed raws — not adjudicable"*. That was an artefact of its oracle: `build/observed_variants.json` only records raws whose fold **discarded tokens**, so a bare `"303"` is structurally invisible to it. A whole-corpus replay shows the raw is literally `303` — `nz_nzta` ×1 + `ua_mvs` ×1 — sitting inside those same two registers' `0303` cluster (ua also writes `"0303"` ×4). The `0303` raws settle the identity: `"BENZ 0303"`, and `"0303/3 MAJESTIC"` + `"0303 DENNING"` are Denning Majestic coaches built on the O 303 chassis. Mercedes' entire bus type-number series in this corpus is O-prefixed (O 302/303/305/307/309/321/345/350/404/405/408/450/510/513/515/516/518/530/550/560/580/814/815/817) — there is no bare-number Mercedes bus line for these rows to belong to.

**`Transfer` is confirmed by the register writing the full name.** `nl_rdw` holds `"SPRINTER TRANSFER 34"` (2018), `"SPRINTER TRANSFER 35"` (2020), `"SPRINTER TRANSFER 45"` (2014, 2019), `"SPRINTER TRANSFER 55"` (2016, 2017), `"316 CDI SPRINTER TRANSFER 34 B"` and `"O 516 CDI SPRINTER TRANSFER 45"` — all of which **already** classify to `Sprinter`. The bare `TRANSFER 35/45/45 LL/55` rows are the same product with the nameplate dropped.

**The MidCity move is corroborated in both directions by the corpus.** `bus/vdl/midcity` already exists (fi|gb|nl). One Mercedes-side raw names the marque outright — `fi_traficom` `merk="Mercedes-Benz"` `handelsbenaming="VDL MidCity"` — and the other is bare `"MIDCITY"`, the same spelling `nl_rdw` uses **under make=VDL** for the same product. VDL's own rows close it: `fi_traficom` files `VDL | Sprinter Mid City` and `VDL | Kusters Mid City`, i.e. VDL bodies on a Sprinter chassis. NAMING §1: *"in `bus`, the bodybuilder is the make"*.

### §A.4.1 — `Marco` is the **Marco Polo**

Same `mercedes()` first-letter-run defect the AMG fix addressed: `"MARCO POLO"` → letter-run `MARCO` → not a class letter → returns `MARCO`. **Unlike AMG this one is curable by curation, because all of it wants one target.** A whole-corpus replay finds 1,044 registrations behind the string across 16 raw rows and **every single raw is Marco Polo**: `"MARCO POLO"` (es 893, lu 5, nl 6), `"Marco Polo"` (fi 61, nl 70), `"MERCEDES-BENZ MARCO POLO"` (nl 2), `"MARCO POLO 250 D"` (nl 1), `"Marco Polo V-Klasse"` (fi 1). Zero contrary raws in any kind.

Type approval corroborates the platform: the minted record carries `e1*2007/46*0457*16…43`, and `e1*2007/46*0457` is the V-Class family approval (`van/viano` holds `*01`, `van/vito` holds `*00`/`*03`).

**Sourcing gap, stated plainly:** the marque page was not retrieved — `mercedes-benz.co.uk` timed out, `mercedes-benz.com` 403, `mbvans.com/en/marco-polo` 404 (2026-08-02). The two-word name rests on two registers writing it in full plus the fi raw that appends the platform.

## Availability union — per fold, at (country, SOURCE) level

```
A.1.1 Citaro    members=3  union=es:es_dgt,fi:fi_traficom,lu:lu_snca,nl:nl_rdw,ua:ua_mvs   LOST=none  GAINED=none
A.1.2 Tourismo  members=1  union=fi:fi_traficom,gb:uk_dft,nl:nl_rdw,ua:ua_mvs              LOST=none  GAINED=none
A.1.3 Travego   members=1  union=fi:fi_traficom,nl:nl_rdw,ua:ua_mvs                        LOST=none  GAINED=none
A.1.4 Integro   members=1  union=fi:fi_traficom,lu:lu_snca,nl:nl_rdw                       LOST=none  GAINED=none
A.1.5 Tourino   members=1  union=fi:fi_traficom,nl:nl_rdw,ua:ua_mvs                        LOST=none  GAINED=nl:nl_rdw
A.1.6 O 303     members=2  union=fi:fi_traficom,nl:nl_rdw,nz:nz_nzta,ua:ua_mvs             LOST=none  GAINED=nz:nz_nzta,ua:ua_mvs
A.1.7 Sprinter  members=1  union=es:es_dgt,fi:fi_traficom,gb:uk_dft,lu:lu_snca,nl:nl_rdw,nz:nz_nzta,ua:ua_mvs  LOST=none  GAINED=none
A.1.8 MidCity   members=1  union=fi:fi_traficom,gb:uk_dft,nl:nl_rdw                        LOST=none  GAINED=none
A.4.1 MarcoPolo members=1  union=es:es_dgt,fi:fi_traficom,lu:lu_snca,nl:nl_rdw             LOST=none  GAINED=(all four, minted id)

UNION CHECK: PASS — no (country,source) pair lost in any fold.
```

## Control vs treatment — all six kinds of change

Both builds **EXIT=0 with ZERO gate failures**. (The 16 `id-contract motorcycle/yamaha/*` failures that main carried earlier tonight are gone — data#190 landed before these builds, so this is a clean "zero on both sides", not "the same failures as control".)

```
CONTROL ids: 13936   TREATMENT ids: 13925   net -11

1. APPEARED (1)      car/mercedes-benz/marco-polo "Marco Polo" d3  es,fi,lu,nl — the minted respell target
2. DISAPPEARED (12)  the 12 intended retirements, every one aliased in former_ids
3. CHANGED name (0)  no display churn anywhere
4. CHANGED pairs (2) o303 GAINED nz:nz_nzta,ua:ua_mvs · tourino GAINED nl:nl_rdw · LOST: nothing, anywhere
5. CHANGED decile(15) all 15 are bus-kind, all ±1
6. CHANGED body (0)
7. CHANGED variants (0)
8. CHANGED former_ids (8)  citaro×3, o303×2, integro, sprinter, tourino, tourismo, travego, vdl/midcity
```

**Why the 15 decile moves are arithmetic, not evidence:** a decile is a rank bucket over the kind's population. The bus kind loses 11 published records (390 → 379), so every bus record below a removed one shifts a rank position and mid-pack records re-bucket at the boundary. Four of the fifteen are the fold survivors moving **up** (`integro` 5→4, `o303` 7→6, `tourino` 8→7, `vdl/midcity` 6→5); the other eleven are unrelated bus records moving ±1. **The car kind is net-zero (1 out, 1 in) and shows zero decile changes** — which is the internal check that this is population arithmetic and nothing else.

**Kind-blindness, swept and then confirmed on the build.** The replay predicted the truck kind would be reached (`nl_rdw` misfiles four coaches there), and the candidate-queue diff matches exactly:

```
GONE from queue:      truck/mercedes-benz/0303 (nl 2)  o530 (nl 1)  o550 (nl 1)
APPEARED in queue:    truck/mercedes-benz/citaro (nl 1)  integro (nl 1)
merged in place:      truck/mercedes-benz/o303  nl 5 -> nl 7
unchanged:            truck/mercedes-benz/mid   nl 2   ← the declined key, see below
```

All sub-threshold; no published record moved kind. The **car/van kinds are not reached at all** — `mercedes()` returns the bare letter `O` for those rows, which is why they pool on `car/mercedes-benz/o` (dossier §C.1, rule-level, filed not fixed). Other makes are untouched because renames are make-scoped — which matters here: `bus/setra/o530g` and `bus/tremonia-mobility/transfer` both exist and both are unaffected.

## Dead-curation audit

`gen_review_pack.rb` records every rename/move probe **at the exact lookup site with all mechanisms active**, so reachability is a set-membership question against what production `classify` actually asked for.

| | control | treatment |
|---|---|---|
| dead Mercedes-Benz keys | `"300 T Td"`, `"902-6 Ka"`, `"220SE B"`, `"300 Te-4-Matic"` | **identical set** |
| dead VDL keys | — | none |

**Identical on both sides.** All 11 new keys were consulted with a matching row; no existing key was orphaned. None of the four pre-existing dead keys is AMG-shaped, so pipeline#130 killed no Mercedes curation either — which is the part of "re-derive anything §A.0 affected" that could have gone wrong silently.

Chain and collision checks, all clean: no `former_ids` **value** is one of the retiring ids (no chains); no `former_ids` key already uses a successor slug; no `enrich` entry sits on a retiring id; no `removals.yml` entry collides; `moves.yml` and `body_types.yml` carry no Mercedes keys at all.

## What I declined, and why

### §A.2 — the nine-key Vito fold on the bare-number band. **Refuted.**

The dossier proposes `"108" "109" "110" "111" "112" "114" "115" "116" "120": Vito`, arguing the surprise is that kind-blindness is a *gain* because *"the car-kind ids with the same numbers are also Vitos"*.

**The NL first-registration years say otherwise.** Measured on the frozen cache:

| raw (nl_rdw, car kind) | n | first-reg years | what it is |
|---|---|---|---|
| `108` | 5 | 1967, 1968, 1970, 1971×2 | **W108** S-Class (1965–72) |
| `110` | 2 | 1966, 1967 | **W110** Fintail (1961–68) |
| `111` | 2 | 1962, 1964 | **W111** Fintail |
| `112 300SE` | 1 | 1965 | **W112** 300 SE — the raw names the car |
| `114` | 13 | 1970–1975 | **W114** 250/280 |
| `115` | 17 | 1968–1976 | **W115** /8 — matches the run exactly |
| `116` | 23 | 1973–1980 | **W116** S-Class — matches 1972–80 exactly |
| `120` | 1 | 1961 | **W120** Ponton 180 |

`car/mercedes-benz/116` is **88% W116** (23 of 26 registrations). A `"116": Vito` key would publish Mercedes' first S-Class as a van.

The dossier's oracle was blind to precisely these rows for the same reason it was blind to `"303"`: `observed_variants.json` only records raws that **lost tokens** in the fold, and a bare `"116"` loses none. Its evidence base was the `fi_traficom` rows, which genuinely *are* Vitos (`"112 CDI-638194-PROSTYLE VITO"` even says so) — but they are not the whole population.

**And curation cannot separate the two.** `collapse_variant` eats `CDI` **before** renames run — replay-verified, `"108 CDI"` and bare `"108"` both produce the string `108` — so one key cannot become two cars. The catalog already publishes `car/mercedes-benz/123` (nl 1976–1984) and `/124` (nl 1985–1996) as exactly this shape, which is the standing proof that NL writes bare W-chassis numbers as Mercedes car models.

**This is not a curation item. It is the same rule-level class as §A.0 and §C.1** — the discriminator is destroyed upstream of the layer that would use it — and it belongs in DEBT with that measurement attached, not in `renames.yml`.

*Side finding, same measurement:* the dossier's hazard #2 calls `108 D`/`110 D` *"D-suffixed T1/L-series rows"*. `nl_rdw` dates them 1996–1999 (`108 D` n=177+27, `110 D` n=162+22) — they are **W638 Vito 108 D / 110 D**, the pre-CDI diesels, not T1. Nothing depends on this here (the ids are untouched), but the comment is wrong and worth correcting before someone acts on it.

### §A.1.8's second key — `"Mercedes-Benz|Mid": "VDL|MidCity"`. **Refuted, and it would have moved the wrong vehicle.**

Moves are kind-blind. In the **truck** kind the string `Mid` is produced by `nl_rdw`'s `"MID-LIFT 10X8"` (×2) — a mid-lift-axle Mercedes **truck**. Shipping that key files a Mercedes truck as a VDL bus. The bus-kind `"MID CITY"` rows it would have rescued (fi ×1, nl ×2) stay on `bus/mercedes-benz/mid`, reported rather than mis-moved — and `nl_rdw` also holds `"SPRINTER MID CITY"` (2011), so the spaced form is not unambiguously VDL on its own either. Closing `bus/mercedes-benz/mid` honestly needs a **kind-scoped** move, which `moves.yml` does not have; filed rather than forced.

### The dossier's `O 303` **respell**, deliberately not taken

§A.1.6 proposes displaying `O 303` (spaced), per the settled `L312: L 312` convention whose comment names `O 319` as an example. That would retire the live `bus/mercedes-benz/o303` and mint `o-303` — and it would leave `O404`, `O405`, `O815D`, `O818D` fused and inconsistent beside it. **These keys merge into the existing `O303` and change no display** (`CHANGED name (0)` above). The spacing question is real but it is a make-wide O-block respell with its own blast radius, not a one-record exception bolted onto a fold.

### Everything the dossier already reports rather than drafts

§A.3 (26 converter-brand records), §A.4.2 (`mb` = MB 100 + Sprinter 3xx + MB-trac, three products under one string), §A.5 (kind misassignment — no mechanism exists), §C.1–C.6 and §D.1/D.5–D.10 are unchanged: reported, not actioned.

**§D.4 is now ANSWERED:** a `VDL` make **does** exist in the bus kind (13 records: `citea`, `futura`, `ambassador`, `midcity`, `synergy`, `sb`, …), display name exactly `VDL`. That is what unblocked the MidCity move — and note the move target had to be `VDL|Midcity`, not the dossier's `VDL|MidCity`: move targets are not re-normalised against the destination make, so the marketing spelling would have minted a second record on the same slug.

## Tripwires added

Nine `spotchecks.yml` rows, including both sides of the date boundary — `mercedes-benz/o405` must **stay** (the control on "someone widened the O-number rule past 1994") — and `mercedes-benz/sprinter` **kind: van** as the kind-blind tripwire for `Transfer: Sprinter`.

## Lints

`lint_overrides` OK · `lint_curation --base=origin/main` OK (109 files) · `reorg_make_blocks --check` OK · `lint_plates` OK

## Merge order

**Not a coupled pair. These two PRs are independent and may merge in either order.** Evidence, rather than the house rule:

- The pipeline PR adds only `enrich/` **facts on ids that are already live in the committed catalog** — `bus/{citaro,tourismo,travego,integro,tourino}`, `van/{vito,sprinter}` all verified present in `catalog/` on `main`. `lint_enrich` runs green against **data `main`** and against **this branch** (both measured), so it does not wait on this PR.
- This PR mints one id (`car/mercedes-benz/marco-polo`) and **deliberately ships no enrich entry for it**, so there is no pending-publish window to sequence.
- The variant labels the enrich PR adds (`O 530`, `O 350`, …) are strings, not ids; they collide with nothing whether or not this PR has merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
