### PR TITLE
byd: the tail wave — ETP3's held fold released on a measurement (+2 countries), Yuan Pro published, 12 keys

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -1488,6 +1488,113 @@ BYD:
   # Tang · 1 key, 2 vehicles, 1 rows
   "Tang Dm-P":                      Tang                    # trim/engine/body designation of the Tang — 2v 1r ua/ua_mvs
 
+  # ══ BYD TAIL WAVE (2026-08-02) — dossier aux/research/2026-08-owner-swarm/
+  # byd-tail.md applied under the EV program (NEGOTIATION.md:22252, rule 2:
+  # BYD-class growth marques are head makes). TWELVE KEYS, 339 vehicles moved
+  # (van 192 · yuan-pro 123 · yuan-plus 16 · sea-lion-07 8), measured by a
+  # control-vs-treatment CANDIDATE diff: all 12 candidate ids disappear, 0 new
+  # candidates appear, so every key fires and none is inert. Frozen-cache
+  # builds off data b7b6187 + pipeline db602aa. GATES: the two sides fail
+  # IDENTICALLY and only on a defect that is already on main — one spotcheck,
+  # 'mercedes-benz/amg missing gb', reproduced in a PRISTINE control worktree
+  # with zero modifications (pipeline#144 moved 57,573 gb AMG-stub vehicles to
+  # real nameplates; spotchecks.yml:469 has not caught up). No other gate fails
+  # on either side. Every produced string replayed byte-exact through the real
+  # Normalizer#classify (12/12).
+  #
+  # THE DOSSIER'S HEADLINE HAZARD IS OBEYED, NOT PAPERED OVER: `Sea Lion 06`
+  # (424 ua) is NOT car/byd/sealion-6 — sealion-6's product is the Song Plus
+  # DM-i (4,775mm/2,765mm wheelbase) and 海狮06 is a different, longer Ocean
+  # SUV (4,810mm/2,820mm). NO KEY BELOW TOUCHES ANY 05/06 STRING, in either
+  # direction, and the only Sea Lion keys here carry `07`, whose target
+  # car/byd/sea-lion-07 is published and already ua-evidenced. The three
+  # near-identical families in this make were each checked before keying:
+  # Sea Lion 05/06/07 vs Sealion 5/6/7/8; Yuan / Yuan Plus / Yuan Pro /
+  # Yuan Up; Seal / Seal 5 / Seal 6 / Seal 06 / Seal U. Renames are EXACT
+  # string keys (normalizer.rb:290 `renames&.key?(nameplate)`), never
+  # prefixes, so no key below can reach a sibling nameplate.
+  #
+  # NOT DONE HERE, and each is argued in the PR body: the Chinese-name heads
+  # (Sea Lion 05/06, Song L/Plus, Tang L, Qin/Qin L/Qin Plus, Han L, Xia,
+  # Yuan Up) take no key at all — their trim suffixes would fold onto
+  # UNPUBLISHED heads, which consolidates candidate mass and rescues nothing
+  # (no head reaches KIND_THRESHOLDS[:car] = 1000 even fully consolidated:
+  # Sea Lion 06 → 659, Song Plus → 423, Song L → 375, Tang L → 139), and for
+  # `Song Plus EV` / `Song Plus Dm I` it would DESTROY the axis that resolves
+  # D-3's one-to-many (Song Plus EV → the BEV Seal U, Song Plus DM-i → the
+  # PHEV Sealion 6 — the powertrain token IS the discriminator). ──
+
+  # ── ETP3 · the dossier's HELD fold, RELEASED on a measurement. Both
+  # byd-tail.md §B.4 and enrich/byd.yml's van/byd/etp3 note hold these four
+  # keys "pending the uk_dft GenModel fix". THE HOLD IS A CONFLATION AND THE
+  # SOURCE FILE REFUTES IT. The §E.1 defect is a GenModel bucket carrying MORE
+  # THAN ONE published nameplate (BYD SEAL DESIGN EV = Seal 15,204 + Seal U
+  # 26,923 + Sealion 7 8,474). Read the same file for THIS bucket: VEH0120
+  # 2026 Q1, BodyType "Light goods vehicles", Make BYD, GenModel "BYD ETP"
+  # holds exactly TWO Model strings and both name ONE nameplate — "ETP3 EV"
+  # (186 Licensed + 0 SORN) and "ETP3" (0 Licensed + 1 SORN) = 187. One
+  # nameplate in, one nameplate out: the BMW "3 SERIES" shape the detector
+  # spec calls CORRECT pooling, not the seal-design-ev shape. No source fix is
+  # owed here and none is being waited on.
+  # MEASURED GAIN (control-vs-treatment, this PR): van/byd/etp3 published
+  # fi,nl and now publishes es,fi,gb,nl — +2 (country,source) pairs,
+  # (gb,uk_dft) + (es,es_dgt), 192 vehicles, 0 pairs lost. All four keys are
+  # UNPUBLISHED candidates, so nothing is retired and no former_ids/removals
+  # line is owed. POWERTRAIN SEED (EV directive rule 3): every gb row carries
+  # VEH0120 Fuel "Battery electric" — the ETP3 is BEV-only. ──
+  Etp:                              ETP3                    # uk_dft GenModel truncation of ETP3 — its OWN Model column writes "ETP3 EV" (186) and "ETP3" (1); 187v 1r gb/uk_dft [van]
+  Etp 3:                            ETP3                    # spaced spelling of ETP3 — 1v 1r es/es_dgt [van]
+  ET3:                              ETP3                    # BYD's short form for the same van (byd.com/eu sells it as ETP3/ET3) — 3v 1r nl/nl_rdw [van]
+  Electric Truck Panel 3 EM3:       ETP3                    # nl_rdw writes the acronym out in full: ETP = Electric Truck Panel, "3" the tonnage class — 1v 1r nl/nl_rdw [van]
+
+  # ── Sea Lion 07 · trim/battery-suffix folds onto the PUBLISHED Chinese-name
+  # record car/byd/sea-lion-07 (es,ua). VALUE IS "Sea Lion 07", TWO WORDS AND
+  # A LEADING ZERO — it slugifies to sea-lion-07 (the 海狮07 record), NOT to
+  # sealion-7 (the export record, also published, de/es/fi/ie/lu/nl/nz/th).
+  # Both records stay live and separate per D-3. No availability moves: both
+  # keys and the target are ua-only on the Chinese side. car/byd/sea-lion-07
+  # carries 0 type approvals, so reconciler.rb:261's 25-TAN cap is not in
+  # play. POWERTRAIN: 海狮07 spans BEV and DM-i; these two rows are the BEV
+  # arm, recorded as a typed variant in enrich/byd.yml rather than left in a
+  # slug (EV directive rule 3). ──
+  Sea Lion 07 EV:                   Sea Lion 07             # powertrain suffix of the 海狮07 (BEV arm) — 5v 1r ua/ua_mvs
+  Sea Lion 07 EV 610 Smart Edition: Sea Lion 07             # battery figure (610 km) + 智驾版 trim — NAMING §6's Leaf 40KWH precedent — 3v 1r ua/ua_mvs
+
+  # ── Yuan Plus · five trim/battery/edition suffixes onto the PUBLISHED
+  # car/byd/yuan-plus (es,ua), the 元PLUS — which is car/byd/atto-3's Chinese
+  # name and stays a separate record per D-3. Checked against the three
+  # near-identical siblings before keying: car/byd/yuan (nl,ua, published),
+  # `Yuan Up` (254 ua, candidate — car/byd/atto-2's Chinese name) and
+  # `Yuan Pro` (below) are all DIFFERENT products and take no key from this
+  # cluster. No availability moves (all ua-only); target carries 0 TANs.
+  # POWERTRAIN: 元PLUS is BEV-only, so `Yuan Plus EV` is a redundant
+  # powertrain token, not an electric line — folding it violates no EV rule. ──
+  Yuan Plus 510 Transcendent:       Yuan Plus               # battery figure (510 km) + 超越型 trim — 7v 1r ua/ua_mvs
+  Yuan Plus Flagship:               Yuan Plus               # 旗舰型 trim — 5v 1r ua/ua_mvs
+  Yuan Plus EV:                     Yuan Plus               # redundant powertrain suffix; the 元PLUS has no non-BEV variant — 2v 1r ua/ua_mvs
+  Yuan Plus EV Premium:             Yuan Plus               # powertrain suffix + trim — 1v 1r ua/ua_mvs
+  Yuan Plus Honor:                  Yuan Plus               # 荣耀版 (Honor Edition), a model-year trim — 1v 1r ua/ua_mvs
+
+  # ── Yuan Pro · ONE KEY THAT MINTS ONE NEW PUBLISHED ID, and that is the
+  # point. byd-tail.md §B.4 spotted that `Yuan Pro EV GS` (123 ar) and
+  # `Yuan Pro` (4 ua) are the same product but scored the pair against the
+  # 1,000-vehicle volume route and filed it as unpublishable. IT MISSED THE
+  # OTHER ARM: publishable? (reconciler.rb:162) is `sources.size >= 2 ||
+  # max_country_count >= threshold`, and this fold takes the FIRST arm —
+  # ar_dnrpa + ua_mvs = 2 sources, 127 vehicles, so car/byd/yuan-pro publishes.
+  # IN-CORPUS CORROBORATION FOR THE WHOLE SHAPE: car/byd/song-pro is ALREADY
+  # published on exactly this pair of registers (ar,ua) — LatAm BYD keeps the
+  # Chinese Dynasty names, so ar_dnrpa and ua_mvs writing the same nameplate is
+  # a demonstrated pattern in this make, not an inference. Both registers write
+  # the nameplate LITERALLY ("YUAN PRO", "YUAN PRO EV GS"); the key strips only
+  # a powertrain token and ar_dnrpa's trim letter, whose trim-ness is itself
+  # corroborated in-corpus by the GS/GL pair on `Dolphin Mini EV GS`(474)/
+  # `GL`(11) and by `Shark Dmo GS`. 元Pro is BEV-only, so `EV` is redundant,
+  # not an electric line — no EV-rule exposure. NOT car/byd/yuan-plus and NOT
+  # car/byd/yuan: three different BYD products, all three strings live in this
+  # corpus, none folded into another. ──
+  Yuan Pro EV GS:                   Yuan Pro                # ar_dnrpa powertrain token + GS trim on the 元Pro — 123v 1r ar/ar_dnrpa; PUBLISHES car/byd/yuan-pro (ar+ua, 2 sources, 127v)
+
 Cadillac:
   # ── junk?-rescue: fi_traficom door-count prefix (2026-08-01, per-row replay
   # of classify; same method as pipeline/tools/report_junk_drops.rb). Finland's


