### PR TITLE
plates: it — Italy, 20 series + province decode table (L1 wave 1)

### DIFF
--- a/plates/_decode/it-provinces.yml
+++ b/plates/_decode/it-provinces.yml
@@ -1,0 +1,348 @@
+# plates/_decode/it-provinces.yml — Italy's two province-keyed code tables.
+#
+# THE SOURCE FINDING, and it is the same shape as the Spanish one: this is NOT
+# Wikipedia. Both tables are ENACTED LAW — Appendice XI al Titolo III of the
+# Regolamento di esecuzione e di attuazione del nuovo codice della strada
+# (D.P.R. 16 dicembre 1992, n. 495), read off Normattiva's Akoma-Ntoso export of
+# the consolidated act. Every row below is that appendix, verbatim, in its own
+# printed order, including its typographical defects (see `sic` below).
+#
+# TWO TABLES, NOT ONE, AND THEY DO NOT INTERCHANGE. This is the trap the file
+# exists to prevent:
+#
+#   * `mctc_offices` (Appendice XI comma 1) — the sigle of the provincial
+#     motorisation offices, a LETTER PLUS A NUMBER (A1 Alessandria, B6 Milano,
+#     P4 Roma, X4 Oristano). This is the PREFIX OF THE TARGA PROVVISORIA
+#     (art. 255 comma 2 lett. a)). Referenced by: it-temporary-provvisoria.
+#   * `province_sigle` (Appendice XI comma 1-bis) — the two-letter sigle of the
+#     provinces, which is what the RIGHT-HAND STICKER on a modern plate carries
+#     (art. 256 comma 4-bis + art. 260 comma 3), and what the pre-1993 provincial
+#     plates carried in the mark itself. Referenced by: it-standard-1999
+#     (sticker only), it-provincial-1959, it-provincial-motorcycle-1959.
+#
+# Rome is P4 in the first table and the literal word "Roma" in the second. A
+# decoder that reaches for the wrong table on an Italian string will produce
+# confident nonsense.
+#
+# WHAT THE STICKER ACTUALLY MEANS (art. 260 comma 3, verbatim): the lower
+# sticker "reca in bianco la sigla della PROVINCIA DI RESIDENZA DELL'INTESTATARIO
+# della carta di circolazione", and both stickers "non formano parte integrante
+# della targa e non influiscono ai fini dell'identificazione del veicolo e del
+# relativo intestatario". So on a post-1999 plate the code is (a) removable,
+# (b) about the KEEPER'S RESIDENCE rather than the place of registration, and
+# (c) legally not part of the plate. On a pre-1993 plate the sigla is in the mark
+# and denotes the province OF REGISTRATION (art. 320 D.P.R. 420/1959). Same two
+# letters, opposite semantics, and a parse API must not blend them. This is
+# Italy's version of the French SIV caution recorded in PRD-PLATES §2.4.
+jurisdiction: it
+topic: provinces
+authority:
+  name: "D.P.R. 16 dicembre 1992, n. 495 — Appendice XI al Titolo III (introdotta/modificata dal D.P.R. 4 settembre 1998, n. 355, art. 5)"
+  url: "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495"
+sources:
+  - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XI al Titolo III, comma 1 (sigle degli uffici provinciali M.C.T.C.) and comma 1-bis (sigle delle province) — every row below, verbatim; accessed 2026-08-02"
+  - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20160101  # the SAME appendix at 1 January 2016, which still carries the four sigle later withdrawn (Carbonia-Iglesias CI, Medio Campidano VS, Ogliastra OG, Olbia-Tempio OT) — the primary for the `withdrawn` rows"
+  - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art255  # art. 255 comma 2 lett. a): the office sigla is the first element of a targa provvisoria, and the list 'può essere aggiornato con decreto del Ministro dei trasporti e della navigazione, a seguito dell'istituzione di ulteriori province'"
+  - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art260  # art. 260 comma 3: what the two stickers carry and their legal non-status"
+period: { start: 1998 }
+period_evidence: instrument-in-force
+period_note: >-
+  Italian province sigle long predate 1998 — they are commonly said to date from
+  1927, for which NO PRIMARY was secured and which is therefore recorded as
+  folklore rather than as a period claim. 1998 is the date of D.P.R. 4 settembre
+  1998, n. 355, the instrument that inserted the list read here (its art. 5
+  amended Appendice XI). A physical plate older than 1998 must be decoded
+  through this table with care: provinces created in 1992 (Lecco LC, Lodi LO,
+  Rimini RN, Prato PO, Crotone KR, Vibo Valentia VV, Verbano-Cusio-Ossola VB) and
+  later (Monza-Brianza MB, Fermo FM, Barletta-Andria-Trani BT in 2004-2009, Sud
+  Sardegna SU in 2016) never appeared on a provincial-era plate at all.
+
+# PERIOD DISCIPLINE (PRD-PLATES §2.4). D.P.R. 20 luglio 2017, n. 140 (GU
+# 22-09-2017 n. 222) withdrew four sigle and added one, and its art. 2 comma 2
+# states the rule every decode table of this kind needs, verbatim:
+#   "I veicoli dotati di targhe di immatricolazione con le sigle delle province,
+#    di cui al comma 1, possono continuare a circolare fino a una nuova
+#    immatricolazione o fino alla cessazione dalla circolazione."
+# Withdrawn codes therefore stay on the road indefinitely and rows are CLOSED BY
+# PERIOD, never deleted — exactly as § 9 Abs. 3 FZV requires for German district
+# codes (plates/de.yml).
+withdrawn_rule_source: "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # AGGIORNAMENTO (55) to Appendice XI: D.P.R. 20 luglio 2017, n. 140, art. 2 comma 2"
+
+# Disambiguation notes a parse API must carry:
+#   * EVERY province sigla is exactly two letters EXCEPT Roma, which the appendix
+#     prints as the whole word "Roma". There is consequently no maximal-munch
+#     problem of the Spanish kind (C vs CA vs CC vs CE...) — the only special
+#     case is the four-letter one. Appendice XII comma 3 legislates the
+#     abbreviation for the one place it is needed: "Nel caso in cui la targa del
+#     veicolo traente contenga la parola Roma essa viene riportata sulla targa
+#     ripetitrice mediante la sigla RM."
+#   * The dataset records serials uppercase (plates/_meta/separators.yml
+#     `case: upper`), so "Roma" is matched as ROMA. The appendix's mixed-case
+#     printing is preserved in `printed_as`.
+#   * Three sigle carry a heraldic device the appendix describes in words and
+#     which a render pipeline must not silently drop: Aosta ("La O è sormontata
+#     dallo stemma"), Bolzano ("La Z è sormontata dallo stemma"), Trento ("La N è
+#     sormontata dallo stemma"). PRD-PLATES §3 placeholder rule applies to those
+#     three emblems.
+maximal_munch: false
+
+province_sigle:
+  - { code: "AG", name: "Agrigento" }
+  - { code: "AL", name: "Alessandria" }
+  - { code: "AN", name: "Ancona" }
+  - { code: "AO", name: "Aosta", emblem_note: "La O è sormontata dallo stemma" }
+  - { code: "AR", name: "Arezzo" }
+  - { code: "AP", name: "Ascoli Piceno" }
+  - { code: "AT", name: "Asti" }
+  - { code: "AV", name: "Avellino" }
+  - { code: "BA", name: "Bari" }
+  - { code: "BT", name: "Barletta - Andria-Trani", printed_as: "Barletta - Andria-Trani" }
+  - { code: "BL", name: "Belluno" }
+  - { code: "BN", name: "Benevento" }
+  - { code: "BG", name: "Bergamo" }
+  - { code: "BI", name: "Biella" }
+  - { code: "BO", name: "Bologna" }
+  - { code: "BZ", name: "Bolzano", emblem_note: "La Z è sormontata dallo stemma" }
+  - { code: "BS", name: "Brescia" }
+  - { code: "BR", name: "Brindisi" }
+  - { code: "CA", name: "Cagliari" }
+  - { code: "CL", name: "Caltanissetta" }
+  - { code: "CB", name: "Campobasso" }
+  - { code: "CE", name: "Caserta" }
+  - { code: "CT", name: "Catania" }
+  - { code: "CZ", name: "Catanzaro" }
+  - { code: "CH", name: "Chieti" }
+  - { code: "CO", name: "Como" }
+  - { code: "CS", name: "Cosenza" }
+  - { code: "CR", name: "Cremona" }
+  - { code: "KR", name: "Crotone" }
+  - { code: "CN", name: "Cuneo" }
+  - { code: "EN", name: "Enna" }
+  - { code: "FM", name: "Fermo" }
+  - { code: "FE", name: "Ferrara" }
+  - { code: "FI", name: "Firenze" }
+  - { code: "FG", name: "Foggia" }
+  - { code: "FC", name: "Forlì Cesena", printed_as: "Forli' Cesena" }
+  - { code: "FR", name: "Frosinone" }
+  - { code: "GE", name: "Genova" }
+  - { code: "GO", name: "Gorizia" }
+  - { code: "GR", name: "Grosseto" }
+  - { code: "IM", name: "Imperia" }
+  - { code: "IS", name: "Isernia" }
+  - { code: "AQ", name: "L'Aquila" }
+  - { code: "SP", name: "La Spezia" }
+  - { code: "LT", name: "Latina" }
+  - { code: "LE", name: "Lecce" }
+  - { code: "LC", name: "Lecco" }
+  - { code: "LI", name: "Livorno" }
+  - { code: "LO", name: "Lodi" }
+  - { code: "LU", name: "Lucca" }
+  - { code: "MC", name: "Macerata" }
+  - { code: "MN", name: "Mantova" }
+  - { code: "MS", name: "Massa Carrara" }
+  - { code: "MT", name: "Matera" }
+  - { code: "ME", name: "Messina" }
+  - { code: "MI", name: "Milano" }
+  - { code: "MO", name: "Modena" }
+  - { code: "MB", name: "Monza-Brianza" }
+  - { code: "NA", name: "Napoli" }
+  - { code: "NO", name: "Novara" }
+  - { code: "NU", name: "Nuoro" }
+  - { code: "OR", name: "Oristano" }
+  - { code: "PD", name: "Padova" }
+  - { code: "PA", name: "Palermo" }
+  - { code: "PR", name: "Parma" }
+  - { code: "PV", name: "Pavia" }
+  - { code: "PG", name: "Perugia" }
+  - { code: "PU", name: "Pesaro e Urbino" }
+  - { code: "PE", name: "Pescara" }
+  - { code: "PC", name: "Piacenza" }
+  - { code: "PI", name: "Pisa" }
+  - { code: "PT", name: "Pistoia" }
+  - { code: "PN", name: "Pordenone" }
+  - { code: "PZ", name: "Potenza" }
+  - { code: "PO", name: "Prato" }
+  - { code: "RG", name: "Ragusa" }
+  - { code: "RA", name: "Ravenna" }
+  - { code: "RC", name: "Reggio Calabria" }
+  - { code: "RE", name: "Reggio Emilia" }
+  - { code: "RI", name: "Rieti" }
+  - { code: "RN", name: "Rimini" }
+  - { code: "ROMA", name: "Roma", printed_as: "Roma", note: "the appendix prints the sigla as the whole word 'Roma'; Appendice XII comma 3 substitutes 'RM' on repeater plates" }
+  - { code: "RO", name: "Rovigo" }
+  - { code: "SA", name: "Salerno" }
+  - { code: "SS", name: "Sassari" }
+  - { code: "SV", name: "Savona" }
+  - { code: "SI", name: "Siena" }
+  - { code: "SR", name: "Siracusa" }
+  - { code: "SO", name: "Sondrio" }
+  - { code: "SU", name: "Sud Sardegna", added_by: "D.P.R. 20 luglio 2017, n. 140", period: { start: 2017 } }
+  - { code: "TA", name: "Taranto" }
+  - { code: "TE", name: "Teramo" }
+  - { code: "TR", name: "Terni" }
+  - { code: "TO", name: "Torino" }
+  - { code: "TP", name: "Trapani" }
+  - { code: "TN", name: "Trento", emblem_note: "La N è sormontata dallo stemma" }
+  - { code: "TV", name: "Treviso" }
+  - { code: "TS", name: "Trieste" }
+  - { code: "UD", name: "Udine" }
+  - { code: "VA", name: "Varese" }
+  - { code: "VE", name: "Venezia" }
+  - { code: "VB", name: "Verbano Cusio Ossola" }
+  - { code: "VC", name: "Vercelli" }
+  - { code: "VR", name: "Verona" }
+  - { code: "VV", name: "Vibo Valentia", printed_as: "Vibo Valenzia", sic: "the appendix misprints the province name as 'Vibo Valenzia'; the code VV is unaffected" }
+  - { code: "VI", name: "Vicenza" }
+  - { code: "VT", name: "Viterbo" }
+
+# WITHDRAWN, NOT DELETED. These four sigle were removed from Appendice XI by
+# D.P.R. 20 luglio 2017, n. 140 when the four Sardinian provinces were
+# reorganised into Sud Sardegna, and vehicles carrying them "possono continuare a
+# circolare fino a una nuova immatricolazione o fino alla cessazione dalla
+# circolazione" (art. 2 comma 2). A decoder must still resolve them.
+province_sigle_withdrawn:
+  - { code: "CI", name: "Carbonia-Iglesias", period: { start: 1998, end: 2017 }, withdrawn_by: "D.P.R. 20 luglio 2017, n. 140" }
+  - { code: "VS", name: "Medio Campidano", period: { start: 1998, end: 2017 }, withdrawn_by: "D.P.R. 20 luglio 2017, n. 140" }
+  - { code: "OG", name: "Ogliastra", period: { start: 1998, end: 2017 }, withdrawn_by: "D.P.R. 20 luglio 2017, n. 140" }
+  - { code: "OT", name: "Olbia-Tempio", period: { start: 1998, end: 2017 }, withdrawn_by: "D.P.R. 20 luglio 2017, n. 140" }
+
+# ---------------------------------------------------------------------------
+# Appendice XI comma 1 — the M.C.T.C. provincial office sigle. The bare region
+# letters (A, B, C, ...) are HEADINGS in the appendix's own layout, not codes: no
+# targa provvisoria carries a bare letter. Recorded because they explain the
+# numbering and because F, G, I, J, K, Q, U, Y and Z are unused, which is itself
+# a useful validation fact.
+# ---------------------------------------------------------------------------
+mctc_offices:
+  used_by: "plates/it.yml#it-temporary-provvisoria"
+  maintenance: "art. 255 comma 2 lett. a): the list 'può essere aggiornato con decreto del Ministro dei trasporti e della navigazione, a seguito dell'istituzione di ulteriori province' — it grows by ministerial decree, so rows need period discipline as provinces are created"
+  regions:
+    A: "Piemonte e Valle d'Aosta"
+    B: "Lombardia"
+    C: "Trentino Alto Adige"
+    D: "Veneto"
+    E: "Friuli Venezia Giulia"
+    H: "Liguria"
+    L: "Emilia Romagna"
+    M: "Toscana"
+    N: "Umbria"
+    O: "Marche"
+    P: "Lazio"
+    R: "Abruzzo e Molise"
+    S: "Campania e Basilicata"
+    T: "Puglia"
+    V: "Calabria"
+    W: "Sicilia"
+    X: "Sardegna"
+  regions_note: "F, G, I, J, K, Q, U, Y and Z are not used as region letters; the groupings are administrative and pair Piemonte with Valle d'Aosta, Abruzzo with Molise and Campania with Basilicata."
+  codes:
+    - { code: "A1", name: "Alessandria" }
+    - { code: "A2", name: "Aosta" }
+    - { code: "A3", name: "Asti" }
+    - { code: "A4", name: "Cuneo" }
+    - { code: "A5", name: "Novara" }
+    - { code: "A6", name: "Torino" }
+    - { code: "A7", name: "Vercelli" }
+    - { code: "A8", name: "Biella" }
+    - { code: "A9", name: "Verbania" }
+    - { code: "B1", name: "Bergamo" }
+    - { code: "B2", name: "Brescia" }
+    - { code: "B3", name: "Como" }
+    - { code: "B4", name: "Cremona" }
+    - { code: "B5", name: "Mantova" }
+    - { code: "B6", name: "Milano" }
+    - { code: "B7", name: "Pavia" }
+    - { code: "B8", name: "Sondrio" }
+    - { code: "B9", name: "Varese" }
+    - { code: "B10", name: "Lecco" }
+    - { code: "B11", name: "Lodi" }
+    - { code: "B12", name: "Monza-Brianza", printed_as: "B 12", sic: "the appendix prints a space inside the code" }
+    - { code: "C1", name: "Bolzano" }
+    - { code: "C2", name: "Trento" }
+    - { code: "D1", name: "Belluno" }
+    - { code: "D2", name: "Padova" }
+    - { code: "D3", name: "Rovigo" }
+    - { code: "D4", name: "Treviso" }
+    - { code: "D5", name: "Venezia" }
+    - { code: "D6", name: "Verona" }
+    - { code: "D7", name: "Vicenza" }
+    - { code: "E1", name: "Gorizia" }
+    - { code: "E2", name: "Udine" }
+    - { code: "E3", name: "Pordenone" }
+    - { code: "E4", name: "Trieste" }
+    - { code: "H1", name: "Genova" }
+    - { code: "H2", name: "Imperia" }
+    - { code: "H3", name: "La Spezia" }
+    - { code: "H4", name: "Savona" }
+    - { code: "L1", name: "Bologna" }
+    - { code: "L2", name: "Ferrara" }
+    - { code: "L3", name: "Forlì", printed_as: "Forli'" }
+    - { code: "L4", name: "Modena" }
+    - { code: "L5", name: "Parma" }
+    - { code: "L6", name: "Piacenza" }
+    - { code: "L7", name: "Ravenna" }
+    - { code: "L8", name: "Reggio Emilia" }
+    - { code: "L9", name: "Rimini" }
+    - { code: "M1", name: "Arezzo" }
+    - { code: "M2", name: "Firenze" }
+    - { code: "M3", name: "Grosseto" }
+    - { code: "M4", name: "Livorno" }
+    - { code: "M5", name: "Lucca" }
+    - { code: "M6", name: "Massa Carrara" }
+    - { code: "M7", name: "Pisa" }
+    - { code: "M8", name: "Pistoia" }
+    - { code: "M9", name: "Siena" }
+    - { code: "M10", name: "Prato" }
+    - { code: "N1", name: "Perugia" }
+    - { code: "N2", name: "Terni" }
+    - { code: "O1", name: "Ancona" }
+    - { code: "O2", name: "Ascoli Piceno" }
+    - { code: "O3", name: "Macerata" }
+    - { code: "O4", name: "Pesaro" }
+    - { code: "O5", name: "Fermo", printed_as: "05", sic: "the appendix prints a zero where every other Marche code has the letter O; read as O5" }
+    - { code: "P1", name: "Frosinone" }
+    - { code: "P2", name: "Latina" }
+    - { code: "P3", name: "Rieti" }
+    - { code: "P4", name: "Roma" }
+    - { code: "P5", name: "Viterbo" }
+    - { code: "R1", name: "Campobasso" }
+    - { code: "R2", name: "Chieti" }
+    - { code: "R3", name: "L'Aquila" }
+    - { code: "R4", name: "Pescara" }
+    - { code: "R5", name: "Teramo" }
+    - { code: "R6", name: "Isernia" }
+    - { code: "S1", name: "Avellino" }
+    - { code: "S2", name: "Benevento" }
+    - { code: "S3", name: "Caserta" }
+    - { code: "S4", name: "Matera" }
+    - { code: "S5", name: "Napoli" }
+    - { code: "S6", name: "Potenza" }
+    - { code: "S7", name: "Salerno" }
+    - { code: "T1", name: "Bari" }
+    - { code: "T2", name: "Brindisi" }
+    - { code: "T3", name: "Foggia" }
+    - { code: "T4", name: "Lecce" }
+    - { code: "T5", name: "Taranto" }
+    - { code: "T6", name: "Barletta-Andria-Trani" }
+    - { code: "V1", name: "Catanzaro" }
+    - { code: "V2", name: "Cosenza" }
+    - { code: "V3", name: "Reggio Calabria" }
+    - { code: "V4", name: "Crotone" }
+    - { code: "V5", name: "Vibo Valentia" }
+    - { code: "W1", name: "Agrigento" }
+    - { code: "W2", name: "Caltanissetta" }
+    - { code: "W3", name: "Catania" }
+    - { code: "W4", name: "Enna" }
+    - { code: "W5", name: "Messina" }
+    - { code: "W6", name: "Palermo" }
+    - { code: "W7", name: "Ragusa" }
+    - { code: "W8", name: "Siracusa" }
+    - { code: "W9", name: "Trapani" }
+    - { code: "X1", name: "Cagliari" }
+    - { code: "X2", name: "Nuoro" }
+    - { code: "X3", name: "Sassari" }
+    - { code: "X4", name: "Oristano" }
+  gaps:
+    - "No office code exists for Sud Sardegna, nor for the four Sardinian provinces withdrawn in 2017 — the office list and the province list were maintained on different schedules and do not correspond one-to-one."
+    - "Verbania (A9) is the office; the province is Verbano-Cusio-Ossola (VB). The names are not interchangeable."
+    - "The appendix gives no office for the pre-1992 provinces that no longer exist, and none for provinces created after the last amendment to comma 1 — recorded gap."

