### PR TITLE
plates: us southeast-a — VA WV NC SC GA (L2 US wave)

### DIFF
--- a/plates/us-ga.yml
+++ b/plates/us-ga.yml
@@ -1,0 +1,644 @@
+# plates/us-ga.yml — Georgia (PRD-PLATES gate L2, group southeast-a).
+#
+# THE GEORGIA FINDING, AND IT IS THE MOST CONSEQUENTIAL artwork_risk RESULT OF
+# THIS GROUP: GEORGIA IS A PUBLIC-DOMAIN STATE THAT HAS CARVED LICENSE PLATE
+# DESIGNS OUT BY STATUTE. Under the Georgia Constitution and its public-records
+# statutes the State and its agents may NOT claim copyright over public records
+# or works unless the legislature specifically permits it, and Wikimedia Commons
+# accordingly maintains {{PD-GAGov}} — Georgia is one of only five US
+# jurisdictions Commons lists as public domain (with California, Florida,
+# Massachusetts and Puerto Rico). The legislature has permitted copyright to a
+# short list of agencies, and THE GEORGIA DEPARTMENT OF REVENUE IS ON IT, FOR
+# LICENSE PLATE DESIGNS, at O.C.G.A. §§ 40-2-60.1, 40-2-85.3 and 40-2-86.1.
+#
+# § 40-2-60.1 says it in terms: "The design of the initial edition of any
+# special license plate, as well as the design of subsequent editions and
+# excepting only any part or parts of the designs owned by others and licensed
+# to the state, SHALL BE OWNED SOLELY BY THE STATE OF GEORGIA FOR ITS EXCLUSIVE
+# USE AND CONTROL, except as authorized by the commissioner."
+#
+# That is a stronger, more specific adverse signal than anything the US/world
+# dossier found for Arizona. Arizona asserts copyright GENERALLY, in a website
+# notice. Georgia asserts ownership of PLATE DESIGNS SPECIFICALLY, in the PLATE
+# STATUTE, in a state that is otherwise affirmatively public domain. The
+# dossier's per-state table should be amended: "AZ asserts copyright" is no
+# longer the most adverse plate-specific posture located in the US pass.
+#
+# THE SPLIT MATTERS AND IS MODELLED: Georgia's plate FACTS — dimensions,
+# retroreflectivity, county designation, service life, display rules — live in
+# O.C.G.A. Title 40 and are EDICTS OF GOVERNMENT, public domain at every level
+# and unaffected by § 40-2-60.1. What § 40-2-60.1 reaches is the ARTWORK. So
+# Georgia is simultaneously the best-sourced and the most render-restricted
+# state in this group, and this file reflects both.
+#
+# SOURCING PATH DISCLOSURE: Georgia's official code is served through a
+# LexisNexis container that does not answer automated fetches, and both
+# law.justia.com and the ga.elaws.us mirror failed (403 / stale-to-2013).
+# O.C.G.A. §§ 40-2-31, 40-2-41 and 40-2-60.1 were read through
+# codes.findlaw.com, disclosed at every citation as "[via FindLaw]". Verbatim
+# quotations below are marked; everything else is a description of text that was
+# read but not quoted back in full. A verifier should re-derive all three
+# sections from the official code before this file is applied.
+#
+# EVIDENCE GRADES — the four defined in us-va.yml.
+jurisdiction: us-ga
+authority:
+  name: Georgia Department of Revenue, Motor Vehicle Division (MVD)
+  url: "https://dor.georgia.gov/motor-vehicles/vehicle-registration-license-plates"
+binding: vehicle
+statute_edition: "Official Code of Georgia Annotated, Title 40 (Motor Vehicles and Traffic), Chapter 2 — §§ 40-2-31, 40-2-41 and 40-2-60.1 as reproduced by codes.findlaw.com and read 2026-08-01"
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4. THE HEADLINE.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: split-public-domain-state-with-statutory-plate-design-carve-out
+  basis: >-
+    GEORGIA IS PUBLIC DOMAIN BY DEFAULT AND ADVERSE ON PLATE ARTWORK BY
+    STATUTE, and both halves are sourced. THE DEFAULT: under the Georgia
+    Constitution and its public-records statutes the State and its agents may
+    not claim copyright over, or prevent disclosure of, public records or works
+    unless the legislature specifically permits it (O.C.G.A. § 50-18-71); a
+    public work is anything "created or received in the performance of duty and
+    paid for by public funds" (§ 50-18-102). Wikimedia Commons maintains
+    {{PD-GAGov}} on that basis and lists Georgia among the five US
+    jurisdictions whose government works are public domain. THE CARVE-OUT: the
+    legislature has specifically permitted copyright to a named short list —
+    the Court of Appeals and Supreme Court for their official reports
+    (§ 50-18-34), the Georgia Lottery (§ 50-27-9), the Department of Economic
+    Development (§ 50-7-8), and THE DEPARTMENT OF REVENUE FOR CERTAIN LICENSE
+    PLATE DESIGNS (§§ 40-2-60.1, 40-2-85.3, 40-2-86.1). The plate-design entry
+    was verified directly against § 40-2-60.1, which reads: "The design of the
+    initial edition of any special license plate, as well as the design of
+    subsequent editions and excepting only any part or parts of the designs
+    owned by others and licensed to the state, shall be owned solely by the
+    State of Georgia for its exclusive use and control, except as authorized by
+    the commissioner."
+  scope_of_the_carve_out: >-
+    READ THE CARVE-OUT NARROWLY AND SAY SO. § 40-2-60.1 as read speaks of
+    "any SPECIAL license plate", within a section about special plates that
+    commemorate events or support agencies, funds or nonprofit programmes. Two
+    consequences. (1) The SPECIALTY catalogue is squarely inside the carve-out
+    — Georgia claims sole ownership and exclusive control of every specialty
+    design and every subsequent edition of it. (2) Whether the carve-out
+    reaches the STANDARD Peach, Peach Orchard and America 250 designs was NOT
+    established: §§ 40-2-85.3 and 40-2-86.1 are the other two cited sections
+    and were NOT read in this pass (recorded gap, and the highest-value single
+    follow-up for Georgia). Until they are read, treat standard-plate artwork
+    as UNRESOLVED and specialty artwork as OWNED.
+  practical_rule: >-
+    Render Georgia from the STATUTE, never from the design. Dimensions,
+    retroreflectivity, the county designation, the required plate contents and
+    the display rules are edicts and are free. The peach graphic, the peach
+    orchard scene, the America 250 artwork and every specialty emblem are the
+    risk surface. `emblem: {present: true, rendered: placeholder}` is not a
+    default here, it is a requirement. Do not trace; do not approximate closely;
+    do not derive from a photograph.
+  america250_extra_caution: >-
+    THE AMERICA 250 DESIGN HAS A NAMED INDIVIDUAL AUTHOR. Georgia DOR states
+    that the plate "features a design created by Georgia middle school students
+    as part of a statewide civics education initiative" and that "the winning
+    design was submitted by Eden Pethel, a student and member of the Children
+    of the American Revolution." A design authored by a private individual and
+    adopted by the State engages § 40-2-60.1's own exception — "excepting only
+    any part or parts of the designs owned by others and licensed to the state"
+    — which means the ownership position on this particular plate may be split
+    between the State and a third party. That is the WORST possible posture for
+    a renderer and the strongest possible argument for the placeholder rule.
+  emblem_rule: "PRD-PLATES §3's placeholder default, applied without exception. The Georgia state seal, if used on any plate, additionally carries seal-misuse protection independent of copyright, which is unresearched."
+  photograph_caution: "Commons photographs of Georgia plates carry the photographer's licence on the photograph, not on the design — and in Georgia the design is affirmatively owned by the State. A CC BY-SA tag on a Georgia plate photo licenses nothing you need and clears nothing you actually risk. Our renders are generated from the statute and never derived from a photograph."
+  sources:
+    - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-60-1.html  # O.C.G.A. § 40-2-60.1 [via FindLaw]: the verbatim state-ownership sentence over special license plate designs and subsequent editions, with the licensed-from-others exception and the commissioner's authorisation power"
+    - "https://commons.wikimedia.org/wiki/Template:PD-GAGov  # the Georgia public-domain tag, its § 50-18-71 / § 50-18-102 basis, and its EXPLICIT list of agencies permitted to claim copyright — including 'Georgia Department of Revenue - O.C.G.A §§ 40-2-60.1, 85.3, 86.1 (certain license plate designs)'"
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # 'most works by government agencies in California, Florida and Georgia are in public domain, EXCEPT SPECIFIED AGENCIES AS STATED'"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: the same agency list, which is what pointed this pass at § 40-2-60.1 in the first place"
+    - "https://dor.georgia.gov/georgia-standard-license-plate-designs  # Georgia DOR: the America 250 design's origin in a student design competition and its named individual author"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; AAMVA's declarative present is RECOMMENDED PRACTICE."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is paywalled and was NOT obtained. No J686 dimension is quoted — and Georgia does not need one, because § 40-2-31(b) legislates minima for both the standard and the motorcycle plate."
+    retroreflectivity: "AAMVA §3.3 recommends readability from at least 75 feet day and night. O.C.G.A. § 40-2-31(c) requires the plate face be 'treated completely with a retroreflective material which will increase the nighttime visibility and legibility' — the same formula South Carolina uses in § 56-3-1230(B), almost word for word. Two neighbouring states with near-identical statutory language is worth noting for anyone tracing where US plate law was copied from."
+    replacement_cycle: "AAMVA §1.1 recommends a cycle not to exceed 7 to 10 years. Georgia legislates a MATERIALS floor rather than a reissue clock: § 40-2-31(b) requires that the 'plate shall provide a minimum service period of at least five years' — the same five-year durability floor South Carolina writes into § 56-3-1230(A), and again with no reissue interval attached in the text read."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' remains COMMONLY REPEATED AND NOT PRIMARY-SOURCED; see us-va.yml. Georgia does not need it: § 40-2-31(b) states the minima in law."
+
+# ---------------------------------------------------------------------------
+# DIGITAL LICENSE PLATES — recorded at file level because it is a fact about
+# GEORGIA'S PLATE LAW, not about any one series, and because it is the only
+# instance found anywhere in group southeast-a.
+# ---------------------------------------------------------------------------
+digital_plates:
+  statutory_hook: >-
+    O.C.G.A. § 40-2-31(a) [via FindLaw] provides for the commissioner to issue
+    plates bearing "a distinctive number OR A DISTINCTIVE NUMBER TO BE
+    DISPLAYED ELECTRONICALLY UPON A LICENSE PLATE BY A DIGITAL LICENSE PLATE
+    PROVIDER."
+  why_it_matters: >-
+    Every schema assumption in this dataset — retroreflective sheeting, stamped
+    or screened characters, a physical validation decal, a fixed design for a
+    period — presumes a metal plate. Georgia has legislated a second kind of
+    thing: a registration number RENDERED ON A DISPLAY by a third-party
+    provider. Its "design" is software, its "colours" are emitted rather than
+    printed, and its content can change without a base change. PRD-PLATES has
+    no field for it and needs none yet, but the dataset should know the case
+    exists before it meets a jurisdiction that has gone digital at scale.
+  scope_gap: "the extent of Georgia's digital-plate programme — which vehicle classes, which providers, whether the digital plate carries the same serial as a metal one — was NOT established in this pass (recorded gap)"
+  source: "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-31.html  # § 40-2-31(a) [via FindLaw]: the digital license plate provider clause"
+
+display_rules:
+  default: "ONE plate, REAR. § 40-2-41 [via FindLaw], verbatim fragments: 'the plate shall be fastened to the rear of the vehicle in a position so as not to swing' and it 'shall be at all times plainly visible'."
+  legibility_duty: "§ 40-2-41: 'It shall be the duty of the operator of any vehicle to keep the license plate legible at all times.' A duty on the OPERATOR, continuing, rather than a condition on the plate — Georgia frames legibility as conduct."
+  covering_rule: "§ 40-2-41, verbatim: 'No license plate shall be covered with any material unless the material is colorless and transparent.' Tighter and simpler than Virginia's four-limb obscuring test in § 46.2-716(B), and it bans tinted covers outright rather than by effect."
+  obstruction: "§ 40-2-41: 'No apparatus that obstructs or hinders the clear display and legibility of a license plate shall be attached to the rear of any motor vehicle.'"
+  sources:
+    - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-41.html  # O.C.G.A. § 40-2-41 [via FindLaw]: rear mounting without swing, continuous plain visibility, the operator's legibility duty, the colorless-and-transparent covering rule, and the rear-apparatus obstruction ban"
+
+# ---------------------------------------------------------------------------
+# COUNTY DESIGNATION — Georgia's region encoding, and it is a DECAL, which
+# makes it different in kind from Florida's printed county legend.
+# ---------------------------------------------------------------------------
+county_designation:
+  statutory_requirement: "§ 40-2-31(b) [via FindLaw]: the plate must 'designate the county from which the license plate was issued'. The county designation is MANDATORY in law."
+  mechanism: "a county name DECAL applied to the plate, not printed into it. § 40-2-31(d) provides for replacement county decals where a vehicle is registered in a different county; §§ 40-2-31(e) and (g) provide that agents offer either a county name decal OR an 'In God We Trust' decal with a new metal plate."
+  opt_out: >-
+    THE REGISTRANT CHOOSES. Where Florida makes the county legend a
+    COUNTY-COMMISSION opt-out (§ 320.06(3)(a): a county may vote to remove the
+    county name and print the state motto or 'Sunshine State' instead),
+    Georgia makes it an INDIVIDUAL opt-out at the counter: county name decal or
+    'In God We Trust' decal, per plate, per registrant. Same visible outcome, a
+    completely different decision-maker, and a modelling problem in both
+    directions — the bottom legend is a property of neither the series nor the
+    jurisdiction.
+  decode_value: >-
+    NONE IN THE SERIAL. Like Florida, Georgia's county information is a LEGEND,
+    not a code: nothing in the plate string encodes geography. And because the
+    Georgia designation is a peelable decal that is replaced on a move and can
+    be declined outright, it is WEAKER evidence of origin than Florida's
+    printed legend. A parse API must not infer county from a Georgia plate
+    string, and should not infer it from an observed decal either.
+  sources:
+    - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-31.html  # § 40-2-31(b) the mandatory county designation; (d) revalidation decals showing the year and month through which registration is valid, and replacement county decals on registering in a different county; (e) and (g) the county-name-or-'In God We Trust' decal election offered with new metal plates"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — GEORGIA OFFERS THREE, BY AGENCY ELECTION.
+  # DOR: "Georgia vehicle owners may select either the current Peach Plate,
+  # Peach Orchard Plate, or the new USA Semiquincentennial/America 250 plate".
+  # =========================================================================
+  - id: us-ga-standard-peach
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2012 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL9999"
+      regex: '\A[A-Z]{3} ?\d{4}\z'
+      format_evidence: secondary-locator-unverified
+      charset:
+        notes: >-
+          No exclusion is sourced for this base. Georgia's documented
+          exclusions are all on EARLIER bases and they move around: the
+          1997-2001 '123 ABC' format excluded I and O, admitting Q, U and V
+          only from 2000; the '1234 AB' format excluded I, O, U and V; the
+          2001-2003 '1234 ABC' format excluded I, O, Q, U and V; and the
+          2003-2012 'ABC 1234' bases excluded O alone. The trajectory is a
+          state progressively RELEASING letters as blocks exhaust, which means
+          a charset exclusion in Georgia is a property of a FORMAT AND A
+          PERIOD, never of the state.
+      progression: "reported: exclusively PFA1000 to PLZ9999 and QFA1000 to QFP6449 on this plain-peach base, running alongside the Peach Orchard base's own blocks. LOCATOR-GRADE."
+      separator_note: "Georgia prints this serial with a small gap and no glyph; the locator writes it closed up ('ABC1234'). `pattern` uses the closed form and `regex` admits an optional space, so both readings match and neither is asserted."
+    design:
+      plate: { w: 12, h: 6, unit: in, w_min_in: 12, h_min_in: 6, dimension_evidence: statutory-minimum }
+      plate_dimension_rule: "§ 40-2-31(b) [via FindLaw]: standard plates 'at least six inches wide and not less than 12 inches in length'. STATUTORY MINIMA — Georgia is one of two states in this group (with South Carolina) that legislates its plate size."
+      material_rule: "§ 40-2-31(b): the 'plate shall provide a minimum service period of at least five years'"
+      retroreflectivity_rule: "§ 40-2-31(c): the plate face must be 'treated completely with a retroreflective material which will increase the nighttime visibility and legibility'"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      colour_note: "NO COLOUR VALUE IS IN § 40-2-31, which mandates retroreflectivity and boldface characters and stops. Screened black serial on reflective white with a peach graphic at the centre is `hex_basis: observed` from a locator description."
+      legend_top: "Georgia"
+      legend_bottom_options: ["<county name decal>", "In God We Trust decal"]
+      slogan: null
+      statutory_content: "§ 40-2-31(b): the plate must show 'in boldface characters the month and year of expiration, the serial number, and either the full name or the abbreviation of the name of the state', and must designate the issuing county"
+      peach_state_authority: "§ 40-2-31(b) also permits the plate to bear 'figures, characters, letters, or combinations thereof as in the judgment of the commissioner will to the best advantage advertise ... Georgia as the \"Peach State\"' — a statutory ADVERTISING mandate for the state's own brand, which is the legal root of the peach that has been on Georgia plates for thirty years"
+      graphic: { present: true, rendered: placeholder, description: "peach graphic at the centre — OWNED ARTWORK, see artwork_risk" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: "county designation by DECAL, mandatory in law but electable between the county name and 'In God We Trust'; nothing geographic in the serial. See the file-level county_designation block."
+    sources:
+      - "https://dor.georgia.gov/georgia-standard-license-plate-designs  # Georgia DOR names the three current standard elections: 'Georgia vehicle owners may select either the current Peach Plate, Peach Orchard Plate, or the new USA Semiquincentennial/America 250 plate'"
+      - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-31.html  # § 40-2-31(a) the distinctive number and the digital-plate clause; (b) the 6 x 12 in minima, the boldface required contents, the county designation, the 'Peach State' advertising authority and the five-year service floor; (c) complete retroreflective treatment; (d)-(g) the decals"
+      - "https://dor.georgia.gov/motor-vehicles/vehicle-registration-license-plates/specialty-prestige-license-plates  # DOR: 'Prestige license plates are only issued on the STANDARD PEACH PLATE BACKGROUND' — which identifies this base, by the agency's own name for it, as Georgia's canonical standard"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Georgia_(U.S._state)  # LOCATOR ONLY (PRD-PLATES §4): the May 2012 start, the ABC1234 arrangement, the PFA1000/QFA1000 blocks, the historical charset exclusions, and the note that 'In God We Trust' can be printed at the bottom in place of the county name"
+    notes: >-
+      GEORGIA'S PLAIN PEACH PLATE — the canonical standard base, and the one
+      the agency itself treats as canonical: DOR states that prestige (vanity)
+      plates issue ONLY on "the standard peach plate background", which
+      distinguishes it from its Peach Orchard sibling as a matter of official
+      practice rather than of appearance. The two run concurrently from the same
+      base change and differ only in the graphic, which under PRD-PLATES §2.3
+      (design difference is sufficient) makes them two series. The statutory
+      "Peach State" advertising clause is the entry's best find: Georgia does
+      not merely permit a peach on its plate, it directs the commissioner to
+      use the plate to advertise the state, which is a legislative theory of
+      what a license plate is FOR and one no other state in this group states.
+
+  - id: us-ga-standard-peach-orchard
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2012 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL9999"
+      regex: '\A[A-Z]{3} ?\d{4}\z'
+      format_evidence: secondary-locator-unverified
+      charset: { notes: "no exclusion is sourced for this base; see us-ga-standard-peach for Georgia's period-bound exclusion history" }
+      progression: "reported: exclusively PAA1000 to PEZ9999 and PMA1000 to QBT1499, and alternating with the plain peach plate across CAA1000 to approximately DEC9999, RAA0001 to approximately SMR9999, and TAA0001 to TGW0701. Note ALTERNATING allocation — the two concurrent designs share blocks rather than partitioning them, which is the opposite of North Carolina's practice. LOCATOR-GRADE."
+    design:
+      plate: { w: 12, h: 6, unit: in, w_min_in: 12, h_min_in: 6, dimension_evidence: statutory-minimum }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      legend_top: "Georgia"
+      legend_bottom_options: ["<county name decal>", "In God We Trust decal"]
+      slogan: "Peach State"
+      graphic: { present: true, rendered: placeholder, description: "rolling hills, peach tree and peaches — OWNED ARTWORK, see artwork_risk" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: "county designation by decal; nothing geographic in the serial. See the file-level county_designation block."
+    sources:
+      - "https://dor.georgia.gov/georgia-standard-license-plate-designs  # Georgia DOR names the 'Peach Orchard Plate' as one of the three current standard elections"
+      - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-31.html  # § 40-2-31(b)-(c): the same statutory frame governs both peach bases — minima, contents, county designation, 'Peach State' advertising authority, five-year service floor, retroreflectivity"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Georgia_(U.S._state)  # LOCATOR ONLY: the May 2012 start, the rolling-hills/peach-tree graphic, the 'Peach State' slogan, and the alternating serial blocks shared with the plain peach base"
+    notes: >-
+      GEORGIA'S PEACH ORCHARD PLATE — the graphic sibling of the plain peach
+      base, concurrent with it since the same 2012 change, and the reason
+      Georgia is harder to parse than North Carolina despite looking similar.
+      North Carolina's three concurrent designs run in DISJOINT letter blocks,
+      so the serial identifies the design. Georgia's two peach bases ALTERNATE
+      through shared blocks, so the serial identifies nothing about which
+      design a plate carries. Two states, the same structural situation, and
+      opposite consequences for a parse API — which is exactly the sort of
+      thing that only becomes visible once serial-block allocation is recorded
+      as data rather than as prose.
+
+  - id: us-ga-standard-america250
+    class: standard
+    categories: [car, van, truck]
+    period:
+      start: 2026
+      scheduled_end: 2030
+      scheduled_end_note: >-
+        Georgia DOR: "This new license plate will remain available for issuance
+        THROUGH 2030." `period.end` is absent because the series is currently
+        issuing and because the lint's period rail rejects an end beyond the
+        current year plus one; `scheduled_end` carries the agency's announced
+        sunset. The same schema gap South Carolina's 2032 statutory sunset
+        exposes — see us-sc.yml and the group dossier.
+    period_evidence: official-agency-date
+    matching: strict
+    format:
+      pattern: "LLL9LL"
+      regex: '\A[A-Z]{3} ?\d[A-Z]{2}\z'
+      format_evidence: secondary-locator-unverified
+      charset:
+        notes: >-
+          A NEW SERIAL SHAPE, NOT JUST A NEW DESIGN. Georgia's peach bases run
+          three letters and four digits; this one runs three letters, one digit
+          and two letters. Georgia is not extending a block, it is opening a
+          new alphabet-heavy space — the standard response of a state whose
+          letter-digit combinations are exhausting, and the same move Brazil
+          made converting the fifth character of its serials for Mercosul. No
+          charset exclusion is sourced.
+      progression: "reported: AAA1AA to ABD6ZG as of 20 April 2026. LOCATOR-GRADE."
+    design:
+      plate: { w: 12, h: 6, unit: in, w_min_in: 12, h_min_in: 6, dimension_evidence: statutory-minimum }
+      background: { color: "#E6D3A3", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      colour_note: "screened black on a reflective TAN graphic ground — the only non-white standard ground in group southeast-a. `hex_basis: observed` from a locator description; no colour value is in Georgia law."
+      legend_top: "GEORGIA"
+      legend_secondary: "250 Year Anniversary Revolutionary War"
+      graphic: { present: true, rendered: placeholder, description: "state map at the left with a US flag behind it and 1776 over the top; red stars marking Georgia Revolutionary War sites — OWNED ARTWORK WITH A NAMED INDIVIDUAL AUTHOR, see artwork_risk.america250_extra_caution" }
+      emblem: { present: true, rendered: placeholder }
+      design_origin: >-
+        Georgia DOR: the plate "features a design created by Georgia middle
+        school students as part of a statewide civics education initiative
+        undertaken in partnership with the Georgia Department of Education",
+        supported by the Georgia Commission on Civics Education, the Georgia
+        Center for Civic Engagement and the Georgia Historical Society; the
+        winning design was submitted by Eden Pethel. The designer's own
+        description of the red stars, quoted by DOR: they "represent the
+        following Georgia Revolutionary War sites from north to south: Fight at
+        Van's Creek/Hornet's Nest, Battle of Kettle Creek, Sieges of Augusta,
+        Battle of Brier Creek, Battles of Savannah, Fort Morris, and the
+        Frederica Naval Action." SEVEN NAMED SITES, geographically ordered —
+        which is a decode table for a GRAPHIC rather than for a serial, and a
+        nice illustration that not all encoded information on a plate lives in
+        the number.
+      rear_differs: false
+    availability: "DOR: choose the plate when titling and registering, or exchange a current plate at a local tag office. Standard fees apply: during the renewal period the standard $20 renewal fee with no additional charge for the new plate; outside the renewal window a $20 exchange fee. It is a STANDARD plate at the standard fee, not a specialty plate."
+    region_encoding: "county designation by decal; nothing geographic in the serial. See the file-level county_designation block."
+    sources:
+      - "https://dor.georgia.gov/georgia-standard-license-plate-designs  # Georgia DOR: 'Available January 1, 2026'; 'This new license plate will remain available for issuance through 2030'; the three-way standard election; the $20 renewal / $20 exchange fees; the student design competition, its partners, the named designer, and the seven Revolutionary War sites the red stars mark"
+      - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-31.html  # § 40-2-31(b)-(c): the statutory minima, required contents, county designation and retroreflectivity that this base carries like any other"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Georgia_(U.S._state)  # LOCATOR ONLY: the ABC1DE serial arrangement, the AAA1AA to ABD6ZG range as of April 2026, and the tan/state-map/1776 design description"
+    notes: >-
+      GEORGIA'S AMERICA 250 STANDARD PLATE. Both period endpoints come from the
+      agency itself — 1 January 2026 available, issuance through 2030 — which
+      makes this the only series in the Georgia file with a real date grade.
+      COMPARE THE THREE SEMIQUINCENTENNIAL RESPONSES NOW IN THIS DATASET, because
+      they are three different constitutional postures on the same anniversary:
+      SOUTH CAROLINA legislated that its ENTIRE regular passenger plate shall
+      commemorate the anniversary from 2026 to 2032, with the artwork minimum in
+      the statute; GEORGIA made it one of three OPTIONAL standard designs
+      through 2030, by agency action, from a schoolchildren's competition;
+      FLORIDA offers "America 250" as one of four standard legend variants
+      within a single statutory design. Same event, same years, three completely
+      different mechanisms — and the dataset can show it, which is the sort of
+      thing the encyclopedia section exists for.
+
+  - id: us-ga-standard-america250-alt
+    class: standard
+    categories: [car, van, truck]
+    period:
+      start: 2026
+      scheduled_end: 2030
+      scheduled_end_note: "same DOR-announced sunset as us-ga-standard-america250; see that entry"
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LL9LLL"
+      regex: '\A[A-Z]{2} ?\d[A-Z]{3}\z'
+      format_evidence: secondary-locator-unverified
+      charset: { notes: "two letters, one digit, three letters — a second new shape opened on the same base two months after the first. No charset exclusion is sourced." }
+      progression: "reported: AA1AAA to AA1ADB as of 20 April 2026, i.e. barely started. LOCATOR-GRADE."
+    design:
+      plate: { w: 12, h: 6, unit: in, w_min_in: 12, h_min_in: 6, dimension_evidence: statutory-minimum }
+      background: { color: "#E6D3A3", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      legend_top: "GEORGIA"
+      legend_secondary: "250 Year Anniversary Revolutionary War"
+      graphic: { present: true, rendered: placeholder, description: "identical to us-ga-standard-america250 — OWNED ARTWORK, see artwork_risk" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: "county designation by decal; nothing geographic in the serial"
+    sources:
+      - "https://dor.georgia.gov/georgia-standard-license-plate-designs  # Georgia DOR: the America 250 plate, available 1 January 2026 through 2030 — the design this serial arrangement sits on"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Georgia_(U.S._state)  # LOCATOR ONLY: a second serial arrangement, AB1CDE, reported from March 2026 on the same base, running AA1AAA to AA1ADB as of April 2026"
+    notes: >-
+      A SECOND SERIAL ARRANGEMENT ON THE AMERICA 250 BASE, GIVEN ITS OWN SERIES
+      BECAUSE PRD-PLATES §2.3 SAYS FORMAT DIFFERENCE IS SUFFICIENT — and it is
+      worth pausing on how odd this is. Georgia opened a new alphabet-heavy
+      format (LLL9LL) in January 2026 and then, two months later, opened a
+      SECOND one (LL9LLL) on the same design. Two readings are possible: the
+      first block is exhausting far faster than planned, or the two arrangements
+      are allocated to different vehicle populations. NEITHER IS ESTABLISHED,
+      and the honest record is both readings and no choice between them
+      (PRD-PLATES §5.3: record disagreements, never average them). This is the
+      thinnest-sourced series in the Georgia file and should be verified before
+      the parse API relies on it.
+
+  # =========================================================================
+  # ONE SERIES BACK.
+  # =========================================================================
+  - id: us-ga-standard-georgiagov-2007
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2007, end: 2012 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL 9999"
+      regex: '\A[A-Z]{3} ?\d{4}\z'
+      regex_strict: '\A[A-NP-Z]{3} ?\d{4}\z'
+      format_evidence: secondary-locator-unverified
+      charset:
+        notes: >-
+          THE LETTER O IS NOT USED IN THIS SERIAL FORMAT — reported for both
+          the December 2003 and May 2007 executions of the ABC 1234 shape, and
+          that is what `regex_strict` encodes as [A-NP-Z]. It is the classic
+          O-versus-zero lookalike exclusion, and it is the ONLY Georgia
+          exclusion that survives into the period this file's one-series-back
+          entry covers; the richer exclusions (I, Q, U, V) belong to the
+          1997-2003 formats and are recorded in us-ga-standard-peach's charset
+          notes rather than encoded, because no series here covers them.
+      progression: "reported: intermittently from AVN 0001 to approximately AWB 1750, then exclusively AWB 1751 to approximately CAQ 9999, with the CAA-CAQ range appearing intermittently across this base and its successor. LOCATOR-GRADE."
+    design:
+      plate: { w: 12, h: 6, unit: in, w_min_in: 12, h_min_in: 6, dimension_evidence: statutory-minimum }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      legend_top: "Georgia"
+      slogan: "GEORGIA.gov"
+      legend_note: "embossed black on reflective white; peach graphic containing a green state shape at the centre; county name on a sticker at the bottom. The immediately preceding execution (December 2003 - April 2007) was the same design on a gradient grey-and-white ground with the slogan written 'www.GEORGIA.gov'; dropping the 'www.' is the only difference between them, which is a delightfully precise way to date a Georgia plate."
+      graphic: { present: true, rendered: placeholder, description: "peach containing a green state shape — OWNED ARTWORK, see artwork_risk" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: "county name on a sticker at the bottom — the same decal mechanism as the current bases"
+    sources:
+      - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-31.html  # § 40-2-31(b)-(c): the same statutory frame governed this base; Georgia's plate law did not change at the boundary"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Georgia_(U.S._state)  # LOCATOR ONLY: May 2007 - April 2012, the GEORGIA.gov slogan, the peach-with-state-shape graphic, the county sticker, the O exclusion, and the AVN/AWB/CAQ blocks"
+    notes: >-
+      THE PREVIOUS GEORGIA STANDARD BASE. Two things earn it a place beyond
+      being the predecessor. First, it carries the only encodable Georgia
+      charset rule in this file — no letter O — which gives the dataset a real
+      `regex_strict` for Georgia where the current bases give none. Second, it
+      is a URL: a US state put its own web address on its standard plate for
+      nine years, and changed the plate when the 'www.' fell out of fashion.
+      Design elements that date themselves that precisely are rare and worth
+      recording, because they let a plate photograph be dated without any
+      serial-range table at all. The 2012 overlap year is the rollout, with old
+      stock issuing on.
+
+  # =========================================================================
+  # CORE CLASSES.
+  # =========================================================================
+  - id: us-ga-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only; § 40-2-31 legislates the motorcycle plate's SIZE but states no serial arrangement for it, and DOR publishes none" }
+    design:
+      plate: { w: 7, h: 4, unit: in, w_min_in: 7, h_min_in: 4, dimension_evidence: statutory-minimum }
+      plate_dimension_rule: >-
+          § 40-2-31(b) [via FindLaw]: motorcycle plates 'at least four inches
+          wide and not less than seven inches in length'. A SEPARATE STATUTORY
+          MINIMUM FOR MOTORCYCLES — Georgia is the only state in group
+          southeast-a that legislates one for permanent plates (South Carolina
+          legislates 4 x 7 in for TEMPORARY motorcycle plates only, at
+          § 56-3-210(A)(3), and the two figures coincide exactly, which is
+          either convergence on the North American motorcycle convention or
+          one legislature reading the other's statute).
+      background: { finish: retroreflective }
+      retroreflectivity_rule: "§ 40-2-31(c) applies to motorcycle plates as to any other"
+      emblem: { present: true, rendered: placeholder }
+    other_sizes: "§ 40-2-31(b) also provides that the size of plates for LOW-SPEED VEHICLES and MULTIPURPOSE OFF-HIGHWAY VEHICLES is determined by the commissioner rather than by statute — so Georgia legislates two plate sizes and delegates a third"
+    region_encoding: none
+    sources:
+      - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-31.html  # § 40-2-31(b) [via FindLaw]: the 4 x 7 in motorcycle minimum, the 6 x 12 in standard minimum, and the commissioner-determined sizes for low-speed and multipurpose vehicles; (c) retroreflectivity"
+      - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-41.html  # § 40-2-41: rear mounting without swing applies to motorcycles as to other vehicles"
+    notes: >-
+      GEORGIA MOTORCYCLE. Modelled separately because Georgia gives the class
+      its own STATUTORY DIMENSION, which is a design difference established by
+      edict rather than inferred from photographs — the strongest kind of
+      evidence a plate dataset can have for a size claim, and the only one of
+      its kind for permanent motorcycle plates in this group. The serial
+      arrangement is a recorded gap.
+
+  - id: us-ga-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only. The governing Georgia dealer-plate section was NOT obtained in this pass; what is sourced is that Georgia MVD operates DEALER, TRANSPORTER and MANUFACTURER OR DISTRIBUTOR registration as three distinct, separately administered programmes." }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+    binding: business
+    programmes: "Georgia MVD lists Dealer Registration, Transporter Registration, and Manufacturer or Distributor Registration as three separate registration programmes under 'Dealers & Business Partners' — a THREE-WAY split where Virginia and South Carolina split two ways (dealer / manufacturer) and where our _meta/classes.yml has a single `dealer` value"
+    region_encoding: none
+    sources:
+      - "https://dor.georgia.gov/motor-vehicles/vehicle-registration-license-plates  # Georgia MVD's own navigation, under 'Dealers & Business Partners': Dealer Registration, Transporter Registration, Manufacturer or Distributor Registration — sourcing the EXISTENCE and the three-way split, and nothing more"
+    notes: >-
+      GEORGIA DEALER, TRANSPORTER AND MANUFACTURER PLATES — DELIBERATELY THIN
+      AND LABELLED AS SUCH. The citation supports exactly one claim: Georgia
+      runs three distinct business-plate programmes. Eligibility, quotas, fees,
+      legends and serials are all recorded gaps, because the governing O.C.G.A.
+      sections were not reached before this pass closed. CLASS VOCABULARY
+      SIGNAL, now recorded from a third state: `dealer` is being asked to carry
+      manufacturer plates (Florida, South Carolina, Georgia) and transporter
+      plates (Virginia, Georgia) as well as dealer plates, with different
+      caps, fees, validity and permitted uses in each case. That is an argument
+      for growing _meta/classes.yml, made in the group dossier and not here.
+
+  # =========================================================================
+  # PRESTIGE (VANITY) + SPECIALTY INDEX.
+  # =========================================================================
+  - id: us-ga-prestige
+    class: personalized
+    categories: [car, van, truck]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          recall-only. Georgia MVD describes a prestige plate as displaying "a
+          combination of letters or numbers selected by the customer" and
+          publishes no character limit or permitted-character list that this
+          pass located. Given that Virginia officially permits an ampersand and
+          North Carolina officially permits ? & $ @ inside a serial, Georgia's
+          permitted set must be checked before any strict regex is written.
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      background_restriction: >-
+          THE DISTINCTIVE FACT: Georgia MVD states that "Prestige license
+          plates are ONLY issued on the STANDARD PEACH PLATE BACKGROUND." So
+          Georgia decouples the two personalisation axes that Florida and North
+          Carolina couple — in Florida any standard or specialty design may be
+          personalized, and in North Carolina both may be, with a reduced
+          four-space limit on specialty plates. In Georgia you may choose your
+          characters or you may choose your design, not both. That single
+          sentence collapses the entire Georgia vanity space onto one base,
+          which is exactly the kind of constraint a parse API can exploit.
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: "county designation by decal, as on any standard Georgia plate"
+    sources:
+      - "https://dor.georgia.gov/motor-vehicles/vehicle-registration-license-plates/specialty-prestige-license-plates  # Georgia MVD: 'Prestige license plates (or vanity plates) display a combination of letters or numbers selected by the customer. Prestige license plates are only issued on the standard peach plate background.'"
+      - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-31.html  # § 40-2-31(a)-(b): the commissioner issues a distinctive number, and the plate's required boldface contents apply to a prestige plate as to any other"
+    notes: >-
+      GEORGIA PRESTIGE (VANITY) PLATES. Modelled as its own series because the
+      serial source differs — customer-chosen rather than commissioner-assigned.
+      The one strong fact is the background restriction, and it is worth stating
+      the comparison plainly: Georgia is the only state in group southeast-a
+      that forbids personalising a specialty design. Character limits, permitted
+      characters and refusal criteria are all recorded gaps.
+
+  - id: us-ga-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "specialty serials are not uniform across programmes; the index makes no arrangement claim and is deliberately recall-only" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+      ownership_warning: >-
+          UNIQUE TO GEORGIA IN THIS GROUP, AND IT BELONGS ON THE DESIGN BLOCK
+          RATHER THAN BURIED IN artwork_risk: every design in this index is
+          claimed by the State. O.C.G.A. § 40-2-60.1: "The design of the initial
+          edition of any special license plate, as well as the design of
+          subsequent editions ... shall be owned solely by the State of Georgia
+          for its exclusive use and control, except as authorized by the
+          commissioner." An L4 specialty-design pass over Georgia is therefore
+          a legal question before it is a research question. Index the
+          programmes; do not reproduce the designs.
+    program_index:
+      count_official: "hundreds"
+      count_official_quote: "Georgia DOR, in its own words: 'Georgia offers hundreds of specialty plate designs to choose from including veterans, colleges, special interest groups and more.'"
+      count_enumerated: 340
+      count_enumerated_method: >-
+        Georgia MVD publishes a plate-design search that renders its full list
+        in one page; enumerating that list gives 340 named designs, running
+        alphabetically from "Abraham Baldwin Agricultural College" to "ZOO
+        Atlanta". This is an ENUMERATION of the agency's own published list,
+        not an agency-stated count, and it is recorded separately from DOR's
+        "hundreds" rather than being presented as if the agency had said 340.
+        (Coincidentally Virginia's DMV facet total is also 340, reconciled from
+        four facets. Two independent states arriving at the same number is
+        noted so that a later reader does not suspect one figure of being
+        copied from the other — they were counted from different services on
+        different days.)
+      discontinued_marked: 14
+      discontinued_note: >-
+        THE BEST CHURN SIGNAL IN THIS GROUP AFTER VIRGINIA'S REPEALED CODE
+        SECTIONS: 14 of the 340 entries carry the suffix "New plates are no
+        longer available" IN THE AGENCY'S OWN LIST (observed examples: Abraham
+        Baldwin Agricultural College, Armstrong Atlantic State University,
+        Brenau University). Georgia therefore publishes, first-party and
+        inline, the distinction between an authorised programme and an
+        obtainable one — the same distinction North Carolina describes in prose
+        ("some may be discontinued") without marking per-programme. An L4 pass
+        can lift Georgia's dead-programme list mechanically.
+      official_list_url: "https://mvd.dor.ga.gov/motor/plates/PlateSelection.aspx"
+      official_programme_url: "https://dor.georgia.gov/motor-vehicles/vehicle-registration-license-plates/specialty-prestige-license-plates"
+      composition_observed: "the enumerated list spans military decorations at fine granularity (Air Medal split per service branch — Air Force, Army, Coast Guard, Marine, Navy — and per body style, with separate motorcycle variants), colleges and universities including OUT-OF-STATE ones (Alabama A&M, Alabama State, University of Mississippi alumni), professional sports foundations (Atlanta Braves Foundation, Atlanta Falcons, Atlanta Hawks Foundation, Atlanta United), civic and fraternal bodies, conservation causes, and functional plates that are not really specialty at all (Alternative Fuel, Amateur Radio, Ambulance)"
+      motorcycle_variants: "many programmes carry a SEPARATE MOTORCYCLE ENTRY in the same list (e.g. 'Air Force Cross - Motorcycle', 'Bronze Star - Motorcycle'), so the 340 figure counts body-style variants as distinct designs — which is a real reason two honest counts of 'Georgia specialty plates' can differ by a large factor depending on whether variants are collapsed"
+      statutory_hook: "O.C.G.A. § 40-2-60.1 governs special license plates commemorating events or supporting agencies, funds or nonprofit programmes beneficial to Georgia residents, and vests their designs in the State"
+    region_encoding: none
+    sources:
+      - "https://dor.georgia.gov/motor-vehicles/vehicle-registration-license-plates/specialty-prestige-license-plates  # Georgia DOR: 'Georgia offers hundreds of specialty plate designs'; the prestige-plate background restriction"
+      - "https://mvd.dor.ga.gov/motor/plates/PlateSelection.aspx  # Georgia MVD's Search License Plate Designs service: the full alphabetical list enumerated at 340 entries, the 14 'New plates are no longer available' markers, and the per-branch/per-body-style military and motorcycle variants"
+      - "https://codes.findlaw.com/ga/title-40-motor-vehicles-and-traffic/ga-code-sect-40-2-60-1.html  # O.C.G.A. § 40-2-60.1 [via FindLaw]: what a special license plate is for, and the State's sole ownership of the designs"
+    notes: >-
+      THE GEORGIA SPECIALTY PROGRAM INDEX — per PRD-PLATES §2.5, a count and a
+      programme-list reference with source URLs, and no individual designs.
+      Three findings worth carrying. FIRST, the count is given twice and
+      honestly: the agency says "hundreds", the agency's own list enumerates to
+      340, and the two are recorded separately rather than blended. SECOND,
+      Georgia marks dead programmes inline, so authorised-versus-obtainable is
+      first-party data here rather than an inference. THIRD, and this is the
+      one that constrains future work: Georgia OWNS these designs by statute.
+      Of all the specialty catalogues in the US pass, this is the one where the
+      §2.5 discipline — index the programmes, never the designs — stops being a
+      scope decision and becomes a legal one.

--- a/plates/us-nc.yml
+++ b/plates/us-nc.yml
@@ -1,0 +1,602 @@
+# plates/us-nc.yml — North Carolina (PRD-PLATES gate L2, group southeast-a).
+#
+# THE NORTH CAROLINA FINDING: THE STANDARD PLATE IS A CHOICE OF THREE, AND THE
+# CHOICE IS IN THE STATUTE. N.C. Gen. Stat. § 20-63(b) gives the owner of a
+# private passenger vehicle a statutory election between "(i) a 'First in
+# Flight' plate, (ii) a 'First in Freedom' plate, or (iii) a 'National/State
+# Mottos' plate", and the same subsection then DESCRIBES one of them in law:
+# the First in Flight plate "shall have the words 'First in Flight' printed at
+# the top of the plate above all other letters and numerals. The background of
+# the 'First in Flight' plate shall depict the Wright Brothers biplane flying
+# over Kitty Hawk Beach." A US state legislature specifying the SCENE on its
+# plate is rare, and it makes North Carolina the only state in this group whose
+# standard artwork is described by an edict of government.
+#
+# CONSEQUENCE FOR THE SCHEMA: North Carolina has THREE CONCURRENT CURRENT
+# STANDARD SERIES, not one, and they are not variants of each other — they run
+# in DISJOINT SERIAL BLOCKS, which means the plate string itself tells you
+# which design you are looking at. That is a genuinely useful parse signal and
+# it is modelled as three series under PRD-PLATES §2.3 (own series iff format
+# OR design OR period differs — here design and period both differ).
+#
+# SOURCING PATH DISCLOSURE, REQUIRED BY HONESTY: the North Carolina General
+# Assembly's own statute service (ncleg.gov) returns HTTP 403 from a Cloudflare
+# challenge to every automated fetch attempted in this pass — HTML and PDF,
+# with and without browser headers. § 20-63 and § 20-79.1 were therefore read
+# through a third-party reproduction (codes.findlaw.com). The UNDERLYING TEXT
+# is an edict of government and public domain; the READING PATH is second-hand
+# and is disclosed at every citation below with the marker "[via FindLaw;
+# ncleg.gov 403]". A verifier with browser access should re-derive both
+# sections from ncleg.gov directly before this file is applied.
+#
+# EVIDENCE GRADES — the four defined in us-va.yml: statutory-date,
+# official-agency-date, instrument-in-force-upper-bound,
+# secondary-locator-unverified.
+jurisdiction: us-nc
+authority:
+  name: North Carolina Division of Motor Vehicles (NCDMV)
+  url: "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx"
+binding: vehicle
+statute_edition: "North Carolina General Statutes, Chapter 20 (Motor Vehicles), Article 3 — §§ 20-63 and 20-79.1 as reproduced by codes.findlaw.com and read 2026-08-01; ncleg.gov itself was unreachable (403)"
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: public-domain-favourable
+  basis: >-
+    NORTH CAROLINA IS THE SECOND-BEST POSTURE IN THIS GROUP AFTER GEORGIA'S
+    GENERAL RULE, AND UNLIKE GEORGIA IT CARRIES NO PLATE-SPECIFIC CARVE-OUT.
+    Two independent supports. First, the public-records statute: N.C. Gen.
+    Stat. Chapter 132 provides that "The public records and public information
+    compiled by the agencies of North Carolina government or its subdivisions
+    are the property of the people. Therefore, it is the policy of this State
+    that the people may obtain copies of their public records and public
+    information free or at minimal cost unless otherwise specifically provided
+    by law." Second, the State Library of North Carolina treats state
+    documents in its collection as public domain under US copyright law and
+    publishes a State Document Public Domain Notice to that effect. Third, and
+    specific to this dataset, the standard plate's artwork is DESCRIBED IN THE
+    STATUTE ITSELF (§ 20-63(b), the Wright Brothers biplane over Kitty Hawk
+    Beach), and statutes are edicts of government — public domain at every
+    level, in every state, including states that assert copyright generally.
+  known_exceptions: >-
+    North Carolina's general "property of the people" rule is NOT absolute and
+    the exceptions are named: state law describes some specific record types
+    in which the State may hold copyright — archaeological resources collected
+    or excavated from State lands together with associated records and data,
+    and original tapes, notes, discs or other records created by stenotype,
+    shorthand or stenomask equipment as part of trial recording. NEITHER
+    EXCEPTION TOUCHES LICENSE PLATES. That matters: the honest posture is
+    "favourable with enumerated carve-outs, none applicable", not "everything
+    North Carolina makes is free".
+  no_commons_tag: >-
+    Wikimedia Commons has NO {{PD-NCGov}} template (HTTP 404, checked
+    2026-08-01), where it does have PD-FLGov, PD-CAGov and PD-GAGov. The
+    absence of a Commons tag is NOT evidence against the posture — it is
+    evidence that nobody has written the tag. Recorded so that a later reader
+    does not mistake a missing template for an adverse finding.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default still applies to the Wright Flyer
+    graphic, the quill-pen graphic and the national-flag motif until each is
+    affirmatively cleared per-emblem. Even under a favourable copyright
+    posture, STATE SEALS AND EMBLEMS carry protection independent of copyright
+    and that question is unresearched for North Carolina. Render `emblem:
+    {present: true, rendered: placeholder}`.
+  photograph_caution: "Commons photographs of North Carolina plates carry the photographer's licence on the photograph, not on the design. Our renders are generated from data, never derived from a photograph, so those obligations never attach."
+  sources:
+    - "https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/ByChapter/Chapter_132.html  # N.C. Gen. Stat. Chapter 132: public records and public information are 'the property of the people' (URL pinned; the host 403s automated fetches, see the header disclosure)"
+    - "http://digital.ncdcr.gov/cdm/ref/collection/p249901coll22/id/63754  # State Document Public Domain Notice, State Library of North Carolina"
+    - "http://copyright.lib.harvard.edu/states/north_carolina/  # Copyright at Harvard Library, North Carolina: the enumerated exceptions (archaeological resources; stenotype/shorthand/stenomask trial records) in which the State may hold copyright"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: the survey entry that chases to the three primaries above"
+    - "https://commons.wikimedia.org/wiki/Template:PD-NCGov  # HTTP 404 — no Commons tag exists; recorded so its absence is not misread as adverse"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; AAMVA's declarative present is RECOMMENDED PRACTICE, not requirement."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is paywalled and was NOT obtained. No J686 dimension is quoted."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges"
+    legibility_comparison: "AAMVA §3.3 asks for readability from at least 75 feet day AND night. N.C. Gen. Stat. § 20-63(c) legislates 100 feet in daylight — the same figure West Virginia legislates in §17A-3-14(b)(2). Two states of this group, one number, arrived at independently."
+    retroreflectivity_gap: >-
+      NORTH CAROLINA'S PLATE STATUTE DOES NOT REQUIRE RETROREFLECTIVITY. This
+      is a real absence, not an oversight in the research: § 20-63 sets a
+      100-foot DAYLIGHT legibility bar and says nothing about night. Compare
+      South Carolina (§ 56-3-1230(B): "The face of the license plate must be
+      treated completely with a retroreflective material"), Georgia
+      (§ 40-2-31(c), same), West Virginia (§17A-3-14(b)(1): "Plates must
+      incorporate reflectorized material") and Florida (§ 320.06(3)(a)). Four
+      of the five states in this group legislate reflectivity; North Carolina
+      does not. Its plates are reflective in fact — the design descriptions all
+      say "reflective white" — but that is DEPARTMENTAL PRACTICE, and this file
+      records it as such.
+    replacement_cycle: "AAMVA §1.1 recommends a cycle not to exceed 7 to 10 years. No North Carolina replacement cycle was located in § 20-63 (recorded gap)."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' remains COMMONLY REPEATED AND NOT PRIMARY-SOURCED; see the fuller note in us-va.yml. North Carolina's plate dimensions are not in § 20-63, so this file makes no North Carolina dimension claim."
+
+display_rules:
+  default: "ONE plate. § 20-63(a) [via FindLaw; ncleg.gov 403]: 'The Division upon registering a vehicle shall issue to the owner one registration plate for a motorcycle, trailer or semitrailer and for every other motor vehicle.'"
+  position: "§ 20-63(d) [via FindLaw; ncleg.gov 403] is drafted for the two-plate case and then falls through: plates 'shall be attached thereto, one in the front and the other in the rear: Provided, that when only one registration plate is issued for a motor vehicle ... said registration plate shall be attached to the rear.' Because § 20-63(a) issues one, the operative North Carolina rule is REAR ONLY — reached through a proviso rather than stated directly, which is worth noting for anyone quoting the statute at a glance."
+  legibility: "§ 20-63(c): 'Such registration plate and the required numerals thereon, except the year number for which issued, shall be of sufficient size to be plainly readable from a distance of 100 feet during daylight.' Note the carve-out — the YEAR NUMBER is exempt from the 100-foot rule, so a legibility model must not apply one threshold to the whole plate."
+  plate_contents: "§ 20-63(b): 'Every license plate must display the registration number assigned to the vehicle for which it is issued, the name of the State of North Carolina, which may be abbreviated, and the year number for which it is issued or the date of expiration.'"
+  sticker_abolition: "OFFICIAL AND DATED: 'Effective October 1, 2026, NCDMV is no longer issuing physical license plate stickers or printed vehicle registration cards.' (NCDMV). A US state removing the validation sticker from the plate entirely is a design change with direct consequences for any renderer or ALPR model that expects one, and it is the single most time-sensitive fact in this file."
+  sources:
+    - "https://codes.findlaw.com/nc/chapter-20-motor-vehicles/nc-gen-st-sect-20-63.html  # N.C. Gen. Stat. § 20-63 [via FindLaw; ncleg.gov 403]: (a) one plate; (b) plate contents and the three-design election, with the First in Flight description; (c) the 100-foot daylight rule and its year-number carve-out; (d) front/rear with the single-plate proviso"
+    - "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx  # NCDMV: the three standard designs by name, the October 1 2026 abolition of physical stickers and printed registration cards, and the specialty and personalized programmes"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — THREE CONCURRENT SERIES, ONE PER STATUTORY
+  # DESIGN ELECTION, RUNNING IN DISJOINT SERIAL BLOCKS.
+  # =========================================================================
+  - id: us-nc-standard-first-in-flight
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2009 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      regex_strict: '\A[A-Z][A-M][A-Z]-?\d{4}\z'
+      format_evidence: secondary-locator-unverified
+      charset:
+        notes: >-
+          THE SECOND LETTER IS THE CONSTRAINT, AND IT IS AN ALLOCATION RULE
+          RATHER THAN A LOOKALIKE EXCLUSION. On the current North Carolina
+          bases the second letter of the serial runs strictly A through M — so
+          AMZ is followed by BAA, BMZ by CAA, and so on. That is what
+          `regex_strict` encodes. It is a rationing device, not a legibility
+          one: North Carolina is not avoiding I/O/Q here, it is halving each
+          three-letter block so that three concurrent designs can share one
+          alphabet without colliding. The mirror-image rule ran on the
+          1985-2007 base with the second letter strictly N through Z, and the
+          switch from N-Z to A-M happened when ZZZ-9999 was reached in 2010.
+      progression: >-
+          Reported blocks for THIS design: AAA-1001 onwards from December 2010,
+          reaching approximately LKE-7520 by mid-2025; the immediately
+          preceding stretch of the same design ran ZNE-1001 to ZZZ-9999 from
+          October 2009. First letters are therefore in the A-L range and are
+          expected to run to N before exhaustion. LOCATOR-GRADE.
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_evidence: convention-not-sourced }
+      plate_dimension_note: "no North Carolina dimension is sourced — § 20-63 states none. 12 x 6 in is the North American convention (AAMVA -> SAE J686, voluntary), not a North Carolina claim."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1F4E9C"
+      colour_note: >-
+          NO COLOUR IS IN § 20-63, AND NEITHER IS REFLECTIVITY (see
+          us_standards.aamva_edition_3.retroreflectivity_gap). Blue serial on
+          reflective white with a light blue Wright Flyer graphic is
+          `hex_basis: observed` from a locator description. One locator detail
+          is worth carrying because it is a legibility fact rather than an
+          aesthetic one: North Carolina ran RED serials on this design from
+          April 2007 and reverted to blue in October 2009 "following
+          complaints that the red serials were too hard to read from a
+          distance" — which is precisely the § 20-63(c) 100-foot bar being
+          enforced by public complaint rather than by statute.
+      legend_top: "First in Flight"
+      legend_rule: >-
+          § 20-63(b) [via FindLaw; ncleg.gov 403], verbatim: the First in
+          Flight plate "shall have the words 'First in Flight' printed at the
+          top of the plate above all other letters and numerals. The background
+          of the 'First in Flight' plate shall depict the Wright Brothers
+          biplane flying over Kitty Hawk Beach." THE STATUTE SPECIFIES THE
+          SCENE. This is the only standard-plate artwork in group southeast-a
+          that is described by an edict of government, and it is the reason
+          North Carolina's design facts are quotable where Virginia's and West
+          Virginia's are not.
+      graphic: { present: true, rendered: placeholder, description: "Wright Brothers biplane flying over Kitty Hawk Beach, per § 20-63(b)" }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      digit_note: "locator-reported: newer production of this and the other two current designs uses an updated '8' glyph to differentiate it from 'B' — a glyph-level anti-confusion change within an unchanged design, invisible to any serial-range model"
+    region_encoding:
+      kind: optional-county-block
+      mechanism: "since 1999 the OBX prefix has been issued as a special series for DARE COUNTY (the Outer Banks). It is a reserved three-letter block carrying a geographic meaning inside an otherwise geography-free serial space."
+      evidence: secondary-locator-unverified
+      note: "this is the ONLY geographic signal located in a North Carolina serial. It is a reserved BLOCK, not a systematic county encoding: 99 of North Carolina's 100 counties leave no trace in the plate string, so a decode table would have exactly one row. Recorded because a one-row decode table is still a real fact and because a parse API that reports 'OBX -> Dare County' is right."
+    sources:
+      - "https://codes.findlaw.com/nc/chapter-20-motor-vehicles/nc-gen-st-sect-20-63.html  # § 20-63(b) [via FindLaw; ncleg.gov 403]: the three-design election and the verbatim First in Flight description (words at top, Wright Brothers biplane over Kitty Hawk Beach); (a) one plate; (c) 100-foot daylight legibility"
+      - "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx  # NCDMV names 'First in Flight' as one of three standard designs available for private passenger and private hauler vehicles and states what it commemorates (the Wright Brothers' first powered flight at Kitty Hawk, 1903)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_North_Carolina  # LOCATOR ONLY (PRD-PLATES §4): the October 2009 blue-serial start, the December 2010 AAA-1001 block reset, the second-letter A-M allocation rule, the red-to-blue legibility reversion, the updated '8' glyph, and the OBX/Dare County series. None asserted as sourced."
+    notes: >-
+      NORTH CAROLINA FIRST IN FLIGHT — the default of the three statutory
+      designs and the oldest continuously issued. It is also one of the five
+      oldest US plate DESIGNS still in use by lineage (the First in Flight
+      concept dates to 1982, when it won ALPCA's Plate of the Year, the only
+      time North Carolina has been so honoured). The period recorded here is
+      for the CURRENT blue-serial execution from October 2009; the 1982-2007
+      lineage is L4 historical depth and is deliberately not modelled at this
+      gate. All three current designs share one format and one allocation rule
+      and differ only in artwork and serial block — which is exactly why they
+      are three series and not one with variants: PRD-PLATES §2.3 makes design
+      difference sufficient.
+
+  - id: us-nc-standard-first-in-freedom
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2015 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      regex_strict: '\A[A-Z][A-M][A-Z]-?\d{4}\z'
+      format_evidence: secondary-locator-unverified
+      charset: { notes: "same second-letter A-M allocation rule as the other two current designs; see us-nc-standard-first-in-flight for the reasoning" }
+      progression: "reported: PAA-1001 onwards from 1 July 2015, reaching approximately RKT-1298 by May 2025, with PMZ followed by RAA and RMZ to be followed by SAA — a P/R/S first-letter block disjoint from First in Flight's A-L and from the Mottos plate's T-V. LOCATOR-GRADE."
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_evidence: convention-not-sourced }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1F4E9C"
+      legend_top: "First In Freedom"
+      legend_rule: "§ 20-63(b) [via FindLaw; ncleg.gov 403] names the 'First in Freedom' plate as one of the three elections but — unlike the First in Flight plate — does NOT describe its artwork. The quill-pen graphic and the two commemorative dates are therefore DEPARTMENTAL DESIGN, not statutory, and are recorded at a lower grade than the First in Flight scene."
+      graphic: { present: true, rendered: placeholder, description: "quill pen; locator-reported to carry the dates 20 May 1775 and 12 April 1776, commemorating the Mecklenburg Declaration and the Halifax Resolves" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://codes.findlaw.com/nc/chapter-20-motor-vehicles/nc-gen-st-sect-20-63.html  # § 20-63(b) [via FindLaw; ncleg.gov 403]: 'First in Freedom' as statutory election (ii), and the absence of any statutory description of its artwork"
+      - "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx  # NCDMV: 'First in Freedom: Recognizes two important North Carolina milestones in the American Revolution'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_North_Carolina  # LOCATOR ONLY: the 1 July 2015 start, the PAA-1001 block, the quill pen, and the two 1775/1776 dates"
+    notes: >-
+      NORTH CAROLINA FIRST IN FREEDOM — the second statutory election, added
+      1 July 2015. The instructive contrast with its sibling is the SOURCING
+      ASYMMETRY inside a single statutory subsection: § 20-63(b) describes the
+      First in Flight plate's background in law and says nothing at all about
+      this one's. A dataset that records "statutory" as a property of the
+      SERIES rather than of the CLAIM would flatten that difference and be
+      wrong twice. Note also the revived slogan: "FIRST IN FREEDOM" was North
+      Carolina's plate slogan on the 1975-78 base, retired, and brought back
+      forty years later as an optional design.
+
+  - id: us-nc-standard-national-state-mottos
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2019 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      regex_strict: '\A[A-Z][A-M][A-Z]-?\d{4}\z'
+      format_evidence: secondary-locator-unverified
+      charset: { notes: "same second-letter A-M allocation rule; see us-nc-standard-first-in-flight" }
+      progression: "reported: TAA-1001 onwards from 1 July 2019, reaching approximately VFT-7102 by May 2025, with TMZ followed by VAA and VMZ to be followed by WAA. Note the SKIPPED LETTER: the block runs T then V, not T then U. LOCATOR-GRADE, and the skip is recorded rather than smoothed."
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_evidence: convention-not-sourced }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1F4E9C"
+      legend_top: "IN GOD WE TRUST"
+      legend_middle: "To Be Rather Than to Seem"
+      legend_rule: "§ 20-63(b) [via FindLaw; ncleg.gov 403] names the 'National/State Mottos' plate as election (iii) without describing it. NCDMV describes it as including both the United States motto ('In God We Trust') and the North Carolina motto ('To Be Rather Than to Seem') — the English translation of Esse quam videri."
+      graphic: { present: true, rendered: placeholder, description: "national flag motif at the top, locator-reported" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://codes.findlaw.com/nc/chapter-20-motor-vehicles/nc-gen-st-sect-20-63.html  # § 20-63(b) [via FindLaw; ncleg.gov 403]: 'National/State Mottos' as statutory election (iii)"
+      - "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx  # NCDMV: 'National/State Motto: Includes both the United States motto (In God We Trust) and North Carolina motto (To Be Rather Than to Seem)'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_North_Carolina  # LOCATOR ONLY: the 1 July 2019 start, the TAA-1001 block, the T-then-V letter skip, and the national flag motif"
+    notes: >-
+      NORTH CAROLINA NATIONAL/STATE MOTTOS — the third and newest statutory
+      election, from 1 July 2019. Two details worth carrying. First, the
+      letter skip: the block goes T then V, so a consumer inferring "the next
+      block after T is U" is wrong, and a serial-range model built on
+      arithmetic rather than on the reported allocation will mis-attribute
+      U-series plates. Second, this design pairs a NATIONAL motto with a STATE
+      motto on the same plate, which is a different move from Florida's "In God
+      We Trust" variant (where the state motto simply replaces the county
+      legend) and worth distinguishing when the encyclopedia section compares
+      them.
+
+  # =========================================================================
+  # ONE SERIES BACK.
+  # =========================================================================
+  - id: us-nc-standard-first-in-flight-red-2007
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2007, end: 2009 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      regex_strict: '\A[A-Z][N-Z][A-Z]-?\d{4}\z'
+      format_evidence: secondary-locator-unverified
+      charset:
+        notes: >-
+          THE ALLOCATION RULE IS THE MIRROR IMAGE OF TODAY'S. On this base and
+          its 1985-2007 predecessor the second letter ran strictly N through Z
+          — AZZ followed by BNA, BZZ by CNA — and that practice continued until
+          ZZZ-9999 was issued in 2010, at which point North Carolina reset to
+          AAA-1001 and inverted the rule to A-M. `regex_strict` here therefore
+          encodes [N-Z] where the current series encode [A-M], and the two are
+          disjoint in the second position. That disjointness is a genuine ERA
+          SIGNAL: second letter N-Z means pre-2010 allocation, A-M means
+          post-2010, and a parse API can date a North Carolina plate from one
+          character.
+      progression: "reported: WTF-1976 to approximately ZND-9999, issued mainly as replacements for earlier First in Flight plates carrying the older ABC-123 and ABC-12 formats. LOCATOR-GRADE."
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_evidence: convention-not-sourced }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      colour_note: "RED serial on reflective white with the light blue Wright Flyer graphic. The red was abandoned in October 2009 after complaints that it was too hard to read at distance — the design difference from the current base is exactly one colour, which under PRD-PLATES §2.3 is enough to make it its own series."
+      legend_top: "First in Flight"
+      graphic: { present: true, rendered: placeholder, description: "Wright Brothers biplane flying over Kitty Hawk Beach, per § 20-63(b)" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://codes.findlaw.com/nc/chapter-20-motor-vehicles/nc-gen-st-sect-20-63.html  # § 20-63(b)-(c) [via FindLaw; ncleg.gov 403]: the same statutory frame and the 100-foot daylight bar the red serial was said to fail in practice"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_North_Carolina  # LOCATOR ONLY: April 2007 - October 2009, red serials, the WTF-1976 to ZND-9999 range, the second-letter N-Z rule, and the legibility complaints that ended it"
+    notes: >-
+      THE PREVIOUS NORTH CAROLINA STANDARD EXECUTION — a colour change, not a
+      redesign, and included for two reasons. First, it is the honest "one
+      series back" for the First in Flight lineage. Second, it carries the
+      second-letter N-Z allocation rule, which is the era signal described in
+      its charset notes and is far more useful to a parser than the colour
+      itself. The 2009 overlap with the current series is the rollout, with old
+      stock issuing on.
+
+  # =========================================================================
+  # CORE CLASSES.
+  # =========================================================================
+  - id: us-nc-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          recall-only. § 20-63 states no motorcycle serial arrangement, and
+          NCDMV does not publish one. The ONE sourced size fact is indirect but
+          real: NCDMV caps a PERSONALIZED private motorcycle plate at SEVEN
+          character spaces against EIGHT for a personal vehicle, so the
+          motorcycle plate's usable field is one character shorter than the
+          car's. The seven-character recall bound here is therefore not
+          arbitrary for North Carolina motorcycles — it matches the state's own
+          published personalized limit — but it is still a recall bound, not a
+          claim about department-assigned serials.
+      halfspace_note: "NCDMV: 'Some special characters occupy one-half space in width. Half-space characters are allowed on motorcycle license plates.' A character-space model that counts glyphs rather than WIDTHS will over- or under-count North Carolina motorcycle plates."
+    design:
+      plate: { unit: in, dimension_note: "reduced-size motorcycle plate; no North Carolina dimension is sourced" }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+    display: "ONE plate, rear (§ 20-63(a) and the (d) proviso)"
+    region_encoding: none
+    sources:
+      - "https://codes.findlaw.com/nc/chapter-20-motor-vehicles/nc-gen-st-sect-20-63.html  # § 20-63(a) [via FindLaw; ncleg.gov 403]: one registration plate for a motorcycle; (d): single plate goes on the rear"
+      - "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx  # NCDMV character-limit table: private motorcycle 7 spaces against 8 for a personal vehicle; the half-space character rule specific to motorcycle plates"
+    notes: >-
+      NORTH CAROLINA MOTORCYCLE. Modelled separately because the statute names
+      motorcycles as their own issuance case in § 20-63(a) and because NCDMV
+      publishes a different character capacity for them. The half-space rule is
+      the kind of detail that never reaches a plate dataset and quietly breaks
+      validators: on a North Carolina motorcycle plate the constraint is
+      TYPOGRAPHIC WIDTH, not character count, so "7 characters" and "7 spaces"
+      are different limits and the state means the second.
+
+  - id: us-nc-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only; § 20-63 names trailers and semitrailers as a distinct issuance case but states no serial arrangement, and NCDMV publishes none. The personalized limit for a private trailer is 8 spaces, the same as a personal vehicle." }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+    display: "ONE plate, rear (§ 20-63(a) and the (d) proviso)"
+    region_encoding: none
+    sources:
+      - "https://codes.findlaw.com/nc/chapter-20-motor-vehicles/nc-gen-st-sect-20-63.html  # § 20-63(a) [via FindLaw; ncleg.gov 403]: 'one registration plate for a motorcycle, trailer or semitrailer' — trailers named as their own case"
+      - "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx  # NCDMV character-limit table: private trailer 8 spaces"
+    notes: >-
+      NORTH CAROLINA TRAILER AND SEMITRAILER. Thin by design: the statute
+      establishes that trailers are separately handled, the DMV establishes
+      that they have their own personalized capacity, and nothing sourced
+      establishes a serial arrangement. Recorded rather than invented.
+
+  - id: us-nc-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only. § 20-79.1 requires the DEALER to write information on the face of the plate by hand rather than the Division to assign a serial, so a 'serial format' in the usual sense may not exist for this class at all — which is itself the finding." }
+    design:
+      plate: { unit: in, dimension_note: "'designed by said Division'; NO design or size specification appears in § 20-79.1 (recorded gap). Contrast South Carolina, which legislates temporary-plate dimensions to the inch." }
+      background: { finish: null }
+      handwritten_content: >-
+          § 20-79.1 [via FindLaw; ncleg.gov 403] requires the dealer to write
+          clearly on the plate: the DATES OF ISSUANCE AND EXPIRATION; the MAKE,
+          MOTOR NUMBER AND SERIAL NUMBERS of the vehicle; and any other
+          information the Division requires. It is an offence to make any
+          misstatement of fact or knowingly to write false information on the
+          face of the plate or marker.
+    validity: >-
+      § 20-79.1: temporary plates or markers "shall expire and become void upon
+      the receipt of the limited registration plates or the annual registration
+      plates from the Division, or upon the rescission of a contract to
+      purchase a motor vehicle, or upon the expiration of 30 DAYS from the date
+      of issuance, depending upon whichever event shall first occur." A second
+      30-day plate may be issued in stated circumstances where title documents
+      cannot be obtained.
+    region_encoding: none
+    sources:
+      - "https://codes.findlaw.com/nc/chapter-20-motor-vehicles/nc-gen-st-sect-20-79-1.html  # N.C. Gen. Stat. § 20-79.1 [via FindLaw; ncleg.gov 403]: the 30-day/receipt-of-plates/rescission expiry triple, the second-plate provision, the dealer's hand-written content duty, the falsification offence, and the absence of any size or design specification"
+    notes: >-
+      NORTH CAROLINA TEMPORARY PLATES, AND A SCHEMA OBSERVATION WORTH THE
+      ENTRY. This series' "format" is not a serial grammar at all: § 20-79.1
+      makes the DEALER write the dates and the vehicle's make and numbers onto
+      the plate face by hand. The identifier on a North Carolina temporary tag
+      is thus partly VEHICLE data, not registration data — closer to a
+      completed form than to an assigned serial. The regex is recall-only and
+      the honest reading of a match is "this could be some North Carolina
+      alphanumeric string", nothing more. THE EXPIRY RULE IS THE VALUABLE PART
+      and it is a triple, not a duration: whichever of receipt-of-plates,
+      contract rescission, or 30 days comes first.
+
+  - id: us-nc-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only; N.C. Gen. Stat. § 20-79 (dealer license plates) was NOT obtained in this pass — ncleg.gov 403s and the FindLaw mirror for that section was not reached. Existence is inferred from § 20-79.1's own title, 'Use of temporary registration plates or markers by purchasers of motor vehicles IN LIEU OF DEALERS' PLATES', which presupposes a dealer plate regime." }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+    binding: business
+    region_encoding: none
+    sources:
+      - "https://codes.findlaw.com/nc/chapter-20-motor-vehicles/nc-gen-st-sect-20-79-1.html  # § 20-79.1's title and text presuppose dealers' plates ('in lieu of dealers' plates'), which sources the EXISTENCE of the class and nothing more"
+    notes: >-
+      NORTH CAROLINA DEALER PLATES — THE WEAKEST ENTRY IN THIS FILE AND
+      LABELLED AS SUCH. § 20-79 is the governing section and it was not
+      obtained: the General Assembly's service 403s automated fetches and the
+      mirror for that particular section was not reached before this pass
+      closed. What is sourced is that the class EXISTS, from the neighbouring
+      section's own title. Everything else — plate count rules, legend,
+      serial, colour — is a recorded gap. A verifier with browser access should
+      open § 20-79 first; it is the single cheapest quality win available for
+      North Carolina.
+
+  # =========================================================================
+  # PERSONALIZED — the second officially-sourced glyph-in-serial finding in
+  # this group, and the wider of the two.
+  # =========================================================================
+  - id: us-nc-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          NORTH CAROLINA OFFICIALLY PERMITS FOUR NON-ALPHANUMERIC GLYPHS INSIDE
+          A SERIAL, AND THE REGEX ABOVE CANNOT SPELL ANY OF THEM. NCDMV, in its
+          own words: "You can use numbers and some special characters,
+          including the question mark (?), ampersand (&), dollar sign ($) and
+          the 'at' symbol (@)." None of ?, &, $ or @ is in the dataset's serial
+          alphabet and none is a separator, so under PRD-PLATES §2.6 this is a
+          SCHEMA AMENDMENT — a `never_separator` entry with its source — and
+          not something a data file may decide alone. `matching: strict` is
+          still the correct value because the regex is NARROWER than what North
+          Carolina issues and §2.7 says narrower is strict; the consequence is
+          a KNOWN, SOURCED set of false negatives, recorded here rather than
+          hidden. SECOND, INDEPENDENT CHARSET FACT, and this one is a genuine
+          normalisation trap: "The letter 'O' is automatically converted into a
+          zero (0) on your personalized license plate to avoid confusion." So
+          North Carolina personalized serials contain NO letter O at all — a
+          state-enforced O-to-0 collapse at issue time, which means an OCR
+          pipeline that "corrects" 0 to O on a North Carolina vanity plate is
+          introducing the error rather than fixing it. THIRD: "Personalized
+          special plate requests must contain at least one letter."
+      character_limits:
+        source_note: "NCDMV's own table, in SPACES not characters (half-space glyphs exist; see us-nc-motorcycle)"
+        personal_vehicle: 8
+        private_motorcycle: 7
+        private_trailer: 8
+        disabled_license_plate: 6
+        special_license_plate: 4
+        note: "the SPECIAL-plate limit of 4 is the striking one: personalizing a North Carolina specialty plate leaves only four spaces, because the programme artwork occupies the rest of the field. Any model that assumes one vanity-length rule per state is wrong here by a factor of two."
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      note: "standard and specialty designs can both be personalized; personalized plates are manufactured by an outside vendor and take about 6-8 weeks (NCDMV)"
+    refusal_policy: >-
+      NCDMV reserves the right to refuse submissions deemed offensive to good
+      taste and decency, over the space limit, or duplicating another issued
+      plate. NCDMV states its own legal theory on the page, which is worth
+      quoting because it is the state explaining the doctrine to the public:
+      "Supreme Court case law has deemed state-issued license plates as
+      'government speech' and provides the issuing agency with broad discretion
+      in refusing to issue or recall a plate with an indecent word/phrase or
+      meaning. Therefore, such speech is not subject to a First Amendment
+      analysis."
+    relinquishment: "a personalized text may not be given away but its RIGHTS may be released: form MVR-27N is filed with the plate, which is returned with a special code that relinquishes the text to a named person, who may then request it (NCDMV)"
+    region_encoding: none
+    sources:
+      - "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx  # NCDMV: the permitted special characters (? & $ @), the automatic O-to-0 conversion, the at-least-one-letter rule, the five character-space limits, the half-space rule, the refusal criteria and the government-speech statement, and the MVR-27N relinquishment mechanism"
+    notes: >-
+      NORTH CAROLINA PERSONALIZED, AND THE STRONGEST SCHEMA FINDING OF GROUP
+      SOUTHEAST-A. Two of five states — North Carolina here with ? & $ @, and
+      Virginia with the ampersand — officially publish permission to print a
+      non-alphanumeric glyph INSIDE a serial. PRD-PLATES §2.6 anticipated this
+      exact case and prescribed the remedy: "A jurisdiction that prints a glyph
+      inside a serial is a schema amendment, not a data entry. If one lands, it
+      goes to _meta/separators.yml's `never_separator` list with its source, and
+      every consumer learns about it from one place." Two have landed, from
+      first-party DMV pages. The amendment is PROPOSED in the group dossier and
+      deliberately NOT made here. The O-to-0 conversion is separately valuable
+      and points the opposite way from every OCR heuristic in the field.
+
+  # =========================================================================
+  # SPECIALTY — PROGRAM INDEX ONLY (PRD-PLATES §2.5).
+  # =========================================================================
+  - id: us-nc-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "specialty serials are shorter than standard ones — the personalized limit on a special plate is FOUR spaces against eight on a personal vehicle — so no arrangement claim is made and the index is recall-only" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: "more than 100"
+      count_official_quote: "NCDMV, in its own words: 'NCDMV issues specialty license plates representing more than 100 causes and interest groups.'"
+      official_list_url: "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx"
+      production_model: >-
+        THE MOST OPERATIONALLY DISTINCTIVE FACT: North Carolina specialty plates
+        are made in LIMITED PRODUCTION RUNS and go out of stock. NCDMV: "Special
+        plates are made in limited production runs, so your chosen plate may not
+        be available at the time you request it. Some speciality plates are
+        replaced with new designs; others may be discontinued. You are free to
+        choose another plate that is available, or if the plate is out of stock,
+        you may choose to have it mailed to you when it is back in stock." So
+        "authorised" and "obtainable" are different states in North Carolina at
+        any given moment, and a programme index that models only authorisation
+        will overstate what a resident can actually buy.
+      membership_gating: "NCDMV: specialty plates for most military and civic clubs are obtainable only on verification of membership or of the specific recognition — e.g. the Purple Heart plate requires proof of the award. The same proof-before-purchase pattern Florida labels a 'special requirement' subtype."
+      establishment_process: "organisations may apply to establish a NEW specialty plate through a published multi-step process (NCDMV, 'Process to establish a specialty plate')"
+      transfer_restriction: "on an owner's death some specialty plates (military, disabled veteran, disability) cannot transfer to a surviving spouse because the plates carry eligibility requirements; others, such as Prisoner of War, are transferable if the surviving spouse does not remarry and continues to renew annually (NCDMV)"
+    region_encoding: none
+    sources:
+      - "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx  # NCDMV: 'more than 100 causes and interest groups'; the limited-production/out-of-stock model; the membership and award verification gating; the establishment process; and the death-transfer restrictions"
+    notes: >-
+      THE NORTH CAROLINA SPECIALTY PROGRAM INDEX — one entry standing for the
+      whole programme, per PRD-PLATES §2.5. The count is NCDMV's own "more than
+      100" and is recorded as an agency estimate, not a count: unlike Virginia,
+      North Carolina does not expose a faceted search that would reconcile a
+      total. What North Carolina gives instead, and no other state in this group
+      does, is an honest statement of the LIMITED-PRODUCTION model — which is
+      the fact that explains why enthusiast catalogues and state lists never
+      agree anywhere in the US. The right L4 move here is not to chase a count
+      but to capture stock state over time, the way the Florida monthly
+      active-plate report should be captured.

--- a/plates/us-sc.yml
+++ b/plates/us-sc.yml
@@ -1,0 +1,605 @@
+# plates/us-sc.yml — South Carolina (PRD-PLATES gate L2, group southeast-a).
+#
+# THE SOUTH CAROLINA FINDING, AND IT IS THE BEST-SOURCED CURRENT SERIES IN THE
+# WHOLE US PASS SO FAR: SOUTH CAROLINA'S PRESENT STANDARD PASSENGER PLATE IS
+# LEGISLATED, WITH BOTH ENDPOINTS AND THE ARTWORK, IN ONE SUBSECTION.
+# S.C. Code § 56-3-1230(C), added by 2025 Act No. 39 (H.3175) effective 12 May
+# 2025, verbatim: "Notwithstanding another provision of law to the contrary,
+# the regular license plate for private passenger vehicles and motorcycles
+# issued by the Department of Motor Vehicles FROM JANUARY 1, 2026, UNTIL
+# DECEMBER 31, 2032, shall commemorate the two hundred fiftieth anniversary of
+# the American Revolution. ... The design ... must be imprinted with the words
+# 'Where the Revolutionary War Was Won' and shall include, at a minimum, a flag
+# featuring the word LIBERTY in white against an indigo background together
+# with a gorget in an upper corner of the flag, also known as the Moultrie
+# Flag."
+#
+# Every other state in group southeast-a required a locator for its start year.
+# South Carolina required none: the start, the sunset, the slogan and the
+# minimum artwork are all edict of government, which is public domain at every
+# level. `period_evidence: statutory-date` is earned here, not asserted.
+#
+# ONE SCHEMA CONSEQUENCE, FLAGGED FOR THE MAINTAINER RATHER THAN WORKED AROUND
+# QUIETLY: the sunset is 31 December 2032, and `scripts/lint_plates.rb` rejects
+# any `period.end` beyond the current year plus one. A legislated FUTURE sunset
+# is a real and recurring shape — Georgia's America 250 plate carries one too
+# (2030, from the Department of Revenue) — and the rail cannot express it. This
+# file therefore keeps `period.end` absent (the series IS currently issuing, so
+# open is the honest reading for a consumer) and carries the sunset in
+# `period.scheduled_end`, which the lint ignores. See the group dossier: the
+# proposed amendment is to let the rail admit a future `scheduled_end`.
+#
+# AUTHORITY FETCH FAILURE, DISCLOSED: scdmvonline.com was UNREACHABLE from this
+# network across repeated attempts on 2026-08-01 (connection reset on HTTP/2,
+# timeout on HTTP/1.1, socket hang-up through the fetch proxy). NOT ONE CLAIM IN
+# THIS FILE COMES FROM SCDMV. That turns out to matter less here than it would
+# anywhere else, because South Carolina legislates what other states delegate —
+# but it does mean the specialty-programme count is derived from the statute
+# book rather than taken from the agency, and it is labelled accordingly.
+#
+# EVIDENCE GRADES — the four defined in us-va.yml.
+jurisdiction: us-sc
+authority:
+  name: South Carolina Department of Motor Vehicles (SCDMV)
+  url: "https://www.scdmvonline.com/Vehicle-Owners/License-Plates"
+  fetch_status: "UNREACHABLE 2026-08-01 (connection reset / timeout / socket hang-up on repeated attempts). No claim in this file rests on it."
+binding: vehicle
+statute_edition: "South Carolina Code of Laws, Title 56 (Motor Vehicles), Chapter 3, as served by scstatehouse.gov and read 2026-08-01 — the chapter text incorporates amendments through 2025 Act No. 39 (eff. 12 May 2025) and 2024 Act No. 178 (eff. 20 November 2024)"
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: adverse
+  basis: >-
+    SOUTH CAROLINA IS ADVERSE, ON JUDICIAL AUTHORITY. The Supreme Court of
+    South Carolina held in Seago v. Horry County, 663 S.E.2d 38 (S.C. 2008),
+    that a South Carolina county CAN hold copyrights on government works. That
+    is an affirmative judicial holding permitting copyright in works of a South
+    Carolina governmental body — a stronger adverse signal than the mere
+    absence of a public-domain rule, and it puts South Carolina alongside New
+    York, Arizona, Pennsylvania and Washington rather than alongside Florida,
+    California, Georgia or North Carolina. Wikimedia Commons has no
+    {{PD-SCGov}} template (HTTP 404, checked 2026-08-01), consistent with that
+    reading, and the Commons US rules page states the default as "Other
+    states: copyrighted".
+  honest_limits: >-
+    TWO LIMITS ON THIS FINDING, STATED SO IT IS NOT OVER-READ. First, Seago
+    concerned a COUNTY, not the State, and the opinion itself was NOT obtained
+    in this pass — it is cited here through a secondary survey that gives the
+    reporter citation and a Google Scholar locator. Second, no instance of
+    South Carolina asserting copyright over a LICENSE PLATE DESIGN was found;
+    what is established is a framework that would permit one, exactly as the
+    US-world dossier concluded for Arizona, Pennsylvania, New York and
+    Washington. Read this field as "the framework permits it and the courts
+    have blessed it", not as "South Carolina has claimed it".
+  edict_carve_out: >-
+    THE CARVE-OUT IS UNUSUALLY POWERFUL IN SOUTH CAROLINA AND IT IS WHY THIS
+    FILE IS RICH DESPITE THE ADVERSE POSTURE. Edicts of government are
+    uncopyrightable at every level, and South Carolina puts an extraordinary
+    amount of plate specification INTO ITS STATUTE: the dimensions, the
+    retroreflectivity requirement, the five-year service life, the ten-year
+    reissue interval, the temporary-plate dimensions to the inch, the
+    unified specialty-plate design rule, the 300-application discontinuation
+    threshold, and — uniquely — the current standard plate's slogan and
+    minimum artwork. All of that is public domain no matter what posture the
+    State takes toward its own works. The adverse posture bites only on
+    elements NOT in the statute: the exact executed artwork, the colour values,
+    and the specialty designs.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies. Note the specific hazard: the
+    statutorily-mandated element of the current plate is the MOULTRIE FLAG —
+    a historic flag, and historic flags are not themselves copyrightable
+    subject matter — but the EXECUTED artwork submitted by the South Carolina
+    Revolutionary War Sestercentennial Commission is a modern work by a state
+    body in an adverse-posture state. Render the flag slot as
+    `emblem: {present: true, rendered: placeholder}` and do not trace the
+    Commission's execution. The Palmetto tree and crescent of earlier bases,
+    and the STATE SEAL used on the 1980-84 base, carry seal-misuse protection
+    independent of copyright, which is unresearched.
+  photograph_caution: "Commons photographs of South Carolina plates carry the photographer's licence on the photograph, not on the design. Our renders are generated from the statute, never derived from a photograph, so those obligations never attach."
+  sources:
+    - "https://scholar.google.com/scholar_case?case=12877392669401300528  # Seago v. Horry County, 663 S.E.2d 38 (S.C. 16 June 2008) — LOCATOR for the opinion, which was NOT read in this pass"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: the South Carolina entry reporting Seago and its holding that a South Carolina county can hold copyrights on government works"
+    - "https://commons.wikimedia.org/wiki/Template:PD-SCGov  # HTTP 404 — no South Carolina public-domain tag exists on Commons (checked 2026-08-01)"
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # the governing default: 'Other states: copyrighted'"
+    - "https://www.scstatehouse.gov/code/t56c003.php  # the statutory plate specification itself — an edict of government, public domain regardless of the State's posture toward its other works"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; AAMVA's declarative present is RECOMMENDED PRACTICE."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is paywalled and was NOT obtained. No J686 dimension is quoted — and South Carolina does not need one, because it legislates its own minima (see us-sc-standard-rev250-2026)."
+    retroreflectivity: "AAMVA §3.3: readable in daylight and at night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3. South Carolina legislates the REQUIREMENT (§ 56-3-1230(B)) and then delegates the SPECIFICATION to the department: 'The department shall prepare the specifications for the retroreflective material.' So the SC spec exists as a departmental document and is a named, findable gap."
+    replacement_cycle: >-
+      AAMVA §1.1 recommends a rolling or full replacement cycle "not to exceed
+      7 to 10 years". SOUTH CAROLINA LEGISLATES THE TOP OF THAT RANGE, exactly
+      as Florida does, and legislates a materials floor beneath it: § 56-3-1230
+      (A) requires the plate be "of a strength and quality to provide a minimum
+      service of five years" and requires a new plate "at intervals the
+      department considers appropriate, but AT LEAST EVERY TEN YEARS". Two
+      states of this group put ten years in law; Virginia and North Carolina
+      put nothing; West Virginia replaces on condition. That spread is the
+      honest answer to "is there a US reissue cadence?" — there is not, there
+      are five different state answers.
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" remains COMMONLY REPEATED AND NOT
+    PRIMARY-SOURCED (see the fuller note in us-va.yml). South Carolina is the
+    state where it matters least: § 56-3-1230(A) states the dimensions in law —
+    "License plates must be at least six inches wide and not less than twelve
+    inches in length" — so this file cites the statute and never the story.
+
+display_rules:
+  default: "ONE plate, REAR. § 56-3-1210: 'Beginning with the licensing year 1975-1976, the Department of Motor Vehicles, upon registering and licensing a vehicle, shall issue to the owner ONE license plate.' § 56-3-1240(A): 'Unless the provisions of this section apply, license plates issued for motor vehicles must be attached to the outside rear of the vehicle, open to view. License plates must always be fastened securely in a horizontal and upright position ... so as to prevent the plate from swinging.'"
+  front_only: "TRUCK TRACTORS AND ROAD TRACTORS: § 56-3-1240(B): 'License plates for truck tractors and road tractors must be attached to the outside FRONT of the vehicle' — the same inversion Florida (§ 320.0706) and Virginia (§ 46.2-715) legislate. THREE of the five states in this group put the tractor plate on the front, which turns an apparent oddity into a regional pattern worth stating."
+  either_end: "single-unit commercial motor vehicles with a GVWR over 26,000 lb may carry the plate on either the outside front or rear (§ 56-3-1240(B))"
+  windshield_temporary: "during the 45 days an intrastate-only large commercial motor vehicle may run on a § 56-3-212 temporary plate, the owner may display a MOTORCYCLE-SIZED temporary plate securely in the front passenger-side windshield with the unique identifying text facing outward, positioned so as not to obstruct the driver's view (§ 56-3-1240(B))"
+  motorcycle_vertical: "§ 56-3-1240(C): where a motorcycle is equipped with VERTICALLY MOUNTED brackets, the plate must be mounted vertically with its top fastened along the RIGHT vertical edge, its bottom not less than twelve inches from the ground, clearly visible per § 56-5-4530, free from foreign materials and clearly legible. A statutory rotated-plate rule — directly relevant to any ALPR or renderer that assumes horizontal text."
+  obstruction: "§ 56-3-1240(D): no other plate, lighting equipment (except as permitted by § 56-5-4530), tag, sign, monogram, tinted cover or inscription may be displayed above or upon the plate other than department-issued validation. A DECAL OR FRAME IS LAWFUL if it does not obscure any letters or numbers, and a TRAILER HITCH may obscure UP TO TWO INCHES of the plate — an explicit, quantified tolerance, which is rare."
+  local_preemption: "§ 56-3-1220: 'No county or municipality shall issue a municipal or county license plate.' South Carolina forecloses the sub-state plate entirely — a useful negative fact for a jurisdiction-completeness detector."
+  ownership: "§ 56-3-1210: 'Every license plate shall remain the property of the State but shall be displayed on the vehicle as required by this chapter.'"
+  sources:
+    - "https://www.scstatehouse.gov/code/t56c003.php  # § 56-3-1210 one plate and state ownership; § 56-3-1220 the county/municipal prohibition; § 56-3-1240(A)-(D) rear default, truck-tractor front rule, the 26,000 lb either-end option, the windshield temporary, the vertical motorcycle bracket rule, and the decal/frame/trailer-hitch tolerances"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — LEGISLATED END TO END.
+  # =========================================================================
+  - id: us-sc-standard-rev250-2026
+    class: standard
+    categories: [car, van, motorcycle]
+    period:
+      start: 2026
+      scheduled_end: 2032
+      scheduled_end_note: >-
+        § 56-3-1230(C) legislates issuance "from January 1, 2026, until
+        December 31, 2032". `period.end` is deliberately ABSENT because the
+        series is currently issuing and because the lint's period rail rejects
+        an end beyond the current year plus one; `scheduled_end` carries the
+        statutory sunset without lying to either audience. This is a schema
+        gap, not a data problem — see the file header and the group dossier.
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      format_evidence: secondary-locator-unverified
+      charset:
+        notes: >-
+          THE FORMAT IS THE ONE THING § 56-3-1230 DOES NOT LEGISLATE. The
+          statute requires the plate to show "in bold characters the year of
+          registration, THE SERIAL NUMBER, the full name or the abbreviation of
+          the name of the state, and other distinctive markings the department
+          may consider advisable to indicate the class of the weight of the
+          vehicle" — it mandates that there BE a serial number and says nothing
+          about its shape. The numeral-first arrangement recorded here is
+          locator-grade. Note the historical charset churn, which is real and
+          documented: on the 2008-2016 base the letter O was NOT used, and that
+          practice ran until October 2023, when O came back in with a new
+          serial font. So a South Carolina O-exclusion rule is period-bound,
+          not permanent, and no `regex_strict` is given because no single
+          exclusion holds across this series.
+      weight_class_note: >-
+          § 56-3-1230(A) authorises "other distinctive markings the department
+          may consider advisable to indicate THE CLASS OF THE WEIGHT of the
+          vehicle" — a statutory hook for weight-class encoding on the plate.
+          South Carolina used exactly that from 1921 to at least the 1920s-30s
+          bases, where the leading letter of the serial corresponded to the
+          weight class. Whether any weight marking survives on the current base
+          was not established (recorded gap), but the LEGAL AUTHORITY for one
+          is live and cited, which is more than most states can show.
+      progression: "reported: intermittently from 101CUV to 999DDL, then exclusively from 101DDM, reaching 433DEN by 7 February 2026. LOCATOR-GRADE."
+      separator_note: "the gap between the numeral and letter groups is spelled as an optional space. The locator writes this base's format without a gap ('123ABC') and the immediately preceding one with a gap ('101 AAA'); the printed plate has a gap in both cases. `[ ]?` covers the disagreement rather than resolving it by fiat."
+    design:
+      plate: { w: 12, h: 6, unit: in, w_min_in: 12, h_min_in: 6, dimension_evidence: statutory-minimum }
+      plate_dimension_note: >-
+          § 56-3-1230(A), verbatim: "License plates must be at least six inches
+          wide and not less than twelve inches in length". STATUTORY MINIMA, and
+          note the same axis oddity Florida's § 320.06(3)(a) has — "six inches
+          wide" and "twelve inches in length" describe the conventional 12-inch
+          -across by 6-inch-tall plate. Recorded in the conventional
+          orientation with the statutory minima preserved separately.
+      material: "§ 56-3-1230(A): 'The plate must be of a strength and quality to provide a minimum service of five years.' A statutory DURABILITY floor, distinct from the reissue interval."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      retroreflectivity_rule: "§ 56-3-1230(B), verbatim: 'The face of the license plate must be treated completely with a retroreflective material which increases the nighttime visibility and legibility of the plate. The department shall prepare the specifications for the retroreflective material.' The requirement is statutory; the SPECIFICATION is a departmental document that was not obtained (recorded gap)."
+      colour_note: "NO COLOUR VALUE IS IN THE STATUTE — § 56-3-1230 mandates retroreflectivity and, for this series, a flag with 'the word LIBERTY in white against an INDIGO background', which is the only colour word anywhere in the South Carolina plate law and applies to the emblem, not to the plate ground. The white ground and black screened serial are `hex_basis: observed`."
+      legend_bottom: "Where the Revolutionary War Was Won"
+      legend_rule: >-
+          § 56-3-1230(C), verbatim: the design "must be imprinted with the words
+          'Where the Revolutionary War Was Won' and shall include, at a minimum,
+          a flag featuring the word LIBERTY in white against an indigo
+          background together with a gorget in an upper corner of the flag,
+          also known as the Moultrie Flag." Note "AT A MINIMUM": the legislature
+          set a floor on the artwork and left the rest to the Commission —
+          a drafting pattern worth recognising, because it means the executed
+          design may lawfully contain more than the statute describes and a
+          renderer built only from the statute will be incomplete by design.
+      design_authority: "the South Carolina Revolutionary War Sestercentennial Commission submits the design, emblem, seal, logo or other symbol to the department for approval (§ 56-3-1230(C))"
+      emblem: { present: true, rendered: placeholder, description: "Moultrie Flag — LIBERTY in white on indigo with a gorget in an upper corner (statutory minimum)" }
+      band: { side: none }
+      rear_differs: false
+    replacement_cycle:
+      years: 10
+      statutory_text: >-
+        § 56-3-1230(A): "A new license plate including personalized and special
+        plates, but excluding license plates provided in Sections 56-3-660 and
+        56-3-670, must be provided by the department at intervals the
+        department considers appropriate, but AT LEAST EVERY TEN YEARS."
+      funding: "§ 56-3-1230(A): since fees collected after 1 July 2002, two dollars of each biennial fee and one dollar of each annual fee go to a restricted account usable SOLELY for producing and issuing new plates; 'The department is not authorized to use this set aside money for any other purpose.' A hypothecated plate-manufacturing fund written into the plate statute — nothing comparable appears in the other four states of this group."
+      exclusions: "vehicles registered under §§ 56-3-660 and 56-3-670 (property-carrying vehicles by weight; farm trucks) are outside the ten-year rule and are reissued at intervals the department considers appropriate; plates for vehicles over 26,000 lb are issued BIENNIALLY with NO revalidation sticker (§ 56-3-1230(A))"
+    validation: "§ 56-3-1230(B): 'In those years in which a metal plate is not issued, a revalidation sticker with a distinctive serial number or other suitable means prescribed by the department must be issued and affixed in the space provided on the license plate.' The revalidation sticker CARRIES ITS OWN SERIAL — a second identifier on the plate that most datasets do not model."
+    fees: "§ 56-3-1230(D): 'Fees for regular license plates shall not exceed the regular motor vehicle license fee set forth in Article 5, Chapter 3, Title 56.' So the 250th-anniversary plate is the REGULAR plate at the REGULAR price, not a specialty plate — which is why it is modelled here as the standard series and not in the specialty index."
+    region_encoding: none
+    sources:
+      - "https://www.scstatehouse.gov/code/t56c003.php  # § 56-3-1230(A): the 6x12 statutory minima, the required plate contents, the weight-class marking authority, the five-year durability floor, the ten-year reissue interval and its exclusions, the hypothecated production fund, the biennial no-sticker rule over 26,000 lb; (B): complete retroreflective treatment, departmental specification, the serialled revalidation sticker; (C): the 1 January 2026 - 31 December 2032 period, the Sestercentennial Commission's design role, 'Where the Revolutionary War Was Won', and the Moultrie Flag minimum; (D): the regular-fee cap. HISTORY line: 2025 Act No. 39 (H.3175), SECTION 1, eff May 12, 2025, which added (C) and (D)."
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Carolina  # LOCATOR ONLY (PRD-PLATES §4): the numeral-first serial arrangement and the 101CUV/101DDM/433DEN block progression. Not asserted as sourced."
+    notes: >-
+      SOUTH CAROLINA CURRENT STANDARD ISSUE — THE MODEL ENTRY FOR THE US PASS.
+      Start date, sunset date, slogan, minimum artwork, dimensions, durability,
+      retroreflectivity, reissue interval and fee cap are ALL statutory and all
+      quoted. Only the serial arrangement is locator-grade, and the file says so
+      at the point of use. Three things a verifier should carry forward. FIRST,
+      the sunset: this series is legislated to stop on 31 December 2032, which
+      means South Carolina has already scheduled its own next base change and a
+      dataset can know about it seven years early — no other state in this group
+      offers that. SECOND, "at a minimum" in § 56-3-1230(C) means the executed
+      artwork lawfully exceeds the statutory description, so a statute-only
+      render is incomplete BY DESIGN rather than by omission. THIRD, this is the
+      REGULAR plate at the REGULAR fee (subsection (D)), not a specialty plate —
+      South Carolina turned its whole standard issue into a commemorative for
+      seven years, which is a different move from Florida's optional "America
+      250" variant and from Georgia's optional America 250 election.
+
+  # =========================================================================
+  # ONE SERIES BACK.
+  # =========================================================================
+  - id: us-sc-standard-while-i-breathe-2016
+    class: standard
+    categories: [car, van, motorcycle]
+    period: { start: 2016, end: 2025 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A(?:[A-Z]{3} ?\d{3}|\d{3} ?[A-Z]{3})\z'
+      format_evidence: secondary-locator-unverified
+      charset:
+        notes: >-
+          TWO ARRANGEMENTS ON ONE BASE, AND A CHARSET CHANGE MID-BASE. From
+          February 2016 the serial ran letters-first (reported LZD 800 to
+          XMV 999); from October 2023, on the same design, South Carolina both
+          switched to a numerals-first arrangement AND changed the serial font
+          AND started using the letter O, which had been excluded since the
+          2008 base. The regex is the union of the two arrangements and is
+          still `strict` — the union is exactly what South Carolina issued on
+          this base, not wider (PRD-PLATES §2.7). No `regex_strict` is given
+          precisely BECAUSE the O-exclusion holds for part of the period and
+          not the rest: a strict twin would be right for 2016-2023 and wrong
+          for 2023-2025, and a twin that is wrong half the time is worse than
+          no twin.
+      progression: "reported: LZD 800 to XMV 999 (letters-first, Feb 2016 - Oct 2023); then YAA 101 to YCL 750 in the letters-first shape alongside 101 AAA to approximately 999 CUU numerals-first (Oct 2023 - Dec 2025). LOCATOR-GRADE."
+      manufacturer_mark: "locator-reported: plates of the October 2023 edition carry a very small number at the bottom centre from the manufacturer — a production mark, not part of the registration number, and exactly the kind of glyph an over-eager OCR pipeline will append to the serial"
+    design:
+      plate: { w: 12, h: 6, unit: in, w_min_in: 12, h_min_in: 6, dimension_evidence: statutory-minimum }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      legend_bottom: "While I Breathe, I Hope."
+      legend_note: "the English of Dum spiro spero, one of South Carolina's two state mottoes. Screened black serial on a white and blue ground with a state flag motif at the centre — locator-grade description; unlike the current base, NO artwork element of this one is legislated."
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    replacement_cycle:
+      years: 10
+      statutory_text: "the same § 56-3-1230(A) ten-year rule governed this base; South Carolina's plate law was unchanged across the boundary except for the addition of subsections (C) and (D) in 2025"
+    region_encoding: none
+    sources:
+      - "https://www.scstatehouse.gov/code/t56c003.php  # § 56-3-1230(A)-(B): the statutory frame that governed this base unchanged — dimensions, durability, ten-year reissue, retroreflectivity, revalidation stickers"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Carolina  # LOCATOR ONLY: February 2016 - December 2025, 'While I Breathe, I Hope.', the state flag motif, the two serial arrangements, the October 2023 font change and return of the letter O, and the manufacturer's mark"
+    notes: >-
+      THE PREVIOUS SOUTH CAROLINA STANDARD BASE, AND THE CLEANEST EXAMPLE IN
+      THIS GROUP OF WHY "ONE BASE = ONE REGEX" IS FALSE. Within a single
+      unchanged design South Carolina flipped the serial arrangement, changed
+      the font, and readmitted a letter it had excluded for fifteen years — all
+      in October 2023, none of it announced in the statute. A consumer holding
+      one regex per base rejects every South Carolina plate issued in the last
+      two years of this base. The boundary with the current series is HARD on
+      one side and soft on the other: 1 January 2026 is statutory for the
+      successor, while December 2025 for this one is inferred from that statute
+      plus a locator, so the end year is graded accordingly.
+
+  # =========================================================================
+  # CORE CLASSES — all statutory, which is the South Carolina pattern.
+  # =========================================================================
+  - id: us-sc-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, moped, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only. § 56-3-210(A)(2) puts the design and layout of temporary plates in the department's hands 'with input from temporary license plate distributors', and no serial grammar is stated. The plate must show the date of expiration and the name of the issuing entity along with identification information." }
+    design:
+      plate: { w: 11, h: 6, unit: in, dimension_evidence: statutory-minimum }
+      plate_dimension_rule: >-
+          § 56-3-210(A)(3), verbatim: "Temporary license plates must be six
+          inches wide and at least eleven inches in length. Temporary
+          motorcycle and moped license plates must be four inches wide and
+          seven inches in length." SOUTH CAROLINA LEGISLATES TEMPORARY-PLATE
+          DIMENSIONS TO THE INCH, AND THEY ARE NOT THE STANDARD SIZE — eleven
+          inches long against the standard twelve. Contrast North Carolina,
+          whose § 20-79.1 specifies no dimension at all. A renderer that
+          assumes every US plate is 12 x 6 gets South Carolina temporaries
+          wrong by a full inch, and its motorcycle temporaries wrong by half.
+      motorcycle_variant: { w: 7, h: 4, unit: in }
+      material: "§ 56-3-210(A)(2): 'of a material specified by the department so as to resist deterioration or fading from exposure to the elements during the period for which display is required'"
+      content: "the date of expiration and the name of the issuing entity, with identification information (§ 56-3-210)"
+    validity: "§ 56-3-210: 'All temporary license plates must be valid for no more than FORTY-FIVE DAYS.' Compare North Carolina's 30 days (§ 20-79.1) — the two neighbours differ by half again, which is exactly the kind of per-state fact a parse or compliance API needs and no aggregate list carries."
+    scope: "the department administers and regulates temporary plates both for items required to be registered in South Carolina AND for items purchased in South Carolina that may be registered in a foreign jurisdiction (§ 56-3-210(A)(1))"
+    region_encoding: none
+    sources:
+      - "https://www.scstatehouse.gov/code/t56c003.php  # § 56-3-210(A)(1) the programme and its two-way scope; (A)(2) departmental design with distributor input and the weathering-resistant material rule; (A)(3) the 6 x 11 in standard and 4 x 7 in motorcycle/moped temporary dimensions; and the forty-five-day validity cap. Also § 56-3-212, referenced by § 56-3-1240(B) for intrastate-only large commercial vehicles."
+    notes: >-
+      SOUTH CAROLINA TEMPORARY PLATES — the best-specified temporary regime in
+      group southeast-a and one of the few anywhere with statutory dimensions.
+      Three facts worth carrying: the non-standard 6 x 11 inch size, the
+      separate 4 x 7 inch motorcycle and moped size, and the forty-five-day
+      cap. A fourth is cross-referenced from the display rules: an
+      intrastate-only large commercial vehicle running on a § 56-3-212
+      temporary may display a MOTORCYCLE-SIZED temporary plate inside the front
+      passenger windshield, which is a lawful US plate that is neither metal
+      nor mounted on the bodywork.
+
+  - id: us-sc-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only; § 56-3-2320 regulates eligibility, quota, use and fee exhaustively but states no serial grammar or design" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+    binding: business
+    eligibility_and_quota: >-
+      § 56-3-2320: no dealer plate issues unless the dealer furnishes proof of
+      a retail business licence under Chapter 36, Title 12 AND has made AT
+      LEAST TWENTY SALES in the twelve months preceding application (waivable
+      if licensed under a year). Quota: two plates for the first fifteen
+      vehicles sold during the preceding year, plus one additional plate for
+      each fifteen sold beyond the initial twenty; a dealer in a manufacturer
+      programme gets two additional per fifteen beyond the initial twenty. The
+      department may issue extras for good cause. Anti-gaming: transferring the
+      same vehicle between the same parties more than once counts as ONE sale,
+      and multiple transfers between licensed dealers to meet eligibility are
+      prohibited.
+    permitted_use: "exclusively on vehicles owned by, assigned to, or loaned for TEST DRIVING to the dealer, when operated by the dealer, its corporate officers, its employees, a prospective purchaser, or a person whose vehicle is being serviced or repaired by the dealer. A prospective purchaser is limited to SEVEN DAYS with a dated demonstration certificate approved by the department; a service-loaner user to THIRTY DAYS, and only where the loaner is part of a manufacturer programme provided at no charge. Dealer plates must NOT be used on wreckers or service vehicles, nor on dealer-owned vehicles leased or rented to the public. (§ 56-3-2320)"
+    fee: "$20 per dealer plate (§ 56-3-2320(A)(3))"
+    region_encoding: none
+    sources:
+      - "https://www.scstatehouse.gov/code/t56c003.php  # § 56-3-2320: dealer plate issuance, the twenty-sale eligibility floor and retail-licence proof, the sales-volume quota and manufacturer-programme uplift, the seven-day demonstration and thirty-day service-loaner limits, the wrecker/service/rental prohibitions, the anti-gaming rules, and the $20 fee"
+    notes: >-
+      SOUTH CAROLINA DEALER PLATES. `binding: business` — the plate follows the
+      dealership, not a vehicle. South Carolina is the most tightly drafted
+      dealer-plate regime in this group: it gates issuance on a sales floor,
+      rations plate counts by volume, times the two permitted third-party uses
+      to the day, and closes two specific gaming routes by name. All of that is
+      edict and quotable; none of it is a serial fact, which is the recorded
+      gap.
+
+  - id: us-sc-manufacturer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only; § 56-3-2330 states no serial grammar" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+    binding: business
+    quota_and_fee: "NOT MORE THAN FIVE HUNDRED manufacturer plates per manufacturer; $200 each, of which $160 is remitted to the county containing the manufacturer's principal facility and $40 goes to the State Highway Fund; each plate is valid for TWO YEARS (§ 56-3-2330(A)-(B))"
+    permitted_use: "exclusively on vehicles, including motorcycles, owned by or in the possession of the manufacturer; not on wreckers, not on vehicles leased or rented to the public. Vehicles so plated — not more than one licensed vehicle per household — may be operated by persons authorised by the manufacturer, on that manufacturer's brand, for TESTING, DISTRIBUTION, EVALUATION AND PROMOTION, and for no more than TWENTY CONSECUTIVE DAYS in connection with civic and sporting events (§ 56-3-2330(A), (C))"
+    region_encoding: none
+    sources:
+      - "https://www.scstatehouse.gov/code/t56c003.php  # § 56-3-2330: the 500-plate cap, the $200 fee and its $160/$40 county/state split, the two-year validity, the permitted uses (testing, distribution, evaluation, promotion), the one-vehicle-per-household limit and the twenty-consecutive-day event rule"
+    notes: >-
+      SOUTH CAROLINA MANUFACTURER PLATES. Given `class: dealer` for the same
+      reason us-fl-manufacturer is — _meta/classes.yml has no `manufacturer`
+      value and the PRD's definition of dealer ("trade/garage plates bound to a
+      business, not a vehicle") fits the binding if not the trade. CLASS
+      VOCABULARY CANDIDATE, recorded a second time in the dataset now: two
+      states have legislated a manufacturer plate distinctly from a dealer
+      plate, with different caps, fees, validity and permitted uses. The
+      one-licensed-vehicle-per-household rule is a genuine oddity — South
+      Carolina limits how many manufacturer-plated cars can live at one address.
+
+  - id: us-sc-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only. What is sourced is that South Carolina registers state and political-subdivision vehicles as a DISTINCT REGISTRATION CLASS at a reduced fee; whether that class carries a distinct plate SERIES or merely a distinct fee is not established (recorded gap), and the regex claims nothing about it." }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+    eligibility_and_transfer_rule: >-
+      § 56-3-1260: where a vehicle "is registered and licensed in the name of
+      the State, any department, agency, or political subdivision of the State,
+      or any department or agency of such a subdivision AND A REDUCED
+      REGISTRATION AND LICENSE FEE HAS BEEN PAID, the owner shall return the
+      registration card and the plate issued for the vehicle to the Department
+      for cancellation, unless the transfer is made to another like agency
+      qualified to obtain a registration and license of the vehicle at the
+      reduced rate." So a South Carolina government plate CANNOT follow a
+      vehicle out of government ownership — it must be cancelled — which is a
+      lifecycle constraint most plate datasets have no field for and which
+      matters to anyone reasoning about plate reuse.
+    region_encoding: none
+    sources:
+      - "https://www.scstatehouse.gov/code/t56c003.php  # § 56-3-1260: the reduced-fee state/agency/political-subdivision registration class and the mandatory cancellation-on-transfer rule with its like-agency exception"
+    notes: >-
+      SOUTH CAROLINA GOVERNMENT REGISTRATION. Deliberately modest: the sourced
+      fact is a distinct reduced-fee registration class with a distinct
+      end-of-life rule, not a distinct plate design or serial series. Recording
+      it this way keeps the useful part — the cancellation-on-transfer
+      constraint, which is a genuine fact about the plate's lifecycle — without
+      inventing a series that may not exist as a separate design.
+
+  # =========================================================================
+  # PERSONALIZED + SPECIALTY INDEX.
+  # =========================================================================
+  - id: us-sc-personalized
+    class: personalized
+    categories: [car, van, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          recall-only. § 56-3-2010(A) says the personalized plates "must be of
+          the design and bear the letters and numerals THE DEPARTMENT
+          PRESCRIBES" — a full delegation, with no length and no alphabet in
+          the statute. The department's prescription was not obtained because
+          scdmvonline.com was unreachable (see the file header). Given that
+          Virginia and North Carolina both officially permit non-alphanumeric
+          glyphs in a personalized serial, South Carolina's permitted set must
+          be checked before any strict regex is written here.
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+    eligibility_and_limits: >-
+      § 56-3-2010(A): personalized plates issue to owners of PRIVATE PASSENGER
+      MOTOR VEHICLES AND MOTORCYCLES on proper application. "However, there may
+      be NO DUPLICATION of registration plates, except South Carolina members
+      of the United States Congress or members of the South Carolina General
+      Assembly may purchase a maximum of the original and TWO DUPLICATE
+      registration plates." A statutory exception to plate uniqueness itself,
+      granted to legislators — which breaks the assumption, near-universal in
+      plate software, that a plate string identifies at most one registration.
+    refusal_policy: "§ 56-3-2010(A): the department 'in its discretion, may refuse the issue of letter combinations which may carry connotations offensive to good taste and decency and MAY NOT ASSIGN to a person not holding the relevant office letters or numerals denoting the holder to have a public office' — the second limb is mandatory, not discretionary"
+    registration_period: "biennial, expiring on a staggered monthly basis; application may be made two months in advance of expiry; plates issued to members of the General Assembly and to members of licensed state or federal commissions and boards expire on 31 January each year (§ 56-3-2010(B))"
+    accessibility: "§ 56-3-2010(C): where the holder also qualifies for a handicapped plate under § 56-3-1910, the personalized plate shall include an International Symbol of Access decal, but only if it can be placed without covering any identifying numbers or letters"
+    region_encoding: none
+    sources:
+      - "https://www.scstatehouse.gov/code/t56c003.php  # § 56-3-2010(A) eligibility, the full delegation of design and characters to the department, the no-duplication rule and its legislator exception, and the two refusal limbs; (B) biennial staggered registration and the 31 January legislative/commission expiry; (C) the International Symbol of Access decal condition"
+    notes: >-
+      SOUTH CAROLINA PERSONALIZED. The entry earns its place for one sentence
+      of statute: § 56-3-2010(A) lets South Carolina members of Congress and of
+      the General Assembly hold the SAME registration plate up to three times
+      (an original and two duplicates). Plate uniqueness is treated as an
+      axiom by essentially every validator, parse API and ALPR pipeline in
+      existence; South Carolina legislates an exception to it. Recorded here
+      because it is the kind of fact that only ever surfaces from the statute,
+      which is precisely the argument PRD-PLATES §4 makes for preferring
+      statutes over brochures.
+
+  - id: us-sc-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "specialty serials sit on a department-designed basic plate; no arrangement is stated in statute and the index makes no claim" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      unified_design_rule: >-
+          THE MOST IMPORTANT SPECIALTY FACT IN THIS FILE. § 56-3-8100(C),
+          verbatim: "The department must develop a BASIC PLATE DESIGN that will
+          be used for ALL special license plates authorized by the General
+          Assembly. The license plate must be the same size and general design
+          of regular motor vehicle license plates but may be imprinted on the
+          license plate in an area specified by the department with an emblem,
+          seal, insignia, or other identifying symbol of the sponsoring
+          organization that the department considers appropriate. NO TEXT OR
+          SLOGANS MAY BE ADDED to the license plate design unless they are part
+          of the approved emblem, seal, insignia, or other identifying symbol.
+          The name of the organization may be imprinted across the top of the
+          license plate. The standard license plate design must be issued for
+          all organizational license plates newly requested after JULY 1, 2013.
+          License plate designs in production as of that date must be changed
+          when the license plate, or license plate class, is replaced."
+          South Carolina has legislated its specialty programme into ONE
+          TEMPLATE with a swappable emblem slot — which means a renderer can
+          produce every post-2013 South Carolina specialty plate from one
+          parametric template plus an emblem, and that the L4 "specialty design
+          depth" problem is, for this state, mostly solved by statute.
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: null
+      count_derived: 153
+      count_method: >-
+        DERIVED, NOT OFFICIAL, AND THE METHOD IS STATED SO IT CAN BE CHECKED.
+        SCDMV was unreachable, so no agency figure exists in this pass. Instead:
+        South Carolina creates each special-plate programme as its own ARTICLE
+        of Title 56 Chapter 3, and the chapter text contains 153 ARTICLE
+        headings, with article NUMBERS running to 155 (the numbering is not
+        dense). Not every article is a plate programme — the early articles
+        cover registration, fees, dealer plates and so on — so 153 is an UPPER
+        BOUND on the number of statutory special-plate programmes, not a count
+        of them. Examples of the pattern at the top of the range: Article 153,
+        Article 154 (South Carolina Association for Pupil Transportation
+        special license plates, 2024 Act No. 178 §10), Article 155 (Hearing
+        Impaired special license plates, recodified from § 56-3-15020 to
+        § 56-3-16410 at the Code Commissioner's direction). RECORDED AS A
+        DERIVED UPPER BOUND. Do not publish it as "South Carolina has 153
+        specialty plates".
+      official_list_url: "https://www.scstatehouse.gov/code/t56c003.php"
+      application_fee: "§ 56-3-8100(A): before producing a special plate created by the General Assembly after 1 January 2006, the department must receive SIX THOUSAND EIGHT HUNDRED DOLLARS from the individual or organisation seeking it AND a marketing plan approved by the department"
+      discontinuation_threshold: >-
+        § 56-3-8100(H), verbatim: "If the department receives LESS THAN THREE
+        HUNDRED biennial applications and renewals for a particular special
+        license plate, it shall not produce additional special license plates
+        in that series. The department shall continue to issue special license
+        plates of that series until the existing inventory is exhausted."
+        THIS IS THE NUMBER THE FLORIDA FILE RECORDED AS A GAP. us-fl's
+        specialty index notes that § 320.08056(8)(a) obliges Florida to
+        discontinue an approved specialty plate in stated circumstances and
+        that "the numeric threshold triggering discontinuation was not
+        extracted in this pass (recorded gap)". South Carolina's equivalent
+        threshold is 300 biennial applications and renewals, and subsection (I)
+        applies the same test by name to thirteen specific articles. The
+        Florida gap is not filled by this — different state, different statute
+        — but the SHAPE is now confirmed twice: US specialty programmes die by
+        numeric threshold, and the plates stay lawfully on the road until
+        inventory runs out.
+      fee_structure: "§ 56-3-8100(D)-(G): the regular biennial registration fee plus an organisation-requested additional fee, changeable only every five years from the first year of issue; if none is requested and none is prescribed by law the department may collect ten dollars; the department's production and administration costs come off the top and the remainder goes to the organisation or, absent a request, to the general fund"
+      biennial_period: "each special plate is issued or revalidated for a biennial period expiring twenty-four months from the month of issue (§§ 56-3-8100(D), 56-3-1230)"
+      motorcycle_rule: "§ 56-3-8100(K): each new classification of special vehicle plate, 'including, but not limited to, MOTORCYCLE license plates', must meet the requirements of Articles 81 and 82 of Chapter 3, Title 56"
+    region_encoding: none
+    sources:
+      - "https://www.scstatehouse.gov/code/t56c003.php  # § 56-3-8100(A) the $6,800 fee and marketing plan; (C) the unified basic design, the emblem slot, the no-added-text rule, the organisation name across the top, and the 1 July 2013 mandatory-adoption date; (D)-(G) the fee structure and distribution; (H) the 300-application discontinuation threshold and issue-until-exhausted rule; (I) the thirteen articles it is applied to by name; (K) the motorcycle classification rule. Also the chapter's 153 ARTICLE headings, from which the derived upper bound is taken."
+    notes: >-
+      THE SOUTH CAROLINA SPECIALTY PROGRAM INDEX — and the one place in group
+      southeast-a where the specialty programme is BETTER sourced than the
+      standard plate, because South Carolina legislates the programme rather
+      than administering it. Three findings. FIRST, the unified basic design
+      (§ 56-3-8100(C)) makes South Carolina's specialty catalogue mechanically
+      renderable from one template plus an emblem — an L4 shortcut no other
+      state in this group offers. SECOND, the 300-application discontinuation
+      threshold answers, for South Carolina, the question us-fl recorded as an
+      open gap for Florida. THIRD, the count is DERIVED and labelled as an
+      upper bound rather than borrowed from an enthusiast site, because the
+      agency was unreachable; a verifier with SCDMV access should replace it
+      with the agency's own figure and keep the statutory structure either way.

--- a/plates/us-va.yml
+++ b/plates/us-va.yml
@@ -1,0 +1,567 @@
+# plates/us-va.yml — Virginia (PRD-PLATES gate L2, group southeast-a).
+#
+# THE VIRGINIA FINDING, stated first because it governs every other claim in
+# this file: VIRGINIA'S PLATE STATUTE SPECIFIES ALMOST NOTHING. § 46.2-712(A)
+# of the Code of Virginia says, verbatim, "Subject to the need for legibility,
+# the size of the plate, the letters, numerals, and decals thereon, and the
+# color of the plate, letters, numerals, and decals shall be in the discretion
+# of the Commissioner." Compare Florida, whose § 320.06(3)(a) fixes a minimum
+# size, a seven-character cap and five mandatory bottom legends. Virginia's
+# legislature delegated the entire design to an administrator and wrote down
+# only what the plate must CARRY (registration number, state name, year or
+# month-and-year). Consequence for this dataset: no Virginia format claim can
+# ever be "statutory", because there is no statutory format. Formats here are
+# graded honestly with `period_evidence` and `format_evidence`, and the
+# serial arrangements come from a LOCATOR, not a primary.
+#
+# EVIDENCE GRADES USED IN THIS FILE (and across group southeast-a):
+#   statutory-date                  a date stated in the statute itself
+#   official-agency-date            a date stated by the issuing agency
+#   instrument-in-force-upper-bound the edition of the instrument read; an
+#                                   UPPER BOUND on the true start
+#   secondary-locator-unverified    the year is reported ONLY by Wikipedia or
+#                                   a collector reference. Recorded WITH its
+#                                   grade attached, asserted as nothing more.
+#                                   This is labelling, not laundering: the
+#                                   PRD forbids passing collector era tables
+#                                   off as sourced years, and every such year
+#                                   in this file is marked at the point of use.
+#
+# SOURCING PATH NOTE: every Code of Virginia section below was fetched from
+# law.lis.virginia.gov (the Division of Legislative Automated Systems' own
+# service), section pages stamped 8/1/2026. Edicts of government are public
+# domain at every level, so the statute is preferred over the DMV brochure
+# wherever both speak — which, in Virginia, is almost nowhere.
+jurisdiction: us-va
+authority:
+  name: Virginia Department of Motor Vehicles (DMV)
+  url: "https://www.dmv.virginia.gov/vehicles/license-plates"
+binding: vehicle
+statute_edition: "Code of Virginia, Title 46.2 (Motor Vehicles), Chapter 6 (Titling and Registration), Articles 9-11 and Chapter 15 — section pages as served by law.lis.virginia.gov and stamped 8/1/2026"
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: no-public-domain-basis-located
+  basis: >-
+    VIRGINIA IS A NEGATIVE RESULT, RECORDED AS ONE. The federal 17 U.S.C. §105
+    public-domain rule does not reach the states, so the default for a state
+    plate design is COPYRIGHTED unless that state says otherwise, and no
+    Virginia instrument saying otherwise was located in this pass. Three
+    pieces of evidence, all fetched: (1) Virginia does not appear at all in
+    the per-state survey of subnational copyright postures that carries
+    Florida, California, Georgia, North Carolina, South Carolina, New Jersey,
+    Massachusetts, New York, Arizona, Pennsylvania and Washington — it is not
+    listed as favourable OR adverse, it is simply absent; (2) Wikimedia
+    Commons has no {{PD-VAGov}} template (HTTP 404), where it does have
+    PD-FLGov, PD-CAGov, PD-GAGov, PD-MAGov, PD-MEGov and PD-PRGov, and its
+    US rules page states the default flatly as "Other states: copyrighted";
+    (3) both Virginia sites read for this file carry all-rights-reserved
+    notices in their own footers — the DMV's ("©2026 Virginia Department of
+    Motor Vehicles. All Rights Reserved.") and the Virginia Law service's
+    ("© Copyright Commonwealth of Virginia. All rights reserved."). None of
+    those three is a copyright assertion over a PLATE DESIGN; together they
+    are enough to say Virginia has no established public-domain posture and
+    must be treated as default-copyrighted.
+  edict_carve_out: >-
+    The Code of Virginia itself is an edict of government and is public
+    domain at every level regardless of the footer notice on the site that
+    serves it. Everything this file cites to § 46.2-711 through § 46.2-750 is
+    therefore freely usable even under the adverse default — which is exactly
+    why PRD-PLATES §4 makes the statute the preferred source. The problem in
+    Virginia is not that the statute is unusable; it is that the statute says
+    so little (see the header).
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies without qualification: render
+    `emblem: {present: true, rendered: placeholder}`. The "VIRGINIA IS FOR
+    LOVERS" wordmark on the current base is a registered tourism brand of the
+    Commonwealth used far beyond plates, which is a TRADEMARK question on top
+    of the copyright one and is unresearched. The red heart glyph that
+    substitutes for the second V is part of that mark. Do not reproduce
+    either; render the slogan slot as a neutral placeholder.
+  photograph_caution: >-
+    Commons photographs of Virginia plates carry the PHOTOGRAPHER's licence
+    on the PHOTOGRAPH; the uploader had no standing over the design. Because
+    our renders are generated from data and never derived from a photograph,
+    those obligations never attach. Same reasoning as us-fl.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR: the per-state survey in which Virginia does NOT appear — the negative result itself"
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # 'Federal, California, Florida, Georgia, Massachusetts, Puerto Rico: public domain / Other states: copyrighted' — the default Virginia falls under"
+    - "https://commons.wikimedia.org/wiki/Template:PD-VAGov  # HTTP 404 — no Virginia public-domain tag exists on Commons (checked 2026-08-01)"
+    - "https://www.dmv.virginia.gov/vehicles/license-plates  # DMV site footer: '©2026 Virginia Department of Motor Vehicles. All Rights Reserved.'"
+    - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-712/  # Virginia Law site footer: '© Copyright Commonwealth of Virginia. All rights reserved.' — asserted over the service, not over the edict it serves"
+
+# ---------------------------------------------------------------------------
+# The US standards chain, recorded once per state file. Voluntary, no federal
+# mandate, and the dimension authority is SAE J686, whose own text is
+# PAYWALLED and UNPINNED — nothing in this file quotes J686.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA writes recommendations in the declarative present; read as RECOMMENDED PRACTICE, never as requirement."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686. J686's own text was NOT obtained (paywalled); no J686 dimension is quoted anywhere in this dataset."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges"
+    jurisdiction_name_layout: "AAMVA §2.1: jurisdiction name in the top centre between the bolt holes, at least 0.25 in above the plate number and 0.125 in from the top edge; jurisdiction characters 0.75-1.0 in"
+    stacked_characters: "AAMVA: stacked characters are part of the official plate number; no more than two stacked. Consequential for normalisation."
+    replacement_cycle: "AAMVA §1.1 recommends a rolling or full replacement cycle not to exceed 7 to 10 years. VIRGINIA LEGISLATES NO REPLACEMENT CYCLE AT ALL — a genuine contrast with South Carolina (10 years in statute) and Florida (10 years in statute), and a real fact about Virginia rather than a gap."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    THE 1956 STORY HAS MOVED, AND THE MOVE IS WORTH RECORDING. The US-world
+    dossier found the "1956 AMA standardization agreement" carrying a
+    `citation needed` since 2017 and copied verbatim across articles. As of
+    this pass the Virginia, West Virginia, North Carolina, South Carolina and
+    Georgia articles all still repeat it, but it now cites a single collector
+    -magazine article — Christopher Garrish, "Reconsidering the Standard
+    Plate Size", Plates (ALPCA), vol. 62 no. 5, October 2016. That is a
+    reference, not a primary, it was NOT obtained (ALPCA's members' magazine
+    is not online), and its own title announces that it RECONSIDERS the
+    received story. Status is therefore unchanged for our purposes:
+    COMMONLY REPEATED, NOT PRIMARY-SOURCED. Virginia's own 6x12 dimension is
+    NOT in the Code of Virginia at all (§ 46.2-712(A) leaves size to the
+    Commissioner), so this file makes no Virginia dimension claim.
+
+# ---------------------------------------------------------------------------
+# Display rules. Virginia is a TWO-PLATE state with the same truck-tractor
+# inversion Florida has — and it is worth noticing that two states which
+# share nothing else share that one odd rule.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates, front and rear. § 46.2-711(A): 'The Department shall furnish one license plate for every registered moped, motorcycle, autocycle, tractor truck, semitrailer, or trailer, and two license plates for every other registered motor vehicle, except to licensed motor vehicle dealers and persons delivering unladen vehicles who shall be furnished one license plate.'"
+  one_plate_classes: "moped, motorcycle, autocycle, tractor truck, semitrailer, trailer, dealers, transporters of unladen vehicles (§ 46.2-711(A))"
+  rear_only: "moped, motorcycle, autocycle, trailer, semitrailer, dealer and transporter plates (§ 46.2-715)"
+  front_only: "TRACTOR TRUCK: '.. The license plate assigned to a tractor truck shall be attached to the front of the vehicle.' (§ 46.2-715) — front-only, the inverse of the state default, and the same outlier Florida legislates in § 320.0706. Two unrelated states, one rule: a classifier keyed on 'plate seen at front therefore commercial' is right in both."
+  mounting: "§ 46.2-716(A): securely fastened so as to prevent swinging, in a position to be clearly visible, and in a condition to be clearly legible"
+  obstruction: "§ 46.2-716(B): no colored glass, plastic, bracket, holder, mounting, frame or other covering may alter or obscure (i) the alpha-numeric information, (ii) THE COLOR OF THE PLATE, (iii) the state name or abbreviation, or (iv) any character, decal or stamp indicating the expiry month or year. Note (ii): Virginia legislates that the plate's COLOUR is legally significant information even though § 46.2-712 refuses to say what that colour is."
+  mail_carrier_exception: "§ 46.2-711(F): the display requirement does not apply to vehicles collecting and delivering US mail to the extent the rear plate is covered by the 'CAUTION, FREQUENT STOPS, U.S. MAIL' sign while so engaged"
+  penalty_relief: "§§ 46.2-711(G), 46.2-715, 46.2-716(D): for any summons issued, the court may in its discretion dismiss it where proof of compliance is provided on or before the court date"
+  sources:
+    - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-711/  # § 46.2-711(A) one-vs-two plates and the classes that get one; (B)-(E) the designated-plate classes; (F) display required + the US-mail exception; (G) dismissal on proof"
+    - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-715/  # § 46.2-715: front and rear default, rear-only classes, TRACTOR TRUCK FRONT ONLY, one plate for dealers and transporters"
+    - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-716/  # § 46.2-716(A) fastening; (B) the covering/obscuring rule including plate COLOUR; (C) Superintendent's mounting regulations"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE.
+  # =========================================================================
+  - id: us-va-standard-lovers
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2014 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      format_evidence: secondary-locator-unverified
+      charset:
+        notes: >-
+          NO CHARSET RESTRICTION IS SOURCED FOR THIS BASE. § 46.2-712(A) states
+          no alphabet, no length and no exclusions — it delegates all three to
+          the Commissioner. The only Virginia letter-exclusion fact located
+          anywhere is HISTORICAL and points the other way: on the 1979-1992
+          base, serials with I, O or Q were withheld and then RELEASED, first
+          (from 1988) with those letters in the first position and finally
+          (from 1990) in the second and third, ending at ZZQ-999. So Virginia
+          demonstrably does issue I, O and Q. No `regex_strict` is given
+          because there is nothing sourced to tighten.
+      progression: >-
+          Reported serial progression on this base: forward through the 'V'
+          series from VAA-1001 to VZZ-9950, then BACKWARDS from UZZ-9950
+          through the 'U', 'T' and now 'S' series. Backwards progression is
+          not a mistake in the record — Virginia has run serials in reverse
+          before, on the 1993 base, reportedly to avoid colliding with an
+          optional plate progressing forwards. LOCATOR-GRADE, not asserted.
+      separator_note: >-
+          The hyphen is written because the plate prints one. `-?` makes it
+          optional so a separator-stripping consumer's canonical form still
+          matches without deriving a twin (PRD-PLATES §2.6 rule 2 keeps the
+          PRINTED form here; the optionality is a convenience, not a claim
+          that Virginia sometimes omits the hyphen).
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_evidence: convention-not-sourced }
+      plate_dimension_note: >-
+          NO VIRGINIA DIMENSION IS SOURCED. § 46.2-712(A) puts plate size in
+          the Commissioner's discretion and no departmental specification was
+          obtained. 12 x 6 in is recorded as the North American CONVENTION
+          (AAMVA -> SAE J686, voluntary) and explicitly not as a Virginia
+          claim. Contrast South Carolina and Georgia, both of which legislate
+          the minima.
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1F3D7A"
+      colour_note: >-
+          NEITHER COLOUR IS IN THE CODE. § 46.2-712(A) leaves plate, letter and
+          numeral colour to the Commissioner — and then § 46.2-716(B) makes it
+          an offence to obscure that unspecified colour, which is a nice piece
+          of statutory drafting. The reflective-white ground with an embossed
+          dark-blue serial is `hex_basis: observed`, from a locator
+          description only. Both hexes are approximations and must not be
+          treated as sourced values.
+      legend_top: "VIRGINIA"
+      legend_bottom: "VIRGINIA IS FOR LOVERS"
+      legend_note: >-
+          The slogan is screened at the bottom in black with a red heart
+          substituting for the second 'V'. It is a Commonwealth tourism mark
+          used far beyond plates — see artwork_risk.emblem_rule. Statutorily
+          the plate need only carry the registration number, the name of the
+          Commonwealth (which may be abbreviated) and the year or month-and-
+          year (§ 46.2-712(A)); the slogan is Commissioner's discretion.
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      validation: "month-and-year decals, placed as the Commissioner prescribes, indicating the month and year of expiration; on issuance a new registration card is issued with the same expiry date (§ 46.2-712(A))"
+    replacement_cycle:
+      years: null
+      note: >-
+          VIRGINIA LEGISLATES NO REPLACEMENT CYCLE. Nothing in §§ 46.2-711 to
+          46.2-716 mandates periodic replacement, and § 46.2-714 goes the
+          other way, authorising PERMANENT plates at the Department's
+          discretion. This is a real state-level fact, not a gap: the answer
+          to "how often does Virginia reissue?" is "the statute does not say,
+          and it expressly contemplates plates that are never replaced."
+    region_encoding: none
+    sources:
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-712/  # § 46.2-712(A): what the plate must display (registration number, name of the Commonwealth, year or month-and-year); the discretion clause that leaves size, letters, numerals and ALL colour to the Commissioner; the decal rule"
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-711/  # § 46.2-711(A): two plates for this class of vehicle"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Virginia  # LOCATOR ONLY (PRD-PLATES §4): the March 2014 start, the ABC-1234 arrangement, the VIRGINIA IS FOR LOVERS slogan and heart, the V/U/T/S serial blocks and the reverse progression. None of it is asserted as sourced."
+    notes: >-
+      VIRGINIA CURRENT STANDARD ISSUE. THE PERIOD AND THE FORMAT ARE BOTH
+      LOCATOR-GRADE AND SAID SO. Virginia is the clearest case in this group of
+      a state whose plate facts simply are not in its law: the Code fixes the
+      CONTENTS of a plate and hands everything else — size, colours, serial
+      arrangement, replacement, slogan — to the Commissioner, and the
+      Commissioner does not publish a specification. So the honest record is a
+      fully sourced statutory frame wrapped around a locator-grade serial
+      arrangement, with the grades attached at every claim rather than blended
+      into one confident-looking row. A Virginia Administrative Code search for
+      a DMV plate specification returned nothing usable in this pass and is the
+      single highest-value follow-up for this state (recorded gap).
+
+  # =========================================================================
+  # ONE SERIES BACK — the immediately preceding standard base.
+  # =========================================================================
+  - id: us-va-standard-plain-2008
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2008, end: 2014 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}-?\d{4}\z'
+      format_evidence: secondary-locator-unverified
+      progression: "reported as running BACKWARDS from XXP-9999 towards approximately WLN-1001, with the 'R' series reserved for rental vehicles — the same rental reservation Virginia is reported to have run from the 1973 base until the late 1990s. Locator-grade."
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_evidence: convention-not-sourced }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1F3D7A"
+      legend_top: "VIRGINIA"
+      legend_bottom: null
+      legend_note: "SLOGAN-FREE. This base is reported as a return to the 1993 design: embossed dark blue serial on reflective white, 'VIRGINIA' screened in blue at the top, and nothing at the bottom. The design difference from the current base is exactly one slogan, which under PRD-PLATES §2.3 (own series iff format OR design OR period differs) makes it its own series."
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-712/  # § 46.2-712(A): the same statutory frame governed this base — Virginia's plate law did not change across the boundary, only the Commissioner's design did"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Virginia  # LOCATOR ONLY: January 2008 - February 2014, the return to the 1993 base, ABC-1234, the backwards progression and the 'R' rental reservation"
+    notes: >-
+      THE PREVIOUS VIRGINIA STANDARD BASE, AND THE REASON THE BOUNDARY IS SOFT.
+      Nothing in Virginia law marks this transition — no effective date, no
+      instrument, no departmental notice was located. The 2014 boundary is a
+      LOCATOR claim on both sides, which is why both this series and its
+      successor carry `secondary-locator-unverified` rather than a date grade.
+      The 2014 overlap year is deliberate and is the honest shape of a rollout:
+      old stock issues on. Verifiers should treat both endpoints as soft and
+      should not "tighten" them without a Virginia primary.
+
+  # =========================================================================
+  # CORE CLASSES. Virginia issues these as separately designated plates by
+  # statute (§ 46.2-711(B)-(E), § 46.2-750, § 46.2-1546), but publishes no
+  # serial specification for any of them — so each is recall-only with the
+  # statutory facts carried and the format recorded as a gap.
+  # =========================================================================
+  - id: us-va-motorcycle
+    class: motorcycle
+    categories: [motorcycle, moped]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          DELIBERATELY OVER-BROAD, HENCE `recall-only`. A match here says only
+          "this string has a shape Virginia could have issued", never "this is
+          a valid Virginia motorcycle registration". The seven-character bound
+          is a DATASET-CHOSEN recall bound following the North American
+          convention; VIRGINIA LAW STATES NO LENGTH CAP — § 46.2-712(A) leaves
+          the letters and numerals entirely to the Commissioner. The bound is
+          therefore explicitly not a legal claim. Contrast Florida, whose
+          § 320.06(3)(a) really does cap at seven and can be cited for it.
+    design:
+      plate: { unit: in, dimension_note: "reduced-size motorcycle plate; no Virginia dimension is sourced (§ 46.2-712(A) leaves size to the Commissioner)" }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+    display: "ONE plate, attached to the REAR (§§ 46.2-711(A), 46.2-715)"
+    region_encoding: none
+    sources:
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-711/  # § 46.2-711(A): one plate for every registered moped, motorcycle or autocycle"
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-715/  # § 46.2-715: the moped/motorcycle/autocycle plate is attached to the rear"
+    notes: >-
+      VIRGINIA MOTORCYCLE AND MOPED. Modelled as its own series because
+      Virginia issues ONE plate here against two for the standard class — a
+      statutory difference, not a design preference. AUTOCYCLES RIDE WITH THE
+      MOTORCYCLES in Virginia law (§§ 46.2-711(A), 46.2-715 name them in the
+      same breath), which is a live modelling question for a dataset whose
+      `categories` vocabulary has no autocycle value; recorded here rather than
+      forced. The serial arrangement is a recorded gap.
+
+  - id: us-va-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only for the same reason as us-va-motorcycle: Virginia publishes no trailer serial specification and § 46.2-712(A) imposes no alphabet or length" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      anti_removal_note: "§ 46.2-711(A), verbatim: 'The license plates for trailers, semitrailers, commercial vehicles, and trucks, other than license plates for dealers, may be of such design as to prevent removal without mutilating some part of the indicia forming a part of the license plate, when secured to the bracket.' A statutory ANTI-THEFT design authorisation — Virginia legislates that these plates may be built to destroy themselves on removal. Nothing comparable was found in the other four states of this group."
+    permanent_registration: "§ 46.2-712(B): the Department MAY issue permanent plates without decals and without a month and year of expiration for all trailers and semitrailers regardless of weight; also for trucks and tractor trucks over 26,000 lb GVWR/GCWR, taxicabs and taxicab-service vehicles, common carriers for hire, business-use trucks between 7,501 and 26,000 lb, and farm vehicles registered under § 46.2-698"
+    display: "ONE plate, attached to the REAR (§§ 46.2-711(A), 46.2-715)"
+    region_encoding: none
+    sources:
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-711/  # § 46.2-711(A): one plate for trailers and semitrailers; the anti-removal design authorisation; (B)(7) trailers and semitrailers as an appropriately designated class"
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-712/  # § 46.2-712(B): permanent, decal-free, expiry-free plates for trailers and semitrailers regardless of weight, and the other permanent classes"
+    notes: >-
+      VIRGINIA TRAILER AND SEMITRAILER. The interesting content is not the
+      serial — which is unsourced — but two statutory design facts that most
+      plate datasets never model: the anti-removal construction authorisation
+      in § 46.2-711(A), and the PERMANENT, decal-free, expiry-free plate in
+      § 46.2-712(B). The second one breaks a common consumer assumption that
+      every US plate carries a visible expiry; in Virginia an entire class
+      lawfully does not.
+
+  - id: us-va-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only; no dealer serial specification is published and § 46.2-712(A) imposes none" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+    binding: business
+    eligibility_and_quota: >-
+      § 46.2-1546: every manufacturer, distributor or dealer must apply for a
+      dealer's certificate of vehicle registration and license plates before
+      operating inventory vehicles. The plate count is rationed by sales
+      volume: fewer than 25 vehicles sold in the last 12 months of the
+      preceding licence year -> no more than TWO plates; at least 25 but fewer
+      than 50 -> no more than FOUR; 50 or more sold during the current licence
+      year -> may apply for additional plates not exceeding four times the
+      number of licensed salespersons employed.
+    display: "ONE plate per set, attached to the REAR (§§ 46.2-711(A), 46.2-715)"
+    region_encoding: none
+    sources:
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter15/section46.2-1546/  # § 46.2-1546: dealer registration and plates, the definition of a vehicle 'in inventory', staggered issue, and the sales-volume plate quota"
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-711/  # § 46.2-711(A): dealers and transporters are furnished ONE plate, not two"
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-715/  # § 46.2-715: dealer plates consist of one plate per set, attached to the rear"
+    notes: >-
+      VIRGINIA DEALER PLATES. `binding: business` for the same reason as
+      Germany's rote Kennzeichen and us-fl-dealer: the plate follows the
+      dealership, not a vehicle. The quota rule in § 46.2-1546 is worth
+      carrying because it is a real constraint on the SIZE of this series —
+      a state where dealer plates are rationed by sales volume has a bounded
+      dealer serial space, which is a fact a parse API can use. Virginia also
+      runs a separate TRANSPORTER plate for persons delivering unladen
+      vehicles (§ 46.2-733), which shares the one-plate/rear treatment; it is
+      not given its own entry because no primary for its format was obtained.
+
+  - id: us-va-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          recall-only. § 46.2-750 does state that "The Commissioner shall
+          reserve a unique series of numbers for use on" state vehicles — so
+          Virginia government plates ARE separately serialized as a matter of
+          law — but the reserved series itself is not published and was not
+          obtained. That is the gap: the EXISTENCE of a distinct series is
+          sourced; its shape is not.
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      legend_rule: >-
+          § 46.2-750(A): plates for vehicles owned by the Commonwealth "shall
+          have conspicuously and legibly inscribed, stamped, or printed
+          thereon words stating that the vehicle is for official state use
+          only", EXCEPT plates used on vehicles (i) devoted solely to police
+          work, (ii) used by the Virginia Economic Development Partnership to
+          the extent approved by the Governor, (iii) used by an institution of
+          higher education solely for vehicle technology research, or (iv)
+          used by the Governor and the Attorney General.
+      emblem: { present: true, rendered: placeholder }
+    eligibility: "motor vehicles, trailers and semitrailers owned by the Commonwealth, by political subdivisions of the Commonwealth, and by regional jail authorities created under Article 3.1 (§ 53.1-95.2 et seq.) of Chapter 3 of Title 53.1, and used SOLELY for governmental purposes (§ 46.2-750(A))"
+    fee: "equal to the Department's cost of purchasing or manufacturing the plates; receipts go to a special fund for Department expenses (§ 46.2-750(A))"
+    region_encoding: none
+    sources:
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-750/  # § 46.2-750(A): eligibility, the cost-only fee, the 'official state use only' legend, the four exceptions to it, and the Commissioner's duty to reserve a unique series of numbers"
+    notes: >-
+      VIRGINIA GOVERNMENT PLATES, AND THE FOUR CARVE-OUTS THAT MATTER TO A
+      CLASSIFIER. The rule is not "state vehicles are marked" — it is "state
+      vehicles are marked UNLESS they are police, economic-development,
+      university research, or the Governor's and Attorney General's cars." A
+      consumer inferring "unmarked therefore private" in Virginia is wrong in
+      four legislated ways, and the police carve-out is the one that will
+      matter most. § 46.2-750.1 (vehicles used for police work) and § 46.2-751
+      (state-owned passenger vehicles) sit alongside and were not read in this
+      pass (recorded gap).
+
+  # =========================================================================
+  # PERSONALIZED. Virginia officially permits a glyph inside the serial —
+  # a PRD-PLATES §2.6 schema-amendment candidate, not a data entry.
+  # =========================================================================
+  - id: us-va-personalized
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          THE AMPERSAND PROBLEM — READ THIS BEFORE TRUSTING THE REGEX. Virginia
+          DMV states, in its own words: "Use any combination of letters,
+          numbers and the special characters DASH, SPACE AND AMPERSAND." Dash
+          and space are emitted separators and are already in the contract.
+          THE AMPERSAND IS NOT: it is not in the serial alphabet, it is not a
+          separator, and under PRD-PLATES §2.6 a jurisdiction that prints a
+          glyph INSIDE a serial is a SCHEMA AMENDMENT, not a data entry. So
+          the regex above cannot represent the ampersand-bearing subset of
+          Virginia personalized plates and does not try to. `matching: strict`
+          is still correct — the regex is NARROWER than what Virginia issues,
+          and §2.7 says narrower is strict — but a real plate reading "M&M"
+          will not match, and that is a KNOWN, SOURCED false negative rather
+          than a defect. See the file-level gap list and the group dossier;
+          North Carolina independently confirms the same problem with a
+          larger glyph set, which is what makes this an amendment rather than
+          a curiosity.
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      note: "a personalized message may be applied to standard or special plate designs; where the design carries a logo (military, university), the logo position is fixed and reduces the characters available, and adding the International Symbol of Access reduces them further (DMV)"
+    fee: "$10 per year plus the prescribed state plate fee; where the underlying plate is a special plate, $10 plus the special-plate fee plus the state plate fee (§ 46.2-726)"
+    content_policy: >-
+      DMV will deny an application whose character combination carries a
+      connotation reasonably seen as profane, obscene or vulgar; sexually
+      explicit or graphic; excretory-related; describing intimate body parts
+      or genitals; condoning or encouraging violence; or describing illegal
+      activities or substances. DMV also reserves recall and cancellation, and
+      states that in deciding it "may consider bumper stickers, decals,
+      magnets, pictures and/or any other material affixed to the vehicle which
+      would influence how a person viewing the license plate would interpret
+      the message" — the surrounding-context rule, which is unusual and
+      quotable.
+    statutory_bar: "§ 46.2-726: no reserved-character plate may be issued to or renewed for any owner or co-owner registered under the Sex Offender and Crimes Against Minors Registry Act (§ 9.1-900 et seq.) if the requested combination could be read, interpreted or understood to be a reference to children"
+    region_encoding: none
+    sources:
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-726/  # § 46.2-726: the Commissioner's discretion to reserve numbers/letters, the $10 fee structure, the sex-offender-registry bar, and issuance for emergency medical services vehicles"
+      - "https://www.dmv.virginia.gov/vehicles/license-plates/personalized-policy  # DMV: 'Use any combination of letters, numbers and the special characters dash, space and ampersand'; the logo/ISA character-count effects; the full denial criteria; the recall power and the surrounding-material rule"
+    notes: >-
+      VIRGINIA PERSONALIZED. Modelled as its own series because the SERIAL
+      SOURCE differs — owner-chosen rather than Commissioner-assigned — which
+      is a format property. The headline is the ampersand: this is the first
+      of two independent, officially-sourced US findings in group southeast-a
+      of a state permitting a non-alphanumeric glyph inside a serial (North
+      Carolina is the other, and its set is wider). PRD-PLATES §2.6 anticipated
+      exactly this case and prescribed the remedy — an amendment to
+      _meta/separators.yml's `never_separator` list, with sources, so every
+      consumer learns it in one place. That amendment is proposed in the group
+      dossier and is NOT made unilaterally here.
+
+  # =========================================================================
+  # SPECIALTY — PROGRAM INDEX ONLY (PRD-PLATES §2.5). Counts and official
+  # links; no individual designs.
+  # =========================================================================
+  - id: us-va-specialty-index
+    class: specialty
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "specialty serials in Virginia are not uniform — many special plates carry a shorter serial to make room for a logo — so the index entry is deliberately recall-only and makes no arrangement claim" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: 340
+      count_official_basis: "the facet counts published by DMV's own Search/View Specialized License Plates service: Special Interest 137, College 96, Military 64, Other 43, and the service's own header 'Displaying 1 - 10 of 340' across 34 pages. 137+96+64+43 = 340, so the facets reconcile exactly with the total — a rare thing in this domain and the reason this figure is recorded as a COUNT rather than as an 'over N' estimate."
+      official_list_url: "https://www.dmv.virginia.gov/vehicles/license-plates/search"
+      categories_official: ["Special Interest", "College", "Military", "Other"]
+      statutory_structure: >-
+        VIRGINIA IS THE STATUTE-PER-PLATE STATE, AND IT IS THE MOST USEFUL
+        STRUCTURAL FACT IN THIS ENTRY. Almost every Virginia specialty plate
+        has its OWN SECTION of the Code of Virginia, in Title 46.2 Chapter 6
+        Article 10 ("Special License Plates", §§ 46.2-725 to 46.2-749.134):
+        § 46.2-728 (Great Seal of Virginia), § 46.2-728.1 (official bird and
+        floral emblem), § 46.2-730 (antique vehicles), § 46.2-738 (amateur
+        radio), § 46.2-742 (Purple Heart), § 46.2-749 (institutions of higher
+        education), § 46.2-749.2 (Chesapeake Bay), § 46.2-749.3 (clean special
+        fuel), § 46.2-749.4 (county/city/town seals), and on for roughly two
+        hundred more. Consequence: Virginia's specialty programme is an EDICT
+        OF GOVERNMENT end to end, and its authorisation, fee and eligibility
+        facts are public domain even though the ARTWORK is not (see
+        artwork_risk). Nothing similar is available for the other four states
+        in this group, where specialty programmes live in agency pages.
+      churn_visible_in_the_code: >-
+        Because each programme is a section, DEAD PROGRAMMES ARE VISIBLE AS
+        REPEALED AND EXPIRED SECTIONS in the Article 10 table of contents —
+        dozens of them, e.g. § 46.2-749.10, .11, .12 (Repealed),
+        § 46.2-749.37, .38 (Expired), § 46.2-746.4:2 (Expired). Most US
+        specialty indexes cannot distinguish "never existed" from
+        "authorised then killed"; Virginia's can, from a public-domain
+        source, at section granularity. That is a genuine differentiator and
+        the right hook for an L4 pass.
+      articles: "Article 9 (§§ 46.2-711 to 46.2-724) is 'License Plates, Generally'; Article 10 (§§ 46.2-725 onward) is 'Special License Plates'; Article 11 (§§ 46.2-750 to 46.2-756) is 'State and Local Motor Vehicle Registration'"
+    region_encoding: none
+    sources:
+      - "https://www.dmv.virginia.gov/vehicles/license-plates/search  # DMV's Search/View Specialized License Plates service: the 340 total and the four facet counts (137/96/64/43)"
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/  # Code of Virginia Title 46.2 Chapter 6 table of contents: Article 10 'Special License Plates' with a section per programme, and the Repealed/Expired markers that make programme churn readable"
+      - "https://law.lis.virginia.gov/vacode/title46.2/chapter6/section46.2-725/  # § 46.2-725: special license plates, generally — the frame the per-programme sections hang off"
+    notes: >-
+      THE VIRGINIA SPECIALTY PROGRAM INDEX — one entry standing for the whole
+      programme, which is what PRD-PLATES §2.5 asks for at this gate. Two
+      things to carry forward. First, the count is EXACT and RECONCILED (340,
+      facets summing to 340) rather than the "over 100"-style estimate every
+      other state in this group publishes, because DMV exposes it through a
+      faceted search rather than a brochure. Second, Virginia authorises each
+      plate by statute, so unlike Florida — where the count is contested
+      between the agency and Wikipedia and the programme list is a PDF — the
+      Virginia programme list is derivable from a public-domain edict and
+      carries its own history of repeals. If any state in the US pass deserves
+      an L4 specialty depth pass first, it is this one.

--- a/plates/us-wv.yml
+++ b/plates/us-wv.yml
@@ -1,0 +1,446 @@
+# plates/us-wv.yml — West Virginia (PRD-PLATES gate L2, group southeast-a).
+#
+# THE WEST VIRGINIA FINDING: WV Code §17A-3-14 WAS GUTTED, AND THE GUTTING IS
+# THE STORY. The section's own heading still promises "Registration plates
+# generally; DESCRIPTION OF PLATES; issuance of special numbers and plates;
+# registration fees; special application fees; exemptions; commissioner to
+# promulgate forms..." — but the operative text no longer describes a plate,
+# sets a fee, or lists a special plate. What survives is four sentences: one
+# plate per vehicle, a registration number "in a configuration determined by
+# the commissioner", reflectorized material, and legibility at 100 feet. A
+# researcher reading only the heading would expect a colour table; the body
+# has none. Recorded here because it is exactly the trap PRD-PLATES §5.3 warns
+# about, and because it means every WEST VIRGINIA FORMAT AND COLOUR CLAIM IS
+# NON-STATUTORY BY CONSTRUCTION.
+#
+# EVIDENCE GRADES — same four used across group southeast-a, defined in
+# us-va.yml: statutory-date, official-agency-date,
+# instrument-in-force-upper-bound, secondary-locator-unverified.
+#
+# WHAT WEST VIRGINIA DOES PUBLISH, AND IT IS BETTER THAN THE STATUTE: the DMV
+# maintains an official MOTOR VEHICLE CLASSIFICATIONS page listing eleven
+# registration classes by letter with their definitions. That page is the real
+# spine of this file and is cited per claim below.
+jurisdiction: us-wv
+authority:
+  name: West Virginia Division of Motor Vehicles (DMV)
+  url: "https://transportation.wv.gov/DMV/Vehicle-Services/License-Plates/Pages/default.aspx"
+binding: vehicle
+statute_edition: "West Virginia Code, Chapter 17A (Motor Vehicle Administration, Registration, Certificate of Title, and Antitheft Provisions), Article 3 — as served by code.wvlegislature.gov and read 2026-08-01"
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    HONESTLY UNRESEARCHED, NOT SILENTLY ASSUMED. West Virginia does not appear
+    in the per-state survey of subnational copyright postures — it is neither
+    listed as favourable (like Florida, California, Georgia, North Carolina,
+    New Jersey, Massachusetts) nor as adverse (like Arizona, New York,
+    Pennsylvania, Washington) nor as judicially resolved (like South
+    Carolina). Wikimedia Commons has no {{PD-WVGov}} template (HTTP 404,
+    checked 2026-08-01). No West Virginia public-records statute, Attorney
+    General opinion or agency policy bearing on copyright in state works was
+    located in this pass. Under the governing default — 17 U.S.C. §105 does
+    not reach the states, so a state work is copyrighted unless that state
+    says otherwise — West Virginia must be TREATED as default-copyrighted for
+    operational purposes, but that is an application of the default, not a
+    finding about West Virginia, and this field says so rather than dressing
+    the default up as research.
+  research_lead: >-
+    The specific instrument to pin next is West Virginia's Freedom of
+    Information Act, W. Va. Code §29B-1-1 et seq., and any state-purchasing or
+    state-publications provision in Chapter 5A (Department of Administration).
+    Neither was read. Also unresearched, and separate from copyright: West
+    Virginia's state-seal misuse law, which would bind the STATE SEAL
+    independently of any copyright answer.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies with extra force here, because
+    the posture is unknown rather than merely adverse. The current base carries
+    a gold-on-dark-blue "West Virginia" bar and, on the 2023 design, a STATE
+    OUTLINE used as the serial separator — a state-shape graphic sitting
+    inside the serial field. Render `emblem: {present: true, rendered:
+    placeholder}` and do not approximate the outline until the posture is
+    resolved.
+  photograph_caution: "Commons photographs of West Virginia plates carry the photographer's licence on the photograph, not a licence to the design. Our renders are generated, never derived from a photograph, so those obligations never attach."
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR: the per-state survey in which West Virginia does not appear at all — the negative result"
+    - "https://commons.wikimedia.org/wiki/Template:PD-WVGov  # HTTP 404 — no West Virginia public-domain tag exists on Commons (checked 2026-08-01)"
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # the governing default: 'Other states: copyrighted'"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; recommendations phrased in the declarative present, read as RECOMMENDED PRACTICE."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686; J686's text is paywalled and was NOT obtained. No J686 dimension is quoted."
+    retroreflectivity: "AAMVA §3.3: readable in daylight and at night from at least 75 feet; materials per ASTM D4956-19 and ISO 7591:1982 clause 3."
+    legibility_comparison: >-
+      WEST VIRGINIA LEGISLATES A LONGER SIGHT LINE THAN AAMVA RECOMMENDS.
+      §17A-3-14(b)(2) requires registration numbers "plainly readable from 100
+      feet during daylight"; AAMVA §3.3 asks for readability "from distances of
+      at least 75 feet" in daylight AND at night. The two are not in conflict —
+      AAMVA's is a floor and covers night as well — but a state statute setting
+      a 100-foot daylight bar is a citable, comparable number, and North
+      Carolina's § 20-63(c) sets exactly the same one. Two states of this group
+      independently legislate 100 feet.
+    replacement_cycle: "AAMVA §1.1 recommends a cycle not to exceed 7 to 10 years. WEST VIRGINIA'S CODE SETS NO CYCLE; the DMV instead offers free replacement of a worn, faded or illegible plate at renewal ($10.50 at any other time) — replacement on CONDITION rather than on a CLOCK, which is a third model alongside Florida/South Carolina's legislated 10 years and Virginia's silence."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' remains COMMONLY REPEATED AND NOT PRIMARY-SOURCED; see the fuller note in us-va.yml, including the ALPCA magazine citation that has since been attached to it and that this pass could not obtain. West Virginia's plate dimensions are not in the WV Code, so this file makes no West Virginia dimension claim."
+
+display_rules:
+  default: "ONE plate. §17A-3-14(a): 'The division, upon registering a vehicle, shall issue to the owner ONE registration plate with a registration number consisting of a combination of letters, numerals, symbols, or characters in a configuration determined by the commissioner.' West Virginia is therefore a single-plate state as a matter of statute, not of practice."
+  position: "rear (the conventional single-plate position). §17A-3-15 governs display and was fetched but its operative text was not extracted in this pass — the POSITION claim is therefore recorded as convention, not as sourced (recorded gap)."
+  legibility: "§17A-3-14(b)(2): registration numbers 'shall be plainly readable from 100 feet during daylight'"
+  material: "§17A-3-14(b)(1): 'Plates must incorporate reflectorized material.'"
+  commissioner_powers: "§17A-3-14(b)(3): the commissioner 'may assign any additional feature to facilitate reciprocal agreements, facilitate interstate travel, promote highway safety, or promote the efficient operation of the division' — an open-ended design power that is the legal basis for anything on a West Virginia plate that the Code does not mention, which is everything"
+  suspension: "§17A-3-14(c): the commissioner may suspend the registration of any owner who displays a damaged or illegible plate or otherwise fails to comply with §17A-3-19"
+  sources:
+    - "https://code.wvlegislature.gov/17A-3-14/  # §17A-3-14(a) one plate and the commissioner-determined configuration; (b)(1) reflectorized material; (b)(2) 100-foot daylight legibility; (b)(3) the additional-feature power; (c) suspension for a damaged or illegible plate"
+    - "https://transportation.wv.gov/DMV/Vehicle-Services/License-Plates/Pages/default.aspx  # DMV: a worn, faded or otherwise illegible plate is replaced free at renewal, $10.50 at any other time"
+
+# ---------------------------------------------------------------------------
+# WEST VIRGINIA'S REGISTRATION CLASS LETTERS — the official taxonomy, from the
+# DMV's own Motor Vehicle Classifications page. This is the spine of the file:
+# WV organises plates by class letter, and the class letter is how the DMV
+# itself talks about them ("plates available for Class A motor vehicles").
+# ---------------------------------------------------------------------------
+registration_classes:
+  source: "https://transportation.wv.gov/DMV/Vehicle-Services/Pages/Classifications.aspx"
+  A: "Cars and Trucks — passenger cars and trucks with a gross weight of 10,000 pounds or less"
+  B: "Trucks — trucks, truck tractors or road tractors with a gross weight of 10,001 pounds or more"
+  C: "Trailers and Semi Trailers — all trailers and semitrailers except house trailers, trailers or semitrailers designed to be drawn by Class A motor vehicles, and having a gross weight of more than 2,000 pounds"
+  G: "Motorcycles (3 wheels or less) — every motorcycle including motor-driven cycles and mopeds, having a saddle and no more than three wheels"
+  H: "Buses — every motor vehicle designed for carrying more than seven passengers or transportation of persons for compensation, excluding taxicabs"
+  J: "Taxi Cabs — motor vehicles used for the transportation of persons for compensation"
+  M: "Mobile Equipment — self-propelled vehicles not designed or used primarily for transportation over the highway (farm equipment, implements of husbandry, well-drillers, cranes, wood-sawing equipment)"
+  R: "Travel Trailers — any vehicle designed to provide temporary living quarters for recreation, travel or camping use"
+  T: "Trailers — trailers, boat trailers or semitrailers designed to be drawn by Class A vehicles with a gross weight of less than 2,000 pounds"
+  V: "Antique Motor Vehicles — at least 25 years old"
+  X: "Farm Trucks — used exclusively for the transportation of farm products and supplies by a farmer"
+  note: >-
+    Eleven classes, and note the pair that a naive trailer model would collapse:
+    CLASS C and CLASS T are both trailers, split at 2,000 pounds and at whether
+    a Class A vehicle tows them. A dataset with one `trailer` class per state
+    cannot express that; ours records it here and models the common case.
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — Class A.
+  # =========================================================================
+  - id: us-wv-standard-2023
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2023 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "999 999L"
+      regex: '\A[0-9OND]\d{2} ?\d{3}[A-Z]\z'
+      regex_strict: '\A[1-9OND]\d{2} ?\d{3}[A-Z]\z'
+      format_evidence: secondary-locator-unverified
+      charset:
+        notes: >-
+          THE FIRST CHARACTER IS NOT PART OF THE SERIAL IN THE ORDINARY SENSE —
+          IT IS THE MONTH OF EXPIRATION. West Virginia has encoded the
+          expiration month in the leading character of its plate number since
+          the 1970-75 base, and the reported system is: 1 through 9 = January
+          through September, O = October, N = November, D = December. That is
+          why `regex_strict` excludes a leading 0 (there is no month zero) and
+          why the loose `regex` tolerates it: the pattern DSL has only 9 and L,
+          so a position that accepts nine digits and three specific letters
+          cannot be spelled in `pattern` and must be carried by the twins.
+          NOTE THE LOOKALIKE HAZARD THIS CREATES: 'O' as a month code sits in
+          the same position a digit otherwise occupies, so O-versus-0 is not a
+          cosmetic OCR problem in West Virginia, it is a semantic one — "O12
+          345A" expires in October and "012 345A" is not a valid plate at all.
+      progression: "not published; the series letter and the block allocation for this base were not obtained (recorded gap)"
+      separator_note: "the gap between the two three-character groups is spelled as an optional space because the plate prints a gap there; on this base the physical separator is reported to be a STATE-OUTLINE graphic rather than a printed glyph, which under PRD-PLATES §2.6 is a design element (design.emblem), never a serial character and never something a consumer may strip as punctuation"
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_evidence: convention-not-sourced }
+      plate_dimension_note: "no West Virginia dimension is sourced — §17A-3-14 states none. 12 x 6 in is the North American convention (AAMVA -> SAE J686, voluntary), recorded as convention and not as a West Virginia claim."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1F3160"
+      colour_note: "NO COLOUR IS IN THE WV CODE. §17A-3-14(b) requires only reflectorized material and 100-foot daylight legibility. The reflective-white ground with an embossed dark-blue serial, a dark blue bar at the top carrying 'West Virginia' in gold, and a thin gold stripe below it, are all `hex_basis: observed` from a locator description. Treat both hexes as approximations."
+      legend_top: "West Virginia"
+      legend_bottom: null
+      separator_graphic: { present: true, description: "state outline used as the separator between the serial groups", rendered: placeholder }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: top, color: "#1F3160", content: "West Virginia in gold" }
+      rear_differs: false
+    region_encoding: none
+    serial_encoding:
+      kind: expiration-month
+      mechanism: "the FIRST character of the plate number encodes the month of expiration: 1-9 = January-September, O = October, N = November, D = December"
+      evidence: secondary-locator-unverified
+      note: >-
+        THIS IS THE MOST VALUABLE FACT IN THE WEST VIRGINIA FILE AND THE ONE
+        MOST WORTH VERIFYING. It is a TIME encoding in the serial — the
+        temporal analogue of Germany's geographic prefix and of the Dutch
+        sidecode's era inference — and it is reported to have run continuously
+        from the 1970-75 base to today, across at least six base designs. If
+        true, a West Virginia plate string alone yields the registration's
+        expiry month, which is a parse-API capability no competitor offers for
+        any US state. It is recorded as `secondary-locator-unverified` because
+        the only source located is an encyclopedia table; the WV DMV does not
+        publish it and §17A-3-14 does not mention it. VERIFY BEFORE SHIPPING
+        ANY DECODE THAT DEPENDS ON IT.
+    sources:
+      - "https://code.wvlegislature.gov/17A-3-14/  # §17A-3-14(a): one plate, registration number 'consisting of a combination of letters, numerals, symbols, or characters in a configuration determined by the commissioner' — the statutory basis for there being no statutory format; (b)(1) reflectorized; (b)(2) 100-foot legibility"
+      - "https://transportation.wv.gov/DMV/Vehicle-Services/Pages/Classifications.aspx  # WV DMV: Class A = passenger cars and trucks of 10,000 lb or less, the class this base serves"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_West_Virginia  # LOCATOR ONLY (PRD-PLATES §4): the July 2023 start, the state-outline separator, the gold-on-blue top bar, the serial arrangement, and the month-code system reported as continuing 'today'. None asserted as sourced."
+    notes: >-
+      WEST VIRGINIA CURRENT STANDARD ISSUE (CLASS A). Everything structural
+      here — one plate, commissioner-set configuration, reflectorization,
+      100-foot legibility — is statutory and cited. Everything visual and every
+      date is locator-grade and marked. The month-code encoding is carried in
+      its own `serial_encoding` block rather than buried in a note, because it
+      is the one West Virginia fact a parse API would actually monetise, and
+      because putting it somewhere prominent is what will get it verified. The
+      series id is dated 2023 to the reported base change; if that date falls,
+      the id keeps its append-only guarantee and gains a former-id alias under
+      the PRD-QUALITY I-5/I-6 contract.
+
+  # =========================================================================
+  # ONE SERIES BACK.
+  # =========================================================================
+  - id: us-wv-standard-wildwonderful-2006
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2006, end: 2023 }
+    period_evidence: secondary-locator-unverified
+    matching: strict
+    format:
+      pattern: "9LL 999"
+      regex: '\A[0-9OND](?:[A-Z] ?\d{4}|[A-Z]{2} ?\d{3}|\d[A-Z] ?\d{3})\z'
+      regex_strict: '\A[1-9OND](?:[A-Z] ?\d{4}|[A-Z]{2} ?\d{3}|\d[A-Z] ?\d{3})\z'
+      format_evidence: secondary-locator-unverified
+      charset:
+        notes: >-
+          THREE ARRANGEMENTS, ONE BASE — and the regex is their union, which is
+          still `strict` because the union is exactly what West Virginia issued
+          on this base and no wider (PRD-PLATES §2.7: narrower or equal is
+          strict; only a DELIBERATELY over-broad regex is recall-only). The
+          three reported arrangements, after the leading month character: one
+          letter plus four digits; two letters plus three digits; one digit,
+          one letter, three digits. The third was reportedly introduced in
+          October 2015 as the two-letter series began to exhaust — a state
+          adding a serial SHAPE mid-base rather than changing the base, which
+          is precisely why `format` cannot be assumed constant across a design
+          period.
+      progression: "reported: series reset to A for all months from the January 1995 base, two-letter series progressing in standard order (AA-AZ, BA-BZ ...), with series S and SA-SZ reserved for optional Scenic plates"
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_evidence: convention-not-sourced }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1F3160"
+      legend_top: "West Virginia"
+      legend_bottom: "Wild, Wonderful"
+      legend_note: "dark blue bar at the top carrying 'West Virginia' in gold with a thin gold stripe beneath; 'Wild, Wonderful' at the bottom. The immediately preceding variant (December 2000 - early 2006) additionally carried 'www.callwva.com' between the state name and the serial, cutting the gold stripe — a URL on a state plate, and a good reminder that plate designs date themselves in ways serial ranges do not."
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: none
+    serial_encoding:
+      kind: expiration-month
+      mechanism: "same leading-character month code as us-wv-standard-2023: 1-9 = January-September, O/N/D = October/November/December"
+      evidence: secondary-locator-unverified
+    sources:
+      - "https://code.wvlegislature.gov/17A-3-14/  # the same statutory frame governed this base; West Virginia's plate law did not change at the boundary"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_West_Virginia  # LOCATOR ONLY: the early-2006 to July-2023 span, 'Wild, Wonderful', the three serial arrangements, the October 2015 introduction of the number-letter series, and the S/SA-SZ Scenic reservation"
+    notes: >-
+      THE PREVIOUS WEST VIRGINIA STANDARD BASE. It earns its place in an L2
+      pass for one reason beyond being the predecessor: it demonstrates, within
+      a single unchanged design, that a US state will ADD A SERIAL ARRANGEMENT
+      mid-base when a block exhausts. Any consumer that treats "one base = one
+      regex" will silently reject West Virginia plates issued after October
+      2015 on a base first issued in 2006. The 2023 overlap year is the honest
+      shape of a rollout, with old stock issuing on.
+
+  # =========================================================================
+  # CORE CLASSES. West Virginia serializes by CLASS LETTER; the class list is
+  # official, the serial arrangements are not published. Each is recall-only.
+  # =========================================================================
+  - id: us-wv-motorcycle
+    class: motorcycle
+    categories: [motorcycle, moped]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "deliberately over-broad, hence recall-only. West Virginia publishes no Class G serial specification and §17A-3-14 imposes no alphabet or length — the seven-character bound is a DATASET-CHOSEN recall bound following the North American convention, not a legal claim." }
+    design:
+      plate: { unit: in, dimension_note: "reduced-size motorcycle plate; no West Virginia dimension is sourced" }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+    eligibility: "CLASS G: 'Every motorcycle including; motor driven cycles mopeds, having saddle, and no more than three wheels' (WV DMV Motor Vehicle Classifications)"
+    region_encoding: none
+    sources:
+      - "https://transportation.wv.gov/DMV/Vehicle-Services/Pages/Classifications.aspx  # WV DMV: Class G definition, including motor-driven cycles and mopeds and the three-wheel bound"
+      - "https://code.wvlegislature.gov/17A-3-14/  # §17A-3-14(a): one plate per registered vehicle, configuration determined by the commissioner — the same rule applies to Class G"
+    notes: >-
+      WEST VIRGINIA CLASS G. Worth noting what West Virginia puts in ONE class
+      that other jurisdictions split across three: motorcycles, motor-driven
+      cycles and MOPEDS all register as Class G, bounded by "no more than three
+      wheels" rather than by engine displacement. The Netherlands gives mopeds
+      their own sidecodes and their own plate colour; West Virginia does not
+      distinguish them at all. Our `categories` records both kinds against the
+      one series, which is the honest mapping.
+
+  - id: us-wv-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only; no Class C or Class T serial specification is published" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+    eligibility: "TWO CLASSES, SPLIT AT 2,000 POUNDS. Class C: all trailers and semitrailers EXCEPT house trailers and trailers/semitrailers designed to be drawn by Class A motor vehicles, having a gross weight of more than 2,000 lb. Class T: trailers, boat trailers or semitrailers designed to be drawn by Class A vehicles with a gross weight of LESS than 2,000 lb. Class R is a third, separate class for travel trailers (temporary living quarters). (WV DMV Motor Vehicle Classifications)"
+    region_encoding: none
+    sources:
+      - "https://transportation.wv.gov/DMV/Vehicle-Services/Pages/Classifications.aspx  # WV DMV: the Class C / Class T / Class R trailer split and its 2,000-pound and tow-vehicle criteria"
+    notes: >-
+      WEST VIRGINIA TRAILERS, MODELLED AS ONE SERIES OVER THREE OFFICIAL
+      CLASSES — and flagged as a simplification rather than pretending the
+      state agrees with us. West Virginia splits trailers three ways (C, T, R)
+      on weight, tow vehicle and habitability. Whether each carries a distinct
+      serial series is exactly the fact not published, so collapsing them is
+      the conservative choice: one recall-only series, the official split
+      recorded verbatim, and the question flagged for the verifier.
+
+  - id: us-wv-antique
+    class: historic
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only; no Class V serial specification is published" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+    eligibility: "CLASS V: 'Antique motor vehicles are at least 25 years old' (WV DMV Motor Vehicle Classifications) — a ROLLING threshold"
+    region_encoding: none
+    sources:
+      - "https://transportation.wv.gov/DMV/Vehicle-Services/Pages/Classifications.aspx  # WV DMV: Class V, antique motor vehicles at least 25 years old"
+    notes: >-
+      WEST VIRGINIA CLASS V, INCLUDED BECAUSE IT SHARPENS A CROSS-STATE
+      COMPARISON THE DATASET IS ALREADY MAKING. Florida runs TWO historic
+      regimes: Horseless Carriage on a FIXED cutoff (model year 1945 or
+      earlier, which never moves) and Antique on a ROLLING 30 years. West
+      Virginia runs one, rolling, at 25 years — the shortest rolling threshold
+      in this group. Rolling thresholds silently change eligibility every year
+      and are the ones that need re-auditing; fixed ones never do. Recording
+      the threshold TYPE, not just the number, is what makes that auditable.
+
+  - id: us-wv-government-official
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only; the special plates for government officials are authorised by a dedicated Code section whose text was not extracted in this pass" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://code.wvlegislature.gov/17A-3-14/  # the section navigation on this page identifies the adjacent section by its official title: '§17A-3-14a. Special registration plates for government officials'"
+    notes: >-
+      WEST VIRGINIA GOVERNMENT-OFFICIAL PLATES. THE CITATION HERE IS A SECTION
+      TITLE, NOT A SECTION TEXT, AND THAT IS STATED RATHER THAN GLOSSED:
+      §17A-3-14a is named "Special registration plates for government
+      officials" in the Code's own navigation, which sources the EXISTENCE of a
+      distinct government-official series and nothing else. Eligibility, design
+      and serial arrangement are all recorded gaps. This entry exists so that a
+      consumer knows the series is real and a verifier knows exactly which
+      section to open; it deliberately claims no more than the title supports.
+
+  # =========================================================================
+  # PERSONALIZED + SPECIALTY INDEX.
+  # =========================================================================
+  - id: us-wv-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "recall-only; West Virginia's personalized character limit and permitted character set were not obtained (recorded gap). Given that Virginia officially permits an ampersand and North Carolina officially permits ? & $ @, West Virginia's permitted set should be checked for non-alphanumeric glyphs before any strict regex is written." }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+    region_encoding: none
+    sources:
+      - "https://transportation.wv.gov/DMV/Vehicle-Services/License-Plates/Pages/Ordering-Info.aspx  # WV DMV 'Personalized Plate Ordering Information': ordering, fees and the personalized plate availability search"
+      - "https://code.wvlegislature.gov/17A-3-14/  # §17A-3-14(a): the commissioner determines the configuration, which is the authority a personalized combination is issued under"
+    notes: >-
+      WEST VIRGINIA PERSONALIZED. Modelled as its own series because the serial
+      source differs — owner-chosen rather than division-assigned. Kept
+      deliberately thin: the ordering page was located but its character rules
+      were not extracted, and inventing a limit would be worse than recording
+      the gap. The cross-state lead is stated in `charset.notes` because two of
+      the five states in this group turned out to permit glyphs inside a
+      serial, and the right move is to check the other three rather than
+      assume.
+
+  - id: us-wv-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset: { notes: "specialty serials are not uniform across programmes; the index makes no arrangement claim and is deliberately recall-only" }
+    design:
+      plate: { unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: null
+      count_status: >-
+        NO OFFICIAL COUNT IS PUBLISHED, AND NONE IS INVENTED HERE. The WV DMV
+        presents its "License Plate Collection (Special Plates)" as four
+        picture galleries with no totals. A naive count of plate images on the
+        four category pages gives Associations & Organizations 42, Colleges &
+        Universities 23, General Interest 35, Military 53 — but those counts
+        include page chrome and navigation images and are NOT asserted as a
+        programme count. This is the weakest specialty index in group
+        southeast-a and is recorded as such rather than padded: contrast
+        Virginia's exactly reconciled 340.
+      official_categories: ["Associations & Organizations", "Colleges & Universities", "General Interest", "Military"]
+      official_list_url: "https://transportation.wv.gov/DMV/Vehicle-Services/License-Plates/Special-Plates/Pages/default.aspx"
+      official_poster_pdf: "https://transportation.wv.gov/DMV/DMVFormSearch/PLATE-POSTERS.pdf"
+      scope_note: "the DMV states that the four galleries show 'plates available for CLASS A motor vehicles' — i.e. the specialty programme is scoped to passenger cars and trucks of 10,000 lb or less, which is a scoping fact most state specialty indexes do not make explicit"
+      eligibility_note: "the DMV states that some plates have specific qualifications and that many MILITARY plates require certification from the West Virginia Department of Veterans Assistance — the same proof-before-purchase pattern Florida calls a 'special requirement' subtype"
+      per_plate_application_forms: "individual programmes are ordered on numbered DMV-54 forms (observed examples: DMV-54_hoopshospital.pdf, DMV-54_PIA_WV-American-Legion-Riders.pdf), so a per-programme enumeration is mechanically derivable from the DMV form index — the right route to a real count in an L4 pass"
+    region_encoding: none
+    sources:
+      - "https://transportation.wv.gov/DMV/Vehicle-Services/License-Plates/Special-Plates/Pages/default.aspx  # WV DMV: the four categories, the Class A scoping, the qualification/certification requirements, the Department of Veterans Assistance rule, and the plate-collection posters"
+      - "https://transportation.wv.gov/DMV/DMVFormSearch/PLATE-POSTERS.pdf  # the official plate-collection posters (linked, not parsed in this pass)"
+    notes: >-
+      THE WEST VIRGINIA SPECIALTY PROGRAM INDEX — and the honest report is that
+      it is thin. West Virginia publishes galleries, not a list, and no count.
+      Rather than borrow a number from an enthusiast site, this entry records
+      the four official categories, the Class A scoping, the certification
+      rule, and the ONE mechanical route to a real count that was actually
+      observed: each programme has its own numbered DMV-54 application form, so
+      enumerating the DMV form index yields a programme list from a first-party
+      source. That is the L4 instruction for this state.


### PR DESCRIPTION
**PRD-PLATES gate L2 (owner-directed acceleration; research parallel, application ordered — L1 landed first per §7.1).** One of eleven US regional-group PRs covering all 50 states + DC + territories (FL was the L0 pilot). Drafted to the `de.yml`/`nl.yml`/`us-fl.yml` standard: primary-law verbatim headers, instrument-dated periods, `strict`/`recall-only` matching tiers, folklore flagged not asserted, **`artwork_risk` recorded per jurisdiction with evidence** (PRD-PLATES §4).

**This PR — southeast-a:** VA WV NC SC GA (5 jurisdictions, 47 pinned primary sources).

**Verification:** researcher linted green in an isolated sandbox (proof file in the group dir, archived to the pipeline program dir); the driving session then independently staged ALL 55 wave files over pristine origin/main — `plates lint: 67 files, 604 series … OK` (385 new series; the _art gate stayed green) — and this branch is linted solo pre-push; CI runs the same gate.

**For the reviewer:** the dossier below carries the gaps (marked in the YAML at point of use), folklore flags, and the artwork_risk findings. The full research dossier follows verbatim.

---

# PRD-PLATES gate L2 — group SOUTHEAST-A dossier
## Virginia · West Virginia · North Carolina · South Carolina · Georgia

Researcher pass, 2026-08-01/02. Method: FETCH-NEVER-ASSUME — every claim in the
five YAML files traces to a URL fetched in this session. Files are drafts for a
human session to verify, lint and apply by PR; `/Users/javi/GitHub/vehiclesdb`
was treated as read-only throughout.

**Deliverables**

| file | series | lint |
|---|---|---|
| `us-va.yml` | 8 | green |
| `us-wv.yml` | 8 | green |
| `us-nc.yml` | 10 | green |
| `us-sc.yml` | 8 | green |
| `us-ga.yml` | 9 | green |

Sandbox proof (canonical `plates/` + `scripts/lint_plates.rb` + these five files):

```
plates lint: 9 files, 116 series
plates lint: matching recall-only=28 strict=88 | twins regex_statutory=8 regex_strict=49 | separators emitted "-"," " forgiving 18
plates lint: OK
```

Baseline before the five drafts was `4 files, 73 series … OK`, so the drafts add
43 series and break nothing.

---

## 1. Evidence grades — introduced by this pass, used in all five files

PRD-PLATES §4 forbids laundering collector-site era tables as sourced years. It
does not forbid RECORDING them with their grade attached, and at L2 the previous
standard base is in scope, which cannot be dated at all under a
statute-or-nothing rule. So each period and format claim carries one of four
grades, defined once in `us-va.yml` and reused:

| grade | meaning |
|---|---|
| `statutory-date` | a date stated in the statute itself |
| `official-agency-date` | a date stated by the issuing agency |
| `instrument-in-force-upper-bound` | the edition of the instrument read; an UPPER BOUND on the true start (the us-fl pilot's grade) |
| `secondary-locator-unverified` | reported only by Wikipedia or a collector reference; recorded WITH the grade, asserted as nothing more |

Distribution across the 10 standard-issue series in this group: **1
`statutory-date`** (SC current), **1 `official-agency-date`** (GA America 250),
**8 `secondary-locator-unverified`**. That ratio is the honest headline of the
US pass so far: nine of ten US standard-base start years in this group are not
in any primary source.

`format_evidence:` is carried separately from `period_evidence:` because they
diverge constantly — South Carolina's current series has a statutory PERIOD and
a locator-grade FORMAT.

---

## 2. artwork_risk — the required §4 field, one line per state

| state | posture | evidence |
|---|---|---|
| **us-ga** | **split: PD state with a STATUTORY PLATE-DESIGN CARVE-OUT** | O.C.G.A. § 40-2-60.1: special plate designs and subsequent editions "shall be owned solely by the State of Georgia for its exclusive use and control". Commons `{{PD-GAGov}}` exists AND names Georgia DOR (§§ 40-2-60.1, 85.3, 86.1, "certain license plate designs") among the agencies permitted to claim copyright. § 40-2-60.1 verified directly; 85.3/86.1 NOT read (gap) |
| **us-nc** | **public-domain-favourable** | N.C.G.S. Ch. 132: public records are "the property of the people"; State Library of NC publishes a State Document Public Domain Notice; enumerated exceptions (archaeological resources; stenotype/shorthand trial records) do NOT reach plates; and § 20-63(b) puts the standard plate's artwork in an EDICT |
| **us-sc** | **adverse** | *Seago v. Horry County*, 663 S.E.2d 38 (S.C. 2008) — the SC Supreme Court held a South Carolina county CAN hold copyrights on government works. Opinion NOT read (cited via a survey with reporter cite + Scholar locator). No `{{PD-SCGov}}` (404). No plate-specific assertion located |
| **us-va** | **no-public-domain-basis-located (default: copyrighted)** | Virginia is ABSENT from the per-state copyright survey; no `{{PD-VAGov}}` (404); both the DMV site and the Virginia Law service carry all-rights-reserved footers. None is a plate-design assertion; together they defeat any PD claim |
| **us-wv** | **unresearched** | West Virginia absent from the survey; no `{{PD-WVGov}}` (404); no WV public-records/copyright instrument located. Recorded as UNRESEARCHED, not dressed up as the default it must operationally be treated as. Lead: W. Va. Code §29B-1-1 et seq. |

Commons template existence was checked individually: `PD-VAGov` 404, `PD-WVGov`
404, `PD-SCGov` 404, `PD-NCGov` 404, `PD-GAGov` **200**.

### 2.1 The finding that should amend the source appendix

The US/world dossier's §4.2 table records **"Arizona — explicitly states works
are not in the public domain"** as the most adverse posture found, and §4.3
records that **no instance of a state asserting copyright on a plate design was
found**. Both need updating:

> **Georgia asserts state ownership of license plate designs by statute, in the
> plate statute, in a state that is otherwise affirmatively public domain.**
> O.C.G.A. § 40-2-60.1, verbatim: *"The design of the initial edition of any
> special license plate, as well as the design of subsequent editions and
> excepting only any part or parts of the designs owned by others and licensed
> to the state, shall be owned solely by the State of Georgia for its exclusive
> use and control, except as authorized by the commissioner."*

Arizona's assertion is general and lives in a website notice. Georgia's is
plate-specific and lives in an edict. The §4.3 negative result ("no known
assertion located") no longer holds.

Read the carve-out **narrowly**: § 40-2-60.1 as read speaks of *special* license
plates. Whether §§ 40-2-85.3 and 40-2-86.1 extend it to the STANDARD Peach,
Peach Orchard and America 250 designs is **the single highest-value follow-up in
this group** and is recorded as a gap, not guessed.

Aggravating factor on the America 250 plate specifically: DOR states the design
was created by a named individual (a student, Eden Pethel) in a competition, so
§ 40-2-60.1's own exception — "excepting only any part or parts of the designs
owned by others and licensed to the state" — may split ownership between the
State and a third party. Worst possible posture for a renderer; strongest
possible argument for §3's placeholder rule.

---

## 3. Two proposed amendments (raised, deliberately NOT made)

### 3.1 `_meta/separators.yml` — `never_separator` needs its first entries

PRD-PLATES §2.6: *"A jurisdiction that prints a glyph INSIDE a serial is a
schema amendment, not a data entry. If one lands, it goes to
`_meta/separators.yml`'s `never_separator` list with its source, and every
consumer learns about it from one place."*

**Two have landed in this group, both from first-party DMV pages:**

| jurisdiction | glyphs | source |
|---|---|---|
| **us-va** personalized | `&` (plus `-` and ` `, already emitted separators) | VA DMV: *"Use any combination of letters, numbers and the special characters dash, space and ampersand."* |
| **us-nc** personalized | `?` `&` `$` `@` | NCDMV: *"You can use numbers and some special characters, including the question mark (?), ampersand (&), dollar sign ($) and the 'at' symbol (@)."* |

These are **serial-significant, non-alphanumeric, and not separators**. A
lenient consumer that strips punctuation would destroy them — which is exactly
the failure `never_separator` exists to prevent, and the disjointness guarantee
in §2.6 consequence 1 is stated dataset-wide, so it is currently **wrong for
these two series**.

Handling in the files (conservative, and lint-clean): both series keep a regex
inside the serial alphabet, `matching: strict` (§2.7 — narrower is still
strict), and a loud `charset.notes` recording the KNOWN, SOURCED false
negatives. No unilateral schema change was made.

**Proposed amendment**, for the maintainer:

```yaml
never_separator:
  - char: "&"
    codepoint: "U+0026"
    name: AMPERSAND
    jurisdictions: [us-va, us-nc]
    note: >-
      Serial-significant on US personalized plates. VA DMV and NCDMV both
      publish permission to use it inside an owner-chosen serial. It is not a
      group boundary and MUST NOT be stripped.
    sources:
      - "https://www.dmv.virginia.gov/vehicles/license-plates/personalized-policy"
      - "https://www.ncdot.gov/dmv/title-registration/license-plates/Pages/default.aspx"
  - { char: "?", codepoint: "U+003F", name: "QUESTION MARK",  jurisdictions: [us-nc] }
  - { char: "$", codepoint: "U+0024", name: "DOLLAR SIGN",    jurisdictions: [us-nc] }
  - { char: "@", codepoint: "U+0040", name: "COMMERCIAL AT",  jurisdictions: [us-nc] }
```

Note `.` and `/` are already in the FORGIVING list; none of the four glyphs
above is, so the amendment does not conflict with the existing contract — it
only adds a positive statement that these are never separators. **Check the
remaining 45 states' vanity character sets before finalising**: this pass found
two in five, and only because it read the DMV pages rather than the statutes.

### 3.2 The period rail cannot express a LEGISLATED FUTURE SUNSET

`lint_plates.rb` fails any `period.end` beyond `NOW + 1`:

```ruby
fail! "... period.end #{en} beyond #{NOW + 1} — typo?" if en.is_a?(Integer) && en > NOW + 1
```

That rail is right for a typo and wrong for a real and recurring shape. **Two of
five states in this group have already legislated or announced when their
current standard base stops:**

- **South Carolina**, in statute: § 56-3-1230(C) — the regular passenger plate
  commemorates the semiquincentennial *"from January 1, 2026, until December 31,
  2032"*. Both endpoints are edict.
- **Georgia**, by the agency: DOR — the America 250 plate *"will remain
  available for issuance through 2030."*

Workaround used in both files: `period.end` is **absent** (honest for a consumer
— the series IS currently issuing) and the sunset is carried in
`period.scheduled_end`, which the lint ignores. That preserves the fact without
lying, but it hides a genuinely valuable capability: **the dataset can know
about a base change up to seven years early, which no competitor can.**

**Proposed amendment:** admit `period.scheduled_end: <Integer>` in the schema,
rail it as `start < scheduled_end` with a generous upper bound (say `NOW + 25`),
and require `period_evidence` on it. Then a consumer can ask "which currently
issued series are scheduled to end?" — a query with obvious product value.

---

## 4. Cross-cutting findings

**4.1 US "standardisation" is five different answers to every question.** Put
side by side, the five states of this group legislate almost nothing in common:

| | plate size | retroreflective | reissue cycle | plates issued | tractor plate |
|---|---|---|---|---|---|
| **VA** | Commissioner's discretion (§ 46.2-712(A)) | not in statute | **none, and §46.2-714 authorises PERMANENT plates** | **2** | **front only** |
| **WV** | not in statute | **yes** (§17A-3-14(b)(1)) | none; free replacement when worn | 1 | — |
| **NC** | not in statute | **NOT IN STATUTE** | none located | 1 | — |
| **SC** | **≥6 × ≥12 in** (§ 56-3-1230(A)) | **yes** (§ 56-3-1230(B)) | **≥ every 10 years, in statute** | 1 | **front only** |
| **GA** | **≥6 × ≥12 in; motorcycle ≥4 × ≥7 in** (§ 40-2-31(b)) | **yes** (§ 40-2-31(c)) | 5-year service floor, no cycle | 1 | — |

Three sub-findings worth carrying:

- **North Carolina is the only one of the five that does not legislate
  retroreflectivity.** Its § 20-63(c) sets a 100-foot **daylight** bar and says
  nothing about night. NC plates are reflective in practice — that is
  departmental practice, recorded as such.
- **The truck-tractor front-plate inversion is not a Florida oddity.** Florida
  (§ 320.0706), Virginia (§ 46.2-715) and South Carolina (§ 56-3-1240(B)) all
  legislate that the tractor plate goes on the FRONT, inverting each state's own
  default. Three of six US jurisdictions now in the dataset.
- **The 100-foot daylight legibility figure appears in two statutes
  independently**: W. Va. Code §17A-3-14(b)(2) and N.C.G.S. § 20-63(c). AAMVA
  §3.3 recommends 75 feet day and night.

**4.2 One base ≠ one regex, demonstrated three times.** Each of these is a
silent-rejection bug waiting for any consumer holding one pattern per design:

- **South Carolina, Oct 2023** — mid-base, unchanged design: serial arrangement
  flipped letters-first → numerals-first, the font changed, AND the letter `O`
  was readmitted after 15 years of exclusion.
- **West Virginia, Oct 2015** — a THIRD serial arrangement (`0`+digit+letter+3
  digits) added to a base first issued in 2006, because the two-letter series
  was exhausting.
- **Georgia, Mar 2026** — a second arrangement (`AB1CDE`) opened on the America
  250 base two months after the first (`ABC1DE`).

**4.3 Serial-block allocation is data, and the two states that look alike behave
oppositely.** North Carolina runs three concurrent standard designs in
**disjoint** first-letter blocks (A–L / P–R / T–V) under a shared second-letter
A–M rule — so the serial identifies the design. Georgia runs two concurrent
peach bases **alternating through shared blocks** — so the serial identifies
nothing. Same structure, opposite parse consequence.

**4.4 North Carolina's second letter is a free ERA SIGNAL.** Pre-2010
allocation: second letter strictly **N–Z**. Post-2010: strictly **A–M**. The two
are disjoint, so one character dates a North Carolina plate to either side of
2010. Encoded as `regex_strict` on all four NC standard series.

**4.5 West Virginia encodes the EXPIRATION MONTH in the leading character.**
`1`–`9` = January–September, `O` = October, `N` = November, `D` = December,
reported as continuous from the 1970–75 base to today. A **time** encoding in
the serial — the temporal analogue of the German prefix and the Dutch sidecode
era inference — and the highest-value single decode in this group. It is
`secondary-locator-unverified`: the WV DMV does not publish it and §17A-3-14
does not mention it. It also creates a **semantic** O/0 hazard: `O12 345A`
expires in October; `012 345A` is not a valid plate. **Verify before shipping
any decode that depends on it.**

**4.6 North Carolina converts `O` → `0` at issue.** NCDMV: *"The letter 'O' is
automatically converted into a zero (0) on your personalized license plate to
avoid confusion."* So NC personalized serials contain **no letter O at all**,
and an OCR pipeline that "corrects" 0→O on a North Carolina vanity plate is
**introducing** the error. This points the opposite way from essentially every
lookalike heuristic in the field.

**4.7 South Carolina legislates an exception to PLATE UNIQUENESS.**
§ 56-3-2010(A): *"there may be no duplication of registration plates, except
South Carolina members of the United States Congress or members of the South
Carolina General Assembly may purchase a maximum of the original and two
duplicate registration plates."* Up to three physical plates carrying the same
registration mark, lawfully, simultaneously. Plate uniqueness is an axiom in
essentially every validator, parse API and ALPR pipeline in existence.

**4.8 SC § 56-3-8100 answers a question us-fl left open, and hands L4 a
shortcut.**
- `us-fl-specialty-index` records: *"The numeric threshold triggering
  discontinuation was not extracted in this pass (recorded gap)."* South
  Carolina's equivalent is explicit — § 56-3-8100(H): **fewer than 300 biennial
  applications and renewals** → no further production, *"continue to issue …
  until the existing inventory is exhausted."* Different state, so the Florida
  gap is not filled — but the SHAPE is now confirmed twice: US specialty
  programmes die by numeric threshold and stay lawfully on the road until stock
  runs out.
- § 56-3-8100(C) requires **one basic plate design for ALL special plates**
  authorised by the General Assembly, with a departmental emblem slot, no added
  text or slogans, the organisation's name across the top, mandatory for
  everything newly requested after **1 July 2013**. South Carolina's entire
  post-2013 specialty catalogue is therefore renderable from **one parametric
  template plus an emblem** — the L4 specialty-design problem, solved by statute
  for one state.

**4.9 Georgia legislates DIGITAL LICENSE PLATES.** § 40-2-31(a) provides for *"a
distinctive number or a distinctive number to be displayed electronically upon a
license plate by a digital license plate provider."* Every schema assumption in
`plates/` presumes metal: retroreflective sheeting, stamped characters, a
physical decal, a fixed design per period. A digital plate's design is software
and its content can change without a base change. No field is needed yet;
recorded at file level in `us-ga.yml` so the dataset meets the case before it
meets a jurisdiction that has gone digital at scale.

**4.10 County designation: three mechanisms, three decision-makers.** Florida
prints the county name and lets the **county commission** vote it off
(§ 320.06(3)(a)). Georgia **mandates** county designation (§ 40-2-31(b)) but
delivers it as a **decal** the **registrant** may swap for "In God We Trust"
(§§ 40-2-31(e), (g)) and which is replaced on moving county (§ 40-2-31(d)).
North Carolina has none, except a single reserved block: **OBX for Dare County
since 1999** — a one-row decode table, and still a real fact. In none of the
three does geography touch the serial.

**4.11 The specialty-count problem, and who solves it.**

| state | figure | kind |
|---|---|---|
| **VA** | **340** (Special Interest 137 + College 96 + Military 64 + Other 43 — facets reconcile exactly to the total) | agency faceted search: a real COUNT |
| **GA** | "hundreds" (agency) / **340 enumerated**, 14 marked "New plates are no longer available" | agency estimate + enumeration of the agency's own list, recorded separately |
| **NC** | "more than 100 causes and interest groups" | agency estimate |
| **SC** | **153 ARTICLE headings**, article numbers to 155 | DERIVED UPPER BOUND from the statute book (SCDMV unreachable) — explicitly not "SC has 153 specialty plates" |
| **WV** | none published | four galleries, no totals; image counts include chrome and are NOT asserted |

VA and GA both landing on 340 is coincidence — counted from different services
on different days — and is flagged in `us-ga.yml` so no later reader suspects
one of being copied from the other.

**Programme CHURN is first-party readable in two states**, which is rare:
Virginia authorises each specialty plate by its own Code section, so dead
programmes appear as **Repealed** and **Expired** sections in the Article 10
table of contents; Georgia marks **14 of 340** entries "New plates are no longer
available" inline in the agency's own list. Both are the right hooks for an L4
pass. Georgia's, however, is the catalogue the State **owns** (§3.1 above) —
index the programmes, never the designs.

**4.12 `_meta/classes.yml` is being asked to carry more than it has.** Recorded
across this group and the pilot:
- **manufacturer** — legislated distinctly from dealer in FL (§ 320.06(3)(a)),
  SC (§ 56-3-2330: 500-plate cap, $200, 2-year validity, one licensed vehicle
  per household) and GA. Currently forced into `dealer`, a third time.
- **transporter** — a separate programme in VA (§ 46.2-733) and GA. Also forced
  into `dealer`.
- **autocycle** — VA law names autocycles alongside motorcycles (§§ 46.2-711(A),
  46.2-715); our `categories` vocabulary has no value for them.
- **weight/commercial** — SC's § 56-3-1230(A) authorises "distinctive markings …
  to indicate the class of the weight of the vehicle"; WV runs eleven official
  registration classes including taxi (J), mobile equipment (M) and farm truck
  (X) with no plate class of ours to match.

Not changed here. The vocabulary grows by PR with a definition, per §2.3.

**4.13 Folklore watch — the 1956 story has MOVED.** The US/world dossier found
the "1956 AMA standardization agreement" carrying a `citation needed` since 2017
and copied verbatim across articles (circular). As of this pass all five state
articles still repeat it, but it now carries a citation:

> Christopher Garrish, **"Reconsidering the Standard Plate Size"**, *Plates*
> (ALPCA), vol. 62 no. 5, October 2016.

That is a collector-magazine article, **not obtained** (ALPCA's members'
magazine is not online), and its **title announces that it revises the received
story**. Status for our purposes is unchanged — **COMMONLY REPEATED, NOT
PRIMARY-SOURCED** — but the change is recorded in all five files, because a
`citation needed` becoming a citation looks like resolution and is not. Two
states of this group make the point moot anyway by legislating their own
dimensions (SC § 56-3-1230(A), GA § 40-2-31(b)); the other three make no
dimension claim in our data at all.

---

## 5. Sourcing obstacles, disclosed rather than papered over

| host | outcome | consequence |
|---|---|---|
| **ncleg.gov** (NC General Assembly) | **403 Cloudflare** on every attempt — HTML and PDF, with and without browser headers, via curl and via the fetch proxy | N.C.G.S. §§ 20-63 and 20-79.1 read through `codes.findlaw.com`; every citation in `us-nc.yml` is marked **"[via FindLaw; ncleg.gov 403]"**. The TEXT is a PD edict; the READING PATH is second-hand. **Re-derive from ncleg.gov before applying.** |
| **Official Code of Georgia** | LexisNexis container does not answer automated fetches; `law.justia.com` 403; `ga.elaws.us` returns a stale 2013 title list | O.C.G.A. §§ 40-2-31, 40-2-41, 40-2-60.1 read through `codes.findlaw.com`, marked **"[via FindLaw]"**. §§ 40-2-85.3 and 40-2-86.1 NOT reached. **Re-derive before applying.** |
| **scdmvonline.com** | **UNREACHABLE** — connection reset on HTTP/2, timeout on HTTP/1.1, socket hang-up through the fetch proxy, repeatedly | **Not one claim in `us-sc.yml` rests on SCDMV.** Mattered less than it would elsewhere, because South Carolina legislates what other states delegate — but the specialty count is derived from the statute book, and the personalized character set is a gap |
| **WebSearch** | session budget exhausted (200/200) before this pass began | all discovery by direct URL construction + link extraction from fetched pages. Some agency sub-pages were reached by guessing and some were not (see gaps) |
| **SAE J686** | not attempted — standing rule | **No J686 dimension is quoted anywhere in these five files.** All geometry cites AAMVA Ed.3 only |

Everything else — law.lis.virginia.gov, code.wvlegislature.gov,
scstatehouse.gov, dmv.virginia.gov, transportation.wv.gov, ncdot.gov/dmv,
dor.georgia.gov, mvd.dor.ga.gov, commons.wikimedia.org — answered directly.

---

## 6. Gaps, ranked by value to the next pass

1. **O.C.G.A. §§ 40-2-85.3 and 40-2-86.1** — decides whether Georgia's
   design-ownership carve-out reaches the STANDARD plates or only specialty
   ones. Highest-value single fetch in the group.
2. **Verify the West Virginia leading-character month code** (§4.5). Currently
   locator-only; it is the one decode in this group with direct parse-API value.
3. **N.C.G.S. § 20-79** (dealer plates) — not obtained; `us-nc-dealer` is the
   weakest entry in the group, sourced only from a neighbouring section's title.
4. **Re-derive all NC and GA statute citations from official hosts** (§5).
5. **Personalized character sets for WV, SC, GA** — VA and NC both turned out to
   permit non-alphanumeric glyphs. Two of five is not a coincidence to assume
   away.
6. **Virginia Administrative Code** — a DMV plate specification, if one exists,
   would convert Virginia's entirely locator-grade design data into sourced
   data. § 46.2-712(A) delegates everything to the Commissioner; nobody has
   found where the Commissioner wrote it down.
7. **SCDMV's own specialty count** — replaces the derived 153 upper bound.
8. **WV §17A-3-15** (display) — fetched but not extracted; `us-wv.yml`'s
   rear-mounting claim is currently recorded as CONVENTION, not sourced.
9. **WV §17A-3-14a** — government-official plates; only the section TITLE is
   cited today.
10. **SC departmental retroreflective specification** — § 56-3-1230(B) creates
    it by name ("The department shall prepare the specifications"); it exists
    and is findable.
11. **VA §§ 46.2-750.1 and 46.2-751** (police / state-owned passenger vehicles)
    and **§ 46.2-733** (transporter) — named, not read.
12. **Georgia dealer/transporter/manufacturer O.C.G.A. sections** — existence
    sourced from MVD navigation only.
13. **State seal / emblem misuse statutes** for all five states — the
    non-copyright protection regime, still the largest hole in the whole US IP
    analysis (flagged as open in the US/world dossier and not closed here).
14. **Specialty-programme enumeration for WV** — the mechanical route was found
    (each programme has a numbered `DMV-54_*.pdf` application form, so the DMV
    form index yields a first-party programme list) but not executed.

---

## 7. Verification notes for the human session

- All five files pass `scripts/lint_plates.rb` unmodified, in a sandbox
  containing the canonical `plates/` tree plus these five files: **9 files, 116
  series, OK**.
- Regex behaviour was spot-checked beyond the lint's round-trip, on real
  reported serials:
  - `us-va-standard-lovers` accepts `VAA-1001`, `SUE-5647`, `VAA1001`; rejects
    `12345678`.
  - `us-wv-standard-2023` accepts `512 345A` and `O12 345A` under both `regex`
    and `regex_strict`; accepts `012 345A` under `regex` but **rejects it under
    `regex_strict`** (no month zero); rejects the previous base's `5AB 123`.
  - `us-nc-standard-first-in-flight` accepts `AAA-1001` / `LKE-7520` strictly;
    `ANA-1001` passes `regex` but **fails `regex_strict`** — correct, N is the
    pre-2010 allocation.
  - `us-sc-standard-rev250-2026` accepts `101 DDM` and `433DEN`, rejects the
    previous base's `ABC 123`.
  - `us-ga-standard-america250` accepts `AAA1AA` and `ABD 6ZG`, rejects the
    peach bases' `AAA1234`.
  - `us-ga-standard-georgiagov-2007` accepts `AWB 1751` strictly and **rejects
    `AOB 1751` under `regex_strict`** — the sourced letter-O exclusion.
- **28 of the 116 series in the sandbox are `recall-only`**, 24 of them from
  this group. That is a deliberate, and high, proportion: where a state
  publishes no serial specification for a class, an over-broad regex plus
  `matching: recall-only` is the honest encoding, and inventing a grammar would
  have been the alternative. Every one of them says so in `charset.notes`,
  including that any seven-character bound is a **dataset-chosen recall bound**
  and not a legal claim (only Florida's § 320.06(3)(a) actually legislates
  seven).
- **`period.scheduled_end` is a new key** appearing on two GA series and one SC
  series. The lint ignores it. See §3.2 before applying.
- **`format_evidence` and `dimension_evidence` are new keys**, used to grade
  claims that `period_evidence` does not cover. Also ignored by the lint.
- Nothing in `/Users/javi/GitHub/vehiclesdb` was modified.
