### PR TITLE
plates: us south-central — TX OK AR LA (L2 US wave)

### DIFF
--- a/plates/us-ar.yml
+++ b/plates/us-ar.yml
@@ -1,0 +1,427 @@
+# plates/us-ar.yml — Arkansas (PRD-PLATES gate L2, group: southcentral).
+#
+# READ THIS BEFORE TRUSTING ANY CLAIM IN THIS FILE. Arkansas is the WEAKEST-
+# SOURCED state in the southcentral group, and the reason is structural rather
+# than lazy: THE ARKANSAS CODE IS NOT FREELY FETCHABLE. Arkansas publishes its
+# code through LexisNexis — the "Arkansas Code" link in the state's own portal
+# navigation points at `advance.lexis.com/container?config=...`, a JavaScript
+# application behind a session — and every free reproduction tried in this pass
+# (law.justia.com, codes.findlaw.com) returned HTTP 403 behind Cloudflare. So
+# unlike Texas (Chapter 504 read in full), Oklahoma (Title 47 read in full) and
+# Louisiana (the OMV policy manual read in full), NOT ONE WORD OF ARKANSAS
+# STATUTE IS QUOTED BELOW. Everything here rests on the DFA — the issuing
+# authority, which is a primary source in its own right under PRD-PLATES §4 —
+# or is explicitly marked locator-grade.
+#
+# THAT IS ITSELF A FINDING, and it belongs in the record: edicts of government
+# are public domain at every level, which means Arkansas's statutes are PD by
+# law while being, in practice, unreachable without a commercial subscription.
+# The rights position and the access position have come apart. A verifier with
+# Lexis access closes most of the gaps in this file in an afternoon; a verifier
+# without it cannot, and no amount of care substitutes for the text.
+#
+# WHAT ARKANSAS IS ACTUALLY INTERESTING FOR: it is the counterexample to the
+# assumption that a new serial format means a new plate. The Arkansas base
+# design has been unchanged since MARCH 2006 — a twenty-year-old current base,
+# in the same league as the "oldest designs still in use" list the US dossier
+# records (Delaware 1959, Colorado 1960, DC 1975, Minnesota 1978, North Carolina
+# 1982) — while the serial ARRANGEMENT changed underneath it in April 2021 when
+# the numeric-first space ran out. Under PRD-PLATES §2.3 ("own series iff format
+# OR design OR period differs") that is two series on one design, and modelling
+# it any other way would let a parse API date an Arkansas plate fifteen years
+# wrong.
+jurisdiction: us-ar
+authority:
+  name: Arkansas Department of Finance and Administration (DFA), Office of Motor Vehicle
+  url: "https://www.dfa.arkansas.gov/office/motor-vehicle/"
+binding: vehicle
+statute_edition: "NONE READ. The Arkansas Code (Title 27, Transportation, subtitle 4, ch. 14 — Motor Vehicle Registration and Licensing) is published through LexisNexis and was not obtainable by fetch in this pass. See the header. Every statutory reference below is a POINTER, not a quotation."
+statute_access_note: >-
+  Attempted and failed: advance.lexis.com (JS container, session-gated, linked as
+  "Arkansas Code" from portal.arkansas.gov's own navigation); law.justia.com
+  (HTTP 403, Cloudflare interstitial); codes.findlaw.com (HTTP 403);
+  arkleg.state.ar.us FTPDocument paths (42-byte empty responses). Recorded so the
+  next pass does not repeat the same four dead ends.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: no-pd-rule-found-default-copyrighted
+  basis: >-
+    ADVERSE BY DEFAULT. 17 U.S.C. §105 does not reach the states, so an Arkansas
+    plate design is copyrighted unless Arkansas says otherwise, and no Arkansas
+    instrument saying otherwise was located: Arkansas does not appear in the
+    favourable column of the US dossier's per-state table, and no {{PD-ARGov}}
+    tag was found in the sampled Commons set. What was found is a general portal
+    assertion rather than a plate-specific one — the Arkansas.gov footer reads
+    "Copyright 2026. All Rights Reserved, Arkansas.gov", and the portal's
+    acceptable-use terms state "You may not capture Arkansas.gov pages within
+    frames or present Arkansas.gov content as your own." Those bind web content,
+    not plate designs, and are recorded as posture evidence only.
+  contractor_wrinkle: >-
+    A complication no other state in this group has. The Arkansas.gov portal is
+    operated by TYLER TECHNOLOGIES (the DMCA designated agent named in the
+    acceptable-use terms is "Tyler Technologies, Inc., Attention: Chief Legal
+    Council, 1 Tyler Drive, Yarmouth, ME"), and the plates themselves are
+    reported to be manufactured by WALDALE MANUFACTURING LIMITED of Amherst,
+    Nova Scotia — a private Canadian contractor, where Texas uses its own prison
+    industries. Where a private contractor draws or manufactures a state design,
+    "is this a state work?" stops being the only question. Flagged, not resolved.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to the DIAMOND graphic that has
+    sat in the centre of the Arkansas base since 2006 (the diamond is an
+    Arkansas state symbol — the state is the only US diamond producer — so the
+    state-symbol regime, independent of copyright, is in play and is
+    unresearched). Render `emblem: {present: true, rendered: placeholder}`.
+  sources:
+    - "https://portal.arkansas.gov/v/acceptable-use/  # Arkansas.gov acceptable-use and legal notices: 'Copyright 2026. All Rights Reserved, Arkansas.gov'; the no-framing / no-passing-off rule; Tyler Technologies as DMCA designated agent"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): §105 does not reach the states; Arkansas is not listed among the states with a favourable rule — used to evidence an ABSENCE"
+
+# ---------------------------------------------------------------------------
+# The US standards chain — recorded once per US file (see us-fl.yml).
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; AAMVA has no enforcement power."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is paywalled and UNPINNED; no J686 dimension is quoted anywhere in this dataset."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of the top and bottom edges"
+    replacement_cycle: "AAMVA §1.1 recommends a rolling or full replacement cycle 'not to exceed 7 to 10 years'. NO ARKANSAS REPLACEMENT CYCLE WAS FOUND, and on the evidence there is none: the current base has been issued continuously since March 2006, which is twenty years and twice AAMVA's outer bound. Recorded as an apparent absence, not as a sourced absence."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' remains COMMONLY REPEATED, UNSOURCED (PRD-PLATES §4). The Arkansas locator repeats it with the same unobtained ALPCA magazine citation the Texas article uses, and adds a genuinely interesting detail that is worth chasing to a primary one day: that Arkansas's 1947, 1952 and 1955 issues were already 6 x 12 in but had NON-STANDARD MOUNTING HOLES, so the 1956 issue was the first to comply fully. If true, that is evidence the 1956 convention was about bolt spacing as much as about size — which is exactly what AAMVA §3.1 still delegates to J686 today."
+
+# ---------------------------------------------------------------------------
+# Display rules. Recorded thinly and honestly, because the Arkansas Code was
+# unreachable and the DFA site does not restate the display rule.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "ONE plate, rear."
+  basis: locator-unconfirmed
+  note: >-
+    The claim "Only rear plates have been required since 1944" comes from a
+    LOCATOR and could not be traced to Arkansas Code § 27-14-716 or to any DFA
+    page in this pass. It is recorded because a display model needs a value and
+    because the claim is consistent with every Arkansas plate image in the
+    locator's tables, but it is NOT sourced and must not be published as though
+    it were. This is the single most-used fact in the file with the weakest
+    support; a verifier should close it first.
+  sources:
+    - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Arkansas  # LOCATOR ONLY (PRD-PLATES §4): 'Only rear plates have been required since 1944.' Not asserted as sourced; the underlying Arkansas Code section was not obtainable."
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES — a new ARRANGEMENT on a twenty-year-old
+  # DESIGN.
+  # =========================================================================
+  - id: us-ar-standard
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2021 }
+    period_evidence: locator-unconfirmed
+    matching: strict
+    format:
+      pattern: "LLL 99L"
+      regex: '\A[A-Z]{3} ?\d{2}[A-Z]\z'
+      serial_basis: locator-unconfirmed
+      charset:
+        notes: >-
+          NO ARKANSAS INSTRUMENT STATING AN ALPHABET OR A LENGTH WAS OBTAINED,
+          because the Code was unreachable and the DFA publishes no format page.
+          The arrangement recorded here — three letters, two numerals, one
+          letter — is locator-grade and is labelled as such throughout. It is
+          NOT given a `regex_strict`, because PRD-PLATES §2.7 reserves that tier
+          for the authority's own alphabet and Arkansas has published none.
+        excluded_reported: ["Q"]
+        excluded_basis: locator-unconfirmed
+        excluded_note: >-
+          Q is reported unused in Arkansas serials since 1968; U and V are
+          reported dropped from 1973 and ADDED BACK IN 2015, which is an unusual
+          direction of travel (most states shed letters over time and never
+          restore them) and is worth verifying precisely because it is unusual.
+          Recorded, not asserted.
+      progression: "reported AAA 01A onward, reaching BJA 95D as of 2025-10-31 (locator). Note this begins at AAA, i.e. the 2021 arrangement RESTARTED the alphabet rather than continuing the previous sequence — the opposite of Oklahoma, whose serials run straight through a base change."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      material: "aluminium; reported manufactured by Waldale Manufacturing Limited, Amherst, Nova Scotia (locator)"
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO HEX ASSERTED. The base is reported as an embossed black serial on a
+        reflective gradient sky-blue-and-white field with a diamond graphic
+        screened in the centre, "Arkansas" in dark red at the top and "The
+        Natural State" in dark red at the bottom. All of that is locator
+        description; no DFA colour spec was obtained and the Code was unreachable.
+      legend_top: "Arkansas"
+      legend_bottom: "The Natural State"
+      graphic: { present: true, rendered: placeholder, description: "diamond, centred — an Arkansas state symbol; not reproduced (see artwork_risk.emblem_rule)" }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    region_encoding: none
+    region_encoding_note: "no geographic encoding in the serial and none reported historically; Arkansas is the plainest of the four states in this group on that axis."
+    sources:
+      - "https://www.dfa.arkansas.gov/office/motor-vehicle/  # the issuing authority: DFA Office of Motor Vehicle, the body that issues and administers Arkansas plates"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Arkansas  # LOCATOR ONLY (PRD-PLATES §4): the ABC 12D arrangement from April 2021, the AAA 01A to BJA 95D range as of 2025-10-31, the 2006 base design and its diamond graphic, the Q/U/V exclusions and the 2015 restoration of U and V, 12 x 6 in aluminium, Waldale manufacture. Wikipedia's own citation for the range is licenseplates.cc, a collector site. Nothing here is asserted as sourced."
+    notes: >-
+      ARKANSAS CURRENT ISSUE — SAME PLATE, NEW NUMBER SHAPE. The modelling
+      decision to record is why this is its own series rather than a note on the
+      2006 entry: PRD-PLATES §2.3 makes a format difference sufficient on its
+      own, and here the format is the ONLY difference — same design, same
+      slogan, same graphic, same everything visible except the arrangement of the
+      characters. A dataset that keyed series to base designs would have one
+      Arkansas series covering twenty years and no way to date a plate; keying to
+      format gives a 2006/2021 boundary that is actually useful to a parser. The
+      cost is that the boundary itself is locator-grade, and it is labelled that
+      way rather than dressed up.
+
+  # =========================================================================
+  # ONE SERIES BACK — the same design with the numeric-first arrangement.
+  # =========================================================================
+  - id: us-ar-standard-2006
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2006, end: 2021 }
+    period_evidence: locator-unconfirmed
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      serial_basis: locator-unconfirmed
+      charset:
+        notes: "three numerals then three letters. Same absence of any published Arkansas alphabet as the current series; U and V are reported re-admitted to the alphabet part-way through this series' life, in 2015 (locator)."
+        excluded_reported: ["Q"]
+        excluded_basis: locator-unconfirmed
+      progression: "reported 001 KPG to 999 ZZZ (locator) — i.e. this arrangement CONTINUED the sequence of the 1996-2006 series rather than restarting it, which is why the base change of March 2006 is invisible in the serial and the format change of 2021 is not."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      background: { finish: retroreflective }
+      colour_note: "IDENTICAL to the current series — reflective gradient sky blue and white, centred diamond, dark red 'Arkansas' and 'The Natural State'. The design did not change in 2021; only the serial did."
+      legend_top: "Arkansas"
+      legend_bottom: "The Natural State"
+      graphic: { present: true, rendered: placeholder, description: "diamond, centred" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://www.dfa.arkansas.gov/office/motor-vehicle/  # the issuing authority"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Arkansas  # LOCATOR ONLY: the March 2006 base introduction, the 123 ABC arrangement, the 001 KPG to 999 ZZZ range, and the April 2021 arrangement change that ends this series"
+    notes: >-
+      THE 2006 ARRANGEMENT. Worth stating plainly for anyone reading the two
+      Arkansas standard series side by side: the DESIGN spans both and has been
+      current since March 2006, which puts Arkansas within reach of the
+      "oldest designs still in use" group the US dossier lists (Delaware 1959,
+      Colorado 1960, DC 1975, Minnesota 1978, North Carolina 1982). If the
+      Arkansas base survives to 2036 it belongs on that list outright. The
+      series split here is a SERIAL boundary, and the file says so in both
+      directions so that no consumer mistakes it for a redesign.
+
+  # =========================================================================
+  # MOTORCYCLE — separately serialized, and on its own arrangement.
+  # =========================================================================
+  - id: us-ar-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2015 }
+    period_evidence: locator-unconfirmed
+    matching: strict
+    format:
+      pattern: "999 LL"
+      regex: '\A\d{3} ?[A-Z]{2}\z'
+      serial_basis: locator-unconfirmed
+      charset: { notes: "three numerals then two letters, on a reduced-size plate. Arkansas has run motorcycle serials on their own sequence since at least 1979, cycling through AB 12, 12 AB, AB 123 and now 123 AB — a state that has repeatedly exhausted a five-character motorcycle space." }
+      progression: "reported 001 AA to 537 EF as of 2021-10-25 (locator)"
+    design:
+      plate: { unit: in, note: "reduced motorcycle size; no dimension obtained from any Arkansas source" }
+      background: { finish: retroreflective }
+      legend_top: "ARK. M CYCLE"
+      legend_basis: locator-unconfirmed
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    registration_note: "all Arkansas motorcycle plates expired on 30 June until 1994, when staggered registration was introduced (locator) — a rare, datable administrative fact about a non-passenger class."
+    region_encoding: none
+    sources:
+      - "https://www.dfa.arkansas.gov/office/motor-vehicle/  # the issuing authority for all Arkansas plate classes"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Arkansas  # LOCATOR ONLY: the 123 AB arrangement from 2015, the 001 AA to 537 EF range, the 'ARK. M CYCLE' legend, and the 1994 move to staggered registration"
+    notes: >-
+      ARKANSAS MOTORCYCLE. Included because L2 names motorcycle as a core class
+      and because Arkansas plainly serializes it separately — the sequence has
+      cycled through four distinct arrangements since 1979, which is only
+      possible on an independent numbering space. Everything about the format is
+      locator-grade and is labelled so. Note the contrast with Texas, where a
+      motorcycle plate certainly exists (§ 504.943(b) makes motorcycles a
+      one-plate class) but no arrangement could be obtained at all, so no series
+      was minted.
+
+  # =========================================================================
+  # TRAILER — Arkansas issues PERMANENT trailer plates, split by tow class.
+  # =========================================================================
+  - id: us-ar-trailer-permanent
+    class: trailer
+    categories: [trailer]
+    period: { start: 2006 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "L999999"
+      regex: '\A[A-Z]{1,2} ?\d{5,6}\z'
+      serial_basis: locator-unconfirmed
+      charset:
+        notes: >-
+          A letter-prefix plus a six-digit block. The interesting fact is that
+          the PREFIX ENCODES THE TOWING CLASS rather than a region or a year:
+          A/B-prefixed permanent trailer plates are reported for trailers hauled
+          by automobiles and class 1 trucks, and PT-prefixed plates for trailers
+          hauled by class 2 through 8 trucks, on a visibly different colour
+          scheme (blue on tan rather than black on white). An S/P prefix is
+          reported as an unidentified third permanent-trailer classification.
+          The regex accepts one or two prefix letters and five or six digits to
+          cover the reported variants without asserting which is which.
+      progression: "reported A000 001 to B649830 as of 2021-05-29 for the automobile/class-1 series, PT00 001? to PT210303 as of 2022-04-28 for the class 2-8 series, and S/P000 001 to S/P000 923 as of 2022-11-29 for the unidentified third (all locator)"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      background: { finish: retroreflective }
+      colour_note: "reported all-embossed black on white for the A/B and S/P series and all-embossed blue on tan for the PT series — a genuine colour-carries-meaning case, where the colour distinguishes the tow class. No hex asserted."
+      emblem: { present: false }
+      rear_differs: false
+    validity: "PERMANENT — Arkansas issues these as non-expiring trailer plates (locator). A permanent plate means no revalidation decal and therefore no year signal anywhere on the artefact, which is a real problem for any dating heuristic."
+    region_encoding: none
+    weight_class_encoding:
+      mechanism: "letter prefix"
+      table:
+        - { prefix: "A", meaning: "permanent trailer, hauled by automobiles and class 1 trucks", basis: locator-unconfirmed }
+        - { prefix: "B", meaning: "permanent trailer, continuation of the A series", basis: locator-unconfirmed }
+        - { prefix: "PT", meaning: "permanent trailer, hauled by class 2 through 8 trucks", basis: locator-unconfirmed }
+        - { prefix: "SP", meaning: "permanent trailer, classification not identified in any source consulted", basis: locator-unconfirmed }
+      note: >-
+        THIS IS THE ONE PLACE IN THE SOUTHCENTRAL GROUP WHERE A PREFIX CARRIES
+        VEHICLE-CLASS SEMANTICS THAT A PARSER COULD USE, which is why it is
+        recorded as a table rather than buried in prose. It is entirely
+        locator-grade and must be verified against DFA's own trailer-registration
+        material before any consumer relies on it.
+    sources:
+      - "https://www.dfa.arkansas.gov/office/motor-vehicle/  # the issuing authority"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Arkansas  # LOCATOR ONLY: the three permanent-trailer prefixes, their reported tow-class meanings, the colour split, and the observed ranges"
+    notes: >-
+      ARKANSAS PERMANENT TRAILER PLATES. Included because L2 names trailer as a
+      core class and because Arkansas's version has an actual decode in it — the
+      prefix tells you what tows the trailer. Everything is locator-grade. The
+      S/P series is recorded WITH ITS UNKNOWN MEANING rather than omitted,
+      because a decode table with a hole in it that says "hole" is more useful
+      than a tidy table that quietly drops the case it cannot explain.
+
+  # =========================================================================
+  # HISTORIC — Arkansas runs a permanent-style antique series, and an older one
+  # that is dead but still lawfully displayed.
+  # =========================================================================
+  - id: us-ar-antique
+    class: historic
+    categories: [car, truck]
+    period: { start: 2007 }
+    period_evidence: locator-unconfirmed
+    matching: strict
+    format:
+      pattern: "L9999"
+      regex: '\A[A-Z]\d{4}\z'
+      serial_basis: locator-unconfirmed
+      charset: { notes: "one letter then four numerals; reported A0001 onward. The predecessor arrangement was five numerals (12345, running to 99999), which exhausted and was re-based with a letter prefix in 2007 — the same exhaust-and-reprefix move Arkansas made on its passenger series in 2021." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      background: { finish: retroreflective }
+      colour_note: "reported black on white with an antique-car graphic at left. No hex asserted."
+      graphic: { present: true, rendered: placeholder, description: "antique car, at left (locator description; not reproduced)" }
+      emblem: { present: true, rendered: placeholder }
+    eligibility:
+      text: >-
+        DFA's own catalogue entry, verbatim: "For historical or special interest
+        vehicles or any vehicle that is THIRTY (30) YEARS OLD OR OLDER, which is
+        essentially unaltered from the original manufacturers specifications."
+        DFA adds that "Certain modifications are permitted if they are
+        characteristic of the approximate era to which the vehicle belongs or
+        considered to be safety related (brakes, seal beam headlights, seat
+        belts, etc.)."
+      threshold_kind: rolling
+      threshold_note: >-
+        A ROLLING thirty-year threshold — eligibility moves every year — which
+        puts Arkansas with Florida's Antique plate (rolling 30 years, § 320.086(2)(a))
+        and against Florida's Horseless Carriage plate (fixed model year 1945 or
+        earlier). Texas's § 504.501 Classic is rolling 25. Three of the four
+        southcentral states therefore use rolling age thresholds and only the
+        fixed-cutoff kind is absent here. The distinction is operationally real:
+        a rolling threshold silently re-qualifies vehicles every 1 January and
+        must be re-audited; a fixed cutoff never changes.
+      plate_category: "DFA classifies it under the catalogue's 'Special Interest' plate category"
+      basis: authority-stated
+    superseded_variants:
+      - "the 1957-2007 five-numeral antique plate is reported NO LONGER ISSUED BUT STILL VALID — a dead series lawfully on the road, exactly the case PRD-PLATES's `ended: true` + `year_end_min:` semantics exist for. It is not given its own entry here because the only source for its own format is a locator and because L2 scope is the current series plus one back per class."
+      - "a separate ANTIQUE MOTORCYCLE plate is reported with a three-numeral-plus-letter arrangement (123A) on an 'ARK. M CYCLE / ANTIQUE' legend — recorded here rather than as a series for the same reason."
+    region_encoding: none
+    sources:
+      - "https://www.dfa.arkansas.gov/specialty-plates/antique-vehicle-license-plate-current/  # DFA's own catalogue entry for the CURRENT antique vehicle plate: the rolling 30-year eligibility rule, the essentially-unaltered condition, the era-characteristic and safety-modification allowances, the Affidavit for License for an Antique Vehicle, and the 'Special Interest' plate category"
+      - "https://www.dfa.arkansas.gov/specialty-plates/antique-vehicle-license-plate-valid-no-longer-issued/  # DFA's own catalogue entry titled 'Antique Vehicle License Plate - Valid - No Longer Issued' — the authority itself distinguishing a VALID but DISCONTINUED series, which is direct support for the ended-but-displayed modelling above"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Arkansas  # LOCATOR ONLY: the A1234 arrangement from 2007, the preceding 12345 arrangement running 1957-2007, the antique-car graphic, and the separate antique-motorcycle plate"
+    notes: >-
+      ARKANSAS ANTIQUE. The genuinely valuable thing here is not the format but
+      the DFA catalogue's own two-entry treatment: the department publishes
+      "Antique Vehicle License Plate - Current" and "Antique Vehicle License
+      Plate - Valid - No Longer Issued" as separate catalogue items. That is an
+      issuing authority explicitly modelling a discontinued-but-still-valid
+      series in its own public catalogue — the same distinction PRD-PLATES draws
+      with `ended: true`, arrived at independently by a state DMV, and the
+      strongest available evidence that the schema's period semantics match how
+      registrars actually think.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX ONLY, per PRD-PLATES §2.5. Arkansas gives the
+  # cleanest COUNT in this group, from the department's own content API.
+  # =========================================================================
+  - id: us-ar-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2021 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL 99L"
+      regex: '\A[A-Z]{3} ?\d{2}[A-Z]\z'
+      serial_basis: locator-unconfirmed
+      charset: { notes: "specialty plates draw from the ordinary passenger allocation unless personalized — the locator records for several classes (Ambulance, School Vehicle) that the serial is 'Taken from passenger allocation' and shows both the 123 ABC and ABC 12D arrangements on them, which is consistent with specialty designs riding the standard sequence across the 2021 format change." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised program; individual designs are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: 131
+      count_basis: authority-enumerated
+      count_method: >-
+        COUNTED FROM THE DEPARTMENT'S OWN CONTENT API, which is the most solid
+        specialty count in this group. dfa.arkansas.gov runs its specialty
+        catalogue as a `specialty-plates` content type; a request to
+        /wp-json/wp/v2/specialty-plates returns an X-WP-Total header of 131
+        (fetched 2026-08-02). That is DFA's own enumeration of its own
+        catalogue, not a third-party tally.
+      count_caveats:
+        - "the total counts CATALOGUE ENTRIES, not currently-issuable programs: at least one entry is 'Antique Vehicle License Plate - Valid - No Longer Issued', i.e. a discontinued design the department still documents"
+        - "at least two apparent DUPLICATE pairs are visible in the first page alone ('Arkansas Sheriffs' Association' twice, 'Arkansas State Lodge Fraternal Order of Police' twice with and without the words 'License Plate'), so 131 is an upper bound on distinct programs"
+        - "the catalogue mixes true optional-design programs with administrative classes (Ambulance, Amateur Radio, Apportioned Truck, Transporter), so it is a plate-type catalogue rather than a specialty-program catalogue in the Florida sense"
+      official_list_url: "https://www.dfa.arkansas.gov/office/motor-vehicle/specialty-plates-placards/"
+      structured_endpoint: "https://www.dfa.arkansas.gov/wp-json/wp/v2/specialty-plates  # a genuinely machine-readable official catalogue with per-plate pages — rarer than it should be, and worth snapshotting periodically the way FLHSMV's monthly report is"
+    region_encoding: none
+    sources:
+      - "https://www.dfa.arkansas.gov/office/motor-vehicle/specialty-plates-placards/  # DFA's official specialty plates and placards catalogue"
+      - "https://www.dfa.arkansas.gov/wp-json/wp/v2/specialty-plates  # the same catalogue as structured data; X-WP-Total: 131 at fetch time 2026-08-02 — the count claim"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Arkansas  # LOCATOR ONLY: that specialty classes such as Ambulance and School Vehicle take their serials 'from passenger allocation' and therefore show both passenger arrangements"
+    notes: >-
+      THE ARKANSAS SPECIALTY INDEX. Arkansas gives the best-structured specialty
+      catalogue of the four states here and the worst statutory access, which is
+      an instructive pairing: the department's WordPress content API happily
+      hands over a complete, paginated, per-plate catalogue with a total in an
+      HTTP header, while the Code that authorises every one of those plates sits
+      behind a commercial subscription. The count is reported with its three
+      caveats rather than as a round number, because 131 is an upper bound on
+      distinct live programs and saying so costs nothing.

--- a/plates/us-la.yml
+++ b/plates/us-la.yml
@@ -1,0 +1,568 @@
+# plates/us-la.yml — Louisiana (PRD-PLATES gate L2, group: southcentral).
+#
+# THE LOUISIANA FIND, and it is the best one in the southcentral group: the
+# Office of Motor Vehicles publishes its ENTIRE POLICY MANUAL, per-policy, as
+# dated PDFs on a public PowerDMS instance, and Section 5 of that manual is
+# "Motor Vehicle License Plate Classifications & Requirements" — 187 numbered
+# policies covering every plate class Louisiana issues, each citing its own
+# authorising Revised Statute, each carrying an effective date and a revision
+# date. That is a primary source of a kind no other state in this group offers:
+# not a brochure, not a FAQ, but the registrar's own operating instructions.
+#
+# TWO CLAIMS IN THIS FILE COME OUT OF THAT MANUAL AND WOULD BE UNSOURCEABLE
+# WITHOUT IT:
+#
+# 1. THE SERIAL ARRANGEMENT, FROM THE NEGATIVE. Policy 21.00 (Personalized
+#    Prestige License Plates, revised 2025-02-14) forbids a vanity plate that
+#    would "Contain a REGULAR PLATE SEQUENCE (i.e. three numbers followed by
+#    three alpha or three alpha followed by three numbers)." The department has
+#    thereby stated, in an instrument, what a regular Louisiana plate looks
+#    like — 999 LLL or LLL 999 — while defining what a vanity plate may not be.
+#    That is the only authority-sourced passenger arrangement in this entire
+#    group other than Texas's prose description of its 2009 base.
+#
+# 2. THE DISPLAY RULE, WITH ITS ODD EXCEPTION. Policy 74.00 (R.S. 47:507) puts
+#    the plate on the rear of a trailer, semi-trailer, MOTORCYCLE, automobile,
+#    pickup, van or other motor vehicle — but lets any truck over 6,000 lb gross
+#    or any dump truck mount EITHER front or rear. Not front-only like a Texas
+#    or Florida truck tractor; either, at the owner's option. That is a third
+#    distinct US answer to the same question and it is in the manual verbatim.
+#
+# THE STATUTE ITSELF WAS UNREACHABLE. legis.la.gov did not resolve and did not
+# connect from this environment on any attempt, and every free reproduction
+# tried (justia, findlaw, onecle, lawserver) 403'd, 404'd or redirect-looped. So
+# the R.S. citations below are the ones the OMV manual gives, quoted as the
+# manual gives them — a registrar citing its own authorising statute is good
+# evidence that the statute says roughly that, and is not the same as reading
+# the statute. Flagged everywhere it matters.
+jurisdiction: us-la
+authority:
+  name: Louisiana Office of Motor Vehicles (OMV), Department of Public Safety and Corrections, Public Safety Services
+  url: "https://expresslane.la.gov/omv"
+binding: vehicle
+statute_edition: "NONE READ DIRECTLY. Louisiana Revised Statutes Title 47 (Revenue and Taxation, ch. 4 — Motor Vehicle License Tax) and Title 32 (Motor Vehicles and Traffic Regulation) are cited below only as the OMV Policy Manual cites them. legis.la.gov was unresolvable/unreachable throughout this pass."
+policy_manual:
+  name: "Louisiana OMV Policy Manual, Section 5 — Motor Vehicle License Plate Classifications & Requirements"
+  index_url: "https://expresslane.la.gov/omv/resources/omv-policy/vehicle-license-plate-classifications-requirements/"
+  host: "https://public.powerdms.com/ladpsc/documents/<id>  # each policy is an individually addressable dated PDF"
+  scale: "187 numbered policies in Section 5, running from 1.00 (Antique License Plates) to 205.00 (Juneteenth Specialty License Plate) — numbering is sparse, so the count and the highest number differ"
+  why_it_matters: "each policy states its authorising R.S. sections, an Effective Date and a Revised Date. Effective dates in Section 5 run from 1973 to 2025, so the manual is also a rough chronology of Louisiana plate policy."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: copyright-asserted-by-agency
+  basis: >-
+    ADVERSE, AND EXPRESSLY SO. The Louisiana Department of Public Safety's own
+    Terms of Use, verbatim: "The usage of the content, images and logos on the
+    LADPS site by any other website is strictly prohibited by law. The usage of
+    data without the expressed written consent of LADPS is a violation of
+    LOUISIANA COPYRIGHT and other proprietary rights. The misrepresentation via
+    modification of information from this website in any presentation is
+    injudicious and shall be dealt with accordingly to the fullest extent of the
+    law." A further clause restricts unauthorised use of the words "Louisiana
+    Department of Public Safety" or the initials "LADPS" or "any imitation 'in a
+    manner reasonably calculated to convey the impression that such [activity]...
+    is approved, endorsed, or authorized'". This puts Louisiana alongside Arizona
+    in the US dossier's adverse column — an EXPRESS agency assertion — and one
+    step below Texas, whose assertion is in a statute rather than a website
+    notice.
+  scope_note: >-
+    Read precisely, the LADPS assertion covers the agency's WEBSITE content,
+    images and logos. It is not, on its face, a claim over the plate DESIGN as
+    such — but it is the same agency, the plate images on the site are its
+    images, and the passing-off clause reaches beyond copyright into
+    endorsement. The correct posture is therefore: treat Louisiana plate artwork
+    as claimed, render nothing derived from an LADPS image, and rely only on
+    facts and on the policy manual's TEXTUAL descriptions, which is what this
+    file does throughout.
+  practical_effect: "PRD-PLATES §3's neutral-placeholder default is mandatory. Note the useful asymmetry: Policy 45.00 describes the plate in WORDS ('blue letters and numbers on a white background with the word \"Louisiana\" appearing in script at the top center of the plate in the color of red'). A description of a design is a fact; a copy of a design is not. Every colour and legend claim below is taken from the words, never from an image."
+  emblem_rule: >-
+    Placeholder. The pelican — Louisiana's state bird and the central element of
+    the state's seal and flag — has appeared on Louisiana bases repeatedly, and
+    the reported current base carries a map of Louisiana ringed with eighteen
+    stars. State seal and symbol statutes are a regime independent of copyright
+    and are UNRESEARCHED for Louisiana (recorded gap).
+  sources:
+    - "https://expresslane.la.gov/omv/terms-of-use/  # LADPS Terms of Use Policy: the copyright and proprietary-rights assertion, quoted verbatim above, and the LADPS name/initials passing-off clause"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): §105 does not reach the states; Louisiana is not among the states with a favourable rule"
+
+# ---------------------------------------------------------------------------
+# The US standards chain — recorded once per US file (see us-fl.yml).
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; AAMVA has no enforcement power."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is paywalled and UNPINNED; no J686 dimension is quoted anywhere in this dataset."
+    jurisdiction_name_layout: "AAMVA §2.1: the jurisdiction name 'appears in the top center location between the bolt holes'. Louisiana's own Policy 45.00 independently requires 'Louisiana' 'at the top center of the plate' — an unusually direct case of a state's own instrument matching the AAMVA recommendation."
+    replacement_cycle: "AAMVA §1.1 recommends a rolling or full replacement cycle 'not to exceed 7 to 10 years'. LOUISIANA HAS NO REPLACEMENT CYCLE BUT HAS A REGISTRATION PERIOD: Policy 38.00 states 'Private auto license plates are issued for a two (2) year registration period' and 'All automobile plates will be valid for two (2) years ONLY.' Plates are also NOT TRANSFERABLE between owners — 'New metal plates are issued when the vehicle is transferred' — so Louisiana replaces on transfer rather than on a clock."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  aamva_relationship_note: "Louisiana OMV is an active AAMVA member and won three 2026 AAMVA awards, which is worth noting only because it makes the voluntary-adoption chain concrete: the state whose plates AAMVA does not govern is the same state that competes in AAMVA's awards programme."
+  folklore_caution: "The '1956 AMA standardization agreement' remains COMMONLY REPEATED, UNSOURCED (PRD-PLATES §4). No Louisiana instrument obtained states plate dimensions at all."
+
+# ---------------------------------------------------------------------------
+# Display rules — from the OMV Policy Manual, which is the registrar's own
+# operating instruction and states them in full.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "ONE plate, REAR. Policy 74.00, verbatim: 'The permanent registration license plates assigned to a trailer, semi-trailer, motorcycle, automobile, pickup truck, van, or other motor vehicle shall be attached to the rear of the vehicle.'"
+  heavy_truck_option: "Policy 74.00, verbatim: 'The permanent registration license plate assigned to any truck having a gross vehicle weight in excess of six thousand pounds or to any dump truck may be attached to EITHER the front or the rear of the vehicle.' Note this is an OPTION, not an inversion — contrast Florida § 320.0706 and Oklahoma § 1113(A)(2), which both force truck tractors to the FRONT. Three states in this dataset, three different heavy-vehicle display rules."
+  mounting: "Policy 74.00: plates 'shall at all times be securely fastened to the vehicle so as to prevent the plate from swinging and at a height of not less than twelve inches from the ground, measuring from the bottom of the plate. The license plate shall be secured in a place and position so as to be clearly visible and shall be maintained free of foreign materials and in such a condition as to be clearly legible.'"
+  replacement_duty: "Policy 74.00: 'If the license plate becomes damaged or worn to the extent that the identification numbers and letters on the plate are no longer legible, the owner shall contact the Office of Motor Vehicles to secure a replacement license plate upon payment of the appropriate fees.' A legibility duty on the owner, with no periodic cycle behind it."
+  authority: "R.S. 47:507, as cited by Policy 74.00 (effective 2001-08-15, revised 2002-05-06). The statute text itself was not obtainable — see statute_edition."
+  sources:
+    - "https://public.powerdms.com/ladpsc/documents/370993  # Louisiana OMV Policy 74.00, 'Proper Display of Permanent License Plates', authority R.S. 47:507 — the rear-display rule, the >6,000 lb / dump-truck either-end option, the 12-inch minimum height, the anti-swing and legibility requirements, and the owner's replacement duty"
+    - "https://expresslane.la.gov/omv/resources/omv-policy/vehicle-license-plate-classifications-requirements/  # the OMV Policy Manual Section 5 index that publishes Policy 74.00 and the other 186 plate policies"
+
+# ---------------------------------------------------------------------------
+# Temporary registration — Louisiana kept PAPER, which is the sharpest contrast
+# in this group with Texas, where HB 718 abolished paper temporary tags on
+# 1 July 2025 and replaced them with metal plates.
+# ---------------------------------------------------------------------------
+temporary_regime:
+  artefact: "PAPER. Policy 6.00 defines a 'Temporary Registration Plate (Temporary Tag or T-Marker)' as 'a temporary vehicle registration that may be issued by a licensed dealer to an ultimate purchaser of eligible types of vehicles, to allow the vehicle to be used on roadways, while awaiting issuance of the permanent license plate.'"
+  validity: "'T-Markers shall be valid for no more than SIXTY (60) DAYS from the date of issuance.'"
+  issuers: "licensed dealers (Policy 6.00) and, separately, lending institutions and auto title companies (Policy 6.01)"
+  one_per_vehicle: "'Dealers may only issue one temporary tag to each vehicle sold, unless approved by the Office of Motor Vehicles.' A second tag is considered only where title transfer is delayed by defective paperwork, must be requested by the original issuing dealer, and is refused where OMV determines the request is being made to avoid registration or fees."
+  database: "every T-Marker must be entered in Louisiana's TEMPORARY TAG DATABASE before the purchaser leaves with the vehicle, and the purchaser gets a receipt evidencing the entry; a Temp Tag Offline Form covers database outages, with entry required as soon as the system is available. Dealers keep temporary-tag records for three years."
+  exclusion: "temporary tags cannot be issued to purchasers of vehicles requiring APPORTIONED plates."
+  serial_format: "NOT PUBLISHED. Policy 6.00 specifies the regime exhaustively and the T-Marker's own serial arrangement not at all. RECORDED GAP — no temporary series is minted rather than have its pattern invented."
+  cross_state_contrast: >-
+    Texas eliminated paper temporary tags outright on 1 July 2025 (HB 718, 88R)
+    after an estimated 1.2 million fraudulent Texas paper tags circulated in
+    2021, and now issues metal plates at the point of sale. Louisiana's answer to
+    the same fraud problem was a mandatory central DATABASE plus a 60-day cap,
+    not a metal plate. Two neighbouring states, the same threat model, opposite
+    remedies — and the plates dataset is one of the few places where that
+    comparison is even visible.
+  authority: "R.S. 47:519-521, as cited by Policy 6.00 (effective 1987-10-16, revised 2024-05-31)"
+  sources:
+    - "https://public.powerdms.com/ladpsc/documents/365301  # Louisiana OMV Policy 6.00, 'Temporary Registration Plates (T-Markers) Issued by Dealers', authority R.S. 47:519-521 — the 60-day validity cap, the one-per-vehicle rule and its exception, the Temporary Tag Database and offline form, the three-year record-keeping duty, and the apportioned-vehicle exclusion"
+    - "https://www.txdmv.gov/dealers/HB718  # the Texas comparator: paper tags eliminated 1 July 2025, metal plates issued at sale"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES. NOTE THE MODELLING CHOICE: the series
+  # boundary is drawn at the FORMAT change, not at the base-design change,
+  # because the format has an authority source and the design dates do not.
+  # =========================================================================
+  - id: us-la-standard
+    class: standard
+    categories: [car, van]
+    period: { start: 2016 }
+    period_evidence: locator-unconfirmed
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      serial_basis: authority-stated-negatively
+      charset:
+        notes: >-
+          SOURCED FROM THE PROHIBITION, WHICH IS THE ONLY PLACE LOUISIANA STATES
+          IT. OMV Policy 21.00 (Personalized Prestige License Plates, revised
+          2025-02-14) lists among the things a vanity plate may NOT do: "Contain
+          a regular plate sequence (i.e. THREE NUMBERS FOLLOWED BY THREE ALPHA OR
+          THREE ALPHA FOLLOWED BY THREE NUMBERS)." The department is defining the
+          regular passenger arrangement in order to reserve it, and in doing so
+          states it. Both orders are named; the numeric-first order is the one
+          currently issued.
+        excluded_reported: ["Q", "U"]
+        excluded_basis: locator-unconfirmed
+        excluded_note: "the Q and U series of serials are reported unused on the 2005-2011 base (locator). Not promoted to a regex_strict — Louisiana publishes no alphabet."
+      progression: "reported 100 AAA onward from May 2016, reaching approximately 799 HUK by the end of 2024 and continuing 100 HUL to 371 JCY as of 2025-03-31 on the successor base (locator). The sequence therefore RUNS THROUGH the base change, so the base cannot be inferred from the serial — the same trap Oklahoma sets."
+      pattern_note: "the separator is the printed GAP between the numeral group and the letter group; Policy 45.00 prescribes layout in words but no separator glyph, so the space is written per the §2.6 emitted set and the regex makes it optional."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      plate_dimension_note: "no Louisiana instrument obtained states dimensions; 12 x 6 in is the North American convention (AAMVA -> SAE J686, unpinned)."
+      background: { finish: retroreflective }
+      colour_note: >-
+        DESCRIBED FROM THE POLICY, NOT FROM AN IMAGE, and therefore stated as
+        colour NAMES with no hex. Policy 45.00 ("Uniform License Plates", R.S.
+        47:463(3) and Senate Concurrent Resolution 196), Category #1, verbatim:
+        the plates "contain the color scheme of BLUE letters and numbers on a
+        WHITE background with the word 'Louisiana' appearing in script at the top
+        center of the plate in the color of RED and the words 'Sportsman's
+        Paradise' appearing in BLUE block letters centered at the bottom of the
+        plate." No hex is asserted because the policy states no value, and
+        because deriving one from an LADPS image would run straight into the
+        artwork_risk assertion above.
+      legend_top: "Louisiana"
+      legend_top_style: "script, red, top centre (Policy 45.00)"
+      legend_bottom: "Sportsman's Paradise"
+      legend_bottom_style: "blue block letters, centred (Policy 45.00)"
+      graphic: { present: true, rendered: placeholder, description: "base graphic varies by issue — see base_designs; not reproduced" }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    base_designs:
+      basis: locator-unconfirmed
+      note: >-
+        THE DESIGN TIMELINE IS RECORDED HERE RATHER THAN AS SERIES BOUNDARIES,
+        DELIBERATELY. Louisiana changed base graphics inside this one serial
+        arrangement, and none of those changes could be tied to a Louisiana
+        instrument in this pass. Minting dated series ids on unsourced design
+        boundaries would mean aliasing them later under the PRD-QUALITY I-5/I-6
+        id contract; recording them as dated design variants under one
+        format-defined series costs nothing and claims nothing false. Compare
+        us-fl-standard, whose id is undated for exactly the same reason.
+      designs:
+        - period: { start: 2016, end: 2024 }
+          description: "the 2005-2011 base continued: embossed black serial on a reflective white, yellow and pink gradient field with a black border line, a pelican graphic screened in the centre, 'Louisiana' in red handwritten script at the top and 'Sportsman's Paradise' in red at the bottom, offset left"
+        - period: { start: 2025 }
+          description: "reported from 1 January 2025: embossed dark blue serial on reflective white with a border line, eighteen stars circled around a map of Louisiana on a red ground with an America 250 logo below, 'LOUISIANA' in red at the top and 'Sportsman's Paradise' at the bottom"
+          caveat: "LOCATOR ONLY. No OMV alert, press release or policy revision announcing this base was located; the OMV alerts feed reachable in this pass begins in 2026. If a verifier finds the announcement, this becomes a series in its own right."
+    registration_period: "TWO YEARS. Policy 38.00 (Automobile License Plates, authority R.S. 47:463(A)): 'Private auto license plates are issued for a two (2) year registration period and are not transferable between owners' and 'All automobile plates will be valid for two (2) years ONLY.'"
+    tax_basis: "Louisiana's registration licence tax is AD VALOREM, which is unusual: Policy 38.00 sets 'a minimum of $10.00 per year up to the first $10,000 value plus $1.00 per thousand-dollar value in excess of $10,000', with 'actual value' defined as the higher of the bill-of-sale price or the NADA full loan value, fixed at first registration and held constant until ownership changes. Recorded because a value-based plate tax is a real reason a state resists frequent reissues."
+    region_encoding: none
+    region_encoding_note: >-
+      NONE TODAY, BUT LOUISIANA HAD ONE AND IT WAS NOT COUNTY-BASED. The
+      1989-1993 base is reported to have carried a letter in the middle of the
+      serial (123A456) where "Letter corresponds to STATE POLICE TROOP AREA of
+      issue" — a policing geography rather than a civil one, and the last
+      Louisiana base to encode any geography at all (locator). Worth flagging as
+      an L4 decode candidate precisely because troop areas are not parishes and
+      a naive decode table would map it wrong.
+    sources:
+      - "https://public.powerdms.com/ladpsc/documents/366665  # Louisiana OMV Policy 21.00, 'Personalized Prestige License Plates' (revised 2025-02-14), authority R.S. 47:462 and 47:463.2 — the prohibition on vanity plates containing 'a regular plate sequence (i.e. three numbers followed by three alpha or three alpha followed by three numbers)', which is the department's own statement of the regular passenger arrangement"
+      - "https://public.powerdms.com/ladpsc/documents/370991  # Louisiana OMV Policy 45.00, 'Uniform License Plates', authority R.S. 47:463(3) and Senate Concurrent Resolution 196 — the Category #1 colour scheme: blue letters and numbers on white, 'Louisiana' in red script at top centre, 'Sportsman's Paradise' in blue block letters at bottom"
+      - "https://public.powerdms.com/ladpsc/documents/366583  # Louisiana OMV Policy 38.00, 'Automobile License Plates', authority R.S. 47:463(A) — eligibility for the passenger class, the two-year registration period, non-transferability between owners, and the ad valorem licence tax"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Louisiana  # LOCATOR ONLY (PRD-PLATES §4): the May 2016 change from ABC 123 to 123 ABC, the 100 AAA to 799 HUK and 100 HUL to 371 JCY ranges, the 2005-2011 and reported 2025 base designs, the Q/U exclusions, and the 1989-1993 State Police troop-area letter. None asserted as sourced."
+    notes: >-
+      LOUISIANA CURRENT ISSUE, KEYED TO THE FORMAT. The choice worth defending
+      explicitly: this series starts in 2016 at the arrangement change, not in
+      2025 at the reported base change, because the arrangement has an authority
+      source (Policy 21.00's prohibition) and a fifteen-year run behind it, while
+      the 2025 base has only a locator. The reported America 250 base is recorded
+      in `base_designs` with its caveat, where it can be promoted to a series the
+      moment an OMV instrument surfaces. Also note what Louisiana does NOT have:
+      no replacement cycle at all, but a two-year registration period, plates
+      that die with the owner rather than transfer, and an ad valorem tax — a
+      combination that churns plates through transfer rather than through age.
+
+  # =========================================================================
+  # ONE SERIES BACK — the alpha-first arrangement, the "Lipstick" base and its
+  # successors, 1993 to 2016.
+  # =========================================================================
+  - id: us-la-standard-lll999
+    class: standard
+    categories: [car, van]
+    period: { start: 1993, end: 2016 }
+    period_evidence: locator-unconfirmed
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      serial_basis: authority-stated-negatively
+      charset: { notes: "the OTHER order named in Policy 21.00's 'regular plate sequence' prohibition — 'three alpha followed by three numbers'. The department reserves both orders from vanity use, which is why both are sourceable from the same instrument." }
+      progression: "reported AAA 000 to approximately KLK 999 on the 1993-2001 issue, then continuing through KLL 000, MSP 000, NFV 000, VCT000, WUH 000, XSA000 and ZPD 000 to ZZZ 999 across successive bases until the arrangement exhausted in May 2016 (locator)"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      background: { finish: retroreflective }
+      colour_note: >-
+        Policy 45.00's uniform scheme (blue on white, red script 'Louisiana' at
+        top centre, blue block 'Sportsman's Paradise' at bottom) was adopted
+        1993-08-02 and revised 1994-12-27, which places its effective date at the
+        START of this series — so this is the arrangement the uniform-plate
+        policy was actually written for. Later bases inside the same arrangement
+        are reported to have departed from it (a 2005 black-on-gradient issue, a
+        2011 bicentennial issue, a 2014 Battle of New Orleans issue), which is
+        itself evidence that a 1994-revised policy has not tracked practice.
+      legend_top: "Louisiana"
+      legend_bottom: "Sportsman's Paradise"
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    base_designs:
+      basis: locator-unconfirmed
+      note: "at least six distinct bases are reported inside this one arrangement, including three explicitly LIMITED-RUN commemoratives — Louisiana Purchase Bicentennial (2002-2004), Louisiana Bicentennial '200 YEARS' (2011-2012) and Battle of New Orleans Bicentennial (2014-2015) — interleaved with ordinary issues. Louisiana runs commemorative GENERAL ISSUES rather than optional specialty designs, which is unusual and which makes base-to-date inference in Louisiana unusually rich and unusually unsourced."
+    region_encoding: none
+    sources:
+      - "https://public.powerdms.com/ladpsc/documents/366665  # Policy 21.00: 'three alpha followed by three numbers' named as a regular plate sequence reserved from vanity use"
+      - "https://public.powerdms.com/ladpsc/documents/370991  # Policy 45.00, effective 1993-08-02, revised 1994-12-27 — the uniform colour and legend scheme adopted at the start of this series under R.S. 47:463(3) and SCR 196"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Louisiana  # LOCATOR ONLY: the 1993 'Lipstick' base and the AAA 000 to ZZZ 999 progression through the successive bases and commemoratives listed above"
+    notes: >-
+      THE ALPHA-FIRST ERA, 1993-2016. Recorded as one series across six reported
+      bases for the same reason the current series is recorded across two: the
+      arrangement is sourceable and the base dates are not. The Louisiana pattern
+      that emerges from both entries is worth stating once — this is a state that
+      changes its PICTURE often and its NUMBER SHAPE almost never, so any
+      Louisiana dating heuristic must key on the base and any Louisiana
+      VALIDATION heuristic must key on the arrangement, and the two answers point
+      in opposite directions.
+
+  # =========================================================================
+  # MOTORCYCLE — its own numbering space, its own four-year registration.
+  # =========================================================================
+  - id: us-la-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1995 }
+    period_evidence: locator-unconfirmed
+    matching: strict
+    format:
+      pattern: "999999"
+      regex: '\A\d{1,6}\z'
+      serial_basis: locator-unconfirmed
+      charset: { notes: "all-numeric, reported six digits. No Louisiana instrument stating the arrangement was obtained — Policy 153.00 specifies eligibility, fees and registration period but not the serial. The unbounded-below quantifier makes no width claim." }
+    design:
+      plate: { unit: in, note: "reduced motorcycle size; no dimension obtained from any Louisiana source" }
+      background: { finish: retroreflective }
+      colour_note: "reported as the 1993-2001 passenger base treatment with 'MC' embossed at the bottom in place of the slogan (locator). No hex asserted."
+      legend_bottom: "MC"
+      legend_basis: locator-unconfirmed
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    definition: "Policy 153.00, verbatim: 'Motorcycle - Every motor vehicle having a seat or saddle for the use of the rider and designed to travel on not more than three wheels in contact with the ground, but excluding a tractor and excluding a motorized bicycle.' Note the THREE-WHEEL inclusion — a Louisiana motorcycle plate is correct on a trike."
+    registration_period: "FOUR YEARS. Policy 153.00: 'Motorcycle plates have a four (4) year registration period', at $12.00 ($3.00 per year). And, unlike passenger plates, 'Motorcycle plates ARE transferable between owners' — the direct opposite of Policy 38.00's rule for automobiles."
+    authority: "R.S. 32:781, R.S. 47:451, R.S. 47:465 and R.S. 32:1, as cited by Policy 153.00 (effective 2013-12-04, revised 2014-05-30)"
+    region_encoding: none
+    sources:
+      - "https://public.powerdms.com/ladpsc/documents/366103  # Louisiana OMV Policy 153.00, 'Motorcycle Plates', authority R.S. 32:781, 47:451, 47:465, 32:1 — the three-wheel motorcycle definition, the four-year registration period, the $12 fee, and the transferability rule that inverts the passenger rule"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Louisiana  # LOCATOR ONLY: the all-numeric six-digit arrangement and the 'MC' bottom legend from c. 1995"
+    notes: >-
+      LOUISIANA MOTORCYCLE. The two facts worth having are both from the policy
+      and neither is about the number: a Louisiana motorcycle plate is lawful on
+      a three-wheeler, and motorcycle plates transfer between owners while
+      automobile plates do not. That transferability asymmetry means a Louisiana
+      motorcycle plate can outlive several owners and several vehicles, so plate
+      identity and vehicle identity come apart on exactly one class — a fact a
+      vehicle-keyed consumer will get wrong unless it is written down.
+
+  # =========================================================================
+  # DEALER — Louisiana calls them DEALER INVENTORY plates, and licenses new and
+  # used dealers through two different commissions.
+  # =========================================================================
+  - id: us-la-dealer
+    class: dealer
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2012 }
+    period_evidence: locator-unconfirmed
+    matching: strict
+    format:
+      pattern: "LL99999"
+      regex: '\A[A-Z]{2} ?\d{5,6}\z'
+      serial_basis: locator-unconfirmed
+      charset: { notes: "reported DI-prefixed, five digits, continuing into a six-digit block after DI99999 (locator). Policy 5.00 governs issuance, allocation, renewal, loss and theft in detail and states no serial arrangement." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      background: { finish: retroreflective }
+      colour_note: "reported from c. 2012 as embossed black on YELLOW with a border line, 'LOUISIANA' at the top and 'DEALER' at the bottom — a colour break from the uniform blue-on-white scheme, consistent with Policy 45.00, which does NOT list dealer plates in its Category #1 or #2 uniform lists under R.S. 47:473 alone. No hex asserted."
+      legend_top: "LOUISIANA"
+      legend_bottom: "DEALER"
+      emblem: { present: false }
+      rear_differs: false
+    binding: business
+    binding_note: "`binding: business` for the same reason as Germany's rote Kennzeichen and Florida's dealer plate: the plate follows the dealership's inventory, not a vehicle."
+    licensing_split: "Policy 5.00 distinguishes NEW motor vehicle dealers, licensed by the Louisiana Motor Vehicle Commission, from USED motor vehicle dealers, licensed by the Louisiana Used Motor Vehicle Commission, and applies different documentary requirements to each (used dealers must show at least $55,000 of garage liability cover). Two regulators, one plate class."
+    fee: "$15.00 per plate (Policy 5.00)"
+    authority: "R.S. 47:473, as cited by Policy 5.00 (effective 1983-09-01, revised 2021-05-04). Policy 45.00 separately lists R.S. 47:473 'Dealer Plates (Motorcycle, XPOW)', R.S. 47:473.1 'Personalized Dealer' and R.S. 47:473.2 'Handicapped Dealer/Commercial Plates' — so Louisiana statutorily subdivides the dealer class three ways."
+    region_encoding: none
+    sources:
+      - "https://public.powerdms.com/ladpsc/documents/370971  # Louisiana OMV Policy 5.00, 'Dealer Inventory Plates', authority R.S. 47:473 — the LMVC/LUMVC licensing split, the $15 per-plate fee, the application form DPSMV1640, and the lost/stolen plate procedure"
+      - "https://public.powerdms.com/ladpsc/documents/370991  # Policy 45.00 Category #2: R.S. 47:473 dealer plates, 47:473.1 personalized dealer, 47:473.2 handicapped dealer/commercial — the statutory three-way subdivision of the dealer class"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Louisiana  # LOCATOR ONLY: the DI prefix, the five-to-six digit rollover, and the black-on-yellow c. 2012 treatment"
+    notes: >-
+      LOUISIANA DEALER INVENTORY PLATES. The class is thoroughly sourced by the
+      policy and the format is not, which is the recurring shape of this file.
+      Worth carrying forward: Louisiana runs new-car and used-car dealer
+      licensing through two separate commissions but issues them the same plate
+      class, and it maintains a PERSONALIZED DEALER plate (R.S. 47:473.1) whose
+      configurations Policy 21.00 expressly deconflicts against ordinary vanity
+      plates — 'Identical personalized prestige plates cannot be issued,
+      INCLUDING personalized prestige plates with the character configuration
+      already on a personalized dealer plate.' Two vanity namespaces sharing one
+      uniqueness constraint is a genuinely unusual registry design.
+
+  # =========================================================================
+  # TRAILER — Louisiana classifies trailers seven ways and prices the plate by
+  # class, with a permanent option that can never be transferred.
+  # =========================================================================
+  - id: us-la-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 1993 }
+    period_evidence: locator-unconfirmed
+    matching: strict
+    format:
+      pattern: "L999999"
+      regex: '\A[A-Z] ?\d{6}\z'
+      serial_basis: locator-unconfirmed
+      charset: { notes: "a single letter prefix and six digits; D and K prefixes are reported on boat trailers (locator). Policy 19.00 governs the class scheme in full and states no serial arrangement." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      background: { finish: retroreflective }
+      colour_note: "reported as the 1993-2001 passenger base with the trailer class name embossed in place of the slogan (locator). No hex asserted."
+      emblem: { present: false }
+      rear_differs: false
+    class_scheme:
+      note: "Policy 19.00 defines SEVEN trailer categories, and the category determines the class of plate issued and its expiry — Louisiana prices and dates the plate from the trailer's kind and weight, which is the closest thing to weight-class encoding in this state."
+      categories:
+        - { name: "Boat Trailer", definition: "noncommercial, used solely and exclusively for transporting pleasure watercraft, loaded gross weight not more than 1,500 lb" }
+        - { name: "Farm Trailer / Farm Semi-Trailer", definition: "owned by persons actually farming and used exclusively to carry own-farm produce to market and goods back" }
+        - { name: "Light-Trailer", definition: "loaded gross weight not more than 500 lb" }
+        - { name: "Mobile Home", definition: "trailer or semitrailer designed and equipped as a dwelling place, or whose shell is so designed but is used for advertising, sales, display or promotion" }
+        - { name: "Semi-Trailer", definition: "no motive power, part of its own weight and load carried by the towing vehicle, one or more load-carrying axles" }
+        - { name: "Trailer", definition: "no motive power, carries its load wholly on its own structure, two or more load-carrying axles" }
+        - { name: "Travel Trailer / Camper Trailer", definition: "designed and equipped as a dwelling place and for use as a highway conveyance" }
+      thresholds: "an IDENTIFICATION TRAILER PLATE must be issued once a semi-trailer exceeds 500 lb gross, a boat trailer 1,500 lb gross (trailer plus boat plus motor), or a farm trailer 6,000 lb gross. Policy 19.00 also records that a TOW DOLLY is not a trailer and cannot be registered at all."
+      terms: "an identification plate may be bought for one year, four years, or PERMANENT (lifetime). One-year and four-year plates transfer to a new owner; 'The permanent trailer license plate CANNOT BE TRANSFERRED FOR ANY REASON' and must be surrendered to OMV when the owner's interest ends, with no refund."
+      dead_class: "'Apportioned trailer license plates are no longer issued in Louisiana (effective January 1, 2002)' — a dated, authority-stated discontinuation, and one of the few in this group that comes with its own effective date."
+    authority: "R.S. 32:1, 47:451, 47:462(B)(1), 47:462(B)(2)(c), 47:463.5, 47:479(6) and 47:501, as cited by Policy 19.00 (effective 1986-05-01, revised 2018-09-13)"
+    region_encoding: none
+    sources:
+      - "https://public.powerdms.com/ladpsc/documents/366669  # Louisiana OMV Policy 19.00, 'Trailer - Classes of License Plates' — the seven trailer categories and their definitions, the 500/1,500/6,000 lb identification-plate thresholds, the tow-dolly exclusion, the one-year/four-year/permanent terms and their transfer rules, the pro-rata refund in $10 increments, and the 1 January 2002 end of apportioned trailer plates"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Louisiana  # LOCATOR ONLY: the D and K boat-trailer prefixes and the six-digit arrangement"
+    notes: >-
+      LOUISIANA TRAILER PLATES. Included because L2 names trailer as a core class
+      and because Louisiana's treatment is the richest of the four states here:
+      seven statutory categories, three weight thresholds, three registration
+      terms and a permanent plate that is non-transferable by rule. The class
+      scheme is fully sourced and the serial arrangement is not, so the scheme is
+      recorded as data and the arrangement as a flagged guess. The 2002 end of
+      apportioned trailer plates is exactly the kind of dated discontinuation
+      PRD-PLATES's `ended: true` semantics exist for, and is recorded here rather
+      than minted as a series because no format for the dead class was obtained.
+
+  # =========================================================================
+  # PERSONALIZED PRESTIGE — the best-specified vanity charset in the group, and
+  # it comes from a policy revised five months before this pass.
+  # =========================================================================
+  - id: us-la-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 1973 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9]){0,6}\z'
+      serial_basis: authority-stated
+      charset:
+        max_characters: 7
+        max_characters_motorcycle_or_handicap: 6
+        allowed:
+          - "letters A to Z, and the configuration MUST CONTAIN AT LEAST TWO LETTERS"
+          - "numbers 0 to 9"
+          - "spaces, or two half spaces, counting as one of the seven characters"
+          - "periods, counting as one space on the plate"
+          - "hyphens, counting as one space on the plate"
+        forbidden:
+          - "more than seven characters"
+          - "two alpha characters used as a prefix followed by numbers"
+          - "a regular plate sequence — three numbers followed by three alpha, or three alpha followed by three numbers"
+          - "the prefixes LSP, DPS, OMV, NOLA, HQ, SP or LA, and the prefix TS"
+          - "special symbols such as #, @, %, & etc."
+          - "a patented logo"
+          - "the number 1 substituted for the letter I, or the number 0 for the letter O"
+          - "ethnic, racial, vulgar or indecent connotations which may be offensive to good taste and decency"
+          - "amateur radio call signs (which have their own plate class under R.S. 47:463.3)"
+        uniqueness: "'Identical personalized prestige plates cannot be issued, including personalized prestige plates with the character configuration already on a personalized dealer plate' — the vanity namespace is shared with the dealer vanity namespace."
+        notes: >-
+          THIS IS THE ONLY FULLY AUTHORITY-STATED CHARSET IN THE SOUTHCENTRAL
+          GROUP. It is deliberately NOT compiled into a `regex_strict`: several
+          of the rules are semantic rather than lexical (offensiveness, patented
+          logos, call signs), the separator-handling rules interact with §2.6 in
+          a way that would need its own decision (Louisiana counts a hyphen as a
+          consumed CHARACTER, where this dataset treats hyphens as separators
+          outside the serial alphabet), and a partial strict twin would claim
+          more precision than the data supports. The rules are recorded as
+          structured data so a consumer can implement them explicitly.
+      separator_conflict_note: >-
+        WORTH A MAINTAINER DECISION. Louisiana permits a hyphen or a period
+        INSIDE a personalized configuration and counts it against the
+        seven-character budget, which means the glyph is part of the customer's
+        chosen string rather than a group separator. Under PRD-PLATES §2.6 rule 3
+        a jurisdiction that prints a glyph inside a serial is "a schema
+        amendment, not a data entry". This is arguably the first such case in the
+        dataset — although it applies only to owner-chosen configurations, not to
+        department-assigned serials, which may be a distinction the separator
+        contract wants to draw explicitly. Flagged, not resolved here.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "Policy 45.00 lists R.S. 47:463.2 personalized prestige plates in its Category #2 uniform group, so the vanity plate carries the standard blue-on-white scheme with its own bottom legend rather than a distinct design"
+      emblem: { present: true, rendered: placeholder }
+    eligibility: "Policy 21.00: 'Personalized prestige plates may be issued to automobiles, private trucks (up to 16,000 lbs.), vans, and motor homes.' Issued first come, first served."
+    fee: "$25.00 per year for a configuration of more than one character; $250.00 per year for a SINGLE ALPHA CHARACTER plate — a ten-fold premium on one-letter plates, echoing the Delaware low-number market the US dossier records, but priced by the state rather than by a secondary market."
+    authority: "R.S. 47:462 and R.S. 47:463.2, as cited by Policy 21.00 (effective 1973-06-19, revised 2025-02-14)"
+    region_encoding: none
+    sources:
+      - "https://public.powerdms.com/ladpsc/documents/366665  # Louisiana OMV Policy 21.00, 'Personalized Prestige License Plates' (revised 2025-02-14), authority R.S. 47:462 and 47:463.2 — the complete allowed/not-allowed table quoted above, the seven-character cap and the six-character motorcycle/handicap cap, the reserved prefixes, the shared uniqueness constraint with personalized dealer plates, the eligibility list, and the $25/$250 fee split"
+    notes: >-
+      LOUISIANA PERSONALIZED PRESTIGE. `period.start: 1973` is Policy 21.00's own
+      stated Effective Date of 19 June 1973 — an instrument-in-force date and
+      therefore an UPPER BOUND on the true start of the class, though a
+      remarkably early one and almost certainly close. The reserved-prefix list
+      is the sort of detail that only ever appears in an operating manual and
+      never in a statute or a brochure: LSP (Louisiana State Police), DPS, OMV,
+      NOLA, HQ, SP, TS and LA are all unavailable to the public, which is a small
+      but real piece of the state's namespace policy. And the $250 single-letter
+      fee is the state pricing what Delaware lets the market price.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX ONLY, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-la-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2016 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      serial_basis: authority-stated-negatively
+      charset: { notes: "specialty plates carry ordinary department-assigned serials on an alternative design unless personalized; Policy 45.00's Category #2 keeps most of them inside the uniform colour scheme with only the bottom legend changing, so a Louisiana specialty plate is usually a LEGEND variant rather than a full redesign." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised program; individual designs are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_policies: 187
+      count_basis: authority-enumerated
+      count_method: >-
+        COUNTED FROM THE OMV POLICY MANUAL'S OWN SECTION 5 INDEX: 187 numbered
+        policies, numbered sparsely from 1.00 to 205.00 (fetched 2026-08-02).
+        This is a count of PLATE POLICIES, not of specialty programs — the same
+        index also covers the passenger class, trailers, dealers, temporary tags,
+        display rules and sticker inventory. The great majority of entries above
+        number 40.00 are individual specialty programs, but the boundary is a
+        judgement call and no cleaner official figure was located, so the raw
+        policy count is published with its definition rather than a tidied number
+        with none.
+      structure_note: >-
+        LOUISIANA'S SPECIALTY CATALOGUE IS LEGISLATED ONE PLATE AT A TIME, like
+        Texas and unlike Florida. Policy 45.00's Category #2 list alone maps
+        thirty-odd named plate types to their own R.S. sections (47:463.3 ham
+        radio, 47:463.8 antique, 47:463.10 National Guard, 47:463.12 street rod,
+        47:463.13 Congressional Medal of Honor, 47:463.26 Purple Heart,
+        47:463.33 street cruiser, 47:463.36 clergy, and so on). Because each is
+        an edict of government, the Louisiana specialty catalogue is enumerable
+        from statute — which is the right route for an L4 pass, and is available
+        even though the statute text itself was unreachable here.
+      exempt_from_uniform_scheme: "Policy 45.00 Category #3 names the three classes NOT subject to the uniform plate law: R.S. 47:463.14 Farhad Grotto, R.S. 47:463.31 University, and R.S. 47:511 Apportioned. A three-item exception list is itself a useful fact — everything else Louisiana issues is blue-on-white by policy."
+      official_list_url: "https://expresslane.la.gov/omv/vehicles/plates/special-personalized-plates/"
+      official_viewer: "OMV publishes a 'Specialty Plates Viewer' from that page, described as letting an applicant 'view available plate options and submit your request online for OMV processing'; it is a JavaScript application and returned no enumerable catalogue to a fetcher (recorded gap)."
+    region_encoding: none
+    sources:
+      - "https://expresslane.la.gov/omv/resources/omv-policy/vehicle-license-plate-classifications-requirements/  # the OMV Policy Manual Section 5 index — 187 numbered plate policies from 1.00 to 205.00, each linking to its own dated PDF; the count claim"
+      - "https://public.powerdms.com/ladpsc/documents/370991  # Policy 45.00 — the Category #1/#2/#3 tables mapping named plate types to their authorising R.S. sections, and the three-class exemption from the uniform scheme"
+      - "https://expresslane.la.gov/omv/vehicles/plates/special-personalized-plates/  # OMV: 'Louisiana offers a wide variety of specialty license plates, as well as your choice of a personalized plate'; the Specialty Plates Viewer; the Specialized Vehicle Unit contact"
+    notes: >-
+      THE LOUISIANA SPECIALTY INDEX. The count published here is deliberately the
+      raw one — 187 numbered plate policies — with an explicit statement of what
+      it counts, rather than a cleaner "roughly 150 specialty programs" that
+      would be a guess wearing a number's clothes. The structurally interesting
+      finding is that Louisiana, like Texas and unlike Florida, authorises
+      specialty plates ONE STATUTE AT A TIME, so its catalogue is recoverable
+      from edicts of government even where the agency's own viewer is
+      unfetchable. That is the route for L4, and it sidesteps the artwork_risk
+      assertion entirely, because a statute naming a plate is public domain no
+      matter what LADPS says about its website.

--- a/plates/us-ok.yml
+++ b/plates/us-ok.yml
@@ -1,0 +1,513 @@
+# plates/us-ok.yml — Oklahoma (PRD-PLATES gate L2, group: southcentral).
+#
+# WHY OKLAHOMA IS THE BEST-SOURCED STATE IN THIS GROUP, and it is not close:
+#
+# 1. THE CURRENT-SERIES-BEFORE-LAST HAS A STATUTORY START DATE. 47 O.S. § 1113.2(D)
+#    directs the Executive Director to "devise a numbering system suitable for a
+#    new general issue of license plates COMMENCING JANUARY 1, 2017", and
+#    § 1113.2(F) makes that design "a part of all license plates issued on or
+#    after January 1, 2017". That is the Florida-apportioned situation — a real
+#    dated claim rather than an instrument-in-force upper bound — and it is rare.
+#
+# 2. OKLAHOMA LEGISLATES A REISSUE CADENCE, WHICH ALMOST NO STATE DOES.
+#    § 1113.2(H): the Department of Public Safety "may request that the Oklahoma
+#    Tax Commission initiate subsequent reissues of the official vehicle license
+#    plate. Provided however, such request shall not occur more frequently than
+#    five (5) years following the most recent reissue." So Oklahoma has a
+#    statutory MINIMUM interval between base redesigns. Compare AAMVA §1.1's
+#    recommended 7-to-10-year REPLACEMENT cycle (a different thing), Florida's
+#    legislated 10-year replacement, and Texas, which abolished replacement
+#    outright in 2016. Four states, four different answers to the same question.
+#
+# 3. THE DESIGN AUTHOR IS NOT THE REGISTRAR. § 1113.2(A): the new plate is
+#    "designed by the OKLAHOMA TOURISM AND RECREATION DEPARTMENT with the
+#    approval of the Department of Public Safety". A tourism agency draws the
+#    plate, a police agency approves it, and a third body issues it. That
+#    three-way split is unique in this group and it is why the current plate
+#    carries a tourism URL as its bottom legend.
+#
+# 4. THREE GOVERNMENT SERIES ARE SPECIFIED CHARACTER-BY-CHARACTER IN STATUTE.
+#    § 1113(B)(5)-(7) spell out the Highway Patrol, Military Department and
+#    Department of Corrections plates down to the literal letter prefixes. Those
+#    are among the very few US serial formats in this whole dataset that come
+#    from a legislature rather than from an agency or a collector.
+#
+# AUTHORITY CAVEAT, and it is load-bearing: every statute quoted below names the
+# OKLAHOMA TAX COMMISSION, because the statute predates the reorganisation.
+# Since HB 3419 (signed 19 May 2022) the motor-vehicle functions sit with
+# SERVICE OKLAHOMA. Both are recorded; the statutory text is quoted unaltered.
+#
+# STATUTE EDITION CAVEAT: the Title 47 text read for this pass is the Oklahoma
+# Senate's published compilation dated 2019. It is the most recent full-title
+# text obtainable by fetch (oscn.net, the official host, timed out on every
+# attempt). Amendments after 2019 are therefore UNCHECKED — a recorded gap that
+# a verifier must close before any § 1113 claim here is promoted past L2.
+jurisdiction: us-ok
+authority:
+  name: Service Oklahoma
+  url: "https://oklahoma.gov/service/popular-services/license-plates.html"
+authority_note: >-
+  Service Oklahoma was "Created by the legislature in May 2022" and provides
+  "driver and motor vehicle services on behalf of the state — think driver
+  licenses, disability parking placards, car registrations, car titles, specialty
+  license plates". Governor Kevin Stitt signed HB 3419 into law on 19 May 2022.
+  Title 47 still reads "Oklahoma Tax Commission" throughout; the statutory quotes
+  below are unedited, and every functional reference should be read as Service
+  Oklahoma today.
+binding: vehicle
+statute_edition: "Oklahoma Statutes Title 47 (Motor Vehicles), Oklahoma Senate published compilation, 2019 — the edition obtainable by fetch. oscn.net (official) timed out on every attempt this pass; post-2019 amendments UNCHECKED (recorded gap)."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: no-pd-rule-found-default-copyrighted
+  basis: >-
+    ADVERSE BY DEFAULT, NOT BY ASSERTION — the weakest of the four postures in
+    this group and honestly labelled as such. 17 U.S.C. §105 does not reach the
+    states, so a US state plate design is copyrighted unless that state says
+    otherwise, and NO Oklahoma instrument saying otherwise was located: no
+    {{PD-OKGov}} tag exists in the Commons set the US dossier sampled, Oklahoma
+    does not appear in the favourable column of the dossier's per-state table,
+    and no Oklahoma open-records provision disclaiming copyright was found. What
+    WAS found is a bare footer assertion — "Copyright (c) 2026 Service Oklahoma"
+    on the agency's own license-plate page — which is evidence of posture but not
+    a rule about plate DESIGNS. Recorded as: default-copyrighted, no affirmative
+    assertion over plate artwork located, UNRESEARCHED at statute level.
+  design_authorship_note: >-
+    An Oklahoma-specific wrinkle worth carrying into any clearance analysis: by
+    § 1113.2(A) the current base was "designed by the Oklahoma Tourism and
+    Recreation Department". Whatever rights exist therefore sit with a tourism
+    agency rather than with the registrar, and the plate's bottom legend is that
+    agency's own promotional URL. Any future clearance request goes to OTRD, not
+    to Service Oklahoma.
+  emblem_rule: >-
+    HIGHEST EMBLEM EXPOSURE IN THIS GROUP. § 1113(B)(5)-(7) put the OKLAHOMA
+    STATE SEAL on the face of the Highway Patrol and Military Department plates
+    by statute, and the Department of Corrections badge on the DOC plate. State
+    seals carry protection INDEPENDENT of copyright (seal-misuse statutes), that
+    regime is unresearched for Oklahoma, and the seal here is not decoration but
+    a statutorily mandated element sitting inside the serial line. Render
+    `emblem: {present: true, rendered: placeholder}` without exception on those
+    three series.
+  sources:
+    - "https://oklahoma.gov/service/popular-services/license-plates.html  # Service Oklahoma's own license-plate page; footer reads 'Copyright (c) 2026 Service Oklahoma' — the only Oklahoma rights assertion located"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): establishes that §105 does not reach the states and that Oklahoma is not among the states with a favourable rule; used to evidence an ABSENCE"
+    - "https://oksenate.gov/sites/default/files/2019-12/os47.pdf  # 47 O.S. § 1113(B)(5)-(7): the state seal and the DOC badge mandated on the face of the OHP, OMD and DOC plates — the emblem exposure, in statute (an edict, and therefore itself PD)"
+
+# ---------------------------------------------------------------------------
+# The US standards chain — recorded once per US file (see us-fl.yml).
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption; AAMVA has no enforcement power."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is paywalled and UNPINNED; no J686 dimension is quoted anywhere in this dataset."
+    retroreflectivity: "AAMVA §3.3: readable in daylight and at night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3. Oklahoma legislates its own version of this at 47 O.S. § 1113(B)(3) — see below."
+    replacement_cycle: "AAMVA §1.1 recommends a replacement cycle 'not to exceed 7 to 10 years'. Oklahoma instead legislates a MINIMUM REISSUE INTERVAL of five years (§ 1113.2(H)) — a different mechanism answering a different question, and the contrast is the point."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  state_retroreflectivity_statute: "47 O.S. § 1113(B)(3), verbatim: 'All license plates and decals shall be made with reflectorized material as a background to the letters, numbers and characters displayed thereon. The reflectorized material shall be of such a nature as to provide effective and dependable brightness during the service period for which the license plate or decal is issued.' Note Oklahoma legislates the PROPERTY (brightness for the service period) and not the measurement, exactly as AAMVA does not."
+  folklore_caution: "The '1956 AMA standardization agreement' remains COMMONLY REPEATED, UNSOURCED (PRD-PLATES §4). Oklahoma's statute states no plate dimensions at all — § 1113(A)(1) leaves size wholly to the agency: 'The license plate and decal shall be of such size, color, design and numbering as the Tax Commission may direct.'"
+
+# ---------------------------------------------------------------------------
+# Display rules. Oklahoma is a ONE-PLATE state with the truck-tractor inversion
+# — the same genuinely unusual rule Florida has, arrived at independently.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "ONE plate, rear. § 1113(A)(1): the agency shall 'issue to the owner of the vehicle a certificate of registration, ONE license plate and a yearly decal'. § 1113(A)(2): 'The license plate shall be securely attached to the rear of the vehicle, except truck-tractor plates which shall be attached to the front of the vehicle.' Service Oklahoma restates it: 'You are required to have at least one (1) License Plate properly installed on your registered vehicle.'"
+  truck_tractor_inversion: "TRUCK-TRACTOR PLATES GO ON THE FRONT — the inverse of the state default. Florida § 320.0706 has the identical rule. Two of the four states in this group invert plate placement for truck tractors, which suggests a shared industry practice rather than a coincidence, and any US display model that assumes 'rear-only means rear' will misclassify tractors in both."
+  decal: "§ 1113(A)(1): a YEARLY DECAL validates the plate for every registration period after the year of issue, and each plate must carry 'a space for the placement of the yearly decals' (§ 1113(B)(1)). Apportioned plates, state-vehicle plates and exempt plates for governmental entities and fire departments are excluded from the yearly-decal regime (§ 1113(B)(2))."
+  off_road_exception: "all-terrain vehicles, utility vehicles and motorcycles used exclusively off roads and highways get a certificate and a decal but NO LICENSE PLATE; the decal goes on the front of the vehicle or on the front fork of the motorcycle (§ 1113(A)(1))."
+  covering_offense: "§ 1113(A)(2): operating a vehicle 'upon which the license plate is covered, overlaid or otherwise screened with any material, whether such material be clear, translucent, tinted or opaque, shall be a violation of this paragraph' — and it applies 'regardless of where such vehicle is registered', reaching out-of-state plates."
+  permanent_plates: "§ 1113(A)(3): a permanent nonexpiring plate may be issued to an owner of one hundred or more commercial motor vehicles and for vehicles registered under § 1120."
+  sources:
+    - "https://oksenate.gov/sites/default/files/2019-12/os47.pdf  # 47 O.S. § 1113(A)(1) one plate plus yearly decal and the off-road exception; § 1113(A)(2) rear display, the truck-tractor front-only inversion, and the covering offense; § 1113(A)(3) permanent nonexpiring plates; § 1113(B)(1)-(3) decal space, apportioned/exempt exclusions, reflectorized background"
+    - "https://oklahoma.gov/service/popular-services/license-plates.html  # Service Oklahoma: 'You are required to have at least one (1) License Plate properly installed on your registered vehicle.'"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES — the "Iconic Oklahoma" plate, and the
+  # most interesting rollout rule in this group: it is NOT reissued.
+  # =========================================================================
+  - id: us-ok-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2024 }
+    period_evidence: authority-stated
+    matching: strict
+    format:
+      pattern: "LLL-999"
+      regex: '\A[A-Z]{3}[- ]?\d{3}\z'
+      serial_basis: locator-corroborated
+      charset:
+        notes: >-
+          NO STATUTORY CONSTRAINT. § 1113(A)(1): "The license plate and decal
+          shall be of such size, color, design and NUMBERING as the Tax
+          Commission may direct", and § 1113.2(D) makes the numbering system the
+          Executive Director's to devise. So Oklahoma, like Texas, delegates the
+          alphanumeric pattern entirely. The three-letter/three-numeral
+          arrangement is continuous with the predecessor base and is corroborated
+          by the fact that the current serials continue the SAME sequence rather
+          than restarting — see progression.
+        excluded_reported: ["C", "N", "O"]
+        excluded_basis: locator-unconfirmed
+        excluded_note: "the 2009-2016 base is reported to have skipped the C, N and O series; whether the exclusion carries into the current sequence is unstated. Recorded, not asserted, and deliberately NOT promoted to a regex_strict."
+      progression: >-
+        Continuous with the predecessor, which is the tell that this is a base
+        change and not a numbering change: reported as issuing intermittently in
+        the PNU-001 to PZG-999 range and exclusively from PZJ-001 onward, reaching
+        VXY-261 as of 2025-11-08 (locator). A parse API can therefore NOT infer
+        the base from the serial in Oklahoma — the serial spans both bases.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      plate_dimension_note: "§ 1113(A)(1) leaves size to the agency; no Oklahoma instrument stating dimensions was obtained. 12 x 6 in is the North American convention (AAMVA -> SAE J686, unpinned)."
+      material: "reflectorized background per § 1113(B)(3); § 1113.2(G) additionally requires that plates 'be issued with identification numbers and letters in a color that provides a DISTINCT CONTRAST WITH A LIGHT-COLORED BACKGROUND in the plate identification area'"
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO HEX IS ASSERTED, and the reason is a live tension worth recording.
+        § 1113.2(G) requires contrast against "a light-colored background in the
+        plate identification area", while the current base is reported as a RED
+        plate with a white serial. Either the identification area is locally
+        light, or practice has moved past the 2016 wording, or the 2019 text read
+        here has since been amended. The statute is quoted and the reported
+        colours are recorded as observation only; the discrepancy is recorded,
+        not resolved (PRD-PLATES §5.3).
+      legend_top: "OKLAHOMA"
+      legend_bottom: "IMAGINE THAT"
+      legend_basis: locator-unconfirmed
+      separator_glyph:
+        printed: "a white star, reported as the star of the original 46th-state flag"
+        basis: locator-unconfirmed
+        consumer_rule: >-
+          NEVER SERIAL. Same normative case as the Texas silhouette and the
+          German coat of arms: a glyph occupying the separator position is a
+          DESIGN element, carried here, never a character. This file writes the
+          emitted `-` at that position per the plates/de.yml precedent.
+      emblem: { present: true, rendered: placeholder }
+      graphic: { present: true, rendered: placeholder, description: "Oklahoma landmarks screened in blue along the bottom of a red field (locator description; not reproduced)" }
+      rear_differs: false
+    rollout_rule:
+      optional_replacement: true
+      authority_text: >-
+        Service Oklahoma, verbatim: "Starting Sept. 1, 2024, Oklahoma's standard
+        issue license plate will have a new design. UNLIKE PREVIOUS PLATE
+        REDESIGNS, OKLAHOMANS WILL NOT AUTOMATICALLY BE REISSUED THE NEWLY
+        DESIGNED PLATE. Anyone who would like the new Iconic Oklahoma Plate can
+        pay a $4 plate replacement fee with their annual vehicle registration
+        renewal or $9 outside of their annual renewal at a local licensed
+        operator."
+      consequence: >-
+        THIS IS A PARALLEL-ISSUANCE SERIES IN THE PRD-PLATES §2.2 SENSE, stated
+        by the authority rather than inferred. The 2017 base was mandatory-replace;
+        the 2024 base is opt-in. Both are therefore lawfully current, both are
+        being issued, and the periods overlap for real. That is exactly the
+        situation the schema's "overlap legal iff distinct notes" rule exists for,
+        and Oklahoma is the cleanest sourced example of it in the US so far.
+    region_encoding: none
+    region_encoding_note: >-
+      NONE IN THE SERIAL, AND THE HISTORY IS THE INTERESTING PART. Oklahoma
+      COUNTY-CODED its passenger serials by letter prefix from 1981 to 2009 —
+      a full three-letter-to-county decode table, county allocations exhausting
+      into a second arrangement, the works. County coding was discontinued with
+      the 2009 base and moved to the MONTH REVALIDATION DECAL as a two-letter
+      county abbreviation; the county-abbreviated decal is reported to have
+      stopped being issued in 2024. So Oklahoma's geographic signal migrated
+      serial -> sticker -> nothing over fifteen years. The historic decode table
+      is L4 scope (PRD-PLATES §7) and is deliberately not built here; it is
+      flagged as a high-value `_decode/` candidate because it is one of the few
+      genuine US serial-to-geography decodes that ever existed.
+    sources:
+      - "https://oklahoma.gov/service/popular-services/license-plates.html  # Service Oklahoma: 'Starting Sept. 1, 2024, Oklahoma's standard issue license plate will have a new design'; the Iconic Oklahoma Plate name; the NOT-automatically-reissued rule; $4 with renewal / $9 outside renewal"
+      - "https://oksenate.gov/sites/default/files/2019-12/os47.pdf  # 47 O.S. § 1113(A)(1) size/colour/design/numbering delegated to the agency; § 1113(B)(3) reflectorized background; § 1113.2(G) contrast against a light-coloured background; § 1113.2(H) the five-year minimum reissue interval that permitted this base"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Oklahoma  # LOCATOR ONLY (PRD-PLATES §4): the ABC-123 arrangement, the 'IMAGINE THAT' bottom legend, the red field with the star separator, and the PNU-001/PZJ-001-to-VXY-261 range as of 2025-11-08. None asserted as sourced."
+    notes: >-
+      THE ICONIC OKLAHOMA PLATE. Its defining fact is administrative rather than
+      visual: Oklahoma broke with its own precedent and did NOT force a fleet
+      reissue, so for the first time two Oklahoma bases are simultaneously
+      current by design. A consumer that models US state bases as a strict
+      succession will get Oklahoma wrong from September 2024 onward. Note also
+      that the serial sequence runs straight through the base boundary, so the
+      base cannot be inferred from the number — the opposite of the Netherlands'
+      sidecodes, and a useful reminder that era-inference is a per-jurisdiction
+      capability, not a general one.
+
+  # =========================================================================
+  # ONE SERIES BACK — the scissor-tailed flycatcher base, with the best-dated
+  # start in this group.
+  # =========================================================================
+  - id: us-ok-standard-scissortail
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2017, end: 2024 }
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "LLL-999"
+      regex: '\A[A-Z]{3}[- ]?\d{3}\z'
+      serial_basis: locator-corroborated
+      charset: { notes: "§ 1113.2(D) put the numbering system for this general issue in the Executive Director's hands: 'the Executive Director shall devise a numbering system suitable for a new general issue of license plates commencing January 1, 2017'. No published numbering instrument was obtained (recorded gap)." }
+      progression: "reported exclusively AAA-001 to LYZ-999, then intermittently in the 'LZ' block, then MAA-001 to PZH-999 on the revised-legend variant (locator). A reversed 123-ABC arrangement is reported as occurring occasionally and is NOT modelled, because no primary establishes when or why."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      material: "reflectorized per § 1113(B)(3) and § 1113.2(G)"
+      background: { finish: retroreflective }
+      colour_note: "reported as a screened black serial on a graphic blue landscape with a white scissor-tailed flycatcher; consistent with § 1113.2(G)'s 'distinct contrast with a light-colored background' in a way the 2024 red base is not. No hex asserted."
+      legend_top: "EXPLORE OKLAHOMA"
+      legend_bottom: "TRAVELOK.COM"
+      legend_note: "the bottom legend is the Oklahoma Tourism and Recreation Department's own promotional URL — the visible consequence of § 1113.2(A) making OTRD the plate's designer."
+      separator_glyph: { printed: "silhouette of the State of Oklahoma", basis: locator-unconfirmed }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    variants:
+      - name: "EXPLORE OKLAHOMA legend"
+        period: { start: 2017, end: 2022 }
+        note: "original legend pairing: 'EXPLORE OKLAHOMA' top, 'TRAVELOK.COM' bottom"
+        format: { pattern: "LLL-999" }
+      - name: "OKLAHOMA legend"
+        period: { start: 2022, end: 2024 }
+        note: "same base, top legend changed to plain 'OKLAHOMA'; recorded as a VARIANT and not a series because format and period are continuous and only the legend text moves (PRD-PLATES §2.3). Both variants are locator-grade."
+        format: { pattern: "LLL-999" }
+    statutory_origin:
+      text: >-
+        § 1113.2(D), verbatim: "Subject to the Oklahoma Tax Commission Fund
+        receiving credit for the funds referenced in subsection C of this
+        section, the Executive Director shall devise a numbering system suitable
+        for a new general issue of license plates commencing January 1, 2017.
+        Unless otherwise provided by the Oklahoma Vehicle License and
+        Registration Act, new license plates will be issued to all registrants
+        applying for an original or renewal registration on or after January 1,
+        2017, and will continue until all previously issued license plates have
+        been replaced. Upon receipt of the new general issue license plate,
+        registrants shall replace any previously issued Oklahoma general issue
+        license plate currently displayed on their vehicle."
+      funding: "§ 1113.2(B)-(C): a $5 per-vehicle registration fee from 1 July 2016 plus the first $1.8m (FY2017) and $2.0m (FY2018) of registration receipts were appropriated to pay for the reissue. Oklahoma is the only state in this group whose base redesign has a line-item price in statute."
+      number_reservation: "§ 1113.2(F): registrants could RESERVE their existing general-issue or personalized plate number across the reissue for $15, payable by 1 November 2016."
+    region_encoding: none
+    region_encoding_note: "county coding had already been discontinued with the 2009 base; the county appeared on the month revalidation decal during this series' life."
+    sources:
+      - "https://oksenate.gov/sites/default/files/2019-12/os47.pdf  # 47 O.S. § 1113.2(A) design by the Oklahoma Tourism and Recreation Department with DPS approval; § 1113.2(B)-(C) the $5 fee and the FY2017/FY2018 appropriations; § 1113.2(D) the January 1, 2017 commencement and mandatory replacement; § 1113.2(F) the $15 number reservation; § 1113.2(H) the five-year minimum before a further reissue"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Oklahoma  # LOCATOR ONLY: the scissor-tailed flycatcher design, the EXPLORE OKLAHOMA / TRAVELOK.COM legends and their 2022 change, the state-shaped separator, and the AAA-001 to PZH-999 ranges"
+    notes: >-
+      THE SCISSORTAIL BASE — MANDATORY WHERE ITS SUCCESSOR IS OPTIONAL. This is
+      the series that carries Oklahoma's statutory-date evidence, and it also
+      carries the reissue MACHINERY: a dedicated fee, two named appropriations, a
+      paid number-reservation window and an express instruction that registrants
+      "shall replace any previously issued Oklahoma general issue license plate".
+      Everything the 2024 base did NOT do. The series is given `end: 2024` because
+      the 2024 base displaced it as the plate issued to new registrants, but note
+      that scissortail plates remain lawfully displayed and transferable, and are
+      reported still to be issued where a buyer transfers an existing plate — see
+      the overlap with us-ok-standard, which is deliberate and sourced.
+
+  # =========================================================================
+  # GOVERNMENT SERIES SPECIFIED IN STATUTE. Three of them, character by
+  # character. These are the best-sourced serial formats in this whole group.
+  # =========================================================================
+  - id: us-ok-highway-patrol
+    class: police
+    categories: [car, van, truck]
+    period: { start: 2008 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "OHP-999"
+      regex: '\AOHP[- ]?\d{1,4}\z'
+      serial_basis: statute-stated
+      charset:
+        notes: >-
+          § 1113(B)(5), verbatim: "the Tax Commission shall design appropriate
+          official license plates for vehicles of the Oklahoma Highway Patrol.
+          The license plates shall have the legend 'Oklahoma OK' and shall
+          contain the letters 'OHP' followed by the state seal and the badge
+          number of the Highway Patrol officer to whom the vehicle is assigned.
+          The words 'Oklahoma Highway Patrol' shall also be included on such
+          license plates." The literal prefix OHP is statutory; the numeric part
+          is a BADGE NUMBER, so it has no fixed width and none is claimed — the
+          quantifier makes no width assertion beyond a practical upper bound.
+      progression: "not sequential in the ordinary sense — the number is the assigned officer's badge number, so the serial is keyed to a PERSON rather than to an issuance counter. That is an unusual binding and it is stated in the statute."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_top: "Oklahoma OK"
+      legend_other: "Oklahoma Highway Patrol"
+      emblem:
+        present: true
+        rendered: placeholder
+        content: "the OKLAHOMA STATE SEAL, mandated by statute, printed between the letters 'OHP' and the badge number"
+        consumer_rule: >-
+          THE SEAL IS NOT A CHARACTER AND NOT A SEPARATOR TO BE READ. This is
+          the exact case `_meta/separators.yml` reserves for German and Austrian
+          coats of arms, and it is here mandated by a legislature rather than by
+          a design office. The emitted `-` in the pattern marks the position; the
+          seal itself lives in `design.emblem` and is rendered as a placeholder,
+          both because seal-misuse statutes are a regime independent of copyright
+          and because Oklahoma's own posture is unresearched.
+    binding: officer
+    binding_note: "`binding: officer` is used rather than `vehicle` or `owner`: the statute ties the serial to 'the Highway Patrol officer to whom the vehicle is assigned', so the identifier follows a person even though the plate is on a fleet vehicle. Flagged as a possible vocabulary addition alongside vehicle/owner/business."
+    region_encoding: none
+    sources:
+      - "https://oksenate.gov/sites/default/files/2019-12/os47.pdf  # 47 O.S. § 1113(B)(5): the 'Oklahoma OK' legend, the literal 'OHP' letters, the state seal, the officer's badge number as the serial, and the 'Oklahoma Highway Patrol' wording"
+    notes: >-
+      OKLAHOMA HIGHWAY PATROL. One of only a handful of US serial formats in this
+      dataset that a LEGISLATURE wrote out character by character. Two facts a
+      parse API should carry: the numeric component is a badge number and
+      therefore not an issuance counter, and the glyph between the letters and
+      the digits is the state seal. PERIOD: `start: 2008` is the year § 1113.2
+      was added (Laws 2008, c. 335) and is an UPPER BOUND on this series' true
+      start, which certainly predates it; the § 1113(B)(5) specification itself
+      carries no date in the text read. Recorded as an upper bound rather than
+      invented.
+
+  - id: us-ok-military-department
+    class: military
+    categories: [car, van, truck, bus]
+    period: { start: 2008 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "OMD-999"
+      regex: '\AOMD[- ]?[A-Z0-9]{3}\z'
+      serial_basis: statute-stated
+      charset:
+        notes: >-
+          § 1113(B)(6), verbatim: the plates "shall have the legend 'Oklahoma OK'
+          and shall contain the letters 'OMD' followed by the state seal and
+          THREE NUMBERS OR LETTERS as designated by the Adjutant General. The
+          words 'Oklahoma Military Department' shall also be included on such
+          license plates." Three characters, alphanumeric, WIDTH FIXED BY STATUTE
+          — which is rarer in this dataset than a fixed prefix.
+        assigner: "the Adjutant General designates the three characters, so allocation is a military rather than a motor-vehicle function."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_top: "Oklahoma OK"
+      legend_other: "Oklahoma Military Department"
+      emblem: { present: true, rendered: placeholder, content: "the OKLAHOMA STATE SEAL, statutory, printed between 'OMD' and the three designated characters — never a character, never a separator" }
+    region_encoding: none
+    sources:
+      - "https://oksenate.gov/sites/default/files/2019-12/os47.pdf  # 47 O.S. § 1113(B)(6): the 'Oklahoma OK' legend, the literal 'OMD' letters, the state seal, three numbers or letters designated by the Adjutant General, and the 'Oklahoma Military Department' wording"
+    notes: >-
+      OKLAHOMA MILITARY DEPARTMENT. Modelled separately from the Highway Patrol
+      plate because the class differs (military vs police in
+      `_meta/classes.yml`), the assigner differs (Adjutant General vs badge
+      number) and the serial WIDTH differs (fixed three vs open badge number) —
+      three independent reasons under PRD-PLATES §2.3, in adjacent statutory
+      paragraphs.
+
+  - id: us-ok-corrections
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2008 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "DOC-999"
+      regex: '\ADOC[- ]?[A-Z0-9]{3}\z'
+      serial_basis: statute-stated
+      charset:
+        notes: >-
+          § 1113(B)(7), verbatim: the plates "shall contain the letters 'DOC'
+          followed by the Department of Corrections badge and three numbers or
+          letters or combination of both as designated by the Director of the
+          agency. The words 'Department of Corrections' shall also be included on
+          such license plates." Note the difference from OHP and OMD: the glyph
+          here is the DOC BADGE, not the state seal, and the statute conspicuously
+          does NOT prescribe the 'Oklahoma OK' legend for this plate.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_other: "Department of Corrections"
+      legend_note: "unlike § 1113(B)(5) and (B)(6), subsection (B)(7) prescribes no 'Oklahoma OK' legend — a real difference between three otherwise parallel paragraphs, recorded rather than smoothed over."
+      emblem: { present: true, rendered: placeholder, content: "the Oklahoma Department of Corrections BADGE (not the state seal), statutory, between 'DOC' and the designated characters" }
+    region_encoding: none
+    sources:
+      - "https://oksenate.gov/sites/default/files/2019-12/os47.pdf  # 47 O.S. § 1113(B)(7): the literal 'DOC' letters, the Department of Corrections badge, three numbers or letters or a combination designated by the Director, and the 'Department of Corrections' wording"
+    notes: >-
+      OKLAHOMA DEPARTMENT OF CORRECTIONS. Included because it completes the set of
+      three statutorily specified government formats and because the differences
+      between the three paragraphs are themselves data: state seal vs agency
+      badge, 'Oklahoma OK' legend vs none, badge-number serial vs designated
+      characters. A dataset that collapsed these into one 'government' series
+      would destroy all of that.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX ONLY, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-ok-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2024 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL-999"
+      regex: '\A[A-Z]{3}[- ]?\d{3}\z'
+      serial_basis: locator-corroborated
+      charset: { notes: "specialty plates carry the ordinary department-assigned arrangement on an alternative design unless personalized; § 1113(A)(1)'s delegation of 'numbering' to the agency applies unchanged. Many Oklahoma specialty designs carry their own literal prefixes, which are NOT enumerated here (that is L4)." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised program; individual designs are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count: null
+      count_note: >-
+        NO COUNT IS ASSERTED, and that is the honest answer. Service Oklahoma's
+        specialty-plate page is an AEM-rendered application that returned no
+        enumerable catalogue to a fetcher, and no Oklahoma instrument stating a
+        program count was located. Contrast Florida ("over 100", FLHSMV's own
+        words) and Arkansas (131 catalogue entries, counted from the DFA's own
+        content API). Recorded as a GAP rather than filled from a locator.
+      official_list_url: "https://oklahoma.gov/service/all-services/auto-vehicle/specialty-plates.html"
+      tribal_plates: >-
+        THE OKLAHOMA-SPECIFIC FACT WORTH MORE THAN THE COUNT: Service Oklahoma
+        lists TRIBAL PLATES as a first-class plate type alongside specialty and
+        personalized. Oklahoma tribal nations issue their own vehicle tags under
+        their own sovereign authority, and those tags are not state issuance at
+        all — they are a separate registration system operating on the same
+        roads. A US plate dataset that models only state issuance will fail to
+        parse a large population of legitimately registered Oklahoma vehicles.
+        Flagged as a distinct JURISDICTION question (tribal nations are not
+        ISO 3166-2 subdivisions) and deliberately not modelled at L2.
+      statutory_frame:
+        - "§ 1113(B)(2): apportioned plates, state-vehicle plates and exempt plates for governmental entities and fire departments organised under 18 O.S. § 592 are excluded from the yearly-decal regime"
+        - "§ 1113(B)(8): where a reissue is initiated, the Oklahoma Tourism and Recreation Department designs the plates and submits them to DPS for approval before the agency may issue them"
+        - "§ 1113.2(F): the reissue design applies to ALL plates issued on or after 1 January 2017 'Except for vehicles registered pursuant to the provisions of Section 1120 of this title and certain official special license plates' — so some specialty and official plates are exempt from base changes, which is why a specialty plate's base cannot be used to date it"
+    region_encoding: none
+    sources:
+      - "https://oklahoma.gov/service/popular-services/license-plates.html  # Service Oklahoma: 'Oklahoma offers several License Plate types, including Physically Disabled License Plates, Specialty Plates, Personalized Plates, and Tribal Plates'; 'In lieu of receiving a Standard License Plate, you may choose to order a Specialty Plate'"
+      - "https://oklahoma.gov/service/all-services/auto-vehicle/specialty-plates.html  # the official specialty catalogue entry point; JavaScript-rendered, no enumerable list retrieved (recorded gap)"
+      - "https://oksenate.gov/sites/default/files/2019-12/os47.pdf  # 47 O.S. § 1113(B)(2) and (B)(8), § 1113.2(F): the statutory carve-outs that keep certain official and special plates off the general-issue base"
+    notes: >-
+      THE OKLAHOMA SPECIALTY INDEX — count deliberately absent. The finding that
+      matters here is not the catalogue but the TRIBAL PLATE question: Oklahoma is
+      the US state where sovereign tribal registration is most visible on the
+      road, Service Oklahoma itself lists tribal plates as a plate type, and none
+      of it is state issuance. That is a jurisdiction-model problem, not a series
+      problem, and it belongs in a maintainer decision before L3 rather than in a
+      series record here.
+
+# ---------------------------------------------------------------------------
+# Classes Oklahoma separately serializes that are DELIBERATELY NOT given series
+# here for want of a sourced format.
+# ---------------------------------------------------------------------------
+notable_classes_not_specced:
+  - class: government
+    subtype: "state vehicles generally"
+    evidence: "§ 1113(B)(4): 'the Tax Commission shall design appropriate official license plates for all state vehicles. Such license plates shall be permanent in nature and designed in such manner as to remain with the vehicle for the duration of the vehicle's life span or until the title is transferred to a nongovernmental owner.' A statutory PERMANENT-plate rule for the state fleet."
+    gap: "no serial arrangement stated in statute and none obtained; the reported 'TAX EXEMPT' plate (E-prefixed, five digits) is locator-grade only"
+  - class: trailer
+    evidence: "a NON-EXPIRING TRAILER plate is reported on the 2017 base; § 1113(A)(3) independently authorises permanent nonexpiring plates for large commercial fleets and § 1120 vehicles"
+    gap: "no arrangement from any authority source"
+  - class: motorcycle
+    evidence: "§ 1113(A)(1) treats motorcycles used exclusively off-road as plate-exempt, which implies on-road motorcycles are plated"
+    gap: "no arrangement obtained"
+  - class: dealer
+    evidence: "Oklahoma licenses dealers and issues dealer plates; the governing provisions were not read this pass"
+    gap: "class not sourced to a specific section; no arrangement obtained"
+  - class: personalized
+    evidence: "§ 1113.2(F) refers to registrants reserving 'their present general issue or PERSONALIZED license plate numbers', so the class plainly exists in statute; Service Oklahoma lists Personalized Plates as a plate type"
+    gap: "no character frame, length cap or content rule obtained — contrast Louisiana, whose OMV policy states all three"

--- a/plates/us-tx.yml
+++ b/plates/us-tx.yml
@@ -1,0 +1,534 @@
+# plates/us-tx.yml — Texas (PRD-PLATES gate L2, group: southcentral).
+#
+# WHY TEXAS IS THE HARD ONE IN THIS GROUP, and what this pass actually settled:
+#
+# 1. THE ARTWORK-RISK QUESTION IS NOW ANSWERED, ADVERSELY, FROM A PRIMARY. The US
+#    research dossier (aux/research/plates-2026-07, §4.2) recorded Texas as
+#    "Not established — treat as default (copyrighted)". It is no longer a
+#    default: Tex. Transp. Code § 504.002(a)(3) says, in terms, that "the
+#    department is the exclusive owner of the design of each license plate", and
+#    § 504.005(a) gives TxDMV "sole control over the design, typeface, color, and
+#    alphanumeric pattern for all license plates". That is a STATUTORY ownership
+#    claim over plate designs — stronger and better sourced than Arizona's
+#    website assertion, which the dossier called "the most adverse posture
+#    found". See `artwork_risk`.
+#
+# 2. THE SEPARATOR ON A TEXAS PLATE IS A STATUTORY GLYPH, NOT PUNCTUATION.
+#    § 504.005(c): the department "shall design each license plate to include a
+#    design at least one-half inch wide that represents in silhouette the shape
+#    of Texas and that appears between letters and numerals." So what a consumer
+#    reads as the hyphen in "ABC-1234" is, in law, a state-shaped emblem sitting
+#    in the separator position. This dataset follows the house precedent set by
+#    plates/de.yml — where the position occupied by the Stempelplakette is still
+#    written as an emitted separator, and the glyph itself is carried in
+#    `design` — so `pattern` spells `-` and `design.separator_glyph` records what
+#    is physically printed. It is flagged to `_meta/separators.yml`'s
+#    `never_separator` discussion, because no consumer may treat the silhouette
+#    as serial content (PRD-PLATES §2.6 rule 3).
+#
+# 3. HB 718 (2023, eff. 1 JULY 2025) KILLED THE PAPER TEMPORARY TAG. Texas is
+#    the loudest US registration-law change of the decade: dealers now hand the
+#    buyer a METAL general-issue plate at the point of sale. Six paper tag types
+#    were abolished and four new limited-use METAL plates created. It is
+#    recorded here in `temporary_regime` rather than as series, because TxDMV
+#    publishes the regime in detail but publishes no serial format for the four
+#    new plates (recorded gap).
+#
+# SOURCING RULE APPLIED HERE (PRD-PLATES §4): the statute over the brochure.
+# Every design-authority, ownership, display and penalty claim below cites
+# Transportation Code Chapter 504. Where Chapter 504 is deliberately silent —
+# and it is silent about the alphanumeric pattern, because § 504.005(a) delegates
+# that to the department entirely — TxDMV's own pages carry the claim, and where
+# even TxDMV is silent the claim is marked `locator-unconfirmed` and NOT
+# laundered into a sourced fact.
+#
+# FETCH NOTE, recorded because it will bite the next researcher: as of this pass
+# statutes.capitol.texas.gov serves an Angular SPA and returns the same 245 KB
+# JS shell for /Docs/TN/htm/TN.504.htm, /SOTWDocs/... and the .pdf path alike —
+# no statute text is retrievable by fetch. The section texts quoted here were
+# read from texas.public.law's reproduction. The TEXT IS AN EDICT OF GOVERNMENT
+# and public domain at every level (PRD-PLATES §4); the canonical citation below
+# is the official URL, and the reproduction is named for reproducibility.
+jurisdiction: us-tx
+authority:
+  name: Texas Department of Motor Vehicles (TxDMV)
+  url: "https://www.txdmv.gov/motorists/license-plates"
+binding: vehicle
+statute_edition: "Texas Transportation Code, Title 7, Subtitle A, Chapter 504 (License Plates), as in force at 2026-08; section texts read 2026-08-02"
+statute_access_note: >-
+  Official host statutes.capitol.texas.gov is a JavaScript single-page
+  application and returns no statute text to a fetcher. Section text was read
+  from https://texas.public.law/statutes/tex._transp._code_section_504.005 (and
+  siblings), a verbatim reproduction. Edicts of government are PD at every level,
+  so the reproduction carries no rights of its own over the text; the official
+  URL is cited as the authority and the reproduction is named as the fetch path.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: copyright-asserted-by-statute
+  basis: >-
+    ADVERSE, AND THE ONLY STATE IN THIS GROUP WHOSE ADVERSE POSTURE IS IN THE
+    STATUTE ITSELF. Tex. Transp. Code § 504.002(a)(3), verbatim: "the department
+    is the exclusive owner of the design of each license plate". § 504.005(a),
+    verbatim: "The department has sole control over the design, typeface, color,
+    and alphanumeric pattern for all license plates." Read together these are an
+    express legislative assertion that plate DESIGNS are departmental property.
+    This resolves the gap the US dossier left open ("Texas and Delaware PD
+    posture — neither appears in the fetched source; treated as default
+    copyrighted"): Texas is not merely default-copyrighted, it is
+    affirmatively-claimed. Nothing was found asserting a PD rule for Texas state
+    works; no {{PD-TXGov}} tag exists on Commons in the sampled set.
+  practical_effect: >-
+    PRD-PLATES §3's neutral-placeholder default is MANDATORY here, not optional.
+    Render facts, layout geometry (AAMVA Ed.3) and colours; never trace or
+    approximate the state-shaped silhouette separator, the security-thread
+    artwork or any specialty graphic. Note the asymmetry that makes the program
+    still workable: § 504.002(a)(3) is itself an EDICT of government and
+    therefore public domain, so we may quote the statute that claims the design
+    while declining to reproduce the design.
+  emblem_rule: >-
+    The § 504.005(c) Texas silhouette is both a design element AND, arguably, a
+    state symbol; state-seal / state-symbol misuse statutes are a regime
+    independent of copyright and were NOT researched for Texas (recorded gap,
+    same gap the US dossier flagged nationally). Render
+    `emblem: {present: true, rendered: placeholder}` and revisit as a named
+    decision.
+  photograph_caution: >-
+    Commons photographs of Texas plates are dominantly CC BY-SA — measured
+    example from the dossier: File:1917-1921 Texas license plate.jpg, CC BY-SA
+    4.0, "own work". That is the PHOTOGRAPHER's licence on the PHOTOGRAPH; the
+    uploader had no standing over the design, and in Texas the department claims
+    that standing by statute. Because our renders are generated from the statute
+    and never derived from a photograph, neither the share-alike obligation nor
+    the department's design claim attaches to a photograph we never touch.
+  sources:
+    - "https://statutes.capitol.texas.gov/Docs/TN/htm/TN.504.htm  # § 504.002(a)(3): 'the department is the exclusive owner of the design of each license plate'; § 504.005(a): sole control over design, typeface, color and alphanumeric pattern (text read via texas.public.law reproduction — see statute_access_note)"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): confirms §105 does not reach the states and that no Texas PD rule is listed; used only to establish the ABSENCE of a favourable rule"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Recorded once per US file, verbatim from the pinned
+# dossier, because it is voluntary and because the delegation trap matters.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA has no enforcement power; it writes recommendations in the declarative present, which must be read as RECOMMENDED PRACTICE, not requirement."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1: 'License plate dimensions and bolt holes comply with the SAE International Motor Vehicle License Plates Standard J686.' J686's own text is paywalled and was NOT obtained; no J686 dimension is quoted anywhere in this dataset."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of the top and bottom edges"
+    jurisdiction_name_layout: "AAMVA §2.1: the jurisdiction name 'appears in the top center location between the bolt holes', at least 0.25 in above the plate number and at least 0.125 in from the top edge; jurisdiction characters 0.75-1.0 in"
+    stacked_characters: "AAMVA: 'If stacked characters are used, they are part of the official license plate number. No more than two characters are to be stacked.'"
+    replacement_cycle: "AAMVA §1.1: 'Because license plates lose significant retro-reflectivity within 7 years, a required rolling or full replacement cycle not to exceed 7 to 10 years is recommended.' TEXAS ABOLISHED ITS CYCLE ENTIRELY — see us-tx-standard.replacement_cycle."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" that supposedly fixed the 6x12 inch
+    plate is UNCITED in its Wikipedia source (a `citation needed` since 2017,
+    copied verbatim across articles — circular). The Texas Wikipedia article
+    repeats it with a different reference (Garrish, "Reconsidering the Standard
+    Plate Size", ALPCA *Plates* 62(5), Oct 2016) — a members' magazine that was
+    NOT obtained. Recorded as COMMONLY REPEATED, STILL UNPINNED. Texas plate
+    dimensions are NOT in Chapter 504 at all (recorded gap): unlike Florida,
+    whose § 320.06(3)(a) states 6x12 in law, the Texas legislature left
+    dimensions entirely to § 504.005(a) departmental discretion.
+
+# ---------------------------------------------------------------------------
+# Display rules. Texas is a TWO-PLATE state by statute, with a statutory
+# one-plate carve-out for road tractors, motorcycles, trailers and semitrailers.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates, front and rear. § 504.943(a): a person commits an offense if the person operates a motor vehicle that 'does not display two license plates that (1) have been assigned by the department for the period; and (2) comply with department rules regarding the placement of license plates'."
+  one_plate_classes: "§ 504.943(b): a road tractor, MOTORCYCLE, trailer or semitrailer must display one plate. Note the class list is in the OFFENSE section, not in the issuance section — Texas defines its one-plate classes by what is not prosecutable."
+  issuance_limit: "§ 504.010(b): 'the department shall issue only one license plate or set of plates for a vehicle during the registration period set by rule'; § 504.010(c) delegates PLACEMENT entirely to board rule, so mounting heights are in 43 TAC ch. 217, not in statute (43 TAC was NOT obtained — the Texas Secretary of State moved the TAC to an Appian portal during this pass; recorded gap)."
+  dealer_exception: "§ 504.943(c): the two-plate offense 'does not apply to a dealer operating a vehicle as provided by law'; TxDMV states that only ONE metal dealer plate is required per vehicle and it is 'displayed in the rear license plate holder'."
+  obscuring: "§ 504.945(a): offense to display a plate with blurring or reflective matter impairing readability of the STATE NAME or the number, with an unauthorised illuminated device/sticker/decal interfering with readability, or with a coating that 'distorts angular visibility or detectability' or obscures half or more of the state name. Express carve-outs at § 504.945(c) for trailer hitches, toll transponders, wheelchair lifts, towed trailers and bike/motorcycle racks."
+  flipper_offense: "§ 504.9465 creates a separate LICENSE PLATE FLIPPER offense — a mechanism to conceal or swap the displayed plate. Few states legislate this by name."
+  penalty: "§ 504.943(e): misdemeanor, fine not to exceed $200; a charge under § 504.943(a)(1) may be dismissed if remedied before first appearance on payment of a reimbursement fee not exceeding $10."
+  sources:
+    - "https://statutes.capitol.texas.gov/Docs/TN/htm/TN.504.htm  # § 504.943 two-plate rule and the road tractor/motorcycle/trailer/semitrailer one-plate class; § 504.945 obscuring offenses and carve-outs; § 504.9465 plate flipper; § 504.010 one set per period, placement delegated to board rule"
+    - "https://www.txdmv.gov/dealers/dealer-license-plates  # TxDMV: 'Only one metal dealer plate is required per vehicle and is displayed in the rear license plate holder.'"
+
+# ---------------------------------------------------------------------------
+# HB 718 — the metal-plate transition. Recorded as a REGIME, not as series,
+# because TxDMV documents the regime exhaustively and the serial formats of the
+# four new plate types not at all.
+# ---------------------------------------------------------------------------
+temporary_regime:
+  instrument: "House Bill 718, 88th Legislature (2023), effective 1 July 2025"
+  effect: "Paper temporary tags eliminated. TxDMV: 'All licensed dealers must issue metal license plates to buyers at the time of sale. Temporary tags will no longer be available to be printed for use.' Six paper tag types were abolished: Buyer's Temporary Tags, Dealer's Temporary Tags, 30-Day & One-Trip Permits, Dealer Agent Tags, Dealer Vehicle Specific Tags, Internet Down Tags."
+  what_the_buyer_gets: "the ordinary general-issue plate. TxDMV: 'The black and white general issue license plate, which replaces the buyer tag, is the one dealers should expect to issue most frequently.' So the buyer's plate is us-tx-standard, issued at the dealership out of a dealer-held allocation, not a distinct series."
+  four_new_metal_plates:
+    - "Buyer Provisional Plate — 'Single issuance plate for short-term use if dealers lack the required plate type for the vehicle in their inventory.'"
+    - "Dealer Temporary Plate (BLUE) — dealer business use: demonstration, loaners, transport, road testing. 'Personal use of vehicles with these plates is prohibited.' $10, two-year term matching the dealer licence."
+    - "Out-of-State Buyer Plate — 'Single issuance plate for vehicles sold to out-of-state buyers.'"
+    - "Temporary Registration Plate (RED) — replaces the one-trip and 30-day paper permits; issued by county tax offices and TxDMV regional service centres, with an expiration sticker on the plate."
+  serial_formats: "NOT PUBLISHED. TxDMV's dealer, county and law-enforcement HB 718 materials describe every one of these plates by use, colour, price and ordering channel, and none of them by serial pattern. RECORDED GAP — these four classes are deliberately not given series here rather than have their patterns invented."
+  manufacture_and_distribution: "plates are produced by the Texas Department of Criminal Justice (TDCJ) and shipped to a centralised warehouse operated by a TxDMV contractor, then direct-to-dealer; dealers order through an Inventory Management System (IMS) and assign through ePLATE (formerly eTAG). Board rules adopted October 2024 require dealers to store plates in a locked room or a bolted-down safe."
+  sequencing_rule: "TxDMV, to dealers: 'The general issue plates MUST be distributed in sequential order.' That is an authority statement that us-tx-standard's serial PROGRESSION is strictly sequential, which is worth more to a parse API than most design facts."
+  aftermath: "Senate Bill 1902 (89th Legislature, 2025) lets a dealer reassign general-issue plates taken in on a trade to another vehicle within 10 days; unassigned plates must be destroyed. Paper tags issued before 1 July 2025 remained valid until their own expiry."
+  sources:
+    - "https://www.txdmv.gov/dealers/HB718  # HB 718 implementation hub: effective 1 July 2025, the six abolished paper tags, the four new metal plates and their uses, TDCJ manufacture, IMS/ePLATE, October 2024 storage rules, SB 1902 10-day reassignment"
+    - "https://www.txdmv.gov/sites/default/files/body-files/2025-06-10_Texas_License_Plate_Changes_Press_Release.pdf  # TxDMV press release, 10 June 2025: 'starting July 1, 2025, motor vehicle dealers will begin issuing metal license plates directly to buyers of new and used vehicles'"
+    - "https://www.txdmv.gov/sites/default/files/body-files/ENF%20HB%20718%20FAQ%20Dealer%20Handout%20032125.pdf  # TxDMV enforcement/dealer handout: the four-plate chart, the blue Dealer Temporary and red Temporary Registration plates, 'The general issue plates MUST be distributed in sequential order'"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES — "The Texas Classic".
+  # =========================================================================
+  - id: us-tx-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2012 }
+    period_evidence: authority-stated
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}[- ]?\d{4}\z'
+      serial_basis: authority-stated-arrangement
+      charset:
+        notes: >-
+          NO STATUTORY CONSTRAINT EXISTS. § 504.005(a) hands the department "sole
+          control over the design, typeface, color, and ALPHANUMERIC PATTERN for
+          all license plates", and Chapter 504 then says nothing further about
+          length or alphabet — the exact opposite of Florida, whose
+          § 320.06(3)(a) caps the plate at seven characters in law. Texas's
+          seven-character frame is an AUTHORITY fact, not a statutory one:
+          TxDMV, describing the 2009 base, writes that "it began the
+          seven-character plate number" after "Texas' growth exhausted the six
+          character alpha-numeric plate patterns". `LLL-9999` is seven characters
+          inside that frame.
+        excluded_reported: ["A", "E", "I", "O", "U", "Q"]
+        excluded_basis: locator-unconfirmed
+        excluded_note: >-
+          VOWELS AND Q ARE REPORTED EXCLUDED FROM TEXAS SERIALS SINCE 1990, and
+          the report is LOCATOR-GRADE ONLY (Wikipedia, whose own citation is the
+          collector site licenseplates.cc). It is NOT promoted to a
+          `regex_strict` here, because PRD-PLATES §2.7 defines the strict tier as
+          "the authority's own alphabet" and TxDMV publishes no alphabet at all.
+          It is recorded because it is CORROBORATED BY THE ISSUED RANGE the same
+          locator gives — BBB-0001 to YZS-4943 as of 2026-03-29 — which begins at
+          BBB rather than AAA and contains no vowel in any reported position.
+          Promote to `regex_strict` when a TxDMV instrument states the alphabet.
+      progression: "strictly sequential. TxDMV, in its HB 718 dealer FAQ: 'The general issue plates MUST be distributed in sequential order.' Reported range BBB-0001 to YZS-4943 as of 2026-03-29 (locator)."
+      pattern_note: >-
+        The separator is written as `-` because that is how TxDMV, law
+        enforcement and every consumer spell a Texas plate number, and because
+        plates/de.yml sets the house precedent of writing an emitted separator at
+        a position physically occupied by a badge. What is actually PRINTED there
+        is the statutory Texas silhouette — see design.separator_glyph. The
+        regex accepts the space form as well, since the separator character set
+        (§2.6) is what a lenient consumer normalises across.
+      no_regex_statutory_note: >-
+        There is deliberately NO `regex_statutory` on any Texas series. Florida
+        has one because § 320.06(3)(a) states an outer legal bound (seven
+        alphanumerics). Texas states no bound whatsoever — § 504.005(a) is a
+        delegation, not a constraint — so a statutory tier would be an invention.
+        The absence is the fact.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_basis: locator-unconfirmed
+      plate_dimension_note: >-
+        Chapter 504 states NO dimensions. 12 x 6 in is the North American
+        convention (AAMVA -> SAE J686, unpinned) and is reported for Texas by a
+        locator. Recorded, flagged, not sourced.
+      material: "aluminium, white sheeting; § 504.005(d): 'To promote highway safety, each license plate shall be made with a reflectorized material that provides effective and dependable brightness for the period for which the plate is issued.'"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      colour_note: >-
+        Both hexes are `observed`, not sourced. § 504.005(a) puts colour under
+        departmental control and no departmental colour spec was obtained
+        (43 TAC ch. 217 was unreachable this pass — recorded gap). TxDMV's own
+        words for the design are "Black lettering on white sheeting design with
+        double security thread in the sheeting" and, in the HB 718 materials,
+        "the black and white general issue license plate".
+      legend_top: "TEXAS"
+      legend_bottom: "The Lone Star State"
+      separator_glyph:
+        printed: "silhouette of the State of Texas, at least one-half inch wide"
+        statutory_text: "§ 504.005(c): 'The department shall design each license plate to include a design at least one-half inch wide that represents in silhouette the shape of Texas and that appears between letters and numerals. The department may omit the silhouette of Texas from specially designed license plates.'"
+        consumer_rule: >-
+          NEVER SERIAL, NEVER DELETABLE-AS-SERIAL. This is the US instance of the
+          case `_meta/separators.yml` already anticipates for German and Austrian
+          coats of arms: a glyph that sits between serial groups is a DESIGN
+          ELEMENT carried in `design`, not a character. A consumer deriving a
+          separator-free twin deletes the emitted `-` we write and is correct;
+          an OCR pipeline that transcribes the silhouette as a character is
+          wrong. Worth adding to `_meta/separators.yml`'s never_separator list
+          by PR, since it is now a sourced, statutory example.
+        omission_clause: "the same subsection lets the department OMIT the silhouette from specially designed plates — so its presence does not identify a Texas plate and its absence does not exclude one."
+      security_features: "TxDMV: 'the first license plate in the country to feature two, high-visibility security threads embedded into the plate sheeting, making it easier for law enforcement to spot legitimate plates.' AAMVA Ed.3 §3.4 requires at least one overt/covert/forensic feature at jurisdiction discretion; Texas chose two overt threads."
+      emblem: { present: true, rendered: placeholder }
+      graphic: { present: false, note: "the Texas Classic is deliberately plain — TxDMV's stated design goal was public-safety legibility, reversing the 2009 full-colour graphic base" }
+      band: { side: none }
+      rear_differs: false
+    replacement_cycle:
+      years: null
+      abolished: true
+      statutory_or_authority_text: "TxDMV: 'As of November 1, 2016, the State of Texas no longer requires automatically replacing your plates after 7 years. However, you may apply at your county tax office for replacement plates if your license plates need to be replaced for cosmetic or readability reasons.'"
+      note: >-
+        TEXAS IS THE COUNTEREXAMPLE TO AAMVA §1.1. Florida legislated 10 years —
+        the top of AAMVA's recommended 7-to-10 band. Texas abolished the concept
+        on 1 November 2016 and now replaces on request only. Any consumer
+        modelling "US plates are replaced every 7-10 years" is wrong for the
+        second-largest vehicle fleet in the country. Voluntary replacement is
+        $6 plus a $0.50 automation fee (§ 504.007(a)(2); TxDMV states the same
+        figures).
+    region_encoding: none
+    region_encoding_note: "Texas encodes NOTHING geographic in the serial and never has in the modern era; the county of registration appears on no part of the plate. Contrast Oklahoma, whose 1981-2009 letter prefixes were county-coded (see us-ok)."
+    sources:
+      - "https://www.txdmv.gov/motorists/license-plates  # TxDMV: 'Current Design: The Texas Classic. Introduced in July 2012'; 'the first license plate in the country to feature two, high-visibility security threads'; 'As of November 1, 2016, the State of Texas no longer requires automatically replacing your plates after 7 years'; general-issue plate numbers 'assigned to you by TxDMV and cannot be personalized'"
+      - "https://statutes.capitol.texas.gov/Docs/TN/htm/TN.504.htm  # § 504.005(a) sole control over design/typeface/color/alphanumeric pattern; § 504.005(c) the half-inch Texas silhouette between letters and numerals, omittable on specially designed plates; § 504.005(d) reflectorized material; § 504.007 $6 replacement fee; § 504.010(b) one plate or set per registration period"
+      - "https://www.txdmv.gov/sites/default/files/body-files/ENF%20HB%20718%20FAQ%20Dealer%20Handout%20032125.pdf  # 'The general issue plates MUST be distributed in sequential order' — the progression claim"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Texas  # LOCATOR ONLY (PRD-PLATES §4): the ABC-1234 arrangement, the range BBB-0001 to YZS-4943 (as of 2026-03-29), the vowel/Q exclusion since 1990, and 12x6 in dimensions. None of these is asserted as sourced."
+    notes: >-
+      TEXAS CLASSIC, THE CURRENT GENERAL ISSUE. Note what Texas does NOT have: no
+      statutory dimension, no statutory colour, no statutory character cap, no
+      replacement cycle, no geographic encoding, and no published alphabet. The
+      entire specification lives in § 504.005(a)'s delegation, which makes Texas
+      the cleanest example in this group of a state whose plate facts are
+      administrative rather than legislative — and therefore the state where the
+      PRD's "prefer the statute over the brochure" rule yields the LEAST, because
+      the statute deliberately says almost nothing. The one thing the statute
+      does specify is the silhouette separator, and that turns out to be the
+      normatively interesting fact in the whole file. PERIOD: `start: 2012` is
+      TxDMV's own "Introduced in July 2012" and is a real claim, not an upper
+      bound; TxDMV separately dates the predecessor's launch to June 2009 while
+      the locator says July 2009, a disagreement that integer-year periods
+      dissolve and which is recorded here rather than averaged (PRD-PLATES §5.3).
+
+  # =========================================================================
+  # ONE SERIES BACK — "Lone Star Texas", the seven-character transition.
+  # =========================================================================
+  - id: us-tx-standard-lone-star
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2009, end: 2012 }
+    period_evidence: authority-stated
+    matching: strict
+    format:
+      pattern: "LL9-L999"
+      regex: '\A[A-Z]{2}\d[- ]?[A-Z]\d{3}\z'
+      serial_basis: authority-stated-arrangement
+      charset:
+        notes: >-
+          TxDMV describes this arrangement in prose rather than in notation, and
+          the prose is the source: "After 33 years, Texas' growth exhausted the
+          six character alpha-numeric plate patterns. The new passenger vehicle
+          plate patterns began with TWO LETTERS, FOLLOWED BY A NUMBER AND THEN A
+          LETTER AND THREE NUMBERS." That is `LL9-L999`, and it is one of the few
+          serial arrangements in this whole group stated by the issuing authority
+          in its own words rather than read off a collector's table.
+        excluded_reported: ["A", "E", "I", "O", "U", "Q"]
+        excluded_basis: locator-unconfirmed
+      progression: "reported BB1-B001 to approximately DZ9-Z999 (locator)"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_basis: locator-unconfirmed
+      material: "reflectorized per § 504.005(d); FIRST NON-EMBOSSED (fully screened/digital) general-issue plate in Texas"
+      background: { finish: retroreflective }
+      colour_note: >-
+        No hex asserted. TxDMV describes it only as the first plate "to use full
+        color and full-plate graphics"; the locator adds a Davis Mountains
+        landscape under a sky, a lone star and red and blue streaks in the upper
+        left. Because Texas asserts ownership of plate designs by statute, the
+        graphic is described but never reproduced.
+      legend_top: "TEXAS"
+      legend_bottom: "The Lone Star State"
+      separator_glyph: { printed: "silhouette of the State of Texas (§ 504.005(c) applied to this base as well)" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    withdrawal_note: "TxDMV, unusually candidly, records WHY this base was replaced: 'the plate design was not favored by law enforcement, and some Texans complained the plate's colors clashed with their vehicle color.' The 2012 successor is monochrome for exactly that reason."
+    region_encoding: none
+    sources:
+      - "https://www.txdmv.gov/motorists/license-plates  # TxDMV 'Previous General-Issue Plate Designs — Lone Star Texas': first digital general-issue plate, first full colour and full-plate graphics, 'launched in June 2009', 'it began the seven-character plate number', the two-letters/number/letter/three-numbers pattern, the e-Vote selection and the law-enforcement objection"
+      - "https://statutes.capitol.texas.gov/Docs/TN/htm/TN.504.htm  # § 504.005(c)-(d): the silhouette separator and the reflectorized-material requirement, which apply to this base identically"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Texas  # LOCATOR ONLY: July 2009 - June 2012 dates and the BB1-B001 to DZ9-Z999 range; TxDMV's own 'June 2009' is preferred and the disagreement is recorded, not averaged"
+    notes: >-
+      LONE STAR TEXAS — THE SEVEN-CHARACTER TRANSITION. This series is the reason
+      the modern Texas format exists: TxDMV states that thirty-three years of
+      six-character patterns ran out and the plate went to seven characters here,
+      in 2009. Its predecessor ("Panoramic Texas", 2000-2009) was, in TxDMV's
+      words, "the last stamped plate in Texas history, and also the last
+      general-issue plate issued with six characters"; it is not given a series
+      in this L2 pass because L2 scope is the current series plus ONE back, and
+      because its several six-character arrangements are locator-grade only.
+
+  # =========================================================================
+  # GOVERNMENT — the EXEMPT plate. In scope per L2 ("government" is a core
+  # separately-serialized class).
+  # =========================================================================
+  - id: us-tx-exempt
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2014 }
+    period_evidence: locator-unconfirmed
+    matching: strict
+    format:
+      pattern: "999-9999"
+      regex: '\A\d{3}[- ]?\d{4}\z'
+      serial_basis: locator-unconfirmed
+      charset: { notes: "all-numeric, seven digits, on the Texas Classic base with 'EXEMPT' set between the state name and the serial. No TxDMV instrument stating the arrangement was obtained." }
+      progression: "reported 118-0000 onward on the current base (locator)"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_top: "TEXAS"
+      legend_bottom: "The Lone Star State"
+      legend_mid: "EXEMPT"
+      separator_glyph: { printed: "silhouette of the State of Texas" }
+      emblem: { present: true, rendered: placeholder }
+    eligibility_note: >-
+      § 504.007(f) confirms the class exists in law by excluding "exempt plates
+      for governmental entities and temporary registration plates" from the
+      replacement-plate reuse rule of § 504.007(e). TxDMV's own 9 July 2025
+      memo, issued under the HB 718 regime, states who qualifies: "governmental
+      agencies (state, federal, city, county)", "public schools" and "certain
+      nonprofit organizations, as defined by statute". The same memo records a
+      distribution rule that matters after HB 718 — "Exempt plates are not
+      issued directly to dealers by the department", so unlike general-issue
+      plates they do not flow through the dealer allocation and must be obtained
+      through the county tax assessor outside webDEALER. The underlying
+      eligibility conditions live in Transportation Code ch. 502 (§ 502.451 et
+      seq.), which was NOT read this pass — recorded gap.
+    region_encoding: none
+    sources:
+      - "https://statutes.capitol.texas.gov/Docs/TN/htm/TN.504.htm  # § 504.007(f): 'exempt plates for governmental entities and temporary registration plates' named as a distinct class in statute"
+      - "https://www.txdmv.gov/sites/default/files/body-files/Memo_Exempt-Plates-Process_07092025.pdf  # TxDMV memo, 9 July 2025: eligible entities are 'governmental agencies (state, federal, city, county)', 'public schools' and 'certain nonprofit organizations, as defined by statute'; and 'Exempt plates are not issued directly to dealers by the department'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Texas  # LOCATOR ONLY: the 123-4567 arrangement, the 'EXEMPT' mid-legend, the 2014 move to the Texas Classic base and the 118-0000 range"
+    notes: >-
+      EXEMPT (GOVERNMENT FLEET) PLATES. Included because L2 names government as a
+      core class and because the statute independently confirms the class exists;
+      the FORMAT, however, is locator-grade and is labelled as such rather than
+      dressed up. The honest summary is: class sourced, arrangement not. A
+      verifier should re-derive the arrangement from 43 TAC ch. 217 once the
+      Texas Administrative Code is reachable again.
+
+  # =========================================================================
+  # PERSONALIZED — statutory, and vendored.
+  # =========================================================================
+  - id: us-tx-personalized
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2012 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9]){0,6}\z'
+      serial_basis: authority-frame-inferred
+      charset:
+        notes: >-
+          Owner-chosen inside the seven-character frame TxDMV describes for
+          general issue. § 504.005(a) leaves the alphanumeric pattern wholly to
+          the department and Chapter 504 states no cap, so the seven-character
+          bound here is INFERRED from TxDMV's own "seven-character plate number"
+          language rather than read off an instrument. TxDMV publishes
+          "Personalized License Plate Guidelines & Restrictions", but that
+          document is served through a JavaScript-rendered link and was NOT
+          retrieved this pass — the content-refusal criteria and the exact
+          character rules are a RECORDED GAP.
+        approval: "§ 504.101 requires the department to issue personalized plates 'including those sold by the private vendor under a contract with the department as provided by Section 504.851'. TxDMV: 'Personalized messages must be approved by the Texas Department of Motor Vehicles.'"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "a personalized configuration may be ordered on the standard base or on most specialty designs; the design is therefore a property of the chosen base, not of this series"
+      emblem: { present: true, rendered: placeholder }
+    vendor: "sold through MyPlates.com, which TxDMV calls 'the state's plate marketing vendor', under the § 504.851 private-vendor contract. Terms are 1, 3 or 5 years; a selection not renewed within 60 days of expiry is automatically cancelled and released for anyone to order."
+    region_encoding: none
+    sources:
+      - "https://statutes.capitol.texas.gov/Docs/TN/htm/TN.504.htm  # § 504.101: the department shall issue personalized plates 'including those sold by the private vendor under a contract with the department as provided by Section 504.851'; § 504.005(a): the alphanumeric pattern is departmental"
+      - "https://www.txdmv.gov/motorists/license-plates  # TxDMV: myplates.com is 'the state's plate marketing vendor'; personalized messages must be approved by TxDMV; 1/3/5-year terms and the 60-day auto-cancellation; no refunds because plates are custom manufactured"
+    notes: >-
+      PERSONALIZED PLATES, MODELLED SEPARATELY BECAUSE THE SERIAL SOURCE DIFFERS —
+      owner-chosen rather than department-assigned — which is a format property
+      even where the character frame matches. The Texas wrinkle is that the
+      channel is PRIVATE: § 504.851 puts a commercial vendor between the citizen
+      and the department for personalized and much specialty issuance, which is
+      unusual among US states and is the reason the specialty index below points
+      at a vendor site rather than at a government catalogue.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX ONLY, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-tx-specialty-index
+    class: specialty
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2012 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}[- ]?\d{4}\z'
+      serial_basis: authority-stated-arrangement
+      charset: { notes: "specialty plates carry ORDINARY department-assigned serials on an alternative design unless personalized; the general-issue arrangement applies. § 504.008(b): 'the department may vary the design of a license plate to accommodate or reflect its use on a motor vehicle other than a passenger car or light truck.'" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised program; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here. § 504.008(a): 'The department shall prepare the designs and specifications of specialty license plates.'"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_secondary: "506 available"
+      count_basis: locator-unconfirmed
+      count_note: >-
+        THE COUNT IS THE WEAKEST FACT IN THIS FILE AND IS LABELLED AS SUCH.
+        Wikipedia states "Texas has more specialty plates than any other state,
+        with 506 available" and cites a TxDMV URL for it; that TxDMV page
+        (/motorists/license-plates/specialty-license-plates) returned HTTP 403 to
+        every fetch attempt in this pass, so the figure could not be confirmed at
+        source. Compare Florida, where FLHSMV states "over 100" in its own words.
+        Recorded as a locator claim with its provenance, NOT reconciled and NOT
+        averaged (PRD-PLATES §5.3).
+      statutory_frame:
+        - "§ 504.008: the department prepares specialty designs and specifications; any motor vehicle other than one manufactured for off-highway use only is eligible"
+        - "§ 504.601(a): the default specialty issuance fee is $30, of which the department keeps $8 for administrative costs"
+        - "§ 504.6011: a SPONSOR may contract with the private vendor for marketing and sale, in which case the § 504.851 vendor fee schedule displaces the $30 and the vendor takes the remainder after the department's costs and the sponsor account deposit"
+        - "§ 504.851: the private-vendor contract itself — the instrument that makes Texas's specialty program commercially operated"
+        - "§ 504.009: SOUVENIR plates, which are NOT insignias of registration and are not street legal; $20, $40 personalized, sold in bulk minimum 25 for fundraising. A genuinely separate artefact that a plate dataset must not confuse with an issued plate."
+      official_program_pages:
+        - "https://www.txdmv.gov/motorists/license-plates  # the index page that names the vendor and the ordering path"
+        - "https://www.myplates.com/  # the § 504.851 private vendor's catalogue — a COMMERCIAL site, cited as the operative catalogue rather than mined"
+        - "http://100plates.txdmv.gov/  # TxDMV-hosted specialty-plate microsite linked from the plates index; not fetched this pass (recorded gap)"
+      military_and_restricted: "Subchapters D-G of Chapter 504 authorise roughly seventy named military, service-award and office-holder plates individually IN STATUTE (§§ 504.301-504.335, 504.400-504.417, 504.501-504.518). Unusually for a US state, Texas legislates specialty plates one statute at a time rather than by a general delegation — so a large part of the Texas specialty catalogue is itself an edict of government and therefore public domain even though the DESIGNS are claimed under § 504.002(a)(3)."
+    region_encoding: none
+    sources:
+      - "https://statutes.capitol.texas.gov/Docs/TN/htm/TN.504.htm  # § 504.008 specialty design authority and eligibility; § 504.601 the $30/$8 default fee split; § 504.6011 the sponsor-vendor route; § 504.009 souvenir plates; §§ 504.301-504.518 the individually legislated military/service/office plates"
+      - "https://www.txdmv.gov/motorists/license-plates  # TxDMV: order through myplates.com, 'the state's plate marketing vendor'; 1/3/5-year specialty terms; the 60-day cancellation rule; souvenir plates 'are not street legal and are not insignias of vehicle registration'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Texas  # LOCATOR ONLY: the '506 available' figure and the claim that Texas leads the US in specialty count — recorded unreconciled because the cited TxDMV page 403s"
+    notes: >-
+      THE TEXAS SPECIALTY INDEX — ONE ENTRY STANDING FOR THE WHOLE PROGRAM, which
+      is exactly what PRD-PLATES §2.5 asks for at this gate. Two things are worth
+      carrying forward. First, Texas is the US state where the specialty program
+      is most thoroughly PRIVATISED: § 504.851 puts a vendor in the middle and
+      §§ 504.6011-504.6012 route the money through it, so the operative catalogue
+      is a commercial website and there is no FLHSMV-style official brochure to
+      count from. Second, and pulling the other way, Texas legislates individual
+      plates by statute more than any other state in this group — which means a
+      large slice of the catalogue can be enumerated from Chapter 504 itself, an
+      edict of government, without touching the vendor at all. That is the route
+      a future L4 pass should take.
+
+# ---------------------------------------------------------------------------
+# Classes Texas separately serializes that are DELIBERATELY NOT given series
+# here, because no serial format was obtainable from any authority source and
+# PRD-PLATES forbids inventing one. Each is a named target for the next pass.
+# ---------------------------------------------------------------------------
+notable_classes_not_specced:
+  - class: dealer
+    evidence: "TxDMV /dealers/dealer-license-plates: metal dealer plates for franchised and independent dealers, manufacturers, converters and in-transit operators; two-year term matching the licence; $90 per Standard Dealer Plate (a $40 plate fee plus a $50 Plate Use Tax under Tex. Tax Code § 152.027); one plate per vehicle, rear only. Authorised by Transportation Code ch. 503, not ch. 504."
+    gap: "serial format not published by TxDMV and not obtained"
+  - class: temporary
+    evidence: "the four HB 718 metal plates — Buyer Provisional, Dealer Temporary (blue), Out-of-State Buyer, Temporary Registration (red) — see `temporary_regime` above"
+    gap: "no serial format published for any of the four"
+  - class: motorcycle
+    evidence: "§ 504.943(b) names motorcycles as a one-plate class, so Texas plainly issues a distinct motorcycle plate"
+    gap: "no arrangement obtained from TxDMV or from the locator's tables"
+  - class: trailer
+    evidence: "§ 504.943(b) names trailers and semitrailers as one-plate classes; § 504.516 sets rental/travel trailer fees"
+    gap: "no arrangement obtained"
+  - class: historic
+    evidence: "§ 504.501: specialty plates for a vehicle 'at least 25 years old or ... a custom vehicle or street rod', bearing 'Classic', 'Custom Vehicle' or 'Street Rod'. § 504.501(b) additionally permits YEAR-OF-MANUFACTURE plates — an owner may run a genuine plate 'of a plate design that was issued by this state in the same year as the model year of the vehicle', embossed with an alphanumeric pattern and approved by the department. That is a real modelling trap: a lawful current Texas registration may display a 1957 Texas plate."
+    gap: "the modern Classic/Custom/Street Rod serial arrangement was not obtained; the year-of-manufacture route has no arrangement of its own by construction"
+  - class: digital
+    evidence: "§§ 504.151-504.157 authorise DIGITAL license plates in Texas, with a $45 annual administrative fee by rule. TxDMV: 'The Texas Department of Motor Vehicles is working to secure a digital plate production partner to continue offering these plates.'"
+    gap: "`_meta/classes.yml` has no `digital` value, and a digital plate's serial is the vehicle's ordinary serial rendered on a screen. Flagged as a VOCABULARY question for the maintainer, not modelled here."


### PR DESCRIPTION
**PRD-PLATES gate L2 (owner-directed acceleration; research parallel, application ordered — L1 landed first per §7.1).** One of eleven US regional-group PRs covering all 50 states + DC + territories (FL was the L0 pilot). Drafted to the `de.yml`/`nl.yml`/`us-fl.yml` standard: primary-law verbatim headers, instrument-dated periods, `strict`/`recall-only` matching tiers, folklore flagged not asserted, **`artwork_risk` recorded per jurisdiction with evidence** (PRD-PLATES §4).

**This PR — southcentral:** TX OK AR LA (4 jurisdictions, 37 pinned primary sources).

**Verification:** researcher linted green in an isolated sandbox (proof file in the group dir, archived to the pipeline program dir); the driving session then independently staged ALL 55 wave files over pristine origin/main — `plates lint: 67 files, 604 series … OK` (385 new series; the _art gate stayed green) — and this branch is linted solo pre-push; CI runs the same gate.

**For the reviewer:** the dossier below carries the gaps (marked in the YAML at point of use), folklore flags, and the artwork_risk findings. The full research dossier follows verbatim.

---

# PRD-PLATES gate L2 — dossier, group `southcentral` (TX, OK, AR, LA)

Researcher pass, 2026-08-02. Method: **fetch-never-assume**. Every claim in the
four YAML files traces to a URL fetched in this session or is explicitly labelled
`locator-unconfirmed`. `/Users/javi/GitHub/vehiclesdb` was treated as read-only
throughout; the drafts were linted in a private sandbox copy.

**Deliverables**

| file | series | source lines |
|---|---|---|
| `us-tx.yml` | 5 | 15 |
| `us-ok.yml` | 6 | 11 |
| `us-ar.yml` | 6 | 14 |
| `us-la.yml` | 7 | 18 |
| **total** | **24** | **79** (plus 21 more on file-level blocks) |

**Lint: GREEN.** `plates lint: 8 files, 97 series … OK` (73 baseline series + 24
new). An independent verifier script additionally round-tripped every pattern
against its regex 5,000 times per series, re-checked anchoring, confirmed every
`sources` entry is a URL, and confirmed every regex survives separator-free twin
derivation (§2.6 rule 1). All pass.

---

## 1. The headline findings

### 1.1 Texas's artwork risk is settled, adversely, from the statute

The US dossier (`plates-research-us-world.md` §4.2) left Texas in the "Not
established — treat as default (copyrighted)" column and listed the gap
explicitly among its unresearched items. **It is now established, and Texas is
the most adverse posture in the dataset so far — more adverse than Arizona,
because the assertion is legislative rather than administrative:**

> Tex. Transp. Code § 504.002(a)(3): "the department is the **exclusive owner of
> the design** of each license plate"
>
> Tex. Transp. Code § 504.005(a): "The department has **sole control** over the
> design, typeface, color, and alphanumeric pattern for all license plates."

Arizona *says* on a website that its works are copyrighted. Texas *legislates*
ownership of the plate design. Recommend the PRD's §4 table row be amended from
"AZ asserts copyright" to name Texas as the statutory case.

The saving asymmetry, recorded in the file: § 504.002(a)(3) is itself an **edict
of government** and therefore public domain, so the dataset may quote the statute
that claims the design while declining to reproduce the design.

### 1.2 A statutory glyph in the separator position — a §2.6 case, sourced

> § 504.005(c): "The department shall design each license plate to include a
> design at least one-half inch wide that **represents in silhouette the shape of
> Texas** and that **appears between letters and numerals**."

That is the first *statutorily mandated* instance in this dataset of the case
`_meta/separators.yml`'s `never_separator_note` currently reserves for German and
Austrian coats of arms. Oklahoma supplies three more, also statutory:
§ 1113(B)(5)–(7) put the **Oklahoma state seal** between "OHP" and the officer's
badge number, between "OMD" and the Adjutant General's three characters, and the
**DOC badge** between "DOC" and the Director's three characters.

**Handling used** (following the `plates/de.yml` precedent, where the position
occupied by the Stempelplakette is still written as an emitted separator): the
`pattern` spells `-`, and the glyph is carried in `design.separator_glyph` /
`design.emblem` with an explicit `consumer_rule` saying it is never a character.

**Recommendation to the maintainer:** add the Texas silhouette and the Oklahoma
seal to `_meta/separators.yml`'s `never_separator` discussion by PR. They are now
sourced, statutory examples of the class that file anticipated in the abstract.

### 1.3 Four states, four different answers to "how often does a plate change?"

This is the sharpest comparative result of the pass, and no existing dataset
carries it:

| state | mechanism | instrument |
|---|---|---|
| **Florida** (baseline) | 10-year **replacement** cycle, legislated | § 320.06(1)(b)1 |
| **Texas** | replacement cycle **abolished** 1 Nov 2016; replace on request only | TxDMV |
| **Oklahoma** | statutory **minimum interval between reissues**: DPS may request a reissue "not more frequently than five (5) years following the most recent reissue" | 47 O.S. § 1113.2(H) |
| **Arkansas** | none found; base unchanged since **March 2006** (20 years — twice AAMVA's outer bound) | apparent absence |
| **Louisiana** | no cycle, but a **two-year registration period** and plates that **do not transfer** between owners, so churn happens on sale | OMV Policy 38.00 |

AAMVA §1.1 recommends "not to exceed 7 to 10 years". Two of these five states are
outside that band in opposite directions, and Oklahoma answers a different
question entirely (redesign frequency, not retro-reflectivity decay).

### 1.4 Texas killed the paper temporary tag; Louisiana kept it and built a database

The same fraud problem, two opposite remedies, in neighbouring states:

- **Texas, HB 718 (88R, 2023), effective 1 July 2025.** Six paper tag types
  abolished. Dealers now issue **metal** general-issue plates at the point of
  sale, from a dealer-held allocation, produced by the Texas Department of
  Criminal Justice and warehoused by a TxDMV contractor. Four new limited-use
  metal plates created (Buyer Provisional; Dealer Temporary, blue; Out-of-State
  Buyer; Temporary Registration, red). Board rules from October 2024 require
  dealers to keep plates in a locked room or a bolted safe.
- **Louisiana, OMV Policy 6.00 (revised 2024-05-31).** T-Markers remain **paper**,
  valid ≤ 60 days, one per vehicle, and every one must be entered in a central
  **Temporary Tag Database** before the buyer leaves the lot, with a receipt and a
  three-year dealer record-keeping duty.

Both regimes are fully recorded as file-level `temporary_regime` blocks. Neither
state publishes serial formats for the temporary artefacts — a recorded gap in
both, and the reason neither got a series.

### 1.5 Oklahoma is running two current standard bases *on purpose*

Service Oklahoma, verbatim:

> "Starting Sept. 1, 2024, Oklahoma's standard issue license plate will have a new
> design. **Unlike previous plate redesigns, Oklahomans will not automatically be
> reissued the newly designed plate.** Anyone who would like the new Iconic
> Oklahoma Plate can pay a $4 plate replacement fee with their annual vehicle
> registration renewal or $9 outside of their annual renewal."

Its predecessor was the opposite: § 1113.2(D) *mandated* replacement ("registrants
shall replace any previously issued Oklahoma general issue license plate currently
displayed on their vehicle"), funded by a $5 per-vehicle fee and two named
appropriations, with a $15 window to reserve your old number.

So the 2017 and 2024 bases are **both lawfully current**, by the authority's own
statement. This is the cleanest sourced US instance of the parallel-issuance case
PRD-PLATES §2.2 legislates for ("overlap legal iff distinct notes"). And because
the serial sequence runs *straight through* the base change, **the base cannot be
inferred from the number** — a fact that matters directly to the parse API.

### 1.6 Serial arrangements sourced from a *prohibition*

Louisiana publishes no format anywhere — but OMV Policy 21.00 forbids a vanity
plate that would

> "Contain a **regular plate sequence** (i.e. three numbers followed by three alpha
> or three alpha followed by three numbers)."

The department defined the regular passenger arrangement in order to reserve it.
That is the only authority-stated passenger arrangement in this group besides
Texas's prose description of its 2009 base ("two letters, followed by a number and
then a letter and three numbers"). **Sourcing a format from the negative is a
technique worth reusing** — most states' vanity-plate rules reserve the ordinary
sequence, and most publish those rules.

### 1.7 Three government serial formats written by a legislature

47 O.S. § 1113(B)(5)–(7) specify the Oklahoma Highway Patrol, Military Department
and Department of Corrections plates **character by character** — literal prefixes
`OHP` / `OMD` / `DOC`, the seal or badge, and the serial component. These are among
the very few US serial formats in the whole dataset that come from a legislature
rather than an agency or a collector, and the differences between three otherwise
parallel paragraphs are themselves data:

| | prefix | glyph | serial | legend |
|---|---|---|---|---|
| OHP | `OHP` | state seal | **officer's badge number** (open width) | "Oklahoma OK" + "Oklahoma Highway Patrol" |
| OMD | `OMD` | state seal | **three** numbers or letters, designated by the Adjutant General | "Oklahoma OK" + "Oklahoma Military Department" |
| DOC | `DOC` | **DOC badge** | three numbers or letters or a combination, designated by the Director | "Department of Corrections" — **no** "Oklahoma OK" |

The OHP plate carries `binding: officer`, a value not in the current vocabulary:
the statute ties the serial to "the Highway Patrol officer to whom the vehicle is
assigned", so the identifier follows a *person* on a fleet vehicle. **Flagged as a
possible vocabulary addition** alongside `vehicle` / `owner` / `business`.

---

## 2. artwork_risk, per state — the required §4 record

| state | posture | evidence |
|---|---|---|
| **TX** | `copyright-asserted-by-statute` — **most adverse in the dataset** | Tex. Transp. Code § 504.002(a)(3) "exclusive owner of the design of each license plate"; § 504.005(a) "sole control over the design, typeface, color, and alphanumeric pattern" |
| **LA** | `copyright-asserted-by-agency` — **adverse, express** | LADPS Terms of Use: "The usage of the content, images and logos on the LADPS site by any other website is strictly prohibited by law. The usage of data without the expressed written consent of LADPS is a violation of Louisiana copyright and other proprietary rights." Plus a passing-off clause over the LADPS name/initials. |
| **OK** | `no-pd-rule-found-default-copyrighted` — **adverse by default, not by assertion** | No Oklahoma PD rule located; no `{{PD-OKGov}}` in the sampled Commons set; bare footer "Copyright © 2026 Service Oklahoma". Design authored by the **Oklahoma Tourism and Recreation Department** (§ 1113.2(A)), so rights, if any, sit with a tourism agency rather than the registrar. |
| **AR** | `no-pd-rule-found-default-copyrighted` — **adverse by default** | No Arkansas PD rule located; Arkansas.gov footer "Copyright 2026. All Rights Reserved, Arkansas.gov" and acceptable-use "You may not … present Arkansas.gov content as your own". Portal operated by **Tyler Technologies**; plates reported manufactured by **Waldale Manufacturing Ltd, Nova Scotia** — a private contractor complication no other state here has. |

**None of the four is public-domain-favourable.** The southcentral group is the
adverse quadrant of the US map, and PRD-PLATES §3's neutral-placeholder default is
mandatory across all four — with a specific caution for Oklahoma, whose OHP/OMD
plates carry the **state seal** by statute, a regime independent of copyright and
unresearched everywhere (the same national gap the US dossier flagged).

---

## 3. Recorded gaps, ranked by how much they cost

1. **Arkansas Code is not freely fetchable.** Arkansas publishes through
   LexisNexis (`advance.lexis.com`, session-gated JS); `law.justia.com` and
   `codes.findlaw.com` both 403 behind Cloudflare; `arkleg.state.ar.us`
   FTPDocument paths return 42-byte empties. **Not one word of Arkansas statute is
   quoted in `us-ar.yml`.** Edicts of government are PD by law and unreachable in
   practice — the rights position and the access position have come apart. A
   verifier with Lexis access closes most of `us-ar.yml`'s gaps in an afternoon.
2. **Louisiana `legis.la.gov` was unreachable** (DNS failed locally; resolved via
   8.8.8.8 to 184.178.144.11 but then timed out on connect; `www.` does not
   resolve at all). All R.S. citations in `us-la.yml` are as the **OMV Policy
   Manual cites them** — a registrar citing its own authorising statute, which is
   good evidence and is not the same as reading the statute.
3. **`statutes.capitol.texas.gov` is now a JavaScript SPA** and returns the same
   245 KB shell for `/Docs/TN/htm/…`, `/SOTWDocs/…` and the `.pdf` path alike.
   Chapter 504 was read from `texas.public.law`'s reproduction. **Worth pinning in
   the source appendix** so the next researcher does not lose an hour.
4. **43 TAC ch. 217 (Texas plate rules) unreachable** — the Texas Secretary of
   State moved the Administrative Code to an Appian portal during this pass
   (`texreg.sos.state.tx.us` now serves a "Site Has Moved" stub). This is where
   Texas colours, dimensions and the serial alphabet would live.
5. **Oklahoma Title 47 read at the 2019 edition** (Oklahoma Senate PDF).
   `oscn.net`, the official host, timed out on every attempt. **Post-2019
   amendments are unchecked** — this is the single most important verification
   step for `us-ok.yml`, because § 1113.2(G)'s "distinct contrast with a
   light-colored background" appears to conflict with the reported red 2024 base.
   Either practice moved past the wording or the wording was amended.
6. **No serial format published for any temporary-class artefact** in Texas (four
   HB 718 metal plates) or Louisiana (T-Markers). Both regimes are richly
   documented and neither has a pattern. No temporary series was minted in either
   state rather than invent one.
7. **Texas dealer / motorcycle / trailer arrangements unobtainable.** The classes
   are sourced (§ 504.943(b) makes motorcycles and trailers one-plate classes;
   TxDMV documents dealer plates in detail) but no arrangement exists in any
   authority source, so no series was minted. Listed in the file's
   `notable_classes_not_specced` block.
8. **Texas specialty count unverifiable.** `txdmv.gov/motorists/license-plates/
   specialty-license-plates` returned **HTTP 403** on every attempt, which is the
   page Wikipedia cites for "506 available". Recorded as a locator claim with its
   provenance, unreconciled.
9. **Oklahoma specialty count: none published.** The Service Oklahoma catalogue is
   an AEM application with no enumerable list. No count is asserted — contrast
   Arkansas (131, from the department's own API) and Florida ("over 100", FLHSMV's
   own words).
10. **State seal / emblem statutes unresearched in all four states** — the same
    gap the US dossier called "the largest remaining gap in the IP analysis". It
    bites hardest in Oklahoma, where the seal is on the plate *by statute*.

---

## 4. Folklore flagged or debunked

- **"1956 AMA standardization agreement"** — remains **commonly repeated,
  unsourced**, exactly as PRD-PLATES §4 records. The Texas and Arkansas Wikipedia
  articles both repeat it, this time citing Garrish, *"Reconsidering the Standard
  Plate Size"*, ALPCA **Plates** 62(5), Oct 2016 — a members' magazine that was
  **not obtained**. So the claim has acquired a citation without acquiring a
  source. Recorded in both files as still unpinned. **Neither Texas nor Oklahoma
  nor Arkansas nor Louisiana states plate dimensions in any instrument obtained** —
  unlike Florida, whose § 320.06(3)(a) states 6×12 in law. All four files carry
  `plate_dimension_basis: locator-unconfirmed`.
- **The Arkansas variant is more interesting than the myth.** The locator claims
  Arkansas's 1947, 1952 and 1955 issues were *already* 6×12 in but had
  **non-standard mounting holes**, so 1956 was the first fully compliant issue. If
  true, the 1956 convention was about **bolt spacing** as much as size — which is
  precisely what AAMVA §3.1 still delegates to SAE J686 today. Recorded as a lead
  worth chasing to a primary, not as a fact.
- **Texas "vowels and Q excluded since 1990"** — locator-grade, its own citation
  being the collector site `licenseplates.cc`. **Deliberately not promoted to a
  `regex_strict`**, because §2.7 reserves that tier for the authority's own
  alphabet and TxDMV publishes none. It *is* recorded, because it is corroborated
  by the reported issued range (BBB-0001 → YZS-4943), which starts at BBB rather
  than AAA and contains no vowel.
- **Arkansas "U and V dropped in 1973, added back in 2015"** — recorded and
  flagged precisely because it runs the *wrong way*: states shed letters and
  almost never restore them. Unusual claims deserve verification, not repetition.
- **Louisiana's 2025 "America 250" base** — locator only. **No OMV alert, press
  release or policy revision announcing it was found** (the reachable OMV alerts
  feed begins in 2026). It is therefore recorded as a dated entry in
  `base_designs` under one format-defined series, **not** as a series boundary,
  so that no id has to be aliased later under the PRD-QUALITY I-5/I-6 contract.
- **TxDMV vs. locator on the 2009 base start** — TxDMV says "launched in June
  2009", the locator says July 2009. Integer-year periods dissolve the conflict;
  the disagreement is **recorded, not averaged** (§5.3).

---

## 5. Modelling decisions a verifier should check first

1. **Arkansas is two series on one design.** The base has been unchanged since
   March 2006; the arrangement changed in April 2021 (`123 ABC` → `ABC 12D`).
   §2.3 makes a format difference sufficient on its own, so `us-ar-standard`
   (2021–) and `us-ar-standard-2006` (2006–2021) share a design. Keying series to
   base designs would give one 20-year Arkansas series and no way to date a plate.
2. **Louisiana is keyed to format, not to base.** `us-la-standard` starts in
   **2016** at the arrangement change (authority-sourced via Policy 21.00's
   prohibition) rather than in 2025 at the reported base change (locator only).
   Six reported bases sit inside the 1993–2016 alpha-first series, three of them
   *limited-run commemorative general issues* — Louisiana changes its picture
   often and its number shape almost never, so **dating heuristics must key on the
   base and validation heuristics on the arrangement**, and the two point in
   opposite directions.
3. **No `regex_strict` and no `regex_statutory` anywhere in this group.** Both
   absences are deliberate and are explained in the files. There is no statutory
   tier because none of the four states states an outer legal bound the way
   Florida's § 320.06(3)(a) does — Texas and Oklahoma expressly *delegate* the
   alphanumeric pattern to the agency, so a statutory twin would be an invention.
   There is no strict tier because no state in the group publishes its alphabet;
   every reported exclusion is locator-grade and is recorded as
   `charset.excluded_reported` + `excluded_basis` instead.
4. **A `serial_basis` field was introduced** on `format`, with values
   `statute-stated` / `authority-stated` / `authority-stated-negatively` /
   `authority-stated-arrangement` / `authority-frame-inferred` /
   `locator-corroborated` / `locator-unconfirmed`. It is not in the PRD schema.
   It exists because this group's evidence quality varies enormously *within* a
   file — Oklahoma's OHP format is from a legislature and its passenger format is
   from a collector — and collapsing that into "has a regex" would be dishonest.
   **Maintainer call:** adopt, rename, or strip.
5. **`us-ok-standard` and `us-ok-standard-scissortail` overlap on purpose** (both
   current, authority-stated), as do the two Arkansas and two Louisiana standard
   pairs at their boundary years. All carry distinct notes per the lint's
   overlap-legal-iff-distinct-notes rule.
6. **`binding: officer`** on `us-ok-highway-patrol` is a new value (see §1.7).

---

## 6. Leads for later gates

- **Oklahoma county-code decode table (1981–2009), `_decode/` candidate.** One of
  the very few genuine US serial→geography decodes that ever existed: three-letter
  prefixes allocated per county, counties exhausting their allocation and spilling
  into a reversed arrangement, then discontinued in 2009 and moved to the month
  revalidation decal, then the decal's county abbreviation itself discontinued in
  2024. A full geography signal migrating **serial → sticker → nothing** over
  fifteen years. L4 scope; flagged as high value.
- **Louisiana State Police *troop area* letter (1989–1993 base).** The middle
  letter of `123A456` is reported to encode a **State Police troop area** — a
  *policing* geography, not a parish. Flagged specifically because a naive decode
  table would map it to parishes and be wrong.
- **Arkansas permanent-trailer prefix decode.** `A`/`B` = trailers hauled by
  automobiles and class-1 trucks; `PT` = class 2–8 trucks (on a different colour
  scheme); `S/P` = **meaning unknown**. Recorded *with* the hole, because a decode
  table that says "hole" beats a tidy one that drops the case it cannot explain.
- **Oklahoma tribal plates.** Service Oklahoma lists **Tribal Plates** as a
  first-class plate type alongside specialty and personalized. Oklahoma tribal
  nations issue tags under their own sovereign authority; that is **not state
  issuance**, and tribal nations are not ISO 3166-2 subdivisions. A US plate
  dataset that models only state issuance will fail to parse a large population of
  lawfully registered Oklahoma vehicles. **This is a jurisdiction-model question
  for the maintainer, not a series question**, and it should be decided before L3.
- **`dfa.arkansas.gov/wp-json/wp/v2/specialty-plates`** is a genuinely
  machine-readable official specialty catalogue with per-plate pages and a total in
  an HTTP header (`X-WP-Total: 131` at 2026-08-02). Worth **periodic snapshotting**
  for the same reason as FLHSMV's monthly active-plate report — it is the second
  structured official plate artefact found in the US programme.
- **Texas and Louisiana both legislate specialty plates one statute at a time**
  (Tex. Transp. Code §§ 504.301–504.518; La. R.S. 47:463.3 through 47:463.38 and
  beyond). Because each is an **edict of government**, both specialty catalogues
  are enumerable **from statute** — which is the right route for L4 and, in
  Louisiana's case, sidesteps the LADPS artwork assertion entirely.
- **Louisiana's vanity separator conflict** deserves a maintainer decision.
  Policy 21.00 permits a hyphen or a period *inside* a personalized configuration
  and counts it against the seven-character budget — i.e. the glyph is part of the
  chosen string, not a group separator. Under §2.6 rule 3 "a jurisdiction that
  prints a glyph inside a serial is a schema amendment, not a data entry". This
  may be the dataset's first such case, though it applies only to owner-chosen
  configurations. Flagged, not resolved.

---

## 7. Source ledger

**37 distinct URLs** cited across the four files (plus one `<id>` template for the
Louisiana PowerDMS document scheme). Breakdown by class:

| class | n | notes |
|---|---|---|
| State statute / statute reproduction | 3 | TX ch. 504 (official + `texas.public.law` reproduction), OK Title 47 (Senate PDF) |
| Registrar policy manual (LA OMV, PowerDMS) | 9 | Policies 5.00, 6.00, 19.00, 21.00, 38.00, 45.00, 74.00, 153.00 + the Section 5 index |
| State DMV / registrar web pages | 12 | TxDMV (4 pages + 3 PDFs), Service Oklahoma (3), Arkansas DFA (4), Louisiana OMV (4) |
| Machine-readable official catalogue | 1 | `dfa.arkansas.gov/wp-json/wp/v2/specialty-plates` |
| Standards | 1 | AAMVA Ed.3 (from the pinned dossier) |
| Government terms-of-use / portal policy | 2 | LADPS Terms of Use, Arkansas.gov acceptable-use |
| Wikipedia — **locator only** | 5 | four state plate articles + the subnational-copyright article |
| Vendor | 1 | `myplates.com`, the § 504.851 Texas private vendor |

Every non-primary citation carries the words **LOCATOR ONLY (PRD-PLATES §4)** in
its own source line, and every claim resting on one carries a `*_basis:` field
saying so. **No enthusiast-site text was copied and no photograph was used.**
`plateshack.com` pages for all four states were fetched as gap-finders and turned
out to be image galleries with no extractable facts; they are not cited, because
nothing from them was used.