--- a/plates/it.yml
+++ b/plates/it.yml
@@ -1,0 +1,1317 @@
+# plates/it.yml — Italy (PRD-PLATES gate L1).
+#
+# EVERY format, colour, dimension and period claim in this file comes from the
+# consolidated text of the REGOLAMENTO DI ESECUZIONE E DI ATTUAZIONE DEL NUOVO
+# CODICE DELLA STRADA — D.P.R. 16 dicembre 1992, n. 495 (GU n. 303 del
+# 28-12-1992, Suppl. Ordinario n. 134) — read article by article and appendix by
+# appendix off Normattiva's own Akoma-Ntoso export of the act, together with the
+# CODICE DELLA STRADA itself (D.Lgs. 30 aprile 1992, n. 285, GU n. 114 del
+# 18-05-1992, S.O. n. 74), D.P.R. 24 novembre 2001, n. 474 (trade plates) and,
+# for the pre-1993 provincial system, the regulation the 1992 regolamento
+# replaced: D.P.R. 30 giugno 1959, n. 420.
+#
+# The L0 EU research dossier recorded Italy as its worst gap — "**No primary
+# source secured.** Everything below is from Wikipedia and must be confirmed
+# against the Codice della Strada and DPR 495/1992" (plates-research-eu-intl.md
+# §2.5 and DEAD-ENDS §8). This file closes that gap: every claim below is
+# instrument-dated, and where the primaries and the enthusiast web disagree the
+# disagreement is RECORDED rather than averaged (PRD-PLATES §5.3).
+#
+# THE SIX STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. THE SERIAL GRAMMAR IS APPENDICE XII, AND IT IS COMPLETE AND SMALL.
+#    Art. 257 comma 1 delegates: "I criteri per la formazione dei dati riportati
+#    nelle targhe di cui all'articolo 100, comma 9, del codice, sono quelli
+#    riportati nell'appendice XII al presente titolo." Appendice XII then spells
+#    out, per vehicle kind, the ORDER of the imprinted elements — e.g. for cars,
+#    verbatim: "due caratteri alfabetici, il marchio ufficiale della Repubblica
+#    italiana, tre caratteri numerici e due caratteri alfabetici". Its comma 2
+#    gives the alphabet, verbatim: "I caratteri alfabetici utilizzabili sono: A,
+#    B, C, D, E, F, G, H, J, K, L, M, N, P, R, S, T, V, W, X, Y, Z". Twenty-two
+#    letters; I, O, Q and U are the four the authority never issues. Comma 2 also
+#    gives the progression, verbatim: "La progressione, entro il campo numerico,
+#    procede secondo la naturale sequenza da destra verso sinistra. I caratteri
+#    alfabetici ... progrediscono in successione da destra verso sinistra,
+#    ciascuno avanzando ad ogni completamento della serie numerica."
+#
+# 2. THE MARCHIO IS NOT A SEPARATOR — IT IS WHAT SITS IN THE GAP. Art. 262
+#    verbatim: "Il marchio ufficiale, che le targhe di ogni tipo devono portare,
+#    è costituito da una stella a cinque punte tra un ramo di olivo ed uno di
+#    quercia, della forma e dimensioni di cui alla figura III.5." Appendice XII
+#    always names it BETWEEN two character groups, so the printed gaps on an
+#    Italian plate are occupied by an emblem, exactly as the German gap is
+#    occupied by the Plaketten (see plates/de.yml). The dataset writes those gaps
+#    as the emitted SPACE separator (PRD-PLATES §2.6) and carries the emblem in
+#    `design.emblem`; no glyph is ever inside an Italian serial.
+#
+# 3. 1993, NOT 1994 — AND THE PRIMARY SAYS SO TWICE. Art. 260 comma 5 as
+#    originally enacted: "Il sistema di targatura stabilito dal presente
+#    regolamento entra in vigore, ai sensi dell'articolo 235, comma 7, del
+#    codice, a partire dal 1 luglio 1993 progressivamente con l'esaurimento delle
+#    targhe di vecchio tipo ancora in giacenza presso gli uffici provinciali
+#    della Direzione generale della M.C.T.C." As amended (text in force from
+#    1997) the date reads "((a partire dal 1 ottobre 1993))" with a hard backstop
+#    "((e comunque non oltre il 31 dicembre 1996))". The ubiquitous "1994" start
+#    date for AA 000 AA is UNCITED wherever it appears (it.wikipedia gives
+#    "dal 28 febbraio 1994" with no source of any kind) and is recorded here as
+#    folklore, not as a period claim. What the primary supports is: legal
+#    commencement 1 October 1993, progressive rollout as each provincial office
+#    exhausted its old-type stock, everything over by 31 December 1996 — which is
+#    also, by the same sentence, the LAST year a provincial plate could issue.
+#
+# 4. THE 1999 CHANGE IS A DESIGN CHANGE, NOT A FORMAT CHANGE — one instrument,
+#    D.P.R. 4 settembre 1998, n. 355 (GU 14-10-1998 n. 240), did all of it: it
+#    rewrote Appendice XII lett. a) and c) to add "una zona rettangolare a
+#    sinistra dove, su fondo blu, è impressa in giallo nella parte superiore la
+#    corona di stelle simbolo della Unione europea e nella parte inferiore è
+#    impressa in bianco la lettera I" plus "una zona rettangolare a destra, a
+#    fondo blu"; it inserted art. 256 comma 4-bis (the province sigla); it
+#    rewrote art. 258's dimensions (the plate physically GREW: 340x109 -> 360x110
+#    front, 486x109 -> 520x110 rear); it rewrote art. 260 comma 3 (the two
+#    stickers) and comma 5, which now names the switchover date itself: "le nuove
+#    targhe in uso dal 1 gennaio 1999". Art. 260 comma 5 also settles that the
+#    SERIAL survived the change — a 1993-series plate may be swapped for a
+#    1999-series one "con la stessa sigla alfanumerica ... senza che si configuri
+#    l'ipotesi di reimmatricolazione".
+#
+# 5. THE RIGHT-HAND BLUE ZONE IS PART OF THE PLATE; WHAT IT CARRIES IS NOT.
+#    Art. 260 comma 3, verbatim: "Nelle targhe di immatricolazione degli
+#    autoveicoli, dei rimorchi e dei motoveicoli la zona rettangolare posta
+#    all'estrema destra è destinata a contenere due talloncini in materiale
+#    autoadesivo, CHE NON FORMANO PARTE INTEGRANTE DELLA TARGA E NON INFLUISCONO
+#    AI FINI DELL'IDENTIFICAZIONE DEL VEICOLO E DEL RELATIVO INTESTATARIO: il
+#    primo, da applicarsi nella parte alta, reca in giallo le ultime due cifre
+#    dell'anno di immatricolazione; il secondo, da applicarsi nella parte bassa,
+#    reca in bianco la sigla della provincia di residenza dell'intestatario della
+#    carta di circolazione." So Italy's celebrated year+province band is, in the
+#    regulation's own words, two removable stickers that are not part of the
+#    plate — which is exactly why they are modelled here as
+#    `design.right_field.stickers` and NOT as serial characters, and why their
+#    absence proves nothing. Note also whose province it is: the province of
+#    RESIDENCE OF THE REGISTRATION-DOCUMENT HOLDER, not of the registering
+#    office.
+#
+# 6. THE MINISTER MAY DEVIATE WITHOUT AMENDING THE APPENDIX. Art. 257 comma 2,
+#    verbatim: "Fermo restando quanto previsto dall'articolo 246, il Ministro dei
+#    trasporti può, in caso di particolari esigenze, stabilire una successione ed
+#    un impiego di caratteri alfanumerici diversi da quelli indicati al comma 1
+#    della suddetta appendice XII." This is the single most important sourcing
+#    caveat for Italy: a ministerial decree can lawfully put a different
+#    character succession on the road than the appendix prints, without leaving a
+#    trace in the regolamento. It is the reason the MOTORCYCLE series below is
+#    `matching: recall-only` — see its notes.
+#
+# REGEX POLICY, as in plates/de.yml and plates/nl.yml: `format.regex` is the
+# lint-round-trippable regex written in PRINTED form (§2.6 rule 2), with the
+# inter-group gap spelled as an optional emitted SPACE because Appendice XII
+# prescribes a marchio in the gap and no separator glyph. `format.regex_strict`
+# carries the sourced twenty-two-letter alphabet of Appendice XII comma 2, which
+# `regex` cannot carry because the lint's pattern generator emits all 26 letters
+# for an "L".
+jurisdiction: it
+authority:
+  name: Ministero delle Infrastrutture e dei Trasporti — Dipartimento per i trasporti terrestri (ex Direzione generale della M.C.T.C.)
+  url: "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495"
+binding: vehicle
+binding_note: >-
+  VEHICLE-bound today, but with a dormant statutory switch that a consumer must
+  know about. Art. 100 comma 3-bis of the Codice della Strada reads, verbatim:
+  "Le targhe di cui ai commi 1, 2 e 3 sono personali, non possono essere abbinate
+  contemporaneamente a più di un veicolo e sono trattenute dal titolare in caso
+  di trasferimento di proprietà, costituzione di usufrutto, stipulazione di
+  locazione con facoltà di acquisto, esportazione all'estero e cessazione o
+  sospensione dalla circolazione" — i.e. a Swiss-style OWNER binding. It is not
+  in force: L. 29 luglio 2010, n. 120, art. 11 comma 6 provides that art. 100
+  comma 3-bis "si applica a decorrere dal sesto mese successivo alla data di
+  entrata in vigore del regolamento di cui al comma 5", and no such regolamento
+  was found in this pass (recorded gap). `binding: vehicle` is therefore the
+  current fact and `binding: owner` is a scheduled future one. The MOPED series
+  is the exception and already carries `binding: owner` — see it-moped-2006.
+instrument:
+  citation: "Decreto del Presidente della Repubblica 16 dicembre 1992, n. 495 — Regolamento di esecuzione e di attuazione del nuovo codice della strada (GU n. 303 del 28-12-1992, Suppl. Ordinario n. 134)"
+  ausfertigungsdatum: "1992-12-16"
+  gazzetta: "GU Serie Generale n. 303 del 28-12-1992 — Suppl. Ordinario n. 134"
+  enabling_act: "D.Lgs. 30 aprile 1992, n. 285 (Nuovo codice della strada), GU n. 114 del 18-05-1992, S.O. n. 74 — artt. 97, 99, 100, 131, 134, 138"
+  replaces: "D.P.R. 30 giugno 1959, n. 420 (regolamento del T.U. delle norme sulla circolazione stradale, D.P.R. 15 giugno 1959, n. 393)"
+  amendments_that_touch_plates:
+    - "D.P.R. 16 settembre 1996, n. 610 (SO n. 212 alla GU 04-12-1996 n. 284) — moved the targatura commencement to 1 ottobre 1993 and added the 31-12-1996 backstop in art. 260 c. 5; widened the repeater-plate box count in Appendice XII lett. h) and i)"
+    - "D.P.R. 4 settembre 1998, n. 355 (GU 14-10-1998 n. 240) — THE 1999 PLATE: EU band + right-hand blue zone in Appendice XII a) and c); art. 256 c. 4-bis; art. 258 dimensions incl. the new 177x177 motorcycle plate; art. 260 c. 1 c-bis), c. 3 and c. 5; Appendice XI (province sigle); Appendice XIII; the Allegati figures"
+    - "D.P.R. 24 novembre 2001, n. 474 (GU 30-01-2002 n. 25) — abrogated the targa prova from the regolamento (Appendice XII lett. l)-o), art. 254, art. 260 c. 1 lett. b)) and re-enacted it with a new format in its own art. 2"
+    - "D.P.R. 6 marzo 2006, n. 153 (GU 15-04-2006 n. 89) — turned the moped 'contrassegno di identificazione' into a 'targa' (artt. 248-250)"
+    - "D.P.R. 28 settembre 2012, n. 198 (GU 22-11-2012 n. 273) — trailers moved from their own 'Rimorchio' format onto the car format; art. 8 c. 1: in force from the ninetieth day after publication and 'si applicano ai soli rimorchi immatricolati successivamente' to that date"
+    - "D.P.R. 20 luglio 2017, n. 140 (GU 22-09-2017 n. 222) — withdrew four province sigle and added Sud Sardegna; art. 2 c. 2: 'I veicoli dotati di targhe di immatricolazione con le sigle delle province, di cui al comma 1, possono continuare a circolare fino a una nuova immatricolazione o fino alla cessazione dalla circolazione'"
+  source: "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Normattiva Akoma-Ntoso export of the consolidated DPR 495/1992 — the whole act incl. Appendici XI, XII and XIII and the AGGIORNAMENTO notes; accessed 2026-08-02"
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+common:
+  alphabet:
+    letters: [A, B, C, D, E, F, G, H, J, K, L, M, N, P, R, S, T, V, W, X, Y, Z]
+    letters_excluded: [I, O, Q, U]
+    digits: "0-9, all values"
+    verbatim: >-
+      Appendice XII comma 2: "I caratteri numerici di cui alle lettere da a) ad s)
+      del comma 1 assumono tutti i valori da zero a nove. La progressione, entro
+      il campo numerico, procede secondo la naturale sequenza da destra verso
+      sinistra. I caratteri alfabetici, previsti nello stesso comma, progrediscono
+      in successione da destra verso sinistra, ciascuno avanzando ad ogni
+      completamento della serie numerica. I caratteri alfabetici utilizzabili
+      sono: A, B, C, D, E, F, G, H, J, K, L, M, N, P, R, S, T, V, W, X, Y, Z
+      (tabelle da III.3/a a III.3/d che fanno parte integrante del presente
+      regolamento)."
+    note: >-
+      The four excluded letters are I, O, Q and U. The regulation gives the
+      positive list only and states no reason; the usual explanation (I/O/Q
+      confusable with 1/0, U with V) is NOT in the text and is not asserted here.
+      Tabelle III.3/a-III.3/d, which the same comma incorporates, are FIGURES and
+      were not text-extractable — the block-allocation order inside the alphabet
+      is therefore a recorded gap.
+    source: "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII al Titolo III, comma 2 — the 22-letter alphabet and the right-to-left progression, verbatim"
+  marchio_ufficiale:
+    description: "una stella a cinque punte tra un ramo di olivo ed uno di quercia"
+    figure: "figura III.5"
+    verbatim: "Art. 262: 'Il marchio ufficiale, che le targhe di ogni tipo devono portare, è costituito da una stella a cinque punte tra un ramo di olivo ed uno di quercia, della forma e dimensioni di cui alla figura III.5.'"
+    exception: "Appendice XII comma 3: repeater plates carry NO marchio ('contengono soltanto la lettera \"R\" in rosso, senza il marchio ufficiale della Repubblica italiana')."
+    licensing: >-
+      The emblem is the Stella d'Italia between olive and oak — an element of the
+      emblem of the Italian Republic, whose use is regulated independently of
+      copyright. PRD-PLATES §3 placeholder rule applies: renders carry
+      `emblem: {present: true, rendered: placeholder}` until a per-emblem
+      clearance exists.
+    source: "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art262  # art. 262 Marchio ufficiale, verbatim"
+  colours:
+    verbatim: >-
+      Art. 260 comma 1: "Il fondo delle targhe è giallo per le targhe di
+      immatricolazione delle macchine agricole semoventi o trainate, delle
+      macchine operatrici semoventi o trainate e per tutte le targhe ripetitrici;
+      è bianco in tutti gli altri casi ad eccezione delle parti poste
+      all'estremità delle targhe per autoveicoli, loro rimorchi e motoveicoli. I
+      caratteri ed il marchio ufficiale della Repubblica italiana sono neri, la
+      sigla I è bianca, ad eccezione dei casi di seguito indicati: a) colore
+      rosso: scritta RIM. AGR.; lettera R delle targhe ripetitrici; marchio
+      ufficiale e caratteri alfanumerici delle targhe di immatricolazione delle
+      macchine operatrici; ... c) colore azzurro: lettere EE di tutte le targhe
+      previste dall'articolo 134, comma 1, del codice. c-bis) colore nero: sigla I
+      alle targhe per escursionisti esteri, quando prevista."
+    note: >-
+      Every Italian plate colour is a NAMED colour — bianco, giallo, nero, rosso,
+      azzurro, blu — with no RAL or RGB value anywhere in the regolamento or in
+      the Appendice XIII disciplinare's extractable text. Every hex in this file
+      is therefore `hex_basis: observed` (a plausible rendering of the named
+      colour) except black and white, which are marked `spec` because the name
+      determines the value. Contrast Germany, whose Anlage 3 and Anlage 4 do give
+      RAL codes. The photometric/colorimetric limits do exist — Appendice XIII
+      point 4.1 "Le prescrizioni cromatiche relative ai colori bianco, giallo e
+      blu sono contenute al punto 4.1" — but the chromaticity tables at that point
+      are figures and were not text-extractable (recorded gap).
+    source: "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art260  # art. 260 commi 1-3"
+  construction:
+    verbatim: >-
+      Art. 260 comma 2: "Tutti i caratteri alfanumerici e gli elementi
+      complementari impressi nelle targhe sono realizzati mediante imbutitura
+      profonda 1,4 ± 0,1 mm". Appendice XIII punto 2.1: "Il supporto metallico
+      deve essere in lamiera di alluminio tipo Al 99,5 UNI 9001, parte seconda,
+      nelle gradazioni H12, H14 o H24, dello spessore di 1,00 ± 0,05 mm".
+      Appendice XIII punto 1.4: "Le targhe devono essere realizzate con quattro
+      fori di fissaggio del diametro di 5 mm e gli spigoli raccordati."
+    embossing_mm: 1.4
+    embossing_tolerance_mm: 0.1
+    substrate: "aluminium Al 99,5 UNI 9001 (H12/H14/H24), 1.00 ± 0.05 mm, phospho-chromated per UNI 4718 or chromated per UNI 4719"
+    finish: retroreflective
+    fixing_holes: { count: 4, diameter_mm: 5 }
+    retroreflection_required_by: "art. 100 comma 5 del codice: 'Le targhe indicate ai commi 1, 2, 3, 4 devono avere caratteristiche rifrangenti.'"
+    source: "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # art. 260 c. 2 and Appendice XIII al Titolo III, punti 1.1-1.4 and 2.1-2.3"
+  font:
+    name: null
+    statutory_basis: >-
+      NO TYPEFACE IS NAMED ANYWHERE. Art. 260 comma 4: "Le dimensioni delle targhe
+      e il formato dei relativi caratteri sono quelli previsti nelle figure
+      allegate al presente regolamento." Appendice XIII punto 1.2: "Le targhe ...
+      devono essere composte con caratteri alfanumerici conformi a quelli indicati
+      nelle figure stesse, con la spaziatura ivi indicata." Art. 261: "I modelli
+      delle targhe sono depositati presso il Ministero dei trasporti."
+    licence: >-
+      Italy is the fourth surveyed country to prescribe the glyphs by STATUTORY
+      DRAWING rather than by named licensable font (after DE, ES and UK — EU
+      dossier §6). PRD-PLATES §6 therefore applies unchanged: the render layer
+      derives glyphs from the statutory figures, never from a third-party
+      "Italian plate font" TTF whose own licence is unstated. The figures
+      themselves were not text-extractable from Normattiva's export and are a
+      recorded gap for the render pass.
+    source: "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art260  # art. 260 c. 4; art. 261 c. 1"
+  euro_band:
+    side: left
+    content: eu-stars+I
+    verbatim: >-
+      Appendice XII lett. a): "una zona rettangolare a sinistra dove, su fondo blu,
+      è impressa in giallo nella parte superiore la corona di stelle simbolo della
+      Unione europea e nella parte inferiore è impressa in bianco la lettera I".
+    note: >-
+      Italy states the band's CONTENT and its three colours in words and gives no
+      geometry at all — no millimetres, no star-circle ratio. The only hard
+      Euroband geometry secured anywhere in this program remains German (FZV
+      Anlage 4 Abschnitt 1 Nr. 3, see plates/de.yml). Italy also does not
+      cross-reference Reg. (CE) 2411/98 the way Germany does.
+    source: "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. a) and c)"
+  right_field:
+    side: right
+    background: blue
+    verbatim: >-
+      Appendice XII lett. a): "una zona rettangolare a destra, a fondo blu,
+      destinata ad ospitare i talloncini di cui al comma 3 dell'articolo 260."
+    stickers:
+      - { position: top, content: "last two digits of the year of registration", colour: yellow }
+      - { position: bottom, content: "sigla of the province of RESIDENCE of the holder of the carta di circolazione", colour: white }
+    legal_status: "art. 260 c. 3: the two stickers 'non formano parte integrante della targa e non influiscono ai fini dell'identificazione del veicolo e del relativo intestatario'"
+    source: "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art260  # art. 260 c. 3, second sentence"
+  no_historic_series:
+    finding: >-
+      ITALY HAS NO HISTORIC/VINTAGE PLATE SERIES, and that is a sourced negative,
+      not a gap. Art. 60 of the codice splits old vehicles in two: "veicoli
+      d'epoca" (cancelled from the P.R.A., museum-kept) and "veicoli di interesse
+      storico e collezionistico" (registered in ASI, Storico Lancia, Italiano
+      FIAT, Italiano Alfa Romeo, Storico FMI). The first group has no plate at
+      all — art. 214 of the regolamento: "Ai veicoli d'epoca ... per la
+      circolazione nei luoghi consentiti, è rilasciato il foglio di via e la targa
+      provvisoria previsti dall'articolo 99 del codice", i.e. they borrow the
+      TEMPORARY series (see it-temporary-provvisoria). The second group keeps its
+      ordinary registration; art. 215 imposes technical conditions, not a plate.
+      There is consequently no Italian equivalent of the German H-Kennzeichen or
+      the Spanish histórico, and no `historic` series is authored here.
+    source: "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # art. 214 (veicoli d'epoca -> foglio di via + targa provvisoria) and art. 215 (veicoli di interesse storico); D.Lgs. 285/1992 art. 60"
+  unsourced_series:
+    diplomatic_and_consular: >-
+      THE CURRENT CD/CC FORMAT IS NOT IN ANY INSTRUMENT READ IN THIS PASS. Art.
+      131 comma 2 of the codice delegates it: for vehicles of diplomatic and
+      career consular agents "il Ministero dei trasporti, su richiesta del
+      Ministero degli affari esteri, ... provvede all'immatricolazione, assegnando
+      speciali targhe di riconoscimento, NEI TIPI E NELLE CARATTERISTICHE
+      DETERMINATE CON DECRETO DEL MINISTRO DEI TRASPORTI, DI CONCERTO CON IL
+      MINISTRO DEGLI AFFARI ESTERI." That decree was not located (Normattiva's
+      full-text search is not reachable without a session and the WebSearch budget
+      was exhausted). This is the same shape as the German district list (§ 9 Abs.
+      3 FZV delegating to the Bundesanzeiger): the MECHANISM is cited, the table
+      is not invented. Art. 131 c. 4 does give one modellable fact — "La validità
+      delle speciali targhe di riconoscimento ... scade al momento in cui cessa lo
+      status diplomatico di colui al quale il veicolo appartiene" — and the
+      PRE-1993 diplomatic plate IS sourced and appears below as
+      it-diplomatic-1959.
+    military_and_police: >-
+      NOT MODELLED, and for a cleaner reason: art. 138 comma 1 of the codice
+      removes military vehicles from the civil system entirely — "Le Forze armate
+      provvedono direttamente nei riguardi dei veicoli di loro dotazione agli
+      accertamenti tecnici, all'immatricolazione militare, al rilascio dei
+      documenti di circolazione e delle targhe di riconoscimento." The EI / MM /
+      AM / CC / GdiF / VF / POLIZIA series therefore live outside DPR 495 and
+      outside every instrument read here. No format is asserted.
+    monopattini: >-
+      A NEW SERIES LANDED IN 2025 AND IS NOT MODELLED. L. 177/2024 and its
+      implementing decree (reported as decreto n. 210 of 27-06-2025) introduce an
+      identification mark for monopattini (e-scooters). Neither text was pinned in
+      this pass; it is flagged for the next Italian pass rather than guessed.
+    source: "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art131  # art. 131 c. 2 and c. 4, verbatim; art. 138 c. 1"
+
+region_encoding_tables:
+  reference: "plates/_decode/it-provinces.yml"
+  note: >-
+    TWO closed, primary, inlineable-sized tables live in Appendice XI al Titolo
+    III, and both are extracted into one decode file: (1) comma 1, the sigle of
+    the provincial M.C.T.C. offices (A1 Alessandria ... X4 Oristano), which are
+    the PREFIX of the targa provvisoria; and (2) comma 1-bis, the sigle of the
+    provinces, which is what the right-hand sticker carries. They are NOT the same
+    table and they do not use the same codes — Rome is "P4" as an office and the
+    literal word "Roma" as a province.
+  source: "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XI al Titolo III, commi 1 and 1-bis"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD SERIES — AA 000 AA with the two blue zones.
+  # =========================================================================
+  - id: it-standard-1999
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL 999 LL"
+      regex: '\A[A-Z]{2} ?\d{3} ?[A-Z]{2}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?[ABCDEFGHJKLMNPRSTVWXYZ]{2}\z'
+      charset:
+        letters: [A, B, C, D, E, F, G, H, J, K, L, M, N, P, R, S, T, V, W, X, Y, Z]
+        letters_excluded: [I, O, Q, U]
+        notes: "Appendice XII comma 2 — see common.alphabet. The exclusion applies to BOTH letter groups; there is no separate rule for the first pair."
+      progression: >-
+        Appendice XII comma 2: the numeric field advances right to left in natural
+        sequence; the alphabetic characters advance right to left, each moving on
+        when the numeric series completes. With 22 letters the space is
+        22 x 22 x 1000 x 22 x 22 = 234,256,000 combinations. The dataset does NOT
+        claim which letter block is current — the block order lives in tabelle
+        III.3/a-III.3/d, which are figures (recorded gap), so an Italian plate
+        cannot be dated from its serial by anything in this file.
+      separator_note: >-
+        The two printed gaps are occupied by the marchio ufficiale (Appendice XII
+        lett. a) names it between the first letter pair and the digits), not by a
+        separator glyph. Both regexes accept the gap as an optional emitted SPACE
+        per PRD-PLATES §2.6.
+      reserved_combinations: >-
+        Art. 100 comma 8 of the codice lets the holder request "una specifica
+        combinazione alfanumerica" at cost, "ferma restando la sequenza
+        alfanumerica fissata dal regolamento" — a personalised SERIAL inside the
+        standard grammar, hence the `personalized` variant below rather than a
+        series of its own (PRD-PLATES §2.3).
+    design:
+      plate: { w: 520, h: 110, unit: mm, note: "targa posteriore, formato A" }
+      plate_variants:
+        - { w: 360, h: 110, unit: mm, note: "targa anteriore" }
+        - { w: 297, h: 214, unit: mm, note: "targa posteriore formato B — 'destinato esclusivamente agli autoveicoli il cui alloggiamento targa non consente l'installazione della targa formato A'" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec, spec_note: "art. 260 c. 1: 'è bianco in tutti gli altri casi ad eccezione delle parti poste all'estremità'" }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+I, hex_basis: observed, stars_color: "#FFCC00", letter_color: "#FFFFFF", note: "art. 260 c. 1: 'la sigla I è bianca'; Appendice XII a): stars 'in giallo', letter I 'in bianco', on 'fondo blu'" }
+      right_field:
+        side: right
+        color: "#003399"
+        hex_basis: observed
+        content: "two adhesive stickers: year of registration (yellow, top) over province sigla of the holder's residence (white, bottom)"
+        note: "art. 260 c. 3 — the stickers are expressly NOT part of the plate and do not affect identification of the vehicle or its holder"
+      emblem: { present: true, rendered: placeholder, note: "marchio ufficiale — five-pointed star between olive and oak branches, figura III.5 (art. 262)" }
+      rear_differs: true
+      rear_differs_note: >-
+        ITALY IS THE EU DOSSIER'S NAMED CASE OF FRONT/REAR ASYMMETRY, and the
+        primary confirms it: art. 258 c. 1 lett. a) gives 360 x 110 mm for the
+        front plate and lett. b) 520 x 110 mm for the rear. Same serial, different
+        plate. A render pipeline must emit two artefacts per Italian registration.
+      display: "front and rear on autoveicoli (art. 100 c. 1 del codice)"
+    region_encoding: "plates/_decode/it-provinces.yml"
+    region_encoding_mechanism: >-
+      NONE IN THE SERIAL. The 1993 reform removed geography from the Italian
+      registration mark completely: Appendice XII lett. a) contains no province
+      element. Geography survives only in the right-hand STICKER (art. 260 c. 3),
+      which is removable, optional in practice, decodes to the HOLDER'S PROVINCE
+      OF RESIDENCE rather than the place of registration, and is expressly not
+      part of the plate. A parse API must treat an Italian province claim as
+      evidence about the sticker, never about the serial — the same "the band lies"
+      caution the EU dossier records for the French SIV département.
+    variants:
+      - class: personalized
+        format: { pattern: "LL 999 LL", regex: '\A[A-Z]{2} ?\d{3} ?[A-Z]{2}\z' }
+        note: >-
+          TARGA A COMBINAZIONE RICHIESTA. Art. 100 c. 8: the holder may request a
+          specific alphanumeric combination at the cost set under art. 101 c. 1;
+          the office checks the combination is unused, registers the vehicle, and
+          the Istituto Poligrafico delivers the plates within thirty days. Format
+          and design are identical to the standard series — a sub-entry, not a
+          series, per PRD-PLATES §2.3. Italy has no vanity ALPHABET: the requested
+          combination must still obey Appendice XII.
+        sources:
+          - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art100  # art. 100 c. 8, verbatim"
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. a) — 'due caratteri alfabetici, il marchio ufficiale della Repubblica italiana, tre caratteri numerici e due caratteri alfabetici' plus the left EU zone and the right blue zone; comma 2 — the 22-letter alphabet"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art258  # art. 258 c. 1 lett. a) and b) — 360x110 front, 520x110 formato A, 297x214 formato B, all 'fermo restando quanto stabilito nella materia dalle norme previgenti per i veicoli immatricolati anteriormente al 1 gennaio 1999'"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art260  # art. 260 c. 1 (colours), c. 3 (the two stickers), c. 5 ('le nuove targhe in uso dal 1 gennaio 1999')"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art100  # art. 100 c. 1 (front and rear), c. 5 (retroreflective), c. 8 (requested combination), c. 9 (what the regolamento must fix)"
+    notes: >-
+      THE CURRENT ITALIAN CAR PLATE. period.start 1999 is the date the primary
+      itself names: art. 260 c. 5, as amended by D.P.R. 4 settembre 1998 n. 355,
+      speaks of "le nuove targhe in uso dal 1 gennaio 1999", and art. 258 c. 1
+      opens by preserving the previous rules "per i veicoli immatricolati
+      anteriormente al 1 gennaio 1999". `period_evidence: instrument-in-force`
+      rather than a harder value because the instrument names a month-and-year
+      switchover, not a first-issue date; the widely repeated "8 febbraio 1999" is
+      uncited and is not adopted. NOTE THE CONTINUITY the same comma establishes:
+      a 1993-series plate may be exchanged for a 1999-series one "con la stessa
+      sigla alfanumerica ... senza che si configuri l'ipotesi di reimmatricolazione
+      di cui all'articolo 102", so serial-space and design-space are orthogonal in
+      Italy, and a 1999-design plate can carry a serial first issued in 1993.
+
+  # =========================================================================
+  # ONE SERIES BACK — the same serial, no bands, smaller plates.
+  # =========================================================================
+  - id: it-standard-1993
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1993, end: 1999 }
+    period_evidence: instrument-in-force
+    period_rollout:
+      legal_commencement: 1993
+      old_stock_backstop: 1996
+      note: >-
+        Art. 260 c. 5: "a partire dal 1 ottobre 1993 progressivamente con
+        l'esaurimento delle targhe di vecchio tipo ancora in giacenza presso gli
+        uffici provinciali della Direzione generale della M.C.T.C. e comunque non
+        oltre il 31 dicembre 1996". Legal commencement and full coverage are three
+        years apart and the regulation says so — the PRD-PLATES §2.2
+        `period.rollout` case, arriving in Italy.
+    matching: strict
+    format:
+      pattern: "LL 999 LL"
+      regex: '\A[A-Z]{2} ?\d{3} ?[A-Z]{2}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?[ABCDEFGHJKLMNPRSTVWXYZ]{2}\z'
+      charset: { letters_excluded: [I, O, Q, U], notes: "identical to the 1999 series — the 1998 amendment did not touch Appendice XII comma 2" }
+    design:
+      plate: { w: 486, h: 109, unit: mm, note: "targa posteriore, formato A (1993 dimensions)" }
+      plate_variants:
+        - { w: 340, h: 109, unit: mm, note: "targa anteriore (1993 dimensions)" }
+        - { w: 336, h: 202, unit: mm, note: "targa posteriore formato B (1993 dimensions)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: none }
+      band_note: "NO EU band and NO right-hand blue zone: Appendice XII lett. a) as enacted read simply 'due caratteri alfabetici, il marchio ufficiale della Repubblica italiana, tre caratteri numerici e due caratteri alfabetici', and art. 260 c. 1 as enacted made the whole ground white with no end-zone exception."
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: true
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=19940101  # Appendice XII lett. a) as originally enacted (no blue zones) and art. 260 c. 5 as originally enacted ('a partire dal 1 luglio 1993'), Normattiva multivigenza export at 1994-01-01"
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=19980101  # art. 260 c. 5 as amended: '((a partire dal 1 ottobre 1993))' and '((e comunque non oltre il 31 dicembre 1996))'; art. 258 c. 1 lett. a)-b) with the 340x109 / 486x109 / 336x202 dimensions"
+    notes: >-
+      THE 1993 SERIES — the first Italian plate with no province in it, and the
+      FOLKLORE FLAG of this file. Every enthusiast source and it.wikipedia date it
+      to 1994 ("dal 28 febbraio 1994", uncited); the regulation dates its own
+      commencement to 1 July 1993 as enacted and 1 October 1993 as amended, and
+      caps the transition at 31 December 1996. Because provincial offices issued
+      old-type stock until it ran out, the first AA 000 AA plate in a given
+      province may well post-date the legal commencement by months — which is
+      exactly why `period_rollout` carries the backstop instead of the folklore
+      year being laundered into `period.start`. Distinct from it-standard-1999
+      only in DESIGN (no bands, smaller plates); the serial grammar is
+      character-for-character the same, and art. 260 c. 5 expressly allows a
+      1993-series serial to be re-plated in the 1999 design.
+
+  # =========================================================================
+  # THE PRE-1993 PROVINCIAL SYSTEM — the real "one series back".
+  # =========================================================================
+  - id: it-provincial-1959
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1959, end: 1996 }
+    period_evidence: instrument-in-force
+    # RECALL-ONLY (PRD-PLATES §2.7): the 1959 regolamento fixes the province
+    # sigla and nothing else — the rest of the mark is "un numero o una
+    # combinazione di lettere e cifre", with no length, no alphabet and no
+    # arrangement. Any regex covering it is necessarily wider than what was
+    # issued, so a match is a shape hit and never a validity claim.
+    matching: recall-only
+    format:
+      pattern: "LL 999999"
+      regex: '\A(?:ROMA|[A-Z]{1,2}) ?[A-Z0-9]{1,6}\z'
+      charset:
+        notes: >-
+          Art. 320 D.P.R. 420/1959, verbatim: "Essa porta in rilievo in carattere
+          bianco su fondo nero, il contrassegno d'immatricolazione dell'autoveicolo,
+          formato dalla sigla di individuazione della provincia in cui è
+          immatricolato e da un numero o da una combinazione di lettere e cifre,
+          con il marchio ufficiale interposto tra i predetti elementi." The serial
+          part is DELIBERATELY unbounded in the primary; the {1,6} in the regex is a
+          practical recall bound, not a sourced one, which is the other half of why
+          this series is recall-only.
+      progression: "not stated in the 1959 regolamento — recorded gap"
+    design:
+      plate: { w: 275, h: 200, unit: mm, note: "targa di riconoscimento posteriore (art. 320)" }
+      plate_variants:
+        - { w: 267, h: 62, unit: mm, note: "targa anteriore, single row (art. 321): 'porta in rilievo, in carattere bianco su fondo nero, su unica riga le indicazioni contenute nella targa di riconoscimento'" }
+      background: { color: "#000000", finish: painted, hex_basis: spec, spec_note: "art. 320: 'in carattere bianco su fondo nero'" }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder, note: "'con il marchio ufficiale interposto tra i predetti elementi' — the emblem sits between the province sigla and the serial, which is why province and serial are visually separated" }
+      rear_differs: true
+      construction: "metal or equivalent, rounded corners, four 5 mm fixing holes (art. 320)"
+      colour_caveat: >-
+        THE COLOUR CLAIM HERE IS THE REGULATION'S, NOT THE ROAD'S. The text of art.
+        320 still read "carattere bianco su fondo nero" in the version in force on
+        1 January 1992, yet the last generation of provincial plates was black on
+        white retroreflective. No instrument changing the colour was located in
+        this pass, so the black-on-white variant is a RECORDED GAP and is not
+        asserted; the sourced colours are recorded here and the discrepancy is
+        flagged rather than averaged (PRD-PLATES §5.3).
+    region_encoding: "plates/_decode/it-provinces.yml"
+    region_encoding_mechanism: >-
+      THE PROVINCE IS IN THE MARK ITSELF — this is the only Italian series where a
+      parse can return a province from the serial. The sigla is the province of
+      registration (art. 320), not of residence, which inverts the modern sticker's
+      semantics. TWO CAUTIONS a decode table must carry: (1) the only
+      primary-sourced sigle list is Appendice XI comma 1-bis of DPR 495/1992, which
+      was inserted in 1998 and uses the province set of that date — provinces
+      created in 1992 (Lecco, Lodi, Rimini, Prato, Crotone, Vibo Valentia,
+      Verbano-Cusio-Ossola) never issued provincial plates at all, and the
+      pre-1992 list is a recorded gap; (2) Rome's sigla is the literal word "Roma",
+      not "RM" — Appendice XII comma 3 has to say so explicitly for repeater
+      plates: "Nel caso in cui la targa del veicolo traente contenga la parola Roma
+      essa viene riportata sulla targa ripetitrice mediante la sigla RM."
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19590630&codiceRedaz=059U0420&dataVigenza=19920101  # D.P.R. 30 giugno 1959, n. 420, art. 320 (rear plate 275x200, white on black, province sigla + marchio + number or letter/digit combination) and art. 321 (front plate 267x62, single row)"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art260  # art. 260 c. 5 — the provincial plates' issuance end: old-type stock ran until exhausted 'e comunque non oltre il 31 dicembre 1996', and already-registered vehicles 'possono continuare a circolare con la targa di immatricolazione ... originale'"
+    notes: >-
+      THE PROVINCIAL SYSTEM (MI 12345, ROMA 123456). period.start 1959 is the date
+      of the instrument that states the rule read here, NOT the date the system
+      began — Italian province codes are commonly said to date from 1927 and no
+      primary for that was secured, so it is recorded as folklore and not as a
+      period claim. period.end 1996 IS sourced, and unusually cleanly: art. 260
+      c. 5 of the 1992 regolamento caps the issuance of old-type plates at 31
+      December 1996. The same comma is the reason a provincial plate is still a
+      live parse target thirty years later: "Gli autoveicoli ... già immatricolati,
+      possono continuare a circolare con la targa di immatricolazione (e con quella
+      anteriore, ove ricorra) originale" — never re-plated, still legal.
+
+  - id: it-provincial-motorcycle-1959
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1959, end: 1996 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "LL 999999"
+      regex: '\A(?:ROMA|[A-Z]{1,2}) ?[A-Z0-9]{1,6}\z'
+      charset: { notes: "art. 322: same open grammar as the car plate — province sigla + marchio + 'un numero o una combinazione di lettere e cifre'" }
+    design:
+      plate: { w: 165, h: 165, unit: mm, note: "square, rounded corners, four 5 mm holes" }
+      background: { color: "#FFFFFF", finish: painted, hex_basis: spec, spec_note: "art. 322: 'in carattere blu su fondo bianco'" }
+      foreground: "#0000A0"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: "plates/_decode/it-provinces.yml"
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19590630&codiceRedaz=059U0420&dataVigenza=19920101  # art. 322: 'La targa di riconoscimento per i motoveicoli è ... di forma quadrata, con il lato di mm. 165 ... Essa porta in rilievo, in carattere blu su fondo bianco, il contrassegno d'immatricolazione del motoveicolo formato dalla sigla d'individuazione della provincia'"
+    notes: >-
+      THE BLUE-ON-WHITE MOTORCYCLE PLATE, and the one genuinely surprising colour
+      fact in Italian plate law: while cars carried white on black, motorcycles
+      carried BLUE on white under the same 1959 regolamento. Its own series rather
+      than a variant of it-provincial-1959 because both design and dimensions
+      differ (PRD-PLATES §2.3). The 165 x 165 mm square survived the 1993 reform
+      unchanged and did not grow until 1999.
+
+  # =========================================================================
+  # MOTORCYCLES — the file's one deliberately over-broad current series.
+  # =========================================================================
+  - id: it-motorcycle-1999
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1999 }
+    period_evidence: instrument-in-force
+    # RECALL-ONLY (PRD-PLATES §2.7), and the reason is a documented conflict
+    # rather than a union of issued shapes — see notes. A match is a shape hit.
+    matching: recall-only
+    format:
+      pattern: "LL 999 LL"
+      regex: '\A(?:[A-Z]{2} ?\d{3} ?[A-Z]{2}|[A-Z]{2} ?\d{5})\z'
+      pattern_note: >-
+        The pattern shows the APPENDIX shape (two letters, three digits, two
+        letters). The regex is the union of that shape and the two-letters +
+        five-digits shape reported everywhere on the enthusiast web and in
+        it.wikipedia, because the two cannot both be right and neither can be
+        discarded — see notes.
+      charset:
+        letters_excluded: [I, O, Q, U]
+        notes: "Appendice XII comma 2's 22-letter alphabet governs whichever shape is in fact issued; it is not written into `regex` because a recall-only series may carry no regex_strict (PRD-PLATES §2.7)."
+    design:
+      plate: { w: 177, h: 177, unit: mm, note: "art. 258 c. 1 lett. e-bis), inserted by D.P.R. 355/1998 — the motorcycle plate GREW from 165x165 to 177x177 when the EU band arrived" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+I, hex_basis: observed }
+      right_field: { side: right, color: "#003399", hex_basis: observed, content: "the same two art. 260 c. 3 stickers as the car plate — year over province" }
+      emblem: { present: true, rendered: placeholder }
+      layout: "two rows on a square plate; the EU band runs the full height at the left"
+      display: "rear only (art. 100 c. 2 del codice)"
+    region_encoding: "plates/_decode/it-provinces.yml"
+    variants:
+      - class: motorcycle
+        design: { background: { color: "#FFCC00", finish: painted, hex_basis: observed }, foreground: "#000000" }
+        note: >-
+          THE OFF-ROAD COMPETITION SUBSTITUTE PANEL, and one of the odder things in
+          the codice. Art. 100 c. 10, verbatim: "I motoveicoli impegnati in
+          competizioni motoristiche fuori strada che prevedono trasferimenti su
+          strada possono esporre, limitatamente ai giorni e ai percorsi di gara, in
+          luogo della targa di cui al comma 2, una targa sostitutiva costituita da
+          un pannello AUTO-COSTRUITO che riproduce i dati di immatricolazione del
+          veicolo. Il pannello deve avere fondo giallo, cifre e lettere nere e
+          caratteristiche dimensionali identiche a quelle della targa che
+          sostituisce." A self-built yellow panel repeating the vehicle's own
+          registration, legal only on race days and race routes, and only for FMI
+          licence holders. Colour-and-substrate variant of the same serial, hence a
+          sub-entry (PRD-PLATES §2.3).
+        sources:
+          - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art100  # art. 100 c. 10, second sentence"
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. c) as amended in 1998: '((c) targa dei motoveicoli (fig. III 4/e): riporta nell'ordine, una zona rettangolare a sinistra dove, su fondo blu, è impressa in giallo ... la corona di stelle ... la lettera I; due caratteri alfabetici, il marchio della Repubblica italiana, tre caratteri numerici e due caratteri alfabetici; una zona rettangolare a destra ...))'"
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=19980101  # the same lett. c) BEFORE the amendment: 'due caratteri alfabetici, il marchio ufficiale della Repubblica italiana e cinque caratteri numerici' — proof that the 1998 amendment deliberately replaced the five-digit tail"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art258  # art. 258 c. 1 lett. e-bis): 'targhe di immatricolazioni dei motoveicoli: 177 mm X 177 mm'"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art257  # art. 257 c. 2 — the Minister's power to set 'una successione ed un impiego di caratteri alfanumerici diversi da quelli indicati' in Appendice XII"
+    notes: >-
+      THE ONE PLACE THIS FILE REFUSES TO CHOOSE, and it is recorded rather than
+      resolved. D.P.R. 355/1998 rewrote Appendice XII lett. c) so that a
+      motorcycle plate carries "tre caratteri numerici e due caratteri alfabetici"
+      — the car grammar — replacing the enacted "cinque caratteri numerici". The
+      consolidated regolamento in force in 2026 still reads that way. But every
+      non-primary description of Italian motorcycle plates, it.wikipedia included,
+      says the second row is FIVE DIGITS, and none of them cites anything.
+      Art. 257 c. 2 supplies a lawful mechanism by which both could be true — the
+      Minister may set a different character succession by decree without amending
+      the appendix — and no such decree was located. Averaging the two would be
+      exactly the failure PRD-PLATES §5.3 forbids, so the series is `recall-only`
+      with a union regex, the appendix text is quoted in the sources, and this is
+      the FIRST item on the verifier's list (see dossier-it.md §Verification).
+      period.start 1999 is the design date (D.P.R. 355/1998 + art. 260 c. 5's
+      1 January 1999); if the five-digit shape is the one actually issued, this
+      series' start is unaffected but its format claim moves to the 1993 entry.
+
+  - id: it-motorcycle-1993
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1993, end: 1999 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL 99999"
+      regex: '\A[A-Z]{2} ?\d{5}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTVWXYZ]{2} ?\d{5}\z'
+      charset: { letters_excluded: [I, O, Q, U], notes: "Appendice XII comma 2" }
+    design:
+      plate: { w: 165, h: 165, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder, note: "the marchio sits between the letter pair and the five digits" }
+      display: "rear only"
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=19940101  # Appendice XII lett. c) as enacted: 'targa dei motoveicoli (fig. III.4/e): riporta, nell'ordine, due caratteri alfabetici, il marchio ufficiale della Repubblica italiana e cinque caratteri numerici'; art. 258 c. 1 lett. e) — 165 x 165 mm"
+    notes: >-
+      THE 1993 MOTORCYCLE SERIES — two letters, the emblem, five digits, on the
+      same 165 mm square the 1959 regolamento used. This entry is `strict` and its
+      1999 successor is not, which is the honest asymmetry: the five-digit shape is
+      unambiguously sourced FOR THIS PERIOD, and the dispute is only about whether
+      it was ever replaced. If the verifier finds that motorcycles never moved off
+      the five-digit tail, the fix is to extend this series rather than to widen
+      it-motorcycle-1999.
+
+  # =========================================================================
+  # MOPEDS — six alphanumerics, owner-bound, and no arrangement in the law.
+  # =========================================================================
+  - id: it-moped-2006
+    class: moped
+    categories: [moped]
+    period: { start: 2006 }
+    period_evidence: instrument-in-force
+    binding: owner
+    matching: strict
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9]{6}\z'
+      charset:
+        notes: >-
+          Art. 250 c. 1 of the regolamento, verbatim: "La targa è composta da sei
+          caratteri alfanumerici, nonché dal marchio ufficiale della Repubblica
+          italiana." Art. 250 c. 4: "Il codice alfanumerico è costituito da una
+          combinazione di lettere e numeri. La progressione delle combinazioni
+          viene stabilita dal Dipartimento per i trasporti terrestri." SIX
+          POSITIONS IS THE WHOLE OF THE SOURCED GRAMMAR — the regulation fixes
+          neither the arrangement of letters and digits nor any excluded character,
+          and expressly hands the progression to the Department. The commonly
+          repeated three-letters-then-three-digits arrangement, the A/E/I/O/Q/U
+          letter exclusion and the "no digit 1" rule are UNSOURCED and are not
+          written into any regex here.
+      progression: "set by the Dipartimento per i trasporti terrestri (art. 250 c. 4); not published in the regolamento — recorded gap"
+    design:
+      plate: { note: "form and dimensions are 'indicati nella figura III 3' and the character format 'nella tabella III 2' (art. 250 c. 2) — both are figures and were not text-extractable; RECORDED GAP" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec, spec_note: "art. 250 c. 1: 'Il fondo della targa è bianco'" }
+      foreground: "#000000"
+      band: { side: none }
+      band_note: "art. 250 gives the moped plate no EU band and no right-hand zone; only art. 260 c. 1's white ground and black characters"
+      emblem: { present: true, rendered: placeholder }
+      illumination: "art. 250 c. 5: 'La targa non deve essere necessariamente illuminata'"
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # artt. 248-251 as amended: art. 248 c. 1 (the art. 97 plate has art. 250's characteristics and an alphanumeric code), c. 3 (owner binding), art. 250 c. 1 (six alphanumeric characters, white ground, black characters, 1.4 mm embossing on 1.00 mm aluminium), c. 2 (figura III 3, tabella III 2), c. 4 (progression set by the Department), c. 5 (need not be illuminated)"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art97  # art. 97 c. 1 lett. b): a moped needs 'una targa, che identifica l'intestatario del certificato di circolazione'; c. 2: 'La targa è personale e abbinata a un solo veicolo'"
+    notes: >-
+      THE ITALIAN MOPED PLATE IS OWNER-BOUND, and it is the only Italian series
+      that is. Art. 97 c. 2 of the codice: "La targa è personale e abbinata a un
+      solo veicolo", retained by the holder on sale; art. 248 c. 3 of the
+      regolamento: "La targa è strettamente legata al titolare, che la applica solo
+      al veicolo identificato nel certificato di circolazione di cui risulta
+      intestatario. Chi risulta intestatario di più veicoli deve conseguentemente
+      munirsi di un corrispondente numero di certificati di circolazione e di
+      targhe." Hence `binding: owner` on this series while the file's default is
+      `binding: vehicle` — the Swiss case arriving in Italy through a different
+      door, and a trap for any vehicle-keyed consumer.
+      PREDECESSOR, NOT MODELLED: before D.P.R. 6 marzo 2006 n. 153 the same
+      vehicles carried a "contrassegno di identificazione" whose art. 250 read
+      only "porta in rilievo su fondo bianco retroriflettente una combinazione di
+      cifre e lettere" — no count, no arrangement, nothing quantifiable — and which
+      was bound to the PERSON so loosely that art. 248 c. 4 let one holder ride
+      several different mopeds on it ("Lo stesso contrassegno permette
+      all'intestatario di circolare con differenti ciclomotori"). A series whose
+      primary fixes no length cannot carry a regex, so none is authored; it is a
+      recorded gap, and the 14 July 2006 date usually given for the changeover is
+      uncited (the instrument's own date, GU 15-04-2006, is what `period.start`
+      rests on).
+
+  # =========================================================================
+  # TRAILERS — the 2013 merge, and the "RIMORCHIO" plate it replaced.
+  # =========================================================================
+  - id: it-trailer-2013
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL 999 LL"
+      regex: '\A[A-Z]{2} ?\d{3} ?[A-Z]{2}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?[ABCDEFGHJKLMNPRSTVWXYZ]{2}\z'
+      charset: { letters_excluded: [I, O, Q, U] }
+    design:
+      plate: { w: 520, h: 110, unit: mm, note: "formato A; art. 258 c. 1 lett. b) extended to 'autoveicoli ((e loro rimorchi))'" }
+      plate_variants:
+        - { w: 297, h: 214, unit: mm, note: "formato B where the mounting cannot take formato A" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+I, hex_basis: observed }
+      right_field: { side: right, color: "#003399", hex_basis: observed, content: "the art. 260 c. 3 stickers" }
+      emblem: { present: true, rendered: placeholder }
+      display: "rear only (art. 100 c. 3 del codice)"
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. a) as amended by D.P.R. 198/2012: 'targa anteriore e posteriore degli autoveicoli, nonché quella posteriore dei loro rimorchi'; lett. b) 'LETTERA SOPPRESSA DAL D.P.R. 28 SETTEMBRE 2012, N. 198'; art. 258 c. 1 lett. b) with '((e loro rimorchi))'"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art260  # AGGIORNAMENTO (44): D.P.R. 28 settembre 2012, n. 198 art. 8 c. 1 — in force from the ninetieth day after publication (GU 22-11-2012 n. 273) and applicable 'ai soli rimorchi immatricolati successivamente'"
+    notes: >-
+      TRAILERS JOINED THE CAR FORMAT IN 2013. D.P.R. 28 settembre 2012 n. 198
+      suppressed Appendice XII lett. b) — the dedicated "Rimorchio" plate — and
+      extended lett. a) to cover "quella posteriore dei loro rimorchi", so an
+      Italian trailer registered after the changeover carries an ordinary AA 000 AA
+      plate with both blue zones and is indistinguishable from a car by its serial.
+      period.start 2013 is derived, not printed: art. 8 c. 1 sets commencement at
+      the ninetieth day after publication in GU of 22 November 2012, which falls in
+      February 2013. The same comma carries the transitional rule that makes the
+      old series a live parse target indefinitely — the new format "si applica ai
+      soli rimorchi immatricolati successivamente alla" that date, with an express
+      option to re-register older trailers.
+
+  - id: it-trailer-1993
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 1993, end: 2013 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL 99999"
+      regex: '\A[A-Z]{2} ?\d{5}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTVWXYZ]{2} ?\d{5}\z'
+      charset: { letters_excluded: [I, O, Q, U] }
+      legend_note: >-
+        The word "Rimorchio" printed above the serial is a LEGEND, not part of the
+        mark: Appendice XII lett. b) as enacted reads "riporta, nell'ordine, la
+        scritta 'Rimorchio', due caratteri alfabetici, il marchio ufficiale della
+        Repubblica italiana e cinque caratteri numerici". It is carried in
+        `design.legend` because it contains a full stop and a space and could never
+        be spelled inside a serial under PRD-PLATES §2.6.
+    design:
+      plate: { w: 340, h: 109, unit: mm, note: "art. 258 c. 1 lett. d) as enacted" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      legend: { text: "RIMORCHIO", color: "#CC0000", note: "art. 260 c. 1 lett. a) as enacted: 'colore rosso: scritte RIMORCHIO, RIM. AGR.'" }
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=19940101  # Appendice XII lett. b) as enacted (the 'Rimorchio' legend + 2 letters + marchio + 5 digits); art. 258 c. 1 lett. d) (340 x 109 mm); art. 260 c. 1 lett. a) (the red legend)"
+    notes: >-
+      THE "RIMORCHIO" PLATE — twenty years of Italian trailers, and the reason a
+      five-digit Italian mark is not automatically a motorcycle. Same serial shape
+      as it-motorcycle-1993 (two letters, five digits) on a completely different
+      plate: 340 x 109 mm landscape, with the red word RIMORCHIO across the top.
+      Distinguishing the two from the string alone is impossible; distinguishing
+      them from the plate is trivial. Recorded so the parse API returns both
+      candidates rather than guessing.
+
+  - id: it-repeater
+    class: trailer
+    categories: [trailer]
+    period: { start: 1993 }
+    period_evidence: instrument-in-force
+    # RECALL-ONLY (PRD-PLATES §2.7): a repeater plate carries the TOWING vehicle's
+    # registration, transcribed by the owner into empty boxes. Its regex is a
+    # container, not a grammar; a match says only that the string could sit in
+    # those boxes. Same situation as nl-export.
+    matching: recall-only
+    format:
+      pattern: "LLR999LL"
+      regex: '\A[A-Z]{2} ?R ?[A-Z0-9]{1,6}\z'
+      pattern_note: >-
+        Appendice XII lett. h): "targa ripetitrice per carrelli appendice: riporta,
+        nell'ordine, due caratteri alfabetici, la lettera 'R', e sei caratteri
+        alfanumerici". Lett. i) gives five alphanumerics for agricultural trailers
+        and trailed operating machines. As enacted in 1992 both were narrower —
+        lett. h) read "tre caratteri numerici e due caratteri alfabetici" — and
+        D.P.R. 610/1996 widened them, which is why one open series is modelled
+        rather than two.
+      fill_rule: >-
+        Appendice XII comma 3, verbatim: "In luogo delle cifre e delle lettere
+        costituenti il numero o il contrassegno di immatricolazione, le targhe
+        ripetitrici sono dotate di riquadri rettangolari, aventi dimensioni di
+        80 x 40 o 60 x 30 o 65 x 31 millimetri ... ciascuno dei quali è riservato a
+        ricevere un carattere alfabetico o numerico. Gli interessati avranno cura
+        di riprodurre su dette targhe, con caratteri neri autoadesivi o impressi
+        con sistemi equivalenti, il numero o il contrassegno di immatricolazione
+        della motrice cui il veicolo viene agganciato, NON IMPEGNANDO LA PRIMA O LE
+        PRIME CASELLE eventualmente eccedenti rispetto alla quantità di caratteri
+        costituenti il numero d'immatricolazione."
+    design:
+      plate: { w: 486, h: 109, unit: mm, note: "formato A (art. 258 c. 1 lett. c))" }
+      plate_variants:
+        - { w: 336, h: 202, unit: mm, note: "formato B where the mounting cannot take formato A" }
+        - { w: 340, h: 109, unit: mm, note: "repeater plates for agricultural trailers and trailed operating machines (art. 258 c. 1 lett. d))" }
+      background: { color: "#FFCC00", finish: retroreflective, hex_basis: observed, spec_note: "art. 260 c. 1: yellow ground for 'tutte le targhe ripetitrici'; Appendice XII c. 3: 'Esse hanno fondo retroriflettente di colore giallo'" }
+      foreground: "#000000"
+      marker: { text: "R", color: "#CC0000", note: "art. 260 c. 1 lett. a): 'colore rosso: ... lettera R delle targhe ripetitrici'" }
+      band: { side: none }
+      emblem: { present: false, note: "Appendice XII c. 3: repeater plates 'contengono soltanto la lettera \"R\" in rosso, SENZA il marchio ufficiale della Repubblica italiana' — the only Italian plate with no emblem" }
+      boxes: { sizes_mm: ["80x40", "60x30", "65x31"], note: "80x40 for carrelli appendice behind autoveicoli; 60x30 behind agricultural/operating machines; 65x31 behind EE autoveicoli" }
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. h) and i) and comma 3 in full; art. 258 c. 1 lett. c) and d); art. 260 c. 1 lett. a) and c. 2"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art100  # art. 100 c. 4: 'I carrelli appendice, quando sono agganciati ad una motrice, devono essere muniti posteriormente di una targa ripetitrice dei dati di immatricolazione della motrice stessa'"
+    notes: >-
+      THE TARGA RIPETITRICE — an owner-filled yellow plate that repeats the towing
+      vehicle's mark, carried by carrelli appendice, agricultural trailers and
+      trailed operating machines. Three facts make it worth its own entry rather
+      than a footnote: it is the ONLY Italian plate with no marchio; it is the only
+      one whose characters are applied by the owner rather than the State; and it
+      contains the single best piece of decode trivia in Italian plate law —
+      Appendice XII comma 3: "Nel caso in cui la targa del veicolo traente contenga
+      la parola Roma essa viene riportata sulla targa ripetitrice mediante la sigla
+      RM." Rome's provincial plates spelled the city out in full, and the repeater
+      plate is where the abbreviation had to be legislated.
+
+  # =========================================================================
+  # AGRICULTURAL AND OPERATING MACHINES — yellow, no EU band, four shapes.
+  # =========================================================================
+  - id: it-agricultural-selfpropelled
+    class: agricultural
+    categories: [tractor]
+    period: { start: 1993 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL 999 L"
+      regex: '\A[A-Z]{2} ?\d{3} ?[A-Z]\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?[ABCDEFGHJKLMNPRSTVWXYZ]\z'
+      charset: { letters_excluded: [I, O, Q, U] }
+    design:
+      plate: { w: 165, h: 165, unit: mm, note: "art. 258 c. 1 lett. e)" }
+      background: { color: "#FFCC00", finish: retroreflective, hex_basis: observed, spec_note: "art. 260 c. 1: 'Il fondo delle targhe è giallo per le targhe di immatricolazione delle macchine agricole semoventi o trainate'" }
+      foreground: "#000000"
+      band: { side: none }
+      band_note: "NO EU band. D.P.R. 355/1998 added the blue zones only to Appendice XII lett. a) and c) — cars and motorcycles. Letters d) to i) were left untouched, so on the regulation's own text an Italian agricultural or operating-machine plate has never carried a Euroband. Flagged for verification against photographs."
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. d): 'targa delle macchine agricole semoventi (figura III.4/f): riporta, nell'ordine, due caratteri alfabetici, il marchio ufficiale della Repubblica italiana, tre caratteri numerici ed un carattere alfabetico'; art. 258 c. 1 lett. e); art. 260 c. 1"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art113  # art. 113 c. 1 of the codice — the registration duty these plates discharge"
+    notes: >-
+      MACCHINE AGRICOLE SEMOVENTI — self-propelled agricultural machines. The
+      Italian yellow family is four series (this one, the agricultural trailer, and
+      the two operating-machine shapes) and they are genuinely four: two different
+      character orders and two different colour rules. This one is the plain
+      yellow-and-black case. Unchanged since 1993 in the regulation's text, which
+      is why `period.start` is the regolamento's own commencement year and
+      `period_evidence` is instrument-in-force.
+
+  - id: it-agricultural-trailer
+    class: agricultural
+    categories: [trailer]
+    period: { start: 1993 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL 999 L"
+      regex: '\A[A-Z]{2} ?\d{3} ?[A-Z]\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?[ABCDEFGHJKLMNPRSTVWXYZ]\z'
+      charset: { letters_excluded: [I, O, Q, U] }
+      legend_note: "the 'Rim. Agr.' legend contains a full stop and a space and is therefore a design element, never part of the serial (PRD-PLATES §2.6)"
+    design:
+      plate: { w: 340, h: 109, unit: mm, note: "art. 258 c. 1 lett. d)" }
+      background: { color: "#FFCC00", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      legend: { text: "RIM. AGR.", color: "#CC0000", note: "art. 260 c. 1 lett. a): 'colore rosso: scritta RIM. AGR.'" }
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. f): 'targa dei rimorchi agricoli (fig. III.4/h): riporta, nell'ordine, la scritta \"Rim. Agr.\", due caratteri alfabetici, il marchio ufficiale della Repubblica italiana, tre caratteri numerici ed un carattere alfabetico'; art. 260 c. 1 lett. a)"
+    notes: >-
+      RIMORCHI AGRICOLI. Identical serial grammar to the self-propelled machines,
+      distinguished on the road by the red RIM. AGR. legend and the landscape
+      340 x 109 plate. Same class as it-agricultural-selfpropelled, but the
+      categories do not overlap ([trailer] vs [tractor]) and the notes are distinct,
+      which is how the parallel-issuance rule is satisfied.
+
+  - id: it-machine-selfpropelled
+    class: agricultural
+    categories: [machine]
+    period: { start: 1993 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL L 999"
+      regex: '\A[A-Z]{2} ?[A-Z] ?\d{3}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTVWXYZ]{2} ?[ABCDEFGHJKLMNPRSTVWXYZ] ?\d{3}\z'
+      charset: { letters_excluded: [I, O, Q, U] }
+      order_note: >-
+        NOTE THE INVERSION, which is the whole point of a separate series:
+        Appendice XII lett. e) puts the single letter BEFORE the three digits
+        ("un carattere alfabetico e tre caratteri numerici") where lett. d) puts it
+        after. Two shapes, one character-count, opposite order — the cheapest
+        possible tell between an agricultural machine and an operating machine.
+    design:
+      plate: { w: 165, h: 165, unit: mm, note: "art. 258 c. 1 lett. e)" }
+      background: { color: "#FFCC00", finish: retroreflective, hex_basis: observed }
+      foreground: "#CC0000"
+      foreground_note: "art. 260 c. 1 lett. a): 'colore rosso: ... marchio ufficiale e caratteri alfanumerici delle targhe di immatricolazione delle macchine operatrici'. RED characters AND a red emblem on yellow — the only Italian plate whose entire imprint is red."
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder, color: "#CC0000" }
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. e): 'targa delle macchine operatrici semoventi (fig. III.4/g): riporta, nell'ordine, due caratteri alfabetici, il marchio ufficiale della Repubblica italiana, un carattere alfabetico e tre caratteri numerici'; art. 260 c. 1 lett. a)"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art114  # art. 114 c. 4 of the codice — the registration duty for macchine operatrici"
+    notes: >-
+      MACCHINE OPERATRICI SEMOVENTI — self-propelled operating machines (excavators,
+      loaders, road plant). CLASS CAVEAT, stated plainly: `_meta/classes.yml` has
+      `agricultural` but nothing for construction/works plant, and art. 114 of the
+      codice is a different regime from art. 113. `agricultural` is recorded as the
+      closest available value and flagged as a vocabulary gap, exactly as
+      plates/de.yml records for the German green tax-exempt plate.
+
+  - id: it-machine-trailed
+    class: agricultural
+    categories: [machine, trailer]
+    period: { start: 1993 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL L 999"
+      regex: '\A[A-Z]{2} ?[A-Z] ?\d{3}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTVWXYZ]{2} ?[ABCDEFGHJKLMNPRSTVWXYZ] ?\d{3}\z'
+      charset: { letters_excluded: [I, O, Q, U] }
+      legend_note: "'Macc. Op.' is a legend, not serial content"
+    design:
+      plate: { w: 340, h: 109, unit: mm, note: "art. 258 c. 1 lett. d)" }
+      background: { color: "#FFCC00", finish: retroreflective, hex_basis: observed }
+      foreground: "#CC0000"
+      legend: { text: "MACC. OP.", note: "Appendice XII lett. g) prints it as 'Macc. Op.'; art. 260 c. 1 lett. a) puts the machine plates' characters and marchio in red but names only 'RIM. AGR.' among the red legends, so the legend's colour is a recorded gap" }
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder, color: "#CC0000" }
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. g): 'targa delle macchine operatrici trainate (fig. III.4/i): riporta, nell'ordine, la scritta \"Macc. Op.\", due caratteri alfabetici, il marchio ufficiale della Repubblica italiana, un carattere alfabetico e tre caratteri numerici'"
+    notes: >-
+      MACCHINE OPERATRICI TRAINATE — trailed operating machines. Same inverted
+      letter-then-digits order as the self-propelled machines, on the landscape
+      340 x 109 plate, with the Macc. Op. legend. Kept separate from
+      it-machine-selfpropelled because dimensions and legend differ; kept separate
+      from it-agricultural-trailer because the character order and the colour rule
+      differ.
+
+  # =========================================================================
+  # EE — ESCURSIONISTI ESTERI. Italy's temporary-import / pre-export series.
+  # =========================================================================
+  - id: it-ee-1993
+    class: export
+    categories: [car, van, truck, bus, trailer]
+    period: { start: 1993 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "EE 999 LL"
+      regex: '\AEE ?\d{3} ?[A-Z]{2}\z'
+      regex_strict: '\AEE ?\d{3} ?[ABCDEFGHJKLMNPRSTVWXYZ]{2}\z'
+      charset:
+        fixed_letters: "EE"
+        letters_excluded: [I, O, Q, U]
+        notes: "Appendice XII lett. p): 'riporta, nell'ordine, il marchio ufficiale della Repubblica italiana, il rettangolo destinato a contenere il talloncino di scadenza, la sigla dello Stato italiano, la scritta \"EE\", tre caratteri numerici e due caratteri alfabetici'"
+    design:
+      plate: { w: 340, h: 109, unit: mm, note: "art. 258 c. 1 lett. d) — EE plates for autoveicoli and their trailers, including repeater plates" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      ee_letters: { color: "#0066CC", hex_basis: observed, note: "art. 260 c. 1 lett. c): 'colore azzurro: lettere EE di tutte le targhe previste dall'articolo 134, comma 1, del codice'" }
+      country_oval: { content: "I", color: "#000000", note: "art. 260 c. 1 lett. c-bis), added in 1998: 'colore nero: sigla I alle targhe per escursionisti esteri, quando prevista' — the EE plate carries the Vienna-style national sign as an ELLIPSE on the plate, not an EU band" }
+      expiry_field:
+        w: 69
+        h: 20
+        unit: mm
+        background: "#CC0000"
+        foreground: "#FFFFFF"
+        content: "month number, a white separating stroke, then the last two digits of the year in which the carta di circolazione expires"
+        note: "art. 260 c. 3, first sentence — a red adhesive sticker in a raised 69 x 20 mm rectangle"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+    validity: { max_months: 12, note: "art. 134 c. 1 del codice: 'una carta di circolazione della durata massima di un anno, salvo eventuale proroga, e una speciale targa di riconoscimento, come stabilito nel regolamento'" }
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. p); art. 258 c. 1 lett. d); art. 260 c. 1 lett. c) and c-bis), c. 2 and c. 3"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art134  # art. 134 c. 1: temporarily imported or factory-new-for-export vehicles belonging to Italians resident abroad or to foreigners passing through; max one year, extendable"
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=19940101  # Appendice XII lett. q) as enacted — the separate EE TRAILER plate ('la sigla dello Stato italiano, la scritta \"Rimorchio\", il rettangolo ..., la scritta \"EE\", il marchio ufficiale ... e cinque caratteri numerici'), suppressed by D.P.R. 198/2012"
+    notes: >-
+      TARGHE EE (ESCURSIONISTI ESTERI) — the plate an Italian resident abroad or a
+      foreigner passing through gets for a temporarily imported vehicle or for a
+      factory-new vehicle bought in Italy for export. CLASS CAVEAT: art. 134 c. 1
+      covers BOTH legs ("importati temporaneamente O nuovi di fabbrica acquistati
+      per l'esportazione") and `_meta/classes.yml` forces a choice; `export` is
+      recorded because the plate's defining feature is that the vehicle is not
+      staying, and `temporary` is the near miss — the twelve-month cap is carried
+      in `validity` so a class-blind consumer still sees it. THE EE PLATE IS THE
+      ONE ITALIAN PLATE WITH A DATE ON IT: a red expiry sticker giving month and
+      year, in a rectangle the regulation embosses into the plate. It carries the
+      national sign as a black "I" in an ellipse rather than as an EU band, which
+      is exactly the pre-amendment Vienna Annex 3 arrangement the EU dossier warns
+      about. Since D.P.R. 198/2012 suppressed Appendice XII lett. q), EE trailers
+      have no separate format and fall under this entry.
+
+  - id: it-ee-motorcycle-1993
+    class: export
+    categories: [motorcycle]
+    period: { start: 1993 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "EE 999 L"
+      regex: '\AEE ?\d{3} ?[A-Z]\z'
+      regex_strict: '\AEE ?\d{3} ?[ABCDEFGHJKLMNPRSTVWXYZ]\z'
+      charset: { fixed_letters: "EE", letters_excluded: [I, O, Q, U] }
+    design:
+      plate: { w: 165, h: 165, unit: mm, note: "art. 258 c. 1 lett. e) — 'targhe EE per motoveicoli'" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      ee_letters: { color: "#0066CC", hex_basis: observed }
+      expiry_field: { w: 69, h: 20, unit: mm, background: "#CC0000", foreground: "#FFFFFF" }
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+    validity: { max_months: 12 }
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XII lett. s): 'targa EE per motoveicoli (fig. III.4/u): riporta, nell'ordine, la sigla \"EE\", il marchio ufficiale della Repubblica italiana, la sigla dello Stato italiano, il rettangolo destinato a contenere il talloncino di scadenza, tre caratteri numerici ed un carattere alfabetico'"
+    notes: >-
+      EE FOR MOTORCYCLES — one letter where the car plate has two, on the 165 mm
+      square. Note the order differs from the car EE plate as well: here "EE" comes
+      FIRST and the marchio and the national sign follow, where lett. p) opens with
+      the marchio. Two entries rather than one because both format and dimensions
+      differ (PRD-PLATES §2.3).
+
+  # =========================================================================
+  # TEMPORARY — targa provvisoria, the only Italian plate with a region prefix
+  # still being issued.
+  # =========================================================================
+  - id: it-temporary-provvisoria
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 1993 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "L9 99999"
+      regex: '\A[A-Z]\d{1,2} ?\d{5}\z'
+      regex_statutory: '\A[A-Z]\d{1,2} ?[A-Z0-9]{5}\z'
+      charset:
+        notes: >-
+          Art. 255 c. 2, verbatim: "I criteri per la formazione dei dati riportati
+          nelle targhe provvisorie sono i seguenti: a) sigla d'individuazione
+          dell'ufficio provinciale, come indicato nella suddetta appendice ...;
+          b) marchio ufficiale della Repubblica Italiana; c) serie progressiva
+          costituita da cinque caratteri numerici. Il Ministero dei trasporti e
+          della navigazione - Direzione generale della M.C.T.C. può stabilire che
+          la serie in questione sia modificata ed integrata da caratteri
+          alfabetici." `regex` is the five-NUMERIC series the article prescribes;
+          `regex_statutory` is the outer bound the last sentence authorises, and is
+          the honest encoding of a power that has been exercised or not — the
+          dataset cannot tell, and says so.
+      progression: "five-digit progressive series per issuing office (art. 255 c. 2 lett. c))"
+    design:
+      note: >-
+        NO DESIGN IS SOURCED. Art. 255 sits outside the art. 256 definitions of
+        immatricolazione / ripetitrici / riconoscimento plates, so art. 258's
+        dimensions, art. 260's colours and Appendice XIII's construction rules do
+        not reach it on their own terms, and no figure for the targa provvisoria was
+        located. Colours and dimensions are a RECORDED GAP and are deliberately not
+        guessed.
+      emblem: { present: true, rendered: placeholder, note: "art. 255 c. 2 lett. b) puts the marchio ufficiale on the plate" }
+    validity:
+      max_days: 60
+      max_days_special: 180
+      note: >-
+        Art. 99 c. 2 del codice: "Il foglio di via deve indicare il percorso, la
+        durata e le eventuali prescrizioni tecniche. La durata non può comunque
+        eccedere i giorni sessanta. Tuttavia, per particolari esigenze di
+        sperimentazione di veicoli nuovi non ancora immatricolati, l'ufficio
+        competente ... può rilasciare alla fabbrica costruttrice uno speciale foglio
+        di via, senza limitazioni di percorso, della durata massima di centottanta
+        giorni."
+    region_encoding: "plates/_decode/it-provinces.yml"
+    region_encoding_mechanism: >-
+      THE PREFIX IS AN OFFICE CODE, NOT A PROVINCE SIGLA, and confusing the two is
+      the trap this decode file exists to prevent. Appendice XI comma 1 lists the
+      M.C.T.C. provincial offices as a letter plus a number — A1 Alessandria, B6
+      Milano, P4 Roma, X4 Oristano — grouped under bare region letters (A Piemonte
+      e Valle d'Aosta, B Lombardia, ...) that are headings and not codes. Art. 255
+      c. 2 lett. a) adds the maintenance rule: "Detto elenco può essere aggiornato
+      con decreto del Ministro dei trasporti e della navigazione, a seguito
+      dell'istituzione di ulteriori province", so the table grows by ministerial
+      decree and decode rows need period discipline.
+    sources:
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art255  # art. 255 c. 1 and c. 2 in full"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art99  # art. 99 c. 1 (the six purposes: technical checks, driving to border crossings for export, military reviews, authorised shows and fairs), c. 2 (60 / 180 days)"
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802  # Appendice XI comma 1 — the office sigle; art. 214 — veicoli d'epoca use this plate"
+    notes: >-
+      TARGA PROVVISORIA, issued with a foglio di via. Two things make it more
+      interesting than a typical temporary plate. First, it is the ONLY Italian
+      series still issued that encodes geography in the mark itself — but as an
+      OFFICE code, not a province sigla, so a decoder that reaches for the province
+      table will produce nonsense. Second, it is Italy's historic-vehicle plate by
+      default: art. 214 of the regolamento sends veicoli d'epoca here — "Ai veicoli
+      d'epoca ... per la circolazione nei luoghi consentiti, è rilasciato il foglio
+      di via e la targa provvisoria previsti dall'articolo 99 del codice" — with the
+      foglio di via capping speed at 40, 25 or 15 km/h depending on brakes and
+      tyres, and the event needing at least fifteen participants. Anyone looking for
+      an Italian H-Kennzeichen finds this instead.
+
+  # =========================================================================
+  # TRADE PLATES — targa prova, before and after DPR 474/2001.
+  # =========================================================================
+  - id: it-dealer-prova-2002
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, moped, trailer, tractor, machine]
+    period: { start: 2002 }
+    period_evidence: enabling-statute
+    binding: business
+    matching: strict
+    format:
+      pattern: "LLP99999"
+      regex: '\A[A-Z0-9]{2} ?P ?[A-Z0-9]{5}\z'
+      charset:
+        notes: >-
+          Art. 2 c. 3 D.P.R. 474/2001, verbatim: "La targa è composta, nell'ordine,
+          da due caratteri alfanumerici, dalla lettera 'P' e da cinque caratteri
+          alfanumerici. Il fondo della targa è bianco. Il colore dei caratteri e
+          della lettera 'P' è nero." ALPHANUMERIC, not alphabetic: unlike every
+          series under Appendice XII, the outer groups may be letters or digits, and
+          the 22-letter alphabet of Appendice XII comma 2 does not govern this
+          decree at all. No strict twin is authored because none is sourced.
+      serial_semantics: "art. 2 c. 1: the character sequence 'corrisponde al numero dell'autorizzazione medesima' — the plate IS the authorisation number"
+    design:
+      plate: { note: "'Le dimensioni della targa ed il formato dei relativi caratteri sono quelli previsti nella figura allegata al presente regolamento' (art. 2 c. 4); the figure was not text-extractable — recorded gap" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec, spec_note: "art. 2 c. 3: 'Il fondo della targa è bianco'" }
+      foreground: "#000000"
+      foreground_note: "art. 2 c. 3: 'Il colore dei caratteri e della lettera P è nero' — the GREEN P of the 1993 plate is gone"
+      band: { side: none }
+      emblem: { present: false, note: "art. 2 c. 3 lists ground, characters, P and the embossing; it does not put a marchio on the plate, and D.P.R. 474/2001 has no equivalent of art. 262" }
+      construction: "1.4 ± 0.1 mm embossing on 1.00 ± 0.05 mm aluminium with retroreflective self-adhesive film (art. 2 c. 3)"
+      display: "rear; on autotreni and autoarticolati the plate goes on the TRAILED vehicle (art. 2 c. 1)"
+    validity: { max_months: 12, note: "the autorizzazione 'ha validità annuale e non è rinnovabile decorsi sei mesi dalla sua scadenza'" }
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=20020130&codiceRedaz=002G0018&dataVigenza=20260802  # D.P.R. 24 novembre 2001, n. 474 (GU 30-01-2002 n. 25), art. 2 commi 1-4: the transferable plate bearing the authorisation number, the 2 + P + 5 composition, white ground and black characters, the figure reference; art. 3 (loss/theft); the annual validity and the six-month non-renewal cliff"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art98  # art. 98 of the codice: commi 1 and 2 'ABROGATO DAL D.P.R. 24 NOVEMBRE 2001, N. 474'; comma 3 still penalises using a prova vehicle for another purpose or without the authorisation holder or a delegated employee aboard"
+    notes: >-
+      TARGA PROVA — Italy's trade plate, and like the German rote Kennzeichen it
+      binds to a BUSINESS rather than a vehicle: art. 2 c. 1 makes it "trasferibile
+      da veicolo a veicolo insieme con la relativa autorizzazione", hence
+      `binding: business` and a warning to any vehicle-keyed consumer not to join on
+      it. `period_evidence: enabling-statute` is earned here rather than assumed:
+      D.P.R. 474/2001 is a self-contained regolamento di semplificazione that both
+      abrogated the old regime (art. 254, Appendice XII lett. l)-o) and art. 260
+      c. 1 lett. b) of DPR 495/1992 all read "ABROGATO/SOPPRESSA DAL D.P.R. 24
+      NOVEMBRE 2001, N. 474") and created this format, and Normattiva records the
+      resulting text as in force from 14 February 2002. One good operational detail
+      for a claims model: art. 2 c. 2-bis requires the ordinary registration plate
+      to stay on and stay legible while the prova plate is fitted — an Italian
+      vehicle can lawfully display two plates at once.
+
+  - id: it-dealer-prova-1993
+    class: dealer
+    categories: [car, van, truck, bus, trailer]
+    period: { start: 1993, end: 2002 }
+    period_evidence: instrument-in-force
+    binding: business
+    matching: strict
+    format:
+      pattern: "LLP 9999"
+      regex: '\A[A-Z]{2} ?P ?\d{4}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTVWXYZ]{2} ?P ?\d{4}\z'
+      charset: { letters_excluded: [I, O, Q, U], notes: "Appendice XII comma 2 governed the prova plates too, since they were letters l)-o) of the same comma 1" }
+    design:
+      plate: { w: 340, h: 109, unit: mm, note: "art. 258 c. 1 lett. d) as enacted — 'targhe prova degli autoveicoli e loro rimorchi'" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: spec }
+      foreground: "#000000"
+      marker: { text: "P", color: "#008000", note: "art. 260 c. 1 lett. b) as enacted, verbatim: 'colore verde: lettera P di tutte le targhe per la circolazione di prova e lettere M ed A ed M ed O che la integrano, rispettivamente, nelle targhe per la circolazione di prova delle macchine agricole e delle targhe per la circolazione di prova delle macchine operatrici'" }
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+    variants:
+      - class: dealer
+        format: { pattern: "LLP999", regex: '\A[A-Z]{2} ?P ?\d{3}\z' }
+        note: "targa prova per motoveicoli (from 1997, 'per ciclomotori e motoveicoli') — Appendice XII lett. m) as enacted: 'due caratteri alfabetici, il marchio ufficiale della Repubblica italiana, la lettera \"P\" e tre caratteri numerici', on the 165 x 165 mm square"
+      - class: dealer
+        format: { pattern: "LLP999", regex: '\A[A-Z]{2} ?P ?\d{3}\z' }
+        note: "targa prova per macchine agricole — Appendice XII lett. n) as enacted, same characters plus 'la scritta \"MA\" con le lettere poste in successione verticale', the M and A in green"
+      - class: dealer
+        format: { pattern: "LLP999", regex: '\A[A-Z]{2} ?P ?\d{3}\z' }
+        note: "targa prova per macchine operatrici — Appendice XII lett. o) as enacted, same characters plus a vertically stacked 'MO' in green"
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=19940101  # Appendice XII lett. l) 'targa prova per autoveicoli e rimorchi (fig. III.4/n): riporta, nell'ordine, due caratteri alfabetici, la lettera \"P\", il marchio ufficiale della Repubblica italiana e quattro caratteri numerici', lett. m), n) and o); art. 258 c. 1 lett. d) and e); art. 260 c. 1 lett. b) — the green P"
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=19980101  # lett. m) retitled '((targa prova per ciclomotori e motoveicoli))' by D.P.R. 610/1996"
+    notes: >-
+      THE GREEN-P TRADE PLATE, 1993-2002. Four shapes under one regime, so the three
+      companions are recorded as variants rather than as three thin series: what
+      distinguishes them is a vertically stacked two-letter suffix (MA, MO) and the
+      plate size, not the serial. The GREEN P is the one colour Italy ever assigned
+      to a functional letter and it did not survive: D.P.R. 474/2001 repainted the P
+      black. Note the letter order relative to the marchio also flipped between
+      lett. l) (P before the marchio) and lett. m)-o) (P after it) — recorded here
+      because a render pipeline needs it and a parser does not.
+
+  # =========================================================================
+  # DIPLOMATIC — sourced only for the pre-1993 era. The modern format is a
+  # documented gap; see common.unsourced_series.
+  # =========================================================================
+  - id: it-diplomatic-1959
+    class: diplomatic
+    categories: [car]
+    period: { start: 1959, end: 1996 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "CD 999999"
+      regex: '\ACD ?\d+\z'
+      charset:
+        fixed_letters: "CD"
+        notes: >-
+          Art. 327 D.P.R. 420/1959, verbatim: "Essa porta, in rilievo, in colore
+          alluminio lucido su fondo nero, la sigla CD, il marchio ufficiale ed il
+          numero di immatricolazione." The registration NUMBER is left entirely
+          unbounded by the primary, so the regex quantifies without a ceiling rather
+          than inventing one — which is also why this series is recall-only.
+    design:
+      plate: { w: 275, h: 200, unit: mm, note: "same dimensions as the ordinary rear plate of art. 320" }
+      background: { color: "#000000", finish: painted, hex_basis: spec }
+      foreground: "#C0C0C0"
+      foreground_note: "art. 327: 'in colore alluminio lucido' — POLISHED ALUMINIUM, not white. The hex is an observed rendering of a metallic finish that no hex can express; a render pipeline should treat it as a material, not a colour."
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      material: "alluminio anticorodal (art. 327)"
+    validity: { note: "art. 131 c. 4 del codice (current law, same rule): validity 'scade al momento in cui cessa lo status diplomatico di colui al quale il veicolo appartiene'; the plate must be returned within ninety days" }
+    region_encoding: none
+    sources:
+      - "https://www.normattiva.it/do/atto/caricaAKN?dataGU=19590630&codiceRedaz=059U0420&dataVigenza=19920101  # D.P.R. 420/1959 art. 327: 'AUTOVETTURE APPARTENENTI AGLI AGENTI DIPLOMATICI' — anticorodal aluminium, 275 x 200 mm, polished-aluminium characters on black, sigla CD + marchio + registration number; transfer to another car of the same owner may be authorised by the Ministry"
+      - "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art131  # art. 131 c. 2: the CURRENT plate's type and characteristics are set 'con decreto del Ministro dei trasporti, di concerto con il Ministro degli affari esteri'; c. 4: expiry with diplomatic status"
+    notes: >-
+      THE PRE-1993 CD PLATE, and the honest limit of this pass. Italy's CURRENT
+      diplomatic and consular plates are real and are not modelled: art. 131 c. 2 of
+      the codice delegates their type and characteristics to a joint decree of the
+      transport and foreign ministries, that decree was not located, and DPR
+      495/1992 contains no diplomatic provision at all. This is the same posture
+      plates/de.yml takes towards the German district list — cite the mechanism,
+      refuse to author the table. What IS sourced is the plate this one replaced,
+      and it is worth having: silver-on-black, the same 275 x 200 mm as an ordinary
+      rear plate, and legally attached to a STATUS rather than to a vehicle or a
+      keeper, since art. 327 let the Ministry move it to another car of the same
+      owner and art. 131 c. 4 kills it the moment diplomatic status ends.


### PR DESCRIPTION
**PRD-PLATES gate L1, wave 1** (owner-directed acceleration; NEGOTIATION turn "PLATES GATE L1 KICKOFF", 2026-08-02). One of eight jurisdiction PRs (gb ch at fr it be se fi), each drafted by an independent researcher pass to the `de.yml`/`nl.yml` standard: primary-law verbatim headers, instrument-dated periods, `strict`/`recall-only` matching tiers, folklore flagged rather than asserted, every source URL pinned with access date.

**This PR — Italy (`it`):** `plates/it.yml` + `plates/_decode/it-provinces.yml` — **20 series**.

**Verification:** `ruby scripts/lint_plates.rb` run green in this branch before push (CI runs the same gate). Full-wave sandbox lint with all 8 drafts + all 7 decode tables staged over baseline: `plates lint: 12 files, 219 series / matching recall-only=15 strict=204 | twins regex_statutory=32 regex_strict=132 | separators emitted "-"," " forgiving 18 / plates lint: OK`.

**For the reviewer:** dossier §4 (folklore), §5 (gaps and open questions, incl. §5.4 vocabulary gaps flagged for `_meta/classes.yml` — flagged, not self-amended).

The full research dossier follows verbatim (it also graduates to `vehiclesdb-pipeline/aux/research/plates-2026-07/` with the wave).

---

# Research dossier — ITALY (`it`), PRD-PLATES gate L1

**Researcher pass, 2026-08-02.** Draft only; a human session verifies, lints and
applies. Nothing under `/Users/javi/GitHub/vehiclesdb` was modified.

**Deliverables**

| file | what it is |
|---|---|
| `it.yml` | the draft jurisdiction file — 20 series |
| `it-provinces.yml` | the decode file (destination `plates/_decode/it-provinces.yml`) — 107 current province sigle + 4 withdrawn + 106 M.C.T.C. office codes |
| `dossier-it.md` | this file |

**Lint:** GREEN. `ruby scripts/lint_plates.rb` in a sandbox copy of `plates/` +
`scripts/` with `it.yml` and `_decode/it-provinces.yml` added:

```
plates lint: 6 files, 106 series
plates lint: matching recall-only=8 strict=98 | twins regex_statutory=9 regex_strict=65 | separators emitted "-"," " forgiving 18
plates lint: OK
```

(The 6 files / 106 series totals include `se.yml`, which appeared in the sandbox
copy of `plates/` from a parallel L1 pass. Italy contributes 20 series, 6 of the
8 `recall-only` values, 1 of the 9 `regex_statutory` twins and 23 `regex_strict`
twins. Removing `se.yml` and `it.yml` reproduces the L0 baseline of 4 files /
73 series, also green.)

---

## 1. Method, and why this pass could close the L0 gap

The L0 EU research dossier
(`vehiclesdb-pipeline/aux/research/plates-2026-07/plates-research-eu-intl.md`)
records Italy as its worst-sourced jurisdiction — §2.5: *"**No primary source
secured.** Everything below is from `https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Italy`
and must be confirmed against the Codice della Strada and DPR 495/1992 before the
PRD relies on it"* — and DEAD-ENDS §8: *"**Italy — no primary source obtained.**
Codice della Strada / DPR 495/1992 not fetched. All Italian claims are
Wikipedia-grade."*

Two things unlocked it:

1. **Normattiva's article permalinks resolve cleanly through WebFetch.** The form
   `https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1992-12-16;495~art258`
   returns the consolidated article text. The bare-act URL returns only a
   JavaScript navigation tree, which is presumably why the L0 pass gave up.
2. **Normattiva publishes an Akoma-Ntoso XML export of the WHOLE act, at any
   vigenza date.** The endpoint is discoverable in the act page's HTML:
   `https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=YYYYMMDD`.
   This is the decisive tool for this program, and it should go in the source
   appendix for every Italian and every future Normattiva-served jurisdiction:
   * it contains the **APPENDICI**, which the per-article permalinks do not — and
     Appendice XII is the entire Italian serial grammar and Appendice XI is the
     entire decode table;
   * varying `dataVigenza` gives **multivigenza diffing**, which is how every
     period boundary in `it.yml` was dated rather than guessed;
   * it carries the `AGGIORNAMENTO (n)` notes, which name the amending decree,
     its Gazzetta reference and its commencement rule.

   The companion endpoint
   `https://www.normattiva.it/do/atto/vediAggiornamentiAllAtto?atto.dataPubblicazioneGazzetta=1992-12-28&atto.codiceRedazionale=092G0531`
   lists every amending act against the articles it touched — that is how D.P.R.
   355/1998 was identified as the single instrument behind the whole 1999 plate.

**WebSearch was unavailable for this pass** (session budget exhausted at the
first call). Everything below was reached by constructing Normattiva URNs
directly and by `curl` against the endpoints above. One Wikipedia fetch was made,
strictly as a LOCATOR under PRD-PLATES §4, to find out what the folklore claims
and what it cites; it cites nothing for any of the claims at issue, which is
recorded in §4 below.

---

## 2. Sources pinned

All accessed **2026-08-02**. All are primary (Normattiva is the official
consolidated-law service of the Italian State, published by the Istituto
Poligrafico e Zecca dello Stato / Presidenza del Consiglio).

### 2.1 D.P.R. 16 dicembre 1992, n. 495 — the regolamento (GU n. 303 del 28-12-1992, S.O. n. 134)

| URL | evidences |
|---|---|
| `https://www.normattiva.it/do/atto/caricaAKN?dataGU=19921228&codiceRedaz=092G0531&dataVigenza=20260802` | **the consolidated act in full.** Appendice XI commi 1 and 1-bis (both decode tables); Appendice XII commi 1–3 (every serial grammar); Appendice XIII (the technical disciplinare: aluminium grade, thickness, embossing depth, fixing holes, the white/yellow/blue chromatic cross-reference); artt. 214–215 (veicoli d'epoca and di interesse storico); artt. 248–251 (moped plate); the AGGIORNAMENTO notes incl. (44) D.P.R. 198/2012 and (55) D.P.R. 140/2017 |
| `…&dataVigenza=19940101` | **the act as enacted.** Appendice XII lett. a) with no blue zones; lett. b) the "Rimorchio" trailer plate; lett. c) motorcycles = 2 letters + marchio + **five digits**; lett. l)–o) the four targa-prova shapes; art. 258 with the 340×109 / 486×109 / 336×202 / 165×165 dimensions; art. 260 c. 1 lett. b) the **green P**; art. 260 c. 5 "**a partire dal 1 luglio 1993**" with no backstop |
| `…&dataVigenza=19980101` | **the act after D.P.R. 610/1996 and before D.P.R. 355/1998.** art. 260 c. 5 now reads "((a partire dal 1 ottobre 1993))" + "((e comunque non oltre il 31 dicembre 1996))"; Appendice XII lett. h)/i) widened to six/five alphanumerics; lett. m) retitled "targa prova per ciclomotori e motoveicoli". **The EU band is absent here** — this is the lower bracket on the 1999 design |
| `…&dataVigenza=19980901` / `19981101` | **the bracket itself.** No Euroband at 1 Sep 1998; Euroband present at 1 Nov 1998 → the amendment took effect in October 1998, consistent with D.P.R. 355/1998 (GU 14-10-1998) and its ordinary 15-day vacatio |
| `…&dataVigenza=20160101` | **the four withdrawn province sigle**, verbatim: Carbonia-Iglesias CI, Medio Campidano VS, Ogliastra OG, Olbia-Tempio OT |
| `…&dataVigenza=20040101` | **the pre-2006 moped regime**: art. 248 "Contrassegno di identificazione per ciclomotori", art. 250 "porta in rilievo su fondo bianco retroriflettente una combinazione di cifre e lettere" — no count, no arrangement |
| `https://www.normattiva.it/do/atto/vediAggiornamentiAllAtto?atto.dataPubblicazioneGazzetta=1992-12-28&atto.codiceRedazionale=092G0531` | **the amendment ledger.** D.P.R. 4 settembre 1998, n. 355 (GU 14-10-1998 n. 240) → art. 256 c. 4-bis, art. 258 c. 1 lett. a)–e-bis), art. 259 c. 2, art. 260 cc. 1/3/5, Appendice XI, Appendice XII, Appendice XIII, the Allegati. Also the GU references for D.P.R. 198/2012 (22-11-2012 n. 273), D.P.R. 474/2001 (30-01-2002 n. 25), D.P.R. 153/2006 (15-04-2006 n. 89), D.P.R. 140/2017 (22-09-2017 n. 222) |
| `…N2Ls?urn:…1992-12-16;495~art255` | targa provvisoria: office sigla + marchio + five-numeral progressive series, and the Ministry's power to modify/integrate it with alphabetic characters |
| `…~art257` | the delegation to Appendice XII **and comma 2's ministerial escape hatch** |
| `…~art258` | the current dimensions incl. lett. e-bis) 177×177 mm motorcycle plate, and the "fermo restando … per i veicoli immatricolati anteriormente al 1 gennaio 1999" preamble |
| `…~art260` | colours (c. 1), embossing (c. 2), the two stickers + the EE expiry sticker (c. 3), the figures reference (c. 4), the 1993/1996/1999 commencement sentence (c. 5) |
| `…~art262` | the marchio ufficiale: five-pointed star between olive and oak branches, figura III.5 |