### PR DESCRIPTION
Applies `aux/research/2026-08-owner-swarm/byd-tail.md` (pipeline repo) under the owner's EV program — rule 2 makes BYD-class growth marques head makes. **Twelve keys in the `BYD:` block of `renames.yml`, 339 vehicles.** One file changed.

The dossier is advisory and recommends no fold anywhere. I shipped the two items it filed as unshippable, because both of its reasons are refuted by measurement, and declined everything else it enumerated — with reasons, below.

## What shipped, per cluster, with the union check

| # | Cluster | Keys | Vehicles | Target | (country,source) union |
|---|---|---:|---:|---|---|
| 1 | **ETP3** | 4 | 192 | `van/byd/etp3` (published fi,nl) | **GAINS `gb:uk_dft` + `es:es_dgt`** · 0 lost |
| 2 | **Sea Lion 07** | 2 | 8 | `car/byd/sea-lion-07` (published es,ua) | unchanged (all ua) · 0 lost |
| 3 | **Yuan Plus** | 5 | 16 | `car/byd/yuan-plus` (published es,ua) | unchanged (all ua) · 0 lost |
| 4 | **Yuan Pro** | 1 | 123 | `car/byd/yuan-pro` — **NEW id** | **PUBLISHES `ar:ar_dnrpa` + `ua:ua_mvs`** |

