### PR TITLE
plates: us northeast — CT MA ME NH RI VT (L2 US wave)

### DIFF
--- a/plates/us-ct.yml
+++ b/plates/us-ct.yml
@@ -1,0 +1,427 @@
+# plates/us-ct.yml — Connecticut (PRD-PLATES gate L2, northeast group).
+#
+# WHY CONNECTICUT IS UNUSUAL, and what the statute actually carries: Connecticut
+# is one of the few states whose CURRENT BASE HAS A STATUTORY START DATE and
+# whose LEGENDS ARE LEGISLATED. C.G.S. § 14-21b(a) says the commissioner "shall
+# issue fully reflectorized safety number plates for new registrations and
+# renewal registrations issued ON AND AFTER JANUARY 1, 2000", that "each plate
+# shall bear the words 'Constitution State' and 'Connecticut'", and that the
+# commissioner "shall issue TWO fully reflectorized safety number plates". So
+# the base year, the two legends, the reflectorization and the two-plate rule
+# are all primary — not brochure, not folklore. What the statute does NOT carry
+# is the SERIAL GRAMMAR: Chapter 246 nowhere states a character count, an
+# alphabet or a dimension. Every serial claim below is therefore secondary and
+# is labelled as such (PRD-PLATES §4: Wikipedia is a LOCATOR; ctplates.info and
+# licenseplates.cc are enthusiast corroboration, cited because they were used).
+#
+# THE SEPARATOR PROBLEM, recorded here because Connecticut is the first
+# jurisdiction in the dataset to hit it: Connecticut prints a RAISED MIDDLE DOT
+# between serial groups (AB·12345), not a hyphen and not a space. U+00B7 is in
+# `_meta/separators.yml`'s FORGIVING set — so a lenient consumer already strips
+# it correctly — but it is NOT in the EMITTED set, so the dataset may not spell
+# it (PRD-PLATES §2.6). Every pattern and regex below therefore writes the gap
+# as U+0020 and this note carries the fact. That is a data-honest workaround,
+# not a silent one; whether the emitted set should grow a third member is a
+# `_meta` PR question and is raised in the group dossier, not decided here.
+#
+# ARTWORK: Connecticut turns out to have the most interesting IP evidence in
+# this group and it is NOT favourable — see `artwork_risk`.
+jurisdiction: us-ct
+authority:
+  name: Connecticut Department of Motor Vehicles (CT DMV)
+  url: "https://portal.ct.gov/dmv"
+binding: vehicle
+statute_edition: >-
+  General Statutes of Connecticut, Title 14 Chapter 246 (Motor Vehicles.
+  Operators and Motor Vehicles), as published by the Connecticut General
+  Assembly and revised to January 1, 2026 — the edition read for this pass.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: adverse-evidence-found
+  basis: >-
+    Connecticut is NOT in the Commons/Wikipedia survey of state public-domain
+    postures (no {{PD-CTGov}} template exists on Commons — checked by API this
+    pass, result MISSING), so the §105 default applies: a state work is
+    copyrighted unless the state says otherwise. Connecticut has said the
+    OPPOSITE of otherwise, in statute. C.G.S. § 14-21w(e) expressly authorises
+    the Commissioner of Motor Vehicles to "provide for the REPRODUCTION AND
+    MARKETING of the Share the Road commemorative number plate IMAGE for use on
+    clothing, recreational equipment, posters, mementoes or other products or
+    programs", with the proceeds going to a statutory account. A legislature
+    that grants its DMV a commercial licensing right over a plate IMAGE is a
+    legislature treating that image as a proprietary asset. The same section,
+    at (a), adds "No use shall be made of such plates except as official
+    registration marker plates." This is direct statutory evidence of an
+    asserted interest and it is stronger evidence than the absence of a Commons
+    tag. Treat Connecticut as adverse alongside NY/PA/WA/AZ.
+  scope_caution: >-
+    § 14-21w(e) is about ONE commemorative plate (Share the Road), not about the
+    standard base. No instrument was found asserting copyright over the standard
+    2000 base itself, and none was found disclaiming it. The honest reading is:
+    Connecticut demonstrably treats at least one plate image as marketable state
+    property, and nothing in the corpus suggests the standard base is treated
+    differently.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies without exception here. The
+    Connecticut base carries a screened STATE SHAPE at top left; state-shape and
+    state-seal protection independent of copyright is unresearched for
+    Connecticut (recorded gap, same gap the FL pilot recorded).
+  photograph_caution: >-
+    Commons photographs of Connecticut plates carry the PHOTOGRAPHER's licence,
+    not the design's — the uploader had no standing over the design. Because our
+    renders are generated from spec and never derived from a photograph, those
+    obligations never attach (PRD-PLATES §4, §6).
+  sources:
+    - "https://www.cga.ct.gov/current/pub/chap_246.htm  # C.G.S. § 14-21w(a) 'No use shall be made of such plates except as official registration marker plates'; § 14-21w(e) the reproduction-and-marketing authority over the plate IMAGE — the adverse evidence"
+    - "https://commons.wikimedia.org/w/api.php?action=query&titles=Template:PD-CTGov  # queried this pass: Template:PD-CTGov is MISSING on Commons — no Connecticut public-domain tag exists, unlike PD-FLGov/PD-CAGov/PD-MAGov/PD-MEGov"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR: Connecticut has no entry in this survey — recorded as unsurveyed, not as favourable"
+
+# ---------------------------------------------------------------------------
+# Display rules — all statutory, all quoted from Chapter 246.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates. § 14-21b(a): the commissioner 'shall issue two fully reflectorized safety number plates'; § 14-18(a)(2): a vehicle for which two number plates have been issued 'shall ... display in a conspicuous place at the front and the rear of such vehicle the number plates'. § 14-18(a)(1) governs the one-plate case (rear only)."
+  legibility: "§ 14-18(c): plates 'shall be entirely unobscured and the numerals and letters thereon shall be plainly legible at all times'; horizontal; 'fastened so as not to swing'; and when lights are required the REAR plate 'shall be so illuminated as to be legible at a distance of fifty feet'."
+  one_per_end: "§ 14-18(c): 'Not more than one number plate shall be displayed on the front or rear of any motor vehicle' — subject to a commissioner's permission exception. A genuinely unusual rule; most states legislate a minimum, Connecticut legislates a maximum."
+  obstruction: "§ 14-18(c): 'Nothing may be affixed to a motor vehicle or to the official number plates displayed on such vehicle that obscures or impairs the visibility of any information on such number plates.'"
+  ownership: "§ 14-18(d): 'All number plates shall be the property of the state and no title therein shall pass to any person registering a motor vehicle' — except that on a new general issue 'the obsolete number plates shall become the property of the registrant upon the expiration date'."
+  sample_plates: "§ 14-18(e): the commissioner may issue a plate inscribed with the legend 'SAMPLE', which may not be displayed on any vehicle."
+  penalty: "§ 14-18(g): violation of subsection (a), (c), (d), (e) or (f) is an INFRACTION. § 14-21b(c): failure to display issued reflectorized plates as provided in § 14-18 is also an infraction."
+  sources:
+    - "https://www.cga.ct.gov/current/pub/chap_246.htm  # § 14-18(a)(1),(a)(2) display front/rear; (c) legibility, horizontality, 50-foot rear illumination, the not-more-than-one rule, the obstruction rule; (d) state ownership of plates; (e) SAMPLE plates; (g) infraction. § 14-21b(a),(c) two reflectorized plates and the display infraction"
+
+# ---------------------------------------------------------------------------
+# The US standards chain, recorded once per jurisdiction file. Nothing below
+# quotes SAE J686 (paywalled, unpinned — the standing rule).
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA writes recommendations in the declarative present; they are RECOMMENDED PRACTICE, not requirement."
+  aamva_geometry: "AAMVA §2.1 jurisdiction name top-centre between the bolt holes, >=0.25 in above the plate number, >=0.125 in from the top edge, characters 0.75-1.0 in; §2.2 serial characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom; §3.3 readable in daylight and at night from >=75 feet, materials per ASTM D4956-19 and ISO 7591:1982 cl.3, entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2."
+  dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is PAYWALLED and was NOT obtained. No J686 dimension is quoted here. Connecticut's own statute states NO plate dimension at all (Chapter 246 was read in full for this pass; the word 'inches' appears nowhere in a plate-size context) — so the 12x6 in figure below is `observed`, not sourced."
+  replacement_cycle_recommendation: "AAMVA §1.1 recommends a rolling or full replacement cycle 'not to exceed 7 to 10 years'. Connecticut legislates NO replacement cycle in Chapter 246 (recorded gap); its 2000 base has been in issue for 26 years, well past the AAMVA recommendation."
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA/AAMVA/NSC standardization agreement" appears in the Connecticut
+    Wikipedia article WITH a citation, unlike the US article where it is a bare
+    `citation needed` — but the citation is Christopher Garrish, "Reconsidering
+    the Standard Plate Size", *Plates* (ALPCA) vol. 62 no. 5, October 2016: a
+    hobby-association members' magazine, not obtained, not obtainable online, and
+    whose very TITLE announces that it reconsiders the standard story. Recorded
+    as COMMONLY REPEATED, STILL UNVERIFIED, with the pointer to the one artefact
+    that might settle it. Connecticut's own 6x12 in plate is not in its statute.
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE.
+  # =========================================================================
+  - id: us-ct-standard-2015
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2015 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "LL 99999"
+      regex: '\A[A-Z]{2} ?\d{5}\z'
+      charset:
+        notes: >-
+          Reported alphabet: letters I, O and Q not used. THE STATUTE STATES NO
+          ALPHABET AND NO LENGTH — Chapter 246 was read in full and contains no
+          character-count or character-set rule for standard plates, so this
+          exclusion is secondary (Wikipedia locator, sourced there to a Hartford
+          Courant report of the September 2015 changeover). It is recorded as a
+          note and deliberately NOT promoted to a `regex_strict`: PRD-PLATES
+          reserves the strict twin for the AUTHORITY's own alphabet, and laundering
+          a newspaper report into a strict twin is exactly the folklore failure
+          §4 forbids.
+      separator_note: >-
+        THE PRINTED SEPARATOR IS A RAISED MIDDLE DOT (U+00B7): the plate reads
+        AB·12345. U+00B7 is in `_meta/separators.yml`'s FORGIVING set but not its
+        EMITTED set, so the dataset spells the gap as U+0020 here and records the
+        true glyph in this note (PRD-PLATES §2.6). A lenient consumer already
+        strips U+00B7 correctly; a consumer RENDERING from this data must read
+        this note, not the pattern, to place the dot.
+      progression: "AA 00001 upward; reported at BW 99865 as of 31 October 2025 (licenseplates.cc — enthusiast corroboration, cited because used)"
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4, hex_basis_note: "dimension OBSERVED, not sourced — Connecticut's statute states no plate size" }
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO HEX IS RECORDED. The base is a GRADIENT (reflective sky blue fading to
+        white) with a dark blue serial, so a single background hex would be a
+        false claim, and § 14-21b mandates reflectorization while naming no
+        colour at all. Recorded as a gap rather than invented — the FL pilot's
+        lesson applied.
+      legend_top: "Connecticut"
+      legend_bottom: "Constitution State"
+      legend_rule: >-
+        STATUTORY. § 14-21b(a), verbatim: "Each plate shall bear the words
+        'Constitution State' and 'Connecticut'." The statute fixes the WORDS but
+        not their placement; top/bottom placement is observed. Note the contrast
+        with the 1987-1999 base, where the same two words appeared with
+        CONNECTICUT at top and CONSTITUTION STATE at bottom after a 1987 swap —
+        i.e. the statute has been satisfied by two different layouts.
+      emblem: { present: true, rendered: placeholder, description: "screened state shape at top left — observed; see artwork_risk" }
+      material: "'fully reflectorized safety number plates' (§ 14-21b(a)); no material is named in statute"
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://www.cga.ct.gov/current/pub/chap_246.htm  # § 14-21b(a): fully reflectorized plates for registrations issued on and after January 1, 2000; the 'Constitution State' and 'Connecticut' legends; two plates issued. § 14-18: display"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Connecticut  # LOCATOR ONLY (PRD-PLATES §4): the August 2015 introduction of the seven-character AB·12345 arrangement, the I/O/Q exclusion, and the AA·00001 start. Its own citation for the changeover is a Hartford Courant news report of 18 September 2015"
+      - "https://www.licenseplates.cc/CT  # enthusiast corroboration, cited because used: the reported serial high-water mark BW·99865 as of 31 October 2025. No text or image copied"
+    notes: >-
+      CONNECTICUT CURRENT STANDARD. THE ID IS DATED 2015, NOT 2000, and that is a
+      deliberate schema decision: the DESIGN base is statutory from 1 January 2000
+      (§ 14-21b) but the SERIAL GRAMMAR changed twice on that base — to the interim
+      1ABCD2 and 1AB·CD2 shapes in 2013, and to the present AB·12345 shape in
+      August 2015. PRD-PLATES §2.3 makes a format change its own series, so the
+      2000 base carries three passenger series, of which this is the current one.
+      PERIOD EVIDENCE: `secondary-dated` — the 2015 date is a news/locator claim,
+      not a statutory one; the STATUTORY date that is beyond doubt is 2000, and it
+      belongs to the base, not to this serial format. The two 2013-2015 interim
+      formats are recorded in the group dossier and are deliberately NOT given
+      series here: they lasted fourteen and twenty months respectively, they are
+      the kind of transitional artefact §2.5 excludes, and no primary establishes
+      their boundaries.
+
+  # =========================================================================
+  # ONE SERIES BACK — the previous standard grammar on the same 2000 base.
+  # =========================================================================
+  - id: us-ct-standard-2000
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2000, end: 2013 }
+    period_evidence: statutory-date-start
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      charset:
+        notes: >-
+          Reported: the 'O' series was not used and the 'V' series was reserved
+          for Veteran plates. Secondary (locator) — not promoted to a strict twin,
+          for the reason given on us-ct-standard-2015.
+      separator_note: "printed as a raised middle dot (123·ABC); spelled U+0020 here per PRD-PLATES §2.6 — see the file header"
+      progression: "100 NZN to 999 ZZX — i.e. it CONTINUED the sequence of the 1987-1999 base rather than restarting, which is why the 2000 base's first plate is not 100 AAA"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "same gradient sky-blue-to-white base with dark blue serial as us-ct-standard-2015; no hex recorded, same reason"
+      legend_top: "Connecticut"
+      legend_bottom: "Constitution State"
+      legend_rule: "§ 14-21b(a) — identical statutory legends; this series and the current one share a design and differ only in serial grammar"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.cga.ct.gov/current/pub/chap_246.htm  # § 14-21b(a): the 1 January 2000 statutory start of the reflectorized base this series is issued on, and its two legends"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Connecticut  # LOCATOR ONLY: the 123·ABC arrangement on the January 2000 - June 2013 window, the 100·NZN to 999·ZZX range continuing from the previous base, the unused 'O' series and the Veteran 'V' reservation"
+    notes: >-
+      THE PREVIOUS STANDARD GRAMMAR, and the one with the best period evidence in
+      the whole Connecticut file: its START is § 14-21b's own "on and after
+      January 1, 2000", which is a statutory date, not a collector's recollection.
+      Its END (2013) is secondary. The sequence detail is the interesting one for
+      a parse API: Connecticut did NOT restart numbering at the base change, so a
+      123·ABC serial alone cannot distinguish a 1987-base plate from a 2000-base
+      plate — only the range can, and the boundary (999·NZM / 100·NZN) is
+      locator-grade. Recorded rather than smoothed over.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES (L2 scope: motorcycle, trailer, dealer, government).
+  # =========================================================================
+  - id: us-ct-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2015 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "00 LLLL"
+      regex: '\A00 ?[A-Z]{4}\z'
+      charset: { notes: "a literal '00' prefix followed by four letters — the two zeros are part of the serial, not a pad. Reported secondary; no statutory grammar exists" }
+      separator_note: "printed as a raised middle dot (00·ABCD); spelled U+0020 here per PRD-PLATES §2.6"
+    design:
+      plate: { w: 7, h: 4, unit: in, dimension_note: "MOTORCYCLE PLATE SIZE NOT OBTAINED — Connecticut's statute states no dimension for any plate and no departmental spec was found. This entry is a PLACEHOLDER carrying the conventional US motorcycle size and must not be treated as sourced (recorded gap)" }
+      background: { finish: retroreflective }
+      legend_top: "Conn"
+      legend_bottom: "Motorcycle"
+      legend_note: "the top legend is reported as the ABBREVIATION 'Conn', not 'Connecticut' — if correct, this is the one Connecticut plate that does not satisfy § 14-21b(a)'s literal wording, which may simply mean § 14-21b does not reach motorcycles (it names 'passenger, combination and commercial registrations and other registrations as the commissioner deems feasible'). Recorded as an open question, not resolved."
+      emblem: { present: false }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Connecticut  # LOCATOR ONLY: the 00·ABCD motorcycle arrangement introduced 2015 and shared with Classic Vehicle plates; the 'Conn'/'Motorcycle' legends"
+      - "https://www.cga.ct.gov/current/pub/chap_246.htm  # § 14-21b(a) scopes the reflectorized-plate duty to 'passenger, combination and commercial registrations and other registrations as the commissioner deems feasible' — the statutory reason motorcycles may sit outside the legend rule"
+    notes: >-
+      MOTORCYCLE. The 00·ABCD block is reported to be SHARED with the Classic
+      Vehicle series — two different classes drawing from one serial space, which
+      means a serial alone does not determine the class and a parse API must
+      return both candidates. That is precisely the ambiguity model PRD-PAID's
+      parse endpoint is specified to expose (ranked candidates, not one answer),
+      and Connecticut is the first US case of it in this dataset.
+
+  - id: us-ct-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2015 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "LL 99999"
+      regex: '\A[A-Z]{2} ?\d{5}\z'
+      charset: { notes: "commercial trailers now draw the same AB·12345 grammar as passenger plates; the older V·12345 and W·12345 prefixed forms are reported to remain on the road (secondary)" }
+      separator_note: "printed as a raised middle dot; spelled U+0020 here per PRD-PLATES §2.6"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "reported as the passenger base with a RED serial and red border line rather than dark blue — a colour-only differentiation; no hex recorded (secondary, and the base is a gradient)"
+      legend_top: "Connecticut"
+      legend_bottom: "Trailer"
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Connecticut  # LOCATOR ONLY: Trailer plates carry the passenger base with red serial and border and a 'Trailer' bottom legend; serial formats V·12345, W·12345 and now AB·12345"
+      - "https://www.cga.ct.gov/current/pub/chap_246.htm  # Chapter 246 is the registration authority; it states no trailer plate grammar (recorded gap)"
+    notes: >-
+      TRAILER. Connecticut differentiates several non-passenger classes by SERIAL
+      COLOUR (red) on an otherwise identical base — Trailer, Commercial,
+      Apportioned, Construction, Factory, Farm and Fire Apparatus all reportedly
+      share the red-serial treatment. Under PRD-PLATES §2.3 a colour-only variant
+      of the same format+period is a sub-entry rather than a series; these are
+      given separate entries only where the FORMAT also differs. Trailer earns its
+      own entry because it also carries a distinct bottom legend, which is a
+      design difference.
+
+  - id: us-ct-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2015 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "XL 9999"
+      regex: '\AM?[XD][A-Z]{1,2} ?\d{1,4}\z'
+      charset:
+        notes: >-
+          Reported structure: a CLASS PREFIX ('X' new dealer, 'D' used dealer,
+          'MX'/'MD' for the motorcycle equivalents), then one or two sequential
+          letters, then a numeric suffix of one to four digits which IDENTIFIES
+          THE DEALERSHIP — the letters advance within a dealership, the number
+          names it. That is the inverse of the usual arrangement and is the reason
+          this series is `recall-only`: the regex is a union across five reported
+          width combinations per prefix and is wider than any single issuing
+          grammar.
+      separator_note: "printed as a raised middle dot (XA·0); spelled U+0020 here per PRD-PLATES §2.6"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_bottom: "Dealer"
+    binding: business
+    region_encoding: "the NUMERIC SUFFIX identifies the DEALERSHIP, not a geography — a business decode, not a region decode. No decode table was obtained (recorded gap); it would be a per-dealer registry, which is out of PRD-PLATES scope in any event"
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Connecticut  # LOCATOR ONLY: the X/D/MX/MD dealer prefixes, the five reported width combinations each, and the rule that the numeric suffix signifies the dealership"
+      - "https://www.cga.ct.gov/current/pub/chap_246.htm  # § 14-21c: number plates for manufacturers of motor vehicles or automotive equipment — the statutory hook for the manufacturer end of this class; the dealer grammar itself is not in Chapter 246 (recorded gap)"
+    notes: >-
+      DEALER. `binding: business` for the same reason as Germany's rote
+      Kennzeichen and Florida's dealer plate: the plate follows the dealership,
+      not a vehicle. `matching: recall-only` is the honest setting — a hit says
+      "this string has a shape Connecticut issues to dealers", not "this is a
+      valid dealer plate", because the regex unions five width variants across
+      four prefixes and no primary bounds any of them. PERIOD: the start is an
+      upper bound from the statute edition read, not a real start; Connecticut
+      dealer plates are reported to date to the 1920s.
+
+  - id: us-ct-municipal
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2015 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{1,3} ?[A-Z]{2,3}\z'
+      charset:
+        notes: >-
+          Reported structure: one to three digits, then TWO OR THREE LETTERS THAT
+          NAME THE MUNICIPALITY. Six width combinations are reported (1·AB, 12·AB,
+          123·AB, 1·ABC, 12·ABC, 123·ABC), which is why this is `recall-only`.
+      separator_note: "printed as a raised middle dot; spelled U+0020 here per PRD-PLATES §2.6"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_bottom: "Municipal"
+      validation_note: "reported to use a 'MUNICIPAL CT' sticker in place of the ordinary validation sticker on the Preserve the Sound variant"
+    region_encoding: >-
+      YES — AND IT IS THE ONLY REAL GEOGRAPHIC DECODE IN A CONNECTICUT PLATE. The
+      two- or three-letter group indicates the TOWN OR CITY that owns the vehicle
+      (police cars and dump trucks included). THE DECODE TABLE WAS NOT OBTAINED —
+      no official municipal-code list was found in this pass, and Connecticut has
+      169 towns, so the table is substantial. Recorded as a gap and as a
+      candidate `plates/_decode/us-ct-municipal.yml` for a later gate. Until it
+      lands, a parse API must say "a Connecticut municipal plate" and stop, not
+      guess a town.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Connecticut  # LOCATOR ONLY: the six Municipal width combinations and the statement that 'the letters in the serial indicate the municipality'"
+      - "https://www.cga.ct.gov/current/pub/chap_246.htm  # Chapter 246 read in full; it contains no municipal plate grammar and no municipal code table (recorded gap)"
+    notes: >-
+      MUNICIPAL — Connecticut's government class, and the one Connecticut series
+      that encodes geography. Modelled `government` rather than `police` even
+      though police cars carry it, because the class is defined by OWNERSHIP (the
+      town) and not by function; PRD-PLATES's `police` class is for fleets with a
+      series distinct from general government, which this is not.
+
+  # =========================================================================
+  # SPECIALTY — PROGRAM INDEX ONLY (PRD-PLATES §2.5). No individual designs.
+  # =========================================================================
+  - id: us-ct-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2015 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LL 99999"
+      regex: '\A[A-Z]{2} ?\d{5}\z'
+      charset: { notes: "commemorative plates carry ORDINARY serials on an alternative design; § 14-21w(b) is explicit that 'such number plates shall have letters and numbers selected by the Commissioner of Motor Vehicles', and several sections allow the registrant to carry over a previously issued number or a low number under § 14-160" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised program; individual designs are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_statutory: 13
+      count_statutory_basis: >-
+        THIS COUNT IS PRIMARY, WHICH IS RARE FOR A US SPECIALTY INDEX. Connecticut
+        authorises commemorative plates ONE STATUTE AT A TIME, so the program list
+        can be counted directly out of Chapter 246's own table of contents rather
+        than off a DMV gallery. Thirteen sections carry the phrase "commemorative
+        number plates" as of the January 2026 revision: § 14-19b (collegiate),
+        14-21e (Long Island Sound), 14-21i (Greenways), 14-21j (Amistad), 14-21l
+        (Olympic Spirit), 14-21o (United We Stand), 14-21q (childhood cancer
+        awareness), 14-21s (wildlife conservation), 14-21u (Support Our Troops!),
+        14-21v (support for the nursing profession), 14-21w (Share the Road),
+        14-21x (Men's Health), 14-21y (Hartford Whalers), 14-21z (Save Our Lakes).
+        NOTE THE ARITHMETIC: that enumeration lists fourteen sections and the
+        phrase-count is thirteen, because § 14-19b's heading spells the program
+        differently ("collegiate commemorative number plates") and § 14-21e's does
+        not use the word "commemorative" at all. The discrepancy is recorded, not
+        resolved by picking a number — PRD-PLATES §5.3.
+      open_ended_route: "§ 14-19a additionally lets the commissioner issue SPECIAL number plates by REGULATION to members of qualifying organizations and to colleges, and to DISCONTINUE them — an open-ended route whose current membership is not countable from statute. So the true program count is 'thirteen-to-fourteen named in statute, plus an unknown number authorised by regulation'."
+      further_statutory_types: "Chapter 246 separately authorises non-commemorative special plates that are NOT part of the specialty program: § 14-20 (antique/rare/special interest, including year-of-manufacture plates), 14-20a (volunteer firefighters), 14-20b/c/d (veterans, war-period service, families of those killed in action), 14-21 (amateur radio), 14-21a (foreign consul), 14-21d (POW and Congressional Medal of Honor), 14-21h (animal population control), 14-27 (public service vehicles), 14-27a (vanpool)."
+      official_list_url: "https://portal.ct.gov/dmv"
+      official_list_caution: "CT DMV's own specialty-plate page was NOT successfully fetched in this pass (portal.ct.gov returns 404 on every guessed path and the Wayback CDX index for portal.ct.gov/dmv surfaces only image assets). The count above therefore rests on the STATUTE, which PRD-PLATES §4 prefers anyway — but the DMV's live catalogue remains unpinned (recorded gap)."
+      ip_note: "§ 14-21w(e) — the reproduction-and-marketing authority over a plate image — sits inside this program and is the file's artwork_risk evidence. See artwork_risk above."
+    region_encoding: none
+    sources:
+      - "https://www.cga.ct.gov/current/pub/chap_246.htm  # the chapter table of contents and section texts: the thirteen 'commemorative number plates' sections counted above; § 14-19a the regulation-made organizational and collegiate route including the discontinuance duty; § 14-21w(b) commissioner-selected letters and numbers, (e) the image-marketing authority"
+    notes: >-
+      THE CONNECTICUT SPECIALTY INDEX — and the best-sourced specialty index this
+      group produced, because Connecticut's legislature does the authorising
+      itself. Two things worth carrying forward. First, a statute-countable
+      program list is a genuinely better artefact than a DMV gallery: it is dated,
+      versioned, PD as an edict of government, and it cannot silently drift.
+      Second, the count is NOT a clean integer and the file says so — the
+      phrase-count (13) and the section-enumeration (14) disagree because two
+      sections word their headings differently, and PRD-PLATES §5.3 forbids
+      averaging a disagreement away.

--- a/plates/us-ma.yml
+++ b/plates/us-ma.yml
@@ -1,0 +1,379 @@
+# plates/us-ma.yml — Massachusetts (PRD-PLATES gate L2, northeast group).
+#
+# THE ONE FACT THAT MAKES MASSACHUSETTS DIFFERENT FROM EVERY OTHER STATE IN THIS
+# GROUP: the LAST DIGIT OF THE SERIAL ENCODES THE MONTH THE REGISTRATION EXPIRES
+# — 1 through 9 for January through September, 0 for October. That is a TIME
+# DECODE inside a US plate serial, the temporal cousin of Germany's district
+# prefix and the Netherlands' sidecode, and it is exactly the kind of thing
+# PRD-PLATES §2.4 exists to model. It is also why Massachusetts runs several
+# serial arrangements CONCURRENTLY rather than sequentially: each month's
+# allocation exhausts at its own rate, so October (digit 0) has needed its own
+# formats since 2018 while January-September were still inside 1ABC 2n. A
+# jurisdiction-keyed schema that assumes one current format per state gets
+# Massachusetts wrong. This file records the current arrangement and states the
+# concurrency rather than flattening it.
+#
+# SOURCING SHAPE HERE: Massachusetts's statute is thin on plates and rich on
+# process. M.G.L. c.90 §6 gives display; c.90 §2 gives reflectorization, the
+# SIX-CHARACTER CAP on "distinctive initial plates" (vanity), and one statutory
+# specialty design (Cape and Islands). Nothing in c.90 states a standard serial
+# grammar, a colour or a dimension. The RMV's own Passenger Plates Booklet is
+# the official catalogue and is cited for the program index. Serial grammars are
+# secondary and labelled as such throughout.
+#
+# FETCH NOTE, recorded because it affects citation honesty: malegislature.gov
+# refused every direct fetch this pass (connection timeouts on HTTPS, and the
+# live page is a JavaScript shell even in a 2025 Wayback capture). The statutory
+# text quoted below was read from a 2014 Wayback capture of the same URLs, which
+# were server-rendered then. The canonical URL is cited; the archive is named.
+# Both §6 and §2 quotations should be re-verified against the live 2026 edition
+# before merge — recorded as a verification task, not papered over.
+jurisdiction: us-ma
+authority:
+  name: Massachusetts Registry of Motor Vehicles (RMV), a division of the Massachusetts Department of Transportation
+  url: "https://www.mass.gov/orgs/massachusetts-registry-of-motor-vehicles"
+binding: vehicle
+statute_edition: >-
+  Massachusetts General Laws, Part I Title XIV Chapter 90 (Motor Vehicles and
+  Aircraft), §§ 2 and 6 — read this pass from a 2014-08-01 Wayback capture of
+  malegislature.gov because the live site was unreachable (see file header).
+  Edition currency is a recorded gap.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: favourable-with-a-stated-limit
+  basis: >-
+    Massachusetts is the second-best posture in this group after nothing (nobody
+    here matches Florida). Commons carries {{PD-MAGov}} — confirmed present by
+    API this pass — on the footing that a "Commonwealth of Massachusetts public
+    record disseminated by a Commonwealth agency or the Massachusetts Archives"
+    is public domain, because the Secretary of the Commonwealth has stated such
+    works can be copied and used FOR ANY PURPOSE. The underlying instrument is
+    the Secretary's own Guide to the Massachusetts Public Records Law, which at
+    page 7 records that all requests "even if made for a commercial purpose"
+    must be honoured, and which defines a public record at M.G.L. c.4 §7(26) as
+    documentary material "regardless of physical form or characteristics" —
+    wording broad enough on its face to reach a plate design held by an agency.
+  limits: >-
+    THE TEMPLATE ITSELF CARRIES TWO WARNINGS AND THEY ARE LOAD-BEARING. First,
+    it is "based on official statements by the Secretary of the Commonwealth,
+    which are NOT DEFINITIVE in the way a statute or a court ruling is" — unlike
+    Florida, where Microdecisions v. Skinner is a judicial holding. Second, the
+    Secretary's statement "only speaks to public records HELD BY THE
+    MASSACHUSETTS ARCHIVES", so extending it to a live RMV plate design is an
+    extrapolation, not a finding. The template also excludes municipal records
+    (M.G.L. c.66 §7). Recorded as favourable-but-not-adjudicated.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies. The current standard base carries
+    no state seal, but several specialty designs do, and Massachusetts
+    state-seal misuse protection independent of copyright is unresearched
+    (recorded gap — the same gap the FL pilot recorded, and the largest
+    remaining hole in the whole US IP analysis per the source dossier).
+  photograph_caution: >-
+    Commons photographs of Massachusetts plates carry the PHOTOGRAPHER's licence
+    on the photograph, not a licence on the design; the uploader had no standing
+    over the design. Our renders are generated from spec and never derived from a
+    photograph, so those obligations never attach.
+  sources:
+    - "https://commons.wikimedia.org/wiki/Template:PD-MAGov  # fetched this pass: the Massachusetts PD tag exists; its text, its reliance on the Secretary of the Commonwealth's statement, and BOTH of its self-declared limitations (not definitive; Archives-held records only)"
+    - "https://www.mass.gov/files/2017-06/Public%20Records%20Law.pdf  # A Guide to the Massachusetts Public Records Law (Secretary Galvin, updated January 2017): p.7 commercial-purpose requests must be honoured; p.40 the c.4 §7(26) definition of a public record. Cited via the Commons template, which quotes it verbatim; the PDF itself was not independently fetched this pass (recorded gap)"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR: the Massachusetts entry, quoting the Secretary of the Commonwealth's Archives research-services statement"
+
+display_rules:
+  default: "TWO plates, front and rear, unless the registrar issues one. M.G.L. c.90 §6, verbatim: every registered motor vehicle or trailer 'shall have its register number displayed conspicuously thereon by the number plates furnished by the registrar ... one number plate to be attached at the front and one at the rear of said motor vehicle, and one number plate to be attached at the rear of said trailer, but if the registrar issues but one number plate it shall be attached to the rear of the vehicle so that it shall always be plainly visible.'"
+  legibility: "§6: plates 'shall be kept clean with the numbers legible and shall not be obscured in any manner by the installation of any device obscuring said numbers', and when lights are required 'the rear register number shall be illuminated so as to be plainly visible at a distance of SIXTY FEET' — note sixty, where Connecticut legislates fifty and Rhode Island legislates a hundred-foot daylight legibility test instead."
+  foreign_plates: "§6: a vehicle registered here and elsewhere by reason of interstate operation 'may display the register number plates of this and any other state or country in which it is registered' provided the Massachusetts plates are also displayed as required — an explicit multi-jurisdiction display permission, unusual in this group."
+  no_other_plates: "§6: 'No number plates other than such as are procured from the registrar or such as may be authorized by him for temporary use ... shall be displayed on any motor vehicle or trailer so operated.'"
+  expiry_grace: "§6: a duly registered vehicle may be operated between noon on the expiration date and noon the following day if that day begins the new registration period and the register number for either period is displayed — a 24-hour statutory grace window written into the display section itself."
+  historic_note: "Both the 1977 green-on-white base and the 1987 'Spirit of America' base remain valid on the road (RMV practice, secondary). On the 1977 base only REAR plates were issued for most types, so a legally compliant Massachusetts car today may display one plate or two depending on which base it carries. A front-plate-requirement field for this state must therefore be conditional on the SERIES, not on the state."
+  sources:
+    - "https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXIV/Chapter90/Section6  # M.G.L. c.90 §6: display front and rear, the one-plate fallback, cleanliness and non-obstruction, sixty-foot rear illumination, the interstate dual-display permission, the no-other-plates rule, temporary plates, the noon-to-noon grace window. Read via https://web.archive.org/web/20140801000000/http://www.malegislature.gov/Laws/GeneralLaws/PartI/TitleXIV/Chapter90/Section6 — the live site was unreachable this pass"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; recommendations, not requirements."
+  aamva_geometry: "AAMVA §2.1 jurisdiction name top-centre between the bolt holes, >=0.25 in above the plate number, >=0.125 in from the top edge, characters 0.75-1.0 in; §2.2 serial characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom; §3.3 legible day and night from >=75 feet, ASTM D4956-19 and ISO 7591:1982 cl.3, entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2."
+  dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, which is PAYWALLED and UNPINNED; no J686 dimension is quoted here. M.G.L. c.90 states no plate dimension, so 12x6 in below is `observed`."
+  reflectorization_is_statutory_here: "M.G.L. c.90 §2, verbatim: 'All number plates issued by the registrar of motor vehicles under this chapter shall be reflectorized in accordance with specifications prescribed by him.' The DUTY is statutory; the SPECIFICATION is delegated to the registrar and was not obtained (recorded gap)."
+  replacement_cycle: "Massachusetts legislates none in c.90 (recorded gap). The 1977 base is still lawfully displayed 49 years on — the single strongest counter-example in this group to AAMVA §1.1's 7-to-10-year recommendation."
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — the "Spirit of America" base.
+  # =========================================================================
+  - id: us-ma-standard-spirit
+    class: standard
+    categories: [car, van]
+    period: { start: 1993 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "9LLL 99"
+      regex: '\A\d[A-Z]{3} ?\d{2}\z'
+      charset:
+        notes: >-
+          Reported alphabet: letters Q and U are never used; I and O were used in
+          the older 123·ABC and 1234 AB arrangements but IA-IZ and OA-OZ blocks
+          were skipped. THE STATUTE STATES NO ALPHABET for standard plates — c.90
+          §2's only character rule is the SIX-character cap on "distinctive
+          initial plates", which is the vanity series, not this one. The Q/U
+          exclusion is therefore secondary and is deliberately NOT promoted to a
+          `regex_strict`.
+        statutory_adjacent: >-
+          M.G.L. c.90 §2, verbatim, on vanity plates: the registrar may issue
+          "number plates of distinctive types, to be known as distinctive initial
+          plates, which may contain a register number consisting of a group of
+          letters or a combination of numbers and letters; provided, however, that
+          such group or combination shall not consist of MORE THAN SIX LETTERS OR
+          NUMBERS or combination thereof; and provided further, that there shall
+          be no duplication of identification." Six is a real statutory bound —
+          but it binds the vanity series only, so it is recorded here rather than
+          encoded as this series' `regex_statutory`.
+      progression: >-
+        The final digit is the MONTH CODE, not a counter, so the sequence advances
+        within a month-block. Reported blocks as of 25 May 2026 run from 1AAA 11
+        to at least 6ZZL 51 (January), 1AAA 12 to at least 6NZT 22 (February), and
+        so on per expiry month.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4, dimension_note: "OBSERVED — c.90 states no plate dimension" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      colour_note: >-
+        BOTH HEXES ARE `observed` AND SHOULD BE TREATED AS UNVERIFIED. c.90 §2
+        mandates reflectorization "in accordance with specifications prescribed by
+        [the registrar]" and names no colour; the registrar's specification was not
+        obtained. The recorded values encode the described design — embossed red
+        serial on reflective white, with the state name and slogan screened in
+        blue — and the red is a plausible-but-unsourced approximation.
+      legend_top: "Massachusetts"
+      legend_bottom: "The Spirit of America"
+      legend_rule: >-
+        NEITHER LEGEND IS STATUTORY. c.90 contains no slogan mandate at all, in
+        pointed contrast to New Hampshire (RSA 261:75(II) mandates "Live Free or
+        Die" by name) and Connecticut (§ 14-21b mandates "Constitution State").
+        Massachusetts's slogan is departmental and could change without
+        legislation.
+      emblem: { present: false }
+      rear_differs: false
+    serial_encoding:
+      kind: expiry-month
+      rule: "The FINAL DIGIT of the serial is the month the registration expires: 1-9 for January through September, 0 for October. November and December expirations were discontinued for passenger plates."
+      consequence: >-
+        A Massachusetts serial carries a renewal date in plain sight, which is a
+        parse-API capability no other state in this group offers — and a
+        modelling hazard, because it means the STATE RUNS TEN PARALLEL SERIAL
+        SPACES, one per month code, exhausting at different rates. October (code
+        0) left the 1ABC 2n arrangement in November 2018 and now runs 12A 340 and
+        123 A40; January through September remain in 1ABC 2n. So "the current
+        Massachusetts format" is genuinely a set, not a value.
+      evidence: "secondary (locator) — the month rule is not in c.90 and no RMV instrument stating it was obtained. Recorded as a strong, consistently reported claim awaiting a primary."
+    region_encoding: none
+    sources:
+      - "https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXIV/Chapter90/Section2  # M.G.L. c.90 §2: the statutory reflectorization duty delegated to the registrar; the SIX-character cap and no-duplication rule on distinctive initial (vanity) plates; the Cape and Islands statutory design. Read via the 2014-08-01 Wayback capture (live site unreachable this pass)"
+      - "https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXIV/Chapter90/Section6  # §6: display, the sixty-foot rear illumination rule"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Massachusetts  # LOCATOR ONLY (PRD-PLATES §4): the 1ABC 2n current arrangement, the month-of-expiration final digit, the Q/U exclusion and I/O skipped blocks, the 1987 first issue for vanity/non-passenger and 1993 adoption as the standard passenger base, the concurrent October formats"
+      - "https://web.archive.org/web/20140704083521/http://www.massrmv.com/Portals/30/docs/manuals/passenger_plates_manual_public.pdf  # RMV Passenger Plates Booklet, July 2014 — the RMV's OWN catalogue; used here for the plate-type inventory, not for serial grammar"
+    notes: >-
+      MASSACHUSETTS STANDARD ISSUE, "Spirit of America" base. PERIOD: 1993 is the
+      reported year this base became the standard PASSENGER base; the base itself
+      was first issued in 1987 for vanity and some non-passenger types, so 1987
+      and 1993 are both true of different things and the file says which. Both
+      dates are secondary. FORMAT CAVEAT, and it is the important one: `regex`
+      encodes the January-September arrangement (1ABC 2n) because that is what is
+      being issued to most registrants now, but October registrations are issued
+      on 123 A40 and 12A 340 concurrently, on the same base, in the same series.
+      Those are not given series of their own because they are the SAME design and
+      the SAME period differing only by month-block — the month rule makes them
+      one system, not several — and because no primary bounds them. Recorded as a
+      known incompleteness of `regex`, which is why `matching: strict` is still
+      correct: a hit on this regex IS a well-formedness claim for the
+      January-September space.
+
+  # =========================================================================
+  # ONE SERIES BACK — the green-on-white base, still lawfully on the road.
+  # =========================================================================
+  - id: us-ma-standard-green-1977
+    class: standard
+    categories: [car, van]
+    period: { start: 1977, end: 1993 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      charset: { notes: "reported 100·AAA to 999·VZZ; the same final-digit month code applies, and November and December expirations were discontinued during this base's life except on non-passenger and older red-on-white plates. An all-numeric 123·456 arrangement ran concurrently on this base from 1983, generally reissuing the serials of holders of the same numbers on the red-on-white base" }
+      separator_note: "printed with a raised dot (123·ABC); spelled U+0020 here per PRD-PLATES §2.6, as for every dot-separated series in this dataset"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#00693E"
+      colour_note: "embossed GREEN serial on reflective white with a border line, 'MASSACHUSETTS' centred at top; both hexes `observed`, same caveat as the current base"
+      legend_top: "MASSACHUSETTS"
+      emblem: { present: false }
+      rear_differs: true
+      rear_differs_note: "on this base only REAR plates were issued for most types — Reserved, Commercial and Taxi excepted, which received front plates too and must still display them. This is the schema's `rear_differs` doing real work: the same jurisdiction, in the same year, has both one-plate and two-plate cars on the road depending on series."
+    serial_encoding:
+      kind: expiry-month
+      rule: "same final-digit month code as the current base"
+      evidence: secondary
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Massachusetts  # LOCATOR ONLY: the 1977-1993 green-on-white base, the 123·ABC and later all-numeric arrangements, the rear-only issuance with the Reserved/Commercial/Taxi exceptions, and the statement that all plates since 1978 remain valid"
+      - "https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXIV/Chapter90/Section6  # §6's display duty is what makes an unreplaced 1977 plate still lawful: the statute requires display of the plates furnished by the registrar, and sets no expiry on a base"
+    notes: >-
+      THE PREVIOUS BASE — AND IT IS STILL BEING DRIVEN. Massachusetts sets no
+      replacement cycle, so green-on-white plates issued as early as 1977 remain
+      lawfully displayed, and registrants reportedly decline free replacement as a
+      point of pride. This is the `period.end` semantics earning their keep: the
+      series STOPPED BEING ISSUED in 1993 but did not stop being VALID, and a
+      consumer that reads `end: 1993` as "reject this plate" is wrong. The practical
+      limit is legibility, not age: an illegible plate fails the annual safety
+      inspection regardless of colour or vintage, which is the real reason old
+      Massachusetts plates leave the road.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES.
+  # =========================================================================
+  - id: us-ma-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2024 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "TZ 9999L"
+      regex: '\ATZ ?\d{4}[A-Z]\z'
+      charset: { notes: "a literal 'TZ' class prefix, four digits, one letter. The preceding arrangement on the same design was TZ 12345 (2021-2024); before that A12·345 (2008-2021), A 1234 (2004-2008) and 123·456 (1987-2004). Reported serials run TZ 1000A to at least TZ 5952M as of 30 April 2026" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_bottom: "TRAILER"
+      legend_note: "embossed 'TRAILER' in place of the slogan on the Spirit base — a design difference, hence its own series under PRD-PLATES §2.3"
+    registration_period: "all Massachusetts trailer plates expire on 30 NOVEMBER, a fixed statewide date rather than a per-registrant month — which is why the trailer series carries no month code in its serial and the passenger series does"
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Massachusetts  # LOCATOR ONLY: the TZ 1234A arrangement from 2024, its four predecessors on the same design, the reported high serial, and the 30 November fixed expiry"
+      - "https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXIV/Chapter90/Section6  # §6 requires ONE plate on a trailer, attached at the rear — the statutory reason this series is single-issue"
+    notes: >-
+      TRAILER. Statutorily single-plate (c.90 §6 names the trailer case
+      explicitly), and administratively single-expiry (30 November for all), which
+      together explain why the trailer serial does the opposite of the passenger
+      serial: no month code, and a class prefix instead. The 'TZ' prefix is the
+      most recent of five arrangements on one unchanged design, a reminder that in
+      Massachusetts a serial-format change is routine and a DESIGN change is rare.
+
+  - id: us-ma-commercial
+    class: standard
+    categories: [truck, van]
+    period: { start: 2019 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "L99 999"
+      regex: '\A[A-Z]\d{2} ?\d{3}\z'
+      charset: { notes: "reported ranges: A 1000 to C99·999 (1991-1993), D 1000 to approximately M63·800 (1993-2007), M63·801 to approximately V43·499 (2007-2019), V43·500 to at least Z27·646 as of 3 May 2026 on the present screened-legend variant. The leading letter is a sequence position, not a class code" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_bottom: "COMMERCIAL"
+      legend_note: "screened rather than embossed since 2019 — the change that dates this sub-series; before 2019 the same word was embossed, and before 1993 'DEC' also appeared at top left"
+    registration_period: "all Massachusetts commercial plates expire on 31 DECEMBER — again a fixed statewide date, again no month code in the serial"
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Massachusetts  # LOCATOR ONLY: the A12·345 commercial arrangement, the four dated design variants, the reported serial ranges, and the 31 December fixed expiry"
+    notes: >-
+      COMMERCIAL. Recorded as class `standard` because _meta/classes.yml has no
+      `commercial` value and the PRD's `dealer` definition (bound to a business,
+      not a vehicle) does not fit — a Massachusetts commercial plate is bound to
+      the vehicle in the ordinary way. The legend carries the meaning, exactly as
+      the FL pilot recorded for its Wrecker and Restricted series. CLASS-VOCABULARY
+      NOTE for the maintainer: three states in this group (MA, ME, RI) separately
+      serialize a commercial/heavy class, and all three are being recorded as
+      `standard` with a legend; if a fourth appears, `commercial` is worth a
+      _meta/classes.yml PR.
+
+  - id: us-ma-apportioned
+    class: standard
+    categories: [truck, bus]
+    period: { start: 2021 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "9LL99L"
+      regex: '\A\d[A-Z]{2}\d{2}[A-Z]\z'
+      charset: { notes: "reported 1AA10A to at least 1AL17T as of 30 April 2026. Predecessors on the same design: 12345 (1987-2018) and 1234 A (2018-2021)" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_bottom: "APPORTIONED"
+      legend_note: "screened 'APPORTIONED' in place of the slogan"
+    registration_period: "all Massachusetts apportioned plates expire on 30 JUNE — the third distinct fixed expiry date in this file, after trailer (30 Nov) and commercial (31 Dec)"
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Massachusetts  # LOCATOR ONLY: the 1AB23C apportioned arrangement from 2021, its two predecessors, the reported serial range and the 30 June fixed expiry"
+    notes: >-
+      APPORTIONED (International Registration Plan). Included because it is
+      separately serialized with its own grammar and its own fixed expiry, and
+      because the three fixed-expiry non-passenger classes together are the
+      clearest evidence for the file's central claim: Massachusetts encodes
+      expiry in the SERIAL only where expiry VARIES per registrant. Where the
+      whole class expires on one day, the month code disappears and the character
+      budget goes to sequence instead. That is a design rule, not an accident,
+      and no competing dataset records it.
+
+  # =========================================================================
+  # SPECIALTY — PROGRAM INDEX ONLY (PRD-PLATES §2.5).
+  # =========================================================================
+  - id: us-ma-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "9LLL 99"
+      regex: '\A\d[A-Z]{3} ?\d{2}\z'
+      charset: { notes: "specialty plates carry ORDINARY serials on an alternative design; the RMV's own booklet records that vanity plates are NOT available for passenger special plates (PAS) and that 'customers cannot request a specific number' on them — so a specialty serial is always department-assigned, which is a real constraint a parse API can use" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised program; individual designs are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official_dated: 50
+      count_basis: >-
+        FIFTY plate-type sections appear in the RMV's own Passenger Plates Booklet
+        (counted mechanically as occurrences of the "Eligibility:" heading, which
+        the booklet uses once per type). THE FIGURE IS DATED: the booklet edition
+        obtained is JULY 2014, retrieved from a Wayback capture. It is the best
+        OFFICIAL count available this pass and it is certainly stale.
+      count_currency_caveat: >-
+        The live mass.gov special-plates page returned HTTP 403 to every fetch
+        attempt this pass, and the Wayback CDX index for mass.gov surfaces only
+        the annual low-number plate lottery pages. So the CURRENT official count
+        is UNPINNED (recorded gap). Do not present 50 as today's number; present
+        it as the RMV's own 2014 number.
+      statutory_designs: "At least one specialty design is created by STATUTE rather than by program: M.G.L. c.90 §2 authorises number plates 'which shall display on the face of said plate a design representing the Cape and Islands'. That makes the Cape and Islands plate an edict-of-government design description and the cleanest specialty fact in the file."
+      transferable_on_death: "The booklet lists 33 plate types a surviving spouse may transfer into their own name, and separately lists types that may not be transferred — an administrative taxonomy of specialty plates that has no analogue in the other five states in this group."
+      official_list_url: "https://www.mass.gov/info-details/massachusetts-rmv-special-license-plates"
+      official_catalogue_url: "https://web.archive.org/web/20140704083521/http://www.massrmv.com/Portals/30/docs/manuals/passenger_plates_manual_public.pdf"
+      low_number_lottery: "Massachusetts runs an annual LOW NUMBER PLATE LOTTERY for reserved low serials released by cancellation — mass.gov publishes a page per year (2024, 2025, 2026 confirmed present in the Wayback index). Reserved serials are a separate space from the standard formats: all-numeric 1 to 99999, or a single letter with a number, plus A#A, A##A, #A#, #AA# shapes. Recorded as an index fact; the reserved space is not given a series here because no primary bounds it."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/20140704083521/http://www.massrmv.com/Portals/30/docs/manuals/passenger_plates_manual_public.pdf  # Massachusetts RMV, Passenger Plates Booklet, July 2014 — the official catalogue: the 50 typed sections counted above, the vanity-unavailable-on-PAS rule, the 33-type surviving-spouse transfer list"
+      - "https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXIV/Chapter90/Section2  # c.90 §2: the Cape and Islands statutory design; the six-character cap on distinctive initial plates that bounds the vanity end of the program"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Massachusetts  # LOCATOR ONLY: the reserved-plate serial shapes and the low-number lottery mechanism"
+    notes: >-
+      THE MASSACHUSETTS SPECIALTY INDEX — a count, its date, and its staleness,
+      which is the honest shape when the live catalogue will not serve. Worth
+      carrying forward: unlike Connecticut, where the legislature authorises each
+      program and the count is therefore statute-derivable, Massachusetts creates
+      most programs administratively and only occasionally by statute (Cape and
+      Islands), so the count can only ever come from an RMV artefact. That makes
+      the RMV booklet worth capturing on a schedule, for the same reason Florida's
+      monthly active-plate report is: it is the only structured record, and its
+      publisher does not archive it.

--- a/plates/us-me.yml
+++ b/plates/us-me.yml
@@ -1,0 +1,445 @@
+# plates/us-me.yml — Maine (PRD-PLATES gate L2, northeast group).
+#
+# MAINE IS THE BEST-SOURCED CURRENT BASE IN THIS GROUP AND POSSIBLY IN THE US.
+# Where Florida's colours had to be recorded `observed` because Chapter 320 says
+# only "retroreflection material", Maine's legislature legislated the ARTWORK.
+# 29-A M.R.S. §451(4-A)(D), enacted by PL 2023 c.421 §3, states in terms that a
+# new registration plate "must have a buff neutral shaded background that does
+# not interfere with any identifying characteristics on the plate, a distinct
+# border and: (1) Blue identification numbers and letters, A REPRESENTATION OF AN
+# EASTERN WHITE PINE TREE AND A BLUE STAR REPRESENTING THE NORTH STAR on the side
+# of the plate; or (2) Blue identification numbers and letters with no other
+# features." Two statutory design variants, named in law, plus statutory
+# character heights and statutory legends. That is an EDICT OF GOVERNMENT
+# describing a plate design — public domain at every level (PRD-PLATES §4) — and
+# it is why the renderer can build Maine from law rather than from a photograph.
+#
+# IT ALSO PRODUCES THIS FILE'S ONE REAL SOURCE CONFLICT, recorded and not
+# averaged (PRD-PLATES §5.3): the STATUTE says "buff neutral shaded background";
+# every secondary description of the plates actually issued from 1 May 2025 says
+# REFLECTIVE WHITE with a dark blue serial, "MAINE" in dark green at top and
+# "VACATIONLAND" in dark green at bottom. Both are recorded below. Nobody should
+# reconcile them without a departmental colour spec, which was not obtained.
+#
+# PERIOD EVIDENCE IS ALSO STATUTORY, which is rare: §451(1-A) says the Secretary
+# of State "shall begin issuing the new plates NO LATER THAN MAY 1, 2025" and
+# "shall complete the issuance of new plates BEFORE JULY 31, 2026". So Maine has
+# a legislated rollout window — announced/first-issue/full-coverage in one
+# subsection — which is exactly the `period.rollout:` shape PRD-PLATES §2.2
+# anticipated for Mercosur and had not yet needed in the US.
+jurisdiction: us-me
+authority:
+  name: Maine Bureau of Motor Vehicles (BMV), Department of the Secretary of State
+  url: "https://www.maine.gov/sos/bmv/"
+binding: vehicle
+statute_edition: >-
+  Maine Revised Statutes Title 29-A (Motor Vehicles and Traffic), Chapter 5
+  Subchapter 1 Article 3 (Registration Plates), §§ 451-453, as served by the
+  Maine Office of the Revisor of Statutes with the page footer "Data for this
+  page extracted on 10/20/2025" — the edition read for this pass.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: favourable-on-the-edict-ground-weak-on-the-general-ground
+  basis: >-
+    Maine splits cleanly into two questions and the answers differ. (1) THE
+    DESIGN AS DESCRIBED IN STATUTE: 29-A M.R.S. §451(4-A) describes the current
+    plate's background, border, colour, pine tree, star and legend heights in
+    the text of a statute. Edicts of government are uncopyrightable at every
+    level of US government ({{PD-US-GovEdict}}), so the DESCRIPTION is
+    unambiguously free to use, and a render derived from the statutory
+    description rather than from artwork is on the strongest footing available
+    anywhere in this group. (2) THE STATE'S GENERAL COPYRIGHT POSTURE: much
+    weaker. Commons does carry a {{PD-MEGov}} template — confirmed present by
+    API this pass — but its entire content is a bare {{PD-copyright holder}}
+    wrapper naming "The State Government of Maine", with NO cited statute, court
+    decision, agency statement or terms-of-use page behind it. Compare
+    {{PD-FLGov}}, which rests on Microdecisions v. Skinner, or {{PD-MAGov}},
+    which quotes the Secretary of the Commonwealth at length. Maine is also
+    absent from the Wikipedia survey of subnational copyright postures.
+  reading: >-
+    Render Maine from §451(4-A)'s words. Do NOT rely on {{PD-MEGov}} for
+    anything, and do not record Maine as a public-domain state on its strength:
+    an untagged assertion on a wiki is not evidence, and treating it as evidence
+    is precisely the laundering PRD-PLATES §4 forbids. Recorded as UNRESEARCHED
+    at the general level with the specific edict ground stated.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies to the PINE TREE and NORTH STAR
+    even here. The 2025 design is reported to pay homage to the Maine state flag
+    of 1901-1909, and flag/seal protection independent of copyright is
+    unresearched for Maine (recorded gap). Note that the statute describes the
+    elements generically — "a representation of an eastern white pine tree",
+    "a blue star representing the North Star" — which is a description of a
+    SUBJECT, not of a specific drawing; an independently drawn pine and star
+    satisfying that description is original work, which is the render posture to
+    take.
+  photograph_caution: "Commons photographs of Maine plates carry the photographer's licence, not the design's; our renders are generated and never derived from a photograph, so those obligations never attach."
+  sources:
+    - "https://legislature.maine.gov/statutes/29-A/title29-Asec451.html  # 29-A M.R.S. §451(4-A)(D): the statutory design description itself — an edict of government, PD"
+    - "https://commons.wikimedia.org/wiki/Template:PD-MEGov  # fetched this pass: the template EXISTS but its full text is a bare {{PD-copyright holder|1=The State Government of Maine}} with no cited instrument — recorded as weak evidence, explicitly not relied upon"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR: Maine has NO entry in this survey"
+
+display_rules:
+  default: "TWO plates. 29-A M.R.S. §452(1): 'A registration plate must be displayed horizontally. Only one set of Maine registration plates may be displayed on one vehicle. A registration plate must be attached to the front and the rear of each vehicle except as follows.'"
+  exceptions:
+    - "trailer and semitrailer: plate 'may be attached only to the rear' (§452(1)(A))"
+    - "motorcycle: plate 'may not be attached to the front of that motorcycle' (§452(1)(B))"
+    - "manufacturer, dealer or transporter: plate 'may be attached only to the rear of the vehicle' (§452(1)(C))"
+    - "TRUCK TRACTOR: plate 'may be attached only to the FRONT of that truck tractor' (§452(1)(D)) — front-only, the inverse of the state default. Maine and Florida are now the two confirmed US front-only-truck-tractor jurisdictions in this dataset; the FL pilot called it 'a genuine outlier' and it turns out to have at least one companion"
+  swinging_plates: "§452(2): the plate for a FARM TRUCK or a vehicle hauling FOREST PRODUCTS 'may be attached by means of a rigid or semirigid bracket that allows the plate to swing freely' — an explicit statutory carve-out from the near-universal no-swing rule, and a Maine-specific one"
+  legibility: "§452(3) 'Registration plates must always be properly displayed'; §452(4) 'Registration plates, including the numbers, letters and words, must always be plainly visible and legible.' Note Maine legislates NO distance test, where Connecticut legislates fifty feet, Massachusetts sixty and Rhode Island a hundred"
+  sources:
+    - "https://legislature.maine.gov/statutes/29-A/title29-Asec452.html  # §452: horizontal display, one set only, front and rear default, the four exceptions including the FRONT-ONLY truck tractor, the farm/forest-products swinging bracket, and the visibility duties"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; recommended practice, not requirement."
+  aamva_geometry: "AAMVA §2.1 jurisdiction name top-centre between the bolt holes, >=0.25 in above the plate number, >=0.125 in from the top edge, jurisdiction characters 0.75-1.0 in; §2.2 serial characters >=2.5 in high, spaced >=0.25 in, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom edges; §3.3 legible day and night from >=75 feet, ASTM D4956-19 and ISO 7591:1982 cl.3, entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2."
+  maine_exceeds_aamva_on_one_axis: >-
+    MAINE LEGISLATES CHARACTER HEIGHTS AND THEY ARE NOT AAMVA'S. §451(4-A)(A):
+    the word "Maine" must be "in letters of at least 3/4 inch in height centered
+    at the top" — AAMVA §2.1 recommends 0.75-1.0 in for the jurisdiction name, so
+    Maine's statutory minimum sits exactly at AAMVA's floor. §451(4-A)(B):
+    "Except on motorcycle plates, registration numbers may not be substantially
+    less than 3 inches high" — AAMVA §2.2 recommends at least 2.5 in, so Maine
+    legislates HIGHER than AAMVA recommends. §451(4-A)(C): "Vacationland" at the
+    bottom "in letters not less than 3/4 inch in height". This is the only state
+    in the northeast group whose own law states renderable geometry.
+  dimensions_delegated: "AAMVA §3.1 sends plate dimensions and bolt holes to SAE J686, PAYWALLED and UNPINNED; no J686 dimension is quoted here. Title 29-A states character heights but NO overall plate dimension, so 12x6 in below is `observed`."
+  replacement_cycle: "§451(1) requires 'a new general issue of registration plates periodically as determined by the Legislature', and 'each new general issue must be easily distinguishable BY COLOR from the preceding general issue' — a statutory legibility-of-generations rule rather than a fixed cycle. §451(1-A) is the Legislature exercising that power for 2025-2026."
+  manufacture: "§451(6): all Maine registration plates are manufactured at the BOLDUC CORRECTIONAL FACILITY, under the charge of the Warden of the State Prison, and only plates that cannot be produced there or whose anticipated demand is below a threshold set by the Secretary of State may be purchased outside. A statutory single-source manufacturing mandate — no other state in this group legislates where its plates are made."
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — the 2025 general issue, statutory variant (D)(1).
+  # =========================================================================
+  - id: us-me-standard-2025-pine
+    class: standard
+    categories: [car, van, truck, bus]
+    period:
+      start: 2025
+      rollout:
+        first_issue_deadline: 2025
+        full_coverage_deadline: 2026
+        statutory_text: "§451(1-A): the Secretary of State 'shall provide for a new general issue of registration plates and shall begin issuing the new plates no later than May 1, 2025. The Secretary of State shall complete the issuance of new plates before July 31, 2026 to all vehicles required to obtain new plates.'"
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      charset:
+        notes: >-
+          THE GRAMMAR IS NOT IN THE STATUTE AND THE STATUTE SAYS SO: §451(4-A)(E)
+          delegates it — 'The Secretary of State shall devise, with the advice of
+          the joint standing committee of the Legislature having jurisdiction over
+          transportation matters, A NUMBERING SYSTEM suitable for a new general
+          issue of registration plates.' So Maine's format is administrative even
+          though its design is statutory, which is the reverse of the usual US
+          split. Reported (secondary): three digits, then three letters, with the
+          MIDDLE letter progressing first, then the last, then the first; letters
+          I and O not used; initial letters A-E reserved for optional and certain
+          non-passenger types; F-H reserved for the plain statutory variant (see
+          us-me-standard-2025-plain); this variant runs from 101 KAA.
+      separator_note: "the group gap is printed as a small raised dot in secondary depictions; spelled U+0020 here because U+00B7 is in the FORGIVING but not the EMITTED set (PRD-PLATES §2.6)"
+      progression: "101 KAA upward, middle letter first"
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_note: "OBSERVED — Title 29-A states character heights but no plate size" }
+      background:
+        finish: retroreflective
+        statutory_description: "'a buff neutral shaded background that does not interfere with any identifying characteristics on the plate, a distinct border' (§451(4-A)(D))"
+        observed_description: "reflective white (secondary)"
+        conflict_note: >-
+          THE STATUTE AND EVERY SECONDARY DESCRIPTION DISAGREE ABOUT THE
+          BACKGROUND. Statute: "buff neutral shaded". Secondary: reflective white.
+          NO HEX IS RECORDED, because recording one would be choosing a side.
+          PRD-PLATES §5.3: disagreements are recorded, never averaged. Resolving
+          this needs a BMV colour specification, which was not obtained.
+      foreground_statutory: "'Blue identification numbers and letters' (§451(4-A)(D)(1)); secondary describes the issued plates as DARK BLUE serial — consistent"
+      legend_top: "MAINE"
+      legend_top_rule: "§451(4-A)(A): 'Registration plates must bear the year of issue or the last 2 numerals of that year and the word \"Maine\" in letters of at least 3/4 inch in height centered at the top of the registration plate.' Secondary reports MAINE screened in DARK GREEN — the statute names no colour for the legend."
+      legend_bottom: "VACATIONLAND"
+      legend_bottom_rule: "§451(4-A)(C): 'On registration plates issued for private use and trucks, the word \"Vacationland\" must be centered at the bottom in letters not less than 3/4 inch in height, except when the Secretary of State determines that, for other than passenger vehicles, that space may be used for CLASS CODES.' So on Maine non-passenger plates the bottom legend slot is a class-code slot — a statutory design switch, and the reason several Maine classes below carry a code where the slogan would be."
+      graphic:
+        present: true
+        rendered: placeholder
+        statutory_description: "'a representation of an eastern white pine tree and a blue star representing the North Star on the side of the plate' (§451(4-A)(D)(1))"
+        note: "the statute describes a SUBJECT, not a drawing — an independently drawn pine and star satisfying the description is original work. See artwork_risk."
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    replacement_cycle:
+      statutory_rule: "§451(1): 'The Secretary of State shall provide a new general issue of registration plates periodically as determined by the Legislature. Each new general issue must be easily distinguishable by color from the preceding general issue.'"
+      note: "Maine legislates a DISTINGUISHABILITY requirement rather than an interval — a different answer to the same problem AAMVA §1.1 answers with 7-to-10 years, and arguably a better one for a dataset, because it guarantees that generations are visually separable."
+    region_encoding: none
+    sources:
+      - "https://legislature.maine.gov/statutes/29-A/title29-Asec451.html  # 29-A M.R.S. §451: (1) periodic general issue distinguishable by colour; (1-A) begin no later than 1 May 2025, complete before 31 July 2026; (4-A)(A) 'Maine' >= 3/4 in at top plus year; (4-A)(B) numbers not substantially less than 3 in; (4-A)(C) 'Vacationland' >= 3/4 in at bottom or class codes; (4-A)(D)(1) buff background, distinct border, blue characters, eastern white pine, blue North Star; (4-A)(E) the numbering system is delegated to the Secretary of State; (6) manufacture at the Bolduc Correctional Facility"
+      - "https://legislature.maine.gov/statutes/29-A/title29-Asec452.html  # §452: display front and rear, the front-only truck tractor rule"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maine  # LOCATOR ONLY (PRD-PLATES §4): the 123·ABC arrangement, the 101·KAA start, the middle-letter-first progression, the I/O exclusion, the A-E and F-H block reservations, the reported reflective-white/dark-blue/dark-green colours that CONFLICT with the statute's 'buff', and the homage to the 1901-1909 state flag"
+    notes: >-
+      MAINE 2025 GENERAL ISSUE, PINE TREE VARIANT. This is the only series in the
+      northeast group whose START DATE, BACKGROUND, BORDER, CHARACTER COLOUR,
+      GRAPHIC SUBJECTS, LEGEND WORDING AND LEGEND HEIGHTS are all statutory, and
+      it is therefore the group's reference case for "render from the edict". The
+      one thing the statute does NOT give is the serial grammar, which it
+      expressly delegates (§451(4-A)(E)) — the exact inverse of Florida, where the
+      character cap is statutory and the colours are not. Two states, two
+      opposite splits between law and administration; a dataset that assumes
+      either split is uniform will mis-source half the country.
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — statutory variant (D)(2), the plain base.
+  # =========================================================================
+  - id: us-me-standard-2025-plain
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2025 }
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      charset: { notes: "same delegated numbering system as the pine variant; distinguished only by SERIAL BLOCK — letters F to H are reported reserved for this variant, which runs from 101 FAA, against the pine variant's K block" }
+      separator_note: "as us-me-standard-2025-pine"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background:
+        finish: retroreflective
+        statutory_description: "same 'buff neutral shaded background ... distinct border' as (D)(1); the same statute/secondary conflict applies and no hex is recorded"
+      foreground_statutory: "'Blue identification numbers and letters with no other features' (§451(4-A)(D)(2)) — the operative words are NO OTHER FEATURES"
+      legend_top: "MAINE"
+      legend_bottom: "VACATIONLAND"
+      graphic: { present: false, statutory_basis: "(D)(2) expressly excludes other features — so this variant's ABSENCE of a graphic is itself statutory, which makes it the cleanest thing in the whole dataset to render: there is nothing to approximate" }
+      emblem: { present: false }
+    region_encoding: none
+    sources:
+      - "https://legislature.maine.gov/statutes/29-A/title29-Asec451.html  # §451(4-A)(D)(2): 'Blue identification numbers and letters with no other features' — the second statutory variant, in the alternative to (D)(1)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maine  # LOCATOR ONLY: the alternative base 'issued concurrently with the pine tree base' from 1 May 2025, running from 101·FAA"
+    notes: >-
+      THE PLAIN 2025 VARIANT — its own series and not a sub-entry, because
+      §451(4-A)(D) offers (1) and (2) as ALTERNATIVES and the design difference
+      (graphic vs no graphic) is exactly the difference PRD-PLATES §2.3 says makes
+      a series. It also has a distinct serial block (F-H vs K), so the format
+      differs in practice as well. WHY THIS MATTERS BEYOND MAINE: a US state
+      offering a deliberately graphic-free standard plate alongside a graphic one
+      is the render layer's dream case — the emblem-placeholder problem of
+      PRD-PLATES §3 simply does not arise for this variant, and a consumer that
+      needs a guaranteed-clean Maine render should ask for this one.
+
+  # =========================================================================
+  # ONE SERIES BACK — the chickadee base, 1999 to April 2025.
+  # =========================================================================
+  - id: us-me-chickadee-1999
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1999, end: 2025 }
+    period_evidence: secondary-dated
+    matching: recall-only
+    format:
+      pattern: "9999 LL"
+      regex: '\A(?:\d{4} ?[A-Z]{2}|\d{3} ?[A-Z]{3})\z'
+      charset: { notes: "letter O not used in the 1234 AB era; letters I and O not used in the 123 ABC era (both secondary)" }
+      union_note: >-
+        THE REGEX IS A UNION AND THAT IS WHY `matching: recall-only`. The
+        chickadee base carried TWO serial grammars in its 26-year life: 1234 AB
+        from 1 July 1999, then 123 ABC from October 2023 until the base was
+        retired on 30 April 2025. A hit on this regex says "this string has a
+        shape Maine issued on the chickadee base" and nothing more — it does not
+        say which grammar, and it does not say the string is a valid Maine
+        registration. Splitting this into two strict series is the right final
+        answer and is deliberately deferred: L2 scope allows ONE series back, no
+        primary bounds either sub-era, and minting two dated ids on secondary
+        boundaries would create two ids to alias later rather than one.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      colour_note: "embossed BLACK serial on reflective white with a border line (secondary). Recorded with hexes because, unlike the 2025 base, no statute contradicts the observation — §451(4) as it stood set legends and heights but no colour"
+      legend_top: "MAINE"
+      legend_bottom: "Vacationland"
+      legend_placement_note: "'Vacationland' was screened in black INSIDE the pine-forest silhouette at the bottom rather than on a clear field — which satisfies §451(4)(C)'s 'centered at the bottom' while making the slogan part of the graphic"
+      graphic: { present: true, rendered: placeholder, description: "black-capped chickadee on a pine cone and tassel screened at left, green pine forest silhouette screened at bottom (secondary)" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://legislature.maine.gov/statutes/29-A/title29-Asec451.html  # §451(4) — the design subsection that governed this base before PL 2023 c.421 replaced it for the new general issue: 'Maine' >= 3/4 in at top with the year, numbers not substantially less than 3 in, 'Vacationland' centred at the bottom for private use"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maine  # LOCATOR ONLY: the chickadee base 1 July 1999 - 30 April 2025, the 1234 AB grammar (1 GA to 9999 ZY, letter O unused) and the 123 ABC grammar from October 2023 (101 JAA to 691 JQJ as of 2 May 2025, letters I and O unused)"
+      - "https://licenseplates.cc/ME  # enthusiast corroboration, cited because used: the reported serial high-water marks. No text or image copied"
+    notes: >-
+      THE CHICKADEE BASE — 26 years, two grammars, one design, and still
+      lawfully on the road during the 2025-2026 rollout window that §451(1-A)
+      leaves open until 31 July 2026. That overlap is legislated, not accidental:
+      Maine law expressly contemplates old and new plates coexisting for fifteen
+      months, which is the `period` overlap PRD-PLATES §2.2 calls legal-iff-noted.
+      Recorded with `end: 2025` because issuance stopped on 30 April 2025; a
+      chickadee plate seen in June 2026 is valid, not expired.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES.
+  # =========================================================================
+  - id: us-me-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2012 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "999 LL"
+      regex: '\A\d{1,3} ?[A-Z]{2}\z'
+      charset: { notes: "reported 1 AA to approximately 500 AR (1995-97), 1 AT onward with 'RIDE SAFE' at the bottom (1998 - mid 2012), 501 HV to present on the current variant. Variable leading-digit width, hence the {1,3} quantifier, which makes no width claim beyond three" }
+    design:
+      plate: { w: 7, h: 4, unit: in, dimension_note: "MOTORCYCLE PLATE SIZE NOT OBTAINED — placeholder carrying the conventional US motorcycle size; must not be treated as sourced (recorded gap)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#00307D"
+      colour_note: "embossed blue serial on white with a border line (secondary); hexes observed"
+      legend_top: "MAINE"
+      legend_bottom: "RIDE SAFE"
+      legend_note: "the vertical 'MC' class marker at left was dropped in mid-2012 — the change that dates this series"
+    statutory_hook: "§451(4-A)(B) exempts motorcycle plates from the 3-inch character-height minimum in terms ('Except on motorcycle plates'), which is the only place Maine's statute acknowledges a reduced-size plate at all"
+    display_rule: "§452(1)(B): a motorcycle plate 'may not be attached to the front of that motorcycle' — rear only"
+    region_encoding: none
+    sources:
+      - "https://legislature.maine.gov/statutes/29-A/title29-Asec451.html  # §451(4-A)(B): the express motorcycle exemption from the 3-inch character minimum"
+      - "https://legislature.maine.gov/statutes/29-A/title29-Asec452.html  # §452(1)(B): motorcycle plates rear only"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maine  # LOCATOR ONLY: the 123 AB motorcycle arrangement, the RIDE SAFE legend from 1998, the mid-2012 removal of the 'MC' marker, and the reported serial ranges"
+    notes: >-
+      MOTORCYCLE. Maine is the only state in this group whose statute
+      acknowledges the reduced-size plate by exempting it from a stated character
+      height rather than by delegating "such dimensions as the department deems
+      necessary" (Florida's approach). The exemption is therefore a real, if
+      indirect, statutory fact about motorcycle plates — and the actual size is
+      still a recorded gap, because an exemption from a height rule is not a size
+      specification.
+
+  - id: us-me-commercial
+    class: standard
+    categories: [truck]
+    period: { start: 2007 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "9L-9999"
+      regex: '\A\d[A-Z]-?\d{4}\z'
+      charset: { notes: "reported 1A-0001 onward from December 2007; the preceding arrangement on the same base was 123-456 (600-001 to 799-999, July 1999 - December 2007), and before that a plain six-digit 123456 on the lobster base with a vertical 'COM' marker" }
+      separator_note: "Maine's commercial plates print a HYPHEN, which IS in the emitted set — so unlike the passenger series this pattern spells the separator exactly as printed (PRD-PLATES §2.6 rule 2)"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_bottom: "COMMERCIAL"
+      legend_rule: "this is §451(4-A)(C) in action: the statute lets the Secretary of State use the 'Vacationland' slot for CLASS CODES on other than passenger vehicles, and 'COMMERCIAL' embossed in place of the slogan is that permission exercised"
+    region_encoding: none
+    sources:
+      - "https://legislature.maine.gov/statutes/29-A/title29-Asec451.html  # §451(4-A)(C): the statutory authority to replace the bottom slogan with class codes on non-passenger plates — the legal basis for this series' legend"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maine  # LOCATOR ONLY: the 1A-2345 commercial arrangement from December 2007 and its two predecessors"
+    notes: >-
+      COMMERCIAL. Recorded as class `standard` with the legend carrying the
+      meaning (no `commercial` value exists in _meta/classes.yml); see the
+      class-vocabulary note in us-ma.yml, which raises the same issue. What makes
+      Maine's case worth recording is that the legend swap is STATUTORILY
+      AUTHORISED rather than merely departmental — §451(4-A)(C) anticipates
+      exactly this substitution.
+
+  - id: us-me-trailer-longterm
+    class: trailer
+    categories: [trailer]
+    period: { start: 2001 }
+    period_evidence: secondary-dated
+    matching: recall-only
+    format:
+      pattern: "99 99999"
+      regex: '\A\d{2} ?(?:\d{5}|\d{4}[A-Z])\z'
+      charset: { notes: "reported 12 34567 and 12 3456A, where the LEADING TWO DIGITS ARE THE YEAR OF EXPIRATION and the remainder is the sequence. Two tail shapes are reported, hence the union and `recall-only`" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#00693E"
+      colour_note: "embossed green serial on white with a border line (secondary)"
+      legend_top: "MAINE"
+      legend_bottom: "SEMI PERMANENT"
+      layout_note: "reported to carry the DAY of expiration at top right and a vertical stacked 'TLR' between the first two digits and the last five — a stacked class marker sitting INSIDE the serial field. AAMVA's rule that stacked characters are part of the official plate number (Ed.3) would make 'TLR' serial-significant; Maine's own usage clearly treats it as a class marker. The contradiction is recorded and belongs to the parse layer, not here."
+    serial_encoding:
+      kind: expiry-year
+      rule: "the first two digits of the serial are the YEAR the registration expires"
+      consequence: "Maine registers these trailers for periods 'between 3 and 25 years' (secondary), so the embedded year is doing real work — it is the only way to read a 25-year registration's expiry off the plate. A second US time-encoding after Massachusetts's month digit, and a different one: MA encodes the month in the LAST character, ME the year in the FIRST TWO."
+      evidence: secondary
+    display_rule: "§452(1)(A): trailer and semitrailer plates 'may be attached only to the rear'"
+    region_encoding: none
+    sources:
+      - "https://legislature.maine.gov/statutes/29-A/title29-Asec452.html  # §452(1)(A): trailer plates rear only"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maine  # LOCATOR ONLY: the long-term/semi-permanent trailer series 2001-2018 and after, the year-coded leading digits, the 3-to-25-year registration periods, the stacked 'TLR' marker and the day-of-expiration field"
+    notes: >-
+      LONG-TERM TRAILER — the second time-encoded serial in this group and the
+      one with the longer horizon. Worth flagging for the parse API: a Maine
+      trailer plate reading "31 12345" is not a 31-thousand-something serial, it
+      is a 2031 expiry with sequence 12345, and any validator that treats the
+      leading pair as sequence will sort Maine trailers into nonsense.
+
+  # =========================================================================
+  # SPECIALTY — PROGRAM INDEX ONLY (PRD-PLATES §2.5).
+  # =========================================================================
+  - id: us-me-specialty-index
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2003 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      charset: { notes: "every Maine optional plate introduced from 2003 onward uses the SAME 123 ABC grammar as the standard series and is distinguished ONLY by its assigned three-letter block — so a Maine specialty serial is indistinguishable from a standard serial except by block lookup" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised program; individual designs are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_reported: 9
+      count_basis: >-
+        NINE optional programs, all introduced from 2003 onward, counted from the
+        secondary catalogue: Lobster (1 May 2003), Black Bear (3 November 2003),
+        Wabanaki (12 August 2005), Agriculture (1 October 2007), Support Our
+        Troops (1 November 2007), Sportsman (7 April 2008), Breast Cancer (1
+        October 2008), Animal Welfare (1 October 2009), The Barbara Bush
+        Children's Hospital (1 October 2018). This is the SMALLEST specialty
+        program in the northeast group by an order of magnitude — Maine has nine
+        where Massachusetts's own 2014 booklet lists fifty and Florida claims over
+        a hundred. The smallness is the finding: "US states have hundreds of
+        specialty plates" is a Florida/Texas generalisation that does not survive
+        contact with New England.
+      count_currency_caveat: "The BMV's own plate catalogue page was NOT successfully fetched this pass (maine.gov/sos/bmv/registrations/plates.html returned 404; the Wayback CDX index for maine.gov/sos/bmv surfaces forms but not the catalogue). The count above is secondary and undated at the upper end — a tenth program added since 2018 would not appear (recorded gap)."
+      serial_block_index:
+        mechanism: "each program is assigned one or more THREE-LETTER BLOCKS in the shared 123 ABC space, e.g. Sportsman AKA-AKZ, ASA-ASZ, AVA-AVZ, BDA-BDZ, BHA-BHZ; Breast Cancer ALA-ALZ, ATA-ATZ, AYA-AYZ; Animal Welfare AMA-AMZ, AWA-AWZ, BGA-BGZ; Barbara Bush Children's Hospital BBA-BBZ, BJA-BJZ."
+        significance: >-
+          THIS IS THE MOST USEFUL SPECIALTY ARTEFACT IN THE WHOLE NORTHEAST GROUP
+          AND NO COMPETING DATASET HAS ANYTHING LIKE IT. Because Maine allocates
+          specialty programs by three-letter block inside the ordinary passenger
+          grammar, a Maine serial's letter group DETERMINES ITS PROGRAM — the plate
+          number itself decodes to a charity. That is a genuine `region_encoding`-
+          shaped decode table (a `plates/_decode/us-me-optional-blocks.yml`
+          candidate) with a program dimension instead of a geographic one, and it
+          would let a parse API answer "which Maine plate design is this?" from
+          the string alone. NOT BUILT HERE: the block list obtained is partial
+          (five of nine programs) and secondary, so building the table on it would
+          bake in gaps. Recorded as the single highest-value follow-up this group
+          identified.
+      statutory_route: "§451(5): 'A vehicle required to be registered in a special class under this Title may display only the number plates designed for that special class of registration' — and the Secretary of State may issue a temporary credential in lieu of a special-class plate, under routine technical rules"
+      official_list_url: "https://www.maine.gov/sos/bmv/"
+    region_encoding: none
+    sources:
+      - "https://legislature.maine.gov/statutes/29-A/title29-Asec451.html  # §451(5): special classes may display only their own plates; the temporary-credential alternative and the routine-technical-rules authority"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maine  # LOCATOR ONLY: the nine optional programs with their introduction dates, the shared 123·ABC grammar from 2003 onward, and the assigned three-letter serial blocks quoted above"
+    notes: >-
+      THE MAINE SPECIALTY INDEX — nine programs, a shared grammar, and a
+      block-allocation scheme that is effectively a decode table waiting to be
+      built. Two things worth carrying forward. First, the count is small enough
+      to be complete, which no other US state's index in this dataset can claim.
+      Second, Maine's vanity plates are a genuinely notable adjacent fact: the
+      legislature removed its vanity review criteria in 2015 as constitutionally
+      doubtful, a proliferation followed, and in 2021 it directed the BMV to make
+      new rules banning profane, violent and derogatory content — with the review
+      committee reportedly consulting Urban Dictionary for arcane lingo. Recorded
+      as index colour, not as a series; the vanity grammar itself (form MV-45,
+      $25 annual fee, three ranked choices, 10-12 week delivery) was obtained but
+      no character rule was stated on the form, so no vanity series is minted.

--- a/plates/us-nh.yml
+++ b/plates/us-nh.yml
@@ -1,0 +1,394 @@
+# plates/us-nh.yml — New Hampshire (PRD-PLATES gate L2, northeast group).
+#
+# NEW HAMPSHIRE'S STATUTE DOES ONE THING AND DOES IT ABSOLUTELY: it mandates the
+# SLOGAN by name and delegates everything else. RSA 261:75(II), verbatim: "The
+# director may make special rules relative to the number of plates, the location
+# of said plate or plates on the vehicle, and the material and design thereof,
+# provided, however, that number plates for passenger vehicles shall have the
+# state motto 'LIVE FREE OR DIE' written thereon." Number of plates: delegated.
+# Location: delegated. Material: delegated. Design: delegated. Four words of
+# motto: mandatory. New Hampshire is the cleanest example in this dataset of a
+# legislature legislating IDENTITY and outsourcing ENGINEERING — the exact
+# inverse of Maine two states away, whose legislature specifies character
+# heights and a pine tree and delegates the numbering system.
+#
+# (The motto mandate is also the reason New Hampshire has a US Supreme Court
+# case about a licence plate. It is deliberately NOT cited here: Wooley v.
+# Maynard (1977) is a compelled-speech decision about covering the motto, not a
+# plate-specification or copyright authority, and the FL pilot's discipline of
+# keeping First Amendment plate cases out of the IP analysis — it excluded
+# Walker v. Texas Div., SCV for the same reason — applies unchanged.)
+#
+# SPECIALTY MODEL: New Hampshire does not run a large specialty catalogue. It
+# runs ONE plate with a 3-inch square hole in it. See us-nh-specialty-index —
+# it is the most structurally interesting specialty program in the group.
+jurisdiction: us-nh
+authority:
+  name: New Hampshire Division of Motor Vehicles, a division of the New Hampshire Department of Safety
+  url: "https://www.dmv.nh.gov/"
+binding: vehicle
+statute_edition: >-
+  New Hampshire Revised Statutes Annotated, Title XXI Chapter 261 (Certificates
+  of Title and Registration of Vehicles), as served by the NH General Court —
+  RSA 261:75 read this pass, source line ending "2002, 165:6, eff. July 1, 2002".
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    HONESTLY UNRESEARCHED, and recorded that way rather than guessed. Three
+    checks were run this pass and all three came back empty or blocked. (1)
+    Commons has NO {{PD-NHGov}} template — queried by API, result MISSING. (2)
+    New Hampshire has NO entry in the Wikipedia survey of subnational copyright
+    postures. (3) The state's own disclaimer page at nh.gov returned HTTP 403 to
+    every fetch attempt, so New Hampshire's terms of use are unpinned. With no
+    affirmative disclaimer located, the §105 default governs: the federal
+    public-domain rule does not extend to states, so a New Hampshire state work
+    is presumed copyrighted. Treat as default-adverse pending research.
+  emblem_rule: >-
+    THE PLACEHOLDER RULE MATTERS MORE HERE THAN ANYWHERE ELSE IN THIS GROUP, for
+    a reason that has nothing to do with copyright. The 1999 base's graphic is
+    the OLD MAN OF THE MOUNTAIN — the granite profile on Cannon Mountain that
+    COLLAPSED on 3 May 2003 and no longer exists. New Hampshire has continued to
+    issue plates depicting it for the twenty-three years since. The image is a
+    state emblem in the strongest sense (it is on the state quarter, the state
+    highway signs and the state seal's neighbourhood), and emblem protection
+    independent of copyright — misuse statutes, state-symbol statutes — is
+    UNRESEARCHED for New Hampshire, as it is for every state in this dataset.
+    Render `emblem: {present: true, rendered: placeholder}` and treat any
+    proposal to draw the profile as a named decision requiring its own research,
+    not as a rendering detail.
+  photograph_caution: "Commons photographs of New Hampshire plates carry the photographer's licence on the photograph, not a licence on the design. Our renders are generated from spec, so those obligations never attach."
+  sources:
+    - "https://commons.wikimedia.org/w/api.php?action=query&titles=Template:PD-NHGov  # queried this pass: MISSING — no New Hampshire public-domain tag exists on Commons"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR: New Hampshire has NO entry — recorded as unsurveyed"
+    - "https://www.nh.gov/disclaimer.htm  # the state's own terms/disclaimer page — returned HTTP 403 to every fetch this pass; UNPINNED (recorded gap)"
+
+display_rules:
+  default: "DELEGATED, not statutory. RSA 261:75(II): every vehicle required to be registered 'shall have displayed conspicuously thereon a number plate or plates to be furnished by the department, together with any current validation sticker', and 'The director may make special rules relative to the NUMBER OF PLATES, the location of said plate or plates on the vehicle, and the material and design thereof'. So even the count of plates is administrative. Two plates (front and rear) for most classes, rear only for motorcycles and trailers, is the reported practice (secondary) — the DIRECTOR'S RULES THEMSELVES WERE NOT OBTAINED (recorded gap)."
+  motto_mandate: "RSA 261:75(II), verbatim proviso: 'provided, however, that number plates for passenger vehicles shall have the state motto \"Live Free or Die\" written thereon.' The only design element New Hampshire's legislature reserves to itself, and it binds PASSENGER plates specifically — which is why the non-passenger series below vary in whether they carry it."
+  validation: "RSA 261:75(I): plates 'shall be furnished by the department yearly or at whatever interval of years the department shall determine. In all cases such plate or plates shall bear on the face thereof a permanent or changeable designation of their effective period.' A statutory requirement that the plate itself declare its validity window — by permanent marking or by sticker."
+  cleanliness: "RSA 261:75(II): 'The plate shall be kept clean.' Four words; no distance test, no obstruction clause, no illumination rule — the shortest display duty in this group."
+  fee: "RSA 261:75(I): $4.00 per plate."
+  sources:
+    - "https://www.gencourt.state.nh.us/rsa/html/XXI/261/261-75.htm  # RSA 261:75(I) department designs and issues, $4.00 per plate, yearly or other interval, the effective-period designation duty; (II) conspicuous display with validation sticker, the delegation of number/location/material/design to the director, the 'Live Free or Die' proviso for passenger plates, and the cleanliness duty"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; recommendations, not requirements."
+  aamva_geometry: "AAMVA §2.1 jurisdiction name top-centre between the bolt holes, >=0.25 in above the plate number, >=0.125 in from the top edge, characters 0.75-1.0 in; §2.2 serial characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom; §3.3 legible day and night from >=75 feet, ASTM D4956-19 and ISO 7591:1982 cl.3, entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2."
+  stacked_characters: "AAMVA Ed.3: 'If stacked characters are used, they are part of the official license plate number. No more than two characters are to be stacked.' NEW HAMPSHIRE STRESSES THIS RULE HARDER THAN ANY OTHER STATE IN THE GROUP — its Conservation and Construction Equipment plates carry a stacked 'C/H' and 'C/E' pair beside the serial, i.e. exactly two stacked characters, which under AAMVA's own words are PART OF THE NUMBER. Whether New Hampshire agrees was not established. Recorded as a live normalisation question for the parse layer."
+  dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, PAYWALLED and UNPINNED; no J686 dimension is quoted here. RSA 261 states no plate dimension (design is delegated to the director in terms), so 12x6 in below is `observed`."
+  replacement_cycle: "RSA 261:75(I) lets the department set the interval — 'yearly or at whatever interval of years the department shall determine' — so New Hampshire's cycle is a departmental decision with statutory authority behind it, not a fixed legislated term. The 1999 base has been in issue 27 years."
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — the 1999 Old Man of the Mountain base.
+  # =========================================================================
+  - id: us-nh-standard-1999
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1999 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "999 9999"
+      regex: '\A\d{3} ?\d{4}\z'
+      charset:
+        notes: >-
+          ALL-NUMERIC, which makes New Hampshire the only standard series in this
+          group with no letters at all and the only one where the separator
+          carries the entire visual structure. RSA 261 states no grammar and no
+          length — design is delegated to the director in terms — so the
+          seven-digit shape is secondary. Reported serials run 100 0000 to
+          553 8164 as of 17 January 2025.
+      concurrent_formats_note: >-
+        THREE SHORTER ARRANGEMENTS RAN ON THE SAME BASE BEFORE THIS ONE AND ARE
+        STILL ON THE ROAD: 12345 (1 to 99999, Old Man graphic at right — also the
+        vanity style), 123 456 (Old Man graphic centred), and the current
+        123 4567 (Old Man graphic slightly left of centre). THE MIDDLE ONE RAN
+        BACKWARDS: 999 999 down to 100 000. A descending serial sequence is rare
+        enough to be worth stating plainly — any consumer inferring age from
+        magnitude on a New Hampshire six-digit plate will get it exactly
+        inverted. Also note the graphic POSITION shifts with the serial width,
+        so on this base the artwork placement is a function of the format.
+      progression: "ascending on the current seven-digit format; DESCENDING on the preceding six-digit format"
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_note: "OBSERVED — RSA 261 states no plate dimension" }
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO BACKGROUND HEX RECORDED. The base is a GRAPHIC plate — the Old Man of
+        the Mountain and Cannon Mountain against a pale blue sky — so a single
+        background hex would misdescribe it. The serial is embossed DARK GREEN
+        (secondary) and the state name and motto are screened dark green.
+      foreground: "#1B4D3E"
+      legend_bottom: "New HAMPSHIRE"
+      legend_bottom_note: "reported as cursive 'New' set above serifed 'HAMPSHIRE' — a two-weight, two-line state name, unusual in US practice and a real render constraint"
+      legend_top: "LIVE FREE OR DIE"
+      legend_rule: "STATUTORY as to the words: RSA 261:75(II) requires passenger plates to bear the state motto 'Live Free or Die'. The statute does not fix its position; top placement is observed."
+      graphic:
+        present: true
+        rendered: placeholder
+        description: "the Old Man of the Mountain profile with Cannon Mountain behind, against a pale blue sky (secondary)"
+        note: "the depicted formation COLLAPSED on 3 May 2003 and the design has continued unchanged since. See artwork_risk."
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://www.gencourt.state.nh.us/rsa/html/XXI/261/261-75.htm  # RSA 261:75(II): the 'Live Free or Die' mandate for passenger plates, and the delegation of number, location, material and design to the director; (I) the department's issuance duty, the $4.00 fee and the effective-period designation"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Hampshire  # LOCATOR ONLY (PRD-PLATES §4): the January 1999 base with the Old Man of the Mountain and Cannon Mountain, the three concurrent numeric arrangements, the DESCENDING six-digit sequence, the current 123 4567 range to 553 8164 as of 17 January 2025, and the graphic-position shift by format"
+      - "https://www.licenseplates.cc/NH  # enthusiast corroboration, cited because used: the reported serial high-water mark. No text or image copied"
+    notes: >-
+      NEW HAMPSHIRE STANDARD ISSUE. The base is dated 1999 and the DESIGN has not
+      changed since, which by the AAMVA §1.1 measure makes it nearly three
+      replacement cycles old — and legally fine, because RSA 261:75(I) leaves the
+      interval to the department. The id is dated to the BASE rather than to the
+      current serial width, deliberately and unlike us-ct-standard-2015: in
+      Connecticut the format changes were accompanied by an official changeover
+      event with a reported date; in New Hampshire the widths simply grew as each
+      space exhausted, with no reported boundary dates at all, so dating an id to
+      a width would be inventing a boundary. Where the evidence differs, the id
+      policy differs, and the file says why.
+
+  # =========================================================================
+  # ONE SERIES BACK — the 1989 base.
+  # =========================================================================
+  - id: us-nh-standard-1989
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1989, end: 1998 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset: { notes: "reported AAA 001 to approximately DEX 500. The immediately preceding arrangement, on the 1987 base, was a plain six-digit 123456 running 1 to 999999" }
+      separator_note: "printed with a hyphen in secondary depictions (ABC-123); spelled U+0020 here, and either reading is inside the emitted set (PRD-PLATES §2.6) — recorded because the two are not interchangeable to a strict matcher"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B4D3E"
+      colour_note: "embossed dark green serial on reflective white, with the state name and Old Man graphic screened in dark green (secondary); hexes observed"
+      legend_top: "NEW HAMPSHIRE"
+      legend_bottom: "LIVE FREE OR DIE"
+      legend_note: "the motto moved from BOTTOM on this base to TOP on the 1999 base — the statute mandates the words, never the position, so both layouts satisfy RSA 261:75(II). A good illustration of how much a slogan mandate does NOT determine."
+      graphic: { present: true, rendered: placeholder, description: "Old Man of the Mountain in a circle between the two words of the state name (secondary)" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.gencourt.state.nh.us/rsa/html/XXI/261/261-75.htm  # RSA 261:75(II): the motto mandate this base satisfies with a different placement than the current one"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Hampshire  # LOCATOR ONLY: the March 1989 - December 1998 base, the ABC-123 arrangement and its AAA-001 to approximately DEX-500 range, and the 1987-1989 predecessor with the pale-green screening"
+    notes: >-
+      THE PREVIOUS BASE. Still the design of record for several New Hampshire
+      NON-PASSENGER classes issued today — Commercial, Disabled, Municipal
+      Government and the older Trailer series are all reported to run "as
+      1989-98 passenger base". So the 1989 base did not retire in 1998; it
+      DEMOTED, from the passenger design to the utility design, and continues in
+      production for other classes. `period.end: 1998` is therefore correct for
+      the PASSENGER series and would be wrong for the base, which is a real
+      argument for keying series to issuance systems rather than to artwork.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES.
+  # =========================================================================
+  - id: us-nh-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2022 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "9L999"
+      regex: '\A\d[A-Z]\d{3}\z'
+      charset: { notes: "reported 1A000 to 1H885 as of 12 October 2024. Predecessors on the same design: 12345 (1987-94), 1234A (1994-2008), A1234 (2008-2022) — four grammars, one design, the New Hampshire pattern" }
+    design:
+      plate: { w: 7, h: 4, unit: in, dimension_note: "MOTORCYCLE PLATE SIZE NOT OBTAINED — placeholder carrying the conventional US motorcycle size; not sourced (recorded gap). RSA 261:75(II) delegates material and design to the director, whose rules were not obtained" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B4D3E"
+      legend_bottom: "MOTORCYCLE"
+      legend_note: "NO MOTTO. Reported slogan: none — and that is statutorily correct, because RSA 261:75(II)'s proviso binds 'number plates for PASSENGER VEHICLES'. New Hampshire motorcycles are outside the mandate, and the plates show it. One of the cleanest statute-to-artefact confirmations in this group."
+      graphic: { present: true, rendered: placeholder, description: "Old Man of the Mountain screened at top left with 'N' and 'H' on either side (secondary)" }
+    region_encoding: none
+    sources:
+      - "https://www.gencourt.state.nh.us/rsa/html/XXI/261/261-75.htm  # RSA 261:75(II): the motto proviso is scoped to PASSENGER vehicles — the statutory reason this series carries no slogan"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Hampshire  # LOCATOR ONLY: the 1A234 motorcycle arrangement from 2022, the three earlier grammars, the reported range, and the absence of a slogan"
+    notes: >-
+      MOTORCYCLE. Worth the entry for the negative fact alone: the absence of the
+      state motto on New Hampshire motorcycle plates is not an oversight, it is
+      the statute's own scoping, and a dataset that records "NH plates carry
+      'Live Free or Die'" as a jurisdiction-level fact would be wrong for an
+      entire class.
+
+  - id: us-nh-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2004 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "T999999"
+      regex: '\AT\d{6}\z'
+      charset: { notes: "a literal 'T' class prefix and six digits; reported T100000 to T792323 as of 23 January 2025. The preceding arrangement was TB1234 — 'T' plus a sequential letter plus four digits — running TA0001 to TZ9999" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_bottom: "LIVE FREE OR DIE"
+      legend_note: "reported to carry the motto even though RSA 261:75(II) does not require it on a trailer — the director's discretion exercised toward uniformity, not away from it"
+      design_note: "runs on the 1989-98 passenger base design and, per the secondary source, uses THE SAME SERIAL DIES as the current passenger base — a manufacturing fact with a rendering consequence: trailer and passenger glyphs are metrically identical even though the bases differ"
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Hampshire  # LOCATOR ONLY: the T123456 trailer arrangement from 2004, its TB1234 predecessor, the reported range, the 1989-98 base design and the shared serial dies"
+      - "https://www.gencourt.state.nh.us/rsa/html/XXI/261/261-75.htm  # RSA 261:75(II): design and number of plates delegated to the director — the authority under which the trailer series is single-issue and carries the motto voluntarily"
+    notes: >-
+      TRAILER. The shared-serial-dies detail is the kind of fact that only
+      matters to a render layer and matters a lot to it: it means one glyph set
+      serves two series, so a Maine-style per-series font decision is unnecessary
+      here.
+
+  - id: us-nh-municipal
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 1989 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "G99999"
+      regex: '\AG\d{5}\z'
+      charset: { notes: "a literal 'G' prefix (for Government) and five digits; reported G10000 to G30914 as of 18 September 2024" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_bottom: "LIVE FREE OR DIE"
+      design_note: "runs on the 1989-98 passenger base design (secondary)"
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Hampshire  # LOCATOR ONLY: the G12345 Municipal Government arrangement from 1989 and its reported range"
+    notes: >-
+      MUNICIPAL GOVERNMENT. Sequential, not geographic — the 'G' prefix marks
+      the class and the digits are a plain counter, so unlike Connecticut's
+      municipal series this one decodes to nothing. The New Hampshire plate that
+      DOES decode geographically is the Municipal Police series; see
+      us-nh-municipal-police.
+
+  - id: us-nh-municipal-police
+    class: police
+    categories: [car, van, truck]
+    period: { start: 1999 }
+    period_evidence: secondary-dated
+    matching: recall-only
+    format:
+      pattern: "LLL 99"
+      regex: '\A[A-Z]{2,4} ?\d{1,3}\z'
+      charset:
+        notes: >-
+          Reported structure: a DEPARTMENT CODE of letters, then a VEHICLE NUMBER
+          — the secondary source writes it as "xxx 12" and glosses it "xxx -
+          department code, 12 - vehicle number". Neither the code width nor the
+          number width is stated anywhere, which is why the regex quantifies
+          loosely and why this series is `recall-only`: a hit is a shape claim,
+          not a validity claim.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "embossed blue serial on a white and blue plate (secondary); no hex recorded because the two-tone field is not describable as one background colour"
+      legend_top: "LIVE FREE OR DIE"
+      legend_bottom: "MUNICIPAL POLICE"
+      layout_note: "'M/P' screened at left — a stacked two-character class marker, the same AAMVA stacked-characters question raised in us_standards above"
+    region_encoding: >-
+      YES — THE LETTER GROUP IS A DEPARTMENT CODE, i.e. a MUNICIPAL DECODE, the
+      New Hampshire analogue of Connecticut's municipal letters. THE DECODE TABLE
+      WAS NOT OBTAINED: no official list of New Hampshire police department codes
+      was found this pass, and the secondary source gives the mechanism without
+      any of the values. Recorded as a gap and as a candidate
+      `plates/_decode/us-nh-police-departments.yml`. Until it lands a parse API
+      must answer "a New Hampshire municipal police vehicle" and stop.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Hampshire  # LOCATOR ONLY: the Municipal Police series from 1999, the two-tone design, the 'M/P' marker, and the explicit gloss that the letter group is a department code and the digits a vehicle number"
+    notes: >-
+      MUNICIPAL POLICE — modelled `police` rather than `government` because New
+      Hampshire serializes it separately from the G-prefixed municipal series,
+      which is exactly the test _meta/classes.yml sets for the police class
+      ("police fleets where distinct from government"). Both a decode mechanism
+      and a stacked-character question in one series; between this and Connecticut
+      the northeast group has produced two municipal decode tables' worth of
+      mechanism and zero rows of table, which is recorded as the group's second
+      structural gap.
+
+  # =========================================================================
+  # SPECIALTY — PROGRAM INDEX ONLY (PRD-PLATES §2.5). New Hampshire's program
+  # is a plate with a hole in it, and that is genuinely novel.
+  # =========================================================================
+  - id: us-nh-specialty-index
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2017 }
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "L9999"
+      regex: '\A[A-Z]\d{4}\z'
+      charset: { notes: "the Decal Plate serial is reported as D1234 — a literal 'D' prefix and four digits, running from D1000. Decal Vanity Plates are also offered, at an additional $40 vanity fee, so the space is not purely sequential" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "the Decal Plate 'resembles a regular New Hampshire passenger license plate' but carries a BLANK 3-inch by 3-inch SQUARE on the left side. The plate itself is one design; the variation lives in a separately purchased adhesive decal. No individual decal design is described here (PRD-PLATES §2.5)."
+      emblem: { present: true, rendered: placeholder, description: "Old Man of the Mountain at right on the decal plate — the graphic moves right to clear the decal square" }
+    program_index:
+      model: >-
+        NEW HAMPSHIRE'S SPECIALTY PROGRAM IS ARCHITECTURALLY DIFFERENT FROM EVERY
+        OTHER STATE IN THIS GROUP AND IT IS THE MOST INTERESTING FINDING IN THIS
+        FILE. Instead of authorising N plate DESIGNS, New Hampshire authorised ONE
+        plate TYPE with a 3in x 3in blank square, and lets legislatively approved
+        501(c)(3) organizations sell DECALS to fill it. The DMV states it plainly:
+        "Decals are NOT available at DMV locations, they have to be purchased
+        directly from the legislatively authorized 501(c)(3) organizations", and
+        "Decals can only be placed on a Decal Plate." The state manufactures one
+        plate; the charities manufacture the variety. Consequences worth stating:
+        the specialty COUNT is a count of ORGANIZATIONS, not of plate designs; the
+        plate's SERIAL SPACE is shared across all of them, so the serial decodes
+        to nothing about the cause; and — decisively for this dataset — the
+        variable artwork IS NOT A STATE WORK AT ALL. It is a charity's decal. The
+        artwork_risk analysis for New Hampshire specialty plates is therefore a
+        question about fifteen private organizations' IP, not about the state's.
+      statutory_basis: "RSA 261-B, in force from 3 July 2017 per the DMV's own words: 'Pursuant to RSA 261:B, starting July 3rd, 2017, the NH DMV began offering our newest plate type, the Decal Plate.' Veteran decal plates run under a parallel chapter, RSA 261-C, restricted to vehicles registered under RSA 261:87-b."
+      count_organizations: 15
+      count_basis: >-
+        FIFTEEN legislatively approved organizations are listed by name on the
+        DMV's own Decal Plates page as of the capture read this pass: Girl Scouts
+        of the Green and White Mountains; the Grand Lodge of Ancient, Free and
+        Accepted Masons in New Hampshire; Harris Center for Conservation
+        Education; Keene State College; NH Firefighters; New England Donor
+        Services; New England Patriot's Foundation; NH Breast Cancer Coalition;
+        NH Catholic Charities d/b/a NH Food Bank; NH Law Enforcement Officers
+        Memorial Association; NH Rotary; Plymouth State University; Seacoast
+        Youth Services; Sophia's Fund; University of New Hampshire Foundation.
+        This is an OFFICIAL count from the issuing agency, which is a better
+        artefact than any other specialty count in this group except Connecticut's
+        statute-derived one.
+      veteran_decals: "RSA 261-C additionally authorises Veteran Decal Plates with a distinguishing veteran design in the same 3x3 square, sold by the NH Office of Veteran Services rather than by a charity. Branch decals cover Army, Navy, Air Force, Marine Corps, Coast Guard and SPACE FORCE — an issuing agency that has already added the newest US service branch. Medal-of-valor decals cover Medal of Honor, Distinguished Service Cross, Navy Cross, Air Force Cross, Silver Star and Bronze Star, each pre-qualified; Gold Star family decals run under RSA 261-C:3-a."
+      other_specialty_series: "Separately from the decal program New Hampshire issues a CONSERVATION plate (the 'moose plate') from 1999, with a stacked 'C/H' marker beside the serial and five reported serial arrangements (C/H1234X, C/H123X4, C/H12X34, C/H1X234, C/HX1234). It is NOT given a series here: five width variants with no primary and a stacked marker of contested serial status is precisely the shape that produces a wrong regex, and PRD-PLATES §2.5 does not require it. Recorded as the file's largest deliberate omission."
+      fees: "$15 per year for a Decal Plate on top of town and state registration fees; $40 more for a Decal Vanity Plate; an $8.00 plate manufacturing fee in the first year only (DMV's own figures)."
+      official_list_url: "https://www.dmv.nh.gov/vehicles-boats-or-titles/vehicle-registrations/decal-plates"
+    region_encoding: none
+    sources:
+      - "https://www.dmv.nh.gov/vehicles-boats-or-titles/vehicle-registrations/decal-plates  # NH DMV's own Decal Plates page: RSA 261-B and the 3 July 2017 start; the 3in x 3in blank square; decals sold by the organizations and not by the DMV; the fifteen approved organizations by name; the $15/$40/$8 fees; RSA 261-C veteran decals, the RSA 261:87-b registration condition, the six service branches including Space Force, the six medals of valor, and RSA 261-C:3-a Gold Star family decals. Read via https://web.archive.org/web/2025/... because dmv.nh.gov returned 403 to direct fetches this pass"
+      - "https://www.gencourt.state.nh.us/rsa/html/XXI/261/261-75.htm  # RSA 261:75(II): the director's design authority under which a plate type with a blank decal field can exist at all"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Hampshire  # LOCATOR ONLY: the D1234 decal-plate serial arrangement from D1000, and the Conservation plate's five reported arrangements with the stacked C/H marker"
+    notes: >-
+      THE NEW HAMPSHIRE SPECIALTY INDEX. `period_evidence: statutory-date`
+      because the DMV cites RSA 261-B and a specific commencement date, 3 July
+      2017, in its own words — the only specialty index in this group with a
+      dated statutory start. THE STRUCTURAL LESSON, which belongs in the PRD's
+      §2.5 discussion and not just in this file: the "specialty programs" concept
+      assumes one design per program, and New Hampshire breaks that assumption by
+      separating the PLATE (state, one design, one serial space) from the DECAL
+      (private, many designs, no serial). A schema that counts "specialty plates"
+      per state is counting different things in different states — Florida's over
+      a hundred DESIGNS, Connecticut's thirteen STATUTES, Maine's nine SERIAL
+      BLOCKS, and New Hampshire's fifteen ORGANIZATIONS SHARING ONE PLATE. The
+      index entries in this group therefore say what they are counting, every
+      time, and no cross-state total is offered.

--- a/plates/us-ri.yml
+++ b/plates/us-ri.yml
@@ -1,0 +1,445 @@
+# plates/us-ri.yml — Rhode Island (PRD-PLATES gate L2, northeast group).
+#
+# RHODE ISLAND IS THE ONLY STATE IN THIS GROUP WHOSE STATUTE SPELLS OUT THE FULL
+# CONTENTS OF THE PLATE, and it does so in one tidy section. R.I. Gen. Laws
+# § 31-3-11(a), verbatim: "Every registration plate shall have displayed upon it
+# the registration number assigned to the vehicle for which it is issued, the
+# name of the state of Rhode Island, WHICH MAY BE ABBREVIATED 'R.I.', and the
+# year number for which it is issued or the date of its expiration. Registration
+# plates shall also have printed on them the words, 'ocean state'." Four
+# mandatory elements — serial, state name, validity marking, slogan — with an
+# express abbreviation permission. And then § 31-3-11(b) does something no other
+# statute in this group does: it carves the slogan mandate BACK OUT for two
+# classes — "The provision requiring the printing of the words 'ocean state' on
+# these plates shall not pertain to commercial plates or to plates issued to
+# recipients of the Purple Heart." A slogan mandate WITH statutory exceptions is
+# a design rule precise enough to validate a render against.
+#
+# NOTE THE CASING. The statute writes the slogan in lower case, twice, inside
+# quotation marks: 'ocean state'. Every plate issued shows it as "Ocean State".
+# Recorded, not smoothed: statutes are not typographic specifications, and a
+# render that follows the statute's casing literally would be wrong.
+#
+# THE PLATE COUNT IS ALSO STATUTORY AND IS PER-CLASS, which is unusual: § 31-3-10
+# names the one-plate classes exhaustively rather than stating a default and an
+# exception. See display_rules.
+jurisdiction: us-ri
+authority:
+  name: Rhode Island Division of Motor Vehicles, Rhode Island Department of Revenue
+  url: "https://dmv.ri.gov/"
+binding: vehicle
+statute_edition: >-
+  Rhode Island General Laws, Title 31 (Motor and Other Vehicles), Chapter 31-3
+  (Registration of Vehicles) — §§ 31-3-10, 31-3-11, 31-3-12 and 31-3-25 read
+  this pass from webserver.rilin.state.ri.us via the Wayback Machine, the live
+  RI legislature hosts being unreachable from this environment (recorded).
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: permissive-policy-no-warranty
+  basis: >-
+    Rhode Island is the only state in this group with an EXPRESS, FETCHED
+    copyright policy of its own, and it is genuinely permissive while refusing to
+    warrant anything. RI.gov's Copyright policy, verbatim: "The State of Rhode
+    Island makes the content of this WWW site available to the public. Anyone may
+    view information found here without obligation to the State of Rhode Island,
+    unless otherwise stated on particular articles of information to which a
+    restriction on fair use may apply. However, THE STATE OF RHODE ISLAND MAKES
+    NO WARRANTY that materials contained herein are free of copyright claims or
+    other restrictions or limitations on fair use or display. THE COMPILED
+    INFORMATION PRESENTED ON THIS WWW SITE IS CONSIDERED PUBLIC INFORMATION AND
+    MAY BE DISTRIBUTED OR COPIED. However, use of appropriate byline/photo/image
+    credits is requested."
+  reading: >-
+    Better than silence, weaker than Florida. Three limits matter. (1) It is a
+    WEBSITE policy, not a statute or a holding — it speaks to "content of this
+    WWW site", and a plate design is not obviously website content. (2) The
+    no-warranty sentence is doing real work: the state declines to say the
+    material is free of third-party claims, which is exactly the situation for a
+    charity plate whose artwork belongs to the charity (see the specialty index —
+    seventeen of Rhode Island's plates carry private organizations' artwork). (3)
+    The credit request is a request, not a condition, but a courteous consumer
+    honours it. Separately, R.I. Gen. Laws § 38-2-3 makes all records kept by a
+    public body public records open to inspection and copying — an ACCESS statute,
+    which is NOT a copyright waiver and is not treated as one here.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies. The current base carries a screened
+    NAVY BLUE ANCHOR at top left — the state's emblem, which also appears on the
+    state flag and seal — and state-emblem protection independent of copyright is
+    unresearched for Rhode Island (recorded gap). The State and State Police
+    series additionally carry the STATE SEAL itself, which is the sharpest case:
+    seal-misuse statutes are a separate regime from copyright and none was
+    located this pass.
+  photograph_caution: "Commons photographs of Rhode Island plates carry the photographer's licence on the photograph; the uploader had no standing over the design. Our renders are generated from spec, so those obligations never attach."
+  sources:
+    - "https://www.ri.gov/policies/copyright/  # fetched this pass: the State of Rhode Island's own Copyright policy, quoted verbatim above — public information may be distributed or copied, no warranty against third-party claims, credits requested"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR: the Rhode Island entry, which cites R.I. Gen. Laws § 38-2-3 (public records open to inspection and copying) and the § 38-2-2(4) exceptions. An access statute, recorded as such"
+    - "https://commons.wikimedia.org/w/api.php?action=query&titles=Template:PD-RIGov  # queried this pass: MISSING — no Rhode Island public-domain tag exists on Commons"
+
+display_rules:
+  plate_count_is_statutory_and_per_class: >-
+    § 31-3-10, verbatim: "The division of motor vehicles, upon registering a
+    vehicle, shall issue to the owner ONE fully reflective registration plate for
+    each MOTORCYCLE, TRAILER, SEMI-TRAILER, IN-TRANSIT VEHICLE, TRANSPORTER,
+    BAILEE VEHICLE, or a DEALER VEHICLE and TWO (2) fully reflective registration
+    plates for EVERY OTHER MOTOR VEHICLE." Note what this does: it enumerates the
+    single-plate classes exhaustively and makes two plates the residual rule, so
+    the front-plate question in Rhode Island is answered by a closed list rather
+    than by a default plus exceptions. It also makes FULL REFLECTIVITY statutory
+    for every class.
+  legibility: "§ 31-3-12: 'Each registration plate and the required letters and numerals on it, except the year number for which issued, shall be of sufficient size to be plainly readable from a distance of ONE HUNDRED FEET (100') during daylight.' The strictest legibility distance in this group — CT legislates fifty feet at night, MA sixty at night, RI a hundred in daylight — and note the express exemption of the year number from the size test."
+  penalty: "§ 31-3-12: violations are subject to the fines enumerated in § 31-41.1-4."
+  contents: "§ 31-3-11(a): serial, the state name (abbreviable to 'R.I.'), the year of issue or the expiration date, and the words 'ocean state'; (b) the slogan requirement does not apply to commercial plates or Purple Heart plates."
+  front_plate_practice_note: >-
+    A widely repeated secondary claim holds that Rhode Island requires a front
+    plate only on vehicles delivered with a factory front bracket, and separately
+    that Rhode Island was moving to single rear plates in June 2026. NEITHER IS
+    SUPPORTED BY § 31-3-10 AS READ THIS PASS, which states a flat two-plate rule
+    for everything outside its enumerated list and says nothing about brackets.
+    The disagreement is recorded, not resolved; if a 2026 amendment exists it was
+    not located, and the statute text captured here is the one that governs until
+    a later instrument is pinned. This is exactly the class of claim PRD-PLATES
+    §9 warns is folklore-prone.
+  sources:
+    - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-10.HTM  # § 31-3-10: one plate for motorcycle, trailer, semi-trailer, in-transit, transporter, bailee and dealer vehicles; two for every other motor vehicle; all fully reflective. Read via the Wayback Machine (live host unreachable this pass)"
+    - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-11.HTM  # § 31-3-11(a) the four mandatory plate contents and the 'R.I.' abbreviation permission; (b) the commercial and Purple Heart carve-outs from the slogan"
+    - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-12.HTM  # § 31-3-12: the 100-foot daylight legibility test, the year-number exemption, and the § 31-41.1-4 penalty hook"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; recommendations, not requirements."
+  aamva_geometry: "AAMVA §2.1 jurisdiction name top-centre between the bolt holes, >=0.25 in above the plate number, >=0.125 in from the top edge, characters 0.75-1.0 in; §2.2 serial characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom; §3.3 legible day and night from >=75 feet, ASTM D4956-19 and ISO 7591:1982 cl.3, entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2."
+  aamva_vs_ri_legibility: "AAMVA §3.3 asks for legibility at >=75 feet in daylight AND at night. Rhode Island legislates 100 feet in daylight and says nothing about night. So Rhode Island's statutory daylight bar is HIGHER than AAMVA's recommendation and its night bar is absent — a jurisdiction can exceed the voluntary standard on one axis and omit it on another, which is what 'voluntary adoption' looks like in practice."
+  dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, PAYWALLED and UNPINNED; no J686 dimension is quoted here. Chapter 31-3 states no plate dimension, so 12x6 in below is `observed`."
+  replacement_cycle: "Rhode Island legislates none for passenger plates. It DOES legislate one for dealer plates: § 31-3-25(a) requires reissuance 'every three (3) years in clearly distinguishable colors'. See us-ri-dealer — it is the only legislated plate cycle found anywhere in the northeast group."
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — the 2023 "Ocean Plate".
+  # =========================================================================
+  - id: us-ri-standard-2023
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2023 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "9LL 999"
+      regex: '\A\d[A-Z]{2} ?\d{3}\z'
+      charset:
+        notes: >-
+          Reported: one digit, two letters, three digits, running 1LE 100 to
+          1ZF 266 as of 30 January 2025. Chapter 31-3 states NO grammar, NO
+          length and NO alphabet — § 31-3-11 requires the plate to display "the
+          registration number assigned to the vehicle" and stops — so the shape
+          is secondary. NOTE THE CONTINUITY: this series did not restart, it
+          continued the wave base's 1AB 234 sequence, which had reached 1KV 999
+          by 2023. So the format alone cannot date a Rhode Island plate; only the
+          leading letter block can, and that boundary is locator-grade.
+        remakes: "the current base is also used for REMAKES of previously issued serials in every older Rhode Island format, so a 2023-base plate may legitimately carry a 1996-era serial shape. A parse API must not infer the base from the serial."
+      separator_note: "printed with a gap (1AB 234). The wave base's 1AL-to-1BQ blocks are reported to have printed the same format with NO space at all, so both spaced and unspaced forms are genuine; the ` ?` quantifier covers both, which is the separator contract working as designed (PRD-PLATES §2.6)"
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_note: "OBSERVED — Chapter 31-3 states no plate dimension" }
+      background: { finish: retroreflective, statutory_basis: "§ 31-3-10 requires 'fully reflective registration plates' for every class — reflectivity is statutory in Rhode Island, unlike its colour" }
+      colour_note: >-
+        NO HEX RECORDED FOR THE BACKGROUND. The base is described as reflective
+        LIGHT BLUE carrying a five-wave graphic, so a single flat hex would
+        misdescribe it; the serial is SCREENED navy blue (not embossed — a
+        manufacturing change from the wave base, which embossed). The statute
+        names no colour anywhere.
+      foreground: "#0B2C5C"
+      legend_top: "Rhode Island"
+      legend_bottom: "Ocean State"
+      legend_rule: >-
+        BOTH LEGENDS ARE STATUTORY IN SUBSTANCE. § 31-3-11(a) requires the plate
+        to bear "the name of the state of Rhode Island, which may be abbreviated
+        'R.I.'" and to have "printed on them the words, 'ocean state'". The
+        statute fixes neither position nor case; the issued plate sets the state
+        name at top and the slogan at the bottom in a script face. See the file
+        header on casing.
+      graphic: { present: true, rendered: placeholder, description: "five-wave graphic across the plate; navy blue anchor screened at top left (secondary)" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    validation_marking: "§ 31-3-11(a) requires 'the year number for which it is issued or the date of its expiration' on the plate face — a statutory validity marking, satisfied in practice by a sticker. § 31-3-12 expressly exempts that year number from the 100-foot legibility test, which is a nice piece of drafting: the law demands the date be present but not that it be readable from a distance."
+    region_encoding: none
+    sources:
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-11.HTM  # § 31-3-11(a): the assigned registration number, the state name with its 'R.I.' abbreviation permission, the year-or-expiration marking, and the mandatory words 'ocean state'"
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-10.HTM  # § 31-3-10: two fully reflective plates for every motor vehicle outside the enumerated single-plate classes"
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-12.HTM  # § 31-3-12: the 100-foot daylight legibility standard and the year-number exemption"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Rhode_Island  # LOCATOR ONLY (PRD-PLATES §4): the 2023 'Ocean Plate', its five-wave light blue design with screened navy serial and anchor, the 1AB 234 arrangement continuing from the wave base, the 1LE 100 to 1ZF 266 range as of 30 January 2025, and the remakes practice"
+    notes: >-
+      RHODE ISLAND CURRENT STANDARD, the "Ocean Plate". The interesting property
+      for a parse API is that Rhode Island DOES NOT PARTITION ITS SERIAL SPACE BY
+      BASE: the 2023 plate continued the 1996 base's sequence, and the 2023 base
+      is also used to remake serials in every historical Rhode Island format. So
+      a Rhode Island serial identifies a REGISTRATION, not a plate generation,
+      and any inference from format to era is unsafe here in a way it is not in
+      Maine or Massachusetts. That is a genuine per-jurisdiction difference in
+      what a serial means, and it is the sort of thing only a period-disciplined
+      dataset can record.
+
+  # =========================================================================
+  # ONE SERIES BACK — the 1996 "wave plate".
+  # =========================================================================
+  - id: us-ri-wave-1996
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1996, end: 2023 }
+    period_evidence: secondary-dated
+    matching: recall-only
+    format:
+      pattern: "9LL 999"
+      regex: '\A(?:\d[A-Z]{2} ?\d{3}|\d{3}-?\d{3}|[A-Z]{2}-?\d{2,3}|\d{1,5})\z'
+      charset:
+        notes: >-
+          FOUR GRAMMARS OVER TWENTY-SEVEN YEARS, run partly in parallel and partly
+          in sequence, which is why this series is `recall-only` and why its regex
+          is a union: (a) a VARIABLE-LENGTH all-numeric 12345, one to five digits,
+          1 to 99999; (b) AB-12 and AB-123, AA-00 to ZZ-999, reported in two
+          separate windows 1996-2007 and again 2015-2020; (c) 123-456, 710-001
+          DOWN TO 399-999 with the leading number progressing IN REVERSE,
+          2007-2015; (d) 1AB234 / 1AB 234, 1AA 100 to 1KV 999, 2020-2023. A hit on
+          the union says only "this string has a shape Rhode Island issued on the
+          wave base".
+      variable_width_note: "the all-numeric form is genuinely VARIABLE WIDTH with no leading zeros — the Delaware problem, and the reason PRD-PLATES §2.2 says regexes quantify rather than fix width. \\d{1,5} makes no width claim beyond five."
+      separator_note: "the AB-12/AB-123 and 123-456 forms print a HYPHEN, which is in the emitted set; the 1AB 234 form prints a space, EXCEPT in the reported 1AL-to-1BQ blocks which printed no separator at all. Every one of those is covered by the optional-separator spelling, which is precisely what §2.6's forgiving/emitted split exists to make sound"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#0B2C5C"
+      colour_note: "embossed navy blue serial on reflective white with a grey wave graphic; 'Rhode Island' screened navy at top with a navy anchor at top left (secondary). Colloquially the 'wave plate'"
+      legend_top: "Rhode Island"
+      legend_bottom: "Ocean State"
+      legend_rule: "§ 31-3-11 — the same statutory contents as the current base; twenty-seven years, four grammars, one unchanged statutory legend set"
+      graphic: { present: true, rendered: placeholder, description: "grey wave graphic; navy anchor at top left (secondary)" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-11.HTM  # § 31-3-11: the statutory contents this base satisfied unchanged across all four of its serial grammars"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Rhode_Island  # LOCATOR ONLY: the 1996-2023 wave base, the four serial arrangements with their windows and ranges, the REVERSE progression of the 123-456 form, and the unspaced 1AL-to-1BQ blocks"
+    notes: >-
+      THE WAVE PLATE. Two facts worth carrying past this gate. First, the
+      123-456 arrangement ran BACKWARDS (710-001 down to 399-999), the second
+      descending US sequence this group found after New Hampshire's six-digit
+      passenger series — descending serials are evidently not a curiosity but a
+      recurring administrative choice, and any era-inference model that assumes
+      monotone ascent is wrong twice in six states. Second, Rhode Island returned
+      to the AB-123 grammar in 2015 after eight years away from it, so the same
+      shape appears in two disjoint windows on one base. `recall-only` is the only
+      honest matching setting for a series like that.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES.
+  # =========================================================================
+  - id: us-ri-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2023 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "99999"
+      regex: '\A\d{1,5}\z'
+      charset: { notes: "variable-length all-numeric, 1 to 99999, plus reissues of dormant serials. The {1,5} quantifier makes no width claim beyond five" }
+    design:
+      plate: { w: 7, h: 4, unit: in, dimension_note: "MOTORCYCLE PLATE SIZE NOT OBTAINED — placeholder at the conventional US motorcycle size; Chapter 31-3 states no dimension for any plate (recorded gap)" }
+      background: { finish: retroreflective, statutory_basis: "§ 31-3-10 requires the motorcycle plate to be 'fully reflective' in the same breath as it limits it to one" }
+      legend_top: "MOTORCYCLE"
+      legend_bottom: "RI"
+      legend_note: "'RI' at bottom left — § 31-3-11(a)'s abbreviation permission ('which may be abbreviated \"R.I.\"') exercised, and the clearest illustration of why that clause is in the statute: a motorcycle plate has no room for the full state name"
+    display_rule: "ONE plate, statutorily: § 31-3-10 names motorcycles first in its single-plate list"
+    region_encoding: none
+    sources:
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-10.HTM  # § 31-3-10: one fully reflective plate for each motorcycle"
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-11.HTM  # § 31-3-11(a): the 'R.I.' abbreviation permission this plate relies on"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Rhode_Island  # LOCATOR ONLY: the 12345 motorcycle arrangement 1 to 99999 with reissues, and the 2023 change from embossed to screened legends"
+    notes: >-
+      MOTORCYCLE. § 31-3-2.2 of the same chapter separately governs the
+      registration of motorcycles, motorized bicycles and motorized tricycles;
+      its text was not obtained (recorded gap), and if it carries a plate rule
+      for motorized bicycles that would be a distinct series this file does not
+      have.
+
+  - id: us-ri-commercial
+    class: standard
+    categories: [truck, van]
+    period: { start: 2023 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "999999"
+      regex: '\A\d{1,6}\z'
+      charset: { notes: "variable-length all-numeric, reported 1 to 260089 plus reissues of dormant serials — the same numeric space as the Combination class, which is a genuine ambiguity: two Rhode Island classes drawing from one range, distinguishable only by the legend on the plate" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_bottom: "COMMERCIAL"
+      legend_rule: >-
+        THIS IS THE STATUTORY CARVE-OUT MADE VISIBLE. § 31-3-11(b): "The
+        provision requiring the printing of the words 'ocean state' on these
+        plates shall not pertain to COMMERCIAL PLATES or to plates issued to
+        recipients of the Purple Heart." So the word COMMERCIAL sits where the
+        slogan would, and it does so with express statutory permission rather
+        than by departmental choice — the only slogan exemption in the northeast
+        group written into law.
+    region_encoding: none
+    sources:
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-11.HTM  # § 31-3-11(b): the express exemption of commercial plates (and Purple Heart plates) from the 'ocean state' slogan requirement"
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-10.HTM  # § 31-3-10: commercial plates are not in the single-plate list, so two plates are issued; the section also directs that commercial-plate applications be available at all DMV offices"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Rhode_Island  # LOCATOR ONLY: the six-digit commercial arrangement, the 1 to 260089 range with reissues, and the shared range with Combination plates"
+    notes: >-
+      COMMERCIAL. Recorded as class `standard` with the legend carrying the
+      meaning; see the class-vocabulary note in us-ma.yml. The statutory slogan
+      exemption is the reason this series earns its own entry rather than a
+      sub-entry: it is a DESIGN difference mandated by law, which is the §2.3 test.
+
+  - id: us-ri-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2018 }
+    period_evidence: statutory-date
+    matching: recall-only
+    format:
+      pattern: "L9999"
+      regex: '\A[A-Z]{1,2} ?\d{1,5}\z'
+      charset:
+        notes: >-
+          THE STATUTE DESCRIBES THE STRUCTURE WITHOUT GIVING THE GRAMMAR, which
+          is rare and useful. § 31-3-25(a): dealer plates "shall have displayed
+          on them THE GENERAL DISTINGUISHING NUMBER ASSIGNED TO THE APPLICANT.
+          Each plate so issued shall also contain A NUMBER OR SYMBOL IDENTIFYING
+          THE PLATE FROM EVERY OTHER PLATE BEARING THE SAME GENERAL DISTINGUISHING
+          NUMBER." So a Rhode Island dealer serial is provably two-part — a
+          dealership identifier plus a per-plate discriminator — and that is a
+          statutory fact about the SEMANTICS of the serial even though no primary
+          gives its widths or alphabet. The regex is a deliberately loose union
+          over the described structure; `recall-only` is the honest setting.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective, statutory_basis: "§ 31-3-10 requires the single dealer plate to be fully reflective" }
+      colour_rule: >-
+        COLOUR IS STATUTORY HERE AND IT IS A CODE. § 31-3-25(a): the division
+        "shall issue dealer's plates every three (3) years IN CLEARLY
+        DISTINGUISHABLE COLORS, ONE COLOR TO BE USED BY NEW VEHICLE DEALERS,
+        ANOTHER COLOR FOR USED VEHICLES DEALERS, AND ANOTHER COLOR FOR
+        TRANSPORTER AND BAILEE PLATES. The color for each category enumerated in
+        this section shall be changed every three (3) years with the issuance of
+        the plates." Three category colours, all rotated on a three-year cycle,
+        all mandated. THE ACTUAL COLOUR VALUES ARE NOT IN THE STATUTE and were not
+        obtained (recorded gap) — the statute mandates that colour CARRY MEANING
+        without saying which colour carries which, exactly as Florida's
+        § 320.086(1) requires historic plates to be "of a distinguishing color"
+        without naming one.
+    replacement_cycle:
+      years: 3
+      statutory_text: "§ 31-3-25(a): dealer plates issued 'every three (3) years in clearly distinguishable colors'; § 31-3-25(b): 'The dealer plate issuance scheduled for January 1, 2017, shall be deferred until January 1, 2018 to coincide with the dealer license renewal cycle.'"
+      note: "THE ONLY LEGISLATED PLATE REPLACEMENT CYCLE FOUND ANYWHERE IN THE NORTHEAST GROUP, and it sits well inside AAMVA §1.1's 7-to-10-year recommendation because its purpose is not retroreflectivity but ENFORCEMENT — a colour that changes every three years makes an expired dealer plate visible at a glance."
+    binding: business
+    region_encoding: "none — the 'general distinguishing number' identifies a DEALERSHIP, not a place. A business decode, and no registry of assigned numbers was obtained (recorded gap)"
+    sources:
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-25.HTM  # § 31-3-25(a): the general distinguishing number, the per-plate discriminating number or symbol, the three-year issuance cycle, and the three mandated category colours (new dealers / used dealers / transporter and bailee); (b) the deferral of the 1 January 2017 issuance to 1 January 2018"
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/31-3-10.HTM  # § 31-3-10: one fully reflective plate for a dealer vehicle, a transporter and a bailee vehicle"
+    notes: >-
+      DEALER — the best-sourced dealer series in this group and one of the
+      best-sourced anywhere in the dataset, because Rhode Island legislates the
+      SEMANTICS of the serial, the CYCLE of reissuance and the FUNCTION of the
+      colour, while leaving the values to the division. `period.start: 2018` is a
+      real statutory date: § 31-3-25(b) moved the cycle's anchor from 1 January
+      2017 to 1 January 2018, so the current three-year cadence runs 2018, 2021,
+      2024, 2027 — a rare case where a dataset can PREDICT the next reissue from
+      the statute alone. Whether it has held is not verified (recorded gap).
+
+  # =========================================================================
+  # SPECIALTY — PROGRAM INDEX ONLY (PRD-PLATES §2.5).
+  # =========================================================================
+  - id: us-ri-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9]{1,6}\z'
+      charset:
+        notes: >-
+          RHODE ISLAND CHARITY PLATES CARRY OWNER-CHOSEN CHARACTER STRINGS WITH
+          PER-PROGRAM LENGTH CAPS, which the DMV states plate by plate: Bristol
+          Fourth of July "a maximum of 6 characters"; Conservation Through
+          Education "a maximum of 5 characters"; Day of Portugal 5; Gaspee Days
+          "a maximum of 6 letters/numbers"; Gloria Gemma 6; New England Patriots
+          5; Plum Beach Lighthouse 5; Pomham Rocks Lighthouse 5. So the specialty
+          space is a VANITY space with a per-program cap of five or six, not a
+          department-assigned sequence — the opposite of Massachusetts, where the
+          RMV states that specialty plates cannot be vanity and no specific number
+          may be requested. Two neighbouring states, opposite rules.
+      union_note: "`recall-only` and a six-character catch-all, because the cap VARIES BY PROGRAM (5 or 6) and no single grammar describes the space. A hit says 'this could be a Rhode Island charity-plate string', nothing more."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised charity; individual designs are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official_in_production: 17
+      count_basis: >-
+        SEVENTEEN charity plates listed as "Currently in Production" on the RI
+        DMV's own page, counted mechanically by the "Enabling Legislation:"
+        heading the DMV attaches to each. The DMV maintains a SECOND list,
+        "Taking Preorders", for authorised-but-not-yet-produced plates — so
+        Rhode Island's index has two states and the count above is the produced
+        one. The preorder list was not counted this pass (recorded gap).
+      every_plate_has_a_statute: >-
+        THE STRUCTURAL FINDING, AND IT MAKES RHODE ISLAND THE SECOND
+        STATUTE-INDEXED SPECIALTY PROGRAM IN THIS GROUP AFTER CONNECTICUT. Every
+        single charity plate is created by its own section of R.I. Gen. Laws
+        Chapter 31-3, and the DMV prints the citation under each entry. Observed
+        this pass: § 31-3-72 (Mr. ...), 31-3-79 (Audubon Society of Rhode Island /
+        Save the Bay — the Osprey "Conservation Through Education" plate), 31-3-85
+        (New England Patriots Charitable Foundation), 31-3-86 (Friends of Plum
+        Beach Lighthouse), 31-3-90 (Red Sox Foundation), 31-3-91 (Bristol Fourth
+        of July Committee), 31-3-93 (Gloria Gemma Breast Cancer Resource
+        Foundation), 31-3-99 (Wildlife Rehabilitators Association of Rhode
+        Island), 31-3-102 (Boston Bruins Foundation), 31-3-105 (Rhode Island
+        private colleges and universities), 31-3-108 (The Rocky Point Foundation),
+        31-3-112 (Gaspee Days Committee), 31-3-118 (Day of Portugal and Portuguese
+        Heritage in RI), 31-3-122 (Friends of Pomham Rocks Lighthouse), 31-3-124
+        (The Rose Island Lighthouse Foundation), 31-3-125 (Beavertail Lighthouse
+        Museum Association), 31-3-126 (Atlantic Shark Institute). Seventeen
+        sections, seventeen plates, one-to-one.
+      surcharge_model: "most programs carry a $10 annual registration renewal surcharge that goes to the organization, on top of $43.50 for the initial order and $33.50 for a remake. Bristol Fourth of July is expressly exempt from the renewal surcharge — a per-program variation the statute presumably carries."
+      vehicle_class_restrictions: "programs differ in which registration classes they may be used on: some passenger-only, some passenger and commercial, the Atlantic Shark Institute plate 'can be put on passenger, motorcycle, combination, and commercial vehicles'. Gaspee Days plates additionally may not be used on new or changed registrations at all — they substitute for an EXISTING private passenger registration only."
+      artwork_ownership_flag: >-
+        DIRECTLY RELEVANT TO artwork_risk AND TO THE RENDER LAYER. Rhode Island's
+        DMV states of the Gaspee Days plate that it is "based on R.I. artist Karl
+        Doerflinger's painting, The Burning of the Gaspee". That is a named
+        living-artist work reproduced on a state plate — the artwork is NOT a state
+        work at all, and the state's own copyright policy expressly disclaims any
+        warranty that its material is free of third-party claims. Together with New
+        Hampshire's charity decals, this is the group's clearest evidence that US
+        specialty-plate artwork frequently belongs to someone other than the state,
+        and that a per-state `artwork_risk` posture does not settle the specialty
+        layer. PRD-PLATES §3's placeholder default is the correct render posture
+        and this is a concrete reason for it.
+      official_list_url: "https://dmv.ri.gov/registrations-plates-titles/license-plates/charity-plates/currently-production"
+      official_preorder_url: "https://dmv.ri.gov/registrations-plates-titles/license-plates/charity-plates/taking-preorders"
+      statutory_index_url: "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/INDEX.HTM"
+      other_statutory_types: "Chapter 31-3 separately authorises non-charity special plates that are not part of the charity program: § 31-3-15 (state officers and mayors), 31-3-16 (General Assembly), 31-3-17 (volunteer fire company), 31-3-17.1 (courtesy), 31-3-17.2 (civil defense), 31-3-17.3 (temporary), 31-3-17.4 (firefighter), 31-3-39 (amateur radio operator), 31-3-42 (camper), 31-3-43 (sheriffs' department), 31-3-44 (ambulance or rescue), 31-3-45 and 31-3-45.1 (police motorcycle and police), 31-3-46 (P.O.W.), 31-3-47 (judiciary), 31-3-48/48.1/48.2 (Purple Heart, Distinguished Service Cross, Bronze Star), 31-3-53 (veterans'), plus four named-individual emeritus sections (31-3-49, 31-3-50, 31-3-51, 31-3-54, 31-3-56) — Rhode Island legislates plates for SPECIFIC NAMED PEOPLE, which no other state in this group does."
+    region_encoding: none
+    sources:
+      - "https://dmv.ri.gov/registrations-plates-titles/license-plates/charity-plates/currently-production  # RI DMV's own 'Currently in Production' charity plate list: the seventeen plates, each with its enabling R.I. Gen. Laws citation, the per-program character caps, the $43.50/$33.50/$10 fee structure, the per-plate vehicle-class restrictions, and the Doerflinger painting attribution. Read via the Wayback Machine (dmv.ri.gov returned 403 to direct fetches this pass)"
+      - "https://webserver.rilin.state.ri.us/Statutes/TITLE31/31-3/INDEX.HTM  # the chapter index from which the non-charity special-plate sections above were enumerated, including the named-individual emeritus plates"
+    notes: >-
+      THE RHODE ISLAND SPECIALTY INDEX — seventeen produced programs, each with
+      its own statute, plus a second preorder tier. Two things to carry forward.
+      First, Rhode Island and Connecticut together establish that a
+      STATUTE-DERIVED specialty count is achievable in at least some states and is
+      strictly better than a gallery count: it is dated, versioned, PD, and
+      countable without fetching a DMV page that 403s. Second, the character caps
+      belong in the parse layer as a per-program constraint — a five-character
+      Rhode Island charity string is not merely short, it is evidence of WHICH
+      program, and with seventeen programs and two cap values that is a real, if
+      weak, discriminator.

--- a/plates/us-vt.yml
+++ b/plates/us-vt.yml
@@ -1,0 +1,458 @@
+# plates/us-vt.yml — Vermont (PRD-PLATES gate L2, northeast group).
+#
+# VERMONT DELEGATES MORE COMPLETELY THAN ANY OTHER STATE IN THIS GROUP. 23 V.S.A.
+# § 304(a), verbatim: "The number plate or plates issued shall be OF THE MATERIAL,
+# SIZE, SHAPE, AND COLOR, AND WITH THE NUMERALS OR LETTERS THEREON, THE
+# COMMISSIONER MAY DETERMINE, and shall be reflectorized in part or in whole."
+# Material, size, shape, colour and grammar — all five delegated in one sentence,
+# with exactly one substantive requirement left standing: reflectorization, and
+# even that only "in part or in whole". No slogan mandate (contrast New
+# Hampshire), no legend list (contrast Rhode Island), no character height
+# (contrast Maine), no design description (contrast Maine again). Vermont's plate
+# law is a grant of authority with a single condition attached.
+#
+# WHAT VERMONT DOES LEGISLATE, in detail, is the VANITY AND ORGANIZATION plate
+# regime — § 304(b) runs to a page of criteria — and that turns out to include
+# the only INTELLECTUAL-PROPERTY CLAUSE about plate artwork found in any statute
+# in this group. See artwork_risk and us-vt-specialty-index.
+#
+# The current green base has been in issue since 1 January 1990: thirty-six years,
+# the longest unbroken standard base in the northeast group and one of the oldest
+# in the country.
+jurisdiction: us-vt
+authority:
+  name: Vermont Department of Motor Vehicles, Vermont Agency of Transportation
+  url: "https://dmv.vermont.gov/"
+binding: vehicle
+statute_edition: >-
+  Vermont Statutes Annotated, Title 23 (Motor Vehicles), Chapter 7 (Operators'
+  Licenses and Registration) — §§ 304 and 511 read this pass from the Vermont
+  General Assembly's statutes service. § 511's amendment line ends "2023, No. 41,
+  § 13, eff. November 1, 2023".
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched-with-one-statutory-signal
+  basis: >-
+    No affirmative Vermont public-domain instrument was located. Commons has NO
+    {{PD-VTGov}} template (queried by API this pass, result MISSING); Vermont has
+    NO entry in the Wikipedia survey of subnational copyright postures; and
+    vermont.gov's published policies, which WERE fetched, address only
+    PHOTOGRAPHS — "Photos displayed on the Vermont.gov website are copyrighted by
+    the photographer. Permission to use the photographs is granted for the
+    following limited uses ... Photos may not be sold or used in any way for
+    profit or commercial purposes" — plus a DMCA notice-and-takedown procedure
+    administered by Tyler Technologies, the state's portal vendor. That policy
+    says nothing about state-authored designs, and its stance on the one thing it
+    does address is restrictive. With no disclaimer located, the §105 default
+    governs: state works are presumed copyrighted.
+  one_statutory_signal: >-
+    THE INTERESTING PIECE, AND IT CUTS THE OTHER WAY FROM CONNECTICUT'S. Vermont
+    is the only state in this group whose plate statute contains an IP clause
+    about plate artwork — and the clause places the burden on the SPONSORING
+    ORGANIZATION, not on the state. 23 V.S.A. § 304(b)(2)(B): a special
+    organization plate's name and emblem "shall not be objectively obscene or
+    confusing to the general public and shall not promote, advertise, or endorse
+    a product, brand, or service provided for sale. THE ORGANIZATION'S NAME AND
+    EMBLEM MUST NOT INFRINGE ON OR VIOLATE A TRADEMARK, TRADE NAME, SERVICE MARK,
+    COPYRIGHT, OR OTHER PROPRIETARY OR PROPERTY RIGHT, AND THE ORGANIZATION MUST
+    HAVE THE RIGHT TO USE THE NAME AND EMBLEM." Two readings, both worth
+    recording. (1) It is direct statutory acknowledgement that plate emblems can
+    and do carry third-party IP — the same thing Rhode Island's Doerflinger
+    painting and New Hampshire's charity decals show empirically. (2) It says
+    nothing at all about the STATE's rights in the plates it designs itself, so it
+    does not resolve the general posture in either direction.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies. The current base carries no state
+    seal; the 1985-1989 base carried a screened sugar maple. Vermont state-emblem
+    protection independent of copyright is unresearched (recorded gap). For
+    ORGANIZATION plates, § 304(b)(2)(B) makes it the organization's own warranty
+    that it may use its emblem — which is a reason to placeholder those emblems
+    rather than reproduce them, since the state has expressly not vouched for
+    them.
+  photograph_caution: "Commons photographs of Vermont plates carry the photographer's licence; and vermont.gov's own photo policy is a live reminder that a state website's images are frequently not the state's to license. Our renders are generated from spec and never derived from a photograph."
+  sources:
+    - "https://legislature.vermont.gov/statutes/section/23/007/00304  # 23 V.S.A. § 304(b)(2)(B): the organization name-and-emblem clause — no infringement of trademark, trade name, service mark, copyright or other proprietary right, and the organization must have the right to use them"
+    - "https://www.vermont.gov/policies  # fetched this pass: the state portal's Photo Use Policy (photos copyrighted by the photographer, non-commercial use only) and its DMCA notice procedure via Tyler Technologies. Nothing about state-authored designs"
+    - "https://commons.wikimedia.org/w/api.php?action=query&titles=Template:PD-VTGov  # queried this pass: MISSING — no Vermont public-domain tag exists on Commons"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR: Vermont has NO entry — recorded as unsurveyed"
+
+display_rules:
+  default: "ONE OR TWO, AT THE COMMISSIONER'S ELECTION. 23 V.S.A. § 511(a), verbatim: 'A motor vehicle operated on any highway shall have displayed in a conspicuous place EITHER ONE OR TWO NUMBER PLATES AS THE COMMISSIONER MAY REQUIRE. ... If only one number plate is furnished, the same shall be securely attached to the rear of the vehicle. If two are furnished, one shall be securely attached to the rear and one to the front.' Vermont does not legislate a plate count at all — it legislates what to do with whichever count the commissioner chooses. Reported practice (secondary): two for most classes, rear only for motorcycles and trailers."
+  legibility: "§ 511(a): plates 'shall be kept entirely unobscured, and the numerals and letters thereon shall be plainly legible at all times. They shall be kept horizontal, shall be so fastened as not to swing.' No distance test — the third different approach in this group after Connecticut's fifty feet at night, Massachusetts's sixty at night and Rhode Island's hundred in daylight."
+  swing_exception: "§ 511(a) carves out a genuinely mechanical exception: a motor truck or truck tractor may carry 'a device that would, upon contact with a substantial object, permit the rear number plate to swing toward the front of the vehicle, provided such device automatically returns the number plate to its original rigid position after contact is released'. A statutorily sanctioned breakaway plate mount."
+  ground_clearance: "§ 511(a): the ground clearance of the lower edges of the plate 'shall be established by the Commissioner pursuant to the provisions of 3 V.S.A. chapter 25' — i.e. by administrative rule, not by statute. The rule was not obtained (recorded gap)."
+  temporary_plates: "§ 511(e): a vehicle issued a temporary or in-transit registration plate under §§ 312, 458, 463 and 516-518 'shall have the temporary or in-transit registration plate displayed horizontally in a conspicuous place ON THE REAR of the vehicle, INCLUDING IN THE REAR WINDOW'. An express permission to display a temporary plate inside the glass — added by 2021 No. 76 and amended by 2023 No. 41 — which most states leave to practice."
+  violation: "§ 511(c): 'A person shall not operate a motor vehicle unless a number plate or number plates are displayed as provided in this section.'"
+  sources:
+    - "https://legislature.vermont.gov/statutes/section/23/007/00511  # 23 V.S.A. § 511(a): one or two plates as the Commissioner may require, rear-first attachment, unobscured and plainly legible, horizontal and non-swinging, the truck/truck-tractor breakaway exception, and the delegation of ground clearance to rule; (c) the operating prohibition; (e) temporary and in-transit plates displayed on the rear including in the rear window"
+    - "https://legislature.vermont.gov/statutes/section/23/007/00304  # § 304(a): the Commissioner assigns a distinctive number and issues the plate or plates; material, size, shape, colour and the numerals or letters are all as the Commissioner may determine; plates 'shall be reflectorized in part or in whole'; certificate and plates delivered free of charge"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; recommendations, not requirements."
+  aamva_geometry: "AAMVA §2.1 jurisdiction name top-centre between the bolt holes, >=0.25 in above the plate number, >=0.125 in from the top edge, characters 0.75-1.0 in; §2.2 serial characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom; §3.3 legible day and night from >=75 feet, ASTM D4956-19 and ISO 7591:1982 cl.3, entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2."
+  vermont_is_the_pure_delegation_case: >-
+    Vermont is the state where AAMVA's voluntary standard has the most room to
+    operate and the least statutory competition: § 304(a) hands material, size,
+    shape, colour and characters to the Commissioner without a single numeric
+    constraint. Whether the Commissioner in fact follows AAMVA Ed.3 WAS NOT
+    ESTABLISHED — no Vermont departmental plate specification was obtained
+    (recorded gap). So for Vermont, AAMVA's geometry is recorded as the general
+    US recommendation and expressly NOT as a claim about Vermont plates.
+  dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, PAYWALLED and UNPINNED; no J686 dimension is quoted here. Title 23 states no dimension — it says the size is whatever the Commissioner determines — so 12x6 in below is `observed`."
+  reflectorization_is_statutory: "§ 304(a): plates 'shall be reflectorized IN PART OR IN WHOLE'. The weakest reflectorization mandate in the group (Rhode Island requires 'fully reflective'; Connecticut requires 'fully reflectorized safety number plates'), and the only one that expressly contemplates a partly reflective plate."
+  replacement_cycle: "Vermont legislates none. The current base dates to 1 January 1990 — thirty-six years, roughly four AAMVA §1.1 cycles."
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — the green base, 1 January 1990 to date.
+  # =========================================================================
+  - id: us-vt-standard-1990
+    class: standard
+    categories: [car, van, bus]
+    period: { start: 1990 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset:
+        notes: >-
+          Reported alphabet: letters I, J, O, Q and U are not used. Letters V and
+          Z were "traditionally skipped" but ARE NOW IN USE as of January 2024,
+          starting with the KPV series — a documented, dated alphabet EXPANSION,
+          which is a rarer event than a format change and a genuine hazard for any
+          strict validator written before 2024. Reported range: intermingled with
+          truck, municipal and large-trailer plates from AAB 100 to BNF 999, then
+          exclusively passenger from BNG 100 to KXA 509 as of 11 May 2025. THE
+          STATUTE STATES NO ALPHABET — § 304(a) delegates "the numerals or letters
+          thereon" to the Commissioner — so none of this is promoted to a
+          `regex_strict`.
+      shared_grammar_note: >-
+        THE SAME ABC 123 GRAMMAR IS USED BY THREE OTHER VERMONT CLASSES — Municipal
+        (with a red base), large Trailer (with a 'TRA' marker) and, until 2009,
+        Truck. And for the first stretch of this base's life the passenger and
+        those other classes were INTERMINGLED IN ONE SEQUENCE (AAB 100 to BNF 999)
+        rather than partitioned. So for roughly the first third of this series, a
+        Vermont serial does not determine a class at all; after BNG 100 it does.
+        A parse API needs the boundary, and the boundary is locator-grade.
+      progression: "ascending; passenger exclusively from BNG 100"
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_note: "OBSERVED — § 304(a) says the size is whatever the Commissioner determines" }
+      background: { color: "#006B3C", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      colour_note: >-
+        Debossed WHITE serial on a GREEN plate (secondary) — Vermont is the only
+        state in this group with a dark-ground plate, and the only one whose
+        serial is DEBOSSED rather than embossed. Both hexes are `observed`: § 304(a)
+        expressly makes colour the Commissioner's choice and names none, so there
+        is no colour authority to cite and no departmental spec was obtained.
+      legend_top: "Vermont"
+      legend_bottom: "Green Mountain State"
+      legend_rule: >-
+        NEITHER LEGEND IS STATUTORY. Vermont has no slogan mandate — the sharpest
+        available contrast with New Hampshire next door, whose RSA 261:75(II)
+        makes 'Live Free or Die' compulsory on every passenger plate. Two adjacent
+        New England states, opposite answers to whether a legislature should own
+        the words on a plate.
+      graphic: { present: false }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://legislature.vermont.gov/statutes/section/23/007/00304  # 23 V.S.A. § 304(a): the Commissioner assigns a distinctive number and determines material, size, shape, colour and the numerals or letters; plates reflectorized in part or in whole; delivered free of charge"
+      - "https://legislature.vermont.gov/statutes/section/23/007/00511  # § 511(a): display of one or two plates as the Commissioner requires, unobscured, horizontal, non-swinging"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Vermont  # LOCATOR ONLY (PRD-PLATES §4): the 1 January 1990 green base, the ABC 123 arrangement, the I/J/O/Q/U exclusion, the January 2024 admission of V and Z beginning with KPV, the intermingled AAB 100 to BNF 999 stretch and the exclusive BNG 100 to KXA 509 range as of 11 May 2025, and the narrow serial dies"
+      - "https://www.licenseplates.cc/VT  # enthusiast corroboration, cited because used: the reported serial high-water mark. No text or image copied"
+    notes: >-
+      VERMONT STANDARD ISSUE — thirty-six years on one base, the longest run in
+      this group. The finding worth carrying past this gate is the JANUARY 2024
+      ALPHABET EXPANSION: Vermont had skipped V and Z by tradition, ran out of
+      combinations, and started issuing them. Format changes are anticipated by
+      every plate dataset; ALPHABET changes on an unchanged format are not, and a
+      regex_strict written against the pre-2024 alphabet would now reject valid
+      current plates. This is the strongest concrete argument in the northeast
+      group for PRD-PLATES §2.7's insistence that `regex` carry the
+      round-trippable shape and `regex_strict` carry the alphabet SEPARATELY: when
+      an alphabet moves, only the twin needs revising, and consumers that never
+      adopted the twin are unaffected.
+
+  # =========================================================================
+  # ONE SERIES BACK — the 1985 sugar-maple base.
+  # =========================================================================
+  - id: us-vt-standard-1985
+    class: standard
+    categories: [car, van, bus]
+    period: { start: 1985, end: 1989 }
+    period_evidence: secondary-dated
+    matching: recall-only
+    format:
+      pattern: "9L999"
+      regex: '\A(?:\d[A-Z]\d{3}|\d{3}[A-Z]\d|\d[A-Z]{2}\d{2}|\d{2}[A-Z]{2}\d)\z'
+      charset:
+        notes: >-
+          FOUR FIVE-CHARACTER GRAMMARS IN FIVE YEARS, which is why this series is
+          `recall-only`: 1A234 (1A100 to 9Y999, 1985-87), 123A4 (100A1 to 999Y9,
+          1987-89), 1AB23 (1AA00 to approximately 9FF99, 1989, issued as
+          replacements for 1977-84 plates) and 12AB3 (10AA0 to approximately
+          99BC9, 1989, issued only to NEW REGISTRANTS). The last two ran
+          simultaneously and were allocated by REGISTRANT TYPE rather than by
+          sequence — replacements got one shape, new registrations the other,
+          which is an allocation rule this dataset has not seen elsewhere.
+      union_note: "a hit on this union says 'a five-character shape Vermont issued on the 1985 base', not which grammar and not that the string is valid"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#006B3C", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      colour_note: "debossed white serial on green with a screened white rectangular box around the serial (secondary); hexes observed for the same reason as the current base"
+      legend_top: "Vermont"
+      legend_bottom: "Green Mountain State"
+      graphic: { present: true, rendered: placeholder, description: "white sugar maple screened at top left (secondary)" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://legislature.vermont.gov/statutes/section/23/007/00304  # § 304(a): the delegation under which all four of this base's grammars were chosen — the statute did not change across any of them"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Vermont  # LOCATOR ONLY: the 1985-1989 sugar-maple base, its four five-character arrangements with ranges, and the 1989 split between replacement plates (1AB23) and new registrations (12AB3)"
+    notes: >-
+      THE PREVIOUS BASE. Its 1989 endgame is the instructive part: with the space
+      exhausted, Vermont ran two grammars at once and split them by REGISTRANT
+      STATUS — replacements on one, new registrations on the other — before
+      abandoning both for ABC 123 on 1 January 1990. Parallel issuance allocated
+      by administrative category rather than by sequence is exactly the "parallel
+      series are REAL" case PRD-PLATES §2.2 has overlap-with-distinct-notes
+      semantics for, and it is recorded here as one series with the split stated
+      rather than as two, because no primary bounds either half.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES.
+  # =========================================================================
+  - id: us-vt-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1990 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LL999"
+      regex: '\A[A-Z]{2}\d{3}\z'
+      charset: { notes: "reported AA100 to present — a single unbroken five-character grammar, in contrast to the passenger series' history. Vermont's vanity rules cap motorcycle plates at SIX characters against seven for cars (see us-vt-specialty-index), which corroborates a smaller plate" }
+    design:
+      plate: { w: 7, h: 4, unit: in, dimension_note: "MOTORCYCLE PLATE SIZE NOT OBTAINED — placeholder at the conventional US motorcycle size. § 304(a) makes size the Commissioner's choice and no departmental spec was obtained (recorded gap). The DMV's own vanity form does establish a SIX-character cap for motorcycle plates, which is a character-budget fact, not a size" }
+      background: { color: "#006B3C", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      colour_note: "debossed white serial on green with a border line (secondary)"
+      legend_top: "VERMONT"
+      legend_bottom: "MOTORCYCLE"
+      layout_note: "reported to carry 'VERMONT' at TOP LEFT rather than centred, with a debossed box for the revalidation sticker at top right — a two-corner layout that does not match AAMVA §2.1's top-centre recommendation. Recorded as a concrete instance of voluntary adoption not being adoption."
+    display_rule: "rear only (secondary practice; § 511(a) leaves the count to the Commissioner)"
+    region_encoding: none
+    sources:
+      - "https://legislature.vermont.gov/statutes/section/23/007/00304  # § 304(a): size, shape and characters as the Commissioner may determine — the authority for a reduced-size motorcycle plate with its own grammar"
+      - "https://dmv.vermont.gov/sites/dmv/files/documents/VD-017-Personalized_Plate.pdf  # Vermont DMV form VD-017, Special (Vanity) Plate Application: 'Motor Driven Cycle, Motorcycle, and small Trailer plates are limited to a maximum of (6) characters' — an official character budget for this class"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Vermont  # LOCATOR ONLY: the AB123 motorcycle arrangement from AA100, the green/white debossed design, the top-left state name and the top-right sticker box"
+    notes: >-
+      MOTORCYCLE. The character-budget evidence here is better than the size
+      evidence, which is the reverse of the usual situation: Vermont's own DMV
+      form states a six-character maximum for motorcycles, motor-driven cycles and
+      small trailers, while no instrument states a plate dimension for any Vermont
+      plate at all.
+
+  - id: us-vt-trailer-small
+    class: trailer
+    categories: [trailer]
+    period: { start: 1990 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z]\d{5}\z'
+      charset: { notes: "reported A10000 to present. Six characters, matching the six-character vanity cap the DMV form states for 'small Trailer' plates — the format and the cap agree, which is weak but real corroboration" }
+    design:
+      plate: { w: 7, h: 4, unit: in, dimension_note: "reported to use the MOTORCYCLE plate design and therefore presumably the motorcycle size; not sourced (recorded gap)" }
+      background: { color: "#006B3C", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      legend_top: "VERMONT"
+      legend_bottom: "TRAILER"
+    display_rule: "rear only (secondary practice)"
+    region_encoding: none
+    sources:
+      - "https://dmv.vermont.gov/sites/dmv/files/documents/VD-017-Personalized_Plate.pdf  # Vermont DMV form VD-017: the six-character maximum covering 'small Trailer' plates"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Vermont  # LOCATOR ONLY: the A12345 small-trailer arrangement from A10000 and its use of the motorcycle plate design with a 'TRAILER' legend"
+    notes: >-
+      SMALL TRAILER. Vermont splits trailers by SIZE into two separately
+      serialized series — this one on the motorcycle-sized plate, and a large
+      trailer series sharing the passenger ABC 123 grammar with a 'TRA' marker.
+      The large series is not given its own entry here: its grammar is identical
+      to the passenger series, its differentiator is a debossed class marker whose
+      serial status is the unresolved AAMVA stacked-character question, and L2
+      scope does not require it. Recorded as a deliberate omission.
+
+  - id: us-vt-truck
+    class: standard
+    categories: [truck]
+    period: { start: 2009 }
+    period_evidence: secondary-dated
+    matching: strict
+    format:
+      pattern: "999L999"
+      regex: '\A\d{3}[A-Z]\d{3}\z'
+      charset: { notes: "reported 100A100 to present. Introduced mid-2009 specifically because truck allocations had been INTERMINGLED with passenger plates in the shared ABC 123 format and that arrangement was discontinued — so this series exists to un-share a serial space" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#006B3C", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      legend_top: "Vermont"
+      layout_note: "'TRK' debossed vertically to the left of the serial — a stacked class marker, same AAMVA question as elsewhere in this group"
+    region_encoding: none
+    sources:
+      - "https://legislature.vermont.gov/statutes/section/23/007/00304  # § 304(a): the Commissioner's authority over the numerals or letters, under which the 2009 re-cut was made"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Vermont  # LOCATOR ONLY: the 123A456 truck arrangement introduced mid-2009 from 100A100, and the statement that it replaced truck allocations intermingled with passenger plates in the ABC 123 format. The secondary source itself flags this claim as uncited (a November 2025 'citation needed'), and it is recorded here at that grade"
+    notes: >-
+      TRUCK. Recorded as class `standard` with the legend and marker carrying the
+      meaning; see the class-vocabulary note in us-ma.yml. FLAGGED EVIDENCE: the
+      2009 date and the un-sharing rationale carry an explicit 'citation needed'
+      on the secondary source, so this is the weakest-sourced series in the
+      Vermont file and is labelled as such rather than quietly levelled up. What
+      is independently visible is that the passenger series' own reported range
+      changes character at BNG 100, which is consistent with a de-intermingling
+      event, so the claim is plausible as well as unverified.
+
+  - id: us-vt-municipal
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 1990 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset: { notes: "the passenger grammar exactly; reported to start AAA100 with serials beginning AA or AB. Distinguished from the passenger series ONLY by plate colour and a class marker, not by serial shape" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#B22234", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      colour_note: "RED rather than green, otherwise the current passenger base (secondary). The hex is a plausible-but-unsourced approximation of the described red; § 304(a) makes colour the Commissioner's choice and names none"
+      legend_top: "Vermont"
+      layout_note: "'MUN' debossed vertically to the left of the serial"
+    region_encoding: none
+    sources:
+      - "https://legislature.vermont.gov/statutes/section/23/007/00304  # § 304(a): colour as the Commissioner may determine — the authority for a colour-coded government class"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Vermont  # LOCATOR ONLY: the Municipal series on a red base with the 'MUN' marker, sharing the ABC 123 grammar from AAA100, serials starting AA or AB"
+    notes: >-
+      MUNICIPAL — Vermont's government class. It is a genuine test of
+      PRD-PLATES §2.3's series rule: format IDENTICAL to the passenger series,
+      period identical, and the only differences are colour and a class marker.
+      §2.3 says a COLOUR-ONLY variant of the same format and period is a
+      sub-entry, not a series. This is given its own series anyway, because the
+      difference is not colour ALONE — the class marker is a second design
+      difference and the issuing population is disjoint (municipalities, not
+      private registrants). Recorded explicitly so a reviewer can disagree: if the
+      house reading is that this should be a sub-entry on us-vt-standard-1990, the
+      merge is mechanical and the id can alias.
+
+  # =========================================================================
+  # SPECIALTY — PROGRAM INDEX ONLY (PRD-PLATES §2.5).
+  # =========================================================================
+  - id: us-vt-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: >-
+          VERMONT'S VANITY AND ORGANIZATION PLATE RULES ARE THE BEST-DOCUMENTED
+          CHARACTER RULES IN THIS GROUP, and they come from the DMV's own form
+          plus the statute. From form VD-017 and 23 V.S.A. § 304(b)(1): a maximum
+          of SEVEN characters; "No more than two (2) numbers are allowed in
+          combination with letters"; "The letter 'O' IS CONSIDERED A NUMBER '0'
+          (zero)" — an explicit collapse of a letter into a digit, which is a
+          normalisation rule a validator must implement or it will accept
+          duplicates the DMV would reject; "Dots, dashes, or other special
+          characters or symbols cannot be used"; a single letter is acceptable but
+          "cannot be an 'I,' 'J,' or 'O'"; and asterisks are used ON THE
+          APPLICATION FORM ONLY to indicate desired spaces, with characters
+          centred if none are given. Class caps: 7 characters normally; 6 for
+          motor-driven cycle, motorcycle and small trailer; 5 for disabled plates;
+          4 for antique and exhibit plates.
+        statutory_backing: >-
+          § 304(b)(1) supplies the statutory frame: vanity plates issue on
+          application and a $58.00 annual fee, the Commissioner "shall not issue
+          two sets of plates bearing the same initials or letters unless the plates
+          also contain a distinguishing number", and plates are subject to
+          reassignment if not renewed within 60 days of expiry. The DMV form
+          restates the same rule in fuller terms: any combination or succession of
+          numerals and letters "provided the total ... does not exceed seven, and
+          further provided the requested combination ... DOES NOT DUPLICATE OR
+          RESEMBLE A REGULAR ISSUE REGISTRATION PLATE" — a rule that makes the
+          vanity space the COMPLEMENT of the standard space, not a superset of it.
+      union_note: "`recall-only` because the regex is a catch-all across four class caps and cannot express the two-numbers-with-letters rule, the O-is-zero collapse or the do-not-resemble-a-regular-issue rule. A hit is a shape claim only"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised organization; individual designs are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder, note: "and see artwork_risk — § 304(b)(2)(B) makes the ORGANIZATION warrant its right to use its emblem, so the state has expressly not vouched for it" }
+    program_index:
+      model: >-
+        VERMONT AUTHORISES CATEGORIES OF SPONSOR, NOT INDIVIDUAL PLATES — the
+        third distinct specialty architecture in this group of six, after
+        Connecticut/Rhode Island (one statute per plate) and New Hampshire (one
+        plate, many decals). 23 V.S.A. § 304(b)(2) defines two eligible classes
+        and lets any qualifying body apply. "SAFETY ORGANIZATIONS are groups that
+        provide police and fire protection, rescue squads, the Vermont National
+        Guard, organizations required to respond to public emergencies, and
+        amateur radio operators licensed by the U.S. Federal Communications
+        Commission", and must have at least 100 in-state members in good standing.
+        "SERVICE ORGANIZATION" covers congressionally and non-congressionally
+        chartered US military veterans' groups, plus any group that (I) has as a
+        primary purpose service to the community through specific programs for
+        public health, education, or environmental awareness and conservation and
+        is not limited to social activities; (II) has 501(c)(3) or (10) status;
+        (III) is registered as a nonprofit corporation with the Secretary of
+        State; and (IV) except for veterans' groups, has at least 100 in-state
+        members in good standing.
+      count: unresearched
+      count_basis: >-
+        NO COUNT IS RECORDED, and that is the honest answer rather than a guess.
+        Vermont's model produces no fixed number: the statute defines eligibility
+        and the Commissioner approves applications "in order of approval, subject
+        to the operating considerations in the Department". The DMV's own plate
+        pages returned HTTP 403 to direct fetches and the Wayback capture of
+        dmv.vermont.gov/curator/registrations/license-plates was retrieved but
+        yielded no enumerated program list. Recorded as a gap. What IS pinned is
+        the FORM INVENTORY, which names specific programs: VD-128 Safety and
+        Service Organization Plate Application, VD-154 Conservation Plate, VD-102
+        Building Bright Futures Plate, VD-003 Legislative Plate, VD-149 Next of
+        Kin Family Plate, plus a Gold Star Family plate and a Bronze Star with
+        Valor plate (the latter announced in DMV law-enforcement bulletin 24-4).
+      one_design_per_organization: "§ 304(b)(2)(B): 'An organization may have only one design, regardless of the number of individual organizational units, squads, or departments within the State' — so Vermont caps the design count at one per sponsor by statute, which is why its program cannot sprawl the way Florida's has."
+      design_authority: "§ 304(b)(2)(B): after consulting the organization's principal contact, 'the Commissioner shall determine the design of the special plate ON THE BASIS THAT THE PRIMARY PURPOSE OF MOTOR VEHICLE NUMBER PLATES IS VEHICLE IDENTIFICATION.' A statutory subordination of decoration to legibility — the clearest statement of design philosophy found in any plate statute in this group, and a useful thing to quote at anyone who thinks US specialty plates are unregulated."
+      content_restrictions: "§ 304(b)(1) and form VD-017 list the refusal criteria: nothing vulgar, scatological or obscene, no racial or ethnic epithets; nothing connoting breast, genitalia, pubic area or buttocks or relating to sexual or eliminatory functions; no reference to intoxicants or drugs or their users or purveyors; no reference to gender, gender identity, sexual orientation or disability status; nothing suggesting a government or governmental agency; nothing suggesting a privilege not given by law; and no slang term, abbreviation, phonetic spelling or MIRROR IMAGE of any of the above. The mirror-image clause is a nice piece of drafting — it anticipates the plate read in a rear-view mirror."
+      fees: "$58.00 annually for a vanity plate (§ 304(b)(1)); $21.00 per set for a special organization plate on top of the annual registration fee (§ 304(b)(2)(B))."
+      excluded_vehicle_types: "vanity plates are not issued to vehicles registered under the International Registration Plan (§ 304(b)(1)), nor, per form VD-017, for dealer, transporter, Veteran or service-and-safety-organization plates."
+      official_list_url: "https://dmv.vermont.gov/registrations/license-plates"
+    region_encoding: none
+    sources:
+      - "https://legislature.vermont.gov/statutes/section/23/007/00304  # 23 V.S.A. § 304(b): the Commissioner's exclusive authority over vanity and organization plates; (b)(1) the $58 fee, the no-duplicate-initials rule and the 60-day reassignment; (b)(2)(A) the safety-organization and service-organization definitions with their 100-member and 501(c)(3)/(10) tests; (b)(2)(B) the $21 fee, the one-design-per-organization cap, the trademark/copyright warranty, and the vehicle-identification design principle"
+      - "https://dmv.vermont.gov/sites/dmv/files/documents/VD-017-Personalized_Plate.pdf  # Vermont DMV form VD-017 (Special (Vanity) Plate Application): the seven-character maximum and the 6/5/4-character class caps; no more than two numbers with letters; 'O' treated as zero; no dots, dashes or symbols; the I/J/O single-letter exclusion; the asterisk spacing convention; the do-not-resemble-a-regular-issue rule; and the content-refusal criteria including the mirror-image clause"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Vermont  # LOCATOR ONLY: general orientation on Vermont plate types"
+    notes: >-
+      THE VERMONT SPECIALTY INDEX — an eligibility regime rather than a catalogue,
+      and the only one in this group with NO COUNT, recorded as unresearched
+      rather than estimated. Two things to carry forward. First, the character
+      rules are the most complete in the group and several of them are
+      NORMALISATION rules rather than validation rules — 'O' is zero, symbols are
+      stripped, spacing is centred by default — which means Vermont is the best
+      available test case for the vehicles gem's separator-forgiving tier and for
+      whatever canonicalisation the parse API adopts. Second, § 304(b)(2)(B)'s
+      declaration that "the primary purpose of motor vehicle number plates is
+      vehicle identification" is worth quoting in the encyclopedia section: it is
+      a legislature saying out loud what this whole dataset assumes.


### PR DESCRIPTION
**PRD-PLATES gate L2 (owner-directed acceleration; research parallel, application ordered — L1 landed first per §7.1).** One of eleven US regional-group PRs covering all 50 states + DC + territories (FL was the L0 pilot). Drafted to the `de.yml`/`nl.yml`/`us-fl.yml` standard: primary-law verbatim headers, instrument-dated periods, `strict`/`recall-only` matching tiers, folklore flagged not asserted, **`artwork_risk` recorded per jurisdiction with evidence** (PRD-PLATES §4).

**This PR — northeast:** CT MA ME NH RI VT (6 jurisdictions, 50 pinned primary sources).

**Verification:** researcher linted green in an isolated sandbox (proof file in the group dir, archived to the pipeline program dir); the driving session then independently staged ALL 55 wave files over pristine origin/main — `plates lint: 67 files, 604 series … OK` (385 new series; the _art gate stayed green) — and this branch is linted solo pre-push; CI runs the same gate.

**For the reviewer:** the dossier below carries the gaps (marked in the YAML at point of use), folklore flags, and the artwork_risk findings. The full research dossier follows verbatim.

---

# PRD-PLATES gate L2 — NORTHEAST group dossier (CT MA ME NH RI VT)

Researcher pass, 2026-08-02. Method: FETCH-NEVER-ASSUME. Every claim in the six
YAML files traces to a URL fetched in this session or is explicitly marked as a
gap. Six files, **40 series, 120 per-claim source lines, 50 distinct URLs**.
Lint: **green** (see `lint-proof.txt`), plus a 127-assertion regex spot-check
against reported real serials (`../../verify.rb`), 0 failures.

`/Users/javi/GitHub/vehiclesdb` was treated as read-only throughout; the lint
ran in a private sandbox copy.

---

## 0. The three findings that should outlive this group

**1. There is no single US answer to "where does plate law live", and the split
runs the opposite way in adjacent states.** Maine legislates the ARTWORK — 29-A
M.R.S. §451(4-A)(D) names the background, the border, the character colour, an
eastern white pine tree and a blue North Star — and expressly DELEGATES the
serial grammar (§451(4-A)(E)). Florida, the L0 pilot, does exactly the inverse:
statutory character cap, departmental colours. Vermont delegates all five of
material, size, shape, colour and characters in one sentence (23 V.S.A. §304(a)).
New Hampshire delegates everything except four words of motto (RSA 261:75(II)).
Rhode Island legislates the plate's full contents list *and* two exceptions to it
(§31-3-11). **A US plates dataset that assumes a uniform statute/administration
split will mis-source half the country**, and the per-claim citation discipline
is what catches it.

**2. Three of the six states carry a time or place decode inside the serial, and
nobody records this.** Massachusetts's final serial digit is the **month of
expiration** (1–9 Jan–Sep, 0 Oct); Maine's long-term trailer serial begins with
the **year of expiration**; Connecticut's municipal letters and New Hampshire's
municipal-police letters are **place codes**. openalpr, validator.js and every
other prior-art corpus record none of it. Two decode tables are identified and
deliberately not built (see §4).

**3. "Specialty plates" is not one thing, and counting them across states is
counting different objects.** This group produced four incompatible
architectures: **one statute per plate** (CT: 13 commemorative sections; RI: 17
charity plates, each with its own §31-3-xx); **one plate, many private decals**
(NH: RSA 261-B, a 3in×3in blank square filled by decals sold by 15 approved
501(c)(3)s); **serial-block allocation inside the ordinary passenger grammar**
(ME: 9 programs, each assigned three-letter blocks); and **an eligibility regime
with no fixed count** (VT: §304(b)(2) defines "safety organization" and "service
organization" and lets qualifiers apply). Every index entry in these files states
*what it is counting*. **No cross-state total is offered, and none should be.**

---

## 1. Per-state summary

| state | current standard | period evidence | one back | classes specced | specialty index |
|---|---|---|---|---|---|
| **CT** | `AB 12345` (2015) on the statutory 2000 reflectorized base | **statutory** for the base (§14-21b: "on and after January 1, 2000"), secondary for the format | `123 ABC` (2000–2013) | motorcycle, trailer, dealer, municipal(gov) | **13 statutes** (+ open regulatory route) |
| **MA** | `1ABC 2n` on the 1987/1993 "Spirit of America" base | secondary | green-on-white `123 ABC` (1977–1993, **still lawfully driven**) | trailer, commercial, apportioned | **50** typed sections, RMV booklet **July 2014 — stale** |
| **ME** | `123 ABC` on the 2025 general issue, **two statutory variants** | **statutory** (§451(1-A): begin ≤ 1 May 2025, complete < 31 Jul 2026) | chickadee base 1999–2025 (recall-only union) | motorcycle, commercial, long-term trailer | **9** programs, allocated by serial block |
| **NH** | `123 4567` on the 1999 Old Man base | secondary | `ABC 123` (1989–1998) | motorcycle, trailer, municipal(gov), municipal police | **15 organizations**, one decal plate, RSA 261-B, **statutory date 3 Jul 2017** |
| **RI** | `1AB 234` "Ocean Plate" (2023) | secondary | wave base 1996–2023 (recall-only, 4 grammars) | motorcycle, commercial, dealer | **17** charity plates, one statute each |
| **VT** | `ABC 123` green base, **1 Jan 1990 — 36 years** | secondary | 1985 sugar-maple base (recall-only, 4 grammars) | motorcycle, small trailer, truck, municipal(gov) | **unresearched** — eligibility regime, no count exists |

---

## 2. artwork_risk — the required §4 column, and it is not a happy one

| state | posture | evidence grade |
|---|---|---|
| **CT** | **ADVERSE — evidence found** | **PRIMARY, and new.** C.G.S. **§14-21w(e)** authorises the DMV to "provide for the **reproduction and marketing** of the Share the Road commemorative number plate **image** for use on clothing, recreational equipment, posters, mementoes or other products", proceeds to a statutory account; §14-21w(a) adds "No use shall be made of such plates except as official registration marker plates." A legislature granting its DMV a commercial licensing right over a plate image is treating that image as proprietary. No `PD-CTGov` template exists (Commons API: MISSING); CT is absent from the subnational-copyright survey. **Connecticut belongs on the adverse list with NY/PA/WA/AZ.** |
| **MA** | favourable **with a stated limit** | `PD-MAGov` exists and rests on the Secretary of the Commonwealth's Public Records Guide (commercial-purpose requests must be honoured; "regardless of physical form"). **The template's own two warnings are load-bearing**: the statement is "not definitive in the way a statute or a court ruling is", and it speaks only to records **held by the Massachusetts Archives**. Extending it to a live RMV design is extrapolation. |
| **ME** | **favourable on the edict ground, weak on the general ground** | §451(4-A) describes the design **in the text of a statute** → `PD-US-GovEdict`; rendering from the statute's words is the strongest footing in the group. But `PD-MEGov` exists only as a bare `{{PD-copyright holder}}` wrapper with **no cited instrument** — explicitly *not* relied upon. ME absent from the survey. |
| **NH** | **UNRESEARCHED → default adverse** | No `PD-NHGov` (API: MISSING); no survey entry; nh.gov disclaimer **403** on every attempt. §105 default governs. Sharpened by the emblem: the plate depicts the **Old Man of the Mountain, which collapsed 3 May 2003** and has been issued for 23 years since. |
| **RI** | **permissive policy, no warranty** | RI.gov's own Copyright policy (fetched): "The compiled information … is considered public information and may be distributed or copied", but "**makes no warranty** that materials … are free of copyright claims", credits requested. A *website* policy, not a statute. §38-2-3 is an **access** statute, not a copyright waiver, and is not treated as one. |
| **VT** | unresearched, **with one statutory signal** | No `PD-VTGov`; no survey entry; vermont.gov policies address **photographs only** and restrictively. But 23 V.S.A. **§304(b)(2)(B)** is the group's only statutory IP clause about plate artwork: an organization's name and emblem "must not infringe … a trademark, trade name, service mark, copyright, or other proprietary or property right, and the organization must have the right to use the name and emblem." It burdens the **sponsor**, and says nothing about the state's own rights. |

**Cross-cutting finding the FL pilot could not see.** Specialty-plate artwork in
this group is frequently **not a state work at all**: Rhode Island's DMV states
its Gaspee Days plate is "based on R.I. artist **Karl Doerflinger**'s painting,
*The Burning of the Gaspee*"; New Hampshire's specialty variety lives entirely in
**decals sold by private charities**; Vermont makes the sponsor warrant its own
emblem rights. **A per-state `artwork_risk` posture does not settle the specialty
layer**, and PRD-PLATES §3's placeholder default is vindicated for a reason the
PRD did not anticipate. Recommend the PRD note this explicitly.

State **seal/emblem** protection independent of copyright remains unresearched
for all six — the same gap the FL pilot recorded and the source dossier calls
"the largest remaining gap in the IP analysis."

---

## 3. Schema and lint issues raised (for the maintainer, not decided here)

**3.1 The middle dot. `_meta/separators.yml` may need a third emitted member —
or an explicit ruling that it never will.**
Connecticut prints a **raised middle dot** (`AB·12345`), and Massachusetts,
Maine and Rhode Island print one in most secondary depictions of their older
formats. **U+00B7 is in the FORGIVING set but not the EMITTED set**, so the
dataset may not spell it (§2.6). Every affected pattern/regex here writes
**U+0020** and carries a `separator_note` recording the true glyph. This is
sound — a lenient consumer already strips U+00B7 — but it means **the printed
form is in a note, not in the data**, which §2.6 rule 2 ("every regex is written
in PRINTED form") arguably forbids. Two clean resolutions: (a) add `·` to
`emitted` with a rationale; (b) amend §2.6 to say the emitted set is the
dataset's *canonical* separator vocabulary and printed-glyph divergence lives in
a typed field. **Recommend (b) plus a typed `format.printed_separator:` key** —
adding a third emitted character widens the surface every consumer must handle,
for a purely typographic fact the render layer needs and the matcher does not.

**3.2 `regex_strict` was deliberately used ZERO times in this group.** All 40
series carry `regex` only (8 `regex_statutory` in the dataset are all FL's). The
reason is a sourcing rule, not an oversight: in every one of these six states the
**alphabet exclusions are secondary** (Wikipedia/enthusiast), because no statute
states an alphabet. PRD-PLATES §2.7 reserves the strict twin for "the authority's
own alphabet"; promoting a newspaper report or a collector site into a
`regex_strict` would launder secondary evidence into a stronger tier. Exclusions
are recorded in `charset.notes` instead. **Vermont proves this was right:** it
excluded V and Z by tradition, ran out of combinations, and **began issuing V and
Z in January 2024 starting with the KPV series**. A `regex_strict` written on the
pre-2024 folklore would now reject valid current plates.

**3.3 `matching: recall-only` used 10 times, all for genuine unions.** Every one
is a base that carried multiple serial grammars over its life (ME chickadee 2, RI
wave 4, VT 1985 4) or a class whose width varies with no primary (CT dealer, CT
municipal, NH municipal police, ME long-term trailer, RI dealer, RI specialty).
None carries a `regex_strict`, as §2.7 requires.

**3.4 A class-vocabulary PR is now warranted.** Three states (MA, ME, RI) and
Vermont's truck series separately serialize a **commercial/heavy** class; all
four are recorded as `standard` with the legend carrying the meaning, exactly as
the FL pilot recorded Wrecker and Restricted. **`commercial` is worth a
`_meta/classes.yml` PR** with a definition; four instances in six states is no
longer an edge case.

**3.5 One §2.3 judgement call flagged for review.** `us-vt-municipal` has the
**identical** format and period to `us-vt-standard-1990` and differs only by
colour (red) and a debossed `MUN` marker. §2.3 says a *colour-only* variant of
the same format+period is a sub-entry. It is given its own series because the
difference is not colour alone (second design difference + disjoint issuing
population), but the file says so explicitly so a reviewer can disagree; the
merge would be mechanical and the id can alias.

**3.6 AAMVA's stacked-character rule collides with US practice in four series
here.** AAMVA Ed.3: "If stacked characters are used, they are **part of the
official license plate number**. No more than two characters are to be stacked."
NH Conservation (`C/H`) and Construction Equipment (`C/E`), NH Municipal Police
(`M/P`), ME long-term trailer (`TLR`), VT truck (`TRK`) and VT municipal (`MUN`)
all carry stacked or vertical markers that the states plainly treat as **class
markers, not serial**. `TLR`/`TRK`/`MUN` are also *three* characters, exceeding
AAMVA's cap. **The normalisation decision belongs in the parse layer** and is
recorded, not resolved.

**3.7 `period_evidence` vocabulary used here.** `statutory-date` (CT 2000 base,
ME 2025 issue, NH 2017 decal plate, RI 2018 dealer cycle),
`statutory-date-start`, `secondary-dated` (a new value — a dated claim resting on
a locator or a news report, not on an instrument), and
`instrument-in-force-upper-bound` (from FL). **`secondary-dated` should be added
to whatever enum eventually governs this field**; it is the honest label for most
US base-year claims and it is distinct from the FL pilot's upper-bound case.

---

## 4. Decode tables identified and deliberately NOT built

Two `plates/_decode/` candidates, both with the **mechanism sourced and zero rows
obtained**. Building either on partial secondary data would bake in gaps.

- **`us-ct-municipal.yml`** — CT municipal plates encode the **town or city** in
  a 2–3 letter group ("the letters in the serial indicate the municipality").
  Connecticut has 169 towns. No official code list located.
- **`us-nh-police-departments.yml`** — NH Municipal Police plates are
  `<department code> <vehicle number>`, glossed as such by the source, with **no
  values given anywhere**.

A **third, higher-value** candidate is not a region table at all:

- **`us-me-optional-blocks.yml`** — Maine allocates each of its 9 optional
  programs one or more **three-letter blocks** inside the ordinary `123 ABC`
  passenger space (Sportsman `AKA–AKZ, ASA–ASZ, AVA–AVZ, BDA–BDZ, BHA–BHZ`;
  Breast Cancer `ALA–ALZ, ATA–ATZ, AYA–AYZ`; Animal Welfare `AMA–AMZ, AWA–AWZ,
  BGA–BGZ`; Barbara Bush `BBA–BBZ, BJA–BJZ`). **The serial therefore decodes to a
  program** — a parse API could answer "which Maine plate design is this?" from
  the string alone. Blocks were obtained for only 5 of 9 programs and are
  secondary. **This is the single highest-value follow-up this group identified.**

---

## 5. Folklore debunked, flagged, or left standing

**The 1956 standardization agreement — a new wrinkle worth recording.** The
source dossier established that the US article's "1956 AMA agreement" claim is
uncited (a `citation needed` since 2017, copied circularly). **The CT, MA and NH
articles carry the same claim WITH a citation** — Christopher Garrish,
*"Reconsidering the Standard Plate Size"*, **Plates** (ALPCA) vol. 62 no. 5,
October 2016. So the story does have *an* underlying source, but it is a hobby
association's members' magazine, not obtainable online, not obtained here — and
its **title announces that it reconsiders the standard story**. Status upgraded
from "uncited" to **"cited to one unobtained hobbyist article whose title implies
it revises the claim."** Recommend acquiring that issue; it is a cheaper target
than SAE J686 and may settle the question outright.

**Rhode Island front plates — a live secondary claim NOT supported by the
statute.** The source dossier reports Wikipedia saying RI was "moving to single
rear plates June 2026", and the current RI article says front plates are required
only on vehicles delivered with a **factory front bracket**. **§31-3-10 as read
this pass says neither.** It enumerates the one-plate classes exhaustively
(motorcycle, trailer, semi-trailer, in-transit, transporter, bailee, dealer) and
makes two plates the residual rule, with no bracket condition anywhere. Either a
2026 amendment exists and was not located, or the secondary claim is wrong.
**Recorded as a disagreement in `us-ri.yml`, not resolved.** This is exactly the
class §9 warns about.

**Two DESCENDING serial sequences found.** NH's six-digit passenger format ran
`999 999 → 100 000`; RI's `123-456` form ran `710-001 → 399-999`. Descending
sequences are evidently a recurring administrative choice, not a curiosity —
**any era-inference model assuming monotone ascent is wrong twice in six
states.**

**Vermont's V/Z alphabet expansion (January 2024, from `KPV`)** — a documented
*alphabet* change on an unchanged format. Recorded because it is the concrete
counter-example to treating collector-site alphabet lore as durable.

**Maine's statute vs. every secondary source on the 2025 background colour.**
Statute: "**buff** neutral shaded background". Every secondary description of the
plates issued from 1 May 2025: **reflective white**. **No hex is recorded for
that series** — recording one would be picking a side. §5.3 forbids averaging.

---

## 6. Gaps, honestly stated

**Blocked or unreachable this pass** (all recorded in-file where they affect a
citation):
- `malegislature.gov` — connection timeouts on every direct fetch; live pages are
  JS shells even in 2025 Wayback captures. **M.G.L. c.90 §§2 and 6 were read from
  a 2014-08-01 Wayback capture** (server-rendered then). Canonical URLs are cited,
  the archive is named, and **re-verification against the live 2026 edition is a
  merge-blocking task**.
- `webserver.rilin.state.ri.us` / `webserver.rilegislature.gov` — unreachable
  directly; RI statutes read via Wayback. §31-3-18 (display/penalties) and
  §31-3-17.3 (temporary plates) **failed to resolve even via Wayback** (returned
  the title index) — not obtained.
- `dmv.nh.gov`, `dmv.ri.gov`, `dmv.vermont.gov`, `mass.gov` — **HTTP 403** to
  direct fetches; NH decal, RI charity and VT plate pages recovered via Wayback,
  **mass.gov special-plates page not recovered at all**.
- `portal.ct.gov/dmv` — 404 on every guessed path; Wayback CDX surfaces only
  image assets. **CT DMV's live specialty catalogue is unpinned** (the statutory
  count is used instead, which §4 prefers anyway).
- `www.nh.gov/disclaimer.htm` — 403. NH terms of use unpinned.
- **WebSearch was unavailable** (session budget exhausted at first call). All
  discovery was URL construction + Wayback CDX enumeration + Wikipedia/Commons
  raw + API. Some official pages certainly exist that were never found.

**Substantive gaps** (each recorded in the relevant file):
- **No plate DIMENSION is sourced for any of the six states.** None of the six
  statutes states one. Every `12x6 in` and every motorcycle size in these files
  is `observed` or an explicit placeholder. SAE J686 remains paywalled/unpinned.
- **No departmental plate specification was obtained for any state** — CT (§14-21b
  delegates), NH (RSA 261:75(II) delegates design to the director), VT (§304(a)
  delegates material/size/shape/colour/characters), MA (§2 delegates
  reflectorization specs to the registrar), ME (§451(4-A)(E) delegates the
  numbering system). **These five administrative-rule sets are the single largest
  recoverable source of primary US plate facts** and none was located.
- **CT temporary plates, MA motorcycle/dealer/temporary/government, ME
  dealer/temporary/government, NH dealer/temporary, RI temporary** — no sourced
  format; **no series minted rather than invented**.
- **NH Conservation ("moose") plate deliberately omitted** — five reported width
  variants plus a stacked `C/H` of contested serial status; the shape that
  produces a wrong regex.
- **VT large-trailer series omitted** — grammar identical to passenger, sole
  differentiator is a stacked marker.
- **MA specialty count is the RMV's own but dated July 2014**; current count
  unpinned.
- **VT specialty count is `unresearched`** — the eligibility model produces no
  fixed number and the DMV list was not recovered.
- **RI charity "Taking Preorders" tier not counted.**
- **CT specialty count is 13 or 14** depending on whether two differently-worded
  headings count; **the discrepancy is recorded, not averaged**.

---

## 7. Files written

```
/private/tmp/claude-501/-Users-javi-GitHub-vehiclesdb-web/dcd37232-4f55-4988-92e6-c13fe869d099/scratchpad/plates-l2/northeast/
  us-ct.yml   7 series   18 source lines
  us-ma.yml   6 series   17 source lines
  us-me.yml   7 series   21 source lines
  us-nh.yml   7 series   18 source lines
  us-ri.yml   6 series   22 source lines
  us-vt.yml   7 series   24 source lines
  DOSSIER-northeast.md  (this file)
  lint-proof.txt        (sandbox lint output, green)
```

Verification performed: `plates/` + `scripts/lint_plates.rb` copied to a private
sandbox, the six drafts added, `ruby scripts/lint_plates.rb` run to green
(10 files, 113 series, 40 of them new). Independently, a 127-assertion regex
spot-check drove reported real serials from the cited sources against each
series' `regex` with positive and negative controls — 0 failures.

**Note for the applying session:** an unrelated `us-va.yml` appeared in a shared
scratchpad sandbox path mid-pass (another group's researcher writing to the same
default location). This group's verification was re-run in an isolated sandbox
(`sandbox-northeast/`) afterwards; the green result above is from the isolated
run and contains only baseline + these six files.