Also read and used for negative findings: `~art254` (abrogated by D.P.R.
474/2001), `~art256` (the definitions of immatricolazione / ripetitrici /
riconoscimento plates + comma 4-bis), `~art259` (installation geometry),
`~art261` (models deposited at the Ministry), `~art263`, `~art264`, `~art265`
(none plate-format-bearing).

### 2.2 D.Lgs. 30 aprile 1992, n. 285 — the Codice della Strada

Whole-act AKN: `https://www.normattiva.it/do/atto/caricaAKN?dataGU=19920518&codiceRedaz=092G0306&dataVigenza=20260802`

| URL | evidences |
|---|---|
| `…N2Ls?urn:nir:stato:decreto.legislativo:1992-04-30;285!vig=~art97` | moped: "una targa, che identifica l'intestatario del certificato di circolazione"; c. 2 "La targa è personale e abbinata a un solo veicolo" |
| `…!vig=~art98` | circolazione di prova: commi 1 and 2 **abrogated by D.P.R. 474/2001** |
| `…!vig=~art99` | foglio di via + targa provvisoria; the six purposes; 60 days, 180 for manufacturer testing |
| `…!vig=~art100` | front+rear on cars, rear on motorcycles and trailers, repeater on carrelli appendice, retroreflective, the regolamento delegation (cc. 7 and 9), **c. 8 the requested combination**, **c. 10 the yellow self-built off-road competition panel**, and **c. 3-bis the dormant owner-binding rule** with AGGIORNAMENTO (99) = L. 120/2010 art. 11 c. 6 deferring it |
| `…!vig=~art113` | targhe delle macchine agricole — rear plate duty; repeater on the last element of a convoy |
| `…!vig=~art114` | c. 4: "Le macchine operatrici semoventi … devono essere munite di una targa …; le macchine operatrici trainate devono essere munite di una speciale targa di immatricolazione" |
| `…!vig=~art131` | **diplomatic**: c. 2 delegates type and characteristics to a joint MIT/MAE decree; c. 4 validity ends with diplomatic status, return within 90 days |
| `…!vig=~art134` | **EE**: temporarily imported or factory-new-for-export vehicles of Italians resident abroad or foreigners passing through; carta di circolazione max 1 year, extendable |
| `…!vig=~art138` | **military**: the Forze armate register their own vehicles and issue their own plates — outside the civil system entirely |
| `…!vig=~art60` | veicoli d'epoca vs veicoli di interesse storico e collezionistico (ASI, Storico Lancia, Italiano FIAT, Italiano Alfa Romeo, Storico FMI) |

