### PR TITLE
plates: us mid-atlantic — NY NJ PA DE MD DC (L2 US wave)

### DIFF
--- a/plates/us-dc.yml
+++ b/plates/us-dc.yml
@@ -1,0 +1,614 @@
+# plates/us-dc.yml — District of Columbia (PRD-PLATES gate L2, mid-Atlantic group).
+#
+# THE DISTRICT IS THE ONLY JURISDICTION IN THE UNITED STATES WHOSE STANDARD
+# PLATE LEGEND IS A POLITICAL DEMAND, AND THE DEMAND IS IN THE STATUTE.
+# DC Official Code § 50-1501.02(f-1) provides that identification tags designed
+# under subsection (f)(3) — excluding for-hire vehicles, organization plates,
+# motorcycles and autocycles — 'shall display the phrase "End Taxation Without
+# Representation"'. And in the same breath it legislates an OPT-OUT: 'An
+# individual who does not wish to display the phrase "End Taxation Without
+# Representation" on his or her identification tag may request an identification
+# tag featuring an alternate design, to be supplied by the Department of Motor
+# Vehicles.' A MANDATED SLOGAN WITH A STATUTORY CONSCIENCE CLAUSE — structurally
+# the same wrinkle as Florida's county-name legend, which is a county-commission
+# opt-out, and modelled the same way: the alternate is its own series because
+# its design differs.
+#
+# THE ARTWORK FINDING HERE IS A DEBUNK, NOT A LOOKUP. Wikimedia Commons carries
+# a {{PD-DC}} template asserting that District of Columbia government works are
+# public domain. THE DISTRICT'S OWN TERMS OF USE SAY THE OPPOSITE: dc.gov
+# content 'is licensed under a Creative Commons Attribution 3.0 License'. A CC BY
+# licence is an EXERCISE of copyright, not a disclaimer of it — you cannot
+# licence what you do not own. The Commons tag and the District's own statement
+# cannot both be right, and the District's own statement is the better authority
+# about the District. See `artwork_risk`; this is recorded as a folklore
+# correction, exactly as PRD-PLATES §4 asks.
+#
+# period_evidence / format_evidence vocabularies as in us-ny.yml.
+jurisdiction: us-dc
+authority:
+  name: District of Columbia Department of Motor Vehicles (DC DMV)
+  url: "https://dmv.dc.gov/"
+binding: vehicle
+statute_edition: "Code of the District of Columbia, Title 50, Chapter 15, as served by code.dccouncil.gov and read 2026-08-02. DCMR Title 18 § 422 ('Display of Identification Tags', effective 11 August 2017) was identified in the DC Register index but its TEXT was not retrieved — the register serves rule metadata and puts the text behind a per-notice viewer. Recorded gap."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: asserted-but-openly-licensed
+  basis: >-
+    THE DISTRICT ASSERTS COPYRIGHT AND THEN LICENSES IT OPENLY. dc.gov's own
+    terms and conditions of use state that 'content on this site is licensed
+    under a Creative Commons Attribution 3.0 License' (excluding third-party
+    copyrighted content), that user submissions are granted to the world under
+    the same licence, and that data on the DC Open Data portal carries a
+    'Creative Commons CC0 1.0 Universal' dedication. The same page separately
+    notes that 'federal government-produced materials appearing on this site or
+    elsewhere are not copyright protected' — the District distinguishing FEDERAL
+    material (public domain) from DISTRICT material (CC BY 3.0), which is itself
+    the clearest possible statement that it does not consider its own works
+    federal.
+  folklore_correction: >-
+    WIKIMEDIA COMMONS IS WRONG, OR AT LEAST UNSUPPORTED, ABOUT THE DISTRICT.
+    Commons carries {{PD-DCGov}} (a redirect to {{PD-DC}}), which asserts that
+    District of Columbia government works are PUBLIC DOMAIN and cites, for
+    authority, the US Copyright Office's Compendium chapter 300 with no pinpoint
+    to any DC-specific holding. That assertion is inconsistent with the
+    District's own published terms, which licence District content CC BY 3.0 —
+    an act that presupposes ownership. The likely root of the error is the
+    federal-enclave intuition (that anything in Washington is federal), but
+    17 U.S.C. § 101 defines a 'work of the United States Government' as one
+    prepared by an officer or employee OF THE UNITED STATES GOVERNMENT, and the
+    District government is a municipal government created by Congress, not a
+    federal agency. RECORDED AS A FOLKLORE CORRECTION per PRD-PLATES §4's
+    standing treatment of circular and unsupported claims. Anyone relying on
+    {{PD-DC}} for a DC plate design should stop.
+  practical_effect: >-
+    The CC BY 3.0 grant is genuinely useful and genuinely encumbered: it permits
+    reuse of dc.gov CONTENT with ATTRIBUTION, which is a real obligation that
+    would propagate into any dataset that copied that content. Because our
+    renders are generated from facts and never derived from District material,
+    the attribution obligation NEVER ATTACHES — the same argument that makes
+    Commons' CC BY-SA photographs harmless to us. The grant is recorded, not
+    relied upon.
+  emblem_rule: >-
+    RENDER PLACEHOLDER. The District's tags carry the DC flag device (three
+    stars over two bars) in several roles — as a graphic on the plate, as a
+    SERIAL SEPARATOR on the trailer series, and in the corners of the current
+    temporary tag. The flag is the District's heraldic device and carries
+    protection independent of copyright, unresearched here as everywhere.
+  photograph_caution: "Standard §4 reading: a Commons photograph carries the photographer's licence on the photograph and says nothing about the design."
+  sources:
+    - "https://dc.gov/page/terms-and-conditions-use  # the District's own terms: 'content on this site is licensed under a Creative Commons Attribution 3.0 License'; DC Open Data under CC0 1.0; 'federal government-produced materials appearing on this site or elsewhere are not copyright protected'"
+    - "https://commons.wikimedia.org/wiki/Template:PD-DCGov  # the Commons tag (a redirect to Template:PD-DC) asserting DC government works are public domain, citing the Copyright Office Compendium chapter 300 with no DC-specific pinpoint — RECORDED AS CONTRADICTED by the District's own terms"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Voluntary; J686 never quoted.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. The District is an AAMVA member jurisdiction like any state; there is no federal plate mandate even in the federal district."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686 (paywalled, NOT obtained). DC Code Chapter 15 states no tag dimension; the design is delegated wholesale to the Mayor by § 50-1501.02(f)(3). No sourced dimension is carried here — though see the temporary tag, whose mounting holes DC DMV states are 'set to vehicle industry standards', an agency acknowledgement of the same unpinned standard."
+    stacked_characters: >-
+      AAMVA: 'If stacked characters are used, they are part of the official
+      license plate number. No more than two characters are to be stacked.' THE
+      DISTRICT ACTUALLY STACKS. Its motorcycle tags are reported with a stacked
+      letter pair — M over a series letter — followed by the numerals. Under
+      AAMVA's rule the stacked pair is SERIAL, not decoration, which is exactly
+      the normalisation trap the dossier flagged: a consumer that reads a
+      stacked pair as one character, or drops it, gets a DC motorcycle serial
+      wrong. Recorded on us-dc-motorcycle.
+    replacement_cycle: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. No District replacement cycle was located; DC DMV offers tag replacement as a service rather than as a schedule."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' is UNCITED in its Wikipedia source and is recorded as COMMONLY REPEATED, UNSOURCED. Note the dossier's finding that the same uncited passage was copied verbatim into the Puerto Rico and Canada articles — territory articles are where this particular folklore propagates."
+
+# ---------------------------------------------------------------------------
+# Display rules. The District is a TWO-TAG jurisdiction.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO tags. DC DMV: 'Vehicles are required to display two current tags: one on the front and the other on the rear of the vehicle.'"
+  exceptions: "DC DMV: 'Exceptions are for motorcycles, mopeds and trailers. For these, one tag is issued to be displayed on the rear of the vehicle.'"
+  mounting: "DC DMV: 'The vehicle tags must be securely fastened in a horizontal position, so that they do not fall off and can be easily read.'"
+  obstruction: "DC DMV: 'District law requires that the tags be visible and not obstructed or covered by any substance (e.g., glass, plastic, spray, license tag holders, etc.).' The underlying instrument is DCMR 18-422 'Display of Identification Tags' (effective 11 August 2017), whose text was not retrieved."
+  issuance: "DC Code § 50-1501.02: the Mayor issues identification tags as part of the registration certificate to owners meeting the statutory requirements; § 50-1501.02(f) requires the Mayor to establish (1) application forms, (2) the forms of registration and special use certificates, (3) THE DESIGN OF IDENTIFICATION TAGS, and (4) a records programme."
+  sources:
+    - "https://dmv.dc.gov/service/dmv-vehicle-tags  # DC DMV: two tags front and rear; motorcycles, mopeds and trailers rear only; horizontal secure fastening; the visibility and non-obstruction rule"
+    - "https://code.dccouncil.gov/us/dc/council/code/sections/50-1501.02  # DC Code § 50-1501.02: issuance of identification tags; (f)(1)-(f)(4) the Mayor's rulemaking duties including 'The design of identification tags'; (f-1) the mandated phrase and the individual opt-out"
+    - "https://dcregs.dc.gov/Common/DCMR/SectionList.aspx?SectionNumber=18-422  # DCMR 18-422 'DISPLAY OF IDENTIFICATION TAGS', effective 11 August 2017 — index metadata only; the rule TEXT was not retrievable through this interface (recorded gap)"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES — with a legend Congress-adjacent
+  # politics put in the statute.
+  # =========================================================================
+  - id: us-dc-end-taxation
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2017 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LL-9999"
+      regex: '\A[A-Z]{2}-?\d{4}\z'
+      charset:
+        notes: >-
+          NO CHARSET RULE IS IN THE DC CODE. § 50-1501.02 delegates 'The design
+          of identification tags' to the Mayor entire and states no length, no
+          alphabet and no exclusions. The two-letter / four-numeral arrangement
+          is locator-grade. Note that the District has been running this same
+          arrangement since at least November 2000 across every base change,
+          which is unusual stability: the DESIGN changes and the GRAMMAR does not.
+      pattern_note: >-
+        SEPARATOR CAVEAT. The locator writes DC serials as AB-1234 with a hyphen,
+        but it also describes at least one DC issue as using 'district flag used
+        as separator in serial' — i.e. the gap may carry the DC flag device
+        rather than a printed hyphen, as it demonstrably does on the trailer
+        series. The dataset spells the emitted hyphen and records the doubt here
+        rather than guessing; if the current base uses the flag device, the
+        correct treatment is the New Jersey one (space in the pattern, glyph in
+        `design.graphic`) and this series should be amended. FLAGGED FOR THE
+        VERIFIER — it is a one-photograph question.
+      progression: "reported to run FN-4000 to GV-9999, then JA-0000 to JU-7808 as of 26 October 2025 (locator)."
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003087"
+      colour_note: "blue serial on reflective white (locator); `hex_basis: observed`. The DC Code states no colour."
+      legend_top: "WASHINGTON, DC"
+      legend_bottom: "END TAXATION WITHOUT REPRESENTATION"
+      legend_rule: >-
+        THE LEGEND IS STATUTORY. DC Code § 50-1501.02(f-1): identification tags
+        designed under subsection (f)(3), 'not including identification tags for
+        vehicles for-hire, motor vehicles bearing organization plates,
+        motorcycles, or autocycles, shall display the phrase "End Taxation
+        Without Representation"'. NOTE THE FOUR CARVE-OUTS — for-hire vehicles,
+        organization plates, motorcycles and autocycles are excluded from the
+        mandate by name, which is why the taxi and motorcycle series below carry
+        no such legend and why an autocycle (a class no other jurisdiction in
+        this group legislates for) appears in a plate statute at all.
+      legend_history_note: >-
+        The phrase CHANGED at this base. The 2013 base and its predecessors read
+        'TAXATION WITHOUT REPRESENTATION'; this base reads 'END TAXATION WITHOUT
+        REPRESENTATION'. One word, and it converts a statement of grievance into
+        a demand. The statute as read today carries the longer phrase, which is
+        consistent with the 2017 base being the one the current subsection
+        describes.
+      graphic: { present: true, rendered: placeholder, description: "DC flag device (three stars over two bars) — position on the current base not established; see the separator caveat above" }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      dimension_note: "NO SOURCED DIMENSION — the DC Code states none and SAE J686 is unpinned."
+    region_encoding: none
+    sources:
+      - "https://code.dccouncil.gov/us/dc/council/code/sections/50-1501.02  # § 50-1501.02(f)(3) the Mayor designs the tags; (f-1) the mandated 'End Taxation Without Representation' phrase, its four carve-outs, and the individual opt-out to an alternate design"
+      - "https://dmv.dc.gov/service/dmv-vehicle-tags  # DC DMV: two tags front and rear — the agency-page-in-force evidence for the display regime"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington,_D.C.  # LOCATOR ONLY (PRD-PLATES §4): August 2017 base, 'WASHINGTON, DC' at top with 'END TAXATION WITHOUT REPRESENTATION' at bottom, AB-1234 from FN-4000, blue on reflective white"
+    notes: >-
+      END TAXATION WITHOUT REPRESENTATION (2017-) — THE CURRENT DISTRICT
+      STANDARD ISSUE, and the only standard-issue plate in the United States
+      whose legend is a political demand fixed by law. The statutory opt-out
+      makes the District structurally like Florida: one statutory design with a
+      legislated escape hatch, so the bottom legend is not a property of the
+      series but of the REGISTRANT'S CHOICE. Modelled as two series because the
+      designs differ; see us-dc-alternate-design. `start: 2017` is locator-grade,
+      though the statute's use of the longer phrase corroborates it. Parallel
+      issuance with the 2013 base is real — no recall was located — which is why
+      the periods overlap with distinct notes.
+
+  - id: us-dc-alternate-design
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2018 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LL-9999"
+      regex: '\A[A-Z]{2}-?\d{4}\z'
+      charset: { notes: "identical grammar to the mandated-legend base — the opt-out changes the LEGEND, not the serial. Reported range EA-3000 onward." }
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003087"
+      legend_top: "WASHINGTON, DC"
+      legend_bottom: "www.dc.gov"
+      legend_rule: >-
+        THE STATUTORY OPT-OUT MADE VISIBLE. § 50-1501.02(f-1): 'An individual who
+        does not wish to display the phrase "End Taxation Without
+        Representation" on his or her identification tag may request an
+        identification tag featuring an alternate design, to be supplied by the
+        Department of Motor Vehicles.' The alternate the District actually
+        supplies is reported to carry a URL where the demand would be — first
+        www.washingtondc.gov (from 2002), then www.dc.gov (from about 2018).
+        A CONSCIENCE CLAUSE ANSWERED WITH A WEB ADDRESS, which is either
+        deliberately anodyne or accidentally perfect.
+      graphic: { present: true, rendered: placeholder }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+    region_encoding: none
+    sources:
+      - "https://code.dccouncil.gov/us/dc/council/code/sections/50-1501.02  # § 50-1501.02(f-1): the individual opt-out and the Department's duty to supply an alternate design"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington,_D.C.  # LOCATOR ONLY: the alternate issue reading 'www.dc.gov' screened in blue at the bottom from about 2018, EA-3000 onward; the earlier 'www.washingtondc.gov' alternate from January 2002"
+    notes: >-
+      THE ALTERNATE DESIGN (2018-). Its own series rather than a variant because
+      its DESIGN differs from the mandated-legend base while its format and
+      period overlap it — the §2.3 test. It is also, together with Florida's
+      county-name opt-out, the second example in this dataset of a US
+      legislature writing an INDIVIDUAL CHOICE into a plate's design, and the
+      first where the choice is a matter of conscience rather than of local
+      government. A consumer must not treat the legend as diagnostic of the
+      series: two District plates issued the same week can read differently and
+      both are standard issue.
+
+  # =========================================================================
+  # ONE SERIES BACK.
+  # =========================================================================
+  - id: us-dc-district-of-columbia
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2013, end: 2017 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LL-9999"
+      regex: '\A[A-Z]{2}-?\d{4}\z'
+      charset: { notes: "same grammar again. Reported range EK-0000 to FN-3999, plus ALL-NUMERIC REMAKES in a 000-000 form — a parallel numeric shape the letter-led regex does not cover and which is recorded here rather than silently folded in." }
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003087"
+      legend_top: "DISTRICT OF COLUMBIA"
+      legend_bottom: "TAXATION WITHOUT REPRESENTATION"
+      legend_note: "the jurisdiction name at the top is the FORMAL one on this base and the colloquial 'WASHINGTON, DC' on the base before and after it — the District has alternated between its two names across issues, which is a small but real trap for any OCR or classifier keyed on the top legend."
+      graphic: { present: true, rendered: placeholder }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington,_D.C.  # LOCATOR ONLY: July 2013 to August 2017, 'DISTRICT OF COLUMBIA' in blue at top, 'TAXATION WITHOUT REPRESENTATION', AB-1234 from EK-0000 to FN-3999, all-numeric remakes"
+    notes: >-
+      DISTRICT OF COLUMBIA (2013-2017) — THE PREVIOUS BASE. `end: 2017` closes
+      ISSUANCE, not validity: no recall was located and these tags remain
+      current registrations. The reported ALL-NUMERIC REMAKES on this base are
+      worth a verifier's attention — a remake is a replacement plate carrying
+      the same registration, and if the District issued them in a different
+      grammar then the same registration can exist in two shapes, which no
+      format model in this dataset currently expresses.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES.
+  # =========================================================================
+  - id: us-dc-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2021 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: recall-only
+    format:
+      pattern: "MY9999"
+      regex: '\A(?:M[TRCXY]\d{4}|\d{4}M|MC\d{3})\z'
+      charset:
+        notes: >-
+          THE DISTRICT STACKS ITS MOTORCYCLE SERIAL. The locator renders the
+          reported forms with superscripts and subscripts — M over T, R, C, X or
+          Y, followed by four numerals — which is the printed convention for a
+          STACKED CHARACTER PAIR. AAMVA is explicit that 'If stacked characters
+          are used, they are part of the official license plate number. No more
+          than two characters are to be stacked', so the stacked letter is
+          SERIAL and must not be dropped or merged. `matching: recall-only`
+          because three different reported shapes are unioned here (M+letter+4
+          digits, 4 digits + M, and MC + 3 digits) and none is dated well enough
+          to elect as current; a match is a shape hit only.
+      stacked_characters_note: >-
+        A RENDER AND NORMALISATION PROBLEM, NOT A FORMAT ONE. The dataset
+        records the stacked pair as two ordinary characters in sequence, which
+        is what AAMVA says they are. The RENDER layer must know they are set one
+        above the other, and a normaliser reading a photograph must emit them in
+        the right order. This is the first stacked serial in the dataset and it
+        should inform the render manifest before any US gallery ships.
+    design:
+      background: { finish: retroreflective }
+      legend_top: "WASHINGTON, DC"
+      legend_exclusion: "§ 50-1501.02(f-1) EXCLUDES motorcycles from the mandated 'End Taxation Without Representation' phrase by name — so a District motorcycle tag carries no political legend as a matter of law."
+      emblem: { present: true, rendered: placeholder }
+      dimension_note: "NO SOURCED DIMENSION."
+    region_encoding: none
+    sources:
+      - "https://code.dccouncil.gov/us/dc/council/code/sections/50-1501.02  # § 50-1501.02(f-1): motorcycles and autocycles are excluded from the mandated phrase"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington,_D.C.  # LOCATOR ONLY: motorcycle forms 1234M, MC123 and the stacked M-over-letter series (M/T, M/R, M/C, M/X, M/Y), current series from 2021"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA: stacked characters are part of the official plate number, at most two stacked"
+    notes: >-
+      MOTORCYCLE — THE DATASET'S FIRST STACKED SERIAL. It is also the only
+      series in the mid-Atlantic group whose legend is governed by a statutory
+      EXCLUSION rather than a statutory mandate, which is a nice demonstration
+      that carve-outs are as load-bearing as rules: a classifier trained to
+      expect the District's slogan will fail on every DC motorcycle, taxi and
+      organization plate, all three excluded by name in § 50-1501.02(f-1).
+
+  - id: us-dc-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 1974 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "T-99999"
+      regex: '\AT-?\d{3,5}\z'
+      charset: { notes: "reported literal T prefix on a numeric serial of variable width, the current sequence reported to have started in 1974 at T-101 and to be running still. A FIFTY-YEAR UNBROKEN SEQUENCE is the longest-running serial space in the mid-Atlantic group and rivals Delaware's." }
+      separator_note: >-
+        THE DISTRICT FLAG IS THE SEPARATOR ON THIS SERIES. The locator states it
+        in terms — the trailer plate uses the 'district flag' as the separator in
+        the serial. That is the THIRD graphic separator found in this group,
+        after New Jersey's state outline and Maryland's War of 1812 flag device,
+        and the pattern is now unmistakable: US jurisdictions routinely put a
+        DEVICE where European ones put a hyphen. The dataset spells an emitted
+        hyphen and carries the flag in `design.graphic`, per
+        `_meta/separators.yml`'s `never_separator_note`.
+    design:
+      background: { finish: retroreflective }
+      legend_top: "WASHINGTON, DC"
+      graphic: { present: true, rendered: placeholder, description: "DC flag device (three stars over two bars) printed in the serial gap as the separator" }
+      emblem: { present: true, rendered: placeholder }
+    display_note: "trailers get ONE tag, displayed on the rear (DC DMV)."
+    region_encoding: none
+    sources:
+      - "https://dmv.dc.gov/service/dmv-vehicle-tags  # DC DMV: trailers among the one-tag, rear-display exceptions"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington,_D.C.  # LOCATOR ONLY: trailer T-12345 with district flag separator, sequence started 1974 at T-101"
+    notes: >-
+      TRAILER. The 1974 start is the earliest period start in the mid-Atlantic
+      group and it is locator-grade, so it is recorded with that grade rather
+      than rounded to the base year. The graphic separator is the interesting
+      structural fact and the reason this series carries its own separator_note.
+
+  - id: us-dc-dealer
+    class: dealer
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2017 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: recall-only
+    binding: business
+    format:
+      pattern: "DLL-9999"
+      regex: '\AD[A-Z]{2}-?\d{4,5}\z'
+      charset:
+        notes: >-
+          The reported serial is a literal DLR prefix on a four- or five-digit
+          numeric serial, the width varying by year. THE DATASET CANNOT SPELL IT
+          EXACTLY, AND THAT IS A SCHEMA FINDING — see `pattern_note`.
+      pattern_note: >-
+        THE HUMAN-PATTERN DSL CANNOT EXPRESS A LITERAL 'L'. `format.pattern`
+        reads 9 as any digit, L as any letter, and every other character as a
+        literal, with no escape mechanism — so 'DLR' is unspellable: the L is
+        eaten as a wildcard and the lint's round-trip generates DUR, DXR, DAR
+        and rejects the exact regex. The same hole exists for a literal '9'.
+        This series is therefore modelled `matching: recall-only` with the
+        middle character widened to any letter: the regex is DELIBERATELY WIDER
+        than the issuing grammar (which is DLR and nothing else), so a match is
+        a shape hit only, which is precisely what §2.7's recall-only tier means.
+        RECOMMENDED AMENDMENT: give the pattern DSL an escape (a backslash, or a
+        quoted-literal run) so that literal L and literal 9 can be spelled;
+        until then, any US jurisdiction with an L or a 9 in a fixed serial
+        position lands in recall-only for a notation reason rather than a
+        factual one, and that is the wrong reason to lose precision.
+    design:
+      background: { finish: retroreflective }
+      legend_top: "WASHINGTON, DC"
+      legend_bottom: "DEALER"
+      annual_redesign: >-
+        THE DISTRICT REDESIGNS ITS DEALER TAGS EVERY YEAR, with a unique colour
+        combination per year (locator). That is a genuinely unusual cadence — an
+        ANNUAL design cycle on one class while the standard base runs for years
+        — and it means the dealer tag's COLOUR is a date field. If confirmed
+        from a primary it would be the sharpest era-inference signal anywhere in
+        this group, because the plate literally encodes its year in its palette.
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington,_D.C.  # LOCATOR ONLY: dealer DLR-1234 / DLR-12345, annual designs with unique colour combinations"
+    notes: >-
+      DEALER. `binding: business`. The annual-colour claim is locator-grade and
+      is the highest-value thing in this entry to verify — a per-year colour
+      table would be a decode table in the §2.4 sense, keyed on colour rather
+      than on characters, which nothing in the schema currently anticipates.
+
+  - id: us-dc-taxi
+    class: taxi
+    categories: [car, van]
+    period: { start: 2017 }
+    period_evidence: statutory-authority-undated
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "H-99999"
+      regex: '\AH-?\d{5}\z'
+      charset: { notes: "reported literal H prefix on a five-digit numeric serial for for-hire vehicles." }
+    design:
+      background: { finish: retroreflective }
+      legend_top: "WASHINGTON, DC"
+      legend_exclusion: "§ 50-1501.02(f-1) excludes 'identification tags for vehicles for-hire' from the mandated 'End Taxation Without Representation' phrase by name — the statutory basis for the for-hire class being visually distinct."
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://code.dccouncil.gov/us/dc/council/code/sections/50-1501.02  # § 50-1501.02(f-1): for-hire vehicles excluded from the mandated phrase"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington,_D.C.  # LOCATOR ONLY: taxi H-12345"
+    notes: >-
+      TAXI (FOR-HIRE). The only `taxi`-class series in the mid-Atlantic group,
+      and it exists as a distinct class BECAUSE THE STATUTE CARVES IT OUT: DC
+      legislates that for-hire tags do not carry the political legend, which
+      necessarily makes them a different design and therefore a different series
+      under §2.3. A carve-out creating a class is a pattern worth watching for
+      in other jurisdictions.
+
+  - id: us-dc-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2017 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    binding: business
+    format:
+      pattern: "99999"
+      regex: '\A\d{5}\z'
+      charset:
+        notes: >-
+          Five numerals. The locator writes the District fleet format as
+          'D/C 12345', where D/C is a legend printed beside the number rather
+          than a serial token — the same shape as Maryland's S/G and L/G markers.
+          THE DATASET CANNOT SPELL THE SOLIDUS: '/' is in
+          `_meta/separators.yml`'s FORGIVING set but not its EMITTED set, so a
+          literal '/' in a pattern or regex is a lint failure by design, and the
+          marker is carried as a legend where it belongs. A parallel GT-1234
+          form is also reported and is not covered by this regex; it is recorded
+          rather than folded in.
+    design:
+      background: { finish: retroreflective }
+      legend_top: "WASHINGTON, DC"
+      legend_bottom: "D/C"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington,_D.C.  # LOCATOR ONLY: 'D/C 12345' District government fleet, and a parallel GT-1234 form"
+    notes: >-
+      DISTRICT GOVERNMENT FLEET. Locator-grade throughout. The second
+      independent appearance of a slash-marker legend in this group (after
+      Maryland's S/G and L/G) is quietly useful evidence that the separator
+      contract's exclusion of the solidus is right: three jurisdictions print it,
+      none of them uses it inside a serial, and in every case it belongs to the
+      legend layer.
+
+  - id: us-dc-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2024 }
+    period_evidence: agency-page-in-force
+    format_evidence: secondary-locator-unverified
+    matching: recall-only
+    format:
+      pattern: "LLLLLLLL"
+      regex: '\A[A-Z0-9]{8}\z'
+      charset:
+        notes: >-
+          DC DMV states the MECHANISM but not the grammar: the tags carry
+          'laser-printed alphanumeric digits generated by the DESTINY motor
+          vehicle information system'. The locator reports the printed form as
+          an eight-character alphanumeric. `matching: recall-only` because an
+          eight-character alphanumeric catch-all is far wider than whatever
+          DESTINY actually emits — a match is a shape hit and nothing more.
+          Earlier reported forms (12345DA, X12345, Z12345, K12345, N12345)
+          belonged to the pre-2024 cardboard tags and are not modelled.
+    design:
+      background: { color: "#FFFFFF", finish: none, hex_basis: observed }
+      material: "DC DMV: 'weather resistant, fade proof and tear proof paper' with 'plate mounting holes set to vehicle industry standards' — an agency acknowledgement of the same unpinned physical standard AAMVA delegates to SAE J686"
+      legend_top: "Washington, DC"
+      graphic: { present: true, rendered: placeholder, description: "DC DMV: 'the DC flag in the upper left and right corner with a Washington, DC heading and the DMV logo in the lower right corner'" }
+      emblem: { present: true, rendered: placeholder }
+    validity: "45 days. DC DMV replaced the temporary registration WINDOW STICKER with a temporary registration CARD 'to be carried in the vehicle for 45 days'."
+    transition: "the redesign took effect 30 September 2024 and tags of the old design remained valid through 14 November 2024 — a stated six-week overlap window, the most precisely dated transition in the entire mid-Atlantic group."
+    region_encoding: none
+    sources:
+      - "https://dmv.dc.gov/release/dc-dmv-redesigns-temporary-tags-mitigate-fraud  # DC DMV's own release: the 30 September 2024 changeover, the DESTINY-generated laser-printed alphanumeric, weather-resistant/fade-proof/tear-proof paper, industry-standard mounting holes, the DC flag corners and DMV logo, the 45-day temporary registration card, and the 14 November 2024 expiry of the old design"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington,_D.C.  # LOCATOR ONLY: the eight-character A1B2C3D4 printed form and the superseded cardboard forms"
+    notes: >-
+      TEMPORARY — THE BEST-DATED SERIES IN THE MID-ATLANTIC GROUP, AND THE ONLY
+      ONE WITH A PRIMARY FOR ITS OWN START DATE. DC DMV published the change
+      itself, with a reason (fraud mitigation), an effective date, a transition
+      window and a physical description. Every other period boundary in this
+      group is locator-grade; this one is agency-stated, which is why
+      `period_evidence` is `agency-page-in-force` and why 2024 is a real claim
+      rather than an upper bound. It is also a useful reminder that agency PRESS
+      RELEASES are systematically better sources for plate transitions than
+      agency service pages, and should be the first place a US pass looks.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-dc-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2017 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "LL-9999"
+      regex: '\A[A-Z]{2}-?\d{4}\z'
+      charset: { notes: "specialty tags carry ordinary serials on an alternative design. § 50-1501.02(f-1) excludes 'motor vehicles bearing organization plates' from the mandated phrase, so a District specialty tag is legally free of the political legend." }
+    design:
+      background: { finish: retroreflective }
+      note: "one design per approved programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: 13
+      count_official_method: >-
+        ENUMERATED FROM DC DMV'S OWN SPECIALTY TAG PAGE on 2026-08-02. The agency
+        publishes the complete menu inline rather than a number, so this is OUR
+        COUNT OF THE AGENCY'S OWN LIST — not an agency claim. Two of the
+        thirteen are counted as single entries although they cover multiple
+        designs: 'Veterans Specialty' spans Army, Navy, Marines, Air Force and
+        Coast Guard, so a design-level count would be higher.
+      programmes_official:
+        - "Anacostia River Commemorative"
+        - "Breast Cancer Awareness"
+        - "DC Veteran"
+        - "DC Woman Veteran"
+        - "Disabled American Veteran (DAV)"
+        - "Pride Lives Here"
+        - "Washington Capitals"
+        - "Washington Mystics"
+        - "Washington Nationals"
+        - "Washington Wizards"
+        - "We Demand Statehood"
+        - "Veterans Specialty (Army, Navy, Marines, Air Force, Coast Guard)"
+        - "Vision Zero Bicycle Awareness"
+      scale_note: >-
+        THIRTEEN. That is the whole District programme, against Delaware's 149
+        and New York's 206, and it makes the District the smallest specialty
+        programme in the group by an order of magnitude. Two of the thirteen —
+        'We Demand Statehood' and 'Pride Lives Here' — are POLITICAL, which no
+        state programme in this group offers: a District whose standard plate is
+        already a political demand also runs statehood advocacy as an optional
+        design.
+      official_list_url: "https://dmv.dc.gov/service/specialty-vehicle-tags"
+      index_url: "https://dmv.dc.gov/service/dmv-vehicle-tags"
+      churn_note: "no discontinuation rule was located in Chapter 15; recorded gap."
+    region_encoding: none
+    sources:
+      - "https://dmv.dc.gov/service/specialty-vehicle-tags  # DC DMV's complete specialty tag menu — the source of the enumeration above, including the newest 'We Demand Statehood' and 'Pride Lives Here' tags"
+      - "https://code.dccouncil.gov/us/dc/council/code/sections/50-1501.02  # § 50-1501.02(f-1): organization plates excluded from the mandated phrase"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX. The District is the small, complete,
+      enumerable case — thirteen programmes, all listed on one agency page,
+      countable in one read. Set against Delaware (149, enumerable), New York
+      (206, agency-counted), New Jersey (17 in one of five tracks, no total) and
+      Pennsylvania (unknown, unenumerable), the mid-Atlantic group now covers the
+      full range of how badly or well a US jurisdiction publishes its own
+      catalogue — which is itself the finding the specialty INDEX exists to
+      surface.
+
+# ---------------------------------------------------------------------------
+# CLASSES THE DISTRICT ISSUES THAT ARE DELIBERATELY NOT MODELLED AS SERIES.
+# ---------------------------------------------------------------------------
+unmodelled_classes:
+  personalized: "DC DMV offers personalised tags but its 'Tag Variations' page 404'd on two URL attempts in this pass, so no character cap, alphabet or fee was obtained. No series is minted without a format. RECORDED GAP."
+  diplomatic: "the District hosts essentially the entire US diplomatic corps, but DIPLOMATIC PLATES ARE ISSUED BY THE US DEPARTMENT OF STATE, NOT BY DC DMV — they are a FEDERAL series that happens to be concentrated in the District, and they belong in a us.yml federation-level file rather than here. Recorded so a later pass does not mistake their absence for an omission."
+  autocycle: "§ 50-1501.02(f-1) names AUTOCYCLES as a class excluded from the mandated legend — the only mention of autocycles in any statute read in this group. Whether the District serialises them apart was not established."
+
+# ---------------------------------------------------------------------------
+# GAPS.
+# ---------------------------------------------------------------------------
+gaps:
+  - "DCMR 18-422 ('Display of Identification Tags', effective 11 August 2017) TEXT NOT RETRIEVED — dcregs.dc.gov serves rule metadata and puts the text behind a per-notice viewer. The display rules here rest on DC DMV's own summary."
+  - "SEPARATOR UNRESOLVED ON THE STANDARD BASE: hyphen or DC flag device? The locator says the flag is used as a separator on at least one issue and demonstrably on the trailer series. One photograph settles it."
+  - "Base-design years (2017, 2013, 2018 alternate) and all serial ranges are locator-grade. Only the 2024 temporary tag has a primary for its own date."
+  - "NO SOURCED DIMENSION and NO SOURCED COLOUR VALUE — the DC Code delegates design wholesale to the Mayor."
+  - "Personalised tag rules unobtained (DC DMV 'Tag Variations' 404'd twice)."
+  - "The annual dealer-tag colour cycle is locator-grade and would be a colour-keyed decode table if confirmed."
+  - "The all-numeric 'remakes' reported on the 2013 base are unexplained — same registration in a second grammar is a case the schema does not model."
+  - "{{PD-DC}} on Commons contradicts the District's own CC BY 3.0 terms. Recorded as a folklore correction; a Copyright Office pinpoint either way would settle it."
+  - "SCHEMA LIMITATION SURFACED BY THIS FILE: the human-pattern DSL has no escape for a literal 'L' or a literal '9', so the District's DLR dealer prefix is unspellable and the series had to be widened to recall-only for a NOTATION reason. See us-dc-dealer format.pattern_note for the recommended amendment."