**Catalog-wide union check: 14 (country,source) pairs in control, 14 in treatment, `vanished=[]`. Zero pairs lost on any surviving id, in any kind.**

## The two refutations

### 1. The ETP3 hold was a conflation — and it cost two countries

`byd-tail.md` §B.4 and `enrich/byd.yml`'s `van/byd/etp3` note both held these four keys *"pending the uk_dft GenModel fix"*, on the grounds that the gb mass "depends on the same uk_dft GenModel/Model question as §E.1".

It does not. **§E.1's defect is a GenModel bucket carrying MORE THAN ONE nameplate** — `BYD SEAL DESIGN EV` = Seal 15,204 + Seal U 26,923 + Sealion 7 8,474. Read the same file for *this* bucket (VEH0120 2026 Q1, BodyType `Light goods vehicles`, Make BYD, GenModel `BYD ETP`), summed over `LicenceStatus` as the six-column key requires:

| Model | Fuel | Licensed | SORN | **Summed** |
|---|---|---:|---:|---:|
| `ETP3 EV` | Battery electric | 186 | 0 | **186** |
| `ETP3` | Battery electric | 0 | 1 | **1** |
| | | | | **187** |

Two Model strings, **one nameplate**. That is the BMW `3 SERIES` shape which `enrich/byd.yml`'s own §E.1 detector spec calls *correct* pooling, not the `seal-design-ev` shape. No source fix is owed here and none is being waited on. The adapter's own count for `van/byd/etp` is 187, independently agreeing with the CSV group-sum.