### 2.3 D.P.R. 24 novembre 2001, n. 474 — targa prova (GU 30-01-2002 n. 25)

`https://www.normattiva.it/do/atto/caricaAKN?dataGU=20020130&codiceRedaz=002G0018&dataVigenza=20260802`
— art. 2 c. 1 (transferable, bears the authorisation number, goes on the trailed
vehicle of an autotreno), c. 2-bis (the registration plate stays on and legible),
**c. 3 the 2 alphanumeric + "P" + 5 alphanumeric composition, white ground, black
characters**, c. 4 (figure), plus the annual validity and the six-month
non-renewal cliff.

### 2.4 D.P.R. 30 giugno 1959, n. 420 — the pre-1993 regolamento

`https://www.normattiva.it/do/atto/caricaAKN?dataGU=19590630&codiceRedaz=059U0420&dataVigenza=19920101`
(consolidated **at 1 January 1992**, i.e. the last state of the old law)
— art. 320 (rear car plate 275×200 mm, **white on black**, province sigla +
marchio + "un numero o una combinazione di lettere e cifre"), art. 321 (front
plate 267×62 mm, single row), art. 322 (**motorcycle: blue on white**, 165×165),
art. 323 (trailer 267×62, white on black, red-ish "RIMORCHIO" legend), art. 325
(EE: sigla EE + number + red expiry rectangle), **art. 327 (diplomatic: CD, 275×200,
polished-aluminium characters on black, anticorodal aluminium)**.