--- a/plates/us-de.yml
+++ b/plates/us-de.yml
@@ -1,0 +1,551 @@
+# plates/us-de.yml — Delaware (PRD-PLATES gate L2, mid-Atlantic group).
+#
+# DELAWARE IS THE SCHEMA STRESS TEST THE US/WORLD DOSSIER NAMED IN ADVANCE.
+# The dossier flagged it as one of two rows that "break the fixed-width
+# alphanumeric on a 6x12 rectangle assumption", because its serial is a BARE
+# NUMBER of VARIABLE LENGTH with no leading zeros — 4 through 999999, one to six
+# digits, nothing else. Every regex here quantifies rather than fixes width, and
+# the no-leading-zeros rule lives in `regex_strict` exactly as PRD-PLATES §2.7
+# says a charset restriction must.
+#
+# DELAWARE ALSO HAS THE OLDEST DESIGN STILL IN USE IN THE UNITED STATES. The
+# gold-on-blue scheme dates to 1959 by the dossier's own reckoning and the plate
+# has not changed colour since. That makes Delaware the one state in this group
+# where "one series back" is a manufacturing change (flat to beveled), not a
+# redesign — and it makes the dataset's `period` semantics do real work, because
+# a Delaware plate's DESIGN cannot date it at all.
+#
+# WHAT IS SOURCED HERE AND WHAT IS NOT. Delaware's statute is unusually
+# generous: 21 Del. C. § 2121 states the ONE-PLATE rule, the plate's required
+# content, the vanity character caps AND — uniquely in this group — actual
+# COLOUR VALUES in law, gold on blue, inverted to blue on gold for the officials
+# and judges of § 2123. What the statute expressly declines to fix is everything
+# else: "Number plates shall be of such design, size, material and color as the
+# Department may determine." So Delaware legislates two colour schemes and then
+# hands the whole design back to the Department in the same section.
+#
+# period_evidence / format_evidence vocabularies as in us-ny.yml.
+jurisdiction: us-de
+authority:
+  name: Delaware Division of Motor Vehicles (DelDOT DMV)
+  url: "https://www.dmv.de.gov/"
+binding: vehicle
+statute_edition: "Delaware Code Title 21 (Motor Vehicles), Chapter 21, Subchapter II (Plates), as served by delcode.delaware.gov and read 2026-08-02."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    NOTHING WAS FOUND, AND THAT IS THE FINDING. The US/world dossier already
+    recorded Delaware as a gap — 'Texas, Delaware: NOT ESTABLISHED. Neither
+    appears in the fetched source. Treat as default (copyrighted)' — and this
+    pass did not close it. Delaware has no entry at all in the Wikipedia survey
+    of subnational copyright status, there is no {{PD-DEGov}} template on
+    Wikimedia Commons, and the only Delaware-wide statement located is a bare
+    copyright notice in the delaware.gov portal footer ('(c)MMXVIII
+    Delaware.gov' / '(c)MMXVI Delaware.gov' depending on the page), which is an
+    assertion of rights with no scope, no grant and no reuse terms attached.
+  posture_default: >-
+    THE DEFAULT APPLIES: 17 U.S.C. § 105 puts only FEDERAL works in the public
+    domain and does not reach the states, so a Delaware state work is
+    COPYRIGHTED UNLESS DELAWARE SAYS OTHERWISE, and Delaware has not been found
+    to say otherwise. Treat as adverse in practice while recording the posture
+    honestly as UNRESEARCHED rather than as a positive finding of adversity —
+    the two are different claims and only one of them is evidenced.
+  what_to_chase: >-
+    Delaware's Government Information Center (gic@delaware.gov) is named on the
+    portal's own privacy page as the body that builds and maintains state web
+    content, and that page directs reuse questions to it. That is the single
+    address a verifier should write to. The Delaware Freedom of Information Act
+    (Title 29, Chapter 100 of the Delaware Code) is referenced on the same page
+    and is the statutory hook worth reading for a records-access-versus-copyright
+    answer of the kind Florida and New Jersey have.
+  emblem_rule: >-
+    RENDER PLACEHOLDER. Delaware's standard plate is the least graphical in the
+    group — a legend, a border and a number, no emblem at all — so the
+    placeholder rule costs almost nothing here. The specialty backgrounds
+    (ducks, lighthouses, horses) are the artwork surface and are L4 scope
+    regardless.
+  photograph_caution: >-
+    Standard §4 reading. One official DMV specialty-plate thumbnail was READ in
+    this pass to confirm the all-numeric serial form; it is not copied into the
+    dataset and no render derives from it.
+  sources:
+    - "https://delaware.gov/help/disclaimer.shtml  # the Delaware portal's own page: a bare '(c) Delaware.gov' notice, the Government Information Center as content owner, a pointer to the Delaware FOIA (Title 29 Ch. 100), and NO reuse grant"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: Delaware has NO ENTRY in this survey - checked, not assumed"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Voluntary; J686 never quoted.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686 (paywalled, NOT obtained). Delaware states no dimension: § 2121 says only that plates 'shall be of such design, size, material and color as the Department may determine'. No sourced dimension is carried here."
+    legibility_comparison: "AAMVA §3.3 recommends legibility 'from distances of at least 75 feet' in daylight AND at night. Delaware legislates a DAYLIGHT-ONLY 100-foot rule that is both longer and narrower than AAMVA's: plates 'shall be of sufficient size to be plainly readable at a distance of 100 feet during daylight'. Two different standards, neither derived from the other, and the state's is law while AAMVA's is advice."
+    replacement_cycle: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. DELAWARE IS THE STRONGEST COUNTEREXAMPLE IN THE COUNTRY: its design has run since 1959 and its serial space has never been reset, which is only possible because Delaware does not replace plates on a cycle at all. No replacement provision was located in Subchapter II."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' is UNCITED in its Wikipedia source and is recorded as COMMONLY REPEATED, UNSOURCED. Delaware states no dimension of its own to put in its place."
+
+# ---------------------------------------------------------------------------
+# Display rules. Delaware is a ONE-PLATE, REAR-ONLY state and says so in law.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "ONE plate, REAR. 21 Del. C. § 2126: 'The number plate assigned to a motor vehicle shall at all times be attached to the rear of the motor vehicle.' § 2121 correspondingly has the Department furnish ONE number plate per vehicle. Delaware is the cleanest one-plate statement in this group — contrast Pennsylvania, whose rear-only practice could not be pinned to any instrument."
+  plate_content: "§ 2121: 'Each number plate shall have displayed thereon the registration number assigned to the vehicle, the name of this State' together with expiration information."
+  design_delegation: "§ 2121: 'Number plates shall be of such design, size, material and color as the Department may determine.' The legislature fixes the CONTENT and then delegates the FORM — with the two colour exceptions below, which it does not delegate."
+  mounting: "§ 2126: securely fastened 'at a height not less than 12 inches from the ground, measuring from the bottom of such plate ... in a place and position to be clearly visible'."
+  legibility: "'Each number plate and identifying letters and numerals thereon ... shall be of sufficient size to be plainly readable at a distance of 100 feet during daylight.' SOURCING CAVEAT: the extraction of Subchapter II did not preserve which section carries this sentence (§ 2121 or § 2126); a verifier should pin the subsection before it is quoted with a section number."
+  obstruction: "§ 2126: 'No number plate, or any portion thereof, shall be covered with any tinted material, nor shall any other material be placed on or around a number plate which would conceal and/or obscure any information.'"
+  penalty: "§ 2126: fines from $25 to $200 depending on the offence."
+  ownership: "§ 2125 is titled 'Ownership of plates' — Delaware legislates the plate's ownership as a distinct question from the vehicle's, which is the statutory root of the state's famous low-number transfer market. The section text was not extracted (recorded gap), but its existence is the pointer a verifier needs."
+  sources:
+    - "https://delcode.delaware.gov/title21/c021/sc02/index.html  # 21 Del. C. Ch. 21 Subchapter II: § 2121 one plate, plate content, the design/size/material/colour delegation, the vanity colour and character rules; § 2125 ownership of plates; § 2126 rear attachment, 12-inch height, the tinted-material prohibition and the $25-$200 penalties; the 100-foot daylight legibility rule"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES.
+  # =========================================================================
+  - id: us-de-standard-beveled
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2008 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: statutory
+    matching: strict
+    format:
+      pattern: "999999"
+      regex: '\A\d{1,6}\z'
+      regex_strict: '\A[1-9]\d{0,5}\z'
+      charset:
+        excluded: []
+        notes: >-
+          DELAWARE'S SERIAL IS A NUMBER, NOT A CODE. There are no letters in an
+          ordinary Delaware passenger serial at all, the width is genuinely
+          VARIABLE from one digit to six, and the reported rule is that there are
+          NO LEADING ZEROS — a one-digit plate is '4', not '000004'. The no-
+          leading-zeros rule is what `regex_strict` carries; `regex` cannot,
+          because PRD-PLATES §2.7 requires `regex` to round-trip against
+          `pattern` and a pattern of six 9s generates leading zeros freely.
+          Reported issued range: 4 to 999999, with 1, 2 and 3 reserved for the
+          Governor, the Lieutenant Governor and the Secretary of State
+          respectively.
+      pattern_note: >-
+        `pattern` shows the SIX-DIGIT form because that is the modal printed
+        plate and a pattern must be a concrete printed shape; the regex is what
+        carries the variability. A consumer must read the regex, not the pattern,
+        for width. This is the shape PRD-PLATES §2.2 anticipated when it said
+        Delaware's variable-width serials mean 'regexes quantify rather than fix
+        width'.
+      progression: "strictly sequential ascending; the space has NEVER been reset, which is why Delaware serials are an unusually good age proxy — a low number is an old registration or an expensive one."
+    design:
+      background: { color: "#00305E", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8A951"
+      colour_note: >-
+        DELAWARE IS THE ONLY STATE IN THIS GROUP WITH A COLOUR SCHEME IN
+        STATUTE. § 2121 prescribes 'Gold letters on a blue background' — for the
+        vanity plates in terms, and the ordinary plate carries the same scheme
+        by long practice. The HEX VALUES are still `observed`, because the
+        statute names colours, not values: 'gold' and 'blue' are the claim, and
+        the exact navy and old-gold recorded here are read off official DMV
+        imagery. Naming a colour in law and specifying it are different acts and
+        the dataset should not blur them.
+      border: { present: true, color: "#C8A951", note: "gold border, observed" }
+      legend_top: "THE FIRST STATE"
+      legend_bottom: "Delaware"
+      graphic: { present: false, rendered: none, description: "the standard Delaware plate carries NO graphic at all - legend, border, number. It is the most minimal standard plate in the mid-Atlantic group and arguably in the country." }
+      emblem: { present: false }
+      band: { side: none }
+      rear_differs: false
+      manufacture: "BEVELED EDGES distinguish this base from the flat plates before it (locator). The design is otherwise unchanged."
+      dimension_note: "NO SOURCED DIMENSION - § 2121 delegates size to the Department and no departmental specification was obtained."
+    replacement_cycle:
+      years: null
+      note: "NO REPLACEMENT PROVISION LOCATED in Subchapter II. Delaware's design has run continuously since 1959 by the dossier's reckoning, which is only possible without a replacement cycle. This is the pole opposite Florida's statutory 10 years."
+    secondary_market:
+      note: >-
+        DELAWARE IS THE ONLY US JURISDICTION WITH A SUBSTANTIAL SECONDARY MARKET
+        IN THE NUMBER ITSELF, and the statutory root is § 2125 ('Ownership of
+        plates'). The dossier records sale prices of $185,000 for #9 (1994),
+        $675,000 for #6 (2008) and roughly $70,000 for a three-digit plate
+        (2023). Recorded because it is the clearest real-world demonstration
+        that in some jurisdictions the registration mark is PROPERTY separable
+        from the vehicle — a `binding` question the schema already models for
+        Switzerland's owner-bound plates.
+      evidence: "locator-grade via the US/world dossier; no Delaware primary for any sale price was sought"
+    region_encoding: none
+    sources:
+      - "https://delcode.delaware.gov/title21/c021/sc02/index.html  # 21 Del. C. § 2121: one plate per vehicle, 'the registration number assigned to the vehicle, the name of this State', 'Number plates shall be of such design, size, material and color as the Department may determine', 'Gold letters on a blue background'; § 2125 ownership of plates; § 2126 rear display"
+      - "https://www.dmv.de.gov/VehicleServices/tags/index.shtml  # DelDOT DMV's own plate index - the agency-page-in-force evidence that this scheme is current"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Delaware  # LOCATOR ONLY (PRD-PLATES §4): the 2008 beveled-edge revision, the 4-999999 range, the 1/2/3 reservations for Governor / Lieutenant Governor / Secretary of State, the no-leading-zeros rule and the low-number market"
+    notes: >-
+      DELAWARE STANDARD ISSUE — VARIABLE-WIDTH NUMERIC, THE SCHEMA'S NAMED
+      STRESS TEST. `start: 2008` is locator-grade and marks a MANUFACTURING
+      change (flat to beveled), not a design change: the colours, the legend and
+      the serial space all run continuously across it. That has a consequence
+      worth stating plainly for consumers — A DELAWARE PLATE'S DESIGN CARRIES NO
+      DATE INFORMATION AT ALL. Every other state in this group can be roughly
+      dated from its base; Delaware can only be dated from its NUMBER, and only
+      by someone holding the issuance history. This is also why the two Delaware
+      series overlap in 2008 with distinct notes: nothing was recalled, so 1969
+      plates and 2008 plates are both current registrations today.
+
+  # =========================================================================
+  # ONE SERIES BACK — a manufacturing change, not a redesign.
+  # =========================================================================
+  - id: us-de-standard-flat
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1969, end: 2008 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: statutory
+    matching: strict
+    format:
+      pattern: "999999"
+      regex: '\A\d{1,6}\z'
+      regex_strict: '\A[1-9]\d{0,5}\z'
+      charset: { notes: "identical to the current base - the same continuous numeric space, no leading zeros. The 1969 boundary is a manufacturing and issue-run boundary only." }
+    design:
+      background: { color: "#00305E", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8A951"
+      legend_top: "THE FIRST STATE"
+      legend_bottom: "Delaware"
+      graphic: { present: false, rendered: none }
+      emblem: { present: false }
+      band: { side: none }
+      manufacture: "FLAT (no beveled edge) - the only reported difference from the current base."
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Delaware  # LOCATOR ONLY: 1969 base, flat, 'Screened gold serial on reflective dark blue plate with gold border', 'THE FIRST STATE' centred at top - identical description to the current base but for the bevel"
+    notes: >-
+      DELAWARE, FLAT (1969-2008). Recorded as its own series because
+      PRD-PLATES §2.3 makes DESIGN difference a series test and the physical
+      construction differs — but recorded with the honest caveat that this is
+      the THINNEST series boundary in the mid-Atlantic group. Format, colours,
+      legends and serial space are all identical across it. A consumer that
+      cannot distinguish a beveled Delaware plate from a flat one will get the
+      right answer to every format question and the wrong answer only to
+      'which series', which is the correct failure mode for a boundary this
+      subtle. Both remain valid: Delaware recalls nothing.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES — Delaware serialises each in its own space, and the
+  # marker letters are the whole grammar.
+  # =========================================================================
+  - id: us-de-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2008 }
+    period_evidence: instrument-in-force-upper-bound
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "99999"
+      regex: '\A\d{1,5}\z'
+      regex_strict: '\A[1-9]\d{0,4}\z'
+      charset: { notes: "reported five-digit numeric motorcycle serial in its own space, with 'M/C' printed at the bottom left rather than encoded in the serial. No leading zeros, on the same reasoning as the passenger series." }
+    design:
+      background: { color: "#00305E", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8A951"
+      legend_top: "THE FIRST STATE"
+      legend_bottom: "M/C"
+      legend_rule: "the CLASS MARKER IS A LEGEND, NOT A SERIAL CHARACTER - 'M/C' sits at the bottom left of the plate. A parser reading only the serial cannot tell a Delaware motorcycle plate from a low-numbered passenger plate; it must read the legend. That is a genuine ambiguity in the Delaware system and is stated rather than hidden."
+      emblem: { present: false }
+      dimension_note: "NO SOURCED DIMENSION."
+    vanity_note: "§ 2121(i) caps a MOTORCYCLE vanity plate at five characters against seven for a passenger vanity plate, and charges the same $40 annually - statutory confirmation that Delaware treats the motorcycle series as its own space."
+    region_encoding: none
+    sources:
+      - "https://delcode.delaware.gov/title21/c021/sc02/index.html  # 21 Del. C. § 2121(i): motorcycle vanity plates 'not to exceed 5 in number', $40 annually"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Delaware  # LOCATOR ONLY: five-digit numeric motorcycle serial with M/C at bottom left"
+    notes: >-
+      MOTORCYCLE. THE AMBIGUITY IS THE POINT: because Delaware's motorcycle
+      serial is all-numeric in a parallel space, the string '12345' is a
+      well-formed serial in BOTH the passenger and the motorcycle series and no
+      amount of regex resolves it. A parse API must return both candidates for
+      Delaware numerics, which is exactly the multi-parse behaviour PRD-PLATES
+      §6's prior-art survey admired in @randock's formatter.
+
+  - id: us-de-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2008 }
+    period_evidence: instrument-in-force-upper-bound
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "T999999"
+      regex: '\AT\d{1,6}\z'
+      charset: { notes: "reported trailer serial: a literal T prefix on the numeric space. Unlike the motorcycle series, the trailer class IS encoded in the serial, which makes trailer plates unambiguous where motorcycle plates are not." }
+    design:
+      background: { color: "#00305E", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8A951"
+      legend_top: "THE FIRST STATE"
+      emblem: { present: false }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Delaware  # LOCATOR ONLY: trailer T123456"
+    notes: "TRAILER. Locator-grade format on a statutory class. The T prefix makes this the one Delaware class a parser can identify from the string alone."
+
+  - id: us-de-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2008 }
+    period_evidence: statutory-authority-undated
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    binding: business
+    format:
+      pattern: "D99999"
+      regex: '\AD\d{1,5}\z'
+      charset: { notes: "reported dealer serial: a literal D prefix on the numeric space." }
+    design:
+      background: { color: "#00305E", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8A951"
+      legend_top: "THE FIRST STATE"
+      emblem: { present: false }
+    region_encoding: none
+    sources:
+      - "https://delcode.delaware.gov/title21/c021/sc02/index.html  # 21 Del. C. § 2124: 'Number plates for manufacturers, dealers, and transporters' - the statutory class, which distinguishes THREE trade categories where most states distinguish one or two"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Delaware  # LOCATOR ONLY: dealer D12345"
+    notes: >-
+      DEALER. `binding: business`. § 2124's heading names MANUFACTURERS, DEALERS
+      AND TRANSPORTERS as three trade categories in one section — the same
+      three-way split Florida draws between Dealer and Manufacturer legends,
+      plus a transporter category Florida lacks. Whether Delaware serialises
+      them apart was not established (recorded gap); only the dealer form was
+      reported.
+
+  - id: us-de-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2021 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "XA999999"
+      regex: '\AX[ABCDPQ]\d{6}\z'
+      charset:
+        notes: >-
+          Reported temporary-plate form: a literal X, a series letter, and six
+          numerals. The series letters reported in use are A, B, C, D, P and Q
+          'as of June 19, 2021', which the locator gives as a dated observation.
+          The regex enumerates exactly those six letters rather than allowing any
+          letter, so it is narrow by any letter subsequently opened — the safe
+          direction. Delaware's temporary plates are reported to have EVOLVED
+          from an all-numeric form to this XA/XB/... scheme, i.e. the X prefix is
+          itself a generation marker.
+    design:
+      background: { finish: unknown }
+      legend_top: "THE FIRST STATE"
+      emblem: { present: false }
+      note: "no design source obtained for the temporary plate stock (recorded gap)."
+    validity: "not sourced. §§ 2129, 2130 and 2131 of Title 21 govern issuance by the Department, issuance by dealers and repair technicians, and 'Effect and duration of temporary registration plates' respectively — § 2131 is the section a verifier should pull for the validity period."
+    region_encoding: none
+    sources:
+      - "https://delcode.delaware.gov/title21/c021/sc02/index.html  # 21 Del. C. §§ 2129, 2130, 2131: issuance of temporary registration plates, issuance by dealers and repair technicians, and the effect and duration of temporary plates - THREE statutory sections on temporary plates, the most detailed treatment in this group"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Delaware  # LOCATOR ONLY: XA123456 form and the XA/XB/XC/XD/XP/XQ series letters as of 19 June 2021"
+    notes: >-
+      TEMPORARY. Delaware devotes three statutory sections to temporary plates
+      where most states devote one clause, including a section specifically for
+      issuance by REPAIR TECHNICIANS — a category no other state in this group
+      names. The class and its structure are statutory; the serial form is
+      locator-grade; § 2131 (duration) is the named gap.
+
+  - id: us-de-state-owned
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2008 }
+    period_evidence: instrument-in-force-upper-bound
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    binding: business
+    format:
+      pattern: "S9999"
+      regex: '\AS\d{1,4}\z'
+      charset: { notes: "reported state-owned vehicle serial: a literal S prefix on the numeric space." }
+    design:
+      background: { color: "#00305E", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8A951"
+      legend_top: "THE FIRST STATE"
+      emblem: { present: false }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Delaware  # LOCATOR ONLY: state-owned S1234"
+    notes: >-
+      STATE-OWNED FLEET. Distinct from the OFFICIALS series below, which is a
+      different statutory animal: this plate goes on a vehicle the State owns,
+      whereas § 2123 plates go to a PERSON holding an office and carry inverted
+      colours. Two government-class series with different bases, different
+      colours and different purposes.
+
+  - id: us-de-officials
+    class: government
+    categories: [car, van, truck]
+    period: { start: 2008 }
+    period_evidence: statutory-authority-undated
+    format_evidence: secondary-locator-unverified
+    matching: recall-only
+    format:
+      pattern: "999"
+      regex: '\A\d{1,5}\z'
+      charset:
+        notes: >-
+          NO FORMAT SOURCE WAS OBTAINED FOR § 2123 PLATES. What IS known is that
+          the three lowest numbers in the whole Delaware space — 1, 2 and 3 —
+          are reported reserved for the Governor, the Lieutenant Governor and
+          the Secretary of State, so the officials' plates draw from the same
+          numeric alphabet. `matching: recall-only` because this regex is a
+          deliberately wide numeric catch-all rather than a sourced grammar: a
+          match says only 'this is a Delaware-shaped number'.
+    design:
+      background: { color: "#C8A951", finish: retroreflective, hex_basis: observed }
+      foreground: "#00305E"
+      colour_note: >-
+        THE COLOURS ARE INVERTED, AND THAT IS IN STATUTE. § 2121 prescribes 'Gold
+        letters on a blue background, EXCEPT for license plates provided for in
+        § 2123', which take 'blue letters on a gold background'. § 2123 is
+        'Number plates for state/federal officers and judges'. So Delaware
+        legislates a colour INVERSION as the mark of high office — the only
+        statutory colour distinction found anywhere in the mid-Atlantic group,
+        and a rare case of a US legislature specifying a design VALUE rather
+        than delegating it.
+      legend_top: "THE FIRST STATE"
+      emblem: { present: false }
+    region_encoding: none
+    sources:
+      - "https://delcode.delaware.gov/title21/c021/sc02/index.html  # 21 Del. C. § 2121: 'Gold letters on a blue background, except for license plates provided for in § 2123 ... blue letters on a gold background'; § 2123 'Number plates for state/federal officers and judges'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Delaware  # LOCATOR ONLY: numbers 1, 2 and 3 reserved for the Governor, Lieutenant Governor and Secretary of State"
+    notes: >-
+      OFFICERS AND JUDGES (§ 2123). Carried as `recall-only` because the COLOUR
+      claim is statutory and valuable while the FORMAT claim does not exist —
+      and the schema has no way to record a series with a sourced design and no
+      sourced grammar except by making the grammar honestly wide. That is
+      precisely what §2.7's recall-only tier is for, and this is its third use
+      in the mid-Atlantic group after New York's vintage plates and
+      Pennsylvania's motorcycles.
+
+  # =========================================================================
+  # VANITY — Delaware puts the character cap and the colours in the STATUTE.
+  # =========================================================================
+  - id: us-de-vanity
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2008 }
+    period_evidence: statutory-authority-undated
+    format_evidence: statutory
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: >-
+          21 Del. C. § 2121(h): a vanity plate's characters are 'not to exceed 7
+          in number', at a fee of '$40 annually for each plate in addition to the
+          regular registration fee'. § 2121(i) caps a motorcycle vanity plate at
+          five. THE CAP IS IN THE STATUTE, not on an agency page — Delaware is
+          one of only two jurisdictions in this group where that is true (New
+          York's eight-character cap in VTL § 404 is the other), and the
+          strongest of the two because § 2121 also fixes the colours in the same
+          section.
+    fee: "$40 annually per plate, in addition to the regular registration fee, for both passenger and motorcycle vanity plates (21 Del. C. § 2121(h), (i))"
+    design:
+      background: { color: "#00305E", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8A951"
+      colour_note: "§ 2121: 'Gold letters on a blue background' - stated for vanity plates in terms."
+      legend_top: "THE FIRST STATE"
+      emblem: { present: false }
+    region_encoding: none
+    sources:
+      - "https://delcode.delaware.gov/title21/c021/sc02/index.html  # 21 Del. C. § 2121(h) seven-character vanity cap, 'Gold letters on a blue background', $40 annual fee; § 2121(i) five-character motorcycle vanity cap, $40 annual fee; § 2121 also covers SPECIAL AMATEUR RADIO plates in the same section"
+    notes: >-
+      VANITY. The section heading is 'Number and registration plates; special
+      amateur radio and vanity plates', which bundles AMATEUR RADIO CALL-SIGN
+      plates into the same provision — a class this file does not model because
+      no format source was obtained, but which is worth recording as present:
+      an amateur radio plate's serial is an FCC-issued call sign, i.e. a serial
+      Delaware does not assign at all. That is a genuinely unusual binding and
+      belongs in a later gate.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-de-specialty-index
+    class: specialty
+    categories: [car, truck]
+    period: { start: 2008 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "999999"
+      regex: '\A\d{1,6}\z'
+      regex_strict: '\A[1-9]\d{0,5}\z'
+      charset: { notes: "specialty plates carry the ORDINARY Delaware numeric serial on an alternative background - confirmed by reading DelDOT DMV's own specialty thumbnails, which show a six-digit numeric sample. The numeric space and the no-leading-zeros rule are unchanged." }
+    design:
+      background: { finish: retroreflective }
+      note: "one background or organisational design per approved programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+      eligibility_note: "DelDOT DMV: 'Special plates are restricted to passenger vehicles or trucks with a 3/4-ton or less manufacturers gross vehicle weight rating.' A WEIGHT CEILING ON SPECIALTY ELIGIBILITY - the only weight-keyed plate rule in this group, and the reason this series' categories are [car, truck] and not the full list."
+    program_index:
+      count_official: 149
+      count_official_method: >-
+        ENUMERATED FROM THE AGENCY'S OWN COMPLETE LIST. DelDOT DMV publishes
+        'Delaware License Plates - All Special Tags', alphabetised A-Z; 149
+        distinct plate images were counted on it on 2026-08-02. The agency
+        states no number itself, so this is OUR COUNT OF THE AGENCY'S OWN LIST
+        and is labelled as such — not an agency claim, and not a locator's.
+      count_caveat: "the count is of DISTINCT IMAGE ENTRIES on the all-tags page and will drift as the page changes; snapshot the date with the number. Military and college plates have their own sub-lists which are included in the all-tags page."
+      official_all_tags_url: "https://www.dmv.de.gov/VehicleServices/tags/index.shtml?dc=tags_all"
+      official_military_url: "https://www.dmv.de.gov/VehicleServices/tags/index.shtml?dc=tags_military"
+      official_college_url: "https://www.dmv.de.gov/VehicleServices/tags/index.shtml?dc=tags_college"
+      index_url: "https://www.dmv.de.gov/VehicleServices/tags/index.shtml"
+      creation_threshold: >-
+        DelDOT DMV, in its own words: 'The law requires a minimum of 200
+        applications from a specific organization before the Division may approve
+        the issuance of the plate. There is an exemption for university or high
+        school alumni associations who only need 25 applications. Exemptions have
+        also been written into the law for a number of other organizations, that
+        have been authorized a plate with less than 200 applications.' THE
+        HIGHEST CREATION THRESHOLD IN THIS GROUP by a factor of eight — compare
+        Maryland's 25 owners per class under Md. Transp. § 13-619.
+      black_tag_programme: >-
+        DELAWARE RUNS A HISTORIC BLACK PORCELAIN TAG PROGRAMME THROUGH AN OUTSIDE
+        VENDOR, linked from the DMV's own plate index at dhptags.com. It is
+        recorded here because a vendored plate programme is the same structural
+        arrangement the dossier found in Texas (specialty vendored to
+        MyPlates.com) and it changes who holds the authoritative list. NOT
+        researched further in this pass; the programme's serial rules and its
+        relationship to the ordinary numeric space are a recorded gap.
+      churn_note: "no discontinuation rule was located in Subchapter II; recorded gap."
+    region_encoding: none
+    sources:
+      - "https://www.dmv.de.gov/VehicleServices/tags/index.shtml  # DelDOT DMV: the specialty overview, the 3/4-ton weight ceiling, the 200-application creation threshold and the 25-application alumni exemption, the $50 Keep Delaware Beautiful price, and the link to the Delaware Black Tag Program"
+      - "https://www.dmv.de.gov/VehicleServices/tags/index.shtml?dc=tags_all  # 'Delaware License Plates - All Special Tags', the agency's own complete alphabetical list - the source of the 149 count"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX. Delaware is the BEST specialty case in the
+      mid-Atlantic group: unlike Pennsylvania (search box, unenumerable) and New
+      Jersey (five tracks, no total), DelDOT DMV publishes one complete
+      alphabetical list of every special tag it offers, so an honest count is
+      available by enumeration. It also publishes the statutory creation
+      threshold in plain words, which is the fact that actually predicts how a
+      state's programme grows: at 200 applications Delaware's bar is eight times
+      Maryland's, and its 149 designs against Maryland's unknown and New York's
+      206 is the shape that bar produces.
+
+# ---------------------------------------------------------------------------
+# GAPS.
+# ---------------------------------------------------------------------------
+gaps:
+  - "ARTWORK POSTURE UNRESEARCHED — no Delaware copyright statement, no case, no Commons tag. The default (copyrighted) applies. Write to the Government Information Center; read Title 29 Ch. 100 (Delaware FOIA)."
+  - "The 100-foot daylight legibility sentence could not be attributed to a specific section (§ 2121 or § 2126) from the subchapter extraction."
+  - "§ 2125 (Ownership of plates) text not extracted — it is the statutory root of the low-number market and should be pulled."
+  - "§ 2131 (Effect and duration of temporary registration plates) not extracted — the temporary validity period is unsourced."
+  - "NO SOURCED PLATE DIMENSION — § 2121 delegates size to the Department and no departmental specification was found."
+  - "Colour VALUES are observed; the statute names 'gold' and 'blue' without specifying them."
+  - "Whether manufacturers, dealers and transporters (§ 2124) are serialised apart was not established."
+  - "The Delaware Black Tag Program (dhptags.com) is unresearched — a vendored programme with unknown serial rules."
+  - "Amateur radio call-sign plates (§ 2121) are not modelled: the serial is FCC-issued, not state-issued, which is a binding the schema has not yet met."

--- a/plates/us-md.yml
+++ b/plates/us-md.yml
@@ -1,0 +1,536 @@
+# plates/us-md.yml — Maryland (PRD-PLATES gate L2, mid-Atlantic group).
+#
+# MARYLAND IS THE BEST-LEGISLATED PLATE IN THIS GROUP. Where New York delegates
+# everything and Pennsylvania delegates almost everything, Md. Code, Transp.
+# § 13-410 legislates: how many plates each vehicle CLASS gets, what the plate
+# must display, an OPTIONAL COUNTY-OF-RESIDENCE STICKER, a five-year minimum
+# service life, and — uniquely in this group — AN ACTUAL PLATE DIMENSION IN LAW:
+# § 13-410(g), motorcycle plates 'shall measure 7 inches wide by 4 inches high'.
+# That is the only sourced plate dimension anywhere in the mid-Atlantic pass,
+# and it did not come from SAE J686 (paywalled, unpinned) or from AAMVA — it
+# came from a state legislature.
+#
+# TWO MARYLAND FACTS WORTH THE WHOLE FILE:
+#   1. CLASS F TRACTORS DISPLAY THEIR SINGLE PLATE ON THE FRONT. § 13-411 sends
+#      the one plate to the front for Class F and to the rear for everything
+#      else. Florida legislates the same inversion for truck tractors in
+#      § 320.0706. TWO STATES, INDEPENDENTLY, PUT THE TRACTOR PLATE ON THE
+#      FRONT — which turns what looked like a Florida oddity into a pattern the
+#      dataset should expect elsewhere.
+#   2. MARYLAND'S HISTORIC THRESHOLD IS A FIXED MODEL YEAR, NOT A ROLLING AGE.
+#      § 13-936(a): a historic motor vehicle 'Is a model year of 1999 or
+#      earlier'. New York and New Jersey both use rolling 25-year tests; Florida
+#      uses a fixed 1945 for Horseless Carriage and a rolling 30 for Antique.
+#      A dataset that models only one kind of threshold is wrong about the other.
+#
+# ACCESS NOTE, STATED UP FRONT: mva.maryland.gov returned HTTP 403 to every
+# request in this pass, including with a browser user agent. Everything below
+# therefore comes from the MARYLAND GENERAL ASSEMBLY'S OWN STATUTE SERVICE — the
+# better source under PRD-PLATES §4 anyway (edicts of government beat brochures)
+# — and the agency-only facts, above all the specialty-plate catalogue, are
+# recorded as gaps rather than sourced from elsewhere.
+#
+# period_evidence / format_evidence vocabularies as in us-ny.yml.
+jurisdiction: us-md
+authority:
+  name: Maryland Department of Transportation Motor Vehicle Administration (MDOT MVA)
+  url: "https://mva.maryland.gov/"
+binding: vehicle
+statute_edition: "Annotated Code of Maryland, Transportation Article, Title 13 (Vehicle Laws - Certificates of Title and Registration of Vehicles), as served by mgaleg.maryland.gov and read 2026-08-02."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    NOTHING WAS FOUND, AND THAT IS THE FINDING — the same honest outcome as
+    Delaware. Maryland has NO ENTRY in the Wikipedia survey of subnational
+    copyright status (checked, not assumed); no {{PD-MDGov}} template exists on
+    Wikimedia Commons, in contrast to the neighbouring {{PD-MAGov}} and
+    {{PD-GAGov}} tags that do; and maryland.gov's terms and copyright pages
+    returned 404 on both URL guesses attempted, while mva.maryland.gov refused
+    every request with a 403. No Maryland copyright statement of any kind was
+    read in this pass.
+  posture_default: >-
+    THE DEFAULT APPLIES: 17 U.S.C. § 105 reaches federal works only, so a
+    Maryland state work is COPYRIGHTED UNLESS MARYLAND SAYS OTHERWISE, and
+    Maryland has not been found to say otherwise. Recorded as UNRESEARCHED, not
+    as adverse — the difference matters, because Maryland may well have a
+    favourable public-records posture that simply was not located.
+  what_to_chase: >-
+    Maryland's Public Information Act (Md. Code, Gen. Prov. §§ 4-101 et seq.) is
+    the statutory hook to read for the records-access-versus-copyright question
+    that produced Florida's and New Jersey's favourable answers. The Maryland
+    State Archives and the Department of Information Technology are the two
+    bodies most likely to publish a reuse statement.
+  emblem_rule: >-
+    RENDER PLACEHOLDER, AND MARYLAND IS THE HARDEST CASE IN THE GROUP TO RENDER
+    LEGITIMATELY. The standard plate's whole lower half is the MARYLAND STATE
+    FLAG — the Calvert and Crossland quarterings — which is not a decorative
+    graphic but the state's heraldic device. State flags and seals carry
+    protection INDEPENDENT of copyright under misuse statutes, exactly as
+    PRD-PLATES §4.5 flags, and that question is unresearched here as it is
+    everywhere. A neutral placeholder in the flag slot is the only defensible
+    v1 render.
+  photograph_caution: "Standard §4 reading: Commons photographs carry the photographer's licence on the photograph and say nothing about the design. No Maryland image was fetched in this pass — MVA refused every request."
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: Maryland has NO ENTRY in this survey - checked, not assumed"
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # the state-exclusion rule and the roster of state PD tags that exist - Maryland is absent from it"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Voluntary; J686 never quoted — AND MARYLAND SHOWS WHY
+# THAT RULE IS SURVIVABLE.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: >-
+      AAMVA §3.1 sends plate dimensions and bolt holes to SAE J686, whose text is
+      paywalled and was NOT obtained, so no J686 dimension is quoted anywhere in
+      this dataset. MARYLAND ROUTES AROUND THE PROBLEM: § 13-410(g) states a
+      dimension in law — 'Class D (motorcycle) registration plates shall measure
+      7 inches wide by 4 inches high'. That is a fully sourced, freely quotable
+      US plate dimension obtained without touching J686, and it is the first one
+      in this dataset. The passenger-plate dimension remains unsourced because
+      Maryland does not state it.
+    retroreflectivity: >-
+      AAMVA §3.3 recommends retroreflective materials per ASTM D4956-19 and
+      ISO 7591:1982. Maryland makes reflectorisation a BUDGET question, not a
+      design one: § 13-410(d) requires plates manufactured to last at least five
+      years and provides that reflectorization requires General Assembly budget
+      approval. A legislature conditioning a plate's optical properties on an
+      appropriation is a modelling fact nothing else in this dataset shows.
+    replacement_cycle: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. Maryland legislates a MINIMUM SERVICE LIFE instead — five years under § 13-410(d) — plus a condition-triggered power in § 13-410(e)(3) for the Administrator to evaluate plate condition and issue new plates as needed. A floor plus discretion, where Florida sets a ceiling and Pennsylvania mandates a programme."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' is UNCITED in its Wikipedia source and is recorded as COMMONLY REPEATED, UNSOURCED. Maryland's 7x4 inch motorcycle plate is instead cited to § 13-410(g), which states it in law."
+
+# ---------------------------------------------------------------------------
+# Display rules — legislated by VEHICLE CLASS, which is what makes Maryland
+# unusual. The plate COUNT is a function of the registration class.
+# ---------------------------------------------------------------------------
+display_rules:
+  plate_count_by_class: >-
+    § 13-410(a)(1): the Administration issues ONE registration plate for a Class
+    D (motorcycle), Class F (tractor), Class G (trailer), Class L (historic)
+    vehicle manufactured at least 50 years before the current model year, or
+    Class N (street rod) vehicle manufactured at least 50 years before the
+    current model year; and TWO registration plates 'for every other vehicle'.
+    § 13-410(a)(2): for a temporary registration the Administration may provide
+    only one plate. NOTE THE COMPOUND TEST ON CLASSES L AND N — a historic
+    vehicle gets one plate only if it is ALSO at least 50 model years old, so a
+    1999-model historic vehicle gets TWO plates while a 1965 one gets one.
+  display_position: "§ 13-411: two-plate vehicles display front and rear. For single-plate vehicles the plate goes on the FRONT for Class F (tractor) and on the REAR for all others."
+  front_plate_outlier: >-
+    MARYLAND PUTS THE TRACTOR PLATE ON THE FRONT — the same inversion Florida
+    legislates in § 320.0706 for truck tractors. Two states reaching the same
+    unusual rule independently makes this a PATTERN to look for, not a Florida
+    quirk. Any consumer modelling 'front plate required?' as a single per-state
+    boolean will be wrong about both states.
+  legibility: "§ 13-411: plates shall be 'maintained free from foreign materials' and 'in a condition to be clearly legible'."
+  mounting: "§ 13-411: plates shall be 'securely fastened' horizontally, in a manner that prevents swinging, and shall remain 'clearly visible'."
+  prohibitions: "§ 13-411: no display of expired plates, no display of plates issued to another vehicle, and vintage plates only under the specific conditions the section states."
+  validation_tabs: "§ 13-410(e): the Administrator may order continued use of valid plates with ANNUAL VALIDATION TABS evidencing payment of the registration fee, displayed as the Administrator requires, and may evaluate plate condition and issue new plates as needed."
+  sources:
+    - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-410&enactments=false  # Md. Code, Transp. § 13-410: (a)(1) one plate for Classes D, F, G and 50-year-old L and N, two for every other vehicle; (a)(2) one temporary plate; (b) plate content; (c) the county sticker option; (d) five-year service life and the reflectorization appropriation; (e) validation tabs; (f) §§ 13-618/13-619 reflectorized plates; (g) MOTORCYCLE PLATES 7 IN WIDE BY 4 IN HIGH; (h) return by mail"
+    - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-411&enactments=false  # Md. Code, Transp. § 13-411: front and rear for two-plate vehicles; FRONT for single-plate Class F tractors and REAR for all other single-plate vehicles; free from foreign materials, clearly legible, securely fastened horizontally, no swinging, clearly visible; the expired-plate, wrong-vehicle and vintage-plate prohibitions"
+
+# ---------------------------------------------------------------------------
+# REGION ENCODING — Maryland's county marker is a STICKER, and it is OPTIONAL.
+# ---------------------------------------------------------------------------
+region_encoding_note:
+  mechanism: sticker-optional
+  text: >-
+    § 13-410(c) lets the owner of a Class A (passenger), Class E (truck
+    registered under § 13-917) or Class M (multipurpose) vehicle OPTIONALLY
+    display a sticker indicating the COUNTY OF RESIDENCE on the registration
+    plate. The Administration approves the designs and must offer the option to
+    applicants; it may charge a fee not exceeding its costs. An owner MAY NOT
+    display a sticker for a county other than their own, and county stickers may
+    NOT be placed on special or commemorative plates.
+  consequence: >-
+    THE COUNTY IS NEVER IN THE SERIAL. Maryland's geography is an optional
+    adhesive on the plate face, so a Maryland serial decodes to nothing
+    geographic and a Maryland PHOTOGRAPH may decode to a county that the serial
+    cannot. It is the mirror image of Florida, where the county appears as a
+    printed LEGEND subject to a county-commission opt-out. Two states, two
+    different ways of putting a county on a plate, and neither puts it in the
+    number — which is a real finding about US plates as a class: unlike Germany,
+    Spain or Italy, US serials are geographically opaque.
+  source: "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-410&enactments=false  # § 13-410(c)(1)-(6)"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES.
+  # =========================================================================
+  - id: us-md-maryland-proud
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2016 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "9LL9999"
+      regex: '\A\d[A-Z]{2}\d{4}\z'
+      charset:
+        notes: >-
+          THE STATUTORY CONSTRAINT IS TWO SENTENCES. § 13-410(b)(1): 'Each
+          registration plate shall display the registration number assigned to
+          the vehicle and the name of Maryland, which may be abbreviated.'
+          § 13-410(b)(2): 'The registration number may consist of letters,
+          numerals, or both.' No length, no alphabet, no exclusions — the same
+          shape as Florida's statute minus Florida's seven-character cap. No
+          Maryland letter exclusions are published anywhere.
+      pattern_note: >-
+        NO PRINTED SEPARATOR ON THIS BASE. The locator writes the current format
+        as 1AB2345 with no separator glyph, in deliberate contrast to the base
+        before it, which it writes as 1A/B2345 — the slash standing for the US
+        flag graphic that base printed between the second and third characters.
+        Maryland therefore DROPPED its graphic separator at the 2016 base change,
+        which is the mirror of what Pennsylvania did with its hyphen in 2025.
+      progression: "reported to run 8CN0000 onward, reaching 1HA3202 as of 7 March 2026 (locator). The leading digit CYCLES rather than counting, which is why the reported progression appears to run backwards from 8 to 1."
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1A1A1A"
+      colour_note: >-
+        NO COLOUR VALUE IS IN THE STATUTE. § 13-410 states plate CONTENT, service
+        life and dimensions for motorcycles, and says nothing about hue;
+        § 13-410(d) treats reflectorisation as a budget matter. Black embossed
+        characters on reflective white with the state name in RED are reported
+        and observed; all three are `hex_basis: observed`.
+      legend_top: "Maryland"
+      legend_top_colour: { value: "#C8102E", hex_basis: observed, note: "the state name is screened in RED, unusually - most US plates set the jurisdiction name in the same colour as the serial" }
+      graphic:
+        present: true
+        rendered: placeholder
+        description: "THE MARYLAND STATE FLAG, screened across the whole lower half of the plate. This is the state's heraldic device, not an illustration, and it is the reason Maryland's emblem_rule is the strictest in this group."
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      manufacture: "serial EMBOSSED, flag SCREENED (locator) - a mixed-process plate, which matters to a render that models relief."
+      service_life: "at least five years by statute (§ 13-410(d))"
+      dimension_note: "NO SOURCED DIMENSION FOR THE PASSENGER PLATE. Maryland states one only for motorcycles (§ 13-410(g), 7 in x 4 in); SAE J686 is unpinned."
+    county_sticker: { available: true, basis: "§ 13-410(c) - optional, county of residence only, not on special or commemorative plates. See region_encoding_note." }
+    region_encoding: "none in the serial; see region_encoding_note for the optional county STICKER, which is the only geographic marker Maryland puts on a plate."
+    sources:
+      - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-410&enactments=false  # § 13-410(b) the plate must display the registration number and the name of Maryland; the number 'may consist of letters, numerals, or both'; (c) the county sticker; (d) the five-year service life"
+      - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-411&enactments=false  # § 13-411 display: front and rear for this class of vehicle"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maryland  # LOCATOR ONLY (PRD-PLATES §4): 'Maryland Proud' from 26 September 2016, 1AB2345 from 8CN0000 to 1HA3202 (7 March 2026), black embossed serial on reflective white with the state flag screened in the bottom half and 'Maryland' screened in red at the top"
+    notes: >-
+      MARYLAND PROUD (2016-) — THE CURRENT STANDARD ISSUE. The statute is strong
+      and the DESIGN HISTORY is weak, and the file says so: everything about the
+      plate's legal frame is § 13-410, and everything about which design is
+      current, when it started and what serial it started at is locator-grade,
+      because mva.maryland.gov refused every request in this pass with an HTTP
+      403. That is the single most important gap in this file. PARALLEL
+      ISSUANCE: Maryland's five-year minimum service life is a FLOOR, not a
+      ceiling, and no recall of the 2010 base was located, so War of 1812 plates
+      remain current registrations — which is why the two series overlap at 2016
+      with distinct notes.
+
+  # =========================================================================
+  # ONE SERIES BACK — and the one that printed a FLAG inside its serial.
+  # =========================================================================
+  - id: us-md-war-of-1812
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2010, end: 2016 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "9L L9999"
+      regex: '\A\d[A-Z] ?[A-Z]\d{4}\z'
+      charset: { notes: "as the current base - no statutory charset. Reported range 1M/D0000 to 9M/D9999, then 1A/A0000 to approximately 7C/N9999." }
+      separator_note: >-
+        THE SEPARATOR ON THIS BASE IS A GRAPHIC, NOT A CHARACTER. The locator
+        writes the format as 1A/B2345, using a slash to stand for the US flag
+        device the plate printed between the second and third characters. The
+        dataset spells the gap as an EMITTED SPACE and carries the flag in
+        `design.graphic`, on exactly the reasoning `_meta/separators.yml`'s
+        `never_separator_note` gives for German and Austrian coats of arms, and
+        exactly as New Jersey's state-outline separator is handled in us-nj.yml.
+        A SOLIDUS could not be spelled even if it were printed: '/' is in the
+        FORGIVING set but not the EMITTED set, so the lint would reject it.
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003087"
+      colour_note: "blue on reflective white (locator); `hex_basis: observed`. No colour value in statute."
+      legend_top: "Maryland"
+      graphic:
+        present: true
+        rendered: placeholder
+        description: "War of 1812 bicentennial commemorative: a US flag device (which doubles as the serial separator) and a Fort McHenry silhouette. A COMMEMORATIVE DESIGN SERVING AS THE STANDARD ISSUE for six years — Maryland ran its bicentennial plate as the default base, which is a policy choice most states reserve for optional specialty plates."
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+    county_sticker: { available: true, basis: "§ 13-410(c)" }
+    region_encoding: "none in the serial; optional county sticker per § 13-410(c)."
+    sources:
+      - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-410&enactments=false  # the statutory frame is unchanged across the base change - § 13-410 did not move"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maryland  # LOCATOR ONLY: War of 1812 200th anniversary commemorative, 14 June 2010 to 25 September 2016, blue on reflective white with US flag and Fort McHenry silhouette, format 1A/B2345 from 1M/D0000"
+    notes: >-
+      WAR OF 1812 (2010-2016) — THE PREVIOUS BASE. It matters to the schema out
+      of proportion to its age because it is the second GRAPHIC SEPARATOR in the
+      mid-Atlantic group after New Jersey's state outline, and the two together
+      establish that a US plate's serial gap being filled by a device is a
+      RECURRING pattern rather than a one-off. `end: 2016` closes ISSUANCE, not
+      validity: these plates are still lawfully on Maryland roads.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES.
+  # =========================================================================
+  - id: us-md-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2016 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "999Y99"
+      regex: '\A\d{3}Y\d{2}\z'
+      charset:
+        notes: >-
+          The Y IS A LITERAL CLASS MARKER, not a placeholder — the locator gives
+          the reported range as 000Y01 onward, which fixes Y in the fourth
+          position across the whole series. Maryland has moved the marker around
+          repeatedly: reported arrangements run 123M45 (2003-06), 1D2345
+          (2006-09), D12345 (2009-10), 12345Y (2010-16) and 123Y45 (2016-),
+          i.e. the class letter has migrated from the middle to the front to the
+          end and back to the middle in twenty years. Only the current
+          arrangement is given a series.
+    design:
+      plate: { w: 7, h: 4, unit: in, w_mm: 177.8, h_mm: 101.6 }
+      plate_dimension_note: >-
+        § 13-410(g), IN LAW: 'Class D (motorcycle) registration plates shall
+        measure 7 inches wide by 4 inches high.' THE ONLY SOURCED PLATE
+        DIMENSION IN THE ENTIRE MID-ATLANTIC GROUP, and it did not come through
+        the AAMVA/J686 chain — a state legislature simply stated it. It is
+        recorded here in inches as the statute gives it, with the millimetre
+        conversion computed, not sourced.
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1A1A1A"
+      legend_top: "Maryland"
+      graphic: { present: true, rendered: placeholder, description: "as the Maryland Proud passenger base (locator)" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-410&enactments=false  # § 13-410(g): 'Class D (motorcycle) registration plates shall measure 7 inches wide by 4 inches high'; § 13-410(a)(1)(i) one plate for Class D"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maryland  # LOCATOR ONLY: 123Y45 from December 2016, range 000Y01 onward, and the five superseded motorcycle arrangements"
+    notes: >-
+      MOTORCYCLE (CLASS D) — THE ONLY SERIES IN THIS GROUP WITH A DIMENSION.
+      § 13-410(g)'s 7 x 4 inches is the answer to a question the whole US slice
+      has been unable to answer since SAE J686 turned out to be paywalled: it
+      shows that per-state statutes CAN supply renderable geometry, and that the
+      right research move for US dimensions is to read fifty vehicle codes rather
+      than to buy one SAE standard.
+
+  - id: us-md-state-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2014 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    binding: business
+    format:
+      pattern: "99999"
+      regex: '\A\d{5}\z'
+      charset:
+        notes: >-
+          Five numerals. THE CLASS MARKER IS NOT IN THE SERIAL: the locator
+          writes the format as '12345 S/G', where S/G is a legend printed after
+          the number rather than a serial token. THE DATASET CANNOT SPELL IT
+          EVEN IF IT WANTED TO — SOLIDUS is in `_meta/separators.yml`'s FORGIVING
+          set but not its EMITTED set, so a literal '/' in a pattern or regex is
+          a lint failure by design. It is therefore carried as `legend_bottom`,
+          which is where it belongs: it is printed matter, not serial.
+    design:
+      background: { finish: retroreflective }
+      foreground: "#1A1A1A"
+      legend_top: "Maryland"
+      legend_bottom: "S/G"
+      emblem: { present: true, rendered: placeholder }
+    fee_exemption: "Md. Code, Transp. § 13-903 exempts from registration fees vehicles owned by 'The United States, this State, or any political subdivision', volunteer fire companies and rescue squads, Civil Air Patrol units, veterans' organisations and Red Cross chapters — and requires that 'Each registered vehicle that is exempt from registration fees under subsection (a) of this section shall display a SPECIAL IDENTIFICATION MARKER approved by the Administrator.' The government plate is that marker's statutory home."
+    region_encoding: none
+    sources:
+      - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-903&enactments=false  # § 13-903: the registration-fee exemption list and the special identification marker requirement"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maryland  # LOCATOR ONLY: state government '12345 S/G' from 2014"
+    notes: >-
+      STATE GOVERNMENT. The statutory hook (§ 13-903's 'special identification
+      marker') is solid; the serial form is locator-grade. The S/G legend is a
+      small but clean demonstration of the separator contract doing its job —
+      the dataset's refusal to spell a solidus forced the marker into the design
+      layer, which is where it actually lives on the plate.
+
+  - id: us-md-local-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2014 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    binding: business
+    format:
+      pattern: "99999"
+      regex: '\A\d{5}\z'
+      charset: { notes: "five numerals with an L/G legend, on the same reasoning as the S/G series above. NOTE THE CONSEQUENCE: state and local government serials are drawn from the same shape, so the SERIAL ALONE CANNOT DISTINGUISH THEM - only the legend can. Maryland's government plates are the second ambiguity of this kind in the group, after Delaware's motorcycle/passenger numerics." }
+    design:
+      background: { finish: retroreflective }
+      foreground: "#1A1A1A"
+      legend_top: "Maryland"
+      legend_bottom: "L/G"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-903&enactments=false  # § 13-903 exempts vehicles of 'any political subdivision' and requires the special identification marker"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Maryland  # LOCATOR ONLY: local government '12345 L/G' from 2014"
+    notes: >-
+      LOCAL GOVERNMENT. Its own series because the legend differs and the
+      issuing population differs (political subdivisions rather than the State),
+      but sharing a serial shape with the state series — which is exactly the
+      case that forces a parse API to return multiple candidates rather than one
+      answer.
+
+  # =========================================================================
+  # HISTORIC — Maryland's threshold is a FIXED MODEL YEAR and the use
+  # restrictions are the most detailed in the group.
+  # =========================================================================
+  - id: us-md-historic
+    class: historic
+    categories: [car, truck, motorcycle]
+    period: { start: 2016 }
+    period_evidence: statutory-authority-undated
+    format_evidence: secondary-locator-unverified
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9]){0,7}\z'
+      charset:
+        notes: >-
+          NO FORMAT SOURCE EXISTS. § 13-936(f) says only that the Administration
+          'shall issue a special, historic motor vehicle registration plate OF
+          THE SIZE AND DESIGN THAT THE ADMINISTRATION DETERMINES', and the
+          determination was not obtained (mva.maryland.gov 403). `matching:
+          recall-only` is the honest encoding: this regex is a deliberately wide
+          catch-all over Maryland-shaped serials and a match is a shape hit only,
+          never a claim that the string is a valid historic registration.
+    eligibility:
+      definition: "§ 13-936(a): a 'historic motor vehicle' means a motor vehicle, including a passenger vehicle, motorcycle or truck, that (1) 'Is a model year of 1999 or earlier'; (2) 'Has not been substantially altered from the manufacturer's original design'; and (3) meets criteria in regulations adopted by the Administration."
+      exclusion: "§ 13-936(b): the definition 'does not include a vehicle that has been remanufactured or reconstructed as a replica of an original vehicle'."
+      threshold_type: fixed-model-year
+      threshold_note: >-
+        MARYLAND'S THRESHOLD IS FIXED AT MODEL YEAR 1999 AND DOES NOT ROLL. It
+        will therefore ADMIT NO NEW VEHICLES EVER, and the eligible population
+        shrinks every year as 1999-and-earlier cars leave the road — the exact
+        opposite dynamic to New York's and New Jersey's rolling 25-year tests,
+        which admit a new model year annually. Florida runs BOTH kinds at once
+        (fixed 1945 Horseless Carriage, rolling 30-year Antique). Only the
+        rolling kind needs annual re-auditing; the fixed kind needs watching for
+        a legislative bump.
+      use_restriction: "§ 13-936(e): the owner must certify that the vehicle 'Will be maintained for use in exhibitions, club activities, parades, tours, and occasional transportation' and 'Will not be used' (i) for general daily transportation; (ii) primarily for the transportation of passengers or property on highways; (iii) for employment; (iv) for transportation to and from employment or school; or (v) for commercial purposes."
+    fees: "§ 13-936(d): annual registration fee $45.50 on or after 1 July 2024 but before 1 July 2025, and $55.50 on or after 1 July 2025. § 13-936(i): for a vehicle manufactured at least 60 years before the current model year there is instead a ONE-TIME $50 registration fee, and that registration is NOT TRANSFERABLE to a subsequent owner."
+    exemptions: "§ 13-936(g): no specific equipment is required unless a Maryland statute required it as a condition of sale when the vehicle was manufactured. § 13-936(h): a vehicle of model year 1985 or earlier is exempt from statutory inspection requirements, and ANY vehicle registered under this section is exempt from emission-control use and inspection requirements."
+    plate_count: "ONE plate if the vehicle was manufactured at least 50 years before the current model year, TWO otherwise (§ 13-410(a)(1)(i)4). A compound test that splits the historic class in half by age."
+    design:
+      background: { finish: retroreflective }
+      legend_top: "Maryland"
+      note: "size and design are whatever the Administration determines (§ 13-936(f)); no determination was obtained."
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-936&enactments=false  # Md. Code, Transp. § 13-936: (a) the fixed model-year-1999 definition and the not-substantially-altered test; (b) the replica exclusion; (c) Class L; (d) the $45.50 / $55.50 fees; (e) the five-part use restriction and the certification; (f) 'of the size and design that the Administration determines'; (g) the equipment exemption; (h) the 1985 inspection exemption and the blanket emissions exemption; (i) the 60-year one-time $50 non-transferable registration"
+      - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-410&enactments=false  # § 13-410(a)(1)(i)4: one plate for a Class L vehicle manufactured at least 50 years before the current model year"
+    notes: >-
+      HISTORIC (CLASS L) — THE RICHEST ELIGIBILITY TEXT IN THE MID-ATLANTIC
+      GROUP AND NO FORMAT AT ALL. That combination is why `recall-only` exists:
+      Maryland tells us precisely who may hold this plate, for what uses, at
+      what fee, with what inspection consequences, and then hands the plate's
+      appearance and numbering entirely to the Administration, whose site
+      refused every request. A verifier who can reach mva.maryland.gov closes
+      this in one page. Note also the § 13-936(i) 60-year one-time fee makes the
+      REGISTRATION non-transferable — a rare case of a US plate right dying with
+      the owner, the opposite of Delaware's tradeable low numbers.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Statute only; the
+  # agency catalogue was unreachable.
+  # =========================================================================
+  - id: us-md-specialty-index
+    class: specialty
+    categories: [car, truck, motorcycle]
+    period: { start: 2016 }
+    period_evidence: statutory-authority-undated
+    format_evidence: statutory
+    matching: strict
+    format:
+      pattern: "9LL9999"
+      regex: '\A\d[A-Z]{2}\d{4}\z'
+      charset:
+        notes: >-
+          § 13-619 gives the organisation a genuine say in its own serial:
+          organisations may choose plates featuring 'any combination of letters,
+          numerals, or both' together with the organisation's name, initials or
+          abbreviation, optionally including 'an emblem or logo as authorized by
+          the Administration'. SO A MARYLAND SPECIALTY SERIAL IS NOT NECESSARILY
+          THE STANDARD ARRANGEMENT — the statute permits per-organisation
+          grammars. The regex here describes the standard arrangement and is
+          therefore narrower than the statute allows; the catalogue that would
+          reveal the exceptions is behind the 403.
+    design:
+      background: { finish: retroreflective }
+      note: "one design per approved organisation; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: null
+      count_official_note: >-
+        NO COUNT WAS OBTAINED AND NONE IS INVENTED. MDOT MVA's plate pages
+        (mva.maryland.gov/vehicles/Pages/licenseplates/general.aspx and
+        .../organizational.aspx) returned HTTP 403 to every request in this pass,
+        including with a browser user agent, so Maryland's specialty catalogue
+        is UNREAD. This is a pure access failure, not an absence of data.
+      creation_threshold: "§ 13-619: 'At least 25 vehicle owners in each class must apply initially.' THE LOWEST CREATION BAR IN THE MID-ATLANTIC GROUP — one eighth of Delaware's 200. Two states, two orders of magnitude, and it is the single best predictor of how many designs a state ends up with."
+      eligible_classes: "§ 13-619: Class A (passenger), Class E (truck of manufacturer's rated capacity one ton or less) and Class M (multipurpose); motorcyclists may register Class D vehicles if members of exempt organisations."
+      design_authority: "§ 13-619: organisations may choose 'any combination of letters, numerals, or both' with the organisation's name, initials or abbreviation, and optionally 'an emblem or logo as authorized by the Administration'."
+      fee_rule: "§ 13-619: an additional fee applies when new plates are issued, and the Administration 'may not exceed the amount required to enable the Administration to recover its costs'. COST-RECOVERY ONLY — Maryland does not use its specialty programme as a revenue instrument the way Florida's annual use fees do."
+      fee_exemptions: "§ 13-619 exempts from the fee certain vehicles and those honouring the Maryland National Guard or volunteer emergency services; a SURVIVING SPOUSE may qualify where the deceased spouse held an active special registration number."
+      official_urls:
+        - "https://mva.maryland.gov/vehicles/Pages/licenseplates/general.aspx  # HTTP 403 in this pass - unread"
+        - "https://mva.maryland.gov/vehicles/Pages/licenseplates/organizational.aspx  # HTTP 403 in this pass - unread"
+      churn_note: "no discontinuation rule was located in § 13-619; recorded gap."
+    region_encoding: "none. NOTE § 13-410(c)(6): county stickers may NOT be placed on special or commemorative plates - so a Maryland specialty plate cannot carry the county marker the standard plate can."
+    sources:
+      - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-619&enactments=false  # Md. Code, Transp. § 13-619: the nonprofit-organisation special plate, the 25-owner threshold per class, the eligible vehicle classes, the letters/numerals/emblem design latitude, cost-recovery-only fees, the National Guard and volunteer emergency service exemptions, and the surviving-spouse provision"
+      - "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtr&section=13-410&enactments=false  # § 13-410(c)(6): county stickers may not be placed on special or commemorative plates; § 13-410(f): reflectorized plates may be issued under §§ 13-618 and 13-619"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — STATUTE-ONLY, BY NECESSITY. Maryland is the
+      inverse of Delaware: Delaware publishes a complete list and no statutory
+      threshold in plain sight, Maryland publishes a precise statutory threshold
+      and a catalogue nobody outside can read. Recording the 25-owner bar and an
+      explicit null count is the honest output, and the 403 is the named,
+      fixable obstacle. A verifier on a residential connection will very likely
+      get straight through.
+
+# ---------------------------------------------------------------------------
+# CLASSES MARYLAND ISSUES THAT ARE DELIBERATELY NOT MODELLED AS SERIES.
+# ---------------------------------------------------------------------------
+unmodelled_classes:
+  trailer: "Class G trailers get ONE plate under § 13-410(a)(1)(i)3, so the class is statutory — but no trailer serial format was obtained from any source. Recorded gap rather than an invented pattern."
+  dealer: "Maryland registers dealers and issues dealer plates, but no format source was obtained and § 13-903 (which was read) turned out to be the fee-exemption section rather than the dealer-plate section. The dealer-plate provision was not located in this pass."
+  temporary: "the locator reports a 60-day BLUE ON WHITE CARDBOARD temporary registration, machine-printed, in use since 2013. § 13-410(a)(2) confirms the class statutorily ('only one temporary registration plate for any vehicle'), but no serial format was obtained. Recorded gap."
+  street_rod: "Class N street rod vehicles are named in § 13-410(a)(1)(i)5 and get one plate when at least 50 model years old. No format, no eligibility text obtained (§ 13-936.1 is cross-referenced by § 13-936(f) and was not pulled). Recorded gap."
+
+# ---------------------------------------------------------------------------
+# GAPS.
+# ---------------------------------------------------------------------------
+gaps:
+  - "mva.maryland.gov RETURNED 403 TO EVERY REQUEST, including with a browser user agent. The specialty catalogue, the historic plate design determination, the trailer/dealer/temporary formats and every agency-stated design fact are unread because of it. THIS IS THE SINGLE LARGEST FIXABLE GAP IN THE MID-ATLANTIC GROUP."
+  - "ARTWORK POSTURE UNRESEARCHED — no Maryland copyright statement located; maryland.gov terms pages 404'd on both guesses. Read the Maryland Public Information Act."
+  - "NO SOURCED DIMENSION FOR THE PASSENGER PLATE — only the motorcycle plate is dimensioned in law (§ 13-410(g))."
+  - "NO SOURCED COLOUR VALUE; § 13-410 states none and treats reflectorisation as an appropriation question."
+  - "Base-design years (2016, 2010) and all serial ranges are locator-grade."
+  - "COMAR Title 11 Subtitle 15 (the MVA regulations § 13-936(a)(3) and § 13-619 delegate to) was not obtained — dsd.maryland.gov redirects to regs.maryland.gov and the target 404'd."
+  - "§ 13-936.1 (cross-referenced from § 13-936(f), presumably street rod plates) not pulled."

--- a/plates/us-nj.yml
+++ b/plates/us-nj.yml
@@ -1,0 +1,547 @@
+# plates/us-nj.yml — New Jersey (PRD-PLATES gate L2, mid-Atlantic group).
+#
+# THE FINDING THIS FILE EXISTS FOR: NEW JERSEY'S SEPARATOR IS NOT A CHARACTER.
+# The gap in the middle of a New Jersey serial is occupied by a SILHOUETTE OF
+# THE STATE, embossed or screened between the third and fourth characters. That
+# is not typography and it is not punctuation — it is a design element sitting
+# in a serial gap, which is precisely the case `_meta/separators.yml`'s
+# `never_separator_note` already contemplates for German and Austrian coats of
+# arms. It was confirmed here TWICE and independently: from NJ MVC's own sample
+# plate image, which reads SAM<state outline>PLE, and from the locator's own
+# wording, which calls it a 'state-shaped separator'. This file therefore spells
+# the gap as an EMITTED SPACE and carries the glyph in `design`, never in the
+# serial. See `separator_finding`.
+#
+# WHY NEW JERSEY IS THE FAVOURABLE ARTWORK CASE IN THIS GROUP. Unlike its two
+# neighbours — New York adverse, Pennsylvania adverse by statute — New Jersey
+# affirmatively invites reuse: the State's own legal statement says 'anyone may
+# view, copy or distribute State information found here without obligation to
+# the State'. See `artwork_risk`.
+#
+# SOURCING RULE APPLIED HERE. New Jersey's plate law is DISPLAY law: N.J.S.A.
+# 39:3-33 governs where a plate goes and how legible it must be, and specifies
+# nothing about design, colour, dimension or serial grammar. So the statute
+# carries display, NJ MVC's own pages carry the charset, the historic and street
+# rod grammars, the plate categories and the dedicated-plate list, and the
+# passenger ARRANGEMENT is locator-grade and labelled per series.
+#
+# period_evidence / format_evidence vocabularies as in us-ny.yml.
+jurisdiction: us-nj
+authority:
+  name: New Jersey Motor Vehicle Commission (NJ MVC)
+  url: "https://www.nj.gov/mvc/"
+binding: vehicle
+statute_edition: "New Jersey Revised Statutes Title 39 (Motor Vehicles and Traffic Regulation), read 2026-08-02 through a third-party reproduction (see the sourcing caveat on 39:3-33). Edicts of government are public domain at every level, so the reproduction carries the text faithfully, but the OFFICIAL New Jersey Legislature service was not reachable in this pass and that is recorded as a gap."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: public-domain-favourable
+  basis: >-
+    New Jersey affirmatively permits reuse of State information. The State of
+    New Jersey's own Legal Statement and Disclaimers says, in terms, that
+    'anyone may view, copy or distribute State information found here without
+    obligation to the State'. The Wikipedia survey of subnational copyright
+    status places New Jersey in the favourable column on the same basis and adds
+    two supports: Burnett v. County of Bergen, 402 N.J. Super. 319 (2008), read
+    as permitting commercial reproduction of records obtained under OPRA, and
+    the New Jersey Open Data Initiative Act (N.J.S.A. 52:18A-234.5), which makes
+    covered State data 'license-free, subject to reuse, and not subject to
+    copyright restrictions'.
+  evidence_grade: >-
+    THE STATE'S OWN LEGAL STATEMENT WAS FETCHED AND IS QUOTED — that is a
+    primary, agency-published source and the strongest artwork evidence in the
+    mid-Atlantic group after nothing at all. The Burnett opinion and the Open
+    Data Initiative Act were NOT fetched; they are recorded as citations located
+    through a locator, for a verifier to pull. The State's statement also
+    carries its own hedge — it makes no warranty that a particular item is free
+    of third-party copyright or trademark — so 'favourable' means the STATE does
+    not assert, not that every element on a plate is clear.
+  emblem_rule: >-
+    RENDER PLACEHOLDER ANYWAY. New Jersey's favourable posture is about
+    COPYRIGHT; the state silhouette that sits inside every standard serial, and
+    the State seal, carry protection INDEPENDENT of copyright under state-seal
+    misuse statutes, and that question is unresearched here exactly as it is for
+    Florida. `graphic: {present: true, rendered: placeholder}` stands until the
+    seal question is answered per-emblem.
+  photograph_caution: >-
+    Commons photographs of New Jersey plates are the photographer's licence on
+    the photograph; the uploader had no standing over the design. Because our
+    renders are generated from data, those share-alike obligations never attach.
+    NJ MVC's own sample-plate image was READ (to establish the separator finding)
+    and is NOT copied into the dataset.
+  sources:
+    - "https://www.nj.gov/nj/legal.shtml  # State of New Jersey Legal Statement and Disclaimers, section F: 'anyone may view, copy or distribute State information found here without obligation to the State', with the State's own no-warranty hedge"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: surfaces Burnett v. County of Bergen, 402 N.J. Super 319 (2008) and N.J.S.A. 52:18A-234.5 (Open Data Initiative Act). Neither was fetched."
+
+# ---------------------------------------------------------------------------
+# THE SEPARATOR FINDING (PRD-PLATES §2.6 / §2.8).
+# ---------------------------------------------------------------------------
+separator_finding:
+  headline: "New Jersey prints a state-outline GRAPHIC in the serial gap."
+  observed: >-
+    NJ MVC's official 'Standard Plate Example' image (www.nj.gov/mvc/images/standard.jpg,
+    fetched and read 2026-08-02) shows the serial SAM<state outline>PLE: three
+    characters, a solid silhouette of New Jersey occupying the gap, three more
+    characters. The locator independently describes the 1993 and later bases as
+    carrying a 'state-shaped separator' added to the serial, and describes the
+    2014 base as having 'serial and separator screened rather than embossed' —
+    i.e. the separator is a printed OBJECT with a manufacturing method, not a
+    character.
+  encoding_decision: >-
+    The gap is spelled as an EMITTED SPACE (U+0020) in `pattern` and as an
+    optional space in `regex`, and the silhouette is carried in `design.graphic`.
+    This is the treatment `_meta/separators.yml` already prescribes for the
+    analogous case: its `never_separator_note` names 'the coats of arms / seals
+    that sit between groups on several German and Austrian plates (a design
+    element, carried in `design.emblem`, never in the serial)'. New Jersey is
+    that case in the United States, and the group's first one.
+  recommended_amendment: >-
+    Add the New Jersey state silhouette to `_meta/separators.yml`'s
+    `never_separator` list by name, with this citation, so the rule is stated
+    once for consumers rather than rediscovered per jurisdiction. No behaviour
+    changes — a separator-stripping consumer already deletes the space and can
+    never see the glyph — but the dataset should say why the space is there.
+  source: "https://www.nj.gov/mvc/vehicles/standplates.htm  # links the official 'Standard Plate Example' image at /mvc/images/standard.jpg, which is where the silhouette was read"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Voluntary; J686 never quoted.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is paywalled and was NOT obtained. New Jersey states no plate dimension in Title 39. This file therefore carries NO sourced dimension — a recorded gap."
+    retroreflectivity: "AAMVA §3.3: readable 'in both daylight and nighttime from distances of at least 75 feet'. New Jersey legislates a DIFFERENT and stricter-sounding night rule of its own — the rear plate must be illuminated so as to be visible from 50 feet at night — which is a LIGHTING duty on the vehicle, not a retroreflectivity duty on the plate. The two are not the same claim and are not merged here."
+    replacement_cycle: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. New Jersey legislates no replacement cycle; no reissuance programme was located. Recorded gap."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' is UNCITED in its Wikipedia source and is recorded as COMMONLY REPEATED, UNSOURCED. New Jersey has no statutory dimension to put in its place."
+
+# ---------------------------------------------------------------------------
+# Display rules. New Jersey is a TWO-PLATE state and legislates an unusual
+# NIGHT-VISIBILITY duty on the rear plate.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates where two are issued — one front, one rear; ONE plate on the rear where only one is issued (N.J.S.A. 39:3-33)."
+  mounting: "§ 39:3-33: the owner 'shall display not less than 12 inches nor more than 48 inches from the ground in a horizontal position, and in such a way as not to swing, a registration plate or plates to be furnished by the commission'."
+  height_exception: "rear plates on TANK TRUCKS, TRAILERS and SANITATION VEHICLES may exceed the 48-inch ceiling (§ 39:3-33) — a genuine outlier clause worth keeping, since a naive validator of mounting height would flag lawful vehicles."
+  legibility: "§ 39:3-33: plates must be kept 'clear and distinct and free from grease, dust, or other blurring matter'."
+  frames: "§ 39:3-33: a plate frame may not conceal the STATE NAME or the REGISTRATION NUMBER. Note what this implies for a parse layer — New Jersey legislates that the jurisdiction legend is part of what must remain readable."
+  night_illumination: "NJ MVC: the rear plate 'must be illuminated to make it visible from 50 feet away at night'. This is a vehicle-lighting requirement, distinct from AAMVA's 75-foot retroreflectivity recommendation."
+  penalty: "§ 39:3-33: fines up to $500 and imprisonment for displaying fictitious numbers; up to $100 for other violations."
+  sources:
+    - "https://codes.findlaw.com/nj/title-39-motor-vehicles-and-traffic-regulation/nj-st-sect-39-3-33.html  # N.J.S.A. 39:3-33 as reproduced by a third party: the 12-48 inch horizontal non-swinging rule, two-plate/one-plate display, the tank truck/trailer/sanitation height exception, 'clear and distinct and free from grease, dust, or other blurring matter', the frame rule, and the penalty tiers. SOURCING CAVEAT: an edict of government is public domain at every level so the text is freely usable, but this is a REPRODUCTION — the official New Jersey Legislature service was unreachable in this pass and a verifier should re-derive from it."
+    - "https://www.nj.gov/mvc/vehicles/standplates.htm  # NJ MVC: 'two license plates - one for the front and one for the rear'; 'The license plates must be clean and visible at all times'; the rear-plate 50-foot night illumination rule"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES.
+  # =========================================================================
+  - id: us-nj-garden-state-screened
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2014 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: official-agency-image
+    matching: strict
+    format:
+      pattern: "L99 LLL"
+      regex: '\A[A-Z]\d{2} ?[A-Z]{3}\z'
+      charset:
+        notes: >-
+          NO CHARSET RULE IS IN TITLE 39 — N.J.S.A. 39:3-33 is a display statute
+          and states no serial grammar. NJ MVC's personalisation rules give the
+          only official character constraint New Jersey publishes: a personalised
+          plate 'must have at least three letters and a maximum of seven
+          characters in combination of letters and numbers'. No letter exclusions
+          are published anywhere for the ordinary series.
+      pattern_note: >-
+        SPLIT EVIDENCE, RECORDED SEPARATELY. The 3+3 GROUPING and the
+        separator's existence are `official-agency-image` — read off NJ MVC's own
+        sample plate. The ALPHANUMERIC ARRANGEMENT within the groups (letter,
+        two numerals | three letters) and the A10-EFF starting point are
+        `secondary-locator-unverified`: only the locator states them. A verifier
+        can confirm the grouping from the agency image without leaving the
+        agency; the arrangement needs a primary that was not found.
+      progression: "reported to run A10-EFF -> Z99-SZZ, then A10-UAA -> R22-WPG as of 5 January 2026 (locator). The second block is evidence the first exhausted, which is useful era-inference signal and is recorded as reported, not as fact."
+    design:
+      background: { color: "#F5D547", finish: retroreflective, hex_basis: observed }
+      foreground: "#231F20"
+      colour_note: >-
+        NEITHER COLOUR IS IN STATUTE. The plate is a GRADIENT — reflective yellow
+        at the top fading to near-white at the bottom — which a single
+        `background.color` cannot express. The hex recorded is the top-of-plate
+        yellow, `hex_basis: observed` from NJ MVC's own sample image; the
+        gradient is stated here rather than flattened silently. This is a real
+        schema stressor: `design.background` assumes one colour and New Jersey
+        has two with a ramp between them.
+      background_gradient: { from: "#F5D547", to: "#FBF6E3", direction: top-to-bottom, hex_basis: observed }
+      legend_top: "New Jersey"
+      legend_bottom: "Garden State"
+      legend_case_note: "New Jersey sets both legends in MIXED CASE with a serif face for the state name and a bold sans for the slogan — unusual among US plates, most of which set the jurisdiction name in caps. Observed from the agency sample image."
+      graphic:
+        present: true
+        rendered: placeholder
+        description: "a solid silhouette of the State of New Jersey, printed IN THE SERIAL GAP between the third and fourth characters. See `separator_finding` — it is design, never serial."
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      security_features: "the 2014 base is SCREENED rather than embossed; the 2010 base immediately before it added security threads to the centre (locator). A barcode appears at the lower right of the agency sample image — observed, purpose unstated by MVC, recorded as an observation."
+      dimension_note: "NO SOURCED DIMENSION (Title 39 states none; SAE J686 unpinned)."
+    region_encoding: none
+    sources:
+      - "https://www.nj.gov/mvc/vehicles/standplates.htm  # NJ MVC's standard-plate page and its official 'Standard Plate Example' image — the source for the 3+3 grouping, the state-outline separator, the gradient, the mixed-case legends and the two-plate rule"
+      - "https://www.nj.gov/mvc/vehicles/personalized.htm  # NJ MVC: 'A personalized plate must have at least three letters and a maximum of seven characters' — the only official New Jersey character constraint"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Jersey  # LOCATOR ONLY (PRD-PLATES §4): the April 2014 date, the A12-BCD arrangement, the A10-EFF start and the R22-WPG progression"
+    notes: >-
+      GARDEN STATE, SCREENED (2014-). The current New Jersey standard issue.
+      `start: 2014` is locator-grade; what is agency-sourced is that this is the
+      design NJ MVC shows as its standard plate today. The 2010 and 2014 bases
+      share a serial arrangement and differ ONLY in manufacture — embossed with
+      security threads versus screened — which is exactly the kind of boundary
+      PRD-PLATES §2.3 says makes a separate series (design differs) while
+      warning that it will look like hair-splitting to a consumer. It is not:
+      an embossed New Jersey plate and a screened one are physically different
+      objects and a renderer must know which it is drawing.
+
+  # =========================================================================
+  # ONE SERIES BACK.
+  # =========================================================================
+  - id: us-nj-garden-state-embossed
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2010, end: 2014 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "L99 LLL"
+      regex: '\A[A-Z]\d{2} ?[A-Z]{3}\z'
+      charset: { notes: "as us-nj-garden-state-screened; no statutory charset. Reported range A10-AAA to T99-EEK." }
+    design:
+      background: { color: "#F5D547", finish: retroreflective, hex_basis: observed }
+      foreground: "#231F20"
+      background_gradient: { from: "#F5D547", to: "#FBF6E3", direction: top-to-bottom, hex_basis: observed }
+      legend_top: "New Jersey"
+      legend_bottom: "Garden State"
+      graphic: { present: true, rendered: placeholder, description: "state silhouette in the serial gap, EMBOSSED on this base" }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      security_features: "security threads added to the centre of the plate on this base (locator)"
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Jersey  # LOCATOR ONLY: July 2010, security threads added, A12-BCD from A10-AAA to T99-EEK"
+    notes: >-
+      GARDEN STATE, EMBOSSED (2010-2014). The previous base. It is the SAME
+      SERIAL FORMAT as the current one, which is why New Jersey is a good
+      warning for consumers: format alone cannot date a New Jersey plate after
+      2010, only the serial BLOCK can, and the blocks are locator-grade. Any
+      era-inference feature over New Jersey must say so.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES.
+  # =========================================================================
+  - id: us-nj-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2009 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "9LLL9"
+      regex: '\A\d[A-Z]{3}\d\z'
+      charset: { notes: "reported five-character motorcycle arrangement, numeral / three letters / numeral, current since 2009. Earlier reported arrangements (AB123, 123AB, A123B, A1234, 1234A) are not given series of their own — no primary for their periods." }
+    design:
+      background: { finish: retroreflective }
+      legend_top: "New Jersey"
+      emblem: { present: true, rendered: placeholder }
+      note: "reduced-size motorcycle plate; NO SOURCED DIMENSION."
+    region_encoding: none
+    sources:
+      - "https://www.nj.gov/mvc/vehicles/standplates.htm  # NJ MVC lists motorcycles among the vehicle types with their own plate handling"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Jersey  # LOCATOR ONLY: current motorcycle format 1ABC2 from 2009 and the five superseded arrangements"
+    notes: "MOTORCYCLE. Class officially evidenced, arrangement locator-grade."
+
+  - id: us-nj-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2023 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "L99 TLL"
+      regex: '\A[A-Z]\d{2} ?T[A-Z]{2}\z'
+      charset:
+        notes: >-
+          The locator writes this format as A12-TCD. The T is read here as a
+          LITERAL trailer marker rather than a placeholder, because the locator's
+          own placeholder convention runs alphabetically (A, B, C, D) and T
+          breaks that run in the fourth-group's first position. THAT IS AN
+          INFERENCE, not a source, and it is flagged as one: if T is in fact a
+          placeholder the regex is wrong by a factor of 26 and must be widened
+          to '\A[A-Z]\d{2} ?[A-Z]{3}\z'.
+    design:
+      background: { finish: retroreflective }
+      legend_top: "New Jersey"
+      graphic: { present: true, rendered: placeholder, description: "state silhouette in the serial gap, as the passenger base" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Jersey  # LOCATOR ONLY: trailer A12-TCD from early 2023"
+    notes: >-
+      TRAILER. THE WEAKEST CLAIM IN THIS FILE and deliberately labelled as such:
+      it rests on a locator plus one inference about placeholder convention. It
+      is included because a recorded, flagged, falsifiable claim is worth more to
+      a verifier than a silent omission — but it must be verified before it
+      carries any five-nines claim.
+
+  - id: us-nj-dealer
+    class: dealer
+    categories: [car, van, truck]
+    period: { start: 2014 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    binding: business
+    format:
+      pattern: "DLL-99"
+      regex: '\AD[A-Z]{2}-?\d{2}\z'
+      charset: { notes: "reported new-car dealer format DBC-12 with the trailing pair reported to be a two-digit YEAR rather than a sequence counter, and reported letter series DAA through DKZ. The leading D is read as a literal dealer marker on the same placeholder-convention reasoning applied to the trailer series." }
+    design:
+      background: { finish: retroreflective }
+      legend_top: "New Jersey"
+      legend_bottom: "Dealer"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Jersey  # LOCATOR ONLY: new-car dealer DBC-12 with two-digit year, series DAA-DKZ"
+    notes: >-
+      DEALER. `binding: business` — the plate follows the dealership. The
+      interesting reported feature is that the last two characters encode a
+      YEAR, which would make the New Jersey dealer plate one of the few US
+      serials with a TIME field in it. Locator-grade; worth a verifier's
+      attention precisely because it would be a decode-table-worthy fact if true.
+
+  - id: us-nj-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2012 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "L999999"
+      regex: '\A[A-Z]\d{6}\z'
+      charset: { notes: "reported single letter plus six numerals, current since 1 April 2012, issued in letter series." }
+    design:
+      background: { finish: unknown }
+      legend_top: "New Jersey"
+      note: "temporary tags are paper/plastic; no design source obtained. NJ MVC's own temporary-tag page was not reachable in this pass (recorded gap)."
+      emblem: { present: false }
+    validity: "not sourced (recorded gap)"
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Jersey  # LOCATOR ONLY: temporary A123456 from 1 April 2012"
+    notes: >-
+      TEMPORARY. Included because New Jersey serialises temporary tags in their
+      own space, which is the L2 test. Every field here except the class is
+      locator-grade; the MVC page that would carry the validity period and the
+      design returned 404 on two attempts and is a recorded gap.
+
+  - id: us-nj-state-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2014 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    binding: business
+    format:
+      pattern: "SG99999"
+      regex: '\ASG\d{5}\z'
+      charset: { notes: "reported STATE GOVERNMENT format SG plus five numerals. New Jersey runs several parallel official series with their own literal prefixes — TD for the Department of Transportation, TPA for the Turnpike Authority, SPA for the State Police — which are NOT given series of their own here because no source beyond the locator was obtained for any of them." }
+    design:
+      background: { finish: retroreflective }
+      legend_top: "New Jersey"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: "the leading token is an AGENCY code, not a geographic one — SG state government, TD transportation, TPA turnpike authority, SPA state police. That makes New Jersey's official plates the one place in this file where the serial carries decodable structure, and it is an ORGANISATIONAL decode, not a regional one. Locator-grade; a real decode table needs a primary."
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Jersey  # LOCATOR ONLY: SG12345 state government, TD12345 DOT, TPA1234 Turnpike Authority, SPA123D State Police"
+    notes: >-
+      STATE GOVERNMENT. Modelled as one series with the sibling agency prefixes
+      recorded in `region_encoding` rather than as four thin series, because
+      minting four locator-only ids would spend four permanent, append-only
+      identifiers on unverified claims. One id, honestly scoped, is the
+      cheaper mistake to correct.
+
+  # =========================================================================
+  # HISTORIC — New Jersey runs TWO distinct regimes and NJ MVC publishes BOTH
+  # serial ranges itself. These are the best-sourced formats in the file.
+  # =========================================================================
+  - id: us-nj-historic
+    class: historic
+    categories: [car, truck, motorcycle]
+    period: { start: 2014 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "QQ9999"
+      regex: '\AQQ\d{4,5}\z'
+      charset:
+        notes: >-
+          NJ MVC publishes the range itself: series QQ1000-QQ99999. The QQ is a
+          LITERAL agency-published token — not an inference, unlike the trailer
+          and dealer markers above — and the numeric part is genuinely
+          VARIABLE-WIDTH (four or five digits), which is why the quantifier is a
+          range rather than a fixed width.
+      progression: "sequential within QQ1000-QQ99999 (NJ MVC)"
+    eligibility: "NJ MVC: 'the vehicle must be at least 25 years old and only used for exhibition and educational purposes' — a ROLLING threshold plus a USE restriction. The use restriction is the operative half: New Jersey does not let an eligible vehicle run historic plates as ordinary transport."
+    fee: "$44 (NJ MVC)"
+    design:
+      background: { finish: retroreflective }
+      legend_top: "New Jersey"
+      legend_bottom: "Historic"
+      legend_rule: "NJ MVC describes the 'Historic' designation as appearing on the bottom rim of the plate."
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.nj.gov/mvc/vehicles/historic.htm  # NJ MVC: 25-year rolling eligibility, exhibition-and-education-only use restriction, series QQ1000-QQ99999, 'Historic' bottom rim, $44 fee"
+    notes: >-
+      HISTORIC. New Jersey's rolling 25-year threshold is the same shape as New
+      York's and the opposite of Maryland's fixed 1999 cutoff and Florida's
+      fixed 1945 — three states, three different threshold designs, in one
+      research group. A dataset that models only one kind will be wrong about
+      the other two, and only the rolling kind needs annual re-auditing.
+
+  - id: us-nj-street-rod
+    class: historic
+    categories: [car]
+    period: { start: 2014 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "R9999"
+      regex: '\AR\d{4}\z'
+      charset: { notes: "NJ MVC publishes the range: series R1000-R9999. R is an agency-published literal." }
+      progression: "sequential within R1000-R9999 (NJ MVC)"
+    eligibility: "NJ MVC: 'modified antique automobiles manufactured before 1949 that are registered in a New Jersey street rod club or an affiliate of the National Street Rod Association Inc.' — a FIXED model-year cutoff (before 1949) PLUS a club-membership condition."
+    fee: "$15 (NJ MVC)"
+    design:
+      background: { finish: retroreflective }
+      legend_top: "New Jersey"
+      legend_bottom: "Street Rod"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.nj.gov/mvc/vehicles/historic.htm  # NJ MVC: street rod eligibility (modified antiques manufactured before 1949, club or NSRA affiliate membership), series R1000-R9999, 'Street Rod' bottom rim, $15 fee"
+    notes: >-
+      STREET ROD. Its own series and not a variant of Historic because format,
+      eligibility and fee all differ. Note that New Jersey requires PRIVATE CLUB
+      MEMBERSHIP as a condition of a government registration class — a
+      delegation of eligibility to a non-governmental body, and the only example
+      of it found anywhere in the mid-Atlantic group.
+
+  # =========================================================================
+  # PERSONALISED.
+  # =========================================================================
+  - id: us-nj-personalized
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2014 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]{3,7}\z'
+      regex_strict: '\A(?=[A-Z0-9]{3,7}\z)[A-Z0-9]*[A-Z][A-Z0-9]*[A-Z][A-Z0-9]*[A-Z][A-Z0-9]*\z'
+      charset:
+        notes: >-
+          NJ MVC, in its own words: 'A personalized plate must have at least
+          three letters and a maximum of seven characters in combination of
+          letters and numbers.' Two constraints, not one: a LENGTH ceiling of
+          seven, and a MINIMUM LETTER COUNT of three. `regex` carries the length
+          bound (and the floor of three characters implied by needing three
+          letters); `regex_strict` carries the at-least-three-letters rule, which
+          the round-trip against `pattern` forbids `regex` from expressing.
+      pattern_note: >-
+        The three-letter minimum is an unusual constraint — most states bound
+        length and alphabet, not letter COUNT — and it is exactly the kind of
+        authority-alphabet rule PRD-PLATES §2.7 invented `regex_strict` for.
+    fee: "$50 initial personalisation; $50 to reactivate a registration expired more than two years; $50 to reissue to a different owner (NJ MVC). Dedicated plates may additionally be personalised with up to FIVE characters for an initial $100 plus the annual renewal."
+    region_encoding: none
+    sources:
+      - "https://www.nj.gov/mvc/vehicles/personalized.htm  # NJ MVC: 'at least three letters and a maximum of seven characters in combination of letters and numbers'; the $50 fee tiers; Form SP-2"
+      - "https://www.nj.gov/mvc/vehicles/dedicated.htm  # NJ MVC: dedicated plates personalisable 'with up to five characters' for an initial $100 fee plus the annual renewal — a TIGHTER cap on a specialty base than on the standard one"
+    notes: >-
+      PERSONALISED. The five-character cap on a DEDICATED base versus seven on
+      the standard base is a real, agency-stated asymmetry and a trap for any
+      validator that treats personalisation as one rule per state.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-nj-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2014 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "L99 LLL"
+      regex: '\A[A-Z]\d{2} ?[A-Z]{3}\z'
+      charset: { notes: "specialty plates carry ORDINARY serials on an alternative design; when personalised they are capped at five characters rather than seven (NJ MVC)." }
+    design:
+      background: { finish: retroreflective }
+      note: "one design per approved programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      structure_official: >-
+        NJ MVC splits its programme into FIVE named tracks rather than one list:
+        Dedicated (special interest), Organizational, Sports, Military and
+        Volunteer, and Professional. Any single count for New Jersey is therefore
+        a count of one track, and this index refuses to invent a total.
+      count_dedicated: 17
+      count_dedicated_method: "ENUMERATED BY HAND from NJ MVC's own dedicated-plate page, read 2026-08-02: Organ Donor, Law Enforcement Memorial, Animal Friendly, Agriculture, Meadowlands, Deborah Heart & Lung, Liberty State Park, Treasure our Trees, Pinelands, United We Stand, Discover NJ History, Baymen's Heritage, Conquer Cancer, USS New Jersey Battleship, Olympic Spirit, Shore to Please, Conserve Wildlife. The agency states no count of its own — this is our enumeration of the agency's own list and is labelled as such."
+      count_organizational_types: 3
+      count_organizational_note: "NJ MVC states 'three organizational plate types' — Service Organizations, Community Organizations, Alumni Organizations — and does not publish the number of organisations within them. NOT a plate count."
+      count_total: null
+      count_total_note: "NO OFFICIAL TOTAL EXISTS for New Jersey and none is fabricated here. This is the honest opposite of Florida, where FLHSMV states 'over 100' itself."
+      dedicated_list_url: "https://www.nj.gov/mvc/vehicles/dedicated.htm"
+      organizational_list_url: "https://www.nj.gov/mvc/vehicles/organizational.htm"
+      sports_list_url: "https://www.nj.gov/mvc/vehicles/sport.htm"
+      index_url: "https://www.nj.gov/mvc/vehicles/standplates.htm"
+      fee_structure: "dedicated plates: $50 initial and $10 annual renewal, with two agency-stated exceptions — USS New Jersey Battleship is $15 annual, and Agriculture is $20 initial with NO annual renewal (NJ MVC). The exceptions matter: a fee model that assumes one rule per state gets New Jersey wrong twice."
+      churn_note: "no discontinuation rule located; whether New Jersey retires dead programmes is a recorded gap."
+    region_encoding: none
+    sources:
+      - "https://www.nj.gov/mvc/vehicles/dedicated.htm  # the 17 dedicated plates enumerated above, the $50/$10 fee structure and its two exceptions, the five-character personalisation cap"
+      - "https://www.nj.gov/mvc/vehicles/organizational.htm  # NJ MVC: 'three organizational plate types' - Service, Community, Alumni; 'Plate fees vary by plate type'"
+      - "https://www.nj.gov/mvc/vehicles/standplates.htm  # the five-track structure: Personalized, Dedicated, Specialty/Organizational, Sports, Special Vehicle (Historic/Hot Rod), Disability"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX. New Jersey is the case that shows why
+      `count_official` must be nullable: the state genuinely does not publish a
+      total, its programme is split across five tracks with different fee rules,
+      and any single number would be our invention. Recording 17 enumerated
+      dedicated plates plus three organisational TYPES plus an explicit null
+      total is the whole truth and is more useful to a consumer than a confident
+      wrong integer.
+
+# ---------------------------------------------------------------------------
+# GAPS.
+# ---------------------------------------------------------------------------
+gaps:
+  - "NO OFFICIAL SOURCE FOR THE PASSENGER SERIAL ARRANGEMENT. The 3+3 grouping is agency-image-sourced; the letter/digit arrangement within the groups is locator-only."
+  - "N.J.S.A. 39:3-33 was read through a third-party reproduction. The official New Jersey Legislature statute service was not reachable; re-derive before applying."
+  - "NO SOURCED PLATE DIMENSION or colour VALUE — Title 39 states neither."
+  - "The trailer T and dealer D literals are INFERENCES from placeholder convention, not sources. Flagged in-series."
+  - "NJ MVC's temporary-tag page 404'd twice; validity period and design unobtained."
+  - "Burnett v. County of Bergen and N.J.S.A. 52:18A-234.5 were not fetched — the artwork posture rests on the State's own legal statement, which WAS fetched."
+  - "No New Jersey equivalent of Florida's monthly issuance-volume report was found."

--- a/plates/us-ny.yml
+++ b/plates/us-ny.yml
@@ -1,0 +1,592 @@
+# plates/us-ny.yml — New York (PRD-PLATES gate L2, mid-Atlantic group).
+#
+# WHY NEW YORK IS THE HARD ARTWORK CASE. The US/world dossier flags NY as
+# ADVERSE: courts have held works of the State of New York generally subject to
+# copyright (County of Suffolk v. First American Real Estate Solutions, 261 F.3d
+# 179 (2d Cir. 2001)), there is no {{PD-NYGov}} tag on Commons, and the current
+# Excelsior base is the most graphically loaded standard plate in this group —
+# Niagara Falls and the New York City skyline across the bottom. Under PRD-PLATES
+# §3 the emblem/graphic slot renders as a NEUTRAL PLACEHOLDER here, and unlike
+# Florida there is no favourable state posture to revisit it against. See
+# `artwork_risk`.
+#
+# SOURCING RULE APPLIED HERE. New York's Vehicle & Traffic Law is unusually
+# THIN on plate design: § 401(3)(a) hands the commissioner discretion over
+# reflectorisation "according to specifications prescribed by the commissioner",
+# and § 402(2)'s entire colour rule is that there be "a marked contrast between
+# the color of the number plates and that of the numerals or letters thereon".
+# NO SERIAL FORMAT, NO COLOUR VALUE AND NO PLATE DIMENSION IS IN THE STATUTE.
+# So the statute carries the display law and the character bound (§ 404), the
+# DMV's own pages carry the charset and the specialty count, and the serial
+# ARRANGEMENTS (ABC-1234) are locator-grade and labelled as such per series in
+# `format_evidence`. Nothing here launders a Wikipedia era table as sourced.
+#
+# period_evidence VOCABULARY used across the mid-Atlantic group:
+#   statutory-date                    the instrument states the date in terms
+#   instrument-in-force-upper-bound   the edition read; an UPPER bound only
+#   agency-page-in-force              an official agency page shows it current
+#   secondary-locator-unverified      a year reported ONLY by a locator
+#                                     (Wikipedia); NOT a sourced claim
+#
+# format_evidence VOCABULARY (same group):
+#   statutory | official-agency-image | official-agency-text |
+#   secondary-locator-unverified
+jurisdiction: us-ny
+authority:
+  name: New York State Department of Motor Vehicles (NYSDMV)
+  url: "https://dmv.ny.gov/"
+binding: vehicle
+statute_edition: "New York Consolidated Laws, Vehicle and Traffic Law (VAT), as served by nysenate.gov and read 2026-08-02. No point-in-time edition marker is exposed by that service, so the read date is the edition marker."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: adverse
+  basis: >-
+    New York is one of the four states the US/world dossier names as ADVERSE.
+    17 U.S.C. § 105 puts only FEDERAL works in the public domain and does not
+    reach the states, so a state work is copyrighted unless the state says
+    otherwise — and New York does not say otherwise. The Second Circuit in
+    County of Suffolk v. First American Real Estate Solutions, 261 F.3d 179 (2d
+    Cir. 2001) held that New York's Freedom of Information Law does not strip
+    copyright from a New York government work, i.e. works of New York
+    governments are GENERALLY COPYRIGHTABLE. No {{PD-NYGov}} template exists on
+    Wikimedia Commons, in contrast to {{PD-FLGov}}, {{PD-CAGov}}, {{PD-GAGov}}
+    and {{PD-MAGov}}.
+  evidence_grade: >-
+    HONEST LIMIT: the County of Suffolk opinion itself was NOT FETCHED in this
+    pass — it was located through the Wikipedia survey of subnational copyright
+    status, which is a LOCATOR under PRD-PLATES §4 and not an authority. The
+    CITATION is recorded so a verifier can pull the opinion (an edict of
+    government, public domain, and freely quotable once obtained). The posture
+    conclusion should be re-derived from the opinion before any render decision
+    is taken on New York artwork.
+  emblem_rule: >-
+    RENDER PLACEHOLDER, and unlike Florida do not expect to revisit it. The
+    Excelsior base carries a photographic-derived Niagara Falls image and a New
+    York City skyline; the Empire Gold base carries none. Both are
+    `graphic: {present: true, rendered: placeholder}`. PRD-PLATES §4.5's own
+    risk ladder puts "exact reproduction of the state's graphic" at the top of
+    the risk column in NY specifically.
+  photograph_caution: >-
+    Commons photographs of New York plates are the photographer's licence on
+    the photograph and say nothing about the design (the standing §4 reading).
+    One New York plate file is genuinely public domain and it is PD BY AGE, not
+    by government status: File:1911 government-issued New York state license
+    plate, 63923.png — pre-1929 publication. That is a design-level clearance
+    for a 1911 plate and for nothing later.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: surfaces County of Suffolk v. First American Real Estate Solutions, 261 F.3d 179 (2d Cir. 2001) and the 'works of this state are subject to copyright restrictions' reading. The opinion itself was not fetched."
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # the state-exclusion rule ('This does not include governments of the individual states') and the list of state PD tags that exist — New York is absent from it"
+
+# ---------------------------------------------------------------------------
+# The US standards chain, recorded per state because adoption is VOLUNTARY.
+# Nothing below quotes SAE J686: its text is paywalled and UNPINNED, and the
+# standing rule is that AAMVA is the only route to a US dimension claim.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA writes recommendations in the declarative present and has no enforcement power."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends plate dimensions and bolt holes to SAE J686. J686's own text was NOT obtained (paywalled); no J686 dimension is quoted here. New York's Vehicle and Traffic Law states no plate dimension at all, so this file carries NO sourced dimension for a New York plate — a recorded gap, not an omission."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges — RECOMMENDED practice, not New York law."
+    jurisdiction_name_layout: "AAMVA §2.1: jurisdiction name in the top centre between the bolt holes, at least 0.25 in above the plate number; jurisdiction characters 0.75-1.0 in. New York's 'NEW YORK' legend sits top-centre, consistent with this recommendation."
+    replacement_cycle: "AAMVA §1.1 recommends a replacement cycle 'not to exceed 7 to 10 years'. New York legislates NO replacement cycle — VAT § 401 has no reissuance clause and § 402 has no plate-age rule. Contrast Pennsylvania, which legislates a reissuance PROGRAM (75 Pa.C.S. § 1331(f)), and Florida, which legislates 10 years."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" that supposedly fixed the 6x12 inch
+    plate is UNCITED in its Wikipedia source (a `citation needed` since 2017,
+    copied verbatim across articles). It is recorded as COMMONLY REPEATED,
+    UNSOURCED. New York, unlike Florida, has no statutory dimension to put in
+    its place, so this file simply carries none.
+
+# ---------------------------------------------------------------------------
+# Display rules. New York is a TWO-PLATE state with a one-plate fallback
+# written into the statute itself.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates. VAT § 402(1)(a) requires number plates displayed 'one on the front and one on the rear of such vehicle', with the fallback that 'in any registration year for which only one number plate is issued, such number plate shall ... be displayed on the rear'."
+  mounting: "§ 402(1)(a): not higher than forty-eight inches and not lower than twelve inches from the ground."
+  legibility: "§ 402(1)(b)(i): 'Number plates shall be kept clean and in a condition so as to be easily readable'."
+  obstruction: "§ 402(1)(b)(iii): 'The view of such number plates shall not be obstructed by any part of the vehicle or by anything carried thereon'."
+  contrast_rule: "§ 402(2): 'there shall be at all times a marked contrast between the color of the number plates and that of the numerals or letters thereon'. THIS IS THE ENTIRE STATUTORY COLOUR LAW OF NEW YORK — a property, not a value, exactly like Florida's 'distinguishing color' for historic plates."
+  issuance: "§ 401(3)(a): the commissioner shall 'assign to such motor vehicle a distinctive number and, without expense to the applicant, issue and deliver ... a certificate of registration ... and two number plates'. A plate 'may, in the discretion of the commissioner, be a plate of a permanent nature, treated with reflectorized material according to specifications prescribed by the commissioner', with an additional fee 'not to exceed twenty-five dollars' when a reflectorized set is issued."
+  sources:
+    - "https://www.nysenate.gov/legislation/laws/VAT/402  # § 402(1)(a) two plates front and rear + one-plate fallback, 48 in / 12 in mounting; (1)(b)(i) clean and easily readable; (1)(b)(iii) no obstruction; (2) the marked-contrast rule"
+    - "https://www.nysenate.gov/legislation/laws/VAT/401  # § 401(3)(a) distinctive number, TWO number plates, reflectorized material to the commissioner's specifications, the $25 reflectorized-set fee; (3)(b) re-assignment of the distinctive number on surrender"
+
+# ---------------------------------------------------------------------------
+# A SCHEMA STRESSOR NEW YORK CREATES ALL BY ITSELF (PRD-PLATES §2.6 rule 3).
+# ---------------------------------------------------------------------------
+serial_alphabet_finding:
+  headline: "New York lets a GRAPHIC be a character inside the serial."
+  text: >-
+    NYSDMV's personalised-plate rules state, in terms: 'A character is a letter
+    (A to Z), number (0 to 9), the state image, or a space.' The state image is
+    counted toward the eight-character allowance, and 'your plate combination
+    cannot begin or end with the state image. It must have at least one
+    character on each side of it.' That is a glyph INSIDE a serial, which
+    PRD-PLATES §2.6 rule 3 says is a SCHEMA AMENDMENT, not a data entry. It is
+    NOT encoded anywhere in this file: `_meta/separators.yml` declares the
+    serial alphabet as A-Z and 0-9 and nothing else, and there is no sanctioned
+    way to spell a state-outline glyph in a pattern or a regex.
+  consequence: >-
+    Every New York regex in this file describes the ALPHANUMERIC-ONLY subset.
+    A New York personalised plate containing the state image is a real,
+    lawfully issued registration that this dataset cannot currently express,
+    and a consumer must not read a non-match as invalidity. Recommended
+    amendment: add the New York state image to `_meta/separators.yml`'s
+    `never_separator` list with this citation, so no consumer's
+    separator-stripping tier ever deletes it, and open the `format.fields[]`
+    question the Japan row already raises.
+  source: "https://dmv.ny.gov/plates/personalized-plate-numbers  # 'A character is a letter (A to Z), number (0 to 9), the state image, or a space'; 2 to 8 characters on a standard plate; the no-leading/trailing-state-image rule"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES.
+  # =========================================================================
+  - id: us-ny-excelsior
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2020 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      charset:
+        notes: >-
+          NO CHARSET RULE IS IN THE STATUTE. VAT § 401(3)(a) says only that the
+          commissioner assigns 'a distinctive number'; § 404 caps SPECIAL plates
+          at 'not more than eight letters, numerals or any combination thereof',
+          which bounds personalised configurations rather than the ordinary
+          series. The letter exclusions reported for New York (I, O and Q
+          excluded from the 2001 Empire State series) are locator-grade and are
+          recorded on `us-ny-empire-state-2001` below, not asserted here.
+      pattern_note: >-
+        The three-letter / four-numeral arrangement and the KAA-1000 starting
+        point are reported by the Wikipedia article and by NOTHING ELSE
+        obtained in this pass. NYSDMV publishes no serial-format statement and
+        the Vehicle and Traffic Law states none. `format_evidence` is therefore
+        `secondary-locator-unverified` and a verifier must re-derive the
+        arrangement before this series carries a five-nines claim. The hyphen is
+        optional in the regex because it is a printed separator (PRD-PLATES
+        §2.6): the canonical separator-free twin is derived, not shipped.
+      stacked_characters_note: "AAMVA treats stacked characters as part of the official number, at most two stacked. New York does not stack on the passenger base."
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003087"
+      colour_note: >-
+        NEITHER COLOUR IS IN THE STATUTE — VAT § 402(2) requires only 'a marked
+        contrast'. Dark-blue characters on white is the reported and observed
+        appearance; both hexes are `hex_basis: observed` and unverified pending a
+        departmental specification. NYSDMV's own page describes the plate only as
+        'featuring New York State landmarks'.
+      legend_top: "NEW YORK"
+      legend_bottom: "EXCELSIOR"
+      graphic:
+        present: true
+        rendered: placeholder
+        description: "Niagara Falls and a New York City skyline across the lower half, with the state motto EXCELSIOR — reported by a locator and visible in NYSDMV's own page imagery. NOT rendered: this is the single highest-risk artwork in the mid-Atlantic group under `artwork_risk` above."
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      dimension_note: "NO SOURCED DIMENSION. New York states no plate size in statute and AAMVA delegates dimensions to the unpinned SAE J686. Recorded gap rather than the conventional 12x6 in assumed."
+    replacement_cycle:
+      years: null
+      note: "NEW YORK LEGISLATES NO REPLACEMENT CYCLE. Neither VAT § 401 nor § 402 states a plate age limit or a reissuance duty. NYSDMV runs a 'Peeling and Damaged License Plates' remedy instead, i.e. condition-triggered rather than age-triggered. This is the opposite pole from Florida's statutory 10 years and from Pennsylvania's statutory reissuance PROGRAM."
+    region_encoding: none
+    sources:
+      - "https://dmv.ny.gov/plates  # NYSDMV: 'DMV now offers Excelsior license plates featuring New York State landmarks' — the official evidence that this design is the current offering (agency-page-in-force)"
+      - "https://www.nysenate.gov/legislation/laws/VAT/401  # § 401(3)(a): the distinctive number, two plates, reflectorized material to the commissioner's specifications — the whole of New York's statutory design law"
+      - "https://www.nysenate.gov/legislation/laws/VAT/402  # § 402(2): the marked-contrast rule, which is why the hexes below are `observed` and not `spec`"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_York  # LOCATOR ONLY (PRD-PLATES §4): the June 2020 introduction, the ABC-1234 arrangement and the KAA-1000 start. None of the three is asserted as sourced."
+    notes: >-
+      EXCELSIOR — THE CURRENT NEW YORK STANDARD ISSUE. `start: 2020` is
+      `secondary-locator-unverified`: the June 2020 rollout is reported by
+      Wikipedia and by no primary obtained here. What IS officially sourced is
+      that the Excelsior plate is the design NYSDMV offers today, which makes
+      2020 a plausible start and 2026 an instrument-in-force upper bound; the
+      honest record is both facts with their grades, not a single confident
+      year. PARALLEL ISSUANCE IS REAL HERE: New York has no replacement cycle,
+      so Empire Gold plates from 2010 remain lawfully on the road indefinitely
+      alongside Excelsior plates — which is why the two series overlap at 2020
+      and why this note and the Empire Gold note differ.
+
+  # =========================================================================
+  # ONE SERIES BACK.
+  # =========================================================================
+  - id: us-ny-empire-gold
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2010, end: 2020 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      charset: { notes: "no charset rule in statute; see us-ny-excelsior. The reported start of this series is FAA-1000." }
+    design:
+      background: { color: "#F2B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#003087"
+      colour_note: "Dark blue serial on a golden-yellow ground — reported and observed, `hex_basis: observed`. VAT § 402(2)'s marked-contrast rule is satisfied by it and says nothing more."
+      legend_top: "NEW YORK"
+      legend_bottom: "EMPIRE STATE"
+      graphic: { present: false, rendered: none, description: "the Empire Gold base is TYPOGRAPHIC ONLY — no landmark imagery. It is therefore the low-artwork-risk New York base and the one a render can approach most safely." }
+      emblem: { present: false }
+      band: { side: none }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://www.nysenate.gov/legislation/laws/VAT/402  # § 402(2) marked contrast — the only colour law the series answers to"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_York  # LOCATOR ONLY: Empire Gold April 2010 - May 2020, ABC-1234 from FAA-1000, dark blue on golden yellow"
+    notes: >-
+      EMPIRE GOLD — THE PREVIOUS STANDARD BASE, and the reason New York needs
+      the overlap rule. Because New York legislates no replacement cycle, an
+      Empire Gold plate issued in 2019 is still a current, valid registration in
+      2026: `end: 2020` closes the ISSUANCE window, not the validity window. A
+      consumer must not treat a series end as an expiry. Both boundary years are
+      `secondary-locator-unverified`.
+
+  - id: us-ny-empire-state-2001
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2001, end: 2010 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      regex_strict: '\A[A-HJ-NPR-Z]{3}-?\d{4}\z'
+      charset:
+        excluded: ["I", "O", "Q"]
+        notes: >-
+          The 2001 Empire State series is reported to EXCLUDE I, O and Q from
+          the letter positions — the lookalike exclusions AAMVA-style systems
+          make. This is the only New York charset restriction reported anywhere
+          and it is LOCATOR-GRADE; it is expressed as `regex_strict` precisely
+          because PRD-PLATES §2.7 forbids `regex` from carrying charset
+          restrictions (the round-trip against `pattern` would fail).
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003087"
+      legend_top: "NEW YORK"
+      graphic: { present: false, rendered: none }
+      emblem: { present: false }
+      band: { side: none }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_York  # LOCATOR ONLY: Empire State 2001 base from ACA-1000, excluding I, O and Q"
+    notes: >-
+      EMPIRE STATE 2001 — carried TWO SERIES BACK, past the L2 minimum, for one
+      reason: it is the only New York base with a reported letter exclusion, and
+      an exclusion is the kind of fact that makes a `regex_strict` twin earn its
+      keep. Everything about this entry is locator-grade. It is included so the
+      exclusion is not lost, and flagged so it is not believed.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES — New York serialises these separately.
+  # =========================================================================
+  - id: us-ny-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2020 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "99LL99"
+      regex: '\A\d{2}[A-Z]{2}\d{2}\z'
+      charset: { notes: "six characters, reported arrangement two numerals / two letters / two numerals, reported start 10RA00. NYSDMV confirms motorcycles are separately serialised by pricing personalised MOTORCYCLE plates apart from passenger ones and capping them at 2 to 6 characters." }
+    design:
+      background: { finish: retroreflective }
+      legend_top: "NEW YORK"
+      emblem: { present: true, rendered: placeholder }
+      note: "reduced-size motorcycle plate; NO SOURCED DIMENSION (New York states none, AAMVA delegates to the unpinned J686)."
+    region_encoding: none
+    sources:
+      - "https://dmv.ny.gov/plates/personalized-plate-numbers  # NYSDMV: '2 to 6 characters on a motorcycle plate', with its own initial ($35.00) and annual ($18.75) fees — the official evidence that the motorcycle series is separately administered"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_York  # LOCATOR ONLY: the 12AB34 arrangement and the 10RA00 start"
+    notes: >-
+      MOTORCYCLE. The CLASS is officially evidenced (separate character cap,
+      separate fee schedule); the ARRANGEMENT is locator-grade. That split is
+      the normal shape of a New York claim in this file and is why
+      `format_evidence` is a per-series field rather than a file-level one.
+
+  - id: us-ny-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2020 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LL-99999"
+      regex: '\A[A-Z]{2}-?\d{5}\z'
+      charset: { notes: "reported two-letter prefix plus five numerals; the reported current prefix block begins CA." }
+    design:
+      background: { finish: retroreflective }
+      legend_top: "NEW YORK"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_York  # LOCATOR ONLY: trailer CA-12345"
+    notes: >-
+      TRAILER. Entirely locator-grade. Included because L2 asks for the core
+      distinct classes a state separately serialises and New York does
+      serialise trailers apart; flagged because nothing official was obtained.
+
+  - id: us-ny-dealer
+    class: dealer
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2020 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    binding: business
+    format:
+      pattern: "9999999"
+      regex: '\A\d{7}\z'
+      charset: { notes: "reported all-numeric seven-digit dealer serial, reported start 7100000." }
+    design:
+      background: { finish: retroreflective }
+      legend_top: "NEW YORK"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_York  # LOCATOR ONLY: dealer 1234567 from 7100000"
+      - "https://dmv.ny.gov/businesses-regulated-dmv  # NYSDMV regulates dealers as a distinct business class — the official hook for the class, not for the format"
+    notes: >-
+      DEALER. `binding: business` for the same reason as Florida's dealer plate
+      and Germany's rote Kennzeichen: the plate follows the dealership, not a
+      vehicle. Format locator-grade.
+
+  - id: us-ny-historic
+    class: historic
+    categories: [car, truck]
+    period: { start: 2020 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "HX9999"
+      regex: '\A(?:HX\d{1,5}|\d{1,5}HX)\z'
+      charset:
+        notes: >-
+          NYSDMV, in its own words: historical plates 'begin or end with the
+          letters "HX" for cars and trucks or "HM" for motorcycles'. The HX
+          token is a LITERAL and its POSITION is genuinely optional — the
+          alternation encodes exactly what the agency states and nothing more.
+          The DIGIT WIDTH is not stated by NYSDMV, so the quantifier is bounded
+          only by the § 404 eight-character frame; it makes no width claim.
+      progression: "not stated by NYSDMV (recorded gap)"
+    eligibility: "NYSDMV: a vehicle 'manufactured more than 25 years before the current calendar year' — a ROLLING threshold, which silently changes every year and must therefore be re-audited annually. Contrast Maryland (fixed model year 1999 or earlier) and Florida Horseless Carriage (fixed model year 1945 or earlier) in this same programme."
+    fee: "initial registration $28.75 standard / $60 personalised for passenger; $23.75 / $42.50 for motorcycle; annual renewal at the same tiers (NYSDMV)"
+    design:
+      background: { finish: retroreflective }
+      legend_top: "NEW YORK"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://dmv.ny.gov/plates/historical-and-vintage-plates  # NYSDMV: the HX (cars and trucks) / HM (motorcycles) letter rule, the 'manufactured more than 25 years before the current calendar year' eligibility, and the fee schedule"
+    notes: >-
+      HISTORICAL. THE BEST-SOURCED FORMAT CLAIM IN THIS FILE — the HX/HM letters
+      come from NYSDMV's own page, not from a locator, which is why
+      `format_evidence` is `official-agency-text` here and
+      `secondary-locator-unverified` almost everywhere else in us-ny. Note the
+      threshold is ROLLING (25 years before the CURRENT calendar year), so the
+      eligibility boundary moves without any instrument changing — the audit
+      case PRD-PLATES §9 warns about.
+
+  - id: us-ny-historic-motorcycle
+    class: historic
+    categories: [motorcycle]
+    period: { start: 2020 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "HM9999"
+      regex: '\A(?:HM\d{1,4}|\d{1,4}HM)\z'
+      charset: { notes: "NYSDMV: historical plates 'begin or end with the letters ... \"HM\" for motorcycles'. Width unstated; the quantifier is bounded by the six-character motorcycle personalisation frame and makes no width claim." }
+    eligibility: "as us-ny-historic: manufactured more than 25 years before the current calendar year (rolling)"
+    design:
+      background: { finish: retroreflective }
+      legend_top: "NEW YORK"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://dmv.ny.gov/plates/historical-and-vintage-plates  # NYSDMV: 'HM' for motorcycles; the motorcycle historical fee tiers ($23.75 standard / $42.50 personalised)"
+    notes: >-
+      HISTORICAL MOTORCYCLE. Its own series rather than a variant because the
+      literal token in the serial differs (HM, not HX) — a FORMAT difference, which
+      PRD-PLATES §2.3 makes the test for a separate series.
+
+  - id: us-ny-vintage
+    class: historic
+    categories: [car, truck, motorcycle]
+    period: { start: 2020 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9]){0,7}\z'
+      charset:
+        notes: >-
+          A VINTAGE PLATE IS AN ORIGINAL NEW YORK PLATE FROM THE YEAR THE
+          VEHICLE WAS MANUFACTURED. NYSDMV requires the authentic plate and
+          states that 'DMV does not accept reproductions'. So this series has no
+          grammar of its own at all — its serial is whatever New York issued in
+          some year between 1901 and roughly 2001, across a century of unrecorded
+          arrangements.
+      pattern_note: >-
+        `matching: recall-only` (PRD-PLATES §2.7), and it is the textbook case
+        alongside `nl-export`: the regex is a deliberate CATCH-ALL over every
+        New York arrangement, so a match says only 'this string has a shape New
+        York has issued' and is emphatically NOT a claim that the string is a
+        valid vintage registration. No `regex_strict` may exist here and the
+        lint enforces that.
+    eligibility: "NYSDMV: the plates must be the original plates for the vehicle's year of manufacture; reproductions are not accepted."
+    fee: "$3.75 initial for passenger and motorcycle where a New York registration already exists (NYSDMV)"
+    design:
+      background: { finish: unknown }
+      note: "the design IS the original year's design — there is no current New York vintage design to record. Renders of this series are meaningless at L2."
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://dmv.ny.gov/plates/historical-and-vintage-plates  # NYSDMV: vintage plates must be the authentic original plates for the year of manufacture, 'DMV does not accept reproductions', $3.75 initial fee"
+    notes: >-
+      VINTAGE — THE SECOND RECALL-ONLY SERIES IN THE WHOLE DATASET, and the
+      first one in the US slice. It matters out of proportion to its size: it
+      proves the §2.7 distinction is not a Netherlands-specific artefact but a
+      recurring shape wherever a jurisdiction re-authorises OLD plates for
+      CURRENT use. Any state with a year-of-manufacture programme will need the
+      same treatment.
+
+  # =========================================================================
+  # PERSONALISED.
+  # =========================================================================
+  - id: us-ny-personalized
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2020 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "LLLLLLLL"
+      regex: '\A[A-Z0-9]{2,8}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){1,7}\z'
+      charset:
+        notes: >-
+          NYSDMV: '2 to 8 characters on a standard plate', '2 to 6 characters on
+          a motorcycle plate', 'up to 6 characters on a picture plate'. The
+          statutory frame behind it is VAT § 404, which defines a special number
+          plate as one containing 'not more than eight letters, numerals or any
+          combination thereof'. A SPACE IS A CHARACTER AND COUNTS TOWARD THE
+          EIGHT — that is why `regex_statutory` is the space-permitting twin and
+          `regex` is the alphanumeric-only core. THE STATE IMAGE IS ALSO A
+          CHARACTER and cannot be spelled at all; see `serial_alphabet_finding`
+          at the top of this file.
+      pattern_note: >-
+        HONEST IMPRECISION, STATED: `regex_statutory` permits up to eight
+        alphanumerics AND interleaved spaces, so it accepts strings longer than
+        eight printed characters, whereas NYSDMV counts each space against the
+        eight. Encoding the exact 'alphanumerics + spaces <= 8' bound requires an
+        alternation the dataset does not need at L2. The twin is therefore
+        slightly LOOSER than the rule, which is the correct direction for a
+        `regex_statutory` (an outer bound), and it is recorded rather than hidden.
+    fee: "passenger/commercial: $60.00 initial, $31.25 annual. Motorcycle: $35.00 initial, $18.75 annual (NYSDMV). VAT § 404 sets the underlying annual service charge at thirty-one dollars and twenty-five cents, with commissioner discretion between $18.75 and $31.25 on budget-director approval — the statute and the fee page agree exactly."
+    region_encoding: none
+    sources:
+      - "https://dmv.ny.gov/plates/personalized-plate-numbers  # NYSDMV: 2-8 characters standard / 2-6 motorcycle / up to 6 on a picture plate; 'A character is a letter (A to Z), number (0 to 9), the state image, or a space'; the state-image position rule; the fee schedule"
+      - "https://www.nysenate.gov/legislation/laws/VAT/404  # § 404: a special number plate contains 'not more than eight letters, numerals or any combination thereof'; the $31.25 annual service charge and the $18.75-$31.25 discretion; 'Nothing contained in this section shall be construed to require the commissioner to issue a special number plate'"
+    notes: >-
+      PERSONALISED. New York is the rare state where the character cap is in
+      STATUTE (§ 404's eight) and the agency page agrees with it to the cent on
+      fees — a clean statute/agency corroboration of the kind the sourcing law
+      wants. It is also the series that surfaces the state-image finding, which
+      is the most consequential schema result of the mid-Atlantic pass.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Count and links only.
+  # =========================================================================
+  - id: us-ny-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2020 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      charset: { notes: "custom picture plates carry ORDINARY serials on an alternative design; when personalised they are capped at SIX characters rather than eight (NYSDMV), which is the one place a New York specialty plate's grammar differs from the standard series." }
+    design:
+      background: { finish: retroreflective }
+      note: "one design per approved organisation or cause; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: 206
+      count_official_quote: "NYSDMV's own Custom Picture Plates catalogue reports '206 items available' (read 2026-08-02)."
+      count_method: "READ FROM THE AGENCY'S OWN RESULT COUNTER, not enumerated by hand and not taken from a locator. It is a live figure and will drift; snapshot the date with the number."
+      categories_official: ["Causes", "Colleges, Fraternities, Sororities", "Counties and Regions", "I Love NY Adventure", "Military and Veterans", "Organizations", "Sports", "Zodiac"]
+      official_list_url: "https://dmv.ny.gov/plates/picture-plates"
+      professional_plates_url: "https://dmv.ny.gov/plates/professional-custom-plates"
+      professional_note: "NYSDMV runs a distinct PROFESSIONAL CUSTOM PLATE track 'exclusively available to emergency, medical, and other qualified professionals' — an eligibility-gated subtype comparable to Florida's SPECIAL REQUIREMENT plates. Not enumerated in this pass."
+      churn_note: "no discontinuation rule was located in VAT § 404, which is purely permissive ('Nothing contained in this section shall be construed to require the commissioner to issue a special number plate'). Whether New York retires dead programmes, and on what trigger, is a recorded gap."
+    region_encoding: none
+    sources:
+      - "https://dmv.ny.gov/plates/picture-plates  # the official catalogue and its '206 items available' counter; the eight listed categories"
+      - "https://dmv.ny.gov/plates  # NYSDMV's three plate tracks: Personalized Plates, Custom Picture Plates, Professional Custom Plates"
+      - "https://www.nysenate.gov/legislation/laws/VAT/404  # § 404: the permissive special-plate authority, the eight-character cap and the service charge"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — one entry standing for the whole programme,
+      which is what PRD-PLATES §2.5 asks for at this gate. New York's count is
+      the CLEANEST in the mid-Atlantic group because the agency publishes a
+      machine-readable result count (206) rather than a rounded claim: contrast
+      Florida's contested 'over 100' (agency) versus 'over 120' (locator). No
+      New York equivalent of Florida's monthly active-plate registration report
+      was found — New York publishes designs, not issuance volumes.
+
+# ---------------------------------------------------------------------------
+# CLASSES NEW YORK ISSUES THAT ARE DELIBERATELY NOT MODELLED AS SERIES.
+# A series needs a format. Where no format was obtained, a recorded gap beats
+# an invented pattern (PRD-PLATES §5.3: record disagreements, never average).
+# ---------------------------------------------------------------------------
+unmodelled_classes:
+  temporary: >-
+    New York's temporary instrument is the IN-TRANSIT PERMIT under VAT § 401-a,
+    'valid for a period of thirty days from the date of issuance', for vehicles
+    being taken out of state for registration elsewhere; a vehicle displaying it
+    is excused from the ordinary number-plate requirement. NO SERIAL FORMAT IS
+    PUBLISHED, so no series is minted. Source:
+    https://www.nysenate.gov/legislation/laws/VAT/401-A and
+    https://dmv.ny.gov/registration/in-transit-vehicle-permits-temporary-registrations
+  government: >-
+    New York issues distinct official/municipal plates (locator-reported forms
+    R-12345 and A1234 with the political subdivision and county named on the
+    plate). Neither a statutory nor an agency format statement was obtained and
+    the locator's own account is inconsistent, so nothing is minted. RECORDED
+    GAP — the highest-value New York follow-up after the base-year primaries.
+  apportioned_and_commercial: >-
+    New York registers commercial vehicles by weight class and participates in
+    the International Registration Plan, but no separate serial grammar was
+    obtained. Recorded gap.
+
+# ---------------------------------------------------------------------------
+# GAPS, stated so the verifier does not have to rediscover them.
+# ---------------------------------------------------------------------------
+gaps:
+  - "NO PRIMARY FOR ANY NEW YORK BASE-DESIGN YEAR. Excelsior 2020, Empire Gold 2010, Empire State 2001 are all locator-grade. The primaries to chase are NYSDMV press releases and the Governor's office announcements of the 2019 plate-design public vote."
+  - "NO SOURCED PLATE DIMENSION for any New York plate. The statute states none and SAE J686 is unpinned."
+  - "NO SOURCED COLOUR VALUE. VAT § 402(2) states a contrast PROPERTY, not values; every hex here is `observed`."
+  - "The County of Suffolk opinion (261 F.3d 179) was not fetched; the adverse posture rests on a locator's reading of it."
+  - "The state-image-as-a-character finding needs a `_meta/separators.yml` amendment before any consumer ships a New York validator."
+  - "Government/official and temporary formats unobtained (see unmodelled_classes)."

--- a/plates/us-pa.yml
+++ b/plates/us-pa.yml
@@ -1,0 +1,506 @@
+# plates/us-pa.yml — Pennsylvania (PRD-PLATES gate L2, mid-Atlantic group).
+#
+# PENNSYLVANIA IS THE ONE STATE IN THIS GROUP WHOSE ADVERSE POSTURE IS IN
+# STATUTE. New York's is judicial and inferred; Pennsylvania's is a legislative
+# grant: 71 P.S. § 636 gives the Department of General Services the power AND
+# THE DUTY 'to copyright, in the name of the Commonwealth, all publications'.
+# A state that has legislated an affirmative duty to copyright is the strongest
+# adverse posture found anywhere in this group. See `artwork_risk`.
+#
+# THREE THINGS PENNSYLVANIA DOES THAT NO OTHER STATE IN THIS GROUP DOES:
+#   1. It LEGISLATES A REISSUANCE PROGRAM (75 Pa.C.S. § 1331(f)) rather than a
+#      fixed cycle — an ongoing duty to replace plates on a staggered basis, and
+#      PennDOT is currently executing it against the oldest 'D', 'E' and 'F'
+#      configurations. This is the third distinct US answer to 'is there a
+#      replacement cadence?' after Florida's flat 10 years and New York's none.
+#   2. It ABOLISHED THE VALIDATION STICKER IN LAW: § 1332(d), in four words that
+#      delete a whole layer of US plate anatomy — 'Validating registration
+#      stickers shall not be issued or required to be displayed.'
+#   3. It legislates against plate treatments that defeat AUTOMATED ENFORCEMENT
+#      and ELECTRONIC TOLL COLLECTION specifically (§ 1332(b)(2)), i.e. it
+#      writes machine readability into the display statute.
+#
+# THE SEPARATOR CHANGED IN 2025 AND IT IS SOURCED FROM THE AGENCY'S OWN IMAGE.
+# PennDOT's official sample of the current plate reads ABC0123 — seven
+# characters, NO hyphen, with the Liberty Bell as a watermark BEHIND the
+# characters. The base it replaced reads ABC-1234. So Pennsylvania dropped the
+# printed separator at the 2025 base change, and this file spells each base's
+# separator as that base actually prints it (PRD-PLATES §2.6 rule 2).
+#
+# period_evidence / format_evidence vocabularies as in us-ny.yml.
+jurisdiction: us-pa
+authority:
+  name: Pennsylvania Department of Transportation, Bureau of Motor Vehicles (PennDOT)
+  url: "https://www.pa.gov/en/agencies/dmv.html"
+binding: vehicle
+statute_edition: "75 Pa.C.S. (Vehicles), Chapter 13, read 2026-08-02. The Pennsylvania General Assembly's own statute service (palegis.us) reset the connection on four attempts in this pass, so §§ 1331 and 1332 were read through a third-party reproduction of the consolidated statutes; edicts of government are public domain at every level so the text is freely usable, but a verifier should re-derive from palegis.us. Recorded gap."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: adverse-by-statute
+  basis: >-
+    Pennsylvania has legislated an affirmative COPYRIGHT DUTY over its own
+    publications. 71 P.S. § 636 provides that the Department of General Services
+    'shall have the power, and its duty shall be ... [t]o copyright, in the name
+    of the Commonwealth, all publications' including State Reports and other
+    publications it deems advisable. Combined with the baseline rule that
+    17 U.S.C. § 105 does not reach the states, that puts Pennsylvania in the most
+    adverse column available: not merely 'may assert' (Arizona) or 'courts have
+    held copyrightable' (New York), but a statutory instruction to assert. No
+    {{PD-PAGov}} template exists on Wikimedia Commons.
+  evidence_grade: >-
+    HONEST LIMIT: 71 P.S. § 636 was NOT FETCHED. The findlaw reproduction
+    returned 403 on both a WebFetch and a browser-user-agent curl, and
+    palegis.us reset the connection repeatedly. The citation and the quoted
+    clause come from the Wikipedia survey of subnational copyright status, which
+    is a LOCATOR under PRD-PLATES §4 and not an authority. The clause is quoted
+    here so a verifier knows exactly what to pull and can falsify it in one
+    fetch. The conclusion should not be relied on for a render decision until
+    the statute itself is in hand.
+  scope_caveat: >-
+    § 636 speaks of PUBLICATIONS. Whether a registration plate DESIGN is a
+    'publication' of the Department of General Services is a question the
+    statute does not answer and this pass did not research. The adverse reading
+    is the conservative one and is adopted; the narrower reading — that § 636
+    reaches printed State documents and not vehicle registration plates issued
+    by a different department — is recorded as the open counter-argument.
+  emblem_rule: >-
+    RENDER PLACEHOLDER. The current base carries a large Liberty Bell image
+    behind the serial and the previous base carries a state outline; neither is
+    approached. Note the Liberty Bell itself is a physical object of the 18th
+    century and no one holds copyright in the bell — but PennDOT's DRAWING of it
+    is a work, and it is the drawing that appears on the plate. Do not confuse
+    the public-domain SUBJECT with the state-produced DEPICTION.
+  photograph_caution: >-
+    Standard §4 reading: Commons photographs carry the photographer's licence on
+    the photograph only. PennDOT's own sample image of the current plate was
+    READ to establish the serial's printed form and the design description; it
+    is NOT copied into the dataset and no render derives from it.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: quotes 71 P.S. § 636 - the Department of General Services 'shall have the power, and its duty shall be ... [t]o copyright, in the name of the Commonwealth, all publications'. The statute itself was NOT fetched (403/connection reset on three routes)."
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # the state-exclusion rule and the roster of state PD tags that exist - Pennsylvania is absent from it"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Voluntary; J686 never quoted.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686 (paywalled, NOT obtained). 75 Pa.C.S. Chapter 13 states no plate dimension. No sourced dimension is carried here."
+    retroreflectivity: "AAMVA §3.3 recommends daylight and nighttime legibility from at least 75 feet, materials per ASTM D4956-19 and ISO 7591:1982 cl.3. Pennsylvania legislates the DUTY but not the value: 75 Pa.C.S. § 1331(d), 'All registration plates, except temporary plates, shall be treated with reflectorizing material in accordance with standards approved by the department.' Standards approved by the department were not obtained (recorded gap)."
+    machine_readability: "AAMVA publishes a separate LPR Program Best Practices Guide because machine readability is a design constraint. Pennsylvania is the only state in this group to write it into the DISPLAY STATUTE: § 1332(b)(2) makes it unlawful to display a plate obscured in a way that inhibits automated enforcement or electronic toll collection, and § 1332(b.1) permits a frame only if the plate remains readable BY THOSE SYSTEMS as well as by an officer."
+    replacement_cycle: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. Pennsylvania legislates a PROGRAM, not a period — see `replacement_cycle` on us-pa-let-freedom-ring."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' is UNCITED in its Wikipedia source and is recorded as COMMONLY REPEATED, UNSOURCED. Pennsylvania has no statutory dimension to put in its place."
+
+# ---------------------------------------------------------------------------
+# Display rules.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "ONE plate, displayed on the REAR. SOURCING CAVEAT: 75 Pa.C.S. § 1332(a) speaks throughout of 'every registration plate' in the singular and prescribes no front position, and § 1331 speaks of the department providing 'registration plates' without a count — consistent with one-plate issuance but not stating it. The rear-only rule is asserted by the locator's front/rear survey and NO Pennsylvania instrument stating it was pinned in this pass. RECORDED GAP; a verifier should look to 67 Pa. Code and to § 1332's implementing regulations."
+  general_rule: "§ 1332(a): 'Every registration plate shall, at all times, be securely fastened to the vehicle to which it is assigned or on which its use is authorized in accordance with regulations promulgated by the department.' Note the delegation — the MOUNTING SPEC is regulatory, not statutory, and 67 Pa. Code was not obtained (recorded gap)."
+  motorcycle_vertical: "§ 1332(a.1): a motorcycle plate may be mounted VERTICALLY only if its identifying characters are themselves displayed vertically; 'A registration plate that has its identifying characters displayed horizontally shall not be displayed and mounted vertically.' The department produces vertical-alignment motorcycle plates on request for a $20 fee in addition to the annual registration. A VERTICAL-CHARACTER PLATE IS A DIFFERENT PHYSICAL OBJECT WITH THE SAME SERIAL — a render-layer fact, not a format fact."
+  obstruction: "§ 1332(b): unlawful to display a plate that is (1) so dirty as to be unreadable at a reasonable distance, (2) obscured in a way that inhibits automated enforcement or electronic toll collection, (3) illegible or obstructed at a reasonable distance, (4) obscuring the issuing jurisdiction, or (5) covered by a tinted material."
+  frames: "§ 1332(b.1): a frame that 'minimally outlines the registration plate' is permitted provided the plate remains readable by automated systems and by law enforcement."
+  penalty: "§ 1332(c): violating § 1332(b)(2) or (b)(4) is a SUMMARY OFFENSE carrying a $100 fine on conviction."
+  no_validation_sticker: "§ 1332(d): 'Validating registration stickers shall not be issued or required to be displayed.' Pennsylvania has legislated the registration sticker out of existence — the single most consequential display fact in this file for anyone rendering or parsing a Pennsylvania plate, because the sticker box that every other state's plate reserves simply is not there."
+  sources:
+    - "https://codes.findlaw.com/pa/title-75-pacsa-vehicles/pa-csa-sect-75-1332.html  # 75 Pa.C.S. § 1332 as reproduced by a third party: (a) secure fastening per department regulations; (a.1) motorcycle vertical mounting and the $20 vertical plate; (b) the five obscuring prohibitions including automated enforcement and tolling; (b.1) the minimal frame allowance; (c) the $100 summary penalty; (d) NO VALIDATING STICKERS. Edict of government - public domain - but a REPRODUCTION; palegis.us was unreachable."
+    - "https://codes.findlaw.com/pa/title-75-pacsa-vehicles/pa-csa-sect-75-1331.html  # 75 Pa.C.S. § 1331: (a) plates provided by the department; (b) plate content; (c) temporary plates; (d) reflectorizing to department standards; (e) issuance by agents; (f) the periodic reissuance program"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES.
+  # =========================================================================
+  - id: us-pa-let-freedom-ring
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2025 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-image
+    matching: strict
+    format:
+      pattern: "LLL9999"
+      regex: '\A[A-Z]{3}\d{4}\z'
+      charset:
+        notes: >-
+          THE STATUTORY CONSTRAINT IS ALMOST NOTHING. 75 Pa.C.S. § 1331(b):
+          'Every registration plate shall have displayed upon it the identifying
+          numbers or letters assigned to the vehicle, the name of the
+          Commonwealth, which may be abbreviated, and any other data the
+          department may deem necessary.' No length, no alphabet, no exclusions.
+          The only official Pennsylvania character rule is on the personalisation
+          side: 'Personalized registration plates may contain up to seven letters
+          and numbers in combination' (PennDOT), which is consistent with the
+          seven-character ordinary serial and is recorded on us-pa-personalized.
+      pattern_note: >-
+        NO SEPARATOR — AND THAT IS SOURCED, NOT ASSUMED. PennDOT's own sample
+        image of this plate (fetched and read 2026-08-02) shows the serial
+        ABC0123 as seven contiguous characters with the Liberty Bell rendered as
+        a watermark BEHIND them. The base it replaced printed ABC-1234 with a
+        hyphen. Pennsylvania therefore dropped the printed separator at the 2025
+        base change, and PRD-PLATES §2.6 rule 2 requires each base's regex to be
+        written in ITS OWN printed form — which is why this series has no hyphen
+        in it and `us-pa-visitpa` does.
+      progression: "reported to run MYR0200 onward, reaching NHJ 3386 as of 25 July 2026 (locator). Note the locator's own rendering of the later serial contains a space, which conflicts with PennDOT's contiguous sample; the conflict is recorded, not resolved."
+    design:
+      background: { color: "#F5F0DC", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B3A6B"
+      colour_note: >-
+        AGENCY WORDING AND AGENCY IMAGE DISAGREE, AND BOTH ARE RECORDED.
+        PennDOT's own alt text describes 'a white background with large blue
+        letters and numbers'; PennDOT's own image of the same plate shows a
+        distinctly CREAM ground, not white, with navy characters and DARK RED
+        legends the alt text does not mention. The hex recorded is the observed
+        cream. PRD-PLATES §5.3 says record disagreements rather than average
+        them, and this is a disagreement inside a single agency page.
+      legend_top: "PENNSYLVANIA"
+      legend_bottom: "LET FREEDOM RING"
+      legend_colour: { value: "#A6192E", hex_basis: observed, note: "state name and slogan both in red - observed from the agency image; not in the alt text and not in statute" }
+      graphic:
+        present: true
+        rendered: placeholder
+        description: "a Liberty Bell, large, centred, rendered as a light watermark BEHIND the serial characters. PennDOT's alt text: 'Pennsylvania license plate with a graphic of the Liberty Bell and the text, \"Pennsylvania\" and \"Let Freedom Ring.\"' A watermark UNDER the serial is a distinct render problem from a graphic beside it and is flagged for the render layer."
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      validation_sticker: { present: false, basis: "75 Pa.C.S. § 1332(d): 'Validating registration stickers shall not be issued or required to be displayed.'" }
+      dimension_note: "NO SOURCED DIMENSION (Chapter 13 states none; SAE J686 unpinned)."
+    replacement_cycle:
+      years: null
+      programme: true
+      statutory_text: "75 Pa.C.S. § 1331(f) requires the department to establish and administer a PROGRAM for the periodic reissuance of registration plates, addressing fee requirements, replacement on a STAGGERED BASIS, recycling of older plates and such other factors as it deems necessary."
+      execution_quote: "PennDOT, in its own words: 'Passenger license plates that start with a tag configuration \"D\", \"E\" and \"F\" are the oldest plates on the road. PennDOT has begun replacing the \"D\", \"E\" and \"F\" configuration through the mail.'"
+      note: >-
+        A PROGRAM, NOT A PERIOD — the third distinct US model. Florida legislates
+        a flat 10 years; New York legislates nothing; Pennsylvania legislates an
+        ongoing duty with staggering and recycling and lets the department choose
+        the cadence. Note what PennDOT's execution reveals: the replacement front
+        is running on SERIAL PREFIX, i.e. Pennsylvania is retiring plates by
+        their position in the alphabet-sequence rather than by issue date. That
+        makes the serial itself the age proxy, which is genuinely useful
+        era-inference signal for a parse API.
+    region_encoding: none
+    sources:
+      - "https://www.pa.gov/en/agencies/dmv/vehicle-services/registration-plates/standard-issue-registration-plate.html  # PennDOT: the 'Liberty Bell style' standard plate, a June 2025 introduction, 'white background with large blue letters and numbers', the $14 replacement fee, the D/E/F reissuance front, and the official sample image showing the contiguous ABC0123 serial"
+      - "https://codes.findlaw.com/pa/title-75-pacsa-vehicles/pa-csa-sect-75-1331.html  # § 1331(b) plate content; (d) reflectorizing; (f) the periodic reissuance program"
+      - "https://codes.findlaw.com/pa/title-75-pacsa-vehicles/pa-csa-sect-75-1332.html  # § 1332(d) no validating stickers"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Pennsylvania  # LOCATOR ONLY (PRD-PLATES §4): a MAY 2025 introduction, ABC1234, MYR0200 to NHJ 3386 as of 25 July 2026"
+    notes: >-
+      LET FREEDOM RING (2025-) — THE CURRENT PENNSYLVANIA STANDARD ISSUE.
+      DATE DISAGREEMENT, RECORDED NOT AVERAGED (PRD-PLATES §5.3): PennDOT's own
+      page says JUNE 2025; the locator says MAY 2025. Both are written down;
+      neither is split. `period.start: 2025` is safe under either. The design
+      name also differs by source — PennDOT calls it the 'Liberty Bell style'
+      plate in prose while the plate itself reads LET FREEDOM RING, and this
+      entry uses the plate's own legend as the name because that is what a
+      person or a camera actually sees. PARALLEL ISSUANCE IS REAL AND
+      AGENCY-STATED: PennDOT warns that 'Plates issued by third-party or
+      non-Commonwealth vendors may still use the previous design', so the 2017
+      base is still entering circulation and the two series legitimately overlap.
+
+  # =========================================================================
+  # ONE SERIES BACK — still being issued, per PennDOT's own warning.
+  # =========================================================================
+  - id: us-pa-visitpa
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2017 }
+    period_evidence: secondary-locator-unverified
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      charset: { notes: "as us-pa-let-freedom-ring: no statutory charset. Reported range KLF-0000 to MYR-0199, i.e. this base ran out exactly where the current one begins (MYR0200) - a clean, checkable boundary claim and the strongest era-inference signal in the file." }
+      pattern_note: "THIS base prints a hyphen. Written in its own printed form per PRD-PLATES §2.6 rule 2; the separator-free twin is derived by the consumer, not shipped."
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B3A6B"
+      colour_note: "dark blue on reflective white with a navy band at the top and a yellow band at the bottom (locator); `hex_basis: observed`. No colour value is in statute."
+      legend_top: "PENNSYLVANIA"
+      legend_bottom: "visitPA.com"
+      legend_note: "A URL AS A STATE SLOGAN. Pennsylvania ran www.state.pa.us on the 1999 base and visitPA.com on the 2004 and 2017 bases - two decades of plates carrying a marketing domain. Worth recording because a URL slogan dates a plate more sharply than a graphic does, and because it is the clearest example anywhere of a plate legend that can go stale independently of the plate."
+      graphic: { present: true, rendered: placeholder, description: "state outline at the top left, added on the 2017 revision of this base (locator)" }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      validation_sticker: { present: false, basis: "75 Pa.C.S. § 1332(d)" }
+    region_encoding: none
+    sources:
+      - "https://www.pa.gov/en/agencies/dmv/vehicle-services/registration-plates/standard-issue-registration-plate.html  # PennDOT: 'Plates issued by third-party or non-Commonwealth vendors may still use the previous design' - the official evidence that this series is STILL ISSUING and therefore has no end year"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Pennsylvania  # LOCATOR ONLY: June 2017 state-outline revision, visitPA.com slogan, ABC-1234, KLF-0000 to MYR-0199"
+    notes: >-
+      visitPA.com (2017-) — THE PREVIOUS BASE, WITH NO END YEAR ON PURPOSE.
+      PennDOT states that third-party and non-Commonwealth vendors may still be
+      issuing it, so closing the period would be a false claim: this is exactly
+      the parallel-issuance case PRD-PLATES §2.2 sanctions ('old stock issues
+      on'), and it is why this series and us-pa-let-freedom-ring overlap. The
+      2004 base carried the same visitPA.com slogan and the same ABC-1234
+      format, differing only in the absence of the state outline; it is NOT given
+      a series of its own because the boundary between them is locator-only and
+      minting a permanent id on it would be exactly the mistake us-fl-standard
+      declined to make.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES.
+  # =========================================================================
+  - id: us-pa-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2017 }
+    period_evidence: instrument-in-force-upper-bound
+    format_evidence: secondary-locator-unverified
+    matching: recall-only
+    format:
+      pattern: "9LL99"
+      regex: '\A(?:[A-Z]{3}\d{2}|\d{4}[A-Z]|[A-Z]\d{4}|\d[A-Z]{2}\d{2})\z'
+      charset:
+        notes: >-
+          FOUR ARRANGEMENTS ARE REPORTED FOR PENNSYLVANIA MOTORCYCLE PLATES -
+          ABC12, 1234A, A1234 and 1AB23 - AND THE LOCATOR DOES NOT SAY WHICH IS
+          CURRENT. Rather than pick one and pretend, this series is
+          `matching: recall-only` and its regex is the UNION of all four. A match
+          says 'this string has a shape Pennsylvania has issued to a motorcycle'
+          and nothing more. PennDOT's own rule caps a personal motorcycle plate
+          at five characters, which every one of the four arrangements satisfies.
+      pattern_note: "recall-only forbids a regex_strict (PRD-PLATES §2.7) and none is given. When a primary establishes which arrangement is current, this series splits and the union becomes a historic parent."
+    design:
+      background: { finish: retroreflective }
+      legend_top: "PENNSYLVANIA"
+      emblem: { present: true, rendered: placeholder }
+      vertical_variant: "75 Pa.C.S. § 1332(a.1)(3): PennDOT produces a VERTICAL-ALIGNMENT motorcycle plate on request for a $20 fee in addition to the annual registration. Same serial, rotated characters, different physical object - a render-layer variant, not a format variant."
+      dimension_note: "NO SOURCED DIMENSION."
+    region_encoding: none
+    sources:
+      - "https://codes.findlaw.com/pa/title-75-pacsa-vehicles/pa-csa-sect-75-1332.html  # § 1332(a.1): the vertical-mounting rule, the prohibition on mounting a horizontal-character plate vertically, and the $20 vertical plate"
+      - "https://www.pa.gov/en/agencies/dmv/vehicle-services/registration-plates/personalized-registration-plates.html  # PennDOT: 'A personal motorcycle registration plate may contain up to five letters and numbers in combination'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Pennsylvania  # LOCATOR ONLY: the four reported motorcycle arrangements ABC12, 1234A, A1234, 1AB23"
+    notes: >-
+      MOTORCYCLE — THE GROUP'S SECOND RECALL-ONLY SERIES AND ITS BEST
+      JUSTIFICATION. The honest position when four arrangements are reported and
+      none is dated is a union with `matching: recall-only`, not a guess dressed
+      as a fact. Pennsylvania also gives the dataset its first VERTICAL PLATE:
+      § 1332(a.1) treats character orientation as a legal property of the plate,
+      which no other statute in this group does.
+
+  - id: us-pa-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2017 }
+    period_evidence: instrument-in-force-upper-bound
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "XLL-9999"
+      regex: '\AX[A-Z]{2}-?\d{4}\z'
+      charset: { notes: "reported trailer format XBC-1234. The leading X is read as a LITERAL trailer marker because the locator's placeholder convention runs alphabetically and X breaks it - the same inference applied to the New Jersey trailer series, and flagged as an inference here too." }
+    design:
+      background: { finish: retroreflective }
+      legend_top: "PENNSYLVANIA"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Pennsylvania  # LOCATOR ONLY: trailer XBC-1234"
+    notes: "TRAILER. Locator-grade with one flagged inference about the X literal."
+
+  - id: us-pa-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2017 }
+    period_evidence: instrument-in-force-upper-bound
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    binding: business
+    format:
+      pattern: "H99-999H"
+      regex: '\A(?:H\d{2}-?\d{3}H|J\d{2}-?\d{3}J|K\d{2}-?\d{3}K)\z'
+      charset:
+        notes: >-
+          Three dealer arrangements are reported - H12-345H, J12-345J and
+          K12-345K - and they share a striking shape: THE SAME LETTER OPENS AND
+          CLOSES THE SERIAL. That is a bracketing marker, not a sequence, so the
+          regex enumerates the three known letters rather than allowing any
+          letter in both positions. If a fourth letter is in use the regex is
+          narrow by exactly that letter, which is the safe direction to be wrong.
+    design:
+      background: { finish: retroreflective }
+      legend_top: "PENNSYLVANIA"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Pennsylvania  # LOCATOR ONLY: dealer H12-345H, J12-345J, K12-345K"
+    notes: >-
+      DEALER. `binding: business`. The bracketing letter is the interesting
+      structural fact - Pennsylvania's dealer serial is the only one in this
+      group whose first and last characters are constrained to be equal, which
+      is a grammar no simple width-and-alphabet model can express.
+
+  - id: us-pa-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2017 }
+    period_evidence: statutory-authority-undated
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "9999-999"
+      regex: '\A\d{4}-?\d{3}\z'
+      charset: { notes: "reported paper in-transit plate, four numerals, separator, three numerals." }
+    design:
+      background: { finish: none, note: "temporary plates are the ONE class Pennsylvania statute exempts from reflectorisation - § 1331(d): 'All registration plates, EXCEPT TEMPORARY PLATES, shall be treated with reflectorizing material'. That exemption is the sourced fact here; the paper stock and the format are locator-grade." }
+      legend_top: "PENNSYLVANIA"
+      emblem: { present: false }
+    validity: "not sourced (recorded gap)"
+    region_encoding: none
+    sources:
+      - "https://codes.findlaw.com/pa/title-75-pacsa-vehicles/pa-csa-sect-75-1331.html  # § 1331(c): 'The department shall provide temporary registration plates for use on vehicles which are to be removed from this Commonwealth or for use as necessary pending issuance of permanent registration plates'; § 1331(d) exempts temporary plates from reflectorisation"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Pennsylvania  # LOCATOR ONLY: temporary in-transit 1234-567 paper plate"
+    notes: >-
+      TEMPORARY. THE CLASS IS STATUTORY AND THE STATUTE IS UNUSUALLY EXPLICIT
+      about what temporary plates are FOR - removal from the Commonwealth, or
+      the gap pending permanent plates - and about their one physical
+      distinction, the reflectorisation exemption. The serial format is
+      locator-grade. `period_evidence: statutory-authority-undated`: § 1331(c)
+      establishes the class without dating it, and the start year here is the
+      instrument-in-force floor, not a claim about when temporary plates began.
+
+  - id: us-pa-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2017 }
+    period_evidence: instrument-in-force-upper-bound
+    format_evidence: secondary-locator-unverified
+    matching: strict
+    binding: business
+    format:
+      pattern: "PA-99999"
+      regex: '\A(?:PA-?\d{5}|\d{5}-?PA)\z'
+      charset: { notes: "reported official-use formats PA-12345 and 12345-PA, i.e. the PA token appears at EITHER END - the same optional-position literal shape as New York's HX historical plates. A commercial official-use variant PA-1234A is also reported and is inside neither alternative; it is recorded here rather than silently widening the regex." }
+    design:
+      background: { finish: retroreflective }
+      legend_top: "PENNSYLVANIA"
+      emblem: { present: true, rendered: placeholder }
+    display_note: "the locator reports that official-use PASSENGER plates require FRONT AND REAR display while official-use COMMERCIAL plates are rear only - which would make Pennsylvania's government fleet the exception to its own one-plate rule. Locator-grade and unverified; if true it is a notable inversion and worth a primary."
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Pennsylvania  # LOCATOR ONLY: official-use PA-12345 / 12345-PA (passenger, front and rear) and PA-12345 / PA-1234A (commercial, rear only)"
+    notes: "GOVERNMENT. Locator-grade throughout; the front-and-rear claim for official passenger plates is the part most worth verifying, because it would contradict the state's general display posture."
+
+  # =========================================================================
+  # PERSONALISED — Pennsylvania publishes the most PRECISE separator rule of
+  # any state in this group, and it is encoded exactly.
+  # =========================================================================
+  - id: us-pa-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2017 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A(?:[A-Z0-9]{1,7}|[A-Z0-9][- ][A-Z0-9]{1,6}|[A-Z0-9]{2}[- ][A-Z0-9]{1,5}|[A-Z0-9]{3}[- ][A-Z0-9]{1,4}|[A-Z0-9]{4}[- ][A-Z0-9]{1,3}|[A-Z0-9]{5}[- ][A-Z0-9]{1,2}|[A-Z0-9]{6}[- ][A-Z0-9])\z'
+      charset:
+        notes: >-
+          PennDOT, in its own words: 'Personalized registration plates may
+          contain up to seven letters and numbers in combination.' And, crucially:
+          'One hyphen or one space is permitted, but not both. Special characters
+          are not available.' THAT IS THE MOST EXACT SEPARATOR RULE ANY
+          AUTHORITY IN THIS GROUP PUBLISHES, and it is encoded exactly rather
+          than approximated - the alternation enumerates the seven ways one
+          separator can split at most seven alphanumerics, so the regex accepts
+          A-B and ABCDEF-G and rejects A-B-C and the eight-character forms. A
+          motorcycle personal plate is capped at five characters instead of seven.
+      pattern_note: >-
+        WHY THE ALTERNATION AND NOT A LOOKAHEAD: bounding total length with a
+        lookahead would require either an unescaped wildcard or a character class
+        MIXING separators with the serial alphabet, and PRD-PLATES §2.8 forbids
+        the second while the lint rejects the first. The alternation is longer
+        and is the only spelling that satisfies the separator contract, which is
+        a small but real demonstration that §2.8's rule has teeth.
+    eligibility: "PennDOT: 'Requests for personal registration plates are restricted to: passenger vehicles, motorcycles, motor homes, trailers, trucks with a registered gross weight of not more than 14,000 pound'."
+    fee: "per Form MV-70S, the Bureau of Motor Vehicles Schedule of Fees; PennDOT does not state the amount on the plate page itself (recorded gap)."
+    region_encoding: none
+    sources:
+      - "https://www.pa.gov/en/agencies/dmv/vehicle-services/registration-plates/personalized-registration-plates.html  # PennDOT: seven characters (five for motorcycles); 'One hyphen or one space is permitted, but not both. Special characters are not available.'; the eligible vehicle list; the MV-70S fee pointer"
+    notes: >-
+      PERSONALISED — THE BEST-SPECIFIED FORMAT IN THE MID-ATLANTIC GROUP.
+      Pennsylvania is the only authority here that states its separator rule in
+      terms, and the rule it states is unusually strict (exactly one, hyphen or
+      space, never both). Encoding it exactly rather than as a loose
+      seven-character bound is the difference between a regex that validates and
+      one that merely shapes.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-pa-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2017 }
+    period_evidence: agency-page-in-force
+    format_evidence: official-agency-text
+    matching: strict
+    format:
+      pattern: "LLL9999"
+      regex: '\A[A-Z]{3}\d{4}\z'
+      charset: { notes: "specialty plates carry ordinary serials on an alternative design and PennDOT says 'the majority of which can be personalized', so the seven-character personalisation frame applies to most of them." }
+    design:
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      structure_official: >-
+        PennDOT publishes SEVEN plate tracks: Standard Issue, Military, Special
+        Fund, Special Organization, Personalized, Specialty, and Plates for
+        Persons with Disabilities. Special Fund and Special Organization are the
+        two that behave like other states' specialty programmes - Special Fund
+        plates direct money to a designated fund, Special Organization plates are
+        sponsored by an outside body.
+      count_official: null
+      count_official_note: >-
+        NO COUNT IS PUBLISHED AND NONE IS INVENTED. PennDOT replaced its static
+        plate lists with a SEARCH INTERFACE, and both the Special Fund and the
+        Special Organization search pages returned 'No results found' for an
+        empty query on 2026-08-02 - i.e. the agency's own catalogue is not
+        enumerable without knowing what to search for. That is a genuine
+        regression in public data and is recorded as such: Pennsylvania is
+        HARDER to index today than it was when the lists were static pages.
+      official_quote: "PennDOT: 'Pennsylvania also offers Special Fund, Speciality, Military and Special Organization license plates, the majority of which can be personalized.' (agency's own spelling of 'Speciality' preserved)"
+      special_organization_quote: "PennDOT: 'We make special organization plates showcasing Pennsylvania as the birthplace of America and featuring the Liberty Bell.'"
+      index_url: "https://www.pa.gov/en/agencies/dmv/vehicle-services/registration-plates.html"
+      special_fund_url: "https://www.pa.gov/services/dmv/apply-for-special-fund-registration-plates.html"
+      special_organization_url: "https://www.pa.gov/services/dmv/apply-for-special-organization-registration-plates.html"
+      eligibility_note: "Special Organization plates are available for passenger cars, trucks under 14,000 pounds, trailers, motorcycles (with approved designs) and motorhomes; PennDOT instructs applicants to 'contact your organization to request a Special Organization Registration Plate Application' rather than applying directly."
+      churn_note: "no discontinuation rule was located in Chapter 13; recorded gap."
+    region_encoding: none
+    sources:
+      - "https://www.pa.gov/en/agencies/dmv/vehicle-services/registration-plates.html  # the seven-track structure and the 'majority of which can be personalized' statement"
+      - "https://www.pa.gov/services/dmv/apply-for-special-organization-registration-plates.html  # the special-organization description, eligibility list and application route; its search interface returned no results for an empty query"
+      - "https://www.pa.gov/services/dmv/apply-for-special-fund-registration-plates.html  # the special-fund track; likewise not enumerable"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX. Pennsylvania is the negative case that makes
+      the index worth having: the programme plainly exists across four tracks,
+      PennDOT describes it in prose, and NOBODY - including PennDOT - publishes
+      a list or a number. Recording an explicit null with the reason (the
+      catalogue is behind a search box that will not enumerate) is the honest
+      output, and it tells a future pass exactly what to fix rather than leaving
+      a silent hole.
+
+# ---------------------------------------------------------------------------
+# GAPS.
+# ---------------------------------------------------------------------------
+gaps:
+  - "71 P.S. § 636 - the whole basis of the adverse artwork posture - was NOT FETCHED (403 on findlaw via two routes; palegis.us reset the connection). Highest-priority verification in this file."
+  - "palegis.us was unreachable on four attempts; §§ 1331 and 1332 were read through a third-party reproduction. Re-derive before applying."
+  - "NO PENNSYLVANIA INSTRUMENT PINNED FOR THE ONE-PLATE / REAR-ONLY RULE. Locator-grade only. Look to 67 Pa. Code."
+  - "67 Pa. Code (the department regulations § 1332(a) delegates mounting to, and the reflectorisation standards § 1331(d) delegates to) was not obtained."
+  - "NO SOURCED PLATE DIMENSION; Chapter 13 states none."
+  - "Introduction date of the current base disagrees between PennDOT (June 2025) and the locator (May 2025). Recorded, not resolved."
+  - "PennDOT's alt text says 'white background'; PennDOT's own image is cream. Recorded, not resolved."
+  - "Specialty catalogue is not enumerable - both official search pages return no results for an empty query."
+  - "Motorcycle: four reported arrangements, none dated; modelled as recall-only until a primary lands."


### PR DESCRIPTION
**PRD-PLATES gate L2 (owner-directed acceleration; research parallel, application ordered — L1 landed first per §7.1).** One of eleven US regional-group PRs covering all 50 states + DC + territories (FL was the L0 pilot). Drafted to the `de.yml`/`nl.yml`/`us-fl.yml` standard: primary-law verbatim headers, instrument-dated periods, `strict`/`recall-only` matching tiers, folklore flagged not asserted, **`artwork_risk` recorded per jurisdiction with evidence** (PRD-PLATES §4).

**This PR — midatlantic:** NY NJ PA DE MD DC (6 jurisdictions, 61 pinned primary sources).

**Verification:** researcher linted green in an isolated sandbox (proof file in the group dir, archived to the pipeline program dir); the driving session then independently staged ALL 55 wave files over pristine origin/main — `plates lint: 67 files, 604 series … OK` (385 new series; the _art gate stayed green) — and this branch is linted solo pre-push; CI runs the same gate.

**For the reviewer:** the dossier below carries the gaps (marked in the YAML at point of use), folklore flags, and the artwork_risk findings. The full research dossier follows verbatim.

---

# PRD-PLATES gate L2 — mid-Atlantic dossier (NY · NJ · PA · DE · MD · DC)

Research date **2026-08-02**. Method: FETCH-NEVER-ASSUME, statutes first.
**WebSearch was unavailable for this entire pass** (session budget exhausted at
the first call), so every source below was reached by WebFetch or `curl` against
a URL derived from a known scheme or harvested from a locator's citation list —
the same constraint the original US/world dossier ran under.

Deliverables, all in this directory:

| file | series | lines |
|---|---|---|
| `us-ny.yml` | 11 | 592 |
| `us-nj.yml` | 11 | 547 |
| `us-pa.yml` | 9 | 506 |
| `us-de.yml` | 10 | 551 |
| `us-md.yml` | 7 | 536 |
| `us-dc.yml` | 10 | 614 |
| `lint-proof.txt` | — | lint + behaviour-test output |
| `verify_regex_behaviour.rb` | — | hand-written accept/reject cases |
| `sources-pinned.txt` | — | 61 unique URLs |

**58 new series. `scripts/lint_plates.rb` green** against the canonical
`plates/` tree plus these six files: `10 files, 131 series … OK`, reproduced
three times identically (the lint seeds deterministically). A separate
behaviour suite hand-checks 15 series and 4 strict-twin cases for accept/reject
correctness beyond what the round-trip proves.

---

## 1. The eight findings that matter beyond this group

### 1.1 US plates put a DEVICE where Europe puts a hyphen — three times in six jurisdictions

New Jersey prints a **silhouette of the state** between the third and fourth
characters of every standard serial. Maryland's 2010–2016 base printed a **US
flag device** between its second and third. The District's trailer series prints
the **DC flag** in its serial gap. That is not a quirk; at three of six it is the
regional norm.

New Jersey was confirmed **twice and independently**: NJ MVC's own sample-plate
image reads `SAM⟨state outline⟩PLE`, and the locator's own wording calls it a
"state-shaped separator" — a printed *object* with a manufacturing method
("serial and separator screened rather than embossed").

`_meta/separators.yml` already anticipated this exactly, in its
`never_separator_note`, for "the coats of arms / seals that sit between groups on
several German and Austrian plates (a design element, carried in `design.emblem`,
never in the serial)". **The US is that case at scale.** All three are encoded as
an emitted space with the glyph carried in `design.graphic`.

**Recommended amendment:** name the New Jersey state outline, the Maryland flag
device and the DC flag in `never_separator`, so the rule is stated once rather
than rediscovered per jurisdiction.

### 1.2 New York lets a GRAPHIC be a character *inside* the serial — §2.6 rule 3, live

NYSDMV, in its own words: *"A character is a letter (A to Z), number (0 to 9),
**the state image**, or a space."* It counts toward the eight-character
allowance, and *"your plate combination cannot begin or end with the state
image. It must have at least one character on each side of it."*

This is **not** 1.1. A separator sits *between* groups and can be deleted
harmlessly; the New York state image is a **serial-significant glyph** — the
schema-amendment case PRD-PLATES §2.6 rule 3 names. Every New York regex here
describes the alphanumeric-only subset, and `us-ny.yml` carries a top-level
`serial_alphabet_finding` saying so loudly. **A lawfully issued New York plate
exists that this dataset cannot express**, and a consumer must not read a
non-match as invalidity.

### 1.3 Maryland has the first sourced US plate dimension — and it did not come through SAE J686

Md. Code, Transp. **§ 13-410(g)**: *"Class D (motorcycle) registration plates
shall measure 7 inches wide by 4 inches high."*

The whole US slice has been blocked on dimensions because AAMVA §3.1 delegates
to SAE J686, which is paywalled and unpinned. **A state legislature simply
stated one.** The strategic consequence is large: the right research move for US
plate geometry is to read fifty vehicle codes, not to buy one SAE standard.
Maryland is proof of concept; Delaware, by contrast, expressly delegates size to
its Department (§ 2121), so the yield will be uneven.

### 1.4 Three states, three different answers to "is there a replacement cadence?"

AAMVA §1.1 recommends "not to exceed 7 to 10 years". Against Florida's
legislated flat 10:

- **New York** — *nothing*. No cycle in VAT § 401 or § 402; NYSDMV runs a
  condition-triggered "Peeling and Damaged License Plates" remedy instead.
- **Pennsylvania** — a **programme, not a period**. 75 Pa.C.S. § 1331(f)
  requires the department to establish and administer periodic reissuance on a
  *staggered basis* with recycling. PennDOT is executing it **by serial prefix**:
  *"Passenger license plates that start with a tag configuration 'D', 'E' and 'F'
  are the oldest plates on the road."* That makes the serial itself the age proxy
  — real era-inference signal for the parse API.
- **Maryland** — a **floor plus discretion**: § 13-410(d) five-year minimum
  service life, § 13-410(e)(3) Administrator discretion to replace on condition.
- **Delaware** — none, and it shows: the same gold-on-blue design has run since
  1959 and the numeric space has *never been reset*.

### 1.5 The tractor-plate-on-the-front rule is a pattern, not a Florida oddity

Md. Code, Transp. **§ 13-411** sends the single plate to the **front** for Class
F (tractor) and to the rear for everything else. Florida § 320.0706 does the same
for truck tractors. **Two states, independently.** Any consumer modelling "front
plate required?" as one per-state boolean is wrong about both.

### 1.6 The District's plate legend is a political demand — and it is in the statute, with a conscience clause

DC Code **§ 50-1501.02(f-1)**: tags *"shall display the phrase 'End Taxation
Without Representation'"* — excluding, **by name**, for-hire vehicles,
organization plates, motorcycles and autocycles. And: *"An individual who does
not wish to display the phrase … may request an identification tag featuring an
alternate design."*

Structurally this is Florida's county-name legend (a statutory design with a
legislated escape hatch), so it is modelled the same way: the alternate — which
carries `www.dc.gov` where the demand would be — is its own series. The four
carve-outs are load-bearing: they are *why* the District has a distinct
`taxi`-class series at all.

### 1.7 artwork_risk: two adverse, one favourable, two unresearched, one debunked

| jurisdiction | posture | evidence |
|---|---|---|
| **NY** | **adverse** | *County of Suffolk v. First American Real Estate Solutions*, 261 F.3d 179 (2d Cir. 2001) — FOIL does not strip copyright from NY government works. No `{{PD-NYGov}}` on Commons. ⚠️ **opinion not fetched** — located via the Wikipedia copyright survey. |
| **PA** | **adverse by statute** | **71 P.S. § 636** — DGS *"shall have the power, and its duty shall be … [t]o copyright, in the name of the Commonwealth, all publications"*. An affirmative legislated **duty** to assert: the most adverse posture in the group. ⚠️ **statute not fetched** (403 on findlaw via two routes, connection reset on palegis.us). Open counter-argument recorded: whether a plate *design* is a "publication" of DGS. |
| **NJ** | **public-domain-favourable** | **The State's own legal statement, fetched**: *"anyone may view, copy or distribute State information found here without obligation to the State."* Plus (located, not fetched) *Burnett v. County of Bergen*, 402 N.J. Super. 319 (2008) and the Open Data Initiative Act, N.J.S.A. 52:18A-234.5. |
| **DE** | **unresearched** | Nothing found. No entry in the copyright survey (checked), no Commons tag, only a bare `©Delaware.gov` footer with no scope or grant. Default (copyrighted) applies. Chase: Government Information Center, Del. FOIA (Title 29 Ch. 100). |
| **MD** | **unresearched** | Nothing found. No survey entry (checked), no Commons tag, `maryland.gov` terms pages 404'd, `mva.maryland.gov` **403 to every request**. Chase: Maryland Public Information Act. |
| **DC** | **asserted-but-openly-licensed** | **FOLKLORE DEBUNKED — see below.** |

**The DC debunk.** Wikimedia Commons carries `{{PD-DC}}` (and `{{PD-DCGov}}`
redirecting to it) asserting District government works are public domain, citing
the Copyright Office Compendium ch. 300 with **no DC-specific pinpoint**. The
District's **own terms of use** say the opposite: dc.gov content *"is licensed
under a Creative Commons Attribution 3.0 License"*, and the same page separately
notes that *"federal government-produced materials … are not copyright
protected"* — the District itself distinguishing federal material (PD) from
District material (CC BY). **A CC BY licence is an exercise of copyright, not a
disclaimer of one.** The likely root of the Commons error is the federal-enclave
intuition, but 17 U.S.C. § 101 defines a work of the *United States Government*
as one prepared by a federal officer or employee, and the District government is
a municipal government created by Congress.

Practical effect: the CC BY grant carries a real **attribution obligation** that
would propagate into anything copying District content. Because our renders are
generated from facts and never derived from District material, **it never
attaches** — the same argument that makes Commons' CC BY-SA photographs harmless.
Recorded, not relied upon.

### 1.8 Two schema limitations the lint found for us

1. **The human-pattern DSL cannot spell a literal `L` or a literal `9`.**
   `pattern` reads `9`→digit, `L`→letter, everything else literal, with **no
   escape**. The District's `DLR` dealer prefix is therefore unspellable: the
   lint's round-trip generated `DUR-0824` and correctly failed. `us-dc-dealer`
   is now `matching: recall-only` with the middle character widened — **losing
   precision for a notation reason, not a factual one**, which is the wrong
   reason to lose it. *Recommended amendment: add a backslash escape or a
   quoted-literal run to the pattern DSL.*
2. **`design.background` assumes one colour; New Jersey has a gradient.** The
   Garden State plate ramps reflective yellow → near-white top-to-bottom. Encoded
   as a scalar `background.color` (the top-of-plate yellow) **plus** an explicit
   `background_gradient` block, stated rather than silently flattened.

**The separator contract earned its keep three times, visibly.** Maryland's
`S/G` and `L/G` and the District's `D/C` government markers all print a solidus;
`/` is in the FORGIVING set but **not** the EMITTED set, so the lint would reject
a literal `/`. In all three cases that forced the marker into the `legend` layer —
**which is where it actually lives on the plate**. Three jurisdictions print it,
none uses it inside a serial. §2.6 was right.

---

## 2. Per-jurisdiction summary

### New York — thin statute, adverse artwork, richest personalisation law
Standard **Excelsior** (2020–, `LLL-9999`, blue on white, Niagara Falls + NYC
skyline) over **Empire Gold** (2010–2020, gold ground, *typographic only* — the
low-risk NY base a render can safely approach). VTL § 402(2)'s entire colour law
is *"a marked contrast between the color of the number plates and that of the
numerals or letters thereon"* — a **property, not a value**, so every NY hex is
`observed`. VTL § 404 caps special plates at **eight** characters and its fee
matches NYSDMV's page to the cent. `us-ny-vintage` is the group's flagship
`recall-only`: a vintage plate **is** an original plate from the vehicle's year
of manufacture ("DMV does not accept reproductions"), so the series has no
grammar of its own — a century-wide union. Specialty count **206**, read from
NYSDMV's own result counter (the cleanest count in the group). Historic plates
begin *or* end with `HX` (cars/trucks) / `HM` (motorcycles) — agency-stated, the
best-sourced NY format.

### New Jersey — the separator finding; best agency documentation
**Garden State screened** (2014–) over **Garden State embossed** (2010–2014):
**same serial format**, differing only in manufacture — so *format alone cannot
date a New Jersey plate after 2010*, only the serial block can, and the blocks are
locator-grade. NJ MVC publishes historic (`QQ1000`–`QQ99999`, 25-year rolling +
exhibition-only use) and street rod (`R1000`–`R9999`, fixed pre-1949 **plus
private club membership** — a delegation of eligibility to a non-governmental
body, unique in the group) serial ranges itself. Personalisation carries an
unusual **minimum letter count** (≥3 letters, ≤7 characters) — encoded in
`regex_strict`, which is exactly what §2.7 built it for. Specialty deliberately
has **`count_total: null`**: five tracks, 17 enumerated dedicated plates, three
organisational *types*, and no official total to report.

### Pennsylvania — adverse by statute; three legislative oddities
**Let Freedom Ring** (2025–, `LLL9999` **no separator**) over **visitPA.com**
(2017–, `LLL-9999` **with hyphen**) — the separator change is sourced from
**PennDOT's own sample image**, which reads `ABC0123` contiguous with the Liberty
Bell as a watermark *behind* the characters. The 2017 base has **no end year on
purpose**: PennDOT states *"Plates issued by third-party or non-Commonwealth
vendors may still use the previous design"* — sanctioned parallel issuance.
§ 1332(d) abolishes the validation sticker in four words. § 1332(b)(2) legislates
against defeating **automated enforcement and electronic toll collection** — the
only state here to write machine readability into its display statute.
§ 1332(a.1) makes **character orientation** a legal property (vertical motorcycle
plates, $20). PennDOT's personalisation rule — *"One hyphen or one space is
permitted, but not both"* — is the most exact separator rule any authority in the
group publishes, and is encoded **exactly** by a 7-branch alternation (a
lookahead was impossible: it would need either an unescaped wildcard or a class
mixing separators with the serial alphabet, both barred by §2.8 and the lint —
a small proof that §2.8 has teeth).

⚠️ **Two date/colour disagreements recorded, not averaged** (§5.3): PennDOT says
**June** 2025, the locator says **May** 2025; PennDOT's alt text says *"white
background"*, PennDOT's own image is **cream**.

### Delaware — the named schema stress test, fully met
Variable-width bare numeric, **1–6 digits, no leading zeros** — `regex`
quantifies, `regex_strict` carries the leading-zero rule. § 2121 is the most
generous statute in the group: one plate per vehicle, plate content, vanity caps
(7 / 5 motorcycle, $40 annually) **and actual colour values in law** — *"Gold
letters on a blue background"*, **inverted** to blue-on-gold for the officers and
judges of § 2123. § 2126: rear only, ≥12 in, no tinted covers, $25–$200.
Specialty **149**, enumerated from DelDOT DMV's own complete A–Z list, with the
**highest creation threshold in the group — 200 applications** (25 for alumni
associations); compare Maryland's 25. **Two genuine ambiguities recorded:**
Delaware motorcycle and passenger serials share the all-numeric space (only the
`M/C` legend distinguishes them), and § 2125 "Ownership of plates" is the
statutory root of the famous low-number market ($675k for #6).

### Maryland — best-legislated plate, worst agency access
§ 13-410 legislates plate count **by vehicle class**, plate content, the
**optional county-of-residence sticker**, a five-year service life, and the
group's only dimension. § 13-936 fixes historic eligibility at **model year 1999
or earlier — a FIXED cutoff that will admit no new vehicles ever**, the opposite
dynamic to NY's and NJ's rolling 25-year tests, with a five-part use restriction
and a 60-year one-time **non-transferable** $50 registration. § 13-619 sets a
**25-owner** creation threshold and **cost-recovery-only** fees.

⚠️ **`mva.maryland.gov` returned HTTP 403 to every request**, including with a
browser user agent. The specialty catalogue, the historic plate design
determination and the trailer/dealer/temporary formats are all **unread because
of it**. This is the single largest *fixable* gap in the group — a verifier on a
residential connection will very likely walk straight through.

**Region encoding:** Maryland's county marker is an **optional sticker**;
Florida's is a **printed legend with a county-commission opt-out**. Neither is in
the serial — which generalises: **US serials are geographically opaque**, unlike
German, Spanish or Italian ones.

### District of Columbia — statutory slogan, stacked serial, best-dated series
Statutory legend + statutory opt-out (§1.6 above). **First stacked serial in the
dataset**: DC motorcycle tags stack `M` over a series letter, and AAMVA is
explicit that *"If stacked characters are used, they are part of the official
license plate number"* — so the stacked letter is **serial**, a render and
normalisation problem flagged for the render manifest. Specialty is **13** — an
order of magnitude below Delaware's 149 and New York's 206 — and **two of the
thirteen are political** ("We Demand Statehood", "Pride Lives Here"), which no
state programme here offers.

`us-dc-temporary` is **the best-dated series in the group and the only one with a
primary for its own start**: DC DMV published the 30 Sept 2024 changeover itself
with a reason (fraud), a physical description, a 45-day validity and a stated
transition window to 14 Nov 2024. **Lesson for the whole US slice: agency PRESS
RELEASES are systematically better sources for plate transitions than agency
service pages, and should be the first place a pass looks.**

---

## 3. Evidence grading — the vocabulary this group introduced

Because almost every US base-design *year* is locator-grade while the statutory
frame is primary, the two are graded **separately and per series**:

`period_evidence`: `statutory-date` · `statutory-authority-undated` ·
`agency-page-in-force` · `instrument-in-force-upper-bound` ·
`secondary-locator-unverified`

`format_evidence`: `statutory` · `official-agency-image` ·
`official-agency-text` · `secondary-locator-unverified`

Neither key is linted (the lint ignores both), so a maintainer may rename them —
but **the split is the point**: it lets a series carry a sourced class, a sourced
statute and an unsourced arrangement without any of the three contaminating the
others. `official-agency-image` earned its place twice: PennDOT's sample plate
established the 2025 separator drop, and NJ MVC's established the state-outline
separator. Neither fact exists in any text anywhere.

**Nothing here launders a locator's era table as a sourced year.** Every
locator-derived claim is labelled in-series *and* re-listed in that file's
`gaps:` block.

---

## 4. What the verifier should do first (ranked)

1. **Get past `mva.maryland.gov`'s 403.** Unblocks Maryland's specialty count,
   the § 13-936(f) historic plate design, and the trailer/dealer/temporary
   formats in one session.
2. **Fetch 71 P.S. § 636.** The entire Pennsylvania adverse posture rests on a
   locator's quotation. One successful fetch confirms or destroys it.
3. **Fetch *County of Suffolk v. First American Real Estate Solutions*,
   261 F.3d 179.** Same for New York. It is an edict of government — public
   domain and freely quotable once in hand.
4. **Re-derive PA §§ 1331/1332 and NJ 39:3-33 from official statute services.**
   Both were read through third-party reproductions (palegis.us reset four times;
   the NJ Legislature service was unreachable). The text is PD either way; the
   *provenance* is what needs fixing.
5. **One photograph settles the DC standard-base separator** — hyphen, or the DC
   flag device as on the trailer series? Flagged in-series.
6. **Chase base-design years from agency press releases**, per the DC temporary
   lesson: NYSDMV/Governor's office for the 2019 Excelsior public vote, PennDOT
   for the 2025 rollout (and the June-vs-May conflict), MDOT MVA for 2016.
7. **Verify the two flagged *inferences***: NJ trailer `T` and PA trailer `X` as
   literal class markers, read off the locator's placeholder convention. If
   either is wrong the regex is off by a factor of 26. Both are labelled as
   inferences in-series.
8. **Decide the two schema amendments** — pattern-DSL escape (§1.8) and the
   `never_separator` additions (§1.1) — before any consumer ships a US validator.

## 5. Standing rules honoured

- **SAE J686 is never quoted.** Every dimension claim routes through AAMVA Ed. 3
  or, in Maryland's case, through a state statute.
- **The 1956 AMA "standardization agreement"** is recorded in all six files as
  **commonly repeated, unsourced**. Noted additionally in `us-dc.yml`: the
  dossier's own finding that the uncited passage was copied verbatim into the
  Puerto Rico and Canada articles means **territory articles are where this
  folklore propagates** — relevant to the rest of L2.
- **Wikipedia is locator-only** throughout, cited as such on every line it
  supports, and never used for a period claim without the
  `secondary-locator-unverified` grade.
- **No photograph is copied.** Two official agency images were *read* (PennDOT,
  NJ MVC) to establish printed serial form; neither is reproduced and no render
  derives from either.
- **Emblem rule §3 applied everywhere**: `rendered: placeholder` on every
  graphic, including under New Jersey's favourable copyright posture, because
  state seals and flags carry protection **independent of copyright** and that
  question remains unresearched.