### 2. `Yuan Pro` was scored against the wrong arm of `publishable?`

§B.4 spotted that `Yuan Pro EV GS` (123 ar) and `Yuan Pro` (4 ua) are the same product, then filed the pair as unpublishable because 127 < 1,000. But `publishable?` (`reconciler.rb:162`) is `sources.size >= 2 || max_country_count >= threshold`, and this fold takes the **first** arm: `ar_dnrpa` + `ua_mvs` = 2 sources.

**In-corpus corroboration for the whole shape, not an inference:** `car/byd/song-pro` is *already published on exactly this register pair* (ar, ua). LatAm BYD keeps the Chinese Dynasty names, so ar_dnrpa and ua_mvs writing the same nameplate is demonstrated in this make. Both registers write the nameplate literally (`YUAN PRO`, `YUAN PRO EV GS`); the key strips only a powertrain token and ar_dnrpa's trim letter — and GS's trim-ness is itself corroborated in-corpus by the GS/GL pair on `Dolphin Mini EV GS` (474) / `GL` (11) and by `Shark Dmo GS`.

## The `Sea Lion 06` class — every near-identical pair checked

The dossier's headline is that **`Sea Lion 06` is NOT `car/byd/sealion-6`** (sealion-6's product is the Song Plus DM-i, 4,775 mm on a 2,765 mm wheelbase; 海狮06 is 4,810 / 2,820). **No key in this PR touches any 05 or 06 string, in either direction.** Every near-identical family in this make was checked before keying:

| Family | Strings that exist in this corpus | Keyed here? |
|---|---|---|
| Sea Lion / Sealion | `Sea Lion 05` · `Sea Lion 06` · **`Sea Lion 07`** (pub) · `Sea Lion` (bare) · `sealion-5` (pub) · `sealion-6` (pub) · `sealion-7` (pub) · `sealion` (pub) · `Sealion 8` | **only the two `Sea Lion 07 EV*` strings** |
| Yuan | `yuan` (pub) · **`yuan-plus`** (pub) · `Yuan Up` · **`Yuan Pro`** · `Yuan Pro EV GS` | only `Yuan Plus *` and `Yuan Pro EV GS` |
| Seal | `seal` (pub) · `seal-6` (pub) · `seal-u` (pub) · `Seal 5` · `Seal 06` · `Seal 06GT` | **none** |
| Song | `song-pro` (pub) · `Song` · `Song L` · `Song Plus` · `Song Plus EV` · `Song Plus Dm I` | **none** |
| Dynasty "L" | `Tang`/`Tang EV` (pub) · `Tang L` · `Han` (pub) · `Han L` · `Qin` · `Qin L` · `Qin Plus` | **none** |
| ETP | **`etp3`** (pub) · `Etp` · `Etp 3` · `ET3` · `Electric Truck Panel 3 EM3` | all four |

Two structural safeguards, not just care: renames are **exact string keys** (`normalizer.rb:290`, `renames&.key?(nameplate)`), never prefixes, so no key can reach a sibling; and cluster 2's value is `Sea Lion 07` — **two words, leading zero** — which slugifies to `sea-lion-07`, not `sealion-7`. **Measured**: `sealion-7`, `sea-lion-07`, `yuan-plus`, `yuan`, `atto-3` all have byte-identical availability in control and treatment.

## Fold-target legitimacy — liveness is not legitimacy

Each of the four targets was checked as a genuine nameplate, not merely a live id (the `cadillac/hardtop` / `ford/roadster` failure class):