### 2.5 Locator, not source

`https://it.wikipedia.org/wiki/Targhe_d'immatricolazione_italiane` — fetched once
under the §4 locator rule to identify folklore and chase citations. **It cites no
primary for any of the claims in §4 below.** No text or table was copied.

---

## 3. What the primaries actually say — the findings that shaped the file

1. **The alphabet is 22 letters and it is printed in the law.** Appendice XII
   comma 2 lists A B C D E F G H J K L M N P R S T V W X Y Z. I, O, Q, U are
   never issued. This is the single most valuable Italian validation fact and it
   is now sourced rather than asserted.
2. **The 1993 → 1999 change is design-only.** Same seven characters, same
   alphabet. Art. 260 c. 5 even provides for re-plating an old serial in the new
   design "con la stessa sigla alfanumerica … senza che si configuri l'ipotesi di
   reimmatricolazione". Consequence for the parse API: **a 1999-design Italian
   plate does not imply a post-1999 first registration.**
3. **Italy is a genuine front/rear-asymmetry jurisdiction, and the primary
   confirms it**: art. 258 c. 1 lett. a) 360×110 front vs lett. b) 520×110 rear.
   The render pipeline needs two artefacts per Italian registration. It was
   asymmetric in 1993 too (340×109 vs 486×109) and in 1959 (267×62 vs 275×200).
