### PR TITLE
plates: us midwest-b — MN IA MO ND SD NE KS (L2 US wave)

### DIFF
--- a/plates/us-ia.yml
+++ b/plates/us-ia.yml
@@ -1,0 +1,438 @@
+# plates/us-ia.yml — Iowa (PRD-PLATES gate L2, group midwest-b).
+#
+# IOWA PUTS THE COUNTY ON EVERY PLATE, BY STATUTE, AND IT IS NOT A CODE. Iowa
+# Code § 321.166(2): "Every registration plate issued by the county treasurer
+# shall display the name of the county". That is a mandatory geographic legend on
+# essentially every Iowa plate — a stronger rule than Florida's, where the county
+# name is a county-level opt-out — but it encodes nothing in the SERIAL. So Iowa
+# is the clearest case in this dataset of geography that is READABLE but not
+# DECODABLE: you can see the county on the plate and you cannot recover it from
+# the plate number. `region_encoding` below says exactly that.
+#
+# IOWA ALSO SPELLS THREE SERIAL AFFIXES INTO STATUTE, which is unusual and
+# genuinely useful, because each is a sourced literal a parser can key on:
+#   * "DV" PRECEDES the number on disabled-veteran plates (§ 321.166(6));
+#   * "D" appears on dealer plates, at serial character size (§ 321.166(3));
+#   * "special" appears on special truck plates (§ 321.166(2)).
+# Those are specified as their own series below.
+#
+# AND IOWA LEGISLATES THAT EACH NEW SERIES MUST LOOK DIFFERENT FROM THE LAST:
+# § 321.166(5), "When a new series of registration plates is issued to replace a
+# current series, the new registration plates shall be of a distinctively
+# different color from the series which is replaced." Kansas legislates the same
+# idea (K.S.A. 8-147(d)). Two neighbouring states have independently made their
+# own series boundaries visually detectable, which is a gift to this dataset.
+jurisdiction: us-ia
+authority:
+  name: Iowa Department of Transportation, Motor Vehicle Division (plates issued through the county treasurers)
+  url: "https://www.legis.iowa.gov/docs/code/321.166.pdf"
+binding: vehicle
+statute_edition: "Iowa Code 2026, Chapter 321 (Motor Vehicles and Law of the Road), §§ 321.34 and 321.166 as published by the Iowa Legislature; and Iowa Administrative Code 761 ch. 401 (Special Registration Plates), whose rule 401.3 carries [ARC 8937C, IAB 2/19/25, effective 3/26/25]"
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    IOWA WAS NOT LOCATED IN ANY COPYRIGHT SURVEY READ FOR THIS PASS. The Wikipedia survey
+    of subnational-government copyright status carries per-state sections for seventeen
+    states and NO section for Iowa; no {{PD-IAGov}} tag was found on Commons. The
+    dossier's default therefore governs: 17 U.S.C. § 105 does not reach the states, so an
+    Iowa plate design is presumed COPYRIGHTED unless Iowa says otherwise, and Iowa has not
+    been shown to say otherwise. Recorded as unresearched, not adverse — absence of a
+    fetched source is weak evidence either way.
+  edict_carve_out: >-
+    Iowa's carve-out is unusually wide because Iowa legislates unusually much of its plate.
+    The size ceiling, the character height and stroke limits, the 100-foot daylight
+    readability rule, the county-name legend, the contrast rule, the distinct-colour rule
+    for new series, the DV prefix, the dealer D and the 'special' truck legend are ALL in
+    the Iowa Code, and the minimum and maximum character counts are in the Iowa
+    Administrative Code. Edicts of government are uncopyrightable at every level
+    ({{PD-US-GovEdict}}), so nearly the whole factual layer of this file is affirmatively
+    clean regardless of Iowa's posture on artwork.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to the current Iowa base graphic and to
+    the 'processed emblem' and 'organization decal' that § 321.166(9) provides space for
+    on special plates. The organization decals carry an ADDITIONAL layer: § 321.34(13)
+    decals are designed by nonprofit organizations and approved by the department, so they
+    are third-party artwork licensed into a state program rather than state work at all,
+    and a clean state posture would not clear them. Render
+    `emblem: {present: true, rendered: placeholder}`. Iowa state-seal misuse statutes are
+    unresearched.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): read to establish that Iowa has NO section in the survey — a negative result, recorded as such"
+    - "https://www.legis.iowa.gov/docs/code/321.166.pdf  # Iowa Code § 321.166, the statutory plate specification itself — an edict of government, PD"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA has no enforcement power; its declarative present is RECOMMENDED PRACTICE."
+  dimensions_delegated: >-
+    AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is PAYWALLED and
+    UNPINNED, and no J686 dimension is quoted here. IOWA IS THE ONE STATE IN GROUP
+    MIDWEST-B THAT DOES NOT NEED IT: § 321.166(1)(a) states a size ceiling in law — plates
+    'of a size NOT TO EXCEED six inches by twelve inches' — so Iowa's dimension is sourced
+    to an Iowa edict and owes nothing to the standards chain or to the uncited 1956 story.
+  geometry_available: >-
+    AAMVA §2.1 and §2.2 supply the renderable layout geometry generally. For Iowa the
+    CHARACTER geometry is in statute and is stricter in kind: § 321.166(3) caps character
+    height at four inches and stroke width at five-eighths of an inch, where AAMVA §2.2
+    sets a 2.5-inch character-height FLOOR. The two are compatible — AAMVA's minimum sits
+    below Iowa's maximum — but note they are opposite instruments, a floor and a ceiling.
+  retroreflectivity: "AAMVA §3.3: legible day and night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3; entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2. Iowa's own statutory legibility rule is a 100-foot DAYLIGHT test (§ 321.166(4)), which is a different measurement, not a stricter version of the same one."
+  replacement_cycle_recommendation: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. Iowa legislates NO replacement cycle in § 321.166 or § 321.34; instead § 321.34(2)(a) lets the department REASSIGN existing plates indefinitely and issue an annual validation sticker. Recorded gap as to any Iowa cycle."
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The '1956 AMA standardization agreement' said to have fixed the 6x12 inch plate is
+    UNCITED in its Wikipedia source (a `citation needed` since 2017, copied across
+    articles — circular). Recorded as COMMONLY REPEATED, UNSOURCED. Iowa is the state where
+    this matters least and is easiest to demonstrate: Iowa's six-by-twelve is cited below to
+    § 321.166(1)(a), which states it in law, so nothing in this file depends on the folklore.
+
+# ---------------------------------------------------------------------------
+# Display rules. Iowa is a TWO-PLATE state with a six-class single-plate list.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates. Iowa Code § 321.34(1): the county treasurer 'shall issue to the owner one registration plate for a motorcycle, motorized bicycle, autocycle, truck tractor, trailer, or semitrailer and TWO registration plates for every other motor vehicle'."
+  single_plate_classes: ["motorcycle", "motorized bicycle", "autocycle", "truck tractor", "trailer", "semitrailer"]
+  validation_sticker: >-
+    § 321.34(2)(a): one validation sticker per set of plates, specifying the month and
+    year of expiration, 'displayed only on the rear registration plate, EXCEPT that the
+    sticker shall be displayed on the FRONT registration plate of a truck tractor' — the
+    truck-tractor inversion again, this time applied to the sticker rather than the plate.
+    A sticker for the upcoming year issued before the current year expires does not
+    invalidate the registration and need not be displayed until the vehicle would otherwise
+    be driving on an expired registration under § 321.39.
+  expiration_on_plate: "§ 321.166(7): the year and month of expiration, which may be abbreviated, shall be displayed on plates issued by the county treasurer; the department may prescribe a distinctive emblem or validation sticker to designate them. Not required on § 321.19 plates."
+  plate_retention_on_transfer: "§ 321.34(1): plates are assigned to the OWNER, not the vehicle — on transferring the vehicle the owner REMOVES the plates and either forwards them to a county treasurer or has them assigned to another vehicle within thirty days. Iowa is therefore closer to the Swiss owner-binding model than most US states, though the binding is still recorded as `vehicle` because registration itself is vehicle-keyed."
+  sources:
+    - "https://www.legis.iowa.gov/docs/code/321.34.pdf  # Iowa Code § 321.34(1): one plate for six named classes and two for every other motor vehicle, plates assigned to the owner, removal on transfer and the thirty-day reassignment window; (2)(a) the validation sticker, its month-and-year content, rear display and the truck-tractor front-display exception, and the early-sticker rule"
+    - "https://www.legis.iowa.gov/docs/code/321.166.pdf  # Iowa Code § 321.166(7): the year and month of expiration displayed on county-treasurer-issued plates"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES.
+  # =========================================================================
+  - id: us-ia-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){1,6}\z'
+      charset:
+        min_characters: 2
+        min_characters_basis: "Iowa Admin. Code r. 761-401.3(1): 'Plates will be issued with a minimum of two characters.' A sourced FLOOR, which almost no state states."
+        notes: >-
+          § 321.166(2) is the statutory grammar and it is broad: 'Every registration plate
+          or pair of plates shall display a registration plate number which shall consist of
+          ALPHABETICAL OR NUMERICAL CHARACTERS OR A COMBINATION THEREOF and the name of this
+          state, which may be abbreviated.' No width and no arrangement are stated, and the
+          department is authorised to 'adopt rules to implement this subsection'. NO LETTER
+          EXCLUSIONS appear in § 321.166 or § 321.34 — whether Iowa skips I/O/Q was NOT
+          established (recorded gap).
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY, on the nl-export precedent. Iowa's serial ARRANGEMENT is
+        not stated in the Code, the implementing rules were not located, and the Iowa DOT
+        website returned HTTP 403 to every request in this pass. What IS sourced is a
+        two-character FLOOR (761-401.3(1)) and, for emblem plates, a five-character ceiling
+        (761-401.3(2)); the regex encodes the floor and stays wide above it, and
+        `matching: recall-only` says a hit is a shape hit only.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: >-
+        § 321.166(1)(a), verbatim: plates 'shall be of metal and of a size NOT TO EXCEED six
+        inches by twelve inches, except that the size of plates issued for use on autocycles,
+        motorized bicycles, motorcycles, motorcycle trailers, and trailers with an empty
+        weight of two thousand pounds or less shall be established by the department.' Note
+        this is a CEILING, unlike Florida's § 320.06(3)(a), which states minima for the same
+        two numbers. The reduced sizes are departmental and were not obtained (gap).
+      small_trailer_option: "§ 321.166(1)(b) and (8): trailers of 2,000 lb empty weight or less receive smaller plates by rule, but 'may, upon request, be licensed with regular-sized license plates'"
+      character_geometry: "§ 321.166(3): the registration plate number 'shall be displayed in characters which shall not exceed a height of four inches nor a stroke width exceeding five-eighths of an inch'. Sizes for autocycles, motorized bicycles, motorcycles, small trailers and motorcycle trailers are prescribed by the department."
+      legibility: "§ 321.166(4): the plate number, except on the small-vehicle classes, 'shall be of sufficient size to be readable from a distance of one hundred feet during daylight' — a DAYLIGHT test, where Minnesota's counterpart is a night test"
+      contrast_rule: "§ 321.166(5): 'There shall be a marked contrast between the color of the registration plates and the data which is required to be displayed on the registration plates.'"
+      series_colour_change_rule: >-
+        § 321.166(5), verbatim and consequential for this dataset: 'When a new series of
+        registration plates is issued to replace a current series, the new registration
+        plates shall be of a DISTINCTIVELY DIFFERENT COLOR from the series which is
+        replaced, except for collegiate registration plates issued under section 321.34,
+        subsection 7 or 7A.' Iowa has legislated that its series boundaries are visually
+        detectable — and then carved collegiate plates out of the rule, so collegiate plates
+        alone may span a boundary without changing colour.
+      legend_state: "Iowa (may be abbreviated, § 321.166(2))"
+      legend_county: "the name of the county — mandatory on every plate issued by a county treasurer (§ 321.166(2))"
+      colour_note: >-
+        NO HEX IS RECORDED. Iowa mandates CONTRAST and mandates CHANGE-ON-REISSUE but names
+        no colour value, the implementing rules were not located, and the Iowa DOT site
+        returned 403. Recorded gap rather than an eyedropped value.
+      emblem: { present: true, rendered: placeholder }
+      material: "metal (§ 321.166(1)(a))"
+    region_encoding:
+      geographic_legend: >-
+        PRESENT, MANDATORY AND NOT DECODABLE. § 321.166(2): 'Every registration plate issued
+        by the county treasurer shall display the name of the county, including any plate
+        issued pursuant to section 321.34' — with named exceptions for Pearl Harbor and
+        purple heart plates issued before 1 January 1997, and for collegiate, fire fighter
+        and medal of honor plates. So the county appears as PRINTED TEXT on essentially
+        every Iowa plate, and encodes nothing in the serial. There is no geographic decode
+        in an Iowa plate string.
+      contrast_with_florida: >-
+        Iowa's county legend is STRONGER than Florida's. Florida § 320.06(3)(a) lets a county
+        commission vote the county name off its plates in favour of the state motto or
+        'Sunshine State'; Iowa gives the county no such opt-out and instead exempts specific
+        PLATE TYPES. The modelling consequence differs accordingly: in Florida the bottom
+        legend is a property of the selling county, in Iowa it is a property of the plate type.
+      contrast_with_neighbours: >-
+        Worth stating for the encyclopedia, because this group contains both designs: Iowa and
+        Kansas put the county on the plate as a LEGEND or letters, while Nebraska and (by
+        report) South Dakota put a county NUMBER into the serial itself. Only the latter is
+        machine-decodable from a plate string.
+    sources:
+      - "https://www.legis.iowa.gov/docs/code/321.166.pdf  # Iowa Code § 321.166(1)(a)-(b): metal, the six-by-twelve CEILING, departmental sizes for small vehicles, the small-trailer regular-plate option; (2) the alphabetical-or-numerical-or-combination grammar, the abbreviable state name, the MANDATORY county name with its Pearl Harbor / purple heart / collegiate / fire fighter / medal of honor exceptions, the 'special' truck legend and the rulemaking authority; (3) four-inch character height and five-eighths-inch stroke ceilings and the dealer 'D'; (4) the 100-foot daylight readability rule; (5) marked contrast and the distinctively-different-colour rule for new series with its collegiate carve-out; (6) the DV prefix; (7) year and month of expiration; (8) small-trailer plates; (9) design consistency and emblem space for special plates; (10) no issuance fee on a special-plate redesign"
+      - "https://www.legis.iowa.gov/docs/iac/chapter/761.401.pdf  # Iowa Admin. Code r. 761-401.3(1): the two-character minimum; 401.3(2): the five-character maximum for plates with a processed emblem and for § 321.34(13) plates. [ARC 8937C, IAB 2/19/25, effective 3/26/25]"
+    notes: >-
+      IOWA STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED and the series is deliberately
+      `recall-only`: Iowa legislates its plate's PHYSICS in unusual detail — a size ceiling,
+      a character-height ceiling, a stroke ceiling, a daylight readability distance — and
+      leaves its GRAMMAR to rules this pass could not reach, with the Iowa DOT website
+      returning 403 to every request.
+      PERIOD CAVEAT: `start: 2026` is the Iowa Code edition read and is an UPPER BOUND on the
+      true start of the current base, not a claim about it. THE ONE SERIES BACK IS A
+      RECORDED GAP — but Iowa is the state where recovering it should be EASIEST, because
+      § 321.166(5) guarantees that each new series differs in colour from the one it
+      replaced, so the series history is in principle a colour sequence and a single
+      departmental source would unlock the whole chain.
+
+  # =========================================================================
+  # THE THREE STATUTORY SERIAL AFFIXES. Each is a sourced literal, which makes
+  # these the most confidently specified Iowa series in the file.
+  # =========================================================================
+  - id: us-ia-disabled-veteran
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "DV999"
+      regex: '\ADV ?[A-Z0-9]{1,5}\z'
+      charset:
+        prefix_literal: "DV"
+        notes: >-
+          § 321.166(6), verbatim: 'Registration plates issued to a disabled veteran under
+          the provisions of section 321.105 shall display the alphabetical characters "DV"
+          which shall PRECEDE the registration plate number.' A statutory literal PREFIX is
+          the single most parser-friendly fact a plate statute can contain, and Iowa states
+          it unambiguously. The number following DV is the ordinary registration plate
+          number, whose grammar is unsourced (see us-ia-standard).
+      pattern_note: "the DV prefix is a sourced literal and is fixed in the regex; the following number is left wide because Iowa's serial grammar is not sourced. The optional separator reflects that § 321.166 prescribes no spacing."
+    design:
+      note: "§ 321.166(6): the plates 'may also display a persons with disabilities parking sticker if issued to the disabled veteran by the department under section 321L.2'"
+      emblem: { present: true, rendered: placeholder }
+      colour_note: "no hex recorded; § 321.166 names no colour value"
+    region_encoding: "county name legend as on the standard series (§ 321.166(2))"
+    sources:
+      - "https://www.legis.iowa.gov/docs/code/321.166.pdf  # Iowa Code § 321.166(6): the mandatory 'DV' prefix on disabled-veteran plates issued under § 321.105, and the optional persons-with-disabilities parking sticker under § 321L.2"
+    notes: >-
+      DISABLED VETERAN PLATES. Its own series because the statute mandates a FORMAT
+      difference — a literal prefix inside the plate number — which under PRD-PLATES §2.3 is
+      a series-making difference of a stronger kind than a mere legend change. CLASS
+      CAVEAT: recorded as `standard`, since _meta/classes.yml has no veteran or disability
+      class and this is an ordinary registration carrying a mandated prefix. Iowa's
+      eligibility criteria are in § 321.105, which was not read in this pass (gap).
+
+  - id: us-ia-dealer
+    class: dealer
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "D9999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){1,6}\z'
+      charset:
+        marker_literal: "D"
+        notes: >-
+          § 321.166(3), verbatim: 'Special plates issued to dealers shall display the
+          alphabetical character "D", which shall be of the SAME SIZE as the characters in
+          the registration plate.' Note what the statute does and does not say: it requires
+          the character D to appear, at serial character size, but — unlike the DV rule in
+          subsection (6) — it does NOT say the D precedes the number or forms part of it.
+          Its POSITION is therefore unsourced, which is why this series is `recall-only`
+          while the disabled-veteran series above is `strict`.
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY. The regex deliberately does NOT pin the D, because
+        pinning it to the front would assert a position the statute does not state. The
+        sourced fact — that a same-size D appears — is carried in
+        `charset.marker_literal` instead, where it cannot be mistaken for a grammar.
+    design:
+      note: "the D is required to be the same size as the serial characters, which distinguishes it from a small legend or emblem and is why it may well be part of the number"
+      emblem: { present: true, rendered: placeholder }
+    binding: business
+    region_encoding: "county name legend as on the standard series, since dealer plates are issued by the county treasurer (§ 321.166(2))"
+    sources:
+      - "https://www.legis.iowa.gov/docs/code/321.166.pdf  # Iowa Code § 321.166(3): the dealer 'D' at the same size as the registration plate characters"
+    notes: >-
+      DEALER PLATES. `binding: business` on the standing reasoning that the plate follows the
+      trade rather than a vehicle. The interesting discipline point is the CONTRAST WITH THE
+      DV RULE two subsections away: Iowa's legislature said 'shall PRECEDE the registration
+      plate number' for DV and merely 'shall display the alphabetical character "D"' for
+      dealers, and this file honours that difference by pinning one and not the other. It
+      would have been easy, and wrong, to write both as prefixes.
+
+  - id: us-ia-special-truck
+    class: standard
+    categories: [truck]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){1,6}\z'
+      pattern_note: "REPRESENTATIVE SHAPE ONLY; § 321.166(2) mandates a LEGEND on these plates and says nothing about their serial, so the standard series' unsourced grammar applies and `matching: recall-only` follows"
+    design:
+      legend: "special"
+      legend_rule: "§ 321.166(2), verbatim: 'Special truck registration plates shall display the word \"special\".'"
+      emblem: { present: true, rendered: placeholder }
+      colour_note: "no hex recorded; § 321.166 names no colour value"
+    region_encoding: "county name legend as on the standard series (§ 321.166(2))"
+    sources:
+      - "https://www.legis.iowa.gov/docs/code/321.166.pdf  # Iowa Code § 321.166(2): the mandatory 'special' legend on special truck registration plates"
+    notes: >-
+      SPECIAL TRUCK PLATES. A statutory legend series on the Florida model — us-fl-restricted
+      and us-fl-wrecker are the same shape of record. CLASS CAVEAT: recorded as `standard`,
+      because the vocabulary has no commercial or farm-truck class and the legend carries the
+      meaning. What a 'special truck' IS under Iowa law is defined elsewhere in Chapter 321
+      and was not resolved in this pass (recorded gap) — the legend and its mandate are
+      sourced, the underlying vehicle class is not.
+
+  # =========================================================================
+  # BLACKOUT — statutory, and the Iowa half of a two-state Midwestern pattern.
+  # =========================================================================
+  - id: us-ia-blackout
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){1,6}\z'
+      pattern_note: "REPRESENTATIVE SHAPE ONLY; § 321.34(11C) authorises the plate and its design without stating a serial grammar, so the standard series' unsourced grammar applies"
+    design:
+      note: >-
+        THE DESIGN IS SOURCED ONLY BY ITS NAME AND BY AN EXEMPTION. § 321.34(11C) creates
+        'Blackout plates' as a numbered special-plate subsection, and § 321.166(9) lists
+        blackout plates among the special plates EXEMPT from the rule that special plates
+        'shall be consistent with the design and color of regular registration plates' —
+        which is the statutory way of saying the blackout plate is allowed to look
+        completely unlike an Iowa plate. Its actual colours are not stated in the Code and
+        the Iowa DOT site returned 403, so no hex is recorded here.
+      design_freedom_basis: "§ 321.166(9) exempts gold star, medal of honor, collegiate, fire fighter, natural resources, BLACKOUT and flying our colors plates from the design-and-colour-consistency requirement imposed on other special plates"
+      emblem: { present: false }
+      colour_note: >-
+        NO HEX RECORDED — and the contrast with North Dakota is the point. North Dakota
+        legislated its blackout plate's colours as VALUES (NDCC § 39-04-10.18(2): 'a solid
+        black background', 'white numbers and letters'), so us-nd-blackout carries
+        `hex_basis: statute`. Iowa legislated only that its blackout plate need not match
+        the regular design. Same plate concept, two states, and only one of them is
+        citable for a colour.
+    region_encoding: "county name legend as on the standard series, since these are county-treasurer-issued plates (§ 321.166(2))"
+    sources:
+      - "https://www.legis.iowa.gov/docs/code/321.34.pdf  # Iowa Code § 321.34(11C): 'Blackout plates' as an authorised special registration plate subsection"
+      - "https://www.legis.iowa.gov/docs/code/321.166.pdf  # Iowa Code § 321.166(9): blackout plates among those exempt from the design-and-colour-consistency requirement, i.e. the statutory licence for the design to differ"
+    notes: >-
+      BLACKOUT PLATES. Broken out as its own series because § 321.166(9) expressly frees it
+      from the design and colour of the regular plate, which is a design difference in the
+      §2.3 sense even though the Code never says what the design IS. Iowa and North Dakota
+      both run statutory blackout plates — a small Midwestern convergence worth recording
+      for the encyclopedia — and comparing the two is instructive about sourcing: one state
+      wrote the colours into law and the other wrote only a permission.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Counted from the statute.
+  # =========================================================================
+  - id: us-ia-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL99"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){1,6}\z'
+      charset:
+        max_characters_emblem_plates: 5
+        max_characters_basis: "Iowa Admin. Code r. 761-401.3(2): 'Plates with a processed emblem, and plates issued under Iowa Code section 321.34(13), are limited to five characters whether personalized or issued as a letter-number designated plate.' A sourced, emblem-conditional ceiling — the frame narrows because the emblem takes plate space."
+        min_characters: 2
+      pattern_note: "REPRESENTATIVE SHAPE ONLY; the index stands for many programs, and the sourced constraints are the two-character floor and the five-character emblem-plate ceiling rather than any arrangement"
+    design:
+      consistency_rule: >-
+        § 321.166(9): special plates other than the exempt list 'shall be CONSISTENT WITH THE
+        DESIGN AND COLOR of regular registration plates but shall provide a space on a
+        portion of the plate for the purpose of allowing the placement of a distinguishing
+        processed emblem or an organization decal.' So Iowa's default specialty plate is the
+        standard plate plus an emblem slot — which is why the emblem-plate character ceiling
+        exists and why most Iowa specialty designs are not free-form.
+      exempt_from_consistency: ["gold star", "medal of honor", "collegiate", "fire fighter", "natural resources", "blackout", "flying our colors"]
+      note: "one design per authorised program; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_statutory: 30
+      count_basis: >-
+        COUNTED FROM THE STATUTE — the numbered subsections of Iowa Code § 321.34 that
+        authorise a plate type: radio operators (3), permanent (4), personalized (5), sample
+        (6), collegiate (7), medal of honor (8), ex-prisoner of war (8A), fire fighter (10),
+        emergency medical services (10A), natural resources (11), love our kids (11A),
+        motorcycle rider education (11B), blackout (11C), flying our colors (11D), persons
+        with disabilities (14), legion of merit (15), national guard (16), Pearl Harbor (17),
+        purple heart (18), United States armed forces retired (19), silver or bronze star
+        (20), distinguished service / navy / air force cross (20A), soldier's / navy and
+        marine corps / airman's medal (20B), Iowa heritage (21), education (22), breast
+        cancer awareness (23), gold star (24), civil war sesquicentennial (25), fallen peace
+        officers (26) and United States veteran (27).
+      count_caveat: >-
+        SUBSECTIONS ARE NOT DESIGNS, and in Iowa the gap is wide in both directions.
+        § 321.34(7) collegiate plates cover every participating institution under one
+        subsection, and § 321.34(13) is an open-ended NONPROFIT ORGANIZATION DECAL program
+        under which any qualifying organization may have a decal approved — so the number of
+        DESIGNS offered is materially greater than 30 and was not obtained. Conversely the
+        count includes subsections that are not really specialty designs at all (permanent
+        plates, sample plates). No Iowa DOT figure exists to reconcile against, because the
+        Iowa DOT site returned HTTP 403 on every request in this pass. Recorded, not
+        averaged (PRD-PLATES §5.3).
+      organization_decal_program: >-
+        § 321.34(13) with Iowa Admin. Code r. 761-401.4: a nonprofit organization meeting the
+        § 321.34(13)'a'/'b' criteria applies on Form 411346 for approval of a decal DESIGN,
+        and the department must notify approval or denial within 60 days; the department may
+        revoke an approved decal on finding a false statement, with notice. This is the
+        mechanism by which the Iowa catalogue grows without further legislation, and it is
+        the reason the design count is unbounded from the statute alone.
+      personalized_rules: >-
+        Iowa Admin. Code r. 761-401.5: personalized plates under § 321.34(5) are orderable
+        online; an application is rejected if the requested combination is already issued or
+        reserved for any other plate series; the department must not issue a combination it
+        determines falls into the rule's prohibited categories (the specific categories were
+        not extracted — gap); personalized plates are unavailable for the plate types listed
+        in 401.2(2)'a' onward.
+      fee_relief_on_redesign: "§ 321.166(10): if the department reissues a new design for a special plate, existing holders 'shall not be required to pay the issuance fee' — a rare statutory protection against redesign churn costs"
+      official_list_url: "https://www.legis.iowa.gov/docs/code/321.34.pdf"
+      iowa_dot_status: "the Iowa DOT plate pages (iowadot.gov) returned HTTP 403 on every request in this pass, via WebFetch and curl alike; recorded so a later run does not mistake it for unfetched-but-fine"
+    region_encoding: "county name legend, EXCEPT that § 321.166(2) exempts collegiate, fire fighter and medal of honor plates, and Pearl Harbor and purple heart plates issued before 1 January 1997 — so on those types the county is genuinely absent"
+    sources:
+      - "https://www.legis.iowa.gov/docs/code/321.34.pdf  # Iowa Code § 321.34: the thirty numbered plate-authorising subsections counted above, including (11C) blackout and (13) the nonprofit organization decal program; (3) radio operator call-letter plates; (5) personalized plates"
+      - "https://www.legis.iowa.gov/docs/code/321.166.pdf  # Iowa Code § 321.166(9): the design-and-colour consistency rule, the emblem/decal space requirement and the seven-type exemption list; (10) no issuance fee on a special-plate redesign; (2) the county-name exemptions for collegiate, fire fighter and medal of honor plates"
+      - "https://www.legis.iowa.gov/docs/iac/chapter/761.401.pdf  # Iowa Admin. Code 761 ch. 401: r. 401.3 the two-character floor and five-character emblem-plate ceiling; r. 401.4 the nonprofit decal approval process, Form 411346, the 60-day decision and revocation; r. 401.5 personalized plate ordering, rejection and prohibition rules"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — one entry standing for the whole program, per
+      PRD-PLATES §2.5, with no individual designs. Iowa counts cleanly from the statute the
+      way North Dakota does, and carries the same honest caveat in sharper form: the
+      open-ended § 321.34(13) decal program means the DESIGN count is unbounded from the
+      Code alone, while several counted subsections are not designs at all. The genuinely
+      novel Iowa facts for this dataset are structural rather than numeric — the default
+      specialty plate is the STANDARD plate plus an emblem slot (§ 321.166(9)), the emblem
+      slot COSTS characters (five-character ceiling, r. 761-401.3(2)), and a redesign cannot
+      be charged to existing holders (§ 321.166(10)).