- **`ETP3`** — BYD's own commercial designation for its 3.5 t electric panel van (`byd.com/eu`); `nl_rdw` writes the acronym out in full, `ELECTRIC TRUCK PANEL 3 EM3`. An alphanumeric badge, like the already-published `van/byd/t3`. Not a body word — a body word here would be "Panel Van".
- **`Sea Lion 07`** — 海狮07, a real BYD nameplate with live first-party model pages.
- **`Yuan Plus`** — 元PLUS, the Atto 3's Chinese nameplate. (`Plus` alone would be a trim word; `Yuan Plus` is the product name.)
- **`Yuan Pro`** — 元Pro, sibling of the already-published `song-pro`.

None appears in `removals.yml`, as a `former_ids` key or value, or in the body-word 92 dossier (`grep` returns nothing for BYD).

## Control vs treatment

Frozen cache (`find cache -type f ! -name 'license_*.txt' -exec touch {} +` — the licence exclusion preserved, so the licence gate stays armed). Control is a **pristine detached worktree of `origin/main`** with zero modifications; treatment is this branch; same base, same pipeline commit, same cache.

```
control ids: 13880   treatment ids: 13881   delta: 1

== IDS ADDED (1) ==
  + car/byd/yuan-pro  "Yuan Pro"  av=ar:ar_dnrpa ua:ua_mvs
== IDS REMOVED (0) ==

== AVAILABILITY (country,SOURCE) CHANGES ON SURVIVING IDS ==
  ~ van/byd/etp3  gained=["es:es_dgt", "gb:uk_dft"]  LOST=[]
  TOTAL (country,source) pairs LOST on surviving ids: 0

== UNION CHECK ==
  control pairs=14 treatment pairs=14 vanished=[]

== TAN COUNT CHANGES (25-cap watch, reconciler.rb:261) ==
  (none)
  ids at the 25 cap in TREATMENT: 185 (control: 185)
```

**Every key proved to fire — a catalog id-diff cannot see an inert key, so the instrument is a CANDIDATE diff:**

```
control candidates=146483  treatment candidates=146470  delta=-13
== CANDIDATES GONE (key fired) ==
  - car/byd/sea-lion-07-ev                     5v {ua}  [ua_mvs]
  - car/byd/sea-lion-07-ev-610-smart-edition   3v {ua}  [ua_mvs]
  - car/byd/yuan-plus-510-transcendent         7v {ua}  [ua_mvs]
  - car/byd/yuan-plus-flagship                 5v {ua}  [ua_mvs]
  - car/byd/yuan-plus-ev                       2v {ua}  [ua_mvs]
  - car/byd/yuan-plus-ev-premium               1v {ua}  [ua_mvs]
  - car/byd/yuan-plus-honor                    1v {ua}  [ua_mvs]
  - car/byd/yuan-pro-ev-gs                   123v {ar}  [ar_dnrpa]
  - car/byd/yuan-pro                           4v {ua}  [ua_mvs]   ← left the queue by PUBLISHING
  - van/byd/etp                              187v {gb}  [uk_dft]
  - van/byd/etp-3                              1v {es}  [es_dgt]
  - van/byd/et3                                3v {nl}  [nl_rdw]
  - van/byd/electric-truck-panel-3-em3         1v {nl}  [nl_rdw]
== CANDIDATES NEW == (none)
```

12/12 keys fire, 0 inert. All 12 produced strings were also replayed byte-exact through the real `Normalizer#classify` before keying.

## Audits

- **TAN cap (`reconciler.rb:261`)** — targets sit at `sea-lion-07` 0/25, `yuan-plus` 0/25, `yuan-pro` 0/25, `etp3` 1/25. No TAN count changes anywhere in the catalog; 185 ids at the cap in both control and treatment. Zero exposure.
- **Rename-value liveness (`scripts/audit_rename_value_liveness.rb`)** — all 15 distinct values in the BYD block resolve to live records, including the four used here. **Zero BYD lines in either risk list.** (The repo-wide 451 dead / 34 resurrection figures are pre-existing and unchanged by this PR.)
- **Dead curation** — probe build with the entire `BYD:` block removed: **44/44 keys fire** (37 re-appear as a candidate or their own published id or are slug-identical display fixes; 7 are `junk?` paren-rescues whose rows are *deleted* without the key, so their absence is the proof). Zero dead lines. Stamped valid as of this base; re-run at merge.
- **Retirement bookkeeping** — 0 published ids retired, so no `former_ids` alias and no `removals.yml` manifest is owed (and neither is written).

## What I declined, and why