4. **The plate physically grew when the Euroband arrived** — front 340→360,
   rear 486→520, motorcycle 165→177. That is a cheap, hard, sourced tell between
   the 1993 and 1999 series in any dimension-aware context.
5. **The famous year+province band is two stickers, and the law says they are not
   part of the plate** (art. 260 c. 3). It also says the province is the
   **keeper's province of residence**, not the place of registration — the
   inverse of the pre-1993 sigla's meaning. Recorded in both the series and the
   decode file; this is Italy's version of the French-SIV caution.
6. **No historic series exists, and that is sourced.** Art. 214 of the
   regolamento routes veicoli d'epoca to the **targa provvisoria**; art. 60 c. 5
   of the codice leaves veicoli di interesse storico on their ordinary
   registration. There is no Italian H-Kennzeichen.
7. **Mopeds are owner-bound.** Art. 97 c. 2 codice + art. 248 c. 3 regolamento.
   The pre-2006 contrassegno was looser still: one holder could ride several
   different mopeds on it (art. 248 c. 4, 2004 text). `binding: owner` is set on
   the series, against a file default of `binding: vehicle`.
8. **A dormant owner-binding rule exists for ALL Italian plates.** Art. 100
   c. 3-bis makes plates personal and retained on sale; L. 120/2010 art. 11 c. 6
   defers it to six months after an implementing regolamento that this pass could
   not find. Recorded in `binding_note` as a scheduled future fact.