--- a/plates/us-ks.yml
+++ b/plates/us-ks.yml
@@ -1,0 +1,351 @@
+# plates/us-ks.yml — Kansas (PRD-PLATES gate L2, group midwest-b).
+#
+# KANSAS IS THE ONLY STATE IN THIS GROUP WHOSE SERIAL ARRANGEMENT IS FIXED BY
+# STATUTE. K.S.A. 8-147(c) does not delegate the format to the agency the way
+# Missouri, Minnesota, North Dakota and South Dakota all do — it states it:
+# "Each license plate shall contain a combination of three letters followed by a
+# combination of three numerals". That is an edict of government specifying a
+# regex, which is the best sourcing situation this program can hope for, and it
+# is why `us-ks-standard` is `matching: strict` while several of its neighbours
+# in this group are `recall-only`.
+#
+# THE STATUTE ALSO WROTE ITS OWN EXHAUSTION CLAUSE, which is unusual foresight
+# and matters for the parse layer: "except that once all allowable combinations
+# of letters and numerals have been used, each license plate shall contain an
+# arrangement of numerals or letters, or both, as shall be assigned by the
+# secretary of revenue." So Kansas law contains BOTH a precise current grammar
+# and a pre-authorised escape hatch out of it. `regex_statutory` encodes the
+# escape hatch; `regex` encodes the grammar.
+#
+# THE ONE THING THIS FILE COULD NOT RESOLVE is the county designation. K.S.A.
+# 8-132(d) refers, in passing and without defining them, to "the letters required
+# to designate the county in which such vehicle is registered" — telling us that
+# Kansas plates carry a county designator that even a vanity plate may not
+# displace, without telling us what it looks like or where on the plate it sits.
+# That gap is recorded in `region_encoding` rather than papered over, because
+# guessing at it would corrupt exactly the decode data this program exists to get
+# right. The Kansas Department of Revenue's own site was UNREACHABLE for this
+# pass (connection timeouts on every attempt), which is why the gap survives.
+jurisdiction: us-ks
+authority:
+  name: Kansas Department of Revenue, Division of Vehicles
+  url: "https://www.ksrevisor.gov/statutes/chapters/ch08/"
+binding: vehicle
+statute_edition: "Kansas Statutes Annotated Chapter 8 (Automobiles and Other Vehicles), Article 1, as published by the Kansas Office of Revisor of Statutes and fetched for this pass. K.S.A. 8-147 carries a 2025 amendment (L. 2025, ch. 75, § 6), so the design provisions read here are current to the 2025 session."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    KANSAS WAS NOT LOCATED IN ANY COPYRIGHT SURVEY READ FOR THIS PASS. The Wikipedia
+    survey of subnational-government copyright status carries per-state sections for
+    seventeen states and NO section for Kansas; no {{PD-KSGov}} tag was found on
+    Commons. The dossier's default therefore governs: 17 U.S.C. § 105 does not reach the
+    states, so a Kansas plate design is presumed COPYRIGHTED unless Kansas says
+    otherwise, and Kansas has not been shown to say otherwise. Recorded as unresearched,
+    not as adverse — absence of a fetched source is weak evidence either way.
+  edict_carve_out: >-
+    KANSAS HAS THE STRONGEST EDICT CARVE-OUT IN GROUP MIDWEST-B, and it is worth stating
+    plainly because it is the practical answer to the unresearched posture above. The
+    facts this program most needs from Kansas — the three-letters-then-three-numerals
+    arrangement, the reflective coating duty, the mandatory colour change on each
+    reissue, the five-year reissue cycle, the personalized character caps — are ALL in
+    the Kansas Statutes Annotated, and edicts of government are uncopyrightable at every
+    level ({{PD-US-GovEdict}}). So the entire format layer of this file is affirmatively
+    clean regardless of what Kansas thinks about its artwork. Only the artwork is exposed.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to whatever graphic the current Kansas
+    base carries — which this pass could not identify, since the Department of Revenue
+    site timed out. Render `emblem: {present: true, rendered: placeholder}`. Kansas
+    state-seal misuse statutes are a protection regime independent of copyright and are
+    unresearched.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): read to establish that Kansas has NO section in the survey — a negative result, recorded as such"
+    - "https://www.ksrevisor.gov/statutes/chapters/ch08/008_001_0047.html  # K.S.A. 8-147, the statutory design spec itself — an edict of government, PD"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA has no enforcement power; its declarative present is RECOMMENDED PRACTICE."
+  dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is PAYWALLED and UNPINNED. No J686 dimension is quoted anywhere in this file."
+  geometry_available: "AAMVA §2.1 (jurisdiction name top-centre between the bolt holes, >=0.25 in above the number, >=0.125 in from the top edge, characters 0.75-1.0 in) and §2.2 (characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom)."
+  retroreflectivity: "AAMVA §3.3: legible day and night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3; entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2."
+  replacement_cycle_recommendation: >-
+    AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. KANSAS LEGISLATED FIVE —
+    TIGHTER THAN AAMVA'S FLOOR — and then legislated a way to stretch it. See
+    `replacement_cycle` on us-ks-standard: this is the most interesting replacement regime
+    in group midwest-b precisely because the legislature anticipated that plates might
+    outlast their nominal life and gave the director a rules-based extension rather than
+    forcing a statutory amendment.
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' is UNCITED in its Wikipedia source (a `citation needed` since 2017, copied across articles). Recorded as COMMONLY REPEATED, UNSOURCED. Chapter 8 states no plate dimension, so this file makes no Kansas dimension claim (recorded gap)."
+
+# ---------------------------------------------------------------------------
+# Display rules. Kansas is a ONE-PLATE, REAR-ONLY state — with five statutory
+# exceptions, three of which move the plate to the FRONT.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "ONE plate, REAR. K.S.A. 8-132(a): the division 'shall furnish to every owner whose vehicle shall be registered one license plate'. K.S.A. 8-133(a): it 'shall be attached to the rear of the vehicle', and 'Except as otherwise provided in subsection (b), a Kansas registered vehicle shall not have a license plate attached to the front of the vehicle' — an express PROHIBITION on front display, not merely an absence of a requirement."
+  exceptions:
+    - "TRUCK TRACTOR: the plate 'shall be attached to the front of the truck tractor' (§ 8-133(b)(1)) — front-only, the inverse of the state default, and the same outlier shape Florida and North Dakota carry"
+    - "ANTIQUE VEHICLE displaying a model-year plate under K.S.A. 8-172 MAY be attached to the front (§ 8-133(b)(2))"
+    - "PERSONALIZED plate issued to a passenger vehicle or truck under § 8-132(c) MAY be attached to the front (§ 8-133(b)(3)) — so a Kansas vanity plate may lawfully appear where a standard plate may not"
+    - "CONCRETE MIXER TRUCK: may be attached to either the front or the rear (§ 8-133(b)(4))"
+    - "DUMP TRUCK of gross weight 26,000 lb or more: 'shall be attached to the front of the vehicle', but NOT if the vehicle is registered as a farm truck (§ 8-133(b)(5))"
+  mounting: "§ 8-133(c): securely fastened to prevent swinging, not less than 12 inches from the ground measured from the bottom of the plate, in a place and position clearly visible, free from foreign materials and legible"
+  enforcement_note: "§ 8-133(e) required a warning citation rather than a penalty for the dump-truck rule, and by its own terms 'shall expire and have no effect on and after January 1, 2022' — a self-repealing grace period, now spent"
+  suspension_contingency: "§ 8-133(d): if plate CONSTRUCTION is suspended under § 8-132, whatever 'plate, tag, token, marker or sign' is assigned is displayed as the director of vehicles prescribes — a wartime-style contingency still sitting in the code"
+  sources:
+    - "https://www.ksrevisor.gov/statutes/chapters/ch08/008_001_0033.html  # K.S.A. 8-133: rear attachment and the express front-display prohibition; the truck-tractor, antique, personalized, concrete-mixer and dump-truck exceptions; the 12-inch mounting rule; the expired warning-citation subsection; the construction-suspension contingency"
+    - "https://www.ksrevisor.gov/statutes/chapters/ch08/008_001_0032.html  # K.S.A. 8-132(a): one plate per registered vehicle"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES — statutory arrangement, statutory reissue cycle,
+  # statutory colour change. Kansas legislates more of its plate than any other
+  # state in this group.
+  # =========================================================================
+  - id: us-ks-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          K.S.A. 8-147(c), verbatim: 'Each license plate shall contain a combination of
+          three letters followed by a combination of three numerals, except that once all
+          allowable combinations of letters and numerals have been used, each license
+          plate shall contain an arrangement of numerals or letters, or both, as shall be
+          assigned by the secretary of revenue. The arrangement of numerals and letters of
+          license plates shall be uniform throughout each classification of registration.
+          The secretary may provide for the arrangement of the numerals and letters in
+          groups or otherwise and for other distinguishing marks on such license plates.'
+          NO LETTER EXCLUSIONS are stated anywhere in Chapter 8 — whether Kansas skips
+          I/O/Q was NOT established (recorded gap).
+      pattern_note: >-
+        `regex` encodes the arrangement the STATUTE fixes. `regex_statutory` encodes the
+        statute's own EXHAUSTION CLAUSE — 'an arrangement of numerals or letters, or both,
+        as shall be assigned by the secretary' — which is the outer legal bound once the
+        three-and-three space is used up, and the honest bound for a Kansas plate of
+        unknown vintage. This is the cleanest example in group midwest-b of the tier order
+        doing real work: the two tiers are not researcher caution, they are two sentences
+        of one statute.
+      grouping: "§ 8-147(c) lets the secretary arrange the characters 'in groups or otherwise', which is why the separator is optional in the regex rather than mandatory"
+    design:
+      material_and_finish: "§ 8-147(d): 'As new license plates are issued, the face of every license plate shall be completely coated with a reflective material. The reflectorized material shall be of such nature as to provide effective and dependable performance in the promotion of highway safety and vehicle identification throughout the service period for which the license plates are issued.' A $0.50 charge is added to the cost of each reflectorized plate."
+      contrast_rule: "§ 8-147(c): 'The letters and numerals of such license plates shall be in such contrast of colors to the background of the license plate as to make such letters and numerals easily readable.'"
+      colour_change_rule: >-
+        THE COLOUR IS REQUIRED TO CHANGE, WHICH IS A FACT ABOUT THE SERIES BOUNDARY ITSELF.
+        § 8-147(d): 'The director shall change the color of such license plates every time
+        new license plates are issued under K.S.A. 8-132(b).' Kansas has therefore
+        legislated that every reissue is visually distinguishable from its predecessor —
+        which means Kansas base generations are, in principle, separable by colour alone,
+        and that a complete Kansas history is a colour sequence. Iowa legislates the same
+        idea in different words (Iowa Code § 321.166(5)).
+      colour_note: >-
+        NO HEX IS RECORDED. Kansas mandates CONTRAST and mandates CHANGE but names no
+        colour value, and the Kansas Department of Revenue site was unreachable in this
+        pass, so no departmental colour specification was obtained. Recording an observed
+        hex from a photograph would attach a value to the wrong authority. Recorded gap.
+      decals: "§ 8-147(c): the secretary designs decals affixed to the plate to identify registration expiration information consistent with K.S.A. 8-134"
+      plate_content: "§ 8-132(a): the plate displays 'the registration number assigned to the vehicle and to the owner thereof, the name of the state, which may be abbreviated, and the year or years for which it is issued'"
+      emblem: { present: true, rendered: placeholder }
+      manufacture: "§ 8-147(b): plates are manufactured under contract with an organization or institution designated in K.S.A. 39-1208 — the Kansas correctional-industries route, the same arrangement South Dakota states more bluntly as its penitentiary plate plant"
+      distribution: "§ 8-147(e): plates ship directly to the treasurer of the county where they are to be used or, 'for digitally fulfilled license plate orders, directly to the customer for whom the plate is issued' — the digital-fulfilment clause is recent and is what the 2025 amendment added"
+    replacement_cycle:
+      years: 5
+      statutory_text: >-
+        § 8-132(b): 'During calendar year 1975 commencing on the effective date of this
+        act, and during every fifth calendar year thereafter, the division of vehicles
+        shall furnish one license plate for any type of vehicle an owner registers or has
+        the registration thereof renewed', with decals furnished in the four intervening
+        years.
+      extension_mechanism: >-
+        THE PART THAT MAKES KANSAS DIFFERENT. § 8-132(b) continues: 'Notwithstanding the
+        foregoing provisions of this subsection, whenever, in the discretion of the
+        director of vehicles, it is determined that the license plates currently being
+        issued and displayed are not deteriorating to the extent that their replacement is
+        warranted, the director may adopt rules and regulations to extend the five-year
+        issuance cycle provided for in this subsection by one year at a time, and in the
+        same manner the director may further extend such cycle by one year at a time,
+        successively as the director determines appropriate.' On expiry of an extended
+        term an owner may keep displaying the current plate 'for a period not to exceed
+        three registration years'. So the NOMINAL cycle is five years and the EFFECTIVE
+        cycle is unbounded — which is precisely why `period.start` on this series is an
+        upper bound and not a computed date. A dataset that inferred Kansas base
+        boundaries by counting five-year steps from 1975 would be wrong, and would look
+        confident while being wrong.
+      note: "AAMVA §1.1 recommends not exceeding 7 to 10 years; Kansas's nominal five is tighter, but the extension mechanism can carry it past AAMVA's ceiling without any change in the law"
+    region_encoding:
+      mechanism: "COUNTY DESIGNATION LETTERS — existence sourced, form NOT sourced"
+      status: unresolved
+      evidence: >-
+        K.S.A. 8-132(d) establishes that Kansas plates carry a county designator, and does
+        so obliquely, while regulating something else. Describing personalized plates, it
+        permits the applicant to choose characters 'in lieu of the letters and numbers
+        required by K.S.A. 8-147, and amendments thereto, OTHER THAN THE LETTERS REQUIRED
+        TO DESIGNATE THE COUNTY IN WHICH SUCH VEHICLE IS REGISTERED.' Two facts follow and
+        no more: (1) Kansas plates carry LETTERS designating the county of registration;
+        (2) those letters are so fundamental that even a vanity plate cannot replace them.
+      not_established: >-
+        WHAT THIS PASS COULD NOT DETERMINE: whether the county letters sit inside the
+        six-character serial or in a separate field such as a printed county name; how
+        many letters they are; the county-to-letters mapping; and whether all 105 Kansas
+        counties are designated or only some. K.S.A. 8-147 defines the serial as three
+        letters and three numerals and says nothing about county letters, which suggests
+        but does not establish that the designator is a SEPARATE plate element rather than
+        part of the serial. The Kansas Department of Revenue site, which would settle it,
+        timed out on every attempt. NOTHING IS ASSERTED — this is exactly the decode data
+        the parse API would lie with if it were guessed.
+      decode_file_planned: "plates/_decode/us-ks-county-designations.yml once the mechanism and the mapping are sourced"
+    sources:
+      - "https://www.ksrevisor.gov/statutes/chapters/ch08/008_001_0047.html  # K.S.A. 8-147(c): the three-letters-then-three-numerals arrangement, the exhaustion clause, uniformity per classification, the grouping discretion, the contrast rule and the expiration decals; (d) the full reflective coating, its $0.50 charge and the mandatory colour change on each reissue; (b) manufacture under a K.S.A. 39-1208 contract; (e) shipping to the county treasurer or, for digitally fulfilled orders, to the customer. History: L. 2025, ch. 75, § 6"
+      - "https://www.ksrevisor.gov/statutes/chapters/ch08/008_001_0032.html  # K.S.A. 8-132(a): one plate bearing the registration number, state name and year; (b) the five-year reissue cycle from 1975, the intervening decals, and the director's rules-based one-year-at-a-time extension with its three-registration-year grace; (d) 'the letters required to designate the county in which such vehicle is registered'"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1, the 7-10 year recommendation Kansas's nominal five sits inside and its extension mechanism can exceed"
+    notes: >-
+      KANSAS STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED, on the same reasoning as
+      us-fl-standard: Kansas reissues on a five-year cycle that the director may extend
+      indefinitely by rule, so base-design generations exist but no primary establishing
+      their boundaries was obtained, and the Department of Revenue site was unreachable.
+      Minting a dated id on an inferred five-year step would be inventing a boundary the
+      statute expressly allows the director to move. When a primary lands, a dated id is
+      added and this id becomes its former-id alias under the PRD-QUALITY I-5/I-6 contract.
+      PERIOD CAVEAT: `start: 2025` is the statute edition read — K.S.A. 8-147 was amended
+      in the 2025 session — and is an UPPER BOUND on the true start of the current base,
+      not a claim about it. THE ONE SERIES BACK IS A RECORDED GAP for the same reason.
+
+  # =========================================================================
+  # PERSONALIZED — statutory caps, and the one Kansas plate that may lawfully be
+  # displayed on the front of a car.
+  # =========================================================================
+  - id: us-ks-personalized
+    class: personalized
+    categories: [car, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: >-
+          K.S.A. 8-132(d), verbatim: 'The division shall design distinctive, personalized
+          license plates to be issued that shall contain not more than seven letters or
+          numbers on truck or passenger vehicle license plates and not more than five
+          letters or numbers on motorcycle license plates, or a combination thereof, to be
+          designated by the applicant in lieu of the letters and numbers required by
+          K.S.A. 8-147 ... other than the letters required to designate the county in which
+          such vehicle is registered.' Note the personalized cap of SEVEN exceeds the
+          standard series' SIX — a Kansas vanity plate can be longer than a Kansas
+          standard plate.
+      pattern_note: "`regex` is the letters-only shape most vanity configurations take; `regex_statutory` is the true statutory frame of up to seven alphanumerics. The five-character motorcycle cap is a narrower bound not separately encoded."
+      availability_rule: "§ 8-132(d): the requested characters are issued 'Unless the letters or numbers designated by the applicant have been assigned to another vehicle' or are otherwise unavailable"
+    design:
+      note: "§ 8-132(c): 'Any license plate issued pursuant to subsection (a) or (b) may be a personalized license plate' and 'The division shall allow an applicant for a personalized license plate to personalize a license plate design established by subsection (a), (b) or (d)' — so personalization is a serial-source difference over an existing design, not a design of its own"
+      emblem: { present: true, rendered: placeholder }
+    eligibility: "any owner or lessee of a passenger vehicle, or of a truck licensed for a gross weight of not more than 20,000 pounds, applying at renewal of registration; also available for motorcycles (§ 8-132(d))"
+    fee: "$40.00 in addition to the ordinary registration fee, paid ONCE during the registration period for which the plates were issued; subsequent renewals within that period pay only the K.S.A. 8-143 registration fee (§ 8-132(d))"
+    display_privilege: "a personalized plate issued under § 8-132(c) MAY be attached to the front of the passenger vehicle or truck (§ 8-133(b)(3)) — an exception to Kansas's express prohibition on front plates"
+    region_encoding: "the county-designating letters are expressly PRESERVED on a personalized plate (§ 8-132(d)); see region_encoding on us-ks-standard for why their form is unresolved"
+    sources:
+      - "https://www.ksrevisor.gov/statutes/chapters/ch08/008_001_0032.html  # K.S.A. 8-132(c): personalization of any subsection (a), (b) or (d) design; (d) the seven-character passenger/truck cap, the five-character motorcycle cap, the 20,000 lb truck eligibility limit, the $40 once-per-period fee, the availability rule, and the preservation of the county-designating letters"
+      - "https://www.ksrevisor.gov/statutes/chapters/ch08/008_001_0033.html  # K.S.A. 8-133(b)(3): a personalized plate may be attached to the front of a passenger vehicle or truck"
+    notes: >-
+      PERSONALIZED PLATES. Modelled as its own series because the SERIAL SOURCE differs —
+      owner-chosen rather than division-assigned. Two Kansas oddities are worth carrying
+      forward. First, the personalized cap (seven) is LONGER than the standard arrangement
+      (six), so a length test alone cannot reject a Kansas plate. Second, a personalized
+      plate is one of only five things Kansas permits on the front of a vehicle, in a state
+      that otherwise forbids front plates outright — so front-plate presence is not
+      evidence of an out-of-state vehicle in Kansas.
+
+  # =========================================================================
+  # ANTIQUE — model-year plates, and the only other Kansas front-display licence.
+  # =========================================================================
+  - id: us-ks-antique
+    class: historic
+    categories: [car, truck]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY. A Kansas antique vehicle may display a MODEL-YEAR
+        plate under K.S.A. 8-172 — i.e. an actual plate from the vehicle's model year —
+        so this series has no grammar of its own at all: its serial space is the union of
+        every historical Kansas series. `matching: recall-only` is mandatory and a hit is
+        a shape hit only. K.S.A. 8-172 itself was not read in this pass (recorded gap);
+        the model-year regime is sourced only through the § 8-133(b)(2) cross-reference.
+    design:
+      note: "a model-year plate is an original historical plate, not a modern issue; no current design property applies"
+      emblem: { present: true, rendered: placeholder }
+    display_privilege: "§ 8-133(b)(2): 'a model year license plate issued for an antique vehicle, in accordance with K.S.A. 8-172 ... may be attached to the front of the antique vehicle'"
+    region_encoding: "unknown — a model-year plate carries whatever county designation its own era used"
+    sources:
+      - "https://www.ksrevisor.gov/statutes/chapters/ch08/008_001_0033.html  # K.S.A. 8-133(b)(2): the model-year antique plate and its front-display permission, cross-referencing K.S.A. 8-172"
+    notes: >-
+      ANTIQUE / MODEL-YEAR PLATES. Included because of what it does to the parse layer
+      rather than for its own sake: like North Dakota's year-of-manufacture option, a
+      Kansas model-year plate means a LAWFULLY DISPLAYED, CURRENTLY REGISTERED vehicle may
+      be wearing a plate from any past decade. Any inference from plate design to
+      registration era must therefore carry an antique-regime exception, and this series
+      exists partly to make that exception visible in the data. K.S.A. 8-172's own
+      eligibility threshold and fee were not obtained (recorded gap).
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-ks-specialty-index
+    class: specialty
+    categories: [car, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "K.S.A. 8-147(c) requires the arrangement to be 'uniform throughout each classification of registration', so a specialty classification has ITS OWN uniform arrangement, which need not be the passenger three-and-three; the arrangement per specialty class was not obtained (recorded gap)" }
+    design:
+      note: "one design per authorised program; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: null
+      count_status: >-
+        NOT ESTABLISHED — AND THE HONEST RECORD IS THAT NO NUMBER WAS OBTAINED, not a
+        number carried over from a secondary source. The Kansas Department of Revenue's
+        vehicle pages (ksrevenue.gov) TIMED OUT on every request in this pass, via two
+        clients and both HTTP versions, so neither an official count nor an official
+        catalogue was reached. Kansas's specialty plates are created individually by
+        statute across K.S.A. Chapter 8 Article 1, so a statutory count is obtainable in
+        principle by enumerating those sections the way this file's North Dakota
+        counterpart does — that enumeration was not completed here and is the top Kansas
+        follow-up.
+      structural_note: "K.S.A. 8-147(c) opens 'Except as authorized by other provisions of law', which is the hook every individually legislated Kansas specialty plate hangs from — the general format rule yields to each specialty statute"
+      official_list_url: "https://www.ksrevenue.gov/dovindex.html"
+      official_list_status: "UNREACHABLE in this pass (connection timeout); recorded so a later run does not mistake it for unfetched-but-fine"
+    region_encoding: "county-designating letters presumably preserved as on the standard series; not separately established"
+    sources:
+      - "https://www.ksrevisor.gov/statutes/chapters/ch08/008_001_0047.html  # K.S.A. 8-147(c): 'Except as authorized by other provisions of law' — the clause under which individually legislated Kansas specialty plates displace the general arrangement, and the per-classification uniformity rule"
+      - "https://www.ksrevisor.gov/statutes/chapters/ch08/008_001_0032.html  # K.S.A. 8-132(c): specialty and standard designs alike may be personalized, which is what makes the specialty serial space share the personalized caps"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — present as required by PRD-PLATES §2.5, but CARRYING NO
+      COUNT, which is the honest outcome for Kansas in this pass. Every other state in
+      group midwest-b yielded either an agency figure or a statutory enumeration; Kansas
+      yielded neither, because its revenue department's site was unreachable and the
+      statutory enumeration was not completed. Recording `count_official: null` with an
+      explicit `count_status` is better than importing Wikipedia's figure and better than
+      silence: a verifier can see precisely what is missing and precisely why. The
+      structural fact that IS sourced — that Kansas specialty plates are individually
+      legislated and displace the general format rule via 8-147(c)'s opening words — is
+      the more useful half for the parse layer anyway.

--- a/plates/us-mn.yml
+++ b/plates/us-mn.yml
@@ -1,0 +1,411 @@
+# plates/us-mn.yml — Minnesota (PRD-PLATES gate L2, group midwest-b).
+#
+# MINNESOTA'S STATUTE IS THE MOST PHYSICALLY SPECIFIC IN THIS GROUP AND THE LEAST
+# FORMAT-SPECIFIC. Minn. Stat. § 168.12 subd. 1 will tell you that a plate must be
+# "at least 100 times brighter than the conventional painted number plates" and
+# must be "visible for a distance of not less than 1,500 feet and readable for a
+# distance of not less than 110 feet" from a vehicle with standard headlights —
+# a testable photometric specification of a kind no other state in group
+# midwest-b legislates. It will not tell you how many characters are on the
+# plate or in what order. That asymmetry drives this whole file.
+#
+# THREE MINNESOTA FACTS WORTH THE READER'S ATTENTION:
+#
+#  1. THE PLATE ENCODES WEIGHT, NOT GEOGRAPHY. § 168.12 subd. 1(b): "When a
+#     vehicle is registered on the basis of total gross weight, the plates issued
+#     must clearly indicate by letters or other suitable insignia the maximum
+#     gross weight for which the tax has been paid." Minnesota is the only state
+#     in this group with a statutory weight-class encoding on the plate itself.
+#
+#  2. THE PLATE CAN SAY "NONCOMMERCIAL". § 168.12 subd. 1(c) requires that legend
+#     on noncommercial-vehicle plates unless a special plate is displayed — a
+#     mandated negative legend, which is an unusual instrument.
+#
+#  3. MINNESOTA REGISTERS ROADABLE AIRCRAFT WITH THEIR FAA TAIL NUMBERS.
+#     § 168.12 subd. 1(i), in terms. That is a direct, statutory bridge between
+#     this dataset's road layer and the aircraft layer PRD-PLATES §7 puts at gate
+#     L6, and it is specified below as its own series because it genuinely is one.
+#
+# WHAT THIS FILE COULD NOT GET: Minnesota's serial ARRANGEMENT and its current
+# base design. § 168.12 delegates both to the commissioner's rules, and the
+# Minnesota DVS website sits behind a bot-protection layer that refused every
+# request in this pass. The standard series is therefore `recall-only` and its
+# arrangement is a recorded gap, not a guess.
+jurisdiction: us-mn
+authority:
+  name: Minnesota Department of Public Safety, Driver and Vehicle Services (DVS)
+  url: "https://www.revisor.mn.gov/statutes/cite/168.12"
+binding: vehicle
+statute_edition: "Minnesota Statutes Chapter 168 (Vehicle Registration, Taxation, Sale), §§ 168.10 and 168.12 as published by the Office of the Revisor of Statutes at revisor.mn.gov. § 168.12 was last amended by 2024 c 104 art 1 s 17, so the design provisions read here are current to the 2024 session."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4. Minnesota is one of
+# only two states in group midwest-b for which ANY evidence exists — and the
+# evidence is that the question is genuinely open.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: contested-unresolved
+  basis: >-
+    MINNESOTA IS THE ONE STATE IN THIS GROUP WHERE THE COPYRIGHT QUESTION HAS BEEN
+    LITIGATED IN OPINIONS AND STILL HAS NO ANSWER. Two official Minnesota legal opinions
+    conflict and no court has resolved them. A state commissioner's statement of December
+    1994 reads, in part, that 'unless specified by the legislature, the public's right of
+    access to and use of public government data cannot be curtailed by a government
+    entity's claim of intellectual property rights in those data' — language a reader
+    might take for a public-domain rule. An Attorney General statement of December 1995
+    expressly contradicts that reading, claims higher authority, and confines the earlier
+    statement to ACCESS rather than COPYRIGHT, offering the narrower phrasing that 'The
+    department may not assert copyright ownership to deny members of the public their
+    right "to inspect and copy public government data at reasonable times and places"
+    under Minn. Stat. § 13.03, subd. 3'.
+    THE STATUTE ITSELF POINTS THE OTHER WAY, and narrowly. Minn. Stat. § 13.03 subd. 5,
+    FETCHED AND READ FOR THIS FILE, provides verbatim: 'A government entity may enforce a
+    copyright or acquire a patent for a COMPUTER SOFTWARE PROGRAM or components of a
+    program created by that government entity without statutory authority. In the event
+    that a government entity acquires a patent to a computer software program or component
+    of a program, the data shall be treated as trade secret information pursuant to section
+    13.37.' Expressly authorising copyright for software and for nothing else is weak
+    evidence that other works are free and weak evidence that they are protected — it is
+    simply a provision about software.
+    (Textual note, since this file quotes a primary against a secondary: the survey renders
+    the opening words as 'may enforce copyright'; the statute as served by the Revisor reads
+    'may enforce A copyright'. Immaterial to the meaning, recorded because the primary was
+    read rather than trusted.)
+    CONCLUSION: contested and unresolved. Treat Minnesota plate ARTWORK as protected by
+    default, per the dossier's rule that state works are presumed copyrighted absent a
+    contrary declaration, and note that Minnesota has arguably made a contrary declaration
+    that its own Attorney General has disclaimed. Do not record Minnesota as public domain
+    on the strength of the 1994 statement.
+  edict_carve_out: >-
+    Every claim in this file cites the Minnesota Statutes. Edicts of government are
+    uncopyrightable at every level ({{PD-US-GovEdict}}), and this carve-out is doing more
+    work in Minnesota than elsewhere precisely BECAUSE the general posture is contested:
+    the photometric specification, the weight-encoding rule, the 'noncommercial' legend,
+    the seven-year plate period and the roadable-aircraft rule are all free to use
+    whatever the answer on artwork turns out to be.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to whatever graphic the current Minnesota
+    base carries — which this pass could not identify, since the DVS site refused every
+    request. Render `emblem: {present: true, rendered: placeholder}`. Minnesota state-seal
+    misuse statutes are a protection regime independent of copyright and are unresearched.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): the Minnesota section, which sets out the conflicting 1994 commissioner and 1995 Attorney General statements and quotes Minn. Stat. § 13.03 subd. 5. The conflict is recorded here, not resolved (PRD-PLATES §5.3)"
+    - "https://www.revisor.mn.gov/statutes/cite/13.03  # Minn. Stat. § 13.03 subd. 5, FETCHED AND READ: the software-only copyright authorization and its trade-secret consequence — an edict, PD, and the primary the secondary account turns on"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA has no enforcement power; its declarative present is RECOMMENDED PRACTICE."
+  dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is PAYWALLED and UNPINNED. No J686 dimension is quoted anywhere in this file."
+  geometry_available: "AAMVA §2.1 (jurisdiction name top-centre between the bolt holes, >=0.25 in above the number, >=0.125 in from the top edge, characters 0.75-1.0 in) and §2.2 (characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom)."
+  retroreflectivity: >-
+    AAMVA §3.3 asks for legibility 'in both daylight and nighttime from distances of at
+    least 75 feet', with ASTM D4956-19 and ISO 7591:1982 clause 3 as the materials
+    standards and a minimum 45 cd/lx/m^2 at 0.2 deg entrance / -4 deg observation.
+    MINNESOTA'S OWN STATUTORY SPECIFICATION IS FAR MORE DEMANDING and is expressed
+    differently — see `design.photometric_spec` on us-mn-standard: 100x brighter than
+    conventional painted plates, visible at 1,500 feet, readable at 110 feet. Minnesota's
+    110-foot READABILITY floor is not directly comparable to AAMVA's 75-foot legibility
+    figure, but it is plainly stricter, and it is in statute rather than in a recommendation.
+  replacement_cycle_recommendation: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. MINNESOTA LEGISLATED SEVEN — the bottom of AAMVA's range and a genuine mandatory replacement, not a floor. See `replacement_cycle` on us-mn-standard."
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The '1956 AMA standardization agreement' is UNCITED in its Wikipedia source (a
+    `citation needed` since 2017, copied across articles). Recorded as COMMONLY REPEATED,
+    UNSOURCED. A second piece of Minnesota-specific folklore is flagged here for the same
+    treatment: the widely repeated claim that Minnesota's base design dates from 1978 and
+    is among the oldest in continuous US use appears in the dossier only as a WIKIPEDIA
+    assertion, and § 168.12's seven-year mandatory REPLACEMENT cycle concerns the physical
+    plate rather than the design. Neither the 1978 date nor its continuity is asserted
+    anywhere in this file; both are recorded as unsourced.
+
+# ---------------------------------------------------------------------------
+# Display rules. NOT ESTABLISHED — recorded as a gap rather than assumed.
+# ---------------------------------------------------------------------------
+display_rules:
+  status: not-established
+  note: >-
+    MINNESOTA'S PLATE-DISPLAY RULES LIVE IN Minn. Stat. § 169.79, WHICH WAS NOT READ IN
+    THIS PASS. § 168.12 subd. 1(f)(4) cross-references it, so its existence and relevance
+    are sourced, but its contents are not. Whether Minnesota requires one plate or two,
+    and where, is therefore NOT recorded here. This is a deliberate omission: the
+    front-plate question is exactly the kind of per-state statutory fact the dossier warns
+    against importing from an aggregate table (§1.2 — 'The dataset should model
+    front-plate requirement as a per-jurisdiction field with a statute citation, not import
+    a list'), and no Minnesota statute stating it was fetched.
+  follow_up: "read Minn. Stat. § 169.79 and record display, mounting and orientation from it"
+  sources:
+    - "https://www.revisor.mn.gov/statutes/cite/168.12  # Minn. Stat. § 168.12 subd. 1(f)(4) cross-references § 169.79 for veterans' plates issued for life — the pointer establishing where Minnesota's display rules live"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES — photometrically specified, format-delegated.
+  # =========================================================================
+  - id: us-mn-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2024 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999LLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          § 168.12 subd. 1(a) is the whole statutory constraint on the serial, and it is
+          almost content-free: the commissioner issues plates 'bearing the state name and
+          an assigned vehicle registration number', and 'The number assigned by the
+          commissioner may be a combination of a letter or sign with figures.' The
+          arrangement is then delegated outright — the plates 'must be lettered, spaced, or
+          distinguished to suitably indicate the registration of the vehicle ACCORDING TO
+          THE RULES OF THE COMMISSIONER.' NO WIDTH, NO ARRANGEMENT and NO LETTER EXCLUSIONS
+          appear in the statute. Note the striking phrase 'a letter or SIGN with figures':
+          Minnesota law contemplates a non-alphanumeric SIGN in a registration number,
+          which if ever exercised would be a `never_separator` amendment under
+          PRD-PLATES §2.6 rule 3. No such sign is known to be in use.
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY, on the nl-export precedent, AND AN HONEST ADMISSION.
+        Neither Minnesota's serial width nor its arrangement was sourced in this pass: the
+        statute delegates both to the commissioner's rules, the relevant rules were not
+        located (Minnesota Rules chapter 7410 was fetched and is DRIVER LICENSING, not
+        plates), and the DVS website refused every request behind a bot-protection layer.
+        The regex is therefore the widest defensible alphanumeric frame and
+        `matching: recall-only` states plainly that a hit is a shape hit and nothing more.
+        Pinning the Minnesota arrangement is the single highest-value follow-up in this
+        group, because Minnesota is its largest state by vehicle count.
+    design:
+      contrast_rule: "§ 168.12 subd. 1(a): 'The color of the plates and the color of the abbreviation of the state name and the number assigned must be in marked contrast.'"
+      photometric_spec: >-
+        THE MOST DEMANDING PLATE SPECIFICATION IN GROUP MIDWEST-B, and it is legislated
+        rather than recommended. § 168.12 subd. 1(e), verbatim: 'The plates must be so
+        treated as to be at least 100 times brighter than the conventional painted number
+        plates. When properly mounted on an unlighted vehicle, the plates, when viewed from
+        a vehicle equipped with standard headlights, must be visible for a distance of not
+        less than 1,500 feet and readable for a distance of not less than 110 feet.' Three
+        testable quantities — a brightness RATIO against a named baseline, a visibility
+        distance and a readability distance — where most states legislate the word
+        'reflectorized' and stop.
+      weight_encoding: >-
+        § 168.12 subd. 1(b), verbatim: 'When a vehicle is registered on the basis of total
+        gross weight, the plates issued must clearly indicate by letters or other suitable
+        insignia the maximum gross weight for which the tax has been paid.' This is a
+        WEIGHT-CLASS ENCODING ON THE PLATE, mandated by statute — the Minnesota analogue of
+        a region code, and the reason `region_encoding` below is not simply 'none'. The
+        letters or insignia used, and their mapping to weight bands, are set by the
+        commissioner and were NOT obtained (recorded gap).
+      noncommercial_legend: >-
+        § 168.12 subd. 1(c), verbatim: 'Plates issued to a noncommercial vehicle must bear
+        the inscription "noncommercial" unless the vehicle is displaying a special plate
+        authorized and issued under this chapter.' A mandated NEGATIVE legend — the plate
+        declares what the vehicle is not — and one that a special plate switches off, so
+        the legend's absence proves nothing about the vehicle.
+      one_ton_pickup_rule: "§ 168.12 subd. 1(d): a one-ton pickup truck used for commercial purposes and subject to § 168.185 is nonetheless eligible to display special plates authorized under the chapter"
+      colour_note: >-
+        NO HEX IS RECORDED. § 168.12 mandates 'marked contrast' and a brightness ratio but
+        names no colour, and no Minnesota departmental colour specification or DVS page was
+        reachable. Recorded gap rather than an eyedropped value.
+      emblem: { present: true, rendered: placeholder }
+    replacement_cycle:
+      years: 7
+      statutory_text: >-
+        § 168.12 subd. 1(f)(2): 'Plates issued for passenger automobiles must be issued for
+        a seven-year period. All plates issued under this paragraph must be replaced if they
+        are seven years old or older at the time of registration renewal or will become so
+        during the registration period.'
+      note: >-
+        A GENUINE MANDATORY REPLACEMENT, at the bottom of AAMVA §1.1's recommended 7-to-10
+        year band — and note the forward-looking trigger, which is a nice piece of drafting:
+        a plate must be replaced not only if it IS seven years old at renewal but if it WILL
+        BECOME so during the coming registration period, so no plate is ever lawfully driven
+        past seven years. Contrast Missouri, whose statute sets a six-year FLOOR and no
+        ceiling, and North Dakota, which legislates no cycle at all.
+      other_classes: "§ 168.12 subd. 1(f)(5): plates for vehicles not otherwise specified 'must be issued for the life of the vehicle' — so the seven-year rule is a PASSENGER-CAR rule, and a Minnesota trailer or truck plate may be arbitrarily old and still current"
+      exempt_agency_plates: "§ 168.12 subd. 1(f)(1): plates issued under § 168.012 subd. 1 to an exempt agency last as long as the agency owns the vehicle, are not transferable between vehicles, but MAY transfer with the vehicle from one tax-exempt agency to another"
+      veterans_plates: "§ 168.12 subd. 1(f)(4): plates under subds. 2c and 2d and §§ 168.123, 168.1235 and 168.1255 are issued for the LIFE OF THE VETERAN under § 169.79"
+      stickers: "§ 168.12 subd. 1(g): in a year in which plates are not issued the commissioner issues a registration sticker showing the year or years for which it is issued; plates and stickers may not be transferred to another vehicle during that period, except for vehicles registered under § 168.187"
+    driver_education_transfer: "§ 168.12 subd. 1(h): plates on a vehicle used for behind-the-wheel instruction in a public-school driver education course may be transferred to another vehicle used for the same purpose without any additional fee, on notice to the commissioner"
+    region_encoding:
+      geographic: none
+      weight_class: >-
+        PRESENT AND STATUTORY, though not geographic: § 168.12 subd. 1(b) requires
+        gross-weight-registered vehicles to carry letters or insignia indicating the maximum
+        gross weight for which tax has been paid. A Minnesota plate on a weight-registered
+        vehicle therefore decodes to a WEIGHT BAND, which is a real decode target for the
+        parse API and is the Minnesota entry in this dataset's region_encoding slot.
+      decode_status: "the letter-or-insignia to weight-band mapping is set by the commissioner and was NOT obtained (recorded gap); a decode file is warranted once it is"
+      decode_file_planned: "plates/_decode/us-mn-gross-weight-letters.yml"
+    sources:
+      - "https://www.revisor.mn.gov/statutes/cite/168.12  # Minn. Stat. § 168.12 subd. 1(a): state name and assigned number, 'a combination of a letter or sign with figures', marked contrast, and delegation of lettering and spacing to the commissioner's rules; (b) the gross-weight letters or insignia; (c) the mandatory 'noncommercial' inscription and its special-plate exception; (d) the one-ton pickup rule; (e) the 100x brightness ratio, 1,500-foot visibility and 110-foot readability; (f)(1)-(5) the issuance periods including the seven-year passenger replacement and the life-of-vehicle default; (g) stickers in non-issue years; (h) the driver-education transfer. History: 2024 c 104 art 1 s 17"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1's 7-10 year recommendation, whose floor Minnesota legislated, and §3.3's 75-foot legibility figure against which Minnesota's statutory photometrics are markedly stricter"
+    notes: >-
+      MINNESOTA STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED and the series is
+      deliberately `recall-only`, and the two go together: Minnesota legislates how BRIGHT
+      a plate must be and how LONG it may live, but delegates what is printed on it, so
+      this dataset can state Minnesota's physics precisely and its grammar not at all.
+      Recording that split honestly is more useful than a plausible-looking regex would be.
+      PERIOD CAVEAT: `start: 2024` is the last amendment year of § 168.12 and is an UPPER
+      BOUND on the true start of the current base, not a claim about it. THE ONE SERIES
+      BACK IS A RECORDED GAP: no primary establishing any Minnesota base-design boundary was
+      obtained, the DVS site was unreachable, and the commonly repeated 1978 date is
+      Wikipedia-grade and is not asserted here (see us_standards.folklore_caution).
+
+  # =========================================================================
+  # ROADABLE AIRCRAFT — the statutory bridge to the aircraft layer. This is a
+  # real series with a real, fully-specified format that Minnesota did not write.
+  # =========================================================================
+  - id: us-mn-roadable-aircraft
+    class: standard
+    categories: [aircraft]
+    period: { start: 2024 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "N99999"
+      regex: '\AN\d{1,5}[A-Z]{0,2}\z'
+      charset:
+        notes: >-
+          MINNESOTA ADOPTS A FEDERAL FORMAT BY REFERENCE. § 168.12 subd. 1(i), verbatim:
+          'In lieu of plates required under this section, the commissioner must issue a
+          registration number identical to the federally issued tail number assigned to a
+          roadable aircraft.' The grammar is therefore 14 CFR 47.15(b)'s, not Minnesota's:
+          'A U.S. registration number may not exceed five symbols in addition to the prefix
+          letter "N". These symbols may be all numbers (N10000), one to four numbers and one
+          suffix letter (N 1000A), or one to three numbers and two suffix letters (N 100AB).
+          The letters "I" and "O" may not be used. The first zero in a number must always be
+          preceded by at least one of the numbers 1 through 9.'
+        excluded: ["I", "O"]
+        excluded_basis: "14 CFR 47.15(b): 'The letters \"I\" and \"O\" may not be used' — a federal exclusion, and the only sourced letter exclusion anywhere in group midwest-b"
+      regex_strict: '\AN(?:[1-9]\d{0,4}|[1-9]\d{0,3}[A-HJ-NP-Z]|[1-9]\d{0,2}[A-HJ-NP-Z]{2})\z'
+      pattern_note: >-
+        `regex` is the shape of an N-number; `regex_strict` is the AUTHORITY'S OWN GRAMMAR
+        and narrows it on two counts the round-trippable form cannot carry — the I/O
+        exclusion, spelled as the ranges A-H, J-N and P-Z, and the leading-zero prohibition,
+        spelled by requiring the first symbol after N to be 1-9. This is a textbook case of
+        why PRD-PLATES §2.7's strict twin exists: the charset restriction is real, sourced
+        and unrepresentable in a regex that must round-trip a human pattern.
+    design:
+      note: "no plate design is prescribed — subd. 1(i) issues a registration NUMBER 'in lieu of plates required under this section', so what is displayed is the aircraft's existing tail number"
+      emblem: { present: false }
+    binding: vehicle
+    region_encoding: "none — an N-number encodes no geography; the FAA assigns it nationally"
+    sources:
+      - "https://www.revisor.mn.gov/statutes/cite/168.12  # Minn. Stat. § 168.12 subd. 1(i): 'the commissioner must issue a registration number identical to the federally issued tail number assigned to a roadable aircraft'"
+      - "https://www.ecfr.gov/current/title-14/section-47.15  # 14 CFR 47.15(b): the N-number grammar Minnesota adopts by reference — five symbols after the N prefix, the three permitted arrangements, the I/O exclusion and the leading-zero rule. A US federal edict, public domain"
+    notes: >-
+      ROADABLE AIRCRAFT. This series is small, strange and genuinely valuable to the
+      dataset, because it is a STATUTORY BRIDGE between the road-vehicle layer this program
+      is building now and the aircraft layer PRD-PLATES §7 schedules for gate L6: Minnesota
+      law says a roadable aircraft's road registration number IS its FAA tail number. Two
+      consequences worth carrying forward. First, `categories: [aircraft]` exercises the
+      schema's kind-extensibility exactly as PRD-PLATES §2.2 anticipated, with no schema
+      change. Second, this is the only series in group midwest-b whose format is fully
+      specified by a fetched primary INCLUDING its charset exclusions, which is why it is
+      the only one here carrying a `regex_strict` — and the specification came from the
+      Code of Federal Regulations rather than from any state. The FAA additionally publishes
+      a free bulk registration database (registry.faa.gov/database/ReleasableAircraft.zip),
+      which would make this the one series in the group testable against a real corpus.
+
+  # =========================================================================
+  # COLLECTOR-VEHICLE FAMILY — four statutory inscriptions, one regime, and a
+  # permanent validity that makes them invisible to any era inference.
+  # =========================================================================
+  - id: us-mn-collector
+    class: historic
+    categories: [car, truck]
+    period: { start: 2024 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY. § 168.10 gives each of these plates 'the registration
+        number OR OTHER COMBINATION OF CHARACTERS authorized under section 168.12,
+        subdivision 2a' — i.e. the serial may be an ordinary assigned number or a
+        personalized combination, so the series' own space is a union and
+        `matching: recall-only` is mandatory. § 168.12 subd. 2a itself was NOT read in this
+        pass (recorded gap), so the personalized frame it authorises is not encoded.
+    design:
+      legend_variants: ["Pioneer", "Classic Car", "Collector", "Street Rod"]
+      legend_rule: >-
+        § 168.10 prescribes the inscription for each sub-regime in near-identical terms:
+        the plate 'shall bear the inscription "Pioneer," "Minnesota" and the registration
+        number or other combination of characters authorized under section 168.12,
+        subdivision 2a, BUT NO DATE', and likewise for 'Classic Car', 'Collector' and
+        'Street Rod'. Four legends, one grammar, one validity rule.
+      no_date: "each of the four expressly bears NO DATE — which is the visible consequence of the permanent validity below, and a real trap for anyone dating a Minnesota vehicle from its plate"
+      emblem: { present: true, rendered: placeholder }
+      colour_note: "no hex recorded; § 168.10 prescribes inscriptions and silence on colour"
+    plate_count: "a SINGLE plate is issued for the Pioneer, Classic Car, Collector and Street Rod regimes ('shall issue a single number plate', § 168.10); a separate Collector provision issues plates in the plural, so the count is not uniform across the family"
+    validity: >-
+      PERMANENT AND UNRENEWED: 'The number plate is valid without renewal as long as the
+      vehicle is in existence in Minnesota' (§ 168.10, repeated for each sub-regime). The
+      commissioner may revoke for failure to comply with the subdivision.
+    region_encoding: none
+    sources:
+      - "https://www.revisor.mn.gov/statutes/cite/168.10  # Minn. Stat. § 168.10: the 'Pioneer', 'Classic Car', 'Collector' and 'Street Rod' inscriptions, each with 'Minnesota' and the registration number or a § 168.12 subd. 2a character combination but NO DATE; single-plate issuance; validity without renewal as long as the vehicle exists in Minnesota; the commissioner's revocation power"
+      - "https://www.revisor.mn.gov/statutes/cite/168.12  # Minn. Stat. § 168.12 subd. 2a, cross-referenced by § 168.10 as the source of the alternative character combinations (text not read in this pass — recorded gap)"
+    notes: >-
+      THE MINNESOTA COLLECTOR FAMILY — Pioneer, Classic Car, Collector and Street Rod —
+      modelled as ONE series with four legend variants rather than four series, because
+      § 168.10 gives them a single grammar, a single validity rule and a single no-date
+      rule, and PRD-PLATES §2.3 makes a variant its own series only where format OR design
+      OR period differs. Here only the inscription word differs.
+      THE FACT WORTH CARRYING FORWARD is the interaction of two provisions: these plates
+      bear NO DATE and are valid FOREVER without renewal. A Minnesota collector plate
+      therefore carries no temporal information whatsoever, cannot be aged from its own
+      face, and may have been issued at any point since the regime began — which, together
+      with the year-of-manufacture regimes in North Dakota and Kansas, means every state in
+      this group has at least one class of plate that defeats era inference.
+      ELIGIBILITY THRESHOLDS for each of the four regimes are in § 168.10's subdivisions and
+      were not extracted in this pass (recorded gap).
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-mn-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2024 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999LLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      pattern_note: "REPRESENTATIVE SHAPE ONLY; the index stands for many programs whose arrangements are not individually stated and whose common frame was not sourced"
+    design:
+      note: "one design per authorised program; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: null
+      count_status: >-
+        NOT ESTABLISHED. No Minnesota specialty-plate count was obtained: DVS pages sit
+        behind a bot-protection layer that refused every request in this pass, and the
+        statutory enumeration — Minnesota creates special plates in a long run of
+        subdivisions of § 168.12 and in §§ 168.123, 168.1235, 168.1255 and neighbours — was
+        not completed. Recording null with an explicit status is better than importing a
+        secondary figure.
+      structural_note: >-
+        WHAT IS SOURCED about the structure: § 168.12 subd. 1(c) shows special plates
+        DISPLACING the mandatory 'noncommercial' legend, and subd. 1(d) shows a commercial
+        one-ton pickup remaining eligible for them, so Minnesota special plates are
+        substitutes for the standard plate rather than overlays on it. § 168.12 subd. 2
+        (amateur radio) is one worked example: the commissioner issues amateur radio plates
+        to an owner of a passenger automobile or recreational vehicle who is a Minnesota
+        resident holding an FCC amateur or citizens-band class D licence in good standing,
+        on payment of the § 168.12 subd. 5 special-plate fee.
+      known_program_hooks: ["168.12 subd. 2 (amateur radio)", "168.12 subds. 2a, 2c, 2d", "168.123", "168.1235", "168.1255"]
+      official_list_url: "https://www.revisor.mn.gov/statutes/cite/168.12"
+      dvs_status: "the Minnesota DVS website (mn.gov/dps/dvs) was UNREACHABLE in this pass — a ShieldSquare/bot-protection challenge on every request, via two clients; recorded so a later run does not mistake it for unfetched-but-fine"
+    region_encoding: none
+    sources:
+      - "https://www.revisor.mn.gov/statutes/cite/168.12  # Minn. Stat. § 168.12 subd. 2: the amateur radio plate and its eligibility and fee conditions, the worked example of a Minnesota special-plate authorization; subd. 1(c)-(d): special plates displacing the 'noncommercial' legend and remaining available to commercial one-ton pickups"
+      - "https://www.revisor.mn.gov/statutes/cite/168.10  # Minn. Stat. § 168.10: the collector-vehicle plate regimes, which sit alongside the specialty programs and are specified separately above"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — present as required by PRD-PLATES §2.5, CARRYING NO
+      COUNT. Minnesota and Kansas are the two states in group midwest-b that yielded no
+      specialty figure at all, in both cases because the issuing agency's website refused
+      automated requests and the statutory enumeration was not completed. The honest record
+      is `count_official: null` plus the sourced structural facts and the specific hooks a
+      later pass should enumerate — which is materially more useful to a verifier than a
+      borrowed number would be.

--- a/plates/us-mo.yml
+++ b/plates/us-mo.yml
@@ -1,0 +1,356 @@
+# plates/us-mo.yml — Missouri (PRD-PLATES gate L2, group midwest-b).
+#
+# MISSOURI LEGISLATES ITS SLOGAN AND DELEGATES ITS SERIAL — the opposite split
+# from Kansas next door. RSMo 301.130.1 fixes, in statute, that every set of
+# plates bears the state name, the words "SHOW-ME STATE", and the month and year
+# of expiration; but the serial itself is only "an arrangement of numbers or
+# letters, or both, as shall be assigned from year to year by the director of
+# revenue." So Missouri's legend is a hard fact and Missouri's format is a
+# delegation, and this file reflects that asymmetry honestly rather than
+# flattening it.
+#
+# THE STATUTE ALSO CARRIES A DESIGN AESTHETIC REQUIREMENT, which is rare enough
+# to be worth flagging: plates "shall be clearly visible at night, and shall be
+# AESTHETICALLY ATTRACTIVE." A legislature legislating attractiveness is a
+# genuine curiosity in a corpus of dimension minima and reflectivity indices.
+#
+# WHERE THE FORMAT EVIDENCE ACTUALLY CAME FROM: Missouri's Department of Revenue
+# runs an official plate-preview tool whose backing data file enumerates every
+# design the state offers and, for each, its character limit. EVERY ONE of the
+# 163 designs is capped at SIX characters. That is a sourced frame — a real
+# constraint from the issuing agency's own system — even though the ARRANGEMENT
+# of those six characters is nowhere stated. Hence `matching: recall-only` on
+# the standard series with a sourced width and an unsourced shape.
+jurisdiction: us-mo
+authority:
+  name: Missouri Department of Revenue, Motor Vehicle Bureau
+  url: "https://dor.mo.gov/motor-vehicle/plates/"
+binding: vehicle
+statute_edition: "Missouri Revised Statutes Chapter 301 (Registration and Licensing of Motor Vehicles), § 301.130 as published by the Revisor of Statutes at revisor.mo.gov, effective 28 August 2018 (the section carries 12 histories)"
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4. Missouri is one of
+# only two states in group midwest-b for which ANY evidence exists.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: no-general-grant-default-copyright
+  basis: >-
+    MISSOURI HAS NO GENERAL STATUTORY COPYRIGHT AUTHORITY FOR STATE WORKS; it has two
+    NARROW, department-specific grants, and the distinction matters. The copyright survey
+    read for this pass glosses Missouri as 'Some Missouri departments and commissions may
+    hold copyright in their works', citing RSMo 630.095 for the proposition that
+    'executive departments may hold copyright for works for hire'.
+    THAT GLOSS OVERSTATES THE STATUTE, and chasing it to the primary is what PRD-PLATES §4
+    requires: RSMo 630.095 sits in CHAPTER 630, which is the DEPARTMENT OF MENTAL HEALTH,
+    and reads 'Copyrights and trademarks by department. — The department may copyright or
+    obtain a trademark for any instructional, training and informational audio-visual
+    materials, manuals...'. It is a grant to ONE department over ITS training materials,
+    not a general executive-branch power, and it has nothing to say about the Department
+    of Revenue or about licence plates. The other cited grant, RSMo 8.007, is likewise
+    confined to the State Capitol Commission and to works depicting the Capitol.
+    CONCLUSION: no Missouri statute authorises the Department of Revenue to copyright a
+    plate design, and none forbids it either. The dossier's default therefore governs —
+    state works are presumed copyrighted absent a contrary declaration — and Missouri has
+    made no contrary declaration. Treat plate ARTWORK as protected; treat the statute as
+    free.
+  folklore_corrected: >-
+    RECORDED AS A DEBUNKING, per PRD-PLATES §9's folklore discipline: the secondary
+    summary that 'executive departments may hold copyright' in Missouri is not what the
+    cited section says. Anyone extending it to the Department of Revenue would be relying
+    on an encyclopedia's paraphrase of a mental-health-department housekeeping provision.
+    The primary was fetched and read for this file precisely to avoid propagating it.
+  edict_carve_out: >-
+    Every format, legend, display and replacement claim in this file cites RSMo Chapter
+    301. Edicts of government are uncopyrightable at every level ({{PD-US-GovEdict}}), so
+    the 'SHOW-ME STATE' legend requirement, the six-year plate period, the single-plate
+    class list and the mounting heights are all affirmatively clean regardless of
+    Missouri's posture on artwork.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to the current Missouri base graphic and
+    to every collegiate and organizational emblem in the catalogue. The collegiate and
+    organizational marks carry an ADDITIONAL layer beyond state copyright: they are
+    third-party university and charity marks, plausibly trademarked and licensed to the
+    program rather than owned by Missouri, so a clean state posture would not clear them
+    even if one existed. Render `emblem: {present: true, rendered: placeholder}`.
+    Missouri state-seal misuse statutes are unresearched.
+  sources:
+    - "https://revisor.mo.gov/main/OneSection.aspx?section=630.095  # RSMo 630.095, fetched and read: 'Copyrights and trademarks by department' — a Department of Mental Health provision covering instructional, training and informational materials. The primary that corrects the secondary gloss"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): the Missouri section, whose paraphrase of RSMo 630.095 was chased to the primary above and found to overstate it. Also cites RSMo 8.007 (State Capitol Commission)"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA has no enforcement power; its declarative present is RECOMMENDED PRACTICE."
+  dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is PAYWALLED and UNPINNED. No J686 dimension is quoted anywhere in this file."
+  geometry_available: "AAMVA §2.1 (jurisdiction name top-centre between the bolt holes, >=0.25 in above the number, >=0.125 in from the top edge, characters 0.75-1.0 in) and §2.2 (characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom)."
+  retroreflectivity: "AAMVA §3.3: legible day and night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3; entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2."
+  replacement_cycle_recommendation: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. Missouri legislates a FLOOR rather than a ceiling — RSMo 301.130.6(4), 'the director of revenue shall issue plates for a period of at least six years' — which is the inverse instrument and does not cap plate age at all."
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' is UNCITED in its Wikipedia source (a `citation needed` since 2017, copied across articles). Recorded as COMMONLY REPEATED, UNSOURCED. RSMo 301.130 states no plate dimension, so this file makes no Missouri dimension claim (recorded gap)."
+
+# ---------------------------------------------------------------------------
+# Display rules. Missouri is a TWO-PLATE state whose single-plate exception list
+# is unusually long and is drawn by VEHICLE CLASS rather than by weight alone.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates, front and rear. RSMo 301.130.5: plates 'shall be fastened to all motor vehicles except trucks, tractors, truck tractors or truck-tractors licensed in excess of twelve thousand pounds on the front and rear of such vehicles not less than eight nor more than forty-eight inches above the ground, with the letters and numbers thereon right side up'."
+  single_plate_classes: >-
+    RSMo 301.130.3: 'only one license plate shall be issued' for property-carrying
+    commercial motor vehicles registered above 12,000 lb gross weight, all
+    passenger-carrying commercial motor vehicles, local transit buses, school buses,
+    trailers, semitrailers, motorcycles, motortricycles, autocycles, motorscooters and
+    driveaway vehicles.
+  optional_second_plate: "RSMo 301.130.3: an applicant registering a property-carrying commercial vehicle above 12,000 lb MAY REQUEST two plates, in which case 'the director of revenue shall provide for distinguishing marks on the plates indicating one plate is for the front and the other is for the rear' — a front/rear asymmetry created on request, which is why `rear_differs` is conditional for that class"
+  front_only: "RSMo 301.130.5: the plate on buses other than school buses, and on trucks, tractors, truck tractors or truck-tractors licensed in excess of 12,000 lb, 'shall be displayed on the front of such vehicles' — front-only unless the optional second plate was taken"
+  rear_and_orientation: "RSMo 301.130.5: plates on trailers, motorcycles, motortricycles, autocycles and motorscooters 'shall be displayed on the rear of such vehicles either horizontally or vertically, with the letters and numbers plainly visible' — Missouri expressly permits VERTICAL display for these classes"
+  mounting: "not less than 8 nor more than 48 inches above the ground, right side up, plainly visible and reasonably clean so the reflective qualities are not impaired; a transparent cover is permitted so long as the plate stays plainly visible and its reflectivity is unimpaired (RSMo 301.130.5)"
+  evidentiary_effect: "RSMo 301.130.5: a properly attached plate 'shall be prima facie evidence that the required fees have been paid'"
+  sources:
+    - "https://revisor.mo.gov/main/OneSection.aspx?section=301.130  # RSMo 301.130.3: the single-plate class list and the optional second plate with front/rear distinguishing marks; .5: two-plate default, the 8-48 inch mounting band, front-only for heavy trucks and non-school buses, rear and vertical-or-horizontal display for trailers and two-wheelers, the transparent-cover allowance, and the prima facie evidence rule"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES — statutory legend, delegated serial, sourced width.
+  # =========================================================================
+  - id: us-mo-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL9L9L"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      charset:
+        max_characters: 6
+        max_characters_basis: >-
+          SOURCED FROM THE ISSUING AGENCY'S OWN SYSTEM. The Missouri Department of Revenue's
+          official plate-preview tool is driven by a data file enumerating every design the
+          state offers, each entry carrying that design's character limit. ALL 163 ENTRIES
+          — 7 standard, 32 collegiate, 49 military, 75 organizational — carry the limit 6.
+          A six-character frame is therefore a real, agency-stated constraint on the
+          Missouri plate, uniform across the entire catalogue.
+        notes: >-
+          RSMo 301.130.1 states the legend and delegates the serial: each set of plates
+          bears 'the name or abbreviated name of this state, the words "SHOW-ME STATE", the
+          month and year in which the registration shall expire, and an arrangement of
+          numbers or letters, or both, as shall be assigned from year to year by the
+          director of revenue.' RSMo 301.130.2 adds that 'The arrangement of letters and
+          numbers of license plates shall be uniform throughout each classification of
+          registration' and that the director 'may provide for the arrangement of the
+          numbers in groups or otherwise'. NO ARRANGEMENT AND NO LETTER EXCLUSIONS are
+          stated in the statute.
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY, on the nl-export precedent, AND THE HONEST POSITION FOR
+        MISSOURI. The WIDTH is sourced (six characters, from the agency's own preview
+        system); the ARRANGEMENT is not sourced anywhere this pass could reach — the
+        statute delegates it, and the Department of Revenue publishes no format
+        specification. The pattern shows a six-character interleaved shape as a
+        representative member of the space, NOT as a claim about Missouri's current
+        arrangement. The regex is deliberately the full six-character alphanumeric frame
+        and `matching: recall-only` says exactly what that means: a hit is a shape hit
+        inside Missouri's sourced width, never a well-formedness claim. Pinning the actual
+        arrangement is the top Missouri follow-up.
+      grouping: "RSMo 301.130.2 lets the director arrange the characters 'in groups or otherwise', which is why the separator is optional in the regex rather than mandatory"
+    design:
+      legend_state: "Missouri"
+      legend_slogan: "SHOW-ME STATE"
+      legend_rule: >-
+        THE SLOGAN IS STATUTORY. RSMo 301.130.1 requires every set of plates to bear 'the
+        words "SHOW-ME STATE"', and then carves out exactly two substitutions: 'Special
+        plates for qualified disabled veterans will have the "DISABLED VETERAN" wording on
+        the license plates in preference to the words "SHOW-ME STATE" and special plates
+        for members of the National Guard will have the "NATIONAL GUARD" wording in
+        preference to the words "SHOW-ME STATE".' Those two displacements are broken out as
+        their own series below, because a mandated legend difference is a design difference
+        under PRD-PLATES §2.3.
+      expiration_display: "RSMo 301.130.1: the plate bears 'the month and year in which the registration shall expire' — Missouri prints the expiry on the PLATE, not only on a sticker"
+      material_and_finish: "RSMo 301.130.1: 'The plates shall also contain fully reflective material with a common color scheme and design for each type of license plate issued pursuant to this chapter.'"
+      aesthetic_requirement: >-
+        RSMo 301.130.1, verbatim and unusual: 'The plates shall be clearly visible at
+        night, and shall be aesthetically attractive.' A statutory attractiveness duty is
+        worth recording as a curiosity of the corpus — it is a design requirement with no
+        testable content, and it sits in the same sentence as a night-visibility
+        requirement that has plenty.
+      colour_note: >-
+        NO HEX IS RECORDED. RSMo 301.130.1 mandates a 'common color scheme' per plate type
+        but names no colour, and no Missouri departmental colour specification was
+        obtained. Recorded gap rather than an eyedropped value.
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    replacement_cycle:
+      years: 6
+      statutory_text: "RSMo 301.130.6(4): 'Except as otherwise provided in this section, the director of revenue shall issue plates for a period of at least six years.'"
+      note: >-
+        A FLOOR, NOT A CEILING — the inverse of Florida's ten-year replacement rule and of
+        AAMVA §1.1's recommended maximum. Missouri law guarantees a plate will be issued
+        for AT LEAST six years and sets no outer limit at all, so Missouri plate age is
+        statutorily unbounded above. A consumer inferring Missouri base generations from a
+        six-year cadence would be reading a minimum as a period.
+      tabs: "RSMo 301.130.6(1): the director issues a tab or set of tabs annually or biennially as evidence of registration IN LIEU of a new set of plates; from 1 January 2010 the director may record additional information on the tab so that it 'positively correlate[s] with the license plate'; (2) one tab per plate, affixed in the designated area"
+    permanent_registration: "RSMo 301.130.6(5): commercial motor vehicles and trailers registered under RSMo 301.041 receive a PERMANENT NONEXPIRING plate for which no tabs are issued; the plate returns to the Highways and Transportation Commission on sale or disposal, or transfers to a replacement commercial vehicle on a supplemental application"
+    region_encoding: none
+    sources:
+      - "https://revisor.mo.gov/main/OneSection.aspx?section=301.130  # RSMo 301.130.1: the state name, the mandatory 'SHOW-ME STATE' legend, the month-and-year expiry on the plate, the delegated arrangement of numbers or letters, fully reflective material with a common colour scheme per type, night visibility and the aesthetic-attractiveness requirement, and the DISABLED VETERAN / NATIONAL GUARD legend substitutions; .2 uniformity per classification and the grouping discretion; .6(1)-(2) tabs in lieu of plates; .6(4) the six-year floor; .6(5) permanent nonexpiring commercial plates"
+      - "https://dor.mo.gov/js/platescript.js  # the data file backing the Missouri DOR's official plate-preview tool at dor.mo.gov/motor-vehicle/plates/personalized-specialty.html#preview: 163 designs across four categories, EVERY ONE carrying a six-character limit"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1, the 7-10 year recommended ceiling against which Missouri's statutory six-year FLOOR is the inverse instrument"
+    notes: >-
+      MISSOURI STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED and the series is deliberately
+      `recall-only`: Missouri's width is sourced and its arrangement is not, and conflating
+      the two would produce a confident regex resting on nothing. `start: 2025` is the
+      instrument-in-force upper bound, not a base-design date — RSMo 301.130 has been
+      effective since 28 August 2018 and Missouri has issued alphanumeric plates for the
+      better part of a century.
+      THE ONE SERIES BACK IS A RECORDED GAP. Missouri's six-year statutory floor means base
+      generations exist, but no primary establishing their boundaries was obtained and the
+      DOR publishes no plate history this pass could reach. Rather than mint a dated series
+      on a collector-site era table, it is omitted and recorded here.
+
+  # =========================================================================
+  # THE TWO STATUTORY LEGEND DISPLACEMENTS. RSMo 301.130.1 names both in one
+  # sentence, so each is its own series under PRD-PLATES §2.3.
+  # =========================================================================
+  - id: us-mo-disabled-veteran
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL9L9L"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      charset: { max_characters: 6, notes: "the six-character frame from the DOR preview catalogue applies; the statute displaces the LEGEND only and says nothing about the serial" }
+      pattern_note: "REPRESENTATIVE SHAPE ONLY — as for us-mo-standard, the width is sourced and the arrangement is not; `matching: recall-only` accordingly"
+    design:
+      legend_state: "Missouri"
+      legend_slogan: "DISABLED VETERAN"
+      legend_rule: "RSMo 301.130.1: 'Special plates for qualified disabled veterans will have the \"DISABLED VETERAN\" wording on the license plates in preference to the words \"SHOW-ME STATE\".'"
+      emblem: { present: true, rendered: placeholder }
+      colour_note: "no hex recorded; the statute's 'common color scheme' duty names no value"
+    region_encoding: none
+    sources:
+      - "https://revisor.mo.gov/main/OneSection.aspx?section=301.130  # RSMo 301.130.1: the DISABLED VETERAN legend displacing SHOW-ME STATE for qualified disabled veterans"
+    notes: >-
+      DISABLED VETERAN PLATES. Its own series rather than a variant because the statute
+      mandates a legend difference in terms, which PRD-PLATES §2.3 treats as a design
+      difference and therefore a series. CLASS CAVEAT: recorded as `standard` because
+      _meta/classes.yml has no veteran or disability class and this is an ordinary
+      registration with a mandated legend, not a separate issuance regime — the same
+      reasoning us-fl-wrecker and us-fl-restricted use. Missouri's eligibility criteria for
+      'qualified disabled veterans' are not in § 301.130 and were not obtained (gap).
+
+  - id: us-mo-national-guard
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL9L9L"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      charset: { max_characters: 6, notes: "the six-character frame from the DOR preview catalogue applies; the statute displaces the LEGEND only" }
+      pattern_note: "REPRESENTATIVE SHAPE ONLY — width sourced, arrangement not; `matching: recall-only` accordingly"
+    design:
+      legend_state: "Missouri"
+      legend_slogan: "NATIONAL GUARD"
+      legend_rule: "RSMo 301.130.1: 'special plates for members of the National Guard will have the \"NATIONAL GUARD\" wording in preference to the words \"SHOW-ME STATE\".'"
+      emblem: { present: true, rendered: placeholder }
+      colour_note: "no hex recorded; the statute's 'common color scheme' duty names no value"
+    region_encoding: none
+    sources:
+      - "https://revisor.mo.gov/main/OneSection.aspx?section=301.130  # RSMo 301.130.1: the NATIONAL GUARD legend displacing SHOW-ME STATE for National Guard members"
+    notes: >-
+      NATIONAL GUARD PLATES. The second of Missouri's two statutory legend displacements,
+      given its own entry for the same §2.3 reason as the disabled-veteran plate above and
+      recorded separately because the statute names the two independently and attaches them
+      to different eligibility groups. Together these two are the whole of Missouri's
+      legislated legend taxonomy — everything else in the Missouri catalogue is a design
+      program under the specialty index below, not a statutory legend.
+
+  # =========================================================================
+  # PERSONALIZED.
+  # =========================================================================
+  - id: us-mo-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z]{1,6}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      charset:
+        max_characters: 6
+        notes: "the six-character cap is uniform across all 163 designs in the DOR's own preview catalogue, and personalization operates inside it; RSMo 301.144 governs the personalized-plate fee, which RSMo 301.130.3 cross-references when capping the surcharge for an optional second commercial plate"
+      pattern_note: "`regex` is the letters-only shape most vanity configurations take; `regex_statutory` is the sourced six-character alphanumeric frame"
+    design:
+      note: "Missouri's preview tool offers personalization across the standard, collegiate, military and organizational categories alike, so personalization is a serial-source difference over an existing design"
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://dor.mo.gov/js/platescript.js  # the DOR preview catalogue: every design, including all seven standard designs, carries a six-character limit"
+      - "https://revisor.mo.gov/main/OneSection.aspx?section=301.130  # RSMo 301.130.3 cross-references 'the fee prescribed for personalized license plates in subsection 1 of section 301.144' — the statutory hook for the personalized program"
+    notes: >-
+      PERSONALIZED PLATES. Modelled as its own series because the SERIAL SOURCE differs —
+      owner-chosen rather than director-assigned. Missouri is the tightest personalized
+      frame in group midwest-b at six characters, against seven in Kansas, North Dakota and
+      South Dakota and seven in Nebraska's message plates. RSMo 301.144's own text was not
+      read in this pass (recorded gap); the fee and the content-refusal criteria are
+      therefore not recorded.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Count and links only.
+  # =========================================================================
+  - id: us-mo-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL9L9L"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      charset: { max_characters: 6, notes: "the six-character frame is uniform across the whole catalogue — specialty designs carry ordinary serials inside the same frame as the standard series" }
+      pattern_note: "REPRESENTATIVE SHAPE ONLY; the index stands for 156 non-standard designs whose arrangements are not individually stated"
+    design:
+      note: "one design per authorised program; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official_total: 163
+      count_official_breakdown: { standard: 7, collegiate: 32, military: 49, organizational: 75 }
+      count_basis: >-
+        COUNTED ROW BY ROW from the data file driving the Missouri DOR's own plate-preview
+        tool — an operational agency system, not a marketing claim — enumerated on the
+        date of this pass. 163 designs total, of which 156 are non-standard. The seven
+        'standard' entries are themselves worth noting because they are not all what a
+        layperson would call standard: Amateur Radio, Custom Vehicle, Historic Vehicle,
+        Shuttle Bus, Standard, Street Rod and Vanpool.
+      count_caveat: >-
+        THIS IS A SNAPSHOT OF A LIVE SYSTEM AND WILL DRIFT. Missouri publishes no stated
+        specialty-plate count anywhere this pass could reach, so there is no agency FIGURE
+        to reconcile the enumeration against — the number above is what the agency's system
+        contained when read, not what the agency says it offers. Recorded as such rather
+        than promoted to an official figure (PRD-PLATES §5.3).
+      official_list_url: "https://dor.mo.gov/motor-vehicle/plates/personalized-specialty.html"
+      official_preview_url: "https://dor.mo.gov/motor-vehicle/plates/personalized-specialty.html#preview"
+      preview_data_url: "https://dor.mo.gov/js/platescript.js"
+      preview_data_note: >-
+        WORTH FLAGGING FOR THE PIPELINE: this file is a machine-readable, per-design
+        catalogue published by the issuing agency — design name, image slug, text colour
+        and character limit for all 163 designs. It is structurally the closest thing
+        Missouri has to Florida's monthly specialty-plate report, and like that report it is
+        unversioned and unarchived by its publisher, so it should be snapshotted on a
+        schedule before its contents drift out of reach.
+    region_encoding: none
+    sources:
+      - "https://dor.mo.gov/js/platescript.js  # the Missouri DOR plate-preview catalogue: 7 standard, 32 collegiate, 49 military and 75 organizational designs, each with a six-character limit and a text colour"
+      - "https://dor.mo.gov/motor-vehicle/plates/personalized-specialty.html  # the DOR's Personalized and Specialty License Plates page, which the preview tool and its four design categories sit behind"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — one entry standing for the whole program, per
+      PRD-PLATES §2.5, with no individual designs. Missouri's index is unusual in this
+      group for being derived from a MACHINE-READABLE agency catalogue rather than from a
+      brochure or a statutory enumeration, which makes the count reproducible and the
+      per-design character limits sourced. The honest weakness, recorded in
+      `count_caveat`, is the mirror image of that strength: an enumeration of a live system
+      is a snapshot with no publisher-stated total behind it, so it dates immediately.

--- a/plates/us-nd.yml
+++ b/plates/us-nd.yml
@@ -1,0 +1,419 @@
+# plates/us-nd.yml — North Dakota (PRD-PLATES gate L2, group midwest-b).
+#
+# NORTH DAKOTA IS THE BEST-SOURCED STATE IN THIS GROUP, and it is worth saying
+# why: NDDOT publishes, on its own license-plate page, a prose specification of
+# the standard plate that names the INTRODUCTION MONTH, the SERIAL FORMAT and
+# every design element. That is rare. Most states publish images and leave the
+# facts to be inferred; North Dakota wrote them down. Consequently `us-nd-standard-2016`
+# carries `period_evidence: agency-stated-date` rather than the
+# instrument-in-force upper bound that the rest of this group is stuck with.
+#
+# THE SECOND NORTH DAKOTA GIFT is that the legislature specified plate CONTENT
+# in the Century Code: § 39-04-12 mandates the slogan "Peace Garden State" in
+# terms, and § 39-04-10.18 fixes the blackout plate's colours as VALUES ("a
+# solid black background" / "white numbers and letters"). Statutory colour
+# VALUES are unusual — Florida's legislature specified only that historic plates
+# be "of a distinguishing color" and named none. So `us-nd-blackout` is the only
+# series in this group whose hexes are `hex_basis: statute`.
+#
+# SOURCING RULE APPLIED HERE (PRD-PLATES §4): edicts of government are public
+# domain at every level, so every content, display, reflectorization and class
+# claim below cites the North Dakota Century Code. The NDDOT page is cited only
+# for what the Code does not carry: the current base design, its introduction
+# date and its serial arrangement.
+jurisdiction: us-nd
+authority:
+  name: North Dakota Department of Transportation (NDDOT), Motor Vehicle Division
+  url: "https://www.dot.nd.gov/motor-vehicle/license-plates"
+binding: vehicle
+statute_edition: "North Dakota Century Code Title 39, Chapter 39-04 (Motor Vehicles — Registration), chapter text as published by the North Dakota Legislative Branch at ndlegis.gov and fetched for this pass"
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    NORTH DAKOTA WAS NOT LOCATED IN ANY COPYRIGHT SURVEY READ FOR THIS PASS. The
+    Wikipedia survey of subnational-government copyright status that the US dossier
+    treats as its core analysis carries per-state sections for Arizona, California,
+    Colorado, Florida, Georgia, Indiana, Massachusetts, Minnesota, Missouri, New
+    Jersey, New York, North Carolina, Pennsylvania, Rhode Island, South Carolina,
+    Utah and Washington — and NO section for North Dakota. No {{PD-NDGov}} tag was
+    found on Commons. Therefore the DEFAULT stated in the dossier governs: 17 U.S.C.
+    § 105 does not reach the states, so a state plate design is presumed COPYRIGHTED
+    unless that state says otherwise, and North Dakota has not been shown to say
+    otherwise. Recorded as unresearched rather than as either PD or adverse, because
+    absence of a fetched source is weak evidence in both directions.
+  edict_carve_out: >-
+    THE PART THAT IS AFFIRMATIVELY CLEAN. Whatever North Dakota's posture on plate
+    ARTWORK, the plate's mandated elements live in the Century Code — the "Peace
+    Garden State" slogan (§ 39-04-12), the reflectorization duty (§ 39-04-12), and the
+    blackout plate's black ground and white characters (§ 39-04-10.18). Edicts of
+    government are uncopyrightable at every level ({{PD-US-GovEdict}}), so those
+    specifications are freely usable EVEN IF the Badlands/bison artwork is not. This
+    is the cleanest legal path the dossier identifies and this file walks it.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to the BISON, the BADLANDS scene and
+    the THREE WHEAT STALKS. These are pictorial artwork described by NDDOT in prose,
+    not drawn in any statutory instrument, so nothing about them is cleared. Render
+    `emblem: {present: true, rendered: placeholder}`. State-seal misuse statutes are a
+    protection regime independent of copyright and are unresearched for North Dakota.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): read to establish that North Dakota has NO section in the survey — a negative result, recorded as such"
+    - "https://www.dot.nd.gov/motor-vehicle/license-plates  # NDDOT's own description of the artwork whose status is unresearched"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Voluntary, no federal mandate; the SAE J686 delegation
+# trap is recorded once per jurisdiction file so each file stands alone.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA writes recommendations in the declarative present; they must be read as RECOMMENDED PRACTICE, not requirement."
+  dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose own text is PAYWALLED and UNPINNED. No J686 dimension is quoted anywhere in this file."
+  geometry_available: "AAMVA §2.1 (jurisdiction name top-centre between the bolt holes, >=0.25 in above the number, >=0.125 in from the top edge, characters 0.75-1.0 in) and §2.2 (characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom) are the renderable geometry this dataset may use."
+  retroreflectivity: "AAMVA §3.3: legible in daylight and at night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3; entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2."
+  replacement_cycle_recommendation: "AAMVA §1.1 recommends a rolling or full replacement cycle not to exceed 7 to 10 years. North Dakota legislates NO replacement cycle at all — see replacement_cycle on us-nd-standard-2016."
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" commonly said to have fixed the 6x12 inch
+    plate is UNCITED in its Wikipedia source (a `citation needed` since 2017, copied
+    across articles — circular). It is recorded as COMMONLY REPEATED, UNSOURCED. North
+    Dakota's Century Code states no plate dimension at all, so this file makes no
+    dimension claim for North Dakota either (recorded gap).
+
+# ---------------------------------------------------------------------------
+# Display rules. North Dakota is a TWO-PLATE state with an unusual inversion for
+# apportioned vehicles and truck tractors.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates, front and rear. § 39-04-11: an individual may not operate a vehicle unless it has 'two number plates, bearing the distinctive number conspicuously displayed, horizontally and in an upright position, one on the front and one on the rear of the vehicle, each securely fastened'."
+  rear_only:
+    - "housetrailer: plates 'must be attached to the rear of the housetrailer' (§ 39-04-11)"
+    - "motorcycle and trailer: 'must be attached to the rear ... and may be displayed vertically' — North Dakota expressly permits VERTICAL display for these two classes, which most states do not (§ 39-04-11)"
+  single_plate_inversion: "§ 39-04-11: when only ONE plate is furnished for an apportioned vehicle registered under the International Registration Plan (§ 39-19-04) or a truck tractor, 'the plate must be attached to the front' — and for a semitrailer, the rear. A front-only plate in a two-plate state is the same outlier shape Florida has for truck tractors."
+  mounting: "§ 39-04-11: the bottom of each plate not less than twelve inches [30.48 cm] above the level surface on which the vehicle stands; mounted visibly so as to clearly display the number and the state name; kept free of mud, ice or snow 'as far as is reasonably possible' — a winter-state qualification worth noticing"
+  old_plates: "§ 39-04-11: all number plates, markers or evidence of registration except for the current year must be REMOVED from the vehicle"
+  ownership: "§ 39-04-11: 'All vehicle license plates issued by the department are the property of the department for the period for which the plates are valid' — the plate is state property, not the registrant's"
+  temporary_permit: "§ 39-04-11: a temporary registration permit from NDDOT or a licensed dealer is displayed on the rear window, the rearmost driver's-side window, or in the rear plate location, clearly visible and unobstructed"
+  sources:
+    - "https://ndlegis.gov/cencode/t39c04.pdf  # NDCC § 39-04-11: two plates front and rear; housetrailer/motorcycle/trailer rear-only and vertical display; the apportioned/truck-tractor FRONT-only and semitrailer rear inversion; 12-inch mounting height; mud/ice/snow duty; removal of prior-year plates; plates are department property; temporary permit placement"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES — and the only series in group midwest-b with a
+  # month-precise, agency-stated introduction date.
+  # =========================================================================
+  - id: us-nd-standard-2016
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2016 }
+    period_evidence: agency-stated-date
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          § 39-04-12(1) is the whole statutory constraint on the serial: the plate bears
+          'a distinctive number for assignment to each vehicle', and 'the distinctive
+          number may be in figures or a combination of figures and letters and must be of
+          a size clearly distinguishable by law enforcement officers and individuals
+          generally'. NO WIDTH, NO ARRANGEMENT AND NO EXCLUDED LETTERS are stated
+          anywhere in Chapter 39-04. Whether North Dakota skips I/O/Q in the letter
+          group — as many states do — was NOT established (recorded gap).
+      pattern_note: >-
+        `regex` encodes the arrangement NDDOT states in its own words: 'The serial format
+        follows a "123 ABC" pattern.' `regex_statutory` encodes the outer bound the
+        Century Code actually permits (any figures, or any combination of figures and
+        letters, of unstated width) and is the honest bound for a North Dakota plate of
+        unknown vintage.
+      progression: "not established (recorded gap) — NDDOT states the format but not the issuing order"
+    design:
+      plate_dimension_note: >-
+        NORTH DAKOTA LEGISLATES NO PLATE DIMENSION. Chapter 39-04 states none, and this
+        file will not import the 6x12 inch convention from the uncited 1956 folklore or
+        from SAE J686, whose text is unpinned. Recorded gap.
+      material: "reflective aluminum (NDDOT); § 39-04-12(1) requires plates to be 'of metal or other suitable material' and 'treated with a reflectorized material according to the specifications prescribed by the department'"
+      legibility: "§ 39-04-12(1): 'To reduce highway accidents at night all number plates and temporary registration permits must be legible for a minimum distance of one hundred feet [30.48 meters] to an approaching motorist by day or night with lawful headlight beams and without other illumination'"
+      legend_top: "Legendary"
+      legend_state: "North Dakota"
+      legend_bottom_left: "Peace Garden State"
+      legend_rule: >-
+        THE SLOGAN IS STATUTORY, WHICH IS UNUSUAL. § 39-04-12(1) requires number plates
+        to bear 'the name of the state, either in full or by abbreviation, the number of
+        the year, the slogan "Peace Garden State" and a distinctive number'. So "Peace
+        Garden State" is not a design choice the department could drop — it is mandated
+        text. "Legendary", by contrast, is a DEPARTMENTAL addition described only by
+        NDDOT and appearing in no instrument.
+      graphic:
+        present: true
+        rendered: placeholder
+        description: "NDDOT's own description: 'a scenic depiction of the state's Badlands, highlighted by a gradient sky transitioning from light blue to orange and yellow, symbolizing a sunrise. A bison stands prominently in the foreground ... while three wheat stalks flank the state's name'"
+      emblem: { present: true, rendered: placeholder }
+      colour_note: >-
+        NO HEX IS RECORDED FOR THIS SERIES, DELIBERATELY. NDDOT describes a GRADIENT sky
+        ('light blue to orange and yellow'), and a gradient is not a colour value — a
+        single background hex would be a fabrication, not an approximation. Neither the
+        Century Code nor NDDOT states a character colour. Both are recorded as gaps
+        rather than invented, which is why `background` and `foreground` are absent here
+        while the blackout series below carries statutory hexes.
+      band: { side: none }
+      rear_differs: false
+    replacement_cycle:
+      years: null
+      note: >-
+        NORTH DAKOTA LEGISLATES NO REPLACEMENT CYCLE. Chapter 39-04 contains no
+        counterpart to Florida's 10-year rule, South Dakota's seven-year redesign duty or
+        Kansas's five-year reissue cycle. § 39-04-12(1) instead provides for an annual
+        'year plate, tab, or sticker'. The 2016 base has therefore run for a decade with
+        no statutory expiry, against AAMVA §1.1's recommended 7-10 year ceiling.
+    fleet_option: "§ 39-04-12(2): an owner of a fleet of 100 or more vehicles may be given plates valid for as many as SIX consecutive years, exempt from annual validation evidence, against a corporate surety bond"
+    region_encoding: none
+    sources:
+      - "https://www.dot.nd.gov/motor-vehicle/license-plates  # NDDOT, verbatim: 'Introduced in November 2016'; the Badlands/gradient-sky/bison/three-wheat-stalks design; the slogans 'Legendary' above the state name and 'Peace Garden State' at the bottom left; 'The serial format follows a \"123 ABC\" pattern'; 'reflective aluminum'"
+      - "https://ndlegis.gov/cencode/t39c04.pdf  # NDCC § 39-04-12(1): state name, year number, the MANDATED slogan 'Peace Garden State', the distinctive number in figures or figures-and-letters, the 100-foot legibility rule, reflectorized material, annual year plate/tab/sticker; § 39-04-12(2) the 100-vehicle fleet six-year plate"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1, the 7-10 year replacement recommendation North Dakota has no counterpart to"
+    notes: >-
+      NORTH DAKOTA STANDARD ISSUE, THE 2016 BADLANDS BASE. The id is dated because the
+      date is real: NDDOT states 'Introduced in November 2016' on its own license-plate
+      page, so `period_evidence: agency-stated-date` and 2016 is a genuine claim rather
+      than the statute-edition upper bound the rest of this group carries. The month is
+      recorded here in prose because the runs shape takes integer years only.
+      THE ONE SERIES BACK IS A RECORDED GAP: NDDOT describes only the current base, the
+      Century Code is design-silent, and no primary establishing North Dakota's
+      pre-November-2016 base or its period was obtained. Rather than mint a series on an
+      enthusiast-site era table, it is omitted and recorded here — the L2 brief asks for
+      one series back where it can be sourced, not for a guess.
+
+  # =========================================================================
+  # BLACKOUT — the only series in group midwest-b with STATUTORY COLOUR VALUES.
+  # =========================================================================
+  - id: us-nd-blackout
+    class: specialty
+    categories: [car, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "§ 39-04-10.18 fixes this plate's COLOURS and its eligibility but says nothing about its serial; the § 39-04-12(1) grammar therefore applies unchanged" }
+      pattern_note: >-
+        ARRANGEMENT INHERITED, NOT SEPARATELY SOURCED. NDDOT says the blackout plate
+        'maintains all required plate elements such as registration decals and
+        identification numbers', which implies but does not state that it carries the
+        standard 123 ABC arrangement. The inheritance is recorded as an assumption here
+        and `regex_statutory` is the honest bound. Flagged as a gap.
+    design:
+      background: { color: "#000000", finish: retroreflective, hex_basis: statute }
+      foreground: "#FFFFFF"
+      colour_rule: >-
+        § 39-04-10.18(2), verbatim: 'Blackout number plates issued under this section must
+        have: a. A solid black background; and b. White numbers and letters.' THE
+        LEGISLATURE NAMED THE COLOUR VALUES. That is rare enough to be worth flagging —
+        contrast Florida, whose legislature required historic plates to be 'of a
+        distinguishing color' and named none, and contrast this file's own standard
+        series, whose colours are unrecorded because nobody official stated them. Black
+        and white are unambiguous as named colours, so these two hexes are the only
+        `hex_basis: statute` values in group midwest-b.
+      emblem: { present: false }
+      note: "NDDOT: 'The blackout design maintains all required plate elements such as registration decals and identification numbers, ensuring it meets legal standards'"
+    eligibility: "§ 39-04-10.18(3): the director may issue blackout plates ONLY to the owner of a passenger motor vehicle, a truck whose registered gross weight does not exceed 20,000 pounds [9071.85 kg], or a motorcycle"
+    fee: "$25.00 per registration period in addition to all other registration fees (§ 39-04-10.18(1))"
+    region_encoding: none
+    sources:
+      - "https://ndlegis.gov/cencode/t39c04.pdf  # NDCC § 39-04-10.18: the $25 per-period fee; (2) 'a solid black background' and 'white numbers and letters'; (3) the passenger / <=20,000 lb truck / motorcycle eligibility limit"
+      - "https://www.dot.nd.gov/motor-vehicle/license-plates/blackout-plate  # NDDOT: 'solid black background with crisp white lettering'; available for 'passenger cars, light trucks, and motorcycles'; 'Like other specialty plates, it comes with an additional fee'; the plate 'maintains all required plate elements'"
+    notes: >-
+      BLACKOUT PLATES. Two things make this series worth its own entry rather than a
+      colour sub-entry on the standard series. First, the colours differ AND they are
+      legislated, so under PRD-PLATES §2.3 the design difference is its own series and
+      the values are sourced to an edict. Second, the eligibility rule is a genuine
+      restriction — a truck over 20,000 lb registered gross weight cannot have one — so
+      the series scopes narrower than its jurisdiction default, which is exactly the
+      case `categories:` exists to carry.
+      PERIOD CAVEAT: `start: 2025` is an UPPER BOUND from the Century Code edition read,
+      not a real date. NDDOT calls the plate 'new' and 'long-awaited', so the true start
+      is recent, but the session law that added § 39-04-10.18 was not pinned in this pass
+      and the chapter text as published carries no source note. Recorded rather than
+      guessed. North Dakota and Iowa both run statutory blackout plates (Iowa Code
+      § 321.34(11C)) — a small Midwestern convergence worth noting for the encyclopedia.
+
+  # =========================================================================
+  # PERSONALIZED — the character caps are statutory and differ by vehicle type.
+  # =========================================================================
+  - id: us-nd-personalized
+    class: personalized
+    categories: [car, van, truck, trailer, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: >-
+          § 39-04-10.3, verbatim: plates 'marked with not more than seven numerals,
+          letters, or combinations of numerals and letters'. For MOTORCYCLES the cap
+          drops: 'The special license plates for motorcycles may contain not more than
+          six numerals, letters, or a combination of not more than six numerals and
+          letters.' The statute also provides that 'A personal plate containing a
+          restricted character may not be renewed' — North Dakota's restricted-character
+          list itself is not in Chapter 39-04 and was not obtained (recorded gap).
+      pattern_note: "`regex` is the letters-only shape most vanity configurations take; `regex_statutory` is the true statutory frame (any mix of up to seven alphanumerics). The six-character motorcycle cap is a narrower bound not separately encoded."
+    design:
+      note: "personalization is a serial-source difference applied over the standard or an eligible specialty design; no distinct design is prescribed"
+      emblem: { present: true, rendered: placeholder }
+    fee: "$25.00 per registration period, waived where the plate is a gold star, military sacrifice or prisoner-of-war plate; a one-time $100.00 fee for vehicles registered as collector vehicles under § 39-04-10.6 (§ 39-04-10.3)"
+    transferable: "on sale or transfer the owner removes the plates (§ 39-04-36) and may transfer them to a replacement motor vehicle on payment of the transfer fee (§ 39-04-10.3)"
+    region_encoding: none
+    sources:
+      - "https://ndlegis.gov/cencode/t39c04.pdf  # NDCC § 39-04-10.3: the seven-character cap, the six-character motorcycle cap, the $25 per-period fee and its gold-star/military-sacrifice/POW waivers, the $100 collector-vehicle one-time fee, the restricted-character non-renewal rule, availability for trailers/travel trailers/motorcycles, and transfer to a replacement vehicle"
+    notes: >-
+      PERSONALIZED PLATES. Modelled as its own series because the SERIAL SOURCE differs —
+      owner-chosen rather than department-assigned — which is a format property even
+      where the character frame is shared. North Dakota is one of the few states in this
+      group to legislate a SEPARATE, SMALLER cap for motorcycles (six rather than seven),
+      and to make a personalized plate available on PERMANENTLY registered collector
+      vehicles for a one-time fee, which is why the categories list includes trailers.
+
+  # =========================================================================
+  # ANTIQUE — a rolling forty-year threshold, permanent, and single-plate by an
+  # express override of the two-plate rule.
+  # =========================================================================
+  - id: us-nd-antique
+    class: historic
+    categories: [car, truck]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY. § 39-04-10.4(1) says the department 'shall design and
+        issue a distinctive number plate for this purpose' and specifies nothing about
+        the serial, so no arrangement is sourced. The regex is deliberately the wide
+        alphanumeric shape and `matching: recall-only` says so: a hit is a shape hit, not
+        a well-formedness claim for this series.
+    design:
+      note: "'a distinctive number plate' designed by the department (§ 39-04-10.4(1)); no colour, dimension or legend is stated in the Century Code"
+      emblem: { present: true, rendered: placeholder }
+    eligibility: "any motor vehicle AT LEAST FORTY YEARS OLD — a ROLLING threshold, so eligibility changes silently every year and this series needs re-auditing on a cadence that a fixed-cutoff regime would not"
+    validity: "permanently licensed on payment of a $10.00 registration fee (§ 39-04-10.4(1))"
+    year_of_manufacture_option: >-
+      § 39-04-10.4(1): in lieu of the distinctive plate the owner may, AT THE DIRECTOR'S
+      DISCRETION, display a number plate from the vehicle's year of manufacture — or, for
+      military vehicles, military identification numbers — provided it would not duplicate
+      a number in the department's records and is legible and restored to the department's
+      satisfaction. A year-of-manufacture regime means a lawfully displayed North Dakota
+      plate may belong to ANY historical series, which is a real trap for a parser: the
+      plate on the car is not evidence of the era of its registration.
+    display_override: "§ 39-04-10.4(1): 'Notwithstanding section 39-04-11, only one number plate needs to be displayed' — an express carve-out from the two-plate rule"
+    use_restriction: "vehicles registered under this section 'may not be used in the routine functions of a business or farming operation' (§ 39-04-10.4(1))"
+    region_encoding: none
+    sources:
+      - "https://ndlegis.gov/cencode/t39c04.pdf  # NDCC § 39-04-10.4(1): the forty-year rolling threshold, the $10 permanent registration, the department-designed distinctive plate, the year-of-manufacture and military-identification alternative with its duplication and legibility conditions, the single-plate override of § 39-04-11, and the business/farming use restriction; (2) the permanent personalized-plate alternative at a one-time $100 fee"
+    notes: >-
+      ANTIQUE MOTOR VEHICLES. North Dakota sets its historic threshold by a ROLLING forty
+      years, the opposite design choice to Florida's fixed model-year-1945 Horseless
+      Carriage cutoff — and a plates dataset must model both, because only the rolling
+      kind silently changes eligibility every year and needs re-auditing. The
+      year-of-manufacture option is the more consequential fact for the parse layer: it
+      means a currently valid North Dakota registration can be displayed on a plate from
+      any past series, so a period inference drawn from plate DESIGN is unsafe for this
+      class of vehicle.
+
+  # =========================================================================
+  # MANUFACTURER / FACTORY REPRESENTATIVE — bound to a person and a role, not to
+  # a vehicle, which is why `binding` is overridden here.
+  # =========================================================================
+  - id: us-nd-manufacturer
+    class: dealer
+    categories: [car, van, truck]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      pattern_note: "REPRESENTATIVE SHAPE ONLY. § 39-04-10.1 says the plate 'must be designed by the director' and states no serial grammar at all; the regex is the wide alphanumeric shape and `matching: recall-only` marks it as a shape hit."
+    design:
+      note: "'designed by the director' (§ 39-04-10.1); no design property is stated in the Century Code"
+      emblem: { present: true, rendered: placeholder }
+    binding: business
+    eligibility: "a RESIDENT FACTORY REPRESENTATIVE of a motor vehicle manufacturer, for the single vehicle used in the course of that employment; separately, a manufacturer of motor vehicles may use a manufacturer plate on its DEMONSTRATION vehicles, issued in the manufacturer's name and used solely for demonstration by the registrant or its designated employees"
+    fee: "$150.00 for a twelve-month period, prorated monthly if procured mid-period; procurement is IN LIEU OF any other registration fee, sales tax or use tax on the vehicle (§ 39-04-10.1)"
+    region_encoding: none
+    sources:
+      - "https://ndlegis.gov/cencode/t39c04.pdf  # NDCC § 39-04-10.1: the resident factory representative, the director-designed plate, the $150 twelve-month fee and monthly proration, the in-lieu-of-tax effect, the personal-use and single-vehicle restrictions, retention of the plate across replacement vehicles, and the separate manufacturer demonstration-vehicle entitlement"
+    notes: >-
+      MANUFACTURER PLATES. `binding: business` for the same reason as Germany's rote
+      Kennzeichen and Florida's dealer plate: the plate follows the representative or the
+      manufacturer, not a vehicle — § 39-04-10.1 says so twice, first by tying the plate
+      to the vehicle 'used by the factory representative in the course of employment' and
+      then by providing that on sale of that vehicle the plate is RETAINED and reused on
+      the replacement. CLASS CAVEAT: recorded as `dealer`, since _meta/classes.yml has no
+      `manufacturer` value and the dealer definition ('trade/garage plates bound to a
+      business, not a vehicle') fits the binding if not the trade — the same caveat
+      us-fl-manufacturer carries.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. No individual designs.
+  # =========================================================================
+  - id: us-nd-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "specialty plates carry ordinary serials on an alternative design; the § 39-04-12(1) grammar applies unchanged, and many North Dakota specialty series are additionally available personalized under § 39-04-10.3" }
+    design:
+      note: "one design per authorised program; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_statutory: 18
+      count_basis: >-
+        COUNTED FROM THE STATUTE, NOT FROM A BROCHURE — which makes this one of the few
+        defensible specialty counts in the group. Chapter 39-04 authorises specialty and
+        special-purpose plate programs in eighteen numbered sections: § 39-04-10 (amateur
+        radio), 10.1 (manufacturer), 10.2 (mobility-impaired), 10.3 (personalized), 10.4
+        (antique), 10.5 (prisoner of war), 10.6 (collector), 10.7 (farm vehicles), 10.8
+        (national guard), 10.9 (law enforcement), 10.10 (North Dakota veterans), 10.11
+        (firefighter's association), 10.12 (Future Farmers of America foundation), 10.13
+        (public or nonprofit organization), 10.14 (gold star), 10.15 (patriotic), 10.16
+        (volunteer emergency responders), 10.17 (military sacrifice), 10.18 (blackout).
+        Note the count is of AUTHORISING SECTIONS, not of designs: § 39-04-10.13 alone is
+        an open-ended public-or-nonprofit-organization program that can carry many
+        designs, so the number of DESIGNS is strictly greater and was not obtained.
+      count_caveat: >-
+        NDDOT publishes no specialty-plate count and no consolidated catalogue was
+        located, so no agency figure exists to reconcile against the statutory count. The
+        discrepancy between 'authorising sections' and 'designs offered' is recorded, not
+        resolved (PRD-PLATES §5.3 — disagreements are recorded, never averaged).
+      official_list_url: "https://www.dot.nd.gov/motor-vehicle/license-plates"
+      organization_program: "§ 39-04-10.13 is the open-ended door: a public or nonprofit organization may have a number plate authorised, which is the mechanism by which the catalogue grows without further legislation"
+    region_encoding: none
+    sources:
+      - "https://ndlegis.gov/cencode/t39c04.pdf  # NDCC §§ 39-04-10 through 39-04-10.18: the eighteen authorising sections counted above, including § 39-04-10.13's open-ended public/nonprofit organization program"
+      - "https://www.dot.nd.gov/motor-vehicle/license-plates  # NDDOT's license-plate index page — the official entry point; publishes no count and no consolidated specialty catalogue"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — one entry standing for the whole program, which is
+      what PRD-PLATES §2.5 asks for at this gate. North Dakota is the cleanest counting
+      case in group midwest-b because its programs are created by NUMBERED STATUTORY
+      SECTIONS rather than by departmental discretion, so the index can be counted from an
+      edict of government instead of from a marketing page. The honest caveat is recorded
+      in `count_caveat`: sections are not designs, and § 39-04-10.13 makes the design
+      count unbounded from the statute alone.
+      NOTE THE OVERLAP: us-nd-blackout above is one of these eighteen programs
+      (§ 39-04-10.18) and is broken out as its own series only because its colours are
+      legislated as VALUES. It is counted once here and specified once there.

--- a/plates/us-ne.yml
+++ b/plates/us-ne.yml
@@ -1,0 +1,483 @@
+# plates/us-ne.yml — Nebraska (PRD-PLATES gate L2, group midwest-b).
+#
+# NEBRASKA IS THE MOST STRUCTURALLY INTERESTING STATE IN THIS GROUP, and the
+# reason is that it runs TWO INCOMPATIBLE SERIAL SYSTEMS SIMULTANEOUSLY, split
+# geographically, with a sourced boundary between them:
+#
+#   * 90 counties issue COUNTY-DESIGNATION plates — a county prefix number, a
+#     hyphen, then the serial (the 1922 system, still running).
+#   * Douglas (1), Lancaster (2) and Sarpy (59) — the three most populous —
+#     converted to ALPHA/NUMERIC plates, `ABC 123`, as does the Department.
+#
+# That is not a historical footnote; it is live, and the DMV polices the seam.
+# The registration manual forbids a message plate spelling `ABC 123` ANYWHERE in
+# the state, "regardless of spacing", precisely because that shape is reserved to
+# the alpha/numeric counties and the Department. A parser that treats Nebraska as
+# one grammar will be wrong for 90 counties or for 3.
+#
+# THE COUNTY NUMBERS ARE NOT ARBITRARY AND THEIR ORIGIN IS SOURCED. The DMV's own
+# history page states that in 1922 the Department of Public Works assigned each
+# county a number BY ITS THEN-REGISTERED VEHICLE COUNT — Douglas most, hence 1;
+# Lancaster second, hence 2. So a Nebraska county prefix is a frozen 1922
+# population-proxy ranking, still printed on plates today, and Geoguessr-grade
+# decode data of a kind almost no other state offers.
+#
+# SOURCING NOTE: Nebraska's legislature site (nebraskalegislature.gov) was
+# UNREACHABLE for this pass — connection timeouts on every attempt, via two
+# clients. So §60-3,100 and its neighbours are cited here ONLY as they are
+# quoted by the DMV's own documents, never as though their text had been read.
+# What saves the entry is that Nebraska's DMV publishes unusually good primary
+# documents: a dated series catalogue, a 17,000-line county registration manual,
+# and an NLETS plate-type-code table with per-type FORMATS. Those are the sources.
+jurisdiction: us-ne
+authority:
+  name: Nebraska Department of Motor Vehicles (Nebraska DMV), Driver and Vehicle Records / Vehicle Title and Registration
+  url: "https://dmv.nebraska.gov/dvr/license-plates"
+binding: vehicle
+statute_edition: "Nebraska Revised Statutes Chapter 60 as CITED BY the Nebraska DMV's own 2023-series catalogue, registration manual and specialty-plate tables. THE STATUTE TEXT ITSELF WAS NOT READ: nebraskalegislature.gov timed out on every request in this pass (recorded gap). No section is quoted verbatim below."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    NEBRASKA WAS NOT LOCATED IN ANY COPYRIGHT SURVEY READ FOR THIS PASS. The Wikipedia
+    survey of subnational-government copyright status carries per-state sections for
+    seventeen states and NO section for Nebraska; no {{PD-NEGov}} tag was found on
+    Commons. The dossier's default therefore governs: 17 U.S.C. § 105 does not reach
+    the states, so a Nebraska plate design is presumed COPYRIGHTED unless Nebraska says
+    otherwise, and Nebraska has not been shown to say otherwise. Recorded as
+    unresearched rather than as adverse, because absence of a fetched source is weak
+    evidence in either direction.
+  edict_carve_out: >-
+    Nebraska is the WEAKEST edict carve-out in group midwest-b, and the reason is the
+    sourcing gap above: because the Revised Statutes could not be reached, this file
+    rests on DMV publications rather than on statutory text. Agency manuals are
+    government works but they are NOT edicts of government in the sense that makes
+    statutes and administrative codes uncopyrightable. Facts in them remain
+    uncopyrightable — which is the ground this file actually stands on — but their TEXT
+    is not free to reproduce, and none is reproduced at length here.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to every Nebraska plate graphic,
+    including the Husker mark, which carries a further layer: it is a UNIVERSITY mark,
+    plausibly trademarked and licensed to the state's program rather than owned by it.
+    Nothing about it is cleared. Render `emblem: {present: true, rendered: placeholder}`.
+    State-seal misuse statutes are unresearched for Nebraska.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): read to establish that Nebraska has NO section in the survey — a negative result, recorded as such"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA has no enforcement power; its declarative present is RECOMMENDED PRACTICE."
+  dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is PAYWALLED and UNPINNED. No J686 dimension is quoted anywhere in this file."
+  geometry_available: "AAMVA §2.1 (jurisdiction name top-centre between the bolt holes, >=0.25 in above the number, >=0.125 in from the top edge, characters 0.75-1.0 in) and §2.2 (characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom)."
+  retroreflectivity: "AAMVA §3.3: legible day and night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3; entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2."
+  replacement_cycle_recommendation: >-
+    AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. NEBRASKA SITS INSIDE
+    THAT RANGE AND IS THE ONLY STATE IN THIS GROUP WHOSE CYCLE CAN BE READ STRAIGHT OFF
+    ITS OWN DOCUMENT TITLES: the DMV catalogues are headed '2017-2023 License Plates'
+    and '2023-2029 License Plates', i.e. a SIX-YEAR issue cycle, comfortably tighter
+    than AAMVA's ceiling. That is a cycle evidenced by the agency's own publication
+    practice rather than by a statute this pass could reach.
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' is UNCITED in its Wikipedia source (a `citation needed` since 2017, copied across articles). Recorded as COMMONLY REPEATED, UNSOURCED. This file makes no Nebraska plate-dimension claim (recorded gap)."
+
+display_rules:
+  default: "TWO plates for passenger motor vehicles, per the plate counts printed against each type in the DMV's 2023-series catalogue and registration manual ('2 Plates')."
+  single_plate: "ONE plate for motorcycles, autocycles, minitrucks, trailers, cabin trailers, semitrailers and mobile homes, per the same catalogue ('1 Plate')."
+  front_plate_decal_option: >-
+    NEBRASKA'S GENUINE ODDITY, AND IT IS DATED. Per the DMV's history page: 'Beginning in
+    2017 owners of passenger vehicles not manufactured or equipped with a front license
+    plate bracket could opt to purchase a single plate decal to be displayed on the
+    driver side of the windshield in lieu of a front plate. Initially, the fee for the
+    purchase was $100.60 annually; effective September 1, 2019 the annual fee was reduced
+    to $50.60.' A paid WINDSCREEN DECAL standing in for a front plate is a display regime
+    no other state in this group has, and it means a Nebraska vehicle lawfully showing one
+    plate may still be a two-plate registration.
+  historical_plate_count: "Per the DMV history page: 'From 1903 to 1920 only a single plate was issued for each vehicle. In 1921 two plates were issued for each vehicle.'"
+  sources:
+    - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/plates/2023_Series_Plates.pdf  # Nebraska DMV, '2023-2029 License Plates', updated August 2023: per-type plate counts (2 Plates / 1 Plate) and the vehicle classes each type serves"
+    - "https://dmv.nebraska.gov/dvr/history-license-plates  # Nebraska DMV history: the 2017 front-plate decal option and its $100.60 -> $50.60 fee change effective 1 September 2019; single plate 1903-1920, two plates from 1921"
+
+series:
+
+  # =========================================================================
+  # STANDARD, SYSTEM A — the ALPHA/NUMERIC counties. This is the only Nebraska
+  # arrangement stated in so many words by an official document.
+  # =========================================================================
+  - id: us-ne-standard-alphanumeric-2023
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2023 }
+    period_evidence: agency-series-catalogue
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset:
+        notes: >-
+          THE ARRANGEMENT IS SOURCED BY A PROHIBITION, which is an unusual and rather
+          strong form of evidence. The DMV registration manual tells county officials that
+          a message plate cannot be issued in this shape: 'Due to the issuance of
+          alpha/numeric plates by Douglas, Lancaster and Sarpy counties and the
+          Department, messages containing three alpha followed by three numeric
+          characters (ABC 123) cannot be processed, regardless of spacing.' The
+          arrangement is therefore three letters then three numerals, and it is RESERVED
+          state-wide. Whether I/O/Q are skipped was NOT established (recorded gap).
+      pattern_note: >-
+        'regardless of spacing' in the source is why the separator is optional in the
+        regex: the DMV treats `ABC123` and `ABC 123` as the same reserved shape, which is
+        exactly the separator-forgiving equivalence PRD-PLATES §2.6 exists to make sound.
+      progression: "not established (recorded gap)"
+    design:
+      graphic: { present: true, rendered: placeholder, description: "the 2023-series Nebraska base graphic; the DMV catalogue carries designs as raster images and describes none of them in text" }
+      emblem: { present: true, rendered: placeholder }
+      colour_note: >-
+        NO HEX IS RECORDED. The Nebraska DMV's series catalogue is a picture book: it
+        shows every plate and describes no colour in words, and no Nebraska colour
+        specification in statute or administrative code was reached in this pass. Rather
+        than eyedrop a PDF raster and present the result as a fact, both colours are left
+        absent and recorded as a gap.
+    issuing_counties: "Douglas (county designation 1), Lancaster (2) and Sarpy (59) — the three most populous — plus the Department itself"
+    region_encoding: >-
+      NONE IN THE SERIAL, and that is the point of the conversion: an alpha/numeric
+      Nebraska plate has dropped the county prefix, so it encodes no geography at all.
+      Knowing a plate is alpha/numeric narrows the vehicle to Douglas, Lancaster, Sarpy
+      or a Department issue — a three-county disjunction, not a decode.
+    sources:
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/county/RegManual.pdf  # Nebraska DMV county registration manual, Chapter 9 (License Plates): the ABC 123 reservation, verbatim — 'messages containing three alpha followed by three numeric characters (ABC 123) cannot be processed, regardless of spacing', attributed to issuance by Douglas, Lancaster and Sarpy counties and the Department"
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/plates/2023_Series_Plates.pdf  # Nebraska DMV, '2023-2029 License Plates': the 'Alpha/Numeric (Douglas, Lancaster, Sarpy)' passenger type, 2 plates, citing Neb. Rev. Stat. §60-370(3)(c) and §60-3,100"
+    notes: >-
+      NEBRASKA STANDARD ISSUE, ALPHA/NUMERIC SYSTEM, 2023-2029 SERIES. This is the series
+      a visitor to Omaha or Lincoln actually sees, and it is the only one of Nebraska's
+      two live systems whose arrangement is stated by an official document. The period is
+      taken from the DMV catalogue's own title, '2023-2029 License Plates' — hence
+      `period_evidence: agency-series-catalogue`, a real claim about the issue window
+      rather than an instrument-in-force upper bound. The `end` is deliberately LEFT OPEN
+      even though the title implies 2029: a title stating an intended window is not the
+      same as evidence that issuance stopped, and old stock issues on.
+
+  # =========================================================================
+  # STANDARD, SYSTEM B — the 90 COUNTY-DESIGNATION counties. The 1922 system.
+  # =========================================================================
+  - id: us-ne-standard-county-2023
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2023 }
+    period_evidence: agency-series-catalogue
+    matching: recall-only
+    format:
+      pattern: "99-L999"
+      regex: '\A\d{1,2}-[A-Z0-9]{1,5}\z'
+      charset:
+        notes: >-
+          THE PREFIX IS SOURCED; THE SUFFIX IS NOT. That the plate opens with the county
+          designation number and a hyphen is established three separate ways: the DMV
+          catalogue's '(Non-alpha/numeric counties)' passenger type, the County Message
+          rule that spells the prefix-and-hyphen construction out, and the dealer plates
+          in the registration manual whose images read 94-B321 / 94-X123 / 94-14. What was
+          NOT obtained is the serial grammar that follows the hyphen for ordinary
+          passenger issues in each of the 90 counties. Hence `matching: recall-only`.
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY, on the nl-export precedent. The regex is deliberately
+        WIDER than anything Nebraska issues: it accepts any one- or two-digit prefix and
+        any one-to-five-character suffix, so a match says 'this string has the shape of a
+        Nebraska county-designation plate' and NOTHING MORE. It is emphatically not the
+        claim that the string is a valid registration. Narrowing this to the real
+        per-county grammar is the single highest-value follow-up for Nebraska.
+      width_rule_observed: >-
+        A STRUCTURAL RULE WORTH CHASING. In the one place Nebraska's grammar IS spelled
+        out — the County Message plates — the suffix width COMPENSATES for the prefix
+        width, so total length is constant: one-digit counties (Douglas 1, Lancaster 2)
+        take a longer suffix than the two-digit county (Sarpy 59). If that rule
+        generalises to the 90 county-designation counties, the per-county grammar is
+        derivable from the county number's digit count alone. Recorded as a HYPOTHESIS
+        drawn from a sourced instance, not as a claim.
+    design:
+      graphic: { present: true, rendered: placeholder, description: "the 2023-series Nebraska base graphic, shared with the alpha/numeric system" }
+      emblem: { present: true, rendered: placeholder }
+      colour_note: "no hex recorded — see us-ne-standard-alphanumeric-2023; the DMV catalogue describes no colour in text"
+    region_encoding:
+      mechanism: "the leading number, before the hyphen, is the COUNTY DESIGNATION — the county of registration, printed in the serial"
+      origin: >-
+        SOURCED TO THE AGENCY, WITH A DATE AND A RULE. Nebraska DMV, in its own words:
+        'In 1922, the Department of Public Works established the practice of using prefix
+        numbers to identify the counties in which vehicles were registered. Each county
+        was assigned a number based on the number of registered vehicles in the county at
+        that time. The county with the most vehicles, Douglas, was assigned the number 1;
+        the county with the second highest number of vehicles, Lancaster, was assigned
+        number 2; and so forth.' A Nebraska county prefix is therefore a FROZEN 1922
+        REGISTERED-VEHICLE RANKING — it does not track present-day population and must
+        never be re-derived from modern census data.
+      anchors_confirmed: { "1": Douglas, "2": Lancaster, "59": Sarpy, "94": "dealer / manufacturer (not a county)" }
+      anchors_basis: "1, 2 and 59 are stated in the DMV catalogue and registration manual repeatedly and independently; 94 is read off the dealer plate images in the registration manual"
+      range: "1 to 93 — Nebraska has 93 counties, of which 90 still use the county-designation system"
+      full_table_status: >-
+        DELIBERATELY NOT PUBLISHED HERE, AND THE REASON IS A MEASURED EXTRACTION FAULT. The
+        registration manual does carry a complete 'County Codes' table (Chapter 12), but
+        the text extracted from its three-column PDF layout renders BOTH 'Cass' and 'Clay'
+        as 30, which cannot be true. One of the two is a column misread. Publishing 93
+        decode rows off an extraction with a known collision would put a silent error into
+        a table consumers would trust, so the table is withheld pending a clean read and
+        recorded as the top follow-up. The four anchors above are published because each is
+        independently corroborated in running prose, not read out of the broken column.
+      decode_file_planned: "plates/_decode/us-ne-county-designations.yml once the table is re-extracted cleanly and verified row by row"
+      one_year_alpha_exception: "Per the DMV history page: 'For one year, 1951, the county number designation was changed from numeric to a one- or two-digit alpha code.' A single-year alpha county code is exactly the kind of one-off that breaks a naive historical parser."
+    sources:
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/plates/2023_Series_Plates.pdf  # Nebraska DMV, '2023-2029 License Plates': the 'Passenger (Non-alpha/numeric counties)' type 'Issued in the 90 non-alpha/numeric counties', 2 plates, citing Neb. Rev. Stat. §60-370 and §60-3,100"
+      - "https://dmv.nebraska.gov/dvr/history-license-plates  # Nebraska DMV history: the 1922 origin of county prefix numbers, assignment by registered-vehicle count, Douglas 1 and Lancaster 2, and the one-year 1951 alpha county code"
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/county/RegManual.pdf  # Nebraska DMV county registration manual: the County Codes table (Chapter 12) and the dealer plate images showing the 94- prefix"
+    notes: >-
+      NEBRASKA STANDARD ISSUE, COUNTY-DESIGNATION SYSTEM, 2023-2029 SERIES. Ninety of
+      Nebraska's ninety-three counties still print a 1922 ranking on every plate, which
+      makes this the most decode-rich standard series in group midwest-b and the reason
+      Nebraska deserved the longest header in it. The series is `recall-only` NOT because
+      Nebraska issues loosely but because this pass could not reach the grammar: the
+      Revised Statutes were unreachable and the DMV catalogue is pictorial. That is a
+      sourcing failure recorded honestly in the matching field, where a consumer will
+      actually see it, rather than hidden behind a confident-looking regex.
+
+  # =========================================================================
+  # ONE SERIES BACK — the 2017-2023 issue, from the DMV's own prior catalogue.
+  # =========================================================================
+  - id: us-ne-standard-2017
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2017, end: 2023 }
+    period_evidence: agency-series-catalogue
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A(?:[A-Z]{3} ?\d{3}|\d{1,2}-[A-Z0-9]{1,5})\z'
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY. This single entry stands for BOTH of Nebraska's
+        systems as they ran in the 2017-2023 issue, so its regex is the union of the
+        alpha/numeric and county-designation shapes and `matching: recall-only` is
+        mandatory: a hit is a shape hit across two grammars, never a validity claim for
+        either. The two systems are split into separate series only for the CURRENT issue,
+        where the evidence supports the split.
+    design:
+      graphic: { present: true, rendered: placeholder, description: "the 2017-series Nebraska base graphic; the DMV catalogue is pictorial and describes no design element in text" }
+      emblem: { present: true, rendered: placeholder }
+      colour_note: "no hex recorded — the 2017 catalogue, like the 2023 one, carries designs as raster images only"
+    structural_continuity: "The 2017 catalogue lists the SAME type structure as the 2023 one — 'Passenger (Non alpha/numeric counties)' and 'Alpha/Numeric (Douglas, Lancaster, Sarpy)', citing the same §60-370 / §60-3,100 / §60-370(3)(c) hooks — so the two-system split predates 2017 and was not introduced by either issue."
+    region_encoding: "county designation on the non-alpha/numeric plates, as for us-ne-standard-county-2023; none on the alpha/numeric plates"
+    sources:
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/plates/2017_Series_Plates-updated.pdf  # Nebraska DMV, '2017-2023 License Plates': the prior issue's title window, its passenger types for the 90 non-alpha/numeric counties and for Douglas/Lancaster/Sarpy, plate counts, and the same statutory hooks as the 2023 series"
+    notes: >-
+      THE ONE SERIES BACK, AND THE CLEANEST IN GROUP MIDWEST-B — because Nebraska's DMV
+      titles its catalogues by issue window, the previous series' period is read directly
+      off an agency document rather than reconstructed from collector-site era tables. The
+      pair '2017-2023' and '2023-2029' also establishes Nebraska's six-year cycle without
+      needing the statute. PERIOD NOTE: `end: 2023` overlaps the current series' `start:
+      2023` by design and by fact — a plate issued under the 2017 series remains valid and
+      on the road well past the changeover, which is exactly the parallel-issuance case
+      PRD-PLATES's overlap-legal-iff-distinct-notes rule exists to permit.
+
+  # =========================================================================
+  # COUNTY MESSAGE — the ONLY Nebraska serial grammar stated in full anywhere,
+  # and the evidence for the width-compensation rule noted above.
+  # =========================================================================
+  - id: us-ne-county-message
+    class: specialty
+    categories: [car, van, truck, trailer]
+    period: { start: 2023 }
+    period_evidence: agency-series-catalogue
+    matching: strict
+    format:
+      pattern: "1-LL99"
+      regex: '\A(?:[12]-[A-Z][A-Z0-9]\d{2}|59-[A-Z][A-Z0-9]\d{3})\z'
+      charset:
+        notes: >-
+          THE FULLY SOURCED GRAMMAR, verbatim from the registration manual: 'Passenger -
+          county designation (1 - Douglas; 2 - Lancaster, 59 - Sarpy), followed by a dash
+          (-), followed by one alpha character, one alpha/numeric character, and three
+          numeric characters for Sarpy county or two numeric characters for Douglas and
+          Lancaster'. Note the second character is expressly ALPHA/NUMERIC, which is why
+          the regex spells `[A-Z0-9]` there and not `[A-Z]`.
+      commercial_variant: >-
+        The same source gives the commercial grammar too: 'county designation ... followed
+        by a dash (-), followed by four numeric for Sarpy county and five numeric for
+        Douglas and Lancaster'. It is recorded here rather than given its own series
+        because it shares this series' period, design and program; a curator who prefers
+        the split can add it without disturbing this id.
+      pattern_note: >-
+        The pattern shows the DOUGLAS form (prefix 1). It cannot show the Sarpy form,
+        and the reason is a genuine limit of the human-pattern DSL rather than a choice:
+        `9` is the DSL's DIGIT TOKEN, so a literal digit 9 cannot be spelled in a
+        `pattern` at all, and `59-` is therefore unwritable. Every Nebraska designation
+        containing a 9 — 59 Sarpy, 94 dealer — hits this. The regex carries all three
+        counties regardless; the width compensation is visible in it directly, two prefix
+        digits buying three suffix digits and one prefix digit buying two.
+    design:
+      note: "'The plates use the same design as Nebraska current plate graphic or Husker Spirit graphic' (registration manual) — so this is a serial-and-eligibility program, not a distinct base design"
+      emblem: { present: true, rendered: placeholder }
+    eligibility: "residents of the three alpha/numeric counties ONLY, who elect to keep 'a format prior to their alpha/numeric conversion'; the registrant must live in the county the prefix names, and must SURRENDER the plate on moving to another county"
+    fee: "$40.00 regular graphic or $70.00 Husker graphic on re-application after a lapse; the message is held for one year only after delinquency, then released to the public (registration manual)"
+    region_encoding: "county designation 1, 2 or 59 in the serial — the ONLY live Nebraska series that puts a county number back onto an alpha/numeric-county vehicle"
+    sources:
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/county/RegManual.pdf  # Nebraska DMV county registration manual, Chapter 9: the passenger and commercial County Message grammars in full, the residency and surrender rules, the shared Nebraska/Husker graphics, the $40/$70 fees and the one-year message hold; cites Neb. Rev. Stat. §60-3,118 - §60-3,121"
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/plates/2023_Series_Plates.pdf  # Nebraska DMV, '2023-2029 License Plates': County Message, County Message Commercial, County Message Farm and County Message Trailer types, each 'issued in lieu of regular county plates', citing §60-3,118(2)(a)"
+    notes: >-
+      COUNTY MESSAGE PLATES — a nostalgia program with unusual evidentiary value. Its
+      function is to let a Douglas, Lancaster or Sarpy resident keep the OLD
+      county-designation look after their county converted to alpha/numeric, and because
+      the DMV had to tell county officials exactly what those legacy serials look like, it
+      is the one place Nebraska's county-designation grammar is written down in full. That
+      is what makes it the evidence base for the width-compensation hypothesis recorded on
+      us-ne-standard-county-2023. Modelled as `specialty` rather than `personalized`
+      because the DMV classes it as a specialty plate issued in lieu of regular county
+      plates, and because the county prefix is assigned, not chosen.
+
+  # =========================================================================
+  # MESSAGE (personalized) — with a charset EXCLUSION that is genuinely unusual.
+  # =========================================================================
+  - id: us-ne-message
+    class: personalized
+    categories: [car, van, truck, trailer, motorcycle]
+    period: { start: 2023 }
+    period_evidence: agency-series-catalogue
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z]{1,7}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        excluded_shapes: ["LLL 999"]
+        notes: >-
+          NEBRASKA EXCLUDES A SHAPE, NOT A LETTER, and that is rare enough to be worth the
+          field. From the registration manual: 'Maximum of 7 characters allowed [except
+          for motorcycle/autocycle (6 characters) and Gold Star Family (5 characters)
+          license plates]. Eight positions are provided to allow for one space if the
+          maximum numbers of characters are used in the message. (Note: A character cannot
+          be substituted for this space.)'; 'Alpha and numeric characters only. All alpha
+          characters are printed in upper case. No punctuation marks or symbols such as
+          slashes, periods, apostrophes or other such symbols are allowed'; and the
+          decisive one — 'messages containing three alpha followed by three numeric
+          characters (ABC 123) cannot be processed, regardless of spacing.' A vanity plate
+          may not impersonate the standard series.
+      pattern_note: "`regex` is the letters-only shape most message configurations take; `regex_statutory` is the true frame — up to seven alphanumerics across eight positions with at most one internal space. The ABC 999 exclusion is recorded in `charset.excluded_shapes` because a regex tier cannot express 'not this other series' without a lookahead the dataset's dialect avoids."
+    design:
+      note: "a message plate is a serial-source difference over the standard or an eligible specialty graphic; the DMV offers regular and Husker graphics"
+      emblem: { present: true, rendered: placeholder }
+    availability_service: "messages may be checked through the DMV's Online Specialty Plate System at clickdmv.ne.gov before application; the manual warns that availability 'is not a guarantee that the message will be approved'"
+    region_encoding: none
+    sources:
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/county/RegManual.pdf  # Nebraska DMV county registration manual, Chapter 9: the seven-character cap and its six-character motorcycle/autocycle and five-character Gold Star Family exceptions, the eight-position/one-space rule, the alpha-and-numeric-only uppercase rule, the ABC 123 prohibition 'regardless of spacing', and the clickdmv.ne.gov availability service"
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/plates/2023_Series_Specialty_Plate_Info_NLETS_Plate_Type_Codes.pdf  # Nebraska DMV, '2023 Series Specialty Plates / NLETS Plate Type Codes', August 2023: Message = 'Up to 7 characters selected by applicant', NLETS code PE"
+    notes: >-
+      MESSAGE PLATES (Nebraska's term for personalized). The interesting fact is the
+      NEGATIVE constraint: Nebraska forbids any message shaped like its own standard
+      alpha/numeric series, state-wide and independent of spacing. That is a jurisdiction
+      actively defending the disjointness of its serial spaces, and it is the cleanest
+      real-world justification in this whole dataset for PRD-PLATES §2.6's
+      separator-forgiving contract — the DMV itself reasons about `ABC123` and `ABC 123`
+      as the same string. Modelled as `personalized` because the serial is owner-chosen.
+
+  # =========================================================================
+  # DEALER — the second reserved number, and the counterpart to South Dakota's 77.
+  # =========================================================================
+  - id: us-ne-dealer
+    class: dealer
+    categories: [car, van, truck, trailer, motorcycle]
+    period: { start: 2023 }
+    period_evidence: agency-series-catalogue
+    matching: recall-only
+    format:
+      pattern: "99-L999"
+      regex: '\A\d{2}-[A-Z0-9]{1,5}\z'
+      charset:
+        designation_reserved: "94"
+        notes: >-
+          THE PREFIX IS THE FACT. Dealer plates in the registration manual carry serials
+          reading 94-B321, 94-X123 and 94-14 — a designation number OUTSIDE the 1-93
+          county range, occupying the county slot. Nebraska thus reserves 94 for the
+          trade exactly as South Dakota reserves 77 (SDCL 32-5-89), and a parser can tell
+          a Nebraska dealer plate from its prefix alone. The suffix grammar is NOT stated
+          and the three examples disagree in shape (one letter plus three digits; one
+          letter plus three digits; two digits), hence `matching: recall-only`.
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY, and the reserved 94 prefix is deliberately NOT in the
+        regex — not because it is unsourced, but because it is UNWRITABLE here. `9` is the
+        human-pattern DSL's digit token, so a literal 9 cannot appear in a `pattern`, and a
+        regex pinned to `94-` could never round-trip against any pattern the DSL can spell.
+        The sourced designation is therefore carried in `charset.designation_reserved` and
+        in `region_encoding` below, where a consumer will still find it, while the regex
+        stays deliberately wide and `matching: recall-only` says so. This is a real, small
+        limitation of the pattern DSL rather than a gap in the evidence, and it will recur
+        for any jurisdiction whose fixed prefix contains a 9.
+    design:
+      note: "the registration manual distinguishes Dealer, Dealer Personal-Use (alpha/numeric), Dealer Personal-Use (remaining 90 counties), Dealer Trailer and Dealer Motorcycle sub-types; only the 94- prefix is common to all and only it is recorded"
+      emblem: { present: true, rendered: placeholder }
+    binding: business
+    eligibility: "dealers and manufacturers licensed through the Nebraska Motor Vehicle Industry Licensing Board; the dealer presents a Treasurer's Certificate for Issuance of Dealer Plates to the county treasurer where the dealership is located"
+    plate_counts: "Dealer motor vehicle / motorcycle / trailer — 1 plate; Personal-Use — 2 plates"
+    fee: "first dealer plate $38.80 total, itemised across county fund, DMV registration, recreation road, highway trust motor vehicle registration, highway trust licence plate and EMS fund lines; dealer plate fees cannot be prorated for a partial year"
+    region_encoding: "designation 94 occupies the county-designation slot but denotes the TRADE, not a county — a decode table must exclude it or it will report a nonexistent 94th county"
+    sources:
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/county/RegManual.pdf  # Nebraska DMV county registration manual: the dealer plate images reading 94-B321 / 94-X123 / 94-14, the Dealer / Dealer Personal-Use / Dealer Trailer / Dealer Motorcycle sub-types with their plate counts, the Licensing Board and Treasurer's Certificate route, and the $38.80 first-plate fee schedule with its no-proration rule"
+    notes: >-
+      DEALER PLATES. `binding: business` because the plate follows the dealership, not a
+      vehicle. The fact worth carrying forward is the RESERVED DESIGNATION: Nebraska's 94
+      and South Dakota's statutory 77 are the same design idea in two states — put the
+      trade in the county slot, above the real county range — and a decode table that
+      treats the leading number as unconditionally geographic will mis-resolve every
+      dealer plate in both states. Recorded on both files for that reason.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Count and links only.
+  # =========================================================================
+  - id: us-ne-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2023 }
+    period_evidence: agency-series-catalogue
+    matching: recall-only
+    format:
+      pattern: "999LL"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY — and here the union is genuinely irreducible, because
+        the index stands for 42 programs with THREE different frames: 'Up to 7 characters'
+        (Message, County Message, Husker, Special Interest), 'Up to 5 characters' (most
+        organizational, cause and military plates), and FCC-assigned call signs (Amateur
+        Radio). The pattern shows the common assigned form the DMV writes as '123AB'.
+    design:
+      note: "one design per authorised program; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: 42
+      count_basis: >-
+        COUNTED ROW BY ROW from the Nebraska DMV's own '2023 Series Specialty Plates /
+        NLETS Plate Type Codes' table (August 2023) — 42 plate types, each carrying its
+        own format and NLETS code. This is a firmer count than most states allow, because
+        it is an operational law-enforcement reference rather than a marketing page: the
+        DMV has to keep it exact.
+      count_by_nlets_code: { PE: 21, OR: 11, CN: 4, VF: 3, AR: 1, CL: 1, DV: 1 }
+      nlets_codes_note: >-
+        THE NLETS CODE COLUMN IS THE FIND, and no competitor dataset carries it. NLETS is
+        the interstate law-enforcement telecommunications network, and these are the codes
+        by which a Nebraska plate type is transmitted between states: PE personalized, OR
+        organizational, CN conservation, VF veteran/military, AR amateur radio, CL
+        collegiate, DV disabled veteran. A plate-parse API that can return the NLETS type
+        alongside the jurisdiction and series is doing something genuinely new.
+      organizational_subtype: "11 of the 42 are 'Organizational' plates, which the document footnotes as requiring '250 prepaid applications from a certified non-profit organization required to initiate plate production' — a sourced barrier to entry that explains why the Nebraska catalogue grows slowly"
+      military_subtypes: "Military Honor plates are available for each service branch (Air Force, Army, Coast Guard, Marines, Army National Guard, Air National Guard, Navy and the Air Force, Army, Coast Guard, Marine Corps and Navy Reserves); Military Honor Campaign plates for the Afghanistan Campaign, Iraq Campaign, Global War on Terrorism Expeditionary, South Asia Service and Vietnam Service medals"
+      official_list_url: "https://dmv.nebraska.gov/dvr/license-plates"
+      official_catalogue_url: "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/plates/2023_Series_Plates.pdf"
+      official_format_table_url: "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/plates/2023_Series_Specialty_Plate_Info_NLETS_Plate_Type_Codes.pdf"
+      availability_service_url: "https://www.clickdmv.ne.gov"
+    region_encoding: "none, except the County Message family, which is broken out as its own series above"
+    sources:
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/plates/2023_Series_Specialty_Plate_Info_NLETS_Plate_Type_Codes.pdf  # Nebraska DMV, August 2023: the 42-row plate-type table with per-type character limits and NLETS codes; the 250-prepaid-application footnote for Organizational plates; the military branch and campaign-medal footnotes"
+      - "https://dmv.nebraska.gov/sites/dmv.nebraska.gov/files/doc/dvr/plates/2023_Series_Plates.pdf  # Nebraska DMV, '2023-2029 License Plates': the same programs shown as plates with their statutory hooks (§60-3,113 handicap, §60-3,118 message, §60-3,127/128 Husker, §60-3,255/256 Nebraska History)"
+      - "https://dmv.nebraska.gov/dvr/license-plates  # the DMV's license-plate index, the official entry point for the program list"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — one entry standing for the whole program, per
+      PRD-PLATES §2.5, with no individual designs. Nebraska is the best-instrumented
+      specialty index in group midwest-b for a reason worth generalising: the state
+      publishes its plate types as an NLETS CODE TABLE, i.e. as operational data for other
+      states' police systems, complete with per-type character limits. Any state that
+      publishes an NLETS plate-type table is publishing a machine-grade specialty index,
+      and that is a source class the remaining L2 states should be searched for by name.

--- a/plates/us-sd.yml
+++ b/plates/us-sd.yml
@@ -1,0 +1,428 @@
+# plates/us-sd.yml — South Dakota (PRD-PLATES gate L2, group midwest-b).
+#
+# SOUTH DAKOTA LEGISLATED ITS REDESIGN CADENCE, WHICH ALMOST NOBODY DOES. SDCL
+# 32-5-83, in seven words that matter more than their length suggests: the number
+# plates "shall be of different design each seven-year period". The US dossier
+# asked whether there is a redesign schedule anywhere in the United States and
+# concluded there is not — only per-state REPLACEMENT cycles. South Dakota is the
+# counter-example: not a replacement cycle for worn plates, but a standing
+# statutory duty that the DESIGN itself change every seven years. That single
+# provision is the most valuable thing in this file, because it means South
+# Dakota's series boundaries are, in principle, computable.
+#
+# THE SECOND SOUTH DAKOTA FIND is SDCL 32-5-89's closing words: dealer plates
+# "shall bear a distinctive number 77". South Dakota has 66 counties, so 77 sits
+# deliberately outside the county range — statutory proof that the leading number
+# on a South Dakota plate occupies a DESIGNATION slot, and that the slot has
+# reserved values. Nebraska does the identical thing with 94 for its dealers.
+#
+# WHAT THIS FILE WILL NOT DO is assert the county-number table. The
+# county-number system is universally reported and is strongly implied by the
+# statutes below, but no primary stating the county-to-number mapping was
+# obtained in this pass: the South Dakota Legislature's site serves individual
+# statutes but renders its chapter indexes as a JavaScript shell, and the
+# Department of Revenue's plate pages 404'd. `region_encoding` records exactly
+# what is proven and exactly what is not.
+jurisdiction: us-sd
+authority:
+  name: South Dakota Department of Revenue, Motor Vehicle Division (plates issued through the county treasurers)
+  url: "https://dor.sd.gov/individuals/motor-vehicle/"
+binding: vehicle
+statute_edition: "South Dakota Codified Laws Title 32, Chapter 32-5 (Registration and Taxation of Motor Vehicles), individual sections as served by sdlegislature.gov and fetched for this pass. SDCL 32-5-83 and 32-5-84 carry 2020 amendments (SL 2020, ch 135, §§ 1-2) and 32-5-85 a 2025 amendment (SL 2025, ch 44, § 15), so the design provisions read here are current."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    SOUTH DAKOTA WAS NOT LOCATED IN ANY COPYRIGHT SURVEY READ FOR THIS PASS. The Wikipedia
+    survey of subnational-government copyright status carries per-state sections for
+    seventeen states and NO section for South Dakota; no {{PD-SDGov}} tag was found on
+    Commons. The dossier's default therefore governs: 17 U.S.C. § 105 does not reach the
+    states, so a South Dakota plate design is presumed COPYRIGHTED unless South Dakota says
+    otherwise, and South Dakota has not been shown to say otherwise. Recorded as
+    unresearched, not adverse.
+  mount_rushmore_caution: >-
+    SOUTH DAKOTA CARRIES AN IP HAZARD NO OTHER STATE IN THIS GROUP HAS, and it is not a
+    state-copyright hazard at all. SDCL 32-5-88 authorises plates to bear 'a replica of the
+    Mount Rushmore National Memorial sculptured figures'. Mount Rushmore is a FEDERAL
+    memorial administered by the National Park Service and a SCULPTURAL WORK in its own
+    right, so a replica of it on a plate raises questions — about the sculpture, about NPS
+    marks, and about the memorial's name — that are entirely independent of whether South
+    Dakota claims copyright in its plate design. NONE of those questions was researched.
+    Flagged prominently because it is exactly the kind of layered exposure PRD-PLATES §3's
+    placeholder rule exists to sidestep, and because an unwary renderer would treat a
+    statutory authorization as a clearance. It is not one.
+  edict_carve_out: >-
+    Every format, design-cadence, plate-count and reflectorization claim in this file cites
+    the South Dakota Codified Laws. Edicts of government are uncopyrightable at every level
+    ({{PD-US-GovEdict}}), so the seven-year design duty, the two-plate rule, the dealer 77
+    and the reflectorization requirement are all affirmatively clean.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies with unusual force here — to the current
+    base graphic, and above all to the Mount Rushmore replica for the reasons above. Render
+    `emblem: {present: true, rendered: placeholder}` and do not render Mount Rushmore even
+    schematically until the federal-memorial question is researched. South Dakota state-seal
+    misuse statutes are unresearched.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): read to establish that South Dakota has NO section in the survey — a negative result, recorded as such"
+    - "https://sdlegislature.gov/api/Statutes/32-5-88.html  # SDCL 32-5-88, the Mount Rushmore replica authorization — an edict, PD, and the source of the layered non-copyright hazard recorded above"
+
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA has no enforcement power; its declarative present is RECOMMENDED PRACTICE."
+  dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is PAYWALLED and UNPINNED. No J686 dimension is quoted anywhere in this file. SDCL 32-5-89 delegates plate size to the department, which published no figure this pass could reach (recorded gap)."
+  geometry_available: "AAMVA §2.1 (jurisdiction name top-centre between the bolt holes, >=0.25 in above the number, >=0.125 in from the top edge, characters 0.75-1.0 in) and §2.2 (characters >=2.5 in high, >=0.25 in apart, stroke 0.2-0.4 in, >=1.25 in clear of top and bottom)."
+  retroreflectivity: "AAMVA §3.3: legible day and night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3; entrance angle 0.2 deg, observation angle -4 deg, minimum 45 cd/lx/m^2. SDCL 32-5-86 requires reflectorization but delegates its extent, method and degree to the department without stating a figure."
+  replacement_cycle_recommendation: >-
+    AAMVA §1.1 recommends a replacement cycle 'not to exceed 7 to 10 years'. SOUTH DAKOTA'S
+    SEVEN-YEAR RULE IS A DIFFERENT INSTRUMENT AND THE DISTINCTION MUST NOT BE COLLAPSED:
+    SDCL 32-5-83 requires a change of DESIGN every seven-year period, which is a duty about
+    what the plate LOOKS LIKE, not about when a worn plate is replaced. AAMVA's
+    recommendation is about retro-reflectivity decay. They coincide numerically at seven and
+    they are not the same rule — see `design_cycle` on us-sd-standard.
+  source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' is UNCITED in its Wikipedia source (a `citation needed` since 2017, copied across articles). Recorded as COMMONLY REPEATED, UNSOURCED. SDCL 32-5-89 delegates size to the department and states none, so this file makes no South Dakota dimension claim (recorded gap)."
+
+# ---------------------------------------------------------------------------
+# Display rules. Two plates, with a four-class single-plate list amended in 2025.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates. SDCL 32-5-85: 'Two number plates must be issued, except that as to a motorcycle, recreational vehicle, semitrailer, and trailer, as such terms are defined in § 32-3-1, one number plate must be issued.'"
+  single_plate_classes: ["motorcycle", "recreational vehicle", "semitrailer", "trailer"]
+  single_plate_note: "the RECREATIONAL VEHICLE entry is unusual — most states in this group give RVs two plates — and the class list was last amended by SL 2025, ch 44, § 15, so it is current to the 2025 session"
+  delivery: "SDCL 32-5-82: on receipt of a registration application the county treasurer or the department delivers 'two number plates or two number stickers, or both', bearing the distinctive number from the application; mailing fees under § 32-5-127, or actual postage and handling if express mailing is requested"
+  county_treasurer_stock: "SDCL 32-5-82 requires each county treasurer's office to stock: standard issue county motor vehicle and standard issue county motorcycle plates; emblem specialty plates under § 32-5-167; commercial trailer plates under § 32-5-8.1; and trailer plates"
+  display_position_status: >-
+    NOT ESTABLISHED. Chapter 32-5 as read here governs issuance rather than mounting; South
+    Dakota's display, position and mounting-height rules were not located in this pass and
+    are a recorded gap. No front/rear position claim is made.
+  sources:
+    - "https://sdlegislature.gov/api/Statutes/32-5-85.html  # SDCL 32-5-85: two plates, with motorcycle, recreational vehicle, semitrailer and trailer receiving one. Source: SL 2016, ch 157, § 1; SL 2025, ch 44, § 15"
+    - "https://sdlegislature.gov/api/Statutes/32-5-82.html  # SDCL 32-5-82: delivery of two plates or stickers bearing the § 32-5-81 distinctive number, mailing and express-mailing fees, and the four plate types every county treasurer's office must stock"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES — and the seven-year statutory design cadence.
+  # =========================================================================
+  - id: us-sd-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "99L999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){1,6}\z'
+      charset:
+        notes: >-
+          SDCL 32-5-84 is the whole statutory grammar and it is deliberately open: the plates
+          'shall be of metal or other suitable material bearing the name of the state, either
+          in full or by abbreviation and a distinctive number for assignment to each vehicle.
+          The distinctive number may be in figures or a combination of figures and letters and
+          shall be of a size clearly distinguishable by law enforcement officers and
+          individuals generally.' NO WIDTH, NO ARRANGEMENT and NO LETTER EXCLUSIONS are
+          stated. SDCL 32-5-89 then delegates everything physical: 'The size, design,
+          thickness of metal or material to be used, color, and general makeup of the number
+          plates for motor vehicles of all classifications shall be determined by the
+          department.'
+      pattern_note: >-
+        REPRESENTATIVE SHAPE ONLY, on the nl-export precedent. South Dakota's serial
+        arrangement is not in the Codified Laws — the statute delegates it — and no
+        departmental specification was reachable: the Department of Revenue's plate pages
+        404'd and the Legislature's chapter indexes render as a JavaScript shell. The pattern
+        shows a county-prefixed shape as a representative member of the space and NOT as a
+        claim; the regex is deliberately wide and `matching: recall-only` states that a hit
+        is a shape hit only.
+    design:
+      material: "metal or other suitable material (SDCL 32-5-84)"
+      contrast_rule: "SDCL 32-5-83: 'there shall be at all times a marked contrast between the color of the number plates and that of the numerals and letters on the plates'"
+      reflectorization: >-
+        SDCL 32-5-86: 'To reduce highway accidents at night all number plates authorized by
+        § 32-5-82 shall be reflectorized to an extent, under such method, and to a degree to
+        be maintained all during the service life of the plates as determined by the
+        department.' Note the duty runs for the SERVICE LIFE of the plate, not merely at
+        issue — a durability requirement rather than a specification.
+      manufacture: >-
+        SDCL 32-5-86 requires the department, in weighing reflectorization bids, to consider
+        'the practicability of manufacture of the plates in the license plate plant of the
+        STATE PENITENTIARY, and the durability of any material proposed by bidders', and to
+        eliminate any bid or process not deemed feasible. South Dakota states its
+        correctional-industries manufacture in the plainest terms of any state in this group;
+        Kansas reaches the same arrangement obliquely, via a K.S.A. 39-1208 contract.
+      mount_rushmore_option: >-
+        SDCL 32-5-88: the plates 'may have impressed thereon, in addition to the words and
+        numerals set forth in § 32-5-84, a replica of the Mount Rushmore National Memorial
+        sculptured figures; provided, that such replica can be reproduced on a motor vehicle
+        license plate so as to be easily discernible, and shall be satisfactory as to the cost
+        and feasibility thereof to the Governor, secretary of revenue, and warden of the state
+        penitentiary.' A design element authorised by statute, conditioned on legibility and
+        on the sign-off of three named officers including the prison warden who has to make
+        it. SEE `artwork_risk.mount_rushmore_caution` — this authorization is not a clearance.
+      colour_note: >-
+        NO HEX IS RECORDED. SDCL 32-5-83 mandates marked CONTRAST and 32-5-89 delegates COLOUR
+        to the department, which named no value this pass could reach. Recorded gap rather
+        than an eyedropped value.
+      emblem: { present: true, rendered: placeholder }
+    design_cycle:
+      years: 7
+      statutory_text: "SDCL 32-5-83: 'The number plates authorized by § 32-5-82 shall be of different design each seven-year period and there shall be at all times a marked contrast between the color of the number plates and that of the numerals and letters on the plates.'"
+      why_this_matters: >-
+        THIS IS THE ANSWER TO A QUESTION THE US DOSSIER RECORDED AS UNANSWERED. The dossier
+        surveyed US redesign cadence and concluded: 'Nothing resembling an official
+        cross-state changelog was found... AAMVA gives a recommended replacement cycle
+        (7-10 yr) but no design registry. States individually publish current designs only.'
+        South Dakota is the exception — a STANDING STATUTORY DUTY TO REDESIGN on a fixed
+        seven-year period, which is categorically different from a replacement cycle for worn
+        plates. Consequences for this dataset: South Dakota's series boundaries are periodic
+        by law, so the series history is enumerable once ONE boundary year is pinned, and a
+        South Dakota base that has run more than seven years is prima facie evidence of a
+        data error rather than of a long-lived design.
+      boundary_not_pinned: >-
+        AND YET NO BOUNDARY YEAR WAS OBTAINED, which is the frustrating half. Knowing the
+        period without knowing the phase yields nothing: seven-year steps from an unknown
+        origin do not locate a single boundary. `period.start` therefore remains an
+        instrument-in-force upper bound and the id remains undated. Pinning ONE South Dakota
+        issue year would unlock the entire series history by arithmetic — the single
+        highest-leverage follow-up anywhere in group midwest-b.
+      amendment_history: "SDCL 32-5-83's source line runs SDC 1939 § 44.0114 through SL 2020, ch 135, § 1 — the seven-year figure itself was last touched in 2010 (SL 2010, ch 154, § 1, eff. June 28, 2010) and 2020, so a session-law read of those two acts is the obvious route to the phase"
+    region_encoding:
+      mechanism: "a leading DESIGNATION NUMBER, widely reported to be the county of registration"
+      status: partially-proven
+      what_is_proven: >-
+        THAT A DESIGNATION-NUMBER SLOT EXISTS, AND THAT IT HAS RESERVED VALUES. SDCL 32-5-89
+        closes: 'The department shall also prescribe the plate to be used by the dealers for
+        demonstration purposes and for all motor vehicles registered by manufacturers or
+        dealers WHICH PLATES SHALL BEAR A DISTINCTIVE NUMBER 77.' South Dakota has 66
+        counties, so 77 is deliberately outside any county range. A statute that reserves a
+        specific number for the trade is a statute that presupposes a numbering scheme in
+        which other numbers mean something else. Additionally, SDCL 32-5-81 and 32-5-82 route
+        issuance through the COUNTY TREASURER and 32-5-82 requires each treasurer's office to
+        stock 'standard issue COUNTY motor vehicle and standard issue COUNTY motorcycle
+        license plates' — the statute's own phrase 'county ... license plates'.
+      what_is_not_proven: >-
+        THE MAPPING. No primary stating which number belongs to which county was obtained,
+        nor a statement that the leading number IS the county rather than some other
+        departmental designation. The county-to-number table is therefore NOT published here
+        and NOT asserted. It is universally reported in secondary sources; that is precisely
+        why asserting it without a primary would be the kind of laundering PRD-PLATES §4
+        forbids, and why 66 wrong decode rows would be worse than none.
+      reserved_values: { "77": "dealer, manufacturer and demonstration plates (SDCL 32-5-89) — statutory" }
+      cross_state_note: >-
+        Nebraska reserves 94 for its dealers in exactly the same slot, by DMV practice rather
+        than by statute. Two neighbouring states put the trade above the county range, and any
+        decode table treating the leading number as unconditionally geographic will
+        mis-resolve every dealer plate in both.
+      decode_file_planned: "plates/_decode/us-sd-county-designations.yml once a primary for the mapping is obtained"
+    sources:
+      - "https://sdlegislature.gov/api/Statutes/32-5-83.html  # SDCL 32-5-83: the seven-year design duty and the marked-contrast rule. Source line SDC 1939 § 44.0114 through SL 2010, ch 154, § 1 and SL 2020, ch 135, § 1"
+      - "https://sdlegislature.gov/api/Statutes/32-5-84.html  # SDCL 32-5-84: metal or other suitable material, the state name in full or abbreviated, the distinctive number in figures or figures-and-letters, and the legibility standard. Source through SL 2020, ch 135, § 2"
+      - "https://sdlegislature.gov/api/Statutes/32-5-86.html  # SDCL 32-5-86: reflectorization to a departmentally determined extent maintained through the plates' service life, and the state penitentiary plate plant in the bid-evaluation criteria"
+      - "https://sdlegislature.gov/api/Statutes/32-5-88.html  # SDCL 32-5-88: the optional Mount Rushmore replica, its discernibility condition and the Governor / secretary of revenue / penitentiary warden sign-off"
+      - "https://sdlegislature.gov/api/Statutes/32-5-89.html  # SDCL 32-5-89: departmental determination of size, design, thickness, colour and general makeup for all classifications, and the dealer plates' 'distinctive number 77'"
+      - "https://sdlegislature.gov/api/Statutes/32-5-81.html  # SDCL 32-5-81: county treasurer registration and issuance of a distinctive number plate, and the fuel-type declaration requirement"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1's recommended 7-10 year REPLACEMENT cycle, distinguished above from South Dakota's seven-year REDESIGN duty"
+    notes: >-
+      SOUTH DAKOTA STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED even though South Dakota is
+      the one state in this group whose series boundaries are fixed by law — because the law
+      fixes the PERIOD and not the PHASE, and a dated id built on an unpinned phase would be a
+      fabrication dressed as arithmetic. `start: 2025` is the instrument-in-force upper bound.
+      THE ONE SERIES BACK IS A RECORDED GAP for the same reason, and it is the most
+      recoverable gap in group midwest-b: one sourced issue year converts SDCL 32-5-83 into a
+      complete series history.
+      SOURCING NOTE: sdlegislature.gov serves individual statute sections cleanly at
+      /api/Statutes/<cite>.html but renders chapter indexes as a JavaScript shell, so sections
+      here were located by probing cites rather than by reading a table of contents. The
+      Department of Revenue's licence-plate pages returned 404. Both are recorded so a later
+      run knows the terrain.
+
+  # =========================================================================
+  # DEALER — the statutory 77, and the cleanest reserved-designation fact in the
+  # whole group.
+  # =========================================================================
+  - id: us-sd-dealer
+    class: dealer
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "77-L999"
+      regex: '\A77[- ]?[A-Z0-9]{1,5}\z'
+      charset:
+        designation_literal: "77"
+        notes: >-
+          SDCL 32-5-89, verbatim: the department 'shall also prescribe the plate to be used by
+          the dealers for demonstration purposes and for all motor vehicles registered by
+          manufacturers or dealers which plates shall bear a distinctive number 77.' The 77 is
+          STATUTORY and is fixed in the regex. What follows it is not stated anywhere — no
+          width, no arrangement, not even whether a separator is printed — hence
+          `matching: recall-only` and the optional separator class.
+      pattern_note: >-
+        The 77 is spellable as a literal here only because neither of its digits is 9; the
+        human-pattern DSL reserves 9 as its digit token, which is why Nebraska's reserved 94
+        could NOT be pinned the same way in us-ne-dealer. Same fact, two states, and the DSL
+        permits it in one and not the other — worth knowing when reading the two files
+        together. The separator is written as the sanctioned separator-only class `[- ]`
+        (PRD-PLATES §2.8) because the statute prescribes no glyph and the printed form was
+        not observed.
+    design:
+      note: "the dealer plate is prescribed by the department under SDCL 32-5-89; no design property beyond the 77 is stated in the Codified Laws"
+      emblem: { present: true, rendered: placeholder }
+    binding: business
+    eligibility: "dealers, for demonstration purposes, and all motor vehicles registered by manufacturers or dealers (SDCL 32-5-89)"
+    region_encoding: "designation 77 occupies the leading-number slot but denotes the TRADE, not a county — a decode table must exclude it or it will report a nonexistent 77th county in a 66-county state"
+    sources:
+      - "https://sdlegislature.gov/api/Statutes/32-5-89.html  # SDCL 32-5-89: dealer and manufacturer plates 'shall bear a distinctive number 77', alongside the department's power to determine size, design, thickness, colour and general makeup"
+    notes: >-
+      DEALER PLATES. `binding: business` on the standing reasoning that the plate follows the
+      trade rather than a vehicle. This is the cleanest reserved-designation fact in group
+      midwest-b — a legislature naming a specific number and handing it to the trade — and it
+      does double duty: it specifies this series AND it is the primary evidence, recorded on
+      us-sd-standard, that South Dakota's leading number is a designation slot at all.
+
+  # =========================================================================
+  # PERSONALIZED — a sourced character range, from statute and agency together.
+  # =========================================================================
+  - id: us-sd-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z]{1,7}\z'
+      charset:
+        min_characters: 1
+        max_characters: 7
+        notes: >-
+          South Dakota Department of Revenue, in its own words: 'Personalized plates can
+          consist of NO MORE THAN SEVEN LETTERS, NOR FEWER THAN ONE.' Note the agency says
+          LETTERS rather than characters — which is why `regex` here is letters-only and
+          carries no alphanumeric statutory twin, unlike its counterparts in Kansas, North
+          Dakota and Missouri. Whether digits are in fact permitted was not established
+          (recorded gap); the regex follows the agency's wording rather than widening it.
+      pattern_note: "the one-to-seven range is sourced directly and the alphabet follows the agency's own word 'letters'; this is the one personalized series in group midwest-b whose regex is narrower than a generic alphanumeric frame BECAUSE the source is narrower"
+    design:
+      note: "personalization is a serial-source difference over an eligible design; no distinct design is prescribed"
+      emblem: { present: true, rendered: placeholder }
+    eligibility: "an owner of a vehicle who is a resident of South Dakota (SD DOR)"
+    fee: "$25.00 annually for cars, trucks and motorhomes and $20.00 for motorcycles, plus the regular licence plate fee, plus a $12.00 mailing fee; application on form MV 1300"
+    content_policy: >-
+      'On September 14, 2023, the Department updated the personal license plate policy.' The
+      Department 'may refuse or recall previously issued personalized license plates', and
+      states that 'Standards have been set to help the Department review and either approve or
+      deny applications fairly and consistently.' The standards document itself was not
+      retrieved (recorded gap) — but the DATED policy update is a firm anchor for a later pass.
+    region_encoding: "not established — whether a personalized South Dakota plate retains a county designation was not determined (recorded gap); Kansas expressly preserves its county letters on vanity plates, and whether South Dakota does the same is unknown"
+    sources:
+      - "https://dor.sd.gov/individuals/motor-vehicle/cars-trucks-vans/personalized-specialty-plates/  # SD DOR: 'Personalized plates can consist of no more than seven letters, nor fewer than one'; the $25/$20 annual fees, the $12 mailing fee, form MV 1300, the 14 September 2023 policy update, and the Department's refusal and recall powers. Cites SDCL 32-5-89.2 and 32-5-89.3"
+    notes: >-
+      PERSONALIZED PLATES. Modelled as its own series because the SERIAL SOURCE differs —
+      owner-chosen rather than department-assigned. The entry is worth reading against its
+      neighbours for a sourcing reason rather than a substantive one: because the South Dakota
+      agency said 'letters' and not 'characters', this regex is letters-only and carries no
+      wider statutory twin, where Kansas, North Dakota and Missouri all get alphanumeric
+      frames from their statutes. The narrower regex is not greater confidence — it is
+      fidelity to a narrower source, and the gap is recorded. SDCL 32-5-89.2 and 32-5-89.3
+      themselves were not read (gap).
+
+  # =========================================================================
+  # TRIBAL — nine named tribes, statutory, and a genuine sovereignty wrinkle.
+  # =========================================================================
+  - id: us-sd-tribal
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){1,6}\z'
+      pattern_note: "REPRESENTATIVE SHAPE ONLY; neither SDCL 32-5-123 as summarised by the agency nor the agency page states a serial grammar for tribal plates, so the regex is wide and `matching: recall-only` follows"
+    design:
+      note: "one design per participating tribe; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+      emblem_caution: >-
+        TRIBAL EMBLEMS ARE A DISTINCT IP AND SOVEREIGNTY QUESTION, not a state-copyright one.
+        These are the marks of nine SOVEREIGN NATIONS appearing on a state-issued plate, and
+        nothing about their reproduction is cleared by anything in `artwork_risk` above, which
+        concerns South Dakota's posture only. Placeholder rendering is not merely the default
+        here but the only defensible option, and this is flagged as an open question rather
+        than an answered one.
+    participating_tribes: ["Cheyenne River Sioux Tribe", "Crow Creek Sioux Tribe", "Lower Brule Sioux Tribe", "Flandreau Santee Sioux Tribe", "Oglala Lakota Sioux Tribe", "Rosebud Sioux Tribe", "Sisseton-Wahpeton Sioux Tribe", "Standing Rock Sioux Tribe", "Yankton Sioux Tribe"]
+    eligibility: "ANY RESIDENT may obtain Indian tribal plates, on having registered the vehicle, paid the current year's county plate fees and supplied a copy of the current registration — note the agency states no tribal-membership requirement"
+    display_rule: "'The Indian tribal plates must be displayed on the vehicle IN PLACE OF the regular number plates' (SD DOR) — a substitute plate, not an addition"
+    fee: "$10.00 initial fee, no renewal fee, plus a $12.00 mailing fee; application on form MV-101"
+    region_encoding: "not established — whether tribal plates carry a county designation was not determined (recorded gap)"
+    sources:
+      - "https://dor.sd.gov/individuals/motor-vehicle/cars-trucks-vans/personalized-specialty-plates/  # SD DOR: the nine participating tribes, the any-resident eligibility rule, the in-place-of-regular-plates display requirement, the $10 initial and no-renewal fee structure, the $12 mailing fee and form MV-101. Cites SDCL 32-5-123"
+    notes: >-
+      TRIBAL PLATES. Included as a core distinct class because South Dakota separately
+      serialises and separately authorises it by statute, and because it is the most
+      substantively distinctive plate program in group midwest-b. CLASS CAVEAT: recorded as
+      `specialty`, since _meta/classes.yml has no tribal or sovereign-nation class — the fit
+      is poor and is flagged, because a tribal plate is not an 'optional-design program on
+      standard serials' in the way a cause plate is. If the vocabulary grows to accommodate
+      sovereign-nation issuance, this series should move; the id contract (PRD-QUALITY I-5)
+      keeps that safe. SDCL 32-5-123's own text was not read (gap).
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-sd-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){1,6}\z'
+      pattern_note: "REPRESENTATIVE SHAPE ONLY; the index stands for programs whose arrangements are not individually stated"
+    design:
+      note: "one design per authorised program; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: null
+      count_status: >-
+        NOT ESTABLISHED. No South Dakota specialty-plate count was obtained: the Department of
+        Revenue's licence-plate pages returned 404 and the Legislature's chapter index for
+        Title 32 renders as a JavaScript shell, so neither an agency figure nor a completed
+        statutory enumeration was reached. Recording null with an explicit status is better
+        than importing a secondary figure.
+      structural_facts_sourced: >-
+        WHAT IS SOURCED about the program: SDCL 32-5-167 authorises EMBLEM SPECIALTY PLATES
+        and SDCL 32-5-82 requires every county treasurer's office to stock them alongside
+        standard issue, which tells us emblem specialty plates are mainstream rather than
+        mail-order. And the SD DOR states a reissue rule with real dataset consequences —
+        CONSERVATION specialty plates 'must be reissued on a three-year cycle', a
+        program-specific cadence running independently of the state's seven-year design duty
+        under SDCL 32-5-83.
+      known_program_hooks: ["32-5-167 (emblem specialty plates)", "32-5-76 (person with substantial physical disability)", "32-5-77 (historical plates)", "32-5-89.2 and 32-5-89.3 (personalized)", "32-5-123 (tribal)"]
+      historical_plates_note: >-
+        SDCL 32-5-77 is titled 'Historical license plates--Application and fee--PERMANENT
+        PLATES--Use of vehicle restricted'. Its title alone establishes that South Dakota runs
+        a permanent historic-plate regime with a use restriction, which is enough to know the
+        class exists and NOT enough to specify it. No series is minted for it here; its text
+        was not read (recorded gap) and the L2 brief asks for sourced classes, not inferred
+        ones.
+      official_list_url: "https://dor.sd.gov/individuals/motor-vehicle/cars-trucks-vans/personalized-specialty-plates/"
+      dor_status: "the South Dakota DOR licence-plate landing pages under /all-vehicles-title-fees-registration/ returned 404 in this pass; the personalized-and-specialty page under /cars-trucks-vans/ resolved and is the working entry point"
+    region_encoding: "not established for specialty plates (recorded gap)"
+    sources:
+      - "https://sdlegislature.gov/api/Statutes/32-5-82.html  # SDCL 32-5-82: emblem specialty plates under § 32-5-167 among the four plate types every county treasurer's office must stock, alongside standard issue county motor vehicle and motorcycle plates, commercial trailer plates under § 32-5-8.1 and trailer plates"
+      - "https://dor.sd.gov/individuals/motor-vehicle/cars-trucks-vans/personalized-specialty-plates/  # SD DOR: the three-year reissue cycle for conservation specialty plates, the personalized and tribal programs and their statutory hooks"
+      - "https://sdlegislature.gov/api/Statutes/32-5-77.html  # SDCL 32-5-77: 'Historical license plates--Application and fee--Permanent plates--Use of vehicle restricted' — the existence and shape of the historic regime, whose text was not read"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — present as required by PRD-PLATES §2.5, CARRYING NO COUNT.
+      South Dakota joins Kansas and Minnesota as the three states in group midwest-b that
+      yielded no specialty figure, in each case because the issuing agency's pages were
+      unreachable or absent. The substantive find here is not a number but a CADENCE: South
+      Dakota runs at least two independent reissue clocks — the statutory seven-year design
+      duty over the standard plate (SDCL 32-5-83) and a three-year reissue cycle over
+      conservation specialty plates — so 'when does a South Dakota plate change' has different
+      answers for different programs, and a single per-state cadence field would be wrong.


### PR DESCRIPTION
**PRD-PLATES gate L2 (owner-directed acceleration; research parallel, application ordered — L1 landed first per §7.1).** One of eleven US regional-group PRs covering all 50 states + DC + territories (FL was the L0 pilot). Drafted to the `de.yml`/`nl.yml`/`us-fl.yml` standard: primary-law verbatim headers, instrument-dated periods, `strict`/`recall-only` matching tiers, folklore flagged not asserted, **`artwork_risk` recorded per jurisdiction with evidence** (PRD-PLATES §4).

**This PR — midwest-b:** MN IA MO ND SD NE KS (7 jurisdictions, 41 pinned primary sources).

**Verification:** researcher linted green in an isolated sandbox (proof file in the group dir, archived to the pipeline program dir); the driving session then independently staged ALL 55 wave files over pristine origin/main — `plates lint: 67 files, 604 series … OK` (385 new series; the _art gate stayed green) — and this branch is linted solo pre-push; CI runs the same gate.

**For the reviewer:** the dossier below carries the gaps (marked in the YAML at point of use), folklore flags, and the artwork_risk findings. The full research dossier follows verbatim.

---

# PRD-PLATES gate L2 — group midwest-b dossier

**States:** MN · IA · MO · ND · SD · NE · KS (7)
**Researcher pass:** 2026-08-02. **Method:** FETCH-NEVER-ASSUME. Every claim in the
seven YAML files traces to a URL fetched in this session, to the pinned dossier at
`vehiclesdb-pipeline/aux/research/plates-2026-07/plates-research-us-world.md`, or is
explicitly marked as a gap. WebSearch was unavailable (session budget exhausted at the
first call), so all discovery was by direct URL construction against known revisor /
legislature / agency URL schemes, plus link-mining of 404 pages.

**Deliverables:** `us-mn.yml` `us-ia.yml` `us-mo.yml` `us-nd.yml` `us-sd.yml` `us-ne.yml`
`us-ks.yml` in this directory. **Lint: GREEN** — 11 files / 110 series in an isolated
sandbox (the four L0 pilot files + these seven), `plates lint: OK`.

---

## 0. The three findings that should shape the rest of L2

**1. There IS a US state with a statutory REDESIGN cadence, and the US dossier said there
wasn't.** The dossier's §1.3 concluded: *"Nothing resembling an official cross-state
changelog was found... AAMVA gives a recommended replacement cycle (7–10 yr) but no design
registry. States individually publish current designs only."* **SDCL 32-5-83 is the
counter-example:** South Dakota number plates *"shall be of different design each
seven-year period."* That is a standing statutory duty about what the plate LOOKS LIKE,
categorically different from a replacement cycle for worn plates. It means South Dakota's
series boundaries are periodic **by law** — the series history is enumerable by arithmetic
the moment one boundary year is pinned. **Recommend amending the dossier's §1.3 finding.**

**2. Replacement/redesign cadence is not one field — this group contains five different
instruments.** Any schema that models "how often does this state's plate change" as a
single per-state number will be wrong for most of these states:

| state | instrument | value | kind |
|---|---|---|---|
| SD | SDCL 32-5-83 | 7 yr | **redesign** duty (design must differ) |
| MN | § 168.12 subd. 1(f)(2) | 7 yr | mandatory **replacement**, forward-looking trigger |
| KS | K.S.A. 8-132(b) | 5 yr | **reissue** cycle, extendable by rule 1 yr at a time, indefinitely |
| MO | RSMo 301.130.6(4) | ≥6 yr | a **floor**, no ceiling — plate age statutorily unbounded |
| NE | DMV catalogue titles | 6 yr | **issue window**, evidenced by agency publication practice |
| ND | — | none | no cycle legislated at all |
| IA | — | none | § 321.34(2)(a) reassigns plates indefinitely + annual sticker |

South Dakota additionally runs a *second, independent* clock: conservation specialty plates
reissue on a **three-year** cycle, so even within one state the answer differs by program.

**3. Two neighbouring states independently legislated that their series boundaries must be
visually detectable.** Iowa § 321.166(5): a new series *"shall be of a distinctively
different color from the series which is replaced"* (collegiate plates carved out). Kansas
K.S.A. 8-147(d): *"The director shall change the color of such license plates every time
new license plates are issued."* For this dataset that is a gift — in both states the series
history is in principle a **colour sequence**, so a single departmental colour list would
unlock an entire chain of base generations.

---

## 1. Per-state summary

### North Dakota — the best-sourced state in the group
NDDOT publishes, in prose on its own plate page, the introduction **month**, the **serial
format** and every design element of the current base. Almost no state does. Result: the only
series in the group carrying `period_evidence: agency-stated-date`.
- **Standard `us-nd-standard-2016`** — introduced **November 2016**; serial **`123 ABC`**;
  Badlands scene, bison, three wheat stalks, "Legendary" above the state name, "Peace Garden
  State" bottom-left; reflective aluminum. `matching: strict`.
- **The slogan is statutory** — NDCC § 39-04-12(1) *mandates* "Peace Garden State". Not a
  departmental choice.
- **Blackout `us-nd-blackout`** — § 39-04-10.18(2) fixes the colours as **VALUES**: *"a solid
  black background"* / *"white numbers and letters"*. **The only `hex_basis: statute` colours
  in the group.** $25/period; passenger, ≤20,000 lb truck, or motorcycle only.
- Also specified: personalized (7 chars, **6 for motorcycles**), antique (rolling **40 years**,
  permanent, **year-of-manufacture plates permitted**), manufacturer (`binding: business`).
- **Specialty index: 18 authorising statutory sections**, counted from the Century Code.

### Nebraska — the most structurally interesting
**Nebraska runs two incompatible serial systems simultaneously, split geographically**, and
the DMV polices the seam.
- **`us-ne-standard-alphanumeric-2023`** — Douglas (1), Lancaster (2), Sarpy (59) **and the
  Department**: `ABC 123`, `matching: strict`.
- **`us-ne-standard-county-2023`** — the other **90 counties**: county-designation number,
  hyphen, serial. `recall-only` (prefix sourced, suffix grammar not).
- **The arrangement is sourced by a PROHIBITION** — the registration manual forbids any
  message plate *"containing three alpha followed by three numeric characters (ABC 123)...
  regardless of spacing"*, because that shape is reserved. That "regardless of spacing" is
  the DMV independently reasoning exactly as PRD-PLATES §2.6's separator contract does.
- **County numbers = a frozen 1922 ranking.** DMV history page, verbatim: in 1922 each county
  was assigned a number *"based on the number of registered vehicles in the county at that
  time"* — Douglas most → 1, Lancaster second → 2. **Never re-derive from modern population.**
- **One series back is the cleanest in the group**: DMV catalogues titled **"2017-2023 License
  Plates"** and **"2023-2029 License Plates"** — period read straight off agency documents.
- **Specialty index: 42 plate types**, counted row-by-row from the DMV's **NLETS Plate Type
  Codes** table, with per-type character limits and NLETS codes (PE 21, OR 11, CN 4, VF 3,
  AR/CL/DV 1 each). **See §4 — this is a reusable source class.**

### Kansas — the only statutory serial arrangement in the group
- **K.S.A. 8-147(c) states the format in law**: *"Each license plate shall contain a
  combination of three letters followed by a combination of three numerals"* — plus a
  pre-authorised **exhaustion clause** for when that space is used up, which `regex_statutory`
  encodes. The cleanest tier-order case in the group: two tiers, two sentences of one statute.
- **Five-year reissue cycle, indefinitely extendable** (8-132(b)) — so a dataset counting
  five-year steps from 1975 would look confident and be wrong.
- **Rear-only with an express PROHIBITION on front plates**, and five exceptions — three of
  which move the plate to the front. A **personalized plate may lawfully sit on the front**
  where a standard plate may not.
- **Unresolved and recorded**: 8-132(d) refers to *"the letters required to designate the
  county"* — proving Kansas plates carry a county designator a vanity plate cannot displace,
  without saying what it looks like. **Nothing asserted.** ksrevenue.gov timed out on every
  attempt.

### Missouri — statutory legend, delegated serial, sourced width
- **"SHOW-ME STATE" is mandated** by RSMo 301.130.1, with exactly two displacements —
  **DISABLED VETERAN** and **NATIONAL GUARD** — each broken out as its own series.
- **Statutory aesthetic requirement**: plates *"shall be clearly visible at night, and shall
  be aesthetically attractive."* A legislature legislating attractiveness.
- **Six-character frame, sourced from the agency's own system**: `dor.mo.gov/js/platescript.js`
  backs the official plate-preview tool and enumerates **163 designs, every one capped at 6
  characters**. The **arrangement** is nowhere stated → `matching: recall-only`.
- **Specialty index: 163 designs** (7 standard / 32 collegiate / 49 military / 75
  organizational), counted from that machine-readable agency catalogue.
- **Replacement: a FLOOR** — *"at least six years"* — with no ceiling.

### Minnesota — most physically specific statute, least format-specific
- **§ 168.12 subd. 1(e)** is the most demanding plate spec in the group and it is legislated:
  *"at least 100 times brighter than the conventional painted number plates"*, visible at
  **1,500 feet**, readable at **110 feet**. Compare AAMVA §3.3's 75-foot legibility figure.
- **The plate encodes WEIGHT, not geography** — subd. 1(b): gross-weight-registered vehicles
  carry *"letters or other suitable insignia"* showing the maximum gross weight taxed. This
  is Minnesota's `region_encoding` entry; the letter→band mapping is a recorded gap.
- **Mandated negative legend**: subd. 1(c) requires *"noncommercial"* on noncommercial plates
  — which a special plate switches off, so its absence proves nothing.
- **§ 168.12 subd. 1(i): roadable aircraft get their FAA tail number** as the state
  registration number. Specified as `us-mn-roadable-aircraft`, `categories: [aircraft]` — a
  statutory bridge to the L6 aircraft layer, exercising schema kind-extensibility with **no
  schema change**. It is the **only series in the group with a `regex_strict`**, because
  14 CFR 47.15(b) supplies real charset exclusions (**I and O barred**, no leading zero).
- **Collector family** (Pioneer / Classic Car / Collector / Street Rod, § 168.10): one series,
  four legends — **no date on the plate, valid forever without renewal**.
- **Format and current base: NOT SOURCED.** § 168.12 delegates to the commissioner's rules;
  Minnesota Rules ch. 7410 turned out to be driver licensing, not plates; **mn.gov sits behind
  a ShieldSquare bot challenge** that refused every request. `recall-only`, gap recorded.

### Iowa — county on every plate, by statute, and three statutory serial affixes
- **§ 321.166(2): every county-treasurer-issued plate displays the county name** — stronger
  than Florida's (Iowa exempts plate TYPES, not counties; Florida lets a county commission opt
  out). **Readable but not decodable**: nothing in the serial.
- **Three sourced literals**: **`DV` PRECEDES** the number on disabled-veteran plates
  (§ 321.166(6)) → `strict`; dealer plates display **`D`** at serial size but the statute does
  **not** state its position (§ 321.166(3)) → `recall-only`, deliberately not pinned; special
  truck plates display **"special"** (§ 321.166(2)). *The legislature drew that distinction two
  subsections apart and the files honour it.*
- **Dimension is in Iowa law**: *"not to exceed six inches by twelve inches"* — a **ceiling**,
  where Florida states the same two numbers as **minima**. Iowa owes nothing to SAE J686 or to
  the 1956 folklore.
- **Blackout plates are statutory** (§ 321.34(11C)) and § 321.166(9) **exempts** them from the
  design-and-colour-consistency rule — a permission, not a colour. *Contrast North Dakota,
  which legislated the actual colours.*
- **Character bounds from administrative code**: min **2** characters (761-401.3(1)); emblem
  plates capped at **5** (761-401.3(2)) — the emblem slot costs characters.
- **Specialty index: 30 statutory subsections** of § 321.34, with an explicit caveat that
  § 321.34(13)'s open-ended nonprofit-decal program makes the DESIGN count unbounded.
- iowadot.gov returned **HTTP 403** on every request.

### South Dakota — the statutory redesign cadence, and the reserved 77
- **SDCL 32-5-83: different design every seven-year period** — see §0 finding 1.
- **SDCL 32-5-89: dealer plates *"shall bear a distinctive number 77."*** South Dakota has 66
  counties, so 77 sits deliberately outside the county range — **statutory proof that the
  leading number is a designation slot with reserved values**. `us-sd-dealer` pins it.
- **Mount Rushmore replica authorised** by SDCL 32-5-88, conditioned on discernibility and on
  sign-off by the Governor, the secretary of revenue **and the penitentiary warden** (who has
  to make it). **Flagged as a layered NON-copyright hazard** — a federal memorial and a
  sculptural work; a statutory authorization is **not** a clearance.
- **Penitentiary manufacture stated plainly** in 32-5-86's bid criteria.
- **County-number table deliberately NOT published** — see §3.

---

## 2. artwork_risk — the honest per-state picture

Only **two of seven** states appear anywhere in the copyright survey the US dossier treats as
its core analysis. The survey has per-state sections for AZ, CA, CO, FL, GA, IN, MA, MN, MO,
NJ, NY, NC, PA, RI, SC, UT, WA — **and none for IA, ND, SD, NE or KS.**

| state | posture recorded | evidence |
|---|---|---|
| **MN** | `contested-unresolved` | 1994 commissioner statement vs **1995 AG statement** that expressly confines it to *access*, not copyright; **Minn. Stat. § 13.03 subd. 5 fetched and read** — copyright authorised for **computer software only** |
| **MO** | `no-general-grant-default-copyright` | **Folklore corrected — see below** |
| IA, ND, SD, NE, KS | `unresearched` | not in the survey; no PD-*Gov Commons tag found. Default governs: §105 does not reach the states → presumed copyrighted |

**Folklore debunked (Missouri).** The survey glosses Missouri as *"executive departments may
hold copyright for works for hire"*, citing RSMo 630.095. **I fetched RSMo 630.095. It sits in
Chapter 630 — the DEPARTMENT OF MENTAL HEALTH** — and reads *"Copyrights and trademarks by
department. — The department may copyright or obtain a trademark for any instructional,
training and informational audio-visual materials, manuals..."* It is a grant to **one
department over its training materials**, not a general executive-branch power, and says
nothing about the Department of Revenue or licence plates. The other cited grant, RSMo 8.007,
is confined to the **State Capitol Commission**. Recorded in `us-mo.yml` under
`artwork_risk.folklore_corrected`.

**Textual correction (Minnesota).** The survey renders § 13.03 subd. 5 as *"may enforce
copyright"*; the Revisor's text reads *"may enforce **a** copyright"*. Immaterial to meaning,
recorded because the primary was read rather than trusted.

**The edict carve-out is what actually saves this group.** Every state here is unresearched or
worse on artwork, and it barely matters for the format layer: the arrangements, cadences,
legends, character bounds and colour-change duties are all in statutes and administrative
codes, which are **uncopyrightable at every level** (`{{PD-US-GovEdict}}`). Only the artwork is
exposed, and PRD-PLATES §3's placeholder rule already handles it.

**Three layered hazards flagged that are NOT state copyright:** SD's Mount Rushmore (federal
memorial + sculpture + NPS marks); SD's **tribal plates** (marks of **nine sovereign nations**
— nothing in a state posture clears them); NE's **Husker** mark and MO/IA's collegiate and
nonprofit decals (third-party trademarks licensed into state programs).

---

## 3. Gaps, stated plainly

**Serial arrangement not sourced (4 of 7): MN, MO, IA, SD.** All four statutes *delegate* the
format to the agency, and all four agency sites were unreachable (MN ShieldSquare challenge;
IA 403; SD DOR 404s; MO publishes a catalogue but no format spec). These four standard series
are `matching: recall-only` with a representative `pattern` + `pattern_note`, following the
`nl-export` precedent. **This is recorded in the `matching:` field where a consumer sees it,
not hidden behind a confident-looking regex.**

**One series back obtained for 1 of 7 — Nebraska only.** ND, KS, MO, MN, IA, SD all lack a
sourced previous base. **South Dakota is the most recoverable**: SDCL 32-5-83 fixes the
*period* (7 yr) but not the *phase*, so **one sourced issue year yields the entire series
history by arithmetic.** Route: the session laws behind SL 2010 ch 154 §1 and SL 2020 ch 135 §1.

**Specialty counts: 4 of 7 counted, 3 recorded as `null`.** ND 18 (statutory sections), IA 30
(statutory subsections), NE 42 (agency NLETS table), MO 163 (agency catalogue). **KS, MN, SD
carry `count_official: null` with an explicit `count_status`** — no figure was imported from a
secondary source.

**Nebraska county decode table WITHHELD, with cause.** The DMV registration manual carries a
complete 93-row County Codes table, but pdftotext on its three-column layout renders **both
"Cass" and "Clay" as 30** — a column misread. Publishing 93 decode rows off an extraction with
a known collision would put a silent error into a table consumers would trust. **Four anchors
published** (Douglas 1, Lancaster 2, Sarpy 59, dealer 94) because each is independently
corroborated in running prose. Re-extract cleanly → `_decode/us-ne-county-designations.yml`.

**South Dakota county-number mapping NOT asserted.** Universally reported; no primary obtained.
What IS proven: a designation slot exists and has reserved values (statutory dealer 77), and
SDCL 32-5-82 uses the phrase *"standard issue **county** motor vehicle... license plates"*.
The mapping itself is not published — 66 wrong decode rows would be worse than none.

**Kansas county letters unresolved** — existence proven by 8-132(d), form unknown.

**Nebraska statutes never read.** nebraskalegislature.gov **timed out on every attempt**, via
two clients. §60-3,100 and neighbours are cited **only as quoted by the DMV's own documents**,
never as though their text had been read; `statute_edition` says so. This is the group's
weakest sourcing footing and is flagged in that file's `artwork_risk.edict_carve_out`: agency
manuals are government works but **not edicts**, so Nebraska rests on facts-are-uncopyrightable
rather than on PD text.

**Other unread primaries** (each recorded in-file): MN § 169.79 (display rules — **so no
Minnesota front/rear claim is made**), MN § 168.12 subd. 2a, KS 8-172, MO 301.144, SD 32-5-77 /
32-5-89.2 / 32-5-89.3 / 32-5-123, IA 321.105.

---

## 4. Two things worth propagating to the rest of L2

**(a) Hunt for NLETS plate-type tables by name.** Nebraska's *"2023 Series Specialty Plates —
NLETS Plate Type Codes"* is an **operational law-enforcement reference**, not a marketing page:
42 rows, each with a **plate-number format** and an interstate NLETS type code. It is the single
best specialty-index source found in this group, and it exists because states must tell each
other's police what their plates look like. **Any state publishing one is publishing a
machine-grade specialty index with formats attached** — and no competitor dataset carries NLETS
codes at all. Search other states for this document class explicitly.

**(b) Mine 404 pages for site navigation.** Three agency sites (NE DMV, ND DOT, SD DOR) returned
404s **carrying full navigation**, and link-mining those 404 bodies is how the Nebraska series
PDFs and the ND plate page were found at all. When an agency site 404s, grep the body for
`href` before concluding the resource is gone.

**Environment notes for follow-up runs.** `nebraskalegislature.gov` and `ksrevenue.gov`: hard
timeouts. `mn.gov`: ShieldSquare bot challenge. `iowadot.gov`: 403. `sdlegislature.gov`: serves
individual statutes at `/api/Statutes/<cite>.html` but renders **chapter indexes as a Vue
shell** — probe cites directly. `legis.iowa.gov` serves clean statute **PDFs** at
`/docs/code/<sec>.pdf` and admin code at `/docs/iac/chapter/<ch>.pdf`. `revisor.mn.gov`,
`revisor.mo.gov`, `ksrevisor.gov`, `ndlegis.gov` (chapter PDFs) all respond well to plain curl.
**The dossier's pathological-grep warning is real** — a `grep -oE ".{0,1200}"` window on a 32 KB
file blew the 2-minute timeout, and a `.{0,900}` window hit ugrep's complexity limit. Split on
lines first.

---

## 5. Schema finding for the maintainer

**The human-pattern DSL cannot spell a literal digit `9`,** because `9` is the digit token
(`L` likewise for letters). This is not hypothetical — it bit twice in this group:

- **Nebraska's reserved dealer designation `94`** could not be pinned in the regex, because no
  DSL pattern can generate a string beginning `94-` for the round-trip to check. The sourced
  fact is carried in `charset.designation_reserved` and `region_encoding` instead, with
  `matching: recall-only`.
- **South Dakota's statutory dealer `77`** *could* be pinned (`pattern: "77-L999"`), purely
  because neither digit is a 9.

Same fact, two neighbouring states, encodable in one and not the other. It will recur for any
jurisdiction whose fixed prefix contains a 9. **Not proposed as a schema change** — the
workaround is honest and documented in both files — but the maintainer should know the DSL has
this blind spot before more county-prefix jurisdictions land at L2.

---

## 6. Verification pointers for the independent verifier

Highest-value re-derivations, in order:
1. **ND `us-nd-standard-2016`** — the only agency-stated date in the group. Re-read
   dot.nd.gov/motor-vehicle/license-plates and confirm "Introduced in November 2016" and
   `123 ABC`.
2. **KS `us-ks-standard`** — confirm K.S.A. 8-147(c)'s three-letters-then-three-numerals and
   that `regex_statutory` faithfully encodes the exhaustion clause.
3. **NE two-system split** — confirm the `ABC 123` reservation passage in the registration
   manual (Chapter 9) and the 1922 county-number origin on the DMV history page.
4. **SD 7-year redesign duty** — confirm SDCL 32-5-83 and, if possible, pin a phase.
5. **MO artwork_risk** — re-read RSMo 630.095 and confirm it is Mental Health only; this file
   contradicts a widely-copied secondary summary.
6. **The four `recall-only` standard series (MN, MO, IA, SD)** — these are the claims most
   likely to be improvable, and each is a sourcing gap rather than a judgement call.