1. **Every trim key onto an UNPUBLISHED head** — `Sea Lion 06 *` (4 strings), `Sea Lion 05 *` (2), `Song Plus *` (6), `Song L *` (2), `Tang L *` (3), `Yuan Up Top`, `Song Champion`. A key onto an unpublished head consolidates candidate mass and rescues nothing; no head reaches `KIND_THRESHOLDS[:car] = 1000` even fully consolidated (`Sea Lion 06` → 659, `Song Plus` → 423, `Song L` → 375, `Tang L` → 139). The dossier's own ordering constraint says not to ship these, and I agree.
2. **`Song Plus EV` (50) and `Song Plus Dm I` (38) specifically** — beyond gaining nothing, folding them destroys the axis that resolves D-3's one-to-many. `Song Plus EV` → the BEV `Seal U`; `Song Plus DM-i` → the PHEV `Sealion 6`. **`ua_mvs`'s FUEL column separates them perfectly**: `SONG PLUS EV` is 71/71 `ЕЛЕКТРО`, `SONG PLUS DM I` is 38/39 `ЕЛЕКТРО АБО БЕНЗИН`. The powertrain token *is* the discriminator, and under EV rule 3 it is exactly the evidence a future `powertrains` field needs.
3. **`Shark Dmo GS` (123 ar) + `Shark 6` (2 nz)** — this *would* mint a published id on the two-source arm, and the dossier missed that route here too. **I still declined it**: the registers do not agree on the nameplate (nz writes `SHARK 6`, ar never writes a numeral), so folding requires asserting that ar's Shark is nz's Shark 6 *and* choosing `Shark 6` as canonical. BYD genuinely uses both "Shark" and "Shark 6" in different markets, which makes it a possible D-3 market-name pair rather than a spelling cluster. Minting a published id on an inference is worse than leaving 125 vehicles in the queue. Contrast with `Yuan Pro`, where **both** registers write the nameplate literally.
4. **The legacy hyphen block** — `E-6` → `E6` would add `(ua, ua_mvs)` to the published `car/byd/e6` for one vehicle. `ua_mvs` demonstrably inserts a hyphen BYD never used (`F-0`, `F-3`, `F-3R`, `F-6`, `G-3`, `G-6`, `S-6`, `E-2`, `E-6` — nine strings, one register, one shape), but the dossier states plainly that it could not verify BYD's closed forms against any first-party material, and my web budget is exhausted. **Availability is load-bearing; I will not add a country to a published record on a pattern.** Named and sized instead.
5. **`Seal 06` / `Seal 06GT` → `Seal 6`** — the `car/byd/seal-6` attribution is contested (dossier §E.1: `enrich/byd.yml` says Qin Plus, first-party evidence points at 海豹06). Nothing is keyed until that is settled.
6. **`Dolphin Mini EV GS`/`GL`, `Atto 1`, `Seagull`** — market names of one product under D-3. Two records, related, never folded.
7. **`K7U` / `12M` → `Ebus`** — held on a source-side comma-join decision already adjudicated in `enrich/byd.yml`; no availability gain (both nl).
8. **`Leopard *` (16 strings, 504 vehicles)** — Fangchengbao/Denza/Yangwang are separate marques under make BYD; `moves.yml` business, not renames, and no target make clears the ≥2-source rule.

## Notes for the reviewer

- **CI will be red on this PR, and it is red on `main` too.** One spotcheck fails **identically in control and treatment**: `mercedes-benz/amg availability [es,fi,lu,nl,nz] missing gb`. The control is a pristine `origin/main` worktree with zero modifications, so this is not mine. It is a cross-repo lockstep gap: pipeline `#144`'s `FW_POOLS` moved the 57,573 gb `MERCEDES AMG CLASS` vehicles off the `mercedes-benz/amg` stub onto real AMG nameplates, while `spotchecks.yml:469` still asserts that stub carries `gb`. No branch fixes it yet. Reported separately; deliberately not touched here, because that row's own text calls it a tripwire and retargeting it is the AMG lane's call.
- **A frozen-cache build is not hermetic.** Both sides made the same live probe and got the same 404 (`es_dgt` month 202607 unavailable), but identical failure text is not guaranteed between runs.
- **Merge order**: this PR **first**, then the pipeline companion. The pipeline PR's notes describe measured outcomes of this one. There is no lint coupling in either direction, so a reversed merge is safe but leaves the prose ahead of the facts for a window.