9. **Trade plates flipped colour.** Green "P" 1993–2002 (art. 260 c. 1 lett. b) as
   enacted), black "P" from D.P.R. 474/2001. The 2001 decree also stopped using
   Appendice XII's 22-letter alphabet — its groups are **alphanumeric**.
10. **The repeater plate is the only Italian plate with no marchio**, the only one
    whose characters are applied by the owner, and the source of the best decode
    line in Italian plate law: Appendice XII c. 3, "Nel caso in cui la targa del
    veicolo traente contenga la parola Roma essa viene riportata sulla targa
    ripetitrice mediante la sigla RM."
11. **Agricultural and operating-machine plates carry no Euroband on the
    regulation's own text** — D.P.R. 355/1998 amended only Appendice XII lett. a)
    and c). Flagged for photographic verification (§5).
12. **Macchine operatrici plates are entirely red on yellow** — art. 260 c. 1
    lett. a) puts both the characters and the marchio in red. The only Italian
    plate with a red imprint.

---

## 4. Folklore flags — commonly repeated, found unsourced or circular

| claim | status |
|---|---|
| **"The AA 000 AA system started in 1994"** (it.wikipedia: "Dal 28 febbraio 1994"; repeated across the enthusiast web and in the L0 dossier's Italy section) | **UNSOURCED.** it.wikipedia cites nothing for it. The primary gives 1 July 1993 as enacted, 1 October 1993 as amended, progressive rollout as provincial stock ran out, backstop 31 December 1996. `period.start` is 1993 with `period_rollout` carrying the backstop; 1994 is not laundered into the data |
| **"The EU-band plate started 8 February 1999"** | **UNSOURCED** in the same way. The primary says "le nuove targhe in uso dal 1 gennaio 1999" (art. 260 c. 5 as amended by D.P.R. 355/1998). Both land on 1999 so `period.start` is unaffected, but the day-precision claim is not adopted |
| **"Current motorcycle plates are 2 letters + 5 digits"** | **CONFLICTS WITH THE PRIMARY.** Appendice XII lett. c), as rewritten by D.P.R. 355/1998 and still in force, says "tre caratteri numerici e due caratteri alfabetici". The five-digit form is exactly what lett. c) said **before** 1999. Neither side is discarded — see §5.1 |
| **"Moped plates are 3 letters + 3 digits, excluding A E I O Q U, no digit 1"** | **UNSOURCED.** Art. 250 c. 1 fixes only "sei caratteri alfanumerici"; c. 4 hands the progression to the Department and publishes nothing. The regex is the six-character grammar; the arrangement and the exclusions are not written into the data |
| **"Province codes date from 1927"** | **UNSOURCED.** No primary secured. The decode file's `period.start` is 1998, the date of the instrument that enacts the list actually read, with the folklore recorded in `period_note` |
| **"I/O/Q/U are excluded because they look like 1/0/V"** | **UNSOURCED RATIONALE.** The exclusion itself is sourced (Appendice XII c. 2 gives the positive list); the reason is not stated anywhere in the regulation and is not asserted |
| **"The moped plate changed over on 14 July 2006"** | **UNSOURCED day.** D.P.R. 153/2006 is GU 15-04-2006 n. 89; `period.start` rests on the instrument |
| **"Rome's plates read RM"** | **FALSE for the provincial era and for the sticker.** Appendice XI comma 1-bis prints the sigla as the word "Roma"; RM exists only as the repeater-plate substitution legislated in Appendice XII comma 3 |

---

## 5. Gaps and open questions — for the verifier

### 5.1 THE ONE THAT MATTERS: the current motorcycle format

`it-motorcycle-1999` is the only current series in this file marked
`matching: recall-only`, and it is not because of a union of issued shapes but
because of a documented conflict:

* **Primary:** Appendice XII lett. c), as amended in 1998 and in force in 2026 —
  two letters, marchio, **three digits and two letters**.
* **Everything else:** it.wikipedia and the enthusiast web — two letters and
  **five digits** — which is precisely the text lett. c) had *before* the 1998
  amendment.
* **The mechanism that would reconcile them:** art. 257 c. 2, which lets the
  Minister set "una successione ed un impiego di caratteri alfanumerici diversi da
  quelli indicati al comma 1 della suddetta appendice XII" **without amending the
  appendix**. No such decree was located (WebSearch unavailable).

The regex is the union of both shapes and the series is `recall-only`, so the
dataset makes no false validity claim either way. **Verifier's task:** obtain
either (a) the ministerial decree under art. 257 c. 2, or (b) a photographic or
registry-corpus determination of what is actually issued. If the five-digit form
is what is on the road, the fix is to **extend `it-motorcycle-1993` past 1999**
(its `strict` five-digit grammar is already correct and sourced) rather than to
widen the 1999 entry. If the appendix form is what is on the road, narrow the
1999 entry to `\A[A-Z]{2} ?\d{3} ?[A-Z]{2}\z`, set `matching: strict` and add the
22-letter `regex_strict`.

### 5.2 Not modelled, with the mechanism cited instead

* **Current diplomatic / consular (CD, CC).** Art. 131 c. 2 codice delegates type
  and characteristics to a joint MIT/MAE decree; the decree was not located, and
  DPR 495/1992 has no diplomatic provision. Same posture as `de.yml` towards the
  Bundesanzeiger district list. The **pre-1993** CD plate IS sourced and is in the
  file as `it-diplomatic-1959`.
* **Military and police (EI, MM, AM, CC, GdiF, VF, POLIZIA).** Art. 138 c. 1
  removes them from the civil system entirely. No format asserted.
* **Monopattini (e-scooters).** A 2025 identification mark exists (L. 177/2024 +
  a reported decree n. 210 of 27-06-2025); neither text was pinned. Flagged as a
  known missing current series.
* **Pre-2006 moped `contrassegno di identificazione`.** Its art. 250 fixed **no
  character count at all** ("una combinazione di cifre e lettere"). A series whose
  primary fixes no length cannot carry a regex, so none was authored; the finding
  is recorded in `it-moped-2006.notes`.

### 5.3 Sourced but incomplete

* **All figures and tables are images.** Tabelle III.3/a–III.3/d (the letter-block
  progression), figura III.5 (the marchio), figura III 3 + tabella III 2 (the
  moped plate's form and character format), the whole `Allegati al Titolo III`
  figure set, the DPR 474/2001 figure, and Appendice XIII point 4.1's chromatic
  tables. Consequences carried in the data: **the moped plate has no dimensions**,
  **the targa provvisoria has no dimensions or colours**, **the targa prova has no
  dimensions**, **no Italian colour has a spec value**, and **an Italian serial
  cannot be dated from its letter block by anything in this file.**
* **Every hex in `it.yml` except black and white is `hex_basis: observed`.** Italy
  names colours (bianco, giallo, nero, rosso, azzurro, blu) and numbers none.
* **The provincial-era colour discrepancy.** Art. 320 D.P.R. 420/1959 still read
  "carattere bianco su fondo nero" in the text in force on 1 January 1992, yet the
  last generation of provincial plates was black on white retroreflective. **No
  instrument changing the colour was located.** The sourced colours are recorded
  and the discrepancy is flagged in `design.colour_caveat` rather than averaged.
  This is the second-priority verification item.
* **Does the Euroband reach agricultural / operating-machine plates?** On the
  regulation's text, no. Verify against photographs; if yes, a ministerial decree
  under art. 257 c. 2 is again the likely instrument and should be pinned.
* **The pre-1998 province sigle list.** The only primary list is Appendice XI
  comma 1-bis, inserted in 1998. Provinces created in 1992 and later never issued
  provincial-era plates, and the pre-1992 list is not sourced. A decode of a
  physical provincial plate must therefore be treated as unresolved for any code
  not in the table, exactly as `es-provinces.yml` says for the pre-RGV Spanish
  contraseñas.
* **`period.start 1959`** on the three provincial-era series is the instrument's
  date, not the system's origin. All three carry
  `period_evidence: instrument-in-force`.
* **`period.start 2013`** on `it-trailer-2013` is DERIVED (ninetieth day after GU
  publication of 22-11-2012), not printed. Verifier may wish to confirm the exact
  day.
* **Is the L. 120/2010 art. 11 c. 5 regolamento in force?** If it is, art. 100
  c. 3-bis is live and `binding:` for every Italian series must flip to `owner`.
  D.P.R. 198/2012 satisfies art. 11 c. 7 (trailers) but its relationship to c. 5
  was not resolved.

### 5.4 Vocabulary gaps flagged for `_meta/classes.yml`

* **No class for works/construction plant.** `it-machine-selfpropelled` and
  `it-machine-trailed` are art. 114 macchine operatrici, a different regime from
  art. 113 agricultural machines; both are recorded as `agricultural` as the
  closest fit, exactly as `de.yml` does for the German green tax-exempt plate.
* **No class for a temporary-import/pre-export hybrid.** The EE plate is both
  (art. 134 c. 1 covers "importati temporaneamente **o** nuovi di fabbrica
  acquistati per l'esportazione"); `export` is recorded and the 12-month cap is
  carried in `validity` so a class-blind consumer still sees the temporary leg.

---

## 6. Verification notes — how to re-derive the period boundaries

Every date in `it.yml` can be re-derived in one command each:

| claim | command / check |
|---|---|
| 1993 system commencement | AKN at `dataVigenza=19940101`, art. 260 c. 5 → "1 luglio 1993"; at `19980101` → "((1 ottobre 1993))" + "((non oltre il 31 dicembre 1996))" |
| 1999 Euroband | AKN at `19980901` (absent) vs `19981101` (present); amendment ledger → D.P.R. 355/1998, GU 14-10-1998 n. 240 |
| motorcycle 165→177 mm | AKN `19940101` art. 258 lett. e) vs consolidated art. 258 lett. e-bis) |
| trailer merge | consolidated Appendice XII lett. b) = "SOPPRESSA DAL D.P.R. 28 SETTEMBRE 2012, N. 198"; AGGIORNAMENTO (44) for the ninetieth-day rule |
| targa prova 1993→2002 | consolidated Appendice XII lett. l)–o) = "ABROGATA DAL D.P.R. 24 NOVEMBRE 2001, N. 474"; DPR 474 AKN art. 2 c. 3 for the new composition |
| moped contrassegno→targa | AKN `20040101` artt. 248/250 vs consolidated; D.P.R. 153/2006 GU 15-04-2006 |
| four withdrawn province sigle | AKN `20160101` Appendice XI c. 1-bis vs consolidated; AGGIORNAMENTO (55) |
| provincial-era end 1996 | art. 260 c. 5, second half of the first sentence |

**Regex behaviour spot-check** (run against the draft; all as designed):

```
it-standard-1999  "AB 123 CD" regex✓ strict✓ | "AB123CD" ✓✓ | "AI 123 CD" regex✓ strict✗ | "AB 12 CD" ✗✗
it-motorcycle-1999 "AB 123 CD" ✓ | "AB 12345" ✓ (union) | "AB 1234" ✗
it-moped-2006     "X5A123" ✓ | "ABC123" ✓ | "AB12" ✗ | "1234567" ✗
it-provincial-1959 "MI 123456" ✓ | "ROMA 123456" ✓ | "AB 1234567" ✗
it-temporary      "A1 12345" ✓ | "B12 12345" ✓ | "A1 1234" ✗ ; statutory accepts "A1 1234X"
it-dealer-2002    "ABP12345" ✓ | "12P34567" ✓ (alphanumeric groups) | "ABP1234" ✗
it-ee-1993        "EE 123 AB" ✓ | "EA 123 AB" ✗
it-diplomatic-1959 "CD 12345" ✓ | "CC 123" ✗
```

**Decode-file integrity check** (run against the draft): 107 province rows,
4 withdrawn rows, 106 office rows; no duplicate codes; no overlap between current
and withdrawn; every province code matches `[A-Z]{2}` or `ROMA`; every office
code matches `[A-Z]\d{1,2}`.

**YAML trap found and fixed, worth propagating:** `code: NO` (Novara) parses as
boolean `false` under Psych's YAML 1.1 boolean rules, silently. Every `code:`
value in `it-provinces.yml` is therefore quoted. `_decode` files are not linted
by `lint_plates.rb`, so nothing would have caught it. **Recommendation for the
maintainer: extend `lint_plates.rb` (or a new `lint_decode.rb`) to load
`plates/_decode/*.yml` and assert that every `code` is a String** — `NO`, `ON`,
`OFF`, `YES` are all live hazards in a code table, and Norway, Ontario and
Nordrhein-Westfalen are all going to want the code `NO` or `ON` eventually.

---

## 7. Series inventory (20)

| id | class | period | matching | note |
|---|---|---|---|---|
| `it-standard-1999` | standard | 1999– | strict | AA 000 AA, EU band + right blue zone |
| `it-standard-1993` | standard | 1993–1999 | strict | same serial, no bands, smaller plates |
| `it-provincial-1959` | standard | 1959–1996 | recall-only | province sigla + open serial |
| `it-provincial-motorcycle-1959` | motorcycle | 1959–1996 | recall-only | **blue on white**, 165×165 |
| `it-motorcycle-1999` | motorcycle | 1999– | recall-only | the disputed one (§5.1) |
| `it-motorcycle-1993` | motorcycle | 1993–1999 | strict | 2 letters + 5 digits |
| `it-moped-2006` | moped | 2006– | strict | six alphanumerics, **binding: owner** |
| `it-trailer-2013` | trailer | 2013– | strict | merged onto the car format |
| `it-trailer-1993` | trailer | 1993–2013 | strict | red "RIMORCHIO" legend |
| `it-repeater` | trailer | 1993– | recall-only | yellow, red R, no marchio, owner-filled |
| `it-agricultural-selfpropelled` | agricultural | 1993– | strict | yellow, LL 999 L |
| `it-agricultural-trailer` | agricultural | 1993– | strict | red "RIM. AGR." legend |
| `it-machine-selfpropelled` | agricultural | 1993– | strict | **all-red imprint**, LL L 999 |
| `it-machine-trailed` | agricultural | 1993– | strict | "MACC. OP." legend |
| `it-ee-1993` | export | 1993– | strict | EE 000 AA, red expiry sticker, black "I" oval |
| `it-ee-motorcycle-1993` | export | 1993– | strict | EE 000 A, 165×165 |
| `it-temporary-provvisoria` | temporary | 1993– | strict | office code prefix; Italy's veicoli-d'epoca plate |
| `it-dealer-prova-2002` | dealer | 2002– | strict | 2 alnum + P + 5 alnum, **binding: business** |
| `it-dealer-prova-1993` | dealer | 1993–2002 | strict | **green P**, + 3 variants |
| `it-diplomatic-1959` | diplomatic | 1959–1996 | recall-only | silver on black; current format is a gap |

Variants (sub-entries, not series): `personalized` on `it-standard-1999`
(art. 100 c. 8); the yellow self-built off-road competition panel on
`it-motorcycle-1999` (art. 100 c. 10); the moto / macchine agricole / macchine
operatrici prova shapes on `it-dealer-prova-1993`.

---

## 8. Suggested PR framing for the maintainer

* `plates/it.yml` — new, 20 series.
* `plates/_decode/it-provinces.yml` — new, two tables in one file (the alternative
  of two files was rejected because the whole point is that a consumer must see
  both and not confuse them).
* Consider amending `_meta/classes.yml` with a `works-plant` (or `machinery`)
  class and reviewing whether `export` should split into `export` and
  `temporary-import` — Italy is the second jurisdiction to strain both.
* Consider adding the decode-file `code`-is-a-String lint noted in §6.
* The source appendix should record the **Normattiva AKN endpoint** as the
  standard tool for Italian (and any Normattiva-served) research — it is what
  turned the L0 dossier's worst gap into 20 fully sourced series in one pass.
