### PR TITLE
plates: us mountain — CO UT NV AZ NM (L2 US wave)

### DIFF
--- a/plates/us-az.yml
+++ b/plates/us-az.yml
@@ -1,0 +1,430 @@
+# plates/us-az.yml — Arizona (PRD-PLATES gate L2, mountain group).
+#
+# ARIZONA IS THE NAMED ADVERSE STATE, and this pass pins the evidence rather
+# than repeating the assertion. The US research dossier recorded Arizona as
+# "the most adverse posture found" but traced it only to a Wikipedia summary.
+# The underlying instrument is the Arizona Secretary of State's own library
+# policy, and its words are quoted verbatim in `artwork_risk` below, with the
+# statutory hook (A.R.S. § 39-121.03) it points to. Read that section before
+# rendering anything Arizonan.
+#
+# THE OTHER ARIZONA SURPRISE is structural: Arizona's statute delegates almost
+# everything. § 28-2351 gives the director colour and design; § 28-2406 gives
+# the department the number of positions on a personalized plate. There is NO
+# statutory character cap of the Florida (seven) or Colorado (six) kind. What
+# the 2022 amendment to § 28-2351 DOES prescribe is oddly specific and worth
+# the whole file: the STATE NAME's typeface class and height, in law.
+#
+# WHY THE FORMAT SECTION READS AS IT DOES: since February 2021 Arizona's
+# standard serial is SIX ALPHANUMERIC POSITIONS OF WHICH ONLY THE FOURTH IS
+# GUARANTEED A DIGIT. The human-pattern DSL (9=digit, L=letter) has no
+# alphanumeric token, so `pattern` shows one representative arrangement and the
+# REGEX carries the real grammar. That divergence is stated in `pattern_note`
+# rather than papered over — Arizona is the schema stressor for a mixed
+# alphanumeric position, exactly as Japan is for composed fields.
+#
+# WHAT IS NOT HERE (PRD-PLATES §2.5): individual special-plate DESIGNS.
+jurisdiction: us-az
+authority:
+  name: Arizona Department of Transportation, Motor Vehicle Division (ADOT MVD)
+  url: "https://azdot.gov/motor-vehicles/vehicle-services/license-plates"
+binding: owner
+binding_note: >-
+  ARIZONA IS A PLATE-FOLLOWS-THE-OWNER STATE, which makes it the North American
+  cousin of Switzerland and the reason `binding:` exists as a field. ADOT's own
+  guidance is that the plate belongs to the vehicle owner and may be transferred
+  from one vehicle to another; § 28-2356 is titled "Transfer of license plates
+  to another vehicle; credit" and governs the transfer and the credit for
+  unexpired fees. A vehicle-keyed consumer that assumes an Arizona plate
+  identifies a VEHICLE across time will be wrong. (The ADOT page stating the
+  ownership rule could not be fetched in this pass — azdot.gov is behind a
+  Cloudflare challenge that returns 403 to every automated client tried — so the
+  claim rests on § 28-2356's existence plus a locator; recorded honestly.)
+statute_edition: >-
+  Arizona Revised Statutes as served by the Arizona State Legislature at
+  azleg.gov, read in this pass. Title 28, Chapter 7, Article 11 (License Plates
+  Generally, §§ 28-2351 to 28-2356) and Article 12 (Special Plates, § 28-2401
+  onward).
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4. THE FLAGGED ONE.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: copyright-expressly-asserted
+  basis: >-
+    Arizona expressly asserts copyright over state government works. The
+    assertion is made by the Arizona State Library, Archives and Public Records
+    — a division of the Arizona Secretary of State — in its published Website
+    Policies, under the heading "Copyright Policy", verbatim: "Arizona state
+    government works: Unlike federal works, state works are not in the public
+    domain and are protected by copyright. However, public records laws may
+    allow reproduction in some instances. Any user intending to obtain any
+    public records information on this website for a commercial purpose is
+    required under Arizona law to pay a commercial fee as established by the
+    Secretary of State's office. You must follow the procedures described in
+    A.R.S. § 39-121.03 in order to obtain permission to use public records for a
+    commercial purpose." The same page states the contrast case in its own
+    words — "Federal government works: Information in federal publications are
+    not protected by copyright (17 USC 105)" — so the state is drawing the
+    distinction deliberately, not by oversight.
+  fetch_note: >-
+    THE LIVE URL COULD NOT BE FETCHED. azlibrary.gov, azdot.gov and az.gov all
+    sit behind a Cloudflare interstitial that returns HTTP 403 to every
+    automated client attempted in this pass. The quotation above was read from
+    the Internet Archive capture of 15 September 2023, which is cited alongside
+    the live URL below. This is recorded because a claim this consequential
+    should carry its retrieval conditions, and because a future pass should
+    re-verify the live text before anything is rendered.
+  what_this_does_and_does_not_reach: >-
+    It does NOT reach the statutes. Edicts of government are uncopyrightable at
+    every level (PRD-PLATES §4), so §§ 28-2351, 28-2354, 28-2356 and 28-2406 —
+    every legal claim in this file — are public domain regardless of Arizona's
+    posture, and the ADOT-sourced facts are facts. What the posture reaches is
+    the DESIGN: the Four Peaks silhouette, the sunset gradient, the saguaro. In
+    Arizona those are the highest-risk act in the whole programme.
+  emblem_rule: >-
+    STRICTEST PATH, no exceptions. Render `graphic: {present: true, rendered:
+    placeholder}` for the desert scene and the saguaro; do not trace, do not
+    trace from a photograph, do not approximate the Four Peaks silhouette
+    closely enough to be substitutable, and do not embed any Arizona typeface
+    binary. Arizona state seal statutes are UNRESEARCHED — the standing gap
+    from the US dossier §4.5 — and the seal regime is independent of copyright,
+    so it would survive even a favourable copyright answer.
+  photograph_caution: >-
+    The Commons finding cuts the same way here as everywhere: a CC BY-SA tag on
+    an Arizona plate photograph is the PHOTOGRAPHER's licence on the PHOTOGRAPH,
+    and the uploader had no standing over the design. In Arizona that cuts
+    BOTH ways and the second direction matters more than usual — a permissive
+    tag on a photo is no permission at all against a state that has asserted
+    copyright in terms. Because our renders are generated from the statute and
+    never derived from a photograph, neither the photographer's obligations nor
+    the photograph itself is ever in the chain.
+  sources:
+    - "https://azlibrary.gov/website-policies  # Arizona State Library, Archives and Public Records (Office of the Arizona Secretary of State), Copyright Policy: 'Arizona state government works: Unlike federal works, state works are not in the public domain and are protected by copyright.' LIVE URL 403s to automated clients; read via https://web.archive.org/web/20230915005643/https://azlibrary.gov/website-policies"
+    - "https://www.azleg.gov/ars/39/00121-03.htm  # A.R.S. § 39-121.03, the commercial-purpose public-records procedure the copyright policy routes commercial users through. NOT FETCHED in this pass (azleg.gov returned a socket hang-up on this section twice); pinned as the target to read, and no content is attributed to it here."
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4) — where the azlibrary.gov pointer was found. The policy itself is what is quoted."
+
+# ---------------------------------------------------------------------------
+# The US standards chain.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is PAYWALLED and UNPINNED. No J686 dimension is quoted."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges."
+    jurisdiction_name_layout: >-
+      AAMVA §2.1 recommends the jurisdiction name in the top centre between the
+      bolt holes, at least 0.25 in above the plate number and 0.125 in from the
+      top edge, with jurisdiction characters 0.75-1.0 in. ARIZONA IS THE ONE
+      STATE IN THIS GROUP THAT LEGISLATED ITS OWN VERSION OF THIS RULE, and it
+      lands INSIDE the AAMVA band: § 28-2351, post-24 September 2022, requires
+      the state name in capitals, in a SANS SERIF font, three-fourths of an inch
+      high. That is 0.75 in — the bottom of AAMVA's recommended range, in
+      Arizona law. A rare, checkable instance of voluntary adoption showing up
+      in statute.
+    stacked_characters: "AAMVA: stacked characters are part of the official plate number and no more than two may be stacked. Arizona's statute is silent; the normalisation decision belongs in the parse layer."
+    replacement_cycle: "AAMVA §1.1 recommends a cycle not to exceed 7 to 10 years. Arizona legislates none (recorded gap)."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" is COMMONLY REPEATED, UNSOURCED
+    (US dossier headline finding 2). The Arizona article does not even offer the
+    ALPCA-magazine footnote the Utah, Nevada, Colorado and New Mexico articles
+    carry. Arizona's plate size is not in Title 28 at all — § 28-2351 states a
+    legibility distance, not a dimension (recorded gap).
+
+display_rules:
+  default: >-
+    ONE plate, rear. § 28-2351: "The department shall provide to every owner one
+    license plate for each vehicle registered", with an additional plate
+    obtainable on request and payment of a fee. Rear-only has been the Arizona
+    rule since 1989 (locator-grade for the year).
+  wheelchair_carrier_rule: >-
+    § 28-2354(A)(3) carries a genuinely unusual attachment rule: for a vehicle
+    issued two special plates under § 28-2409, "one plate on the rear of the
+    vehicle and one plate on the operator's wheelchair carrier or wheelchair
+    lift when it is attached to the vehicle". A plate mounted on a removable
+    accessory rather than on the vehicle — the display model has to allow it.
+  legibility: "§ 28-2351: letters and numerals 'of sufficient size to be plainly readable during daylight from a distance of one hundred feet'"
+  contrast_and_state_name: >-
+    § 28-2351, as amended effective 24 September 2022: the background colour
+    must contrast significantly with the letters, numerals and state name, and
+    "The name of this state shall appear on the license plate in capital letters
+    in sans serif font and be three-fourths of an inch in height." This is the
+    most typographically prescriptive plate provision found in this group of
+    five states, and it prescribes a FONT CLASS rather than a font — consistent
+    with PRD-PLATES §6's finding that no surveyed jurisdiction mandates a
+    licensable typeface.
+  reflectivity: "§ 28-2351: 'The director shall coat the license plate with a reflective material that is consistent with the determination of the department regarding the color and design.'"
+  sources:
+    - "https://www.azleg.gov/ars/28/02351.htm  # § 28-2351 License plate provided; design: one plate per vehicle, additional plate on request, director determines colour and design, reflective coating, 100-foot daylight legibility, and the post-2022 contrast rule and sans-serif three-quarter-inch state name"
+    - "https://www.azleg.gov/ars/28/02354.htm  # § 28-2354 License plates; attachment; civil penalty — including the wheelchair-carrier placement in (A)(3)"
+    - "https://www.azleg.gov/ars/28/02356.htm  # § 28-2356 Transfer of license plates to another vehicle; credit — the plate-follows-the-owner mechanism"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — the "alphabet soup" generation.
+  # =========================================================================
+  - id: us-az-standard-2021
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2021 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "LLL 9LL"
+      regex: '\A[A-Z0-9]{3} ?\d[A-Z0-9]{2}\z'
+      charset:
+        notes: >-
+          NO STATUTORY CONSTRAINT EXISTS. § 28-2351 gives the director colour
+          and design and says nothing about serial length or alphabet;
+          § 28-2406 hands the department "the number of positions allowed" on a
+          personalized plate. Arizona is therefore the pure delegated case in
+          this group — contrast Florida's seven-character statutory cap and
+          Colorado's six. The grammar recorded here comes from ADOT's own
+          announcement of the 2020 change plus contemporaneous reporting, read
+          through a Wikipedia locator: six positions, every one of which may be
+          a letter OR a digit, EXCEPT the fourth, which is always a digit; each
+          position runs A-Z then 0-9.
+      pattern_note: >-
+        READ THIS BEFORE USING `pattern`. The human-pattern DSL has exactly two
+        tokens, 9 (digit) and L (letter), and Arizona's current serial has
+        FIVE POSITIONS THAT ARE NEITHER — they are alphanumeric. `pattern`
+        therefore shows ONE REPRESENTATIVE ARRANGEMENT ("ABC 1DE", which is the
+        arrangement the locator record itself uses as the exemplar) and the
+        REGEX carries the actual grammar. The round-trip still holds, because
+        every serial the pattern generates is inside the regex; what does not
+        hold is the usual reading that `pattern` describes the alphabet.
+        Arizona is the schema stressor for a mixed alphanumeric position and it
+        should be cited when `format.fields:` is next discussed.
+      progression: >-
+        NOT LEXICOGRAPHIC. ADOT introduced a new plate-coding system in June
+        2020 replacing one dating from the mid-1980s; the resulting serials were
+        reported as "random" but in fact increment in a non-standard order
+        (locator records the 2021-onward order as CEA 1DB — that is, positions
+        advance in a fixed but non-left-to-right sequence). Consequence for the
+        parse API: an Arizona serial's alphabetical position tells you almost
+        nothing about its issue date, and any era inference built on ordinary
+        odometer logic will be wrong.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: "NOT IN TITLE 28. Arizona states a legibility distance, not a dimension. The 12x6 figure is the North American convention from the AAMVA/SAE chain and is not attributed to any Arizona instrument (recorded gap)."
+      background: { finish: retroreflective }
+      material: "reflective coating mandated by § 28-2351; the specific material is 'consistent with the determination of the department' and no departmental material spec was obtained (recorded gap)"
+      colour_note: >-
+        NO HEX IS CLAIMED. § 28-2351 mandates significant CONTRAST between
+        background and characters and leaves every hue to the director. The
+        design is described by a Wikipedia LOCATOR as a dark green serial on a
+        graphic desert scene — turquoise, white and orange gradient sky, a white
+        setting sun, purple mountains in the shape of Four Peaks, and cacti —
+        with "ARIZONA" screened in turquoise with white outlines at the top and
+        "GRAND CANYON STATE" in dark green below the serial. That is recorded as
+        a lead. Given the artwork posture above, an approximated render must be
+        deliberately unlike it, not faithfully like it.
+      legend_top: "ARIZONA"
+      legend_bottom: "GRAND CANYON STATE"
+      state_name_typography: "capital letters, sans serif font, three-fourths of an inch high (§ 28-2351, post-24 September 2022) — the only statutory typography in this group"
+      graphic: { present: true, rendered: placeholder, description: "desert scene with Four Peaks and saguaro; security threads at plate centre since the 2008 flat-printed generation — locator-grade" }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: >-
+      NONE. Arizona used county coding historically (the Wikipedia article keeps
+      a county-coding section) but no modern Arizona serial encodes geography,
+      and the current alphanumeric grammar leaves no positional room for it.
+    sources:
+      - "https://www.azleg.gov/ars/28/02351.htm  # § 28-2351: the absence of any statutory serial constraint, the director's design power, the reflective coating, the contrast rule and the sans-serif state-name height"
+      - "https://azdot.gov/adot-news/your-eyes-don%E2%80%99t-deceive-you-new-license-plate-numbers-are-different  # ADOT's own June 2020 announcement of the new plate-numbering system. NOT FETCHED — azdot.gov 403s to automated clients behind Cloudflare; pinned as the primary to read on a browser-capable pass, and no wording is attributed to it here."
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Arizona  # LOCATOR ONLY (PRD-PLATES §4): the February 2021 arrangement change, the six-position alphanumeric grammar with a digit fixed in position four, the non-standard progression order, the AAA 0AA start and the design description. None is asserted as sourced."
+    notes: >-
+      ARIZONA STANDARD ISSUE, CURRENT GENERATION. THE BASE DESIGN IS OLDER THAN
+      THE SERIES: the desert scene dates to 1996 (flat-printed from January
+      2008), and 2021 is a SERIAL-GRAMMAR boundary, not a redesign. The id is
+      dated because the grammar is what distinguishes the series, and
+      `period_evidence: corroboration-only` states plainly that February 2021
+      rests on a locator and contemporaneous press, not on an Arizona
+      instrument. WHY THIS SERIES IS INTERESTING BEYOND ARIZONA: it is the
+      cleanest US example of a state exhausting its serial space and answering
+      with an alphabet change rather than a redesign — 999 ZZZ ran out in
+      mid-January 2008, ABC1234 ran out by April 2020, and the answer both times
+      was more characters or a wider alphabet on the SAME plate.
+
+  # =========================================================================
+  # ONE SERIES BACK.
+  # =========================================================================
+  - id: us-az-standard-2008
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2008, end: 2020 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "LLL9999"
+      regex: '\A[A-Z]{3}\d{4}\z'
+      charset: { notes: "three letters then four numerals, printed with no separator; no statutory constraint applies, for the same reason as the current series" }
+      progression: "sequential from AAA0001 to approximately CWX9999; the CWL0001-CWX9999 block was assigned to rental cars from 2020 (locator-grade)"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "the same 1996 desert-scene base as the current series, with the serial screened rather than embossed and security threads added at the plate centre. No hex claimed."
+      legend_top: "ARIZONA"
+      legend_bottom: "GRAND CANYON STATE"
+      graphic: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.azleg.gov/ars/28/02351.htm  # § 28-2351: the design power under which this arrangement was issued"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Arizona  # LOCATOR ONLY: the January 2008 to April 2020 window, the exhaustion of 999 ZZZ in mid-January 2008 reported by The Arizona Republic, and the AAA0001-CWX9999 range"
+    notes: >-
+      THE PREVIOUS ARRANGEMENT. Recorded partly for its own sake and partly
+      because the exhaustion story is documented: contemporaneous reporting
+      (The Arizona Republic, 30 April 2008) attributes the seventh character to
+      ADOT running out of combinations "when it issued plate 999 ZZZ in
+      mid-January". A dated exhaustion event is the most useful kind of era
+      evidence a plates dataset can hold, and it is why this series' boundary is
+      better attested than most in this group even though it remains
+      corroboration-grade.
+
+  # =========================================================================
+  # THE 2020-21 TRANSITIONAL GENERATION — seven positions, recorded because it
+  # is short, real, and still on the road.
+  # =========================================================================
+  - id: us-az-standard-2020-transitional
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2020, end: 2021 }
+    period_evidence: corroboration-only
+    matching: recall-only
+    format:
+      pattern: "LLL9LLL"
+      regex: '\A[A-Z0-9]{3}\d[A-Z0-9]{3}\z'
+      charset:
+        notes: >-
+          SEVEN positions, printed without a separator, with the fourth always a
+          digit and every other position alphanumeric — the same rule as the
+          current six-position grammar, one character longer. The locator record
+          says sixty-four arrangements were theoretically available and only
+          eight were used; those eight are not individually sourced here, which
+          is exactly why this series is `recall-only`: the regex is the union of
+          all seven-position strings with a digit in position four, which is
+          deliberately wider than the eight arrangements Arizona actually issued.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "the same 1996 desert-scene base; no hex claimed"
+      legend_top: "ARIZONA"
+      legend_bottom: "GRAND CANYON STATE"
+      graphic: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Arizona  # LOCATOR ONLY: the April 2020 to January 2021 window, the AAA0AAA-SXA6DTA range, the sixty-four-available/eight-used arrangement count, and the ADOT coding-system change behind it"
+      - "https://www.azleg.gov/ars/28/02351.htm  # § 28-2351: the delegated design power that made an arrangement change possible without legislation"
+    notes: >-
+      A NINE-MONTH SERIES, KEPT ON PURPOSE. It is the smallest series in this
+      group and it earns its place three ways: it is the reason the current
+      six-position grammar exists at all; it is still lawfully on the road, so a
+      parser meeting a seven-character Arizona serial with a digit in position
+      four is not looking at an error; and it is the clearest `recall-only` case
+      in the mountain group — a regex written as a union because the members of
+      the union were not individually sourced. Contrast us-az-standard-2021,
+      whose regex IS the grammar and is therefore strict.
+
+  # =========================================================================
+  # PERSONALIZED.
+  # =========================================================================
+  - id: us-az-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]+\z'
+      charset:
+        notes: >-
+          § 28-2406, verbatim on the only point it addresses: "The department
+          shall determine the number of positions allowed on the personalized
+          special plates." The statute sets NO cap and NO alphabet. The
+          departmental determination was not obtained (azdot.gov is unfetchable
+          from here), so the regex MAKES NO WIDTH CLAIM — an unbounded
+          quantifier, on the same reasoning as us-fl-horseless-carriage's
+          '\A\d+\z'. Recording a guessed maximum would be worse than recording
+          none.
+        refusal_criteria: >-
+          § 28-2406: the department may refuse, suspend, cancel or revoke
+          combinations "that carry connotations that are offensive to good taste
+          and decency", combinations that are misleading, and duplicates of
+          existing plates. The applicant requests; the department decides.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "personalized configurations are offered on the standard base and on special plate designs; which designs accept personalization was not obtained (recorded gap)"
+    region_encoding: none
+    sources:
+      - "https://www.azleg.gov/ars/28/02406.htm  # § 28-2406 Personalized special plates: the department determines the number of positions; the good-taste-and-decency, misleading and duplicate refusal grounds; the refuse/suspend/cancel/revoke powers"
+    notes: >-
+      PERSONALIZED PLATES, and a deliberate demonstration of the
+      no-width-claim discipline. Every other state in this group states a
+      personalized character range somewhere — Colorado two to seven in statute,
+      New Mexico one to eight on the MVD's own page — and Arizona states none at
+      any level this pass could reach. The regex says so. PERIOD CAVEAT:
+      `start: 2026` is the statute edition read and is an upper bound; Arizona
+      has issued personalized plates for decades.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-az-special-plate-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL 9LL"
+      regex: '\A[A-Z0-9]+(?: [A-Z0-9]+)?\z'
+      charset: { notes: "special plates carry ordinary serials on an alternative design; because no statutory cap exists and no departmental determination was obtained, no width claim is made and the regex is an explicit recall bound" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count: unresearched
+      count_note: >-
+        NO COUNT IS ASSERTED. Arizona's specialty catalogue lives on azdot.gov,
+        which returned HTTP 403 behind a Cloudflare challenge to every automated
+        client attempted, and has no Internet Archive capture under the paths
+        tried. Rather than launder a figure out of a collector site or an
+        encyclopedia, the count is recorded as UNRESEARCHED with the official
+        URLs pinned for a browser-capable pass. This is the same discipline that
+        made Florida's contested "over 100 vs over 120" worth recording: an
+        honest absence beats a sourced-looking number.
+      official_list_url: "https://azdot.gov/motor-vehicles/vehicle-services/license-plates"
+      statutory_frame: >-
+        Arizona authorises special plates BY STATUTE, in Title 28, Chapter 7,
+        Article 12 (§ 28-2401 onward), which is why the catalogue can eventually
+        be enumerated from the code rather than from a web page. § 28-2401
+        supplies the article's definitions — "special plates" means "plates
+        issued pursuant to this article", and "immediate family member" means "a
+        spouse or a parent, child, brother or sister whether by adoption or
+        blood", the latter mattering because several Arizona special plates pass
+        to family. § 28-2402 governs special plate fees; § 28-2403 governs
+        transfers and makes a violation a criminal classification; § 28-2406 is
+        the personalized-plate section modelled separately above.
+      fees_note: "§ 28-2402 (Special plate fees) and § 28-2353 (Special license plate replacement fee) were identified but their figures were not extracted in this pass (recorded gap)."
+    region_encoding: none
+    sources:
+      - "https://www.azleg.gov/arsDetail/?title=28  # the Title 28 section index from which Article 11 (28-2351 to 28-2356) and Article 12 (28-2401 onward) were read"
+      - "https://www.azleg.gov/ars/28/02401.htm  # § 28-2401 Definitions: 'special plates' means plates issued pursuant to this article; the immediate-family-member definition"
+      - "https://azdot.gov/motor-vehicles/vehicle-services/license-plates  # ADOT MVD's own plate index — PINNED BUT NOT FETCHED (403, Cloudflare). No claim in this entry rests on it."
+    notes: >-
+      THE SPECIAL-PLATE PROGRAM INDEX — one entry for the whole programme, per
+      PRD-PLATES §2.5. IT IS DELIBERATELY THIN, and the thinness is the finding:
+      Arizona is the only state in the mountain group whose issuing agency could
+      not be reached at all. Everything in this file that is stated as fact came
+      from azleg.gov (the legislature) or from an archived Secretary of State
+      policy page; everything ADOT would have supplied — the specialty count,
+      the personalized character limit, the departmental colour and material
+      specifications, the plate-belongs-to-the-owner statement — is recorded as
+      a gap with its URL pinned. A future pass with a browser should start here.

--- a/plates/us-co.yml
+++ b/plates/us-co.yml
@@ -1,0 +1,452 @@
+# plates/us-co.yml — Colorado (PRD-PLATES gate L2, mountain group).
+#
+# WHY COLORADO IS UNUSUAL, stated up front: it is the only state in this group
+# whose legislature legislates the SERIAL LENGTH and the COLOURS OF ITS OWN
+# RETIRED DESIGNS. § 42-3-201(5)(a) C.R.S. caps a standard plate at "no more
+# than a total of six numbers and letters" — Florida's seven-character cap has
+# a six-character cousin here — and § 42-3-206.5, added in 2021, orders the
+# department to reissue four named historic styles, describing each ONE BY ITS
+# COLOURS in the statutory text. That second section is the most colour-
+# specific plate provision found anywhere in this group's five states.
+#
+# ARTWORK POSTURE, and it is the bad news: Colorado is ADVERSE. § 24-72-203(4)
+# C.R.S. specifically authorises the state to obtain and enforce copyright over
+# public records. See `artwork_risk` — this is a pinned primary, not an
+# inference from a secondary summary.
+#
+# SOURCING RULE APPLIED HERE (PRD-PLATES §4): edicts of government are public
+# domain at every level, so every claim that CAN come from Title 42 does. The
+# Colorado Revised Statutes 2023 were read as the Colorado General Assembly's
+# own PDF (Office of Legislative Legal Services). The Division of Motor
+# Vehicles' own pages are cited only for what the statute does not carry: which
+# designs are currently offered, the group-special catalogue, and the
+# manufacture/Print-On-Demand arrangements.
+#
+# WHAT IS NOT HERE (PRD-PLATES §2.5): individual group-special DESIGNS. The
+# index entry `us-co-group-special-index` stands for the whole programme.
+jurisdiction: us-co
+authority:
+  name: Colorado Department of Revenue, Division of Motor Vehicles (DMV)
+  url: "https://dmv.colorado.gov/license-plates"
+binding: vehicle
+statute_edition: >-
+  Colorado Revised Statutes 2023, Title 42 (Vehicles and Traffic) and Title 24
+  (Government - State), read from the Office of Legislative Legal Services PDFs
+  published at leg.colorado.gov. Marked "Uncertified Printout" by the publisher;
+  it is nevertheless the legislature's own edition, which is what §4 asks for.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: adverse-copyright-authorised-by-statute
+  basis: >-
+    Colorado's open-records act expressly reserves copyright to the state.
+    § 24-72-203(4) C.R.S., verbatim: "Nothing in this article shall preclude the
+    state or any of its agencies, institutions, or political subdivisions from
+    obtaining and enforcing trademark or copyright protection for any public
+    record, and the state and its agencies, institutions, and political
+    subdivisions are hereby specifically authorized to obtain and enforce such
+    protection in accordance with the applicable federal law; except that this
+    authorization shall not restrict public access to or fair use of copyrighted
+    materials and shall not apply to writings which are merely lists or other
+    compilations." The subsection was added by L. 92, p. 1104, § 3, effective
+    1 July 1992. This is the same shape of hazard as Arizona's, arrived at by a
+    different route: Arizona asserts copyright in an agency policy, Colorado
+    authorises it in statute.
+  what_this_does_and_does_not_reach: >-
+    The authorisation is over PUBLIC RECORDS and is expressly subject to fair
+    use, and expressly does NOT apply to "writings which are merely lists or
+    other compilations" — which is precisely the character of a serial-format
+    table. Nothing in the section touches the uncopyrightability of facts, and
+    nothing in it reaches the STATUTE itself: § 42-3-201, § 42-3-206.5 and
+    § 42-3-211 are edicts of government and public domain at every level
+    (PRD-PLATES §4). So the facts in this file are clean; the RENDERED MOUNTAIN
+    GRAPHIC is the exposure, and it routes through the strict path.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies with extra force here. The
+    Colorado mountain-range graphic is the single most recognisable element of
+    the plate and it has been continuously in use since 1960 — render
+    `graphic: {present: true, rendered: placeholder}` and do not trace, do not
+    trace from a photograph, and do not approximate closely enough to be
+    substitutable. Colorado state seal statutes are UNRESEARCHED (the standing
+    gap from the US dossier §4.5, unclosed here).
+  photograph_caution: >-
+    Unchanged from the pilot's finding: a Commons CC BY-SA tag on a Colorado
+    plate photograph is the PHOTOGRAPHER's licence on the PHOTOGRAPH. The
+    uploader had no standing over the design, and because our renders are
+    generated from the spec and never derived from a photograph, those
+    share-alike obligations never attach. That reasoning is what keeps an
+    adverse-posture state renderable at all.
+  sources:
+    - "https://leg.colorado.gov/sites/default/files/images/olls/crs2023-title-24.pdf  # § 24-72-203(4): the state is 'specifically authorized to obtain and enforce' copyright over public records; the fair-use and mere-lists carve-outs; Source note L. 92 p. 1104 § 3"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4) — this is where the § 24-72-203 pointer was found; the statute above was then read directly and is what is cited"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Recorded per file because each state file must stand
+# alone. Full treatment lives in us-fl.yml; the delegation trap is restated
+# because it is the reason no dimension below is attributed to SAE J686.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA has no enforcement power."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends plate dimensions and bolt holes to SAE J686, whose own text is PAYWALLED and UNPINNED. No J686 dimension is quoted here or anywhere in this dataset."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges."
+    jurisdiction_name_layout: "AAMVA §2.1: jurisdiction name in the top centre between the bolt holes, at least 0.25 in above the plate number and 0.125 in from the top edge; jurisdiction characters 0.75-1.0 in."
+    replacement_cycle: "AAMVA §1.1 recommends a rolling or full replacement cycle 'not to exceed 7 to 10 years'. COLORADO HAS NO STATUTORY REPLACEMENT CYCLE AT ALL — see `replacement_posture` below."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" appears in the Wikipedia Colorado
+    article footnoted to an ALPCA members' magazine article by Christopher
+    Garrish titled "Reconsidering the Standard Plate Size" (Plates, October
+    2016). Note what that means: the citation offered for the claim is an
+    article whose title announces that it RECONSIDERS the claim, and it is a
+    hobbyist magazine, not a primary instrument. The US dossier already found
+    the same story uncited on the parent article. Recorded here as COMMONLY
+    REPEATED, UNSOURCED. Colorado's plate size is not stated in Title 42 at all
+    (recorded gap) — § 42-3-201(2) states a legibility distance, not a size.
+
+replacement_posture:
+  statutory_cycle: none
+  basis: >-
+    Title 42 sets NO replacement cycle. § 42-3-201(1)(b)(I): "The department may
+    issue the number plates required in this section for one or more
+    registration periods." § 42-3-201(5)(b): "The department of revenue may
+    require the replacement of any license plate as necessary to ensure that
+    license plates are legible as required by section 42-3-202 (2)." So
+    replacement in Colorado is CONDITION-TRIGGERED and discretionary, not
+    scheduled — the opposite pole from Florida's legislated 10 years, and a
+    second data point for the standing answer that there is no US redesign
+    cadence, only per-state replacement regimes.
+  plate_expires_on_transfer: >-
+    SB 21-069 made Class C plates EXPIRE ON TRANSFER of the owner's title or
+    interest, unless the plate is personalized or carries a reserved valuable
+    registration number under the Laura Hershey Disability Support Act. A
+    Colorado plate therefore does not follow the car to its next owner — which
+    makes `binding: vehicle` true only for the duration of one ownership.
+
+display_rules:
+  default: "TWO plates, front and rear. § 42-3-202(1)(a)(I): 'the owner shall attach the number plates assigned to a self-propelled vehicle to the vehicle with one in the front and the other in the rear.'"
+  rear_only_classes:
+    - "motorcycle (§ 42-3-202(1)(a)(II)(A))"
+    - "autocycle (§ 42-3-202(1)(a)(II)(B))"
+    - "street rod vehicle (§ 42-3-202(1)(a)(II)(C))"
+    - "trailer, semitrailer, or other vehicle drawn by a motor vehicle (§ 42-3-202(1)(a)(II)(D))"
+    - "special mobile machinery (§ 42-3-202(1)(a)(II)(E))"
+  one_plate_issued_for: "the same list, plus items of special mobile machinery, per § 42-3-201(1)(a)(I)(A)-(G); and the executive director may issue one plate for any other vehicle at discretion (§ 42-3-201(1)(a)(II))"
+  legibility: "§ 42-3-201(2): the plate and its letters and numerals, except the year number, 'must be of sufficient size to be plainly readable from a distance of one hundred feet during daylight'"
+  displayed_content: "§ 42-3-201(2): the registration number, the year number for which issued, the month in which it expires, 'and any other appropriate symbol, word, or words designated by the department'. Permanent plates without year/month are authorised by rule; Class A commercial trailers and semitrailers carry no month/year and get no validating sticker (§ 42-3-201(7))."
+  digital_plates: >-
+    COLORADO AUTHORISES DIGITAL NUMBER PLATES. § 42-3-201(8)(a): the owner "may
+    display a digital number plate in lieu of one or both of the plates issued
+    under subsection (1)(a)(I) if the registration number and expiration date
+    are clearly visible at a distance of one hundred feet in normal sunlight";
+    (8)(b) "Digital number plates need not display more than one color";
+    (8)(d) defines one as "an electronic display that is mounted on a vehicle in
+    the place of and that serves the function of a number plate". THE
+    AUTHORISATION IS TIME-LIMITED: (8)(e) repeals subsection (8) effective
+    1 September 2027. A plates dataset now has to model a plate that is not a
+    plate; recorded here rather than in a series because no format, colour or
+    layout is prescribed for it.
+  sources:
+    - "https://leg.colorado.gov/sites/default/files/images/olls/crs2023-title-42.pdf  # § 42-3-201 plates furnished, one-vs-two, displayed content, 100-foot legibility, six-character cap, digital plates and their 2027 repeal; § 42-3-202 front-and-rear attachment and the rear-only classes"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE. The mountain base has been continuously in use
+  # since January 2000; the SERIAL ARRANGEMENT changed in mid-2018.
+  # =========================================================================
+  - id: us-co-standard-2018
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2018 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "LLL-L99"
+      regex: '\A[A-Z]{3}-?[A-Z]\d{2}\z'
+      regex_statutory: '\A[A-Z0-9](?:-?[A-Z0-9]){0,5}\z'
+      charset:
+        notes: >-
+          § 42-3-201(5)(a) C.R.S., verbatim: "A new or replacement license plate
+          issued by the department shall, to the extent that it is practical,
+          have standardized coloring and identifying characters limited to no
+          more than a total of six numbers and letters; except that such
+          character limitation does not apply to personalized license plates
+          issued under section 42-3-211." That is the WHOLE statutory constraint
+          on a Colorado standard serial: a six-character maximum, softened by
+          "to the extent that it is practical", and an alphabet of numbers and
+          letters. No letter exclusions appear anywhere in Title 42.
+        letter_exclusions_unsourced: >-
+          Collector tracking reports that the letter O has not been used in the
+          fourth position since 2024, and that Q was withheld from the 2000-2015
+          series until the base run was exhausted and then reintroduced position
+          by position. NEITHER IS ENCODED IN `regex_strict`, because the only
+          evidence is a collector site (licenseplates.cc) reached through a
+          Wikipedia locator. Recorded as a lead for a future pass, not as a
+          sourced charset.
+      pattern_note: >-
+        `regex` encodes the current arrangement — three letters, separator, one
+        letter, two numerals, six characters in all, which sits exactly at the
+        statutory cap. `regex_statutory` encodes what § 42-3-201(5)(a) actually
+        permits: up to six alphanumerics, written in PRINTED form per
+        PRD-PLATES §2.6 rule 2 so that it accepts the hyphen the plate shows.
+      progression: >-
+        Not alphabetical in issuance. The DMV's own explanation, via the
+        collector record: plates are MANUFACTURED alphabetically but ISSUED from
+        stock, and "the most progressive numbers are often found on low-volume
+        special plates, as they are typically issued after being manufactured
+        rather than kept in stock". Consequence for era inference: a Colorado
+        serial's position in the alphabet bounds its MANUFACTURE date, not its
+        issue date. Corroboration-grade.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: >-
+        NOT IN TITLE 42. Colorado's statute states a legibility distance
+        (§ 42-3-201(2), one hundred feet in daylight) and no dimension at all.
+        The 12x6 inch figure is the North American convention recorded in the
+        AAMVA/SAE chain above and is NOT attributed to any Colorado instrument
+        (recorded gap).
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO COLOUR VALUE IS CLAIMED. Title 42 says only "standardized coloring"
+        (§ 42-3-201(5)(a)) and never names a hue. No departmental colour
+        specification was obtained. The design is described by a Wikipedia
+        LOCATOR as an embossed dark green serial on a reflective graphic plate
+        carrying a mountain range; that description is recorded as a lead, and
+        no hex is asserted (contrast us-fl, where an official brochure at least
+        depicted the colours). This is the honest state of the claim.
+      graphic: { present: true, rendered: placeholder, description: "mountain range, continuously part of the Colorado design since 1960 except 1973 and 1975-76; a screened, more detailed rendering replaced the earlier version in January 2000 — locator-grade" }
+      emblem: { present: false }
+      legend_top: "COLORADO"
+      rear_differs: false
+    region_encoding: >-
+      NONE TODAY, BUT COLORADO IS THE COUNTY-CODE STATE. Numeric county codes
+      were introduced on passenger and motorcycle plates in 1932, ordered by the
+      then-populations of the state's 63 counties, and ran through 1958 (Denver
+      last used code 1 in 1955). Nothing in a modern Colorado serial encodes
+      geography. The 1932-58 code table is L4 scope and is NOT reproduced here;
+      it is flagged as a real decode table waiting to be built.
+    sources:
+      - "https://leg.colorado.gov/sites/default/files/images/olls/crs2023-title-42.pdf  # § 42-3-201(5)(a): the SIX-CHARACTER cap, 'standardized coloring', and the personalized-plate exception; (2): displayed content and the 100-foot legibility rule"
+      - "https://dmv.colorado.gov/license-plates  # Colorado DMV: all Colorado plates are printed by Colorado Correctional Industries; the Print-On-Demand programme for low-issuance plates; plate expiry on transfer under SB 21-069"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Colorado  # LOCATOR ONLY (PRD-PLATES §4): the mid-2018 arrangement change, the AAA-A00 start, the mountain-base continuity since 1960 and the January 2000 screened redesign. None is asserted as sourced."
+    notes: >-
+      COLORADO STANDARD ISSUE, CURRENT ARRANGEMENT. The id carries 2018 because
+      the format boundary is what makes this a distinct series, but
+      `period_evidence: corroboration-only` is the honest grade: mid-2018 comes
+      from a Wikipedia locator and a collector site, NOT from any Colorado
+      instrument, and no primary establishing the boundary was obtained. The
+      BASE DESIGN did not change in 2018 — the mountain plate dates to January
+      2000 and the mountain motif to 1960 — so a reader must not read this
+      series' start as a redesign date. If the department publishes an issuance
+      record, this id keeps its meaning and only the period sharpens; if the
+      boundary moves, the PRD-QUALITY I-5/I-6 alias contract applies.
+
+  # =========================================================================
+  # ONE SERIES BACK. Same base design, previous arrangement.
+  # =========================================================================
+  - id: us-co-standard-2015
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2015, end: 2018 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "LLL-999"
+      regex: '\A[A-Z]{3}-?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9](?:-?[A-Z0-9]){0,5}\z'
+      charset: { notes: "the same § 42-3-201(5)(a) six-character cap and letters-and-numbers alphabet; this arrangement spends the cap as 3+3" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "identical base design to us-co-standard-2018 — the 2015-2018 change was to the SERIAL ARRANGEMENT only. No hex claimed, for the same reason."
+      graphic: { present: true, rendered: placeholder }
+      legend_top: "COLORADO"
+    region_encoding: none
+    sources:
+      - "https://leg.colorado.gov/sites/default/files/images/olls/crs2023-title-42.pdf  # § 42-3-201(5)(a): the six-character cap this arrangement also sits at"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Colorado  # LOCATOR ONLY: the mid-2015 to mid-2018 window and the reuse of unissued 1982-92 serials"
+    notes: >-
+      THE PREVIOUS ARRANGEMENT, and the interesting thing about it is that it
+      was BACKFILL, not progression: the locator record has Colorado working
+      through serials left unissued in 1982-92 and then reissuing 1982-92
+      serials outright. A dataset that assumes serial order implies chronology
+      is wrong about Colorado twice over — once because plates are issued from
+      stock rather than in manufacture order, and once because the state has
+      demonstrably reused a retired serial run. Recorded because it bears
+      directly on the parse API's era inference.
+
+  # =========================================================================
+  # RETIRED-STYLE PLATES — the best-specified series in this file, because the
+  # legislature described the designs BY COLOUR in the statutory text.
+  # =========================================================================
+  - id: us-co-retired-style-2023
+    class: standard
+    categories: [car, truck, motorcycle]
+    period: { start: 2023 }
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "LLL-L99"
+      regex: '\A[A-Z]{3}-?[A-Z]\d{2}\z'
+      regex_statutory: '\A[A-Z0-9](?:-?[A-Z0-9]){0,5}\z'
+      charset: { notes: "a retired STYLE, not a retired numbering system: the plate carries a current serial under the § 42-3-201(5)(a) six-character cap. § 42-3-206.5(3) additionally allows a retired-style plate to be personalized under § 42-3-211, which lifts the cap to seven positions for that case." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      statutory_styles:
+        - "White letters and numbers on a background of green mountains and a white sky (§ 42-3-206.5(1)(a)(I))"
+        - "White letters and numbers on a background of black with a white border (§ 42-3-206.5(1)(a)(II))"
+        - "White letters and numbers on a background of blue with a white border (§ 42-3-206.5(1)(a)(III))"
+        - "White letters and numbers on a background of red with a white border (§ 42-3-206.5(1)(a)(IV))"
+      colour_note: >-
+        THIS IS THE ONE PLACE IN THIS GROUP'S FIVE STATES WHERE A LEGISLATURE
+        NAMES PLATE COLOURS. The four bullets above are the statute's own words.
+        They are still not hex values — "green mountains and a white sky" is a
+        description, not a specification — so no hex is asserted, but a renderer
+        has statutory authority for the colour RELATIONSHIPS, which is more than
+        the current standard plate gives it.
+      graphic: { present: true, rendered: placeholder }
+      design_authority: "§ 42-3-206.5(2.5): the Colorado disability funding committee pays for the design work, and 'the design for the previously retired license plate styles shall conform with standards established by the department'"
+    eligibility: "motorcycles, passenger cars, trucks, and noncommercial or recreational motor vehicles not exceeding sixteen thousand pounds empty weight (§ 42-3-206.5(1))"
+    fee: "regular taxes and fees plus an annual $25 fee credited to the disability support fund created in § 24-30-2205.5 (§ 42-3-206.5(1)(b))"
+    sunset_risk: "§ 42-3-206.5(2.5): after 1 January 2028 the department MAY STOP producing a style if demand, including willingness to pay the fee, is not sufficiently high. A style can therefore die without a repeal — exactly the `ended: true` + `year_end_min:` case, pre-announced."
+    region_encoding: none
+    sources:
+      - "https://leg.colorado.gov/sites/default/files/images/olls/crs2023-title-42.pdf  # § 42-3-206.5: 'Beginning January 1, 2023' or on department capability, whichever is earlier; the four styles quoted by colour; the $25 disability-support fee; the design-conformance duty; the post-2028 discontinuation power; (3) personalization of a retired style; Source note L. 2021 SB 21-069, L. 2022 SB 22-217"
+    notes: >-
+      RETIRED-STYLE PLATES, and the ONE Colorado series in this file with a
+      properly dated start: § 42-3-206.5(1) says "Beginning January 1, 2023, or
+      when the department is able to issue license plates pursuant to section
+      24-30-2203 (6)(j), whichever is earlier", so 2023 is `statutory-date` and
+      an UPPER bound on the true first issue rather than a guess. Note also what
+      the section proves about the earlier catalogue: the green-mountains-on-
+      white-sky style it revives is described in law, which is how a
+      colour claim about a 1970s Colorado plate can be made at all.
+
+  # =========================================================================
+  # PERSONALIZED — the statute lifts the six-character cap to seven positions.
+  # =========================================================================
+  - id: us-co-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]{2,7}\z'
+      charset:
+        notes: >-
+          § 42-3-211(3)(a) C.R.S., verbatim: personalized plates "must be the
+          same color and design as regular motor vehicle license plates, must
+          consist of any combination of numbers or letters not exceeding seven
+          positions and not less than two positions except as otherwise provided
+          in section 24-30-2210, C.R.S., and must not conflict with existing
+          passenger, commercial, trailer, motorcycle, or other special license
+          plates series". A TWO-CHARACTER FLOOR as well as a seven-character
+          ceiling — the floor is unusual and is a real constraint, not decoration.
+        refusal_criteria: "§ 42-3-211(5): no duplication of registration numbers, and the department may refuse any combination that carries 'connotations offensive to good taste and decency', is misleading, or duplicates any other plate provided for in the article"
+    fee: "$35 on issuance, $25 on reissuance, $25 annual renewal, $12 to transfer to another vehicle (§ 42-3-211(6)(a)-(c)); a plate of only two alphabetic figures and up to four numeric figures costs the actual cost of issuing it (§ 42-3-211(6)(e))"
+    street_rod_carve_out: >-
+      § 42-3-211(2)(b) folds STREET ROD plates into the personalized definition,
+      and (3)(a) then exempts them from the same-colour-and-design rule: a street
+      rod plate is "of a design determined by the executive director of the
+      department, which design shall be different from those used by the state
+      for regular motor vehicle license plates". So Colorado's street rod plate
+      is a personalized plate that must NOT look like one.
+    county_opt_out: "§ 42-3-211(3)(b): where plates include the county of registration, the owner may take a personalized plate WITHOUT the county designation — a vestigial rule, since modern Colorado plates carry no county legend"
+    region_encoding: none
+    sources:
+      - "https://leg.colorado.gov/sites/default/files/images/olls/crs2023-title-42.pdf  # § 42-3-211: the 2-to-7-position frame, same-colour-and-design rule, street rod exception, county opt-out, refusal criteria, the full fee schedule and the priority-loss rule in (6)(d)"
+      - "https://dmv.colorado.gov/license-plates  # Colorado DMV: the application-then-approval-then-payment sequence, 6-8 week production, and the $60 one-time / $25 annual figures quoted on the FAQ (note the discrepancy against the statute's $35/$25 — recorded, not reconciled)"
+    notes: >-
+      PERSONALIZED PLATES. A DISCREPANCY IS RECORDED RATHER THAN AVERAGED
+      (PRD-PLATES §5.3): § 42-3-211(6)(a) states $35 on issuance and $25 on
+      reissuance, while the DMV's own FAQ states "a one-time personalization fee
+      of $60 upon their initial registration and are an additional $25 upon
+      renewal each year after". Both are cited above with their sources; neither
+      is preferred here, because fees are not a claim this dataset is trying to
+      win and the point of recording it is to show the two instruments disagree.
+      PERIOD CAVEAT: `start: 2023` is the statute edition read and is an upper
+      bound; Colorado has issued personalized plates for decades.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-co-group-special-index
+    class: specialty
+    categories: [car, truck, motorcycle]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL-L99"
+      regex: '\A[A-Z0-9](?:-?[A-Z0-9]){0,5}\z'
+      charset: { notes: "the § 42-3-201(5)(a) six-character statutory frame, which group-special plates share; the individual arrangements per programme were NOT obtained" }
+      pattern_note: >-
+        `matching: recall-only` is deliberate and is the honest reading. This
+        entry stands for FIFTY-ODD DIFFERENT PROGRAMMES whose individual serial
+        arrangements were not researched (they are L4 scope); the regex is
+        therefore the statutory outer frame and a match against it is a shape
+        hit and nothing more. It is emphatically NOT the claim that a matching
+        string is a valid Colorado group-special serial.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_measured: 50
+      count_basis: >-
+        FIFTY entries counted mechanically in the Colorado DMV's own
+        Group Special License Plates catalogue as archived 2024-01-21, by
+        counting the per-plate "Number of Plates Allowed" field. This is a
+        MEASURED count of one page at one instant, not a figure the department
+        publishes as a total, and it excludes the military, historical/special
+        and disability catalogues which the DMV keeps on separate pages. Stated
+        that way on purpose: no competitor distinguishes a counted index from a
+        quoted one, and the difference is the whole credibility of the number.
+      official_list_url: "https://dmv.colorado.gov/group-special-license-plates"
+      official_historical_special_url: "https://dmv.colorado.gov/historical-and-special-license-plates"
+      creation_threshold: >-
+        THE HARDEST STATUTORY GATE IN THIS GROUP. § 42-3-207(6): the department
+        "shall verify that the nonprofit organization proposing a group special
+        license plate has collected the signatures of at least three thousand
+        persons committed to purchasing the proposed license plate" — and
+        § 42-3-207(5) requires written notification of compliance from the
+        director BEFORE the sponsor may even seek legislation. Nevada's
+        equivalent threshold is 250 applications; Colorado's is three thousand
+        signatures collected in advance.
+      retirement_rule: >-
+        § 42-3-207(1)(b)(II): special plates approved under that section "shall
+        be retired, effective March 1, 2008, unless such plates are issued for
+        at least three thousand vehicles", with the executive director to
+        promulgate retirement standards. § 42-3-207(7) then lets remaining
+        INVENTORY of a below-threshold plate continue to be issued until
+        exhausted — so a retired Colorado programme keeps producing new
+        registrations after its retirement date. That is the same
+        dead-but-still-issuing shape as Florida's "Collectible" plate and it is
+        why `ended: true` semantics cannot be inferred from a retirement date.
+      closed_authorisation_route: "§ 42-3-207(1)(b)(I): 'A special license plate shall not be issued pursuant to this section unless such license plate was approved prior to January 1, 2001.' The rulemaking route to new special plates was shut in 2001; every plate since is its own statute, which is why §§ 42-3-208 to 42-3-218 read as a list of named programmes."
+      no_profit_sponsors: "§ 42-3-207(3): the department shall not issue an approval notification letter to any business entity conducted for profit"
+      donation_escalator: "§ 42-3-207(8): a sponsoring organisation may raise its minimum donation by $10 and, from 1 July 2019, adjust that increase annually for inflation, rounded to the nearest dollar"
+      fee: "regular registration taxes and fees plus a one-time $25 additional fee to the highway users tax fund (§ 42-3-207(4)); no fee for the privilege of a special plate may be collected unless expressly authorised by statute (§ 42-3-207(1)(a))"
+    region_encoding: none
+    sources:
+      - "https://leg.colorado.gov/sites/default/files/images/olls/crs2023-title-42.pdf  # § 42-3-207 in full: the pre-2001 approval cut-off, the March 2008 retirement rule and its three-thousand-vehicle threshold, the three-thousand-signature creation gate, the no-for-profit-sponsor rule, the inventory-exhaustion carve-out, the $25 fee and the donation escalator; §§ 42-3-208 to 42-3-218 as the named-programme list"
+      - "https://dmv.colorado.gov/group-special-license-plates  # the Colorado DMV's own group-special catalogue — the page the count of 50 was measured from, archived 2024-01-21"
+    notes: >-
+      THE GROUP-SPECIAL PROGRAM INDEX — one entry for the whole programme, which
+      is what PRD-PLATES §2.5 asks for at this gate. Two things worth carrying
+      forward. First, Colorado's programme is STATUTE-SHAPED in a way Florida's
+      is not: the rulemaking route closed on 1 January 2001, so the catalogue is
+      literally a list of sections of Title 42, and a future pass can enumerate
+      it from the code rather than from a web page. Second, the three-thousand-
+      signature gate plus the three-thousand-vehicle retirement threshold make
+      Colorado's index unusually STABLE — programmes here are expensive to
+      create and mechanically pruned, which is the opposite of the churn Florida
+      records.

--- a/plates/us-nm.yml
+++ b/plates/us-nm.yml
@@ -1,0 +1,574 @@
+# plates/us-nm.yml — New Mexico (PRD-PLATES gate L2, mountain group).
+#
+# THREE STANDARD PLATES, THREE DIFFERENT SERIAL LENGTHS, ALL CURRENT. New
+# Mexico's Motor Vehicle Division lists a "Standard Red and Yellow License
+# Plate", a "Standard Centennial License Plate" (turquoise) and a "Chile Plate"
+# as its standard issue, and they take 6, 6 and 6 characters in three DIFFERENT
+# arrangements — 123-ABC, ABC-123 and ABCD12 — while their PERSONALIZED
+# counterparts take 1-7, 1-8 and 1-6 characters respectively. A consumer that
+# assumes one current standard arrangement per US state is wrong about New
+# Mexico three ways at once, and the MVD states all six limits itself.
+#
+# THE SEPARATOR FINDING, AND IT IS THE BEST ONE IN THIS GROUP: the glyph
+# between the serial groups on the yellow and turquoise plates is the ZIA SUN
+# SYMBOL — the emblem on the state flag. It is a design element occupying a
+# separator position, and the MVD says so in the only way that really settles
+# it, by forbidding it in a serial: "Special characters such as the Zia symbol,
+# hash tag, asterisk, dash, underscore, space, or any other special characters
+# are not allowed." The authority itself lists the Zia alongside the dash and
+# the space as a NON-CHARACTER. See `design.serial_separator_glyph` on
+# us-nm-standard-yucca and the note to _meta/separators.yml in the group
+# dossier.
+#
+# NEW MEXICO ALSO PUTS "USA" ON ITS PLATES, to stop the state being mistaken
+# for the country it borders. That is not trivia here: it is why the legend
+# fields below carry "NEW MEXICO USA" and not "NEW MEXICO".
+#
+# SOURCING: New Mexico authorises its special plates ONE STATUTE AT A TIME, and
+# the MVD's own plate pages cite the NMSA 1978 section for nearly every plate
+# they describe. That makes the specialty index unusually well-founded even
+# though NMSA itself could not be fetched in this pass (nmonesource.com returned
+# 403/404 to every attempt) — the section NUMBERS come from the agency, and are
+# recorded as pointers rather than quoted.
+jurisdiction: us-nm
+authority:
+  name: New Mexico Taxation and Revenue Department, Motor Vehicle Division (MVD)
+  url: "https://www.mvd.newmexico.gov/vehicles/license-plates/"
+binding: vehicle
+statute_edition: >-
+  NOT READ. The Motor Vehicle Code is NMSA 1978 Chapter 66; the plate sections
+  cited throughout are those the MVD itself cites. nmonesource.com (the New
+  Mexico Compilation Commission's official service) returned 403 and 404 to
+  every path attempted, and no statutory text is quoted anywhere in this file.
+  Section numbers are pointers, not sources.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    NO EVIDENCE EITHER WAY WAS FOUND, AND NONE IS INVENTED. New Mexico does not
+    appear in the survey of state copyright postures the US research dossier
+    relied on — the Wikipedia article on the copyright status of works by
+    subnational governments has a New Mexico heading and NOTHING UNDER IT, the
+    same empty-section result as Nevada. No New Mexico public-records provision
+    was read and no state agency policy asserting or disclaiming copyright was
+    located. Under the governing rule (17 U.S.C. § 105 does not reach the
+    states) the default for a US state design is copyrighted unless that state
+    says otherwise, so New Mexico must be treated as default-copyrighted until
+    researched.
+  a_specific_extra_hazard: >-
+    THE ZIA SUN SYMBOL IS NOT AN ORDINARY GRAPHIC and must not be treated as
+    one. It is the emblem of the Zia Pueblo, appears on the New Mexico state
+    flag, and is the subject of a long-running and well-documented dispute
+    between the Pueblo and the state over its use — a controversy that is about
+    cultural appropriation and state emblem law, NOT copyright, and that
+    therefore would survive any favourable copyright finding. The Zia sits in
+    the separator position of two of the three current standard plates, so a
+    faithful New Mexico render cannot avoid it. THIS IS THE STRONGEST
+    PLACEHOLDER CASE IN THE ENTIRE MOUNTAIN GROUP: render the separator position
+    as a neutral gap or a neutral glyph, never as the Zia, and do not treat the
+    §3 emblem rule as satisfied by a copyright analysis alone. The dispute is
+    recorded here as a FLAGGED, UNRESEARCHED legal question — no source for it
+    was fetched in this pass and none is cited.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies, with the Zia carve-out above
+    treated as non-negotiable. New Mexico state seal and state symbol statutes
+    are UNRESEARCHED (standing gap, US dossier §4.5), and New Mexico is the one
+    state in this group where that gap is known in advance to be load-bearing.
+  photograph_caution: >-
+    Standard finding: a Commons CC BY-SA tag on a New Mexico plate photograph
+    licenses the PHOTOGRAPH, not the design, and never reaches a render
+    generated from the spec. Note that it also would not reach the Zia question,
+    which is not a copyright question at all.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): consulted, and recorded because its New Mexico section is EMPTY — the negative result is the claim"
+    - "https://www.mvd.newmexico.gov/vehicles/license-plates/  # New Mexico MVD, on personalized plates: 'Special characters such as the Zia symbol, hash tag, asterisk, dash, underscore, space, or any other special characters are not allowed.' Cited here because it is the state's own statement that the Zia is not a serial character."
+
+# ---------------------------------------------------------------------------
+# The US standards chain.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, PAYWALLED and UNPINNED. No J686 dimension is quoted."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges."
+    jurisdiction_name_layout: >-
+      AAMVA §2.1 recommends the jurisdiction name in the TOP CENTRE between the
+      bolt holes. NEW MEXICO'S CURRENT PLATES DEPART FROM THIS: on the turquoise
+      and chile designs the state name sits BELOW the serial, with the slogan
+      above. A render engine that hard-codes AAMVA §2.1 will place New Mexico's
+      state name wrongly — which is the practical reason the standard is
+      recorded as RECOMMENDED PRACTICE and not as a requirement.
+    retroreflectivity: "AAMVA §3.3: readable in daylight and at night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3; 45 cd/lx/m2 minimum. No New Mexico counterpart was read."
+    replacement_cycle: "AAMVA §1.1 recommends a cycle not to exceed 7 to 10 years. No New Mexico replacement cycle was read (recorded gap). New Mexico DOES set a five-year revalidation cycle for horseless-carriage plates — see that series."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  manufacture_note: >-
+    New Mexico's plates are reported by a locator to be manufactured by Waldale
+    Manufacturing Limited of Amherst, Nova Scotia — i.e. by a FOREIGN COMMERCIAL
+    CONTRACTOR rather than by a prison industry, which is the arrangement in
+    Colorado (Colorado Correctional Industries) and Nevada (Northern Nevada
+    Correctional Center, by statutory command in NRS 482.267). Locator-grade,
+    recorded because a commercial manufacturer changes the design-IP picture:
+    where a vendor designs, a vendor may claim.
+  folklore_caution: >-
+    The "1956 agreement" sentence appears in the Wikipedia New Mexico article
+    with the same Christopher Garrish, "Reconsidering the Standard Plate Size",
+    Plates (ALPCA, October 2016) footnote carried by the Utah, Nevada and
+    Colorado articles — a hobbyist magazine whose title announces that it
+    reconsiders the claim, attached to four articles as though it supported it.
+    COMMONLY REPEATED, UNSOURCED.
+
+display_rules:
+  default: "ONE plate, rear. Rear plates only have been required since 1961 (locator-grade; no New Mexico instrument was read)."
+  state_name_legend: >-
+    "NEW MEXICO USA", not "NEW MEXICO". New Mexico is the only US state that
+    puts USA on its plates, to avoid confusion with the neighbouring country. A
+    render must carry the USA, and a jurisdiction-name matcher that expects the
+    bare state name will miss it.
+  sources:
+    - "https://www.mvd.newmexico.gov/vehicles/license-plates/  # New Mexico MVD's own plate index and the standard/personalized/collegiate/handicapped/historical/military/organization/police/motorcycle category structure"
+    - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Mexico  # LOCATOR ONLY (PRD-PLATES §4): rear-only since 1961; the USA legend and its rationale; the Waldale manufacture; the design descriptions and serial ranges cited per series below"
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD (1) — the yellow "Land of Enchantment" base. The oldest
+  # continuously issued design in this group's five states.
+  # =========================================================================
+  - id: us-nm-standard-yucca-1991
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1991 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "999-LLL"
+      regex: '\A\d{3}[- ]?[A-Z]{3}\z'
+      regex_strict: '\A\d{3}[- ]?[A-DF-HJ-NPR-TW-Z]{3}\z'
+      charset:
+        notes: >-
+          SIX LETTERS ARE EXCLUDED FROM NEW MEXICO SERIALS — E, I, O, Q, U and
+          V — which is the widest exclusion set found in the mountain group and
+          twice the size of Nevada's. It is what `regex_strict` encodes; the
+          round-trip forbids `regex` from carrying it (PRD-PLATES §2.7). The
+          exclusion is CORROBORATION-GRADE, from a collector reference reached
+          through a locator, and the locator additionally records that E was
+          separately withheld from the 123-ABC arrangement when it began. No New
+          Mexico instrument stating the alphabet was read.
+      pattern_note: >-
+        The separator is spelled as the sanctioned separator-only class `[- ]`
+        (PRD-PLATES §2.8) rather than as a bare hyphen, and DELIBERATELY: the
+        plate does not print a hyphen at all. It prints the Zia sun symbol. The
+        class is the honest encoding of a gap whose printed glyph is not in the
+        emitted set, exactly as `es-consular-cc-1999` uses it for a gap whose
+        glyph the Spanish authority never specified. `pattern` shows the
+        canonical printed separator, per §2.8's final rule.
+      progression: "sequential; the locator has the arrangement running from 001-AAA in early 1991 to 275-XJX as of 18 January 2025 — thirty-four years and not yet exhausted"
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: "no New Mexico instrument was read; the 12x6 figure is the North American convention from the AAMVA/SAE chain and is not attributed to New Mexico (recorded gap)"
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO HEX IS CLAIMED and no New Mexico colour specification was read.
+        Locator description: an embossed red serial on a yellow plate with a
+        light blue yucca graphic screened at the lower left, Native American
+        zigzag bands screened at the top corners, "New Mexico USA" screened in
+        red below the serial and "Land of Enchantment" screened in light blue at
+        the bottom. From early 1999 the dies are smaller and the stamped
+        indentation for a county-name sticker is gone.
+      serial_separator_glyph: >-
+        THE ZIA SUN SYMBOL. Embossed between the numeric and alphabetic groups.
+        It is NOT a serial character and the MVD says so by listing it with the
+        dash and the space among the "special characters" that may not appear in
+        a personalized serial. Under PRD-PLATES §2.6 the dataset may emit only
+        '-' and ' ', so the regexes spell the position with the separator-only
+        class `[- ]` and this field records what is printed. New Mexico and
+        Nevada together are the US cases that should be added to
+        _meta/separators.yml's never_separator discussion by PR — a state emblem
+        in a separator position, on plates issued by the million.
+      legend_bottom: "Land of Enchantment"
+      legend_state_name: "New Mexico USA"
+      graphic: { present: true, rendered: placeholder, description: "yucca (the state flower) at lower left; zigzag bands at the top corners; Zia sun symbol as separator — SEE artwork_risk, the Zia is a flagged non-copyright hazard" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: >-
+      NONE IN THE SERIAL, BUT NEW MEXICO ONCE PUT THE COUNTY ON THE PLATE AS A
+      STICKER. The 1990-97 issue carries "a stamped indentation at top center
+      for county-name sticker", and county-name stickers were discontinued
+      sometime after 1996 (locator-grade). That is a third mechanism alongside
+      Florida's printed county LEGEND and Nevada's county-coded SERIAL: a
+      physically recessed slot for a removable county label. Worth recording
+      because it means a New Mexico plate of that vintage may carry county
+      information that is not in its serial and not in its printed legend.
+    sources:
+      - "https://www.mvd.newmexico.gov/vehicles/license-plates/  # New Mexico MVD lists 'Standard Red and Yellow License Plate' among its current standard plates, and states the Zia-symbol exclusion from personalized serials"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Mexico  # LOCATOR ONLY (PRD-PLATES §4): the late-1990 base introduction, the 123-ABC arrangement from early 1991, the 001-AAA to 275-XJX range as of January 2025, the E/I/O/Q/U/V exclusion, the design description and the county-sticker indentation. None is asserted as sourced."
+    notes: >-
+      NEW MEXICO'S YELLOW BASE — THE LONGEST-RUNNING CURRENT DESIGN IN THE
+      MOUNTAIN GROUP, and by a distance: continuously issued since late 1990 in
+      an arrangement unchanged since early 1991, still short of exhaustion after
+      thirty-four years. Set that against the US dossier's list of the five
+      oldest US designs still in use (Delaware 1959, Colorado 1960 continuously
+      since 1978, DC 1975, Minnesota 1978, North Carolina 1982) — New Mexico's
+      is younger than all five, but its SERIAL ARRANGEMENT has outlasted every
+      arrangement in this group by a decade. `period_evidence:
+      corroboration-only`: 1991 is a locator date and no New Mexico instrument
+      was read.
+
+  # =========================================================================
+  # CURRENT STANDARD (2) — the turquoise Centennial base.
+  # =========================================================================
+  - id: us-nm-standard-turquoise-2010
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2010 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "LLL-999"
+      regex: '\A[A-Z]{3}[- ]?\d{3}\z'
+      regex_strict: '\A[A-DF-HJ-NPR-TW-Z]{3}[- ]?\d{3}\z'
+      charset: { notes: "the same E/I/O/Q/U/V exclusion, corroboration-grade, encoded in the strict twin only" }
+      pattern_note: "separator spelled as the sanctioned separator-only class `[- ]` for the same reason as the yellow base: the printed glyph is the Zia sun symbol, not a hyphen"
+      progression: "sequential; LGR-001 in 2010 through NZT-499, then NZT-500 onward on the post-2016 variant, reaching SBC-521 as of 28 January 2025 (locator-grade). A 'W' series is used on mail-order plates."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO HEX CLAIMED. Locator description: an embossed yellow serial on a
+        turquoise plate with a border line, a yellow-and-red Zia sun symbol
+        embossed in the centre, and "NEW MEXICO" screened in white below the
+        serial. The 2010-16 issue carries "CENTENNIAL 1912-2012" screened in
+        white at the top and "LAND OF ENCHANTMENT" in yellow at the bottom;
+        from 2016 the centennial slogan is dropped, "NEW MEXICO USA" appears
+        below the serial and the slogan moves to the top.
+      serial_separator_glyph: "the Zia sun symbol, embossed at the centre of the plate between the serial groups — see the yellow base's note and artwork_risk"
+      legend_state_name: "NEW MEXICO USA (post-2016 variant; 'NEW MEXICO' on the 2010-16 centennial variant)"
+      legend_slogan: "LAND OF ENCHANTMENT"
+      graphic: { present: true, rendered: placeholder }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.mvd.newmexico.gov/vehicles/license-plates/  # New Mexico MVD lists 'Standard Centennial License Plate' among its current standard plates, and offers a matching 'Centennial Vanity Plate'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Mexico  # LOCATOR ONLY: the 2010 introduction, the 2016 slogan/legend change, the ABC-123 arrangement, the LGR-001 to SBC-521 range, the mail-order W series and the ALPCA 'Plate of the Year' award for 2010"
+    notes: >-
+      THE TURQUOISE CENTENNIAL BASE, and the reason New Mexico is the schema
+      stressor for CONCURRENT STANDARD DESIGNS. It was introduced for the 1912
+      statehood centennial, kept after the centennial passed with only the
+      slogan changed, and now runs alongside the yellow base and the chile base
+      as an equally standard option. The 2016 change — slogan moved, "USA"
+      added — is a DESIGN change on an unchanged arrangement, which under
+      PRD-PLATES §2.3 argues for a separate series; it is recorded as a variant
+      inside this entry instead, because no primary establishes the boundary and
+      minting a dated id on a locator date would be exactly the folklore
+      boundary the PRD warns against. A verifier with a primary should split it.
+
+  # =========================================================================
+  # CURRENT STANDARD (3) — the chile base. Six characters, no separator, and
+  # the only one of the three whose serial has no group break at all.
+  # =========================================================================
+  - id: us-nm-standard-chile-2017
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2017 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "LLLL99"
+      regex: '\A[A-Z]{4}\d{2}\z'
+      regex_strict: '\A[A-DF-HJ-NPR-TW-Z]{4}\d{2}\z'
+      charset: { notes: "the same E/I/O/Q/U/V exclusion, corroboration-grade, in the strict twin only. FOUR letters then two digits — the only four-letter arrangement in the mountain group." }
+      progression: "sequential from AAAA01 in July 2017, reaching CAFX50 as of 2 February 2025 (locator-grade); a 'W' series is used on mail-order plates"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO HEX CLAIMED. Locator description: an embossed yellow serial on a
+        black plate with a border line, green and red chili peppers screened at
+        the left, "New Mexico USA" screened in red below the serial, "CHILE
+        CAPITAL OF THE WORLD" screened in yellow at the top and "Land of
+        Enchantment" screened in green at the bottom.
+      serial_separator_glyph: "NONE — the chile plate prints an unbroken six-character serial, which is why its regex carries no separator class while the other two standards do"
+      legend_state_name: "New Mexico USA"
+      legend_top: "CHILE CAPITAL OF THE WORLD"
+      legend_bottom: "Land of Enchantment"
+      graphic: { present: true, rendered: placeholder, description: "green and red chili peppers at left" }
+      emblem: { present: false }
+    region_encoding: none
+    sources:
+      - "https://www.mvd.newmexico.gov/vehicles/license-plates/  # New Mexico MVD lists the 'Chile Plate' among its current standard plates and gives its personalized character limits (1-6, or 1-5 for a motorcycle)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Mexico  # LOCATOR ONLY: the July 2017 introduction, the ABCD12 arrangement, the AAAA01 to CAFX50 range, the mail-order W series and the ALPCA 'Plate of the Year' award for 2017"
+    notes: >-
+      THE CHILE BASE. Its value to the dataset is that it breaks two patterns at
+      once: it is the only current mountain-group standard with FOUR consecutive
+      letters, and the only New Mexico standard with NO separator position, so
+      it is the control case proving that the Zia on the other two plates is a
+      design choice rather than a structural necessity. `period_evidence:
+      corroboration-only`; the MVD confirms the plate exists and is standard,
+      the July 2017 date is a locator.
+
+  # =========================================================================
+  # ONE BASE BACK — the 1999-2010 hot-air-balloon base.
+  # =========================================================================
+  - id: us-nm-standard-balloon-1999
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1999, end: 2010 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z]{3}\d{3}\z'
+      regex_strict: '\A[A-DF-HJ-NPR-TW-Z]{3}\d{3}\z'
+      charset: { notes: "the same E/I/O/Q/U/V exclusion applies to the alternative passenger plates of this era (corroboration-grade)" }
+      pattern_note: >-
+        SEVEN ARRANGEMENTS RAN ON THIS ONE BASE and the regex covers only the
+        last. The locator records NM1234, 1NM234, 12NM34, 123NM4, 1234NM,
+        AB 123 and finally ABC123 — the first five embedding the literal letters
+        NM at a MIGRATING POSITION inside the serial, which is a serial-design
+        idea found nowhere else in this group and arguably nowhere else in the
+        US. They are not given series of their own because no primary
+        establishes their boundaries, and they are recorded here so that a
+        parser meeting `123NM4` knows it is looking at a real New Mexico plate
+        and not a corruption.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO HEX CLAIMED. Locator description: an embossed red serial on a white,
+        yellow and orange gradient plate with a green, yellow, orange and red
+        hot-air-balloon graphic screened at the left carrying a red Zia sun
+        symbol on its yellow section, "NEW MEXICO USA" screened in yellow at the
+        bottom and "Land of Enchantment" in yellow above the state name.
+      legend_state_name: "NEW MEXICO USA"
+      legend_slogan: "Land of Enchantment"
+      graphic: { present: true, rendered: placeholder, description: "hot-air balloon at left, carrying a Zia sun symbol" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Mexico  # LOCATOR ONLY: the 1999-2010 window, the seven arrangements with their ranges, and the balloon design description"
+    notes: >-
+      THE PREVIOUS BASE, and the reason to keep it is the MIGRATING NM DIGRAPH.
+      A base that spends its serial space by moving a fixed two-letter token
+      along the string — NM1234, 1NM234, 12NM34, 123NM4, 1234NM — is a distinct
+      exhaustion strategy, different from Arizona's (add a character), Nevada's
+      (change the arrangement) and Colorado's (reuse retired serials). Four
+      states, four answers to the same problem, all in this one group; that
+      comparison is the sort of thing the encyclopedia section exists to make.
+
+  # =========================================================================
+  # PERSONALIZED ("prestige") — the MVD states all six character limits.
+  # =========================================================================
+  - id: us-nm-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]{1,8}\z'
+      charset:
+        notes: >-
+          THE AUTHORITY STATES THE LIMITS ITSELF, per design and per vehicle
+          type, which no other state in this group does: "A yellow prestige
+          plate may have 1-7 characters (1-6 characters for a motorcycle). A
+          turquoise prestige plate may have 1-8 characters (1-6 characters for a
+          motorcycle). A Chile prestige plate may have 1-6 characters (1-5
+          characters for a motorcycle). The characters can include any
+          combination of letters and numbers." The regex is the UNION of those
+          six sourced ranges — 1 to 8 — and is `strict` because the union is
+          exactly what New Mexico issues across the three designs, not wider.
+          A consumer needing the per-design bound must read this note; the
+          series does not split, because the three designs share one programme,
+          one fee and one refusal rule.
+        alphabet: >-
+          "Only alphanumeric characters (letters and numbers) can be used" and
+          "Special characters such as the Zia symbol, hash tag, asterisk, dash,
+          underscore, space, or any other special characters are not allowed."
+          THE STATE LISTS ITS OWN EMBLEM AMONG THE FORBIDDEN NON-CHARACTERS,
+          which is the cleanest authority statement in the whole dataset that a
+          glyph in a separator position is not part of a serial.
+        refusal_criteria: >-
+          A requested set may be rejected if it duplicates an existing plate, if
+          the division finds it derogatory or obscene, or if it "falsely states
+          or implies that the vehicle or the driver represents the authority of
+          a governmental agency or official" (MVD).
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "available on all three standard designs — the MVD offers 'Centennial Vanity Plate' and 'Red & Yellow Prestige (Vanity)' alongside the chile option, for both regular and motorcycle plates"
+    fee: "$17.00 initially and on each regular registration renewal (MVD)"
+    ordering: "orderable online with free shipping through the MVD's Personalized Plate Application, as well as in person"
+    region_encoding: none
+    sources:
+      - "https://www.mvd.newmexico.gov/vehicles/license-plates/  # New Mexico MVD: the per-design and per-vehicle-type character limits, the alphanumeric-only rule, the forbidden special characters INCLUDING THE ZIA SYMBOL, the three refusal grounds, the $17.00 fee and the online ordering route"
+    notes: >-
+      PRESTIGE (PERSONALIZED) PLATES — THE BEST-SOURCED CHARACTER CONSTRAINT IN
+      THE MOUNTAIN GROUP. Colorado's two-to-seven range comes from statute and
+      is one range; New Mexico's comes from the agency and is SIX ranges, split
+      by design and by vehicle type, all stated in one paragraph. It is also the
+      entry that supplies this file's separator finding, which is why the
+      alphabet note is quoted at length rather than summarised: the MVD's
+      sentence is the authority for a claim the dataset makes structurally.
+
+  # =========================================================================
+  # HISTORIC — horseless carriage, and the year-of-manufacture programme,
+  # which is a genuinely different idea.
+  # =========================================================================
+  - id: us-nm-year-of-manufacture
+    class: historic
+    categories: [car]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9]+(?:[- ][A-Z0-9]+)*\z'
+      charset:
+        notes: >-
+          THERE IS NO FORMAT, AND THAT IS THE POINT. A New Mexico
+          year-of-manufacture plate is "an AUTHENTIC plate issued in New Mexico
+          during the motor vehicle's model year" (MVD, citing NMSA 1978
+          § 66-3-423), inspected by the division for condition and for
+          non-duplication of a number already assigned or in use. Its serial is
+          therefore whatever New Mexico was issuing in that year — the union of
+          every historic New Mexico arrangement back to 1912. `recall-only` is
+          the only honest grade: a match says the string has a shape New Mexico
+          has issued at some point, and nothing more. This is the same case as
+          `nl-export`, which carries the vehicle's existing registration, and it
+          is the second-cleanest recall-only in the dataset.
+    design:
+      note: "the design is the ORIGINAL PLATE, whatever it was; there is nothing to render and nothing to specify"
+      background: {}
+    eligibility: "motor vehicles 30 or more years old; the plate must be authentic to the vehicle's model year, in good condition, and its number must not already be assigned or in use (MVD, citing NMSA 1978 § 66-3-423)"
+    transfer: "on sale or transfer the plate may remain with the vehicle and pass to the new owner on payment of a $10.00 fee in addition to regular registration fees"
+    fee: "$27.00 on initial registration; $12.00 on transfer to a new owner"
+    region_encoding: "whatever the original plate encoded — which for a mid-century New Mexico plate is nothing, and for a plate of some other era may be a county"
+    sources:
+      - "https://www.mvd.newmexico.gov/vehicles/license-plates/  # New Mexico MVD on year-of-manufacture plates, citing Motor Vehicle Code Section 66-3-423 NMSA 1978: the 30-year threshold, the authenticity and inspection requirements, the non-duplication rule, the transfer rule and the fees"
+    notes: >-
+      YEAR-OF-MANUFACTURE PLATES — THE SERIES THAT BREAKS THE SCHEMA MOST
+      INTERESTINGLY. Nevada's Circa 1982 Replica is a NEW plate made to an old
+      design; New Mexico's year-of-manufacture plate is the OLD PLATE ITSELF,
+      re-registered. One is a manufacturing programme, the other is an
+      authentication programme, and a dataset that models both has to be able to
+      say that a currently valid registration carries a serial from a series
+      that ended decades ago. Recorded here rather than omitted precisely
+      because it is the case that shows why `period` on a SERIES and validity of
+      a PLATE are different facts.
+
+  - id: us-nm-horseless-carriage
+    class: historic
+    categories: [car]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9]+(?:[- ][A-Z0-9]+)*\z'
+      charset: { notes: "NO FORMAT WAS OBTAINED. The MVD describes the eligibility and the revalidation cycle and says nothing about the serial; NMSA 1978 § 66-3-27 was not read. The regex makes no width or arrangement claim and the series is `recall-only` for that reason — a recorded gap wearing its grade openly rather than an invented pattern." }
+    eligibility: >-
+      "A 'horseless carriage' is a motor vehicle at least 35 years old, owned as
+      a collector's item, and used solely for exhibition and educational
+      purposes" (MVD, citing NMSA 1978 § 66-3-27). A ROLLING 35-year threshold
+      with a USE RESTRICTION — contrast Florida's fixed 1945 model-year cutoff
+      for its horseless carriage plate and its rolling 30-year antique
+      threshold, and New Mexico's own 30-year year-of-manufacture threshold in
+      the entry above. Three different thresholds in two states, and New Mexico
+      runs two of them side by side.
+    validity: "the plate remains with the vehicle on transfer of ownership; it must be REVALIDATED EVERY FIVE YEARS — $17.50 initially, then $7.50 every five years"
+    design:
+      note: "no design description was obtained (recorded gap)"
+      background: {}
+    region_encoding: none
+    sources:
+      - "https://www.mvd.newmexico.gov/vehicles/license-plates/  # New Mexico MVD on horseless carriage plates, citing Motor Vehicle Code Section 66-3-27 NMSA 1978: the 35-year rolling threshold, the collector's-item and exhibition/educational-use conditions, the plate-stays-with-the-vehicle rule and the five-year revalidation at $7.50"
+    notes: >-
+      HORSELESS CARRIAGE. Included despite having no sourced format because the
+      ELIGIBILITY RULE is the fact worth having: a five-year revalidation cycle
+      on a historic plate is unusual (Florida's equivalent is permanent, "valid
+      for use without renewal so long as the vehicle is in existence"), and a
+      rolling 35-year threshold silently changes the eligible fleet every year
+      in a way a fixed cutoff never does. The format gap is recorded, not
+      papered over.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. New Mexico's is
+  # statute-per-plate, and the MVD cites the section for nearly every entry.
+  # =========================================================================
+  - id: us-nm-special-plate-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9]+(?:[- ][A-Z0-9]+)*\z'
+      charset: { notes: "arrangements vary per programme and were not obtained; the Amateur Radio plate is expressly inscribed with the holder's FCC call letters rather than an assigned serial, which alone makes any single arrangement claim false. Recall bound, no width claim." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      structure: >-
+        NEW MEXICO AUTHORISES EACH SPECIAL PLATE BY ITS OWN STATUTE, and the MVD
+        cites the section for nearly every plate it describes — which makes this
+        the best-founded specialty index in the mountain group even though NMSA
+        itself could not be fetched. TWENTY-SIX distinct NMSA 1978 sections are
+        cited across the MVD's plate pages, of which EIGHTEEN sit in the
+        66-3-424.x special-plate block: 66-3-424.3, .5, .6, .8, .9, .13, .15,
+        .16, .17, .18, .19, .22, .23, .24, .27, .30, .33, .37. The remaining
+        eight are 66-3-16 (disabled person), 66-3-27 (horseless carriage),
+        66-3-413 (national guard), 66-3-417 (amateur radio operator), 66-3-420
+        and 66-3-420.1 (children's trust fund), 66-3-422 and 66-3-423
+        (year of manufacture).
+      count_measured: 18
+      count_basis: >-
+        EIGHTEEN sections in the 66-3-424.x block, counted mechanically from the
+        NMSA citations the MVD prints on its own plate pages as archived 27 May
+        2025. This is a FLOOR, not a total: the block certainly contains
+        sections for plates the MVD page does not describe, the collegiate
+        programme adds ten institutions with no section cited, and eight
+        military-service designs and four city/limited-run designs are listed
+        without sections. Stated as a floor on purpose.
+      categories_offered: >-
+        The MVD organises the catalogue as: Standard, Personalized, Collegiate
+        (ten institutions — Eastern New Mexico, New Mexico, New Mexico Military
+        Institute, New Mexico Highlands, New Mexico State, New Mexico Tech,
+        Western New Mexico, Northern New Mexico College, Central New Mexico
+        Community College, New Mexico Junior College), Handicapped, Historical
+        and Vintage, Military and Veterans, Organizations and Causes, Police /
+        Firefighters / EMT, and Motorcycle.
+      dead_programmes: >-
+        The MVD's own page keeps discontinued entries visible: the "Santa Fe
+        400th Anniversary" city plate is marked "Limited Run Plate - Discontinued
+        as of 6/30/12". A specialty index that silently drops dead programmes
+        loses exactly the fact a plate-spotter needs.
+      one_of_a_kind: >-
+        The Amateur Radio Operator plate (§ 66-3-417) is inscribed with the
+        applicant's official FCC call letters, with the words "amateur radio
+        operator" added on request; its stated legislative purpose is "to
+        readily identify personnel in aid of the performance of necessary duties
+        for civil defense in the communications field", and CB licensees are
+        ineligible. A plate whose serial is issued by a DIFFERENT authority
+        entirely — the FCC — is a real modelling wrinkle and worth flagging for
+        the parse layer.
+      official_list_url: "https://www.mvd.newmexico.gov/vehicles/license-plates/"
+    region_encoding: none
+    sources:
+      - "https://www.mvd.newmexico.gov/vehicles/license-plates/  # New Mexico MVD's plate catalogue: the category structure, the ten collegiate institutions, the per-plate NMSA 1978 citations counted above, the Amateur Radio call-letter rule and its civil-defence purpose, and the discontinued Santa Fe 400th Anniversary plate"
+    notes: >-
+      THE SPECIAL-PLATE PROGRAM INDEX — one entry for the whole programme, per
+      PRD-PLATES §2.5. What makes New Mexico's worth returning to is that the
+      catalogue is a LIST OF STATUTE SECTIONS, published as such by the agency:
+      a future pass with access to NMSA can enumerate the 66-3-424.x block
+      directly and get a complete, dated, primary-sourced specialty index — the
+      first in the dataset — because each section carries its own enactment
+      history. Colorado and Nevada have the same structural advantage; New
+      Mexico is the one where the agency has already done the cross-referencing.

--- a/plates/us-nv.yml
+++ b/plates/us-nv.yml
@@ -1,0 +1,655 @@
+# plates/us-nv.yml — Nevada (PRD-PLATES gate L2, mountain group).
+#
+# NEVADA IS THE BEST-LEGISLATED PLATE SYSTEM IN THIS GROUP. Where Arizona
+# delegates everything and Colorado legislates a character cap, NRS Chapter 482
+# writes the plate itself: § 482.270 fixes what must appear on every plate and
+# how bright it must be, § 482.265 fixes how many are issued and sets the
+# 250-application threshold every special plate must clear, § 482.272 and
+# § 482.274 give motorcycles, mopeds and trailers their own sections, and
+# § 482.266 does something no other state in this group does at all — it orders
+# the department to MANUFACTURE REPLICAS OF ITS OWN PRE-1982 PLATES "using
+# substantially the same process, dies and materials".
+#
+# THE 1982 LINE IS THE THING TO UNDERSTAND ABOUT NEVADA. Three separate
+# sections turn on it. § 482.270(3) forbids the department to issue redesigned
+# plates to a person who held plates before 1 January 1982 without that
+# person's approval. § 482.2705(3) keeps a pre-1982 passenger designation valid
+# "during the period for which the plate was originally issued as well as during
+# any extensions by stickers". § 482.266 lets anyone else buy a replica of the
+# same design. So Nevada has a legislatively protected legacy fleet AND a
+# legislatively authorised reproduction programme — a live series and a revival
+# series of the same design, side by side, both current.
+#
+# THE SEPARATOR FINDING (PRD-PLATES §2.6): the glyph between the serial groups
+# on a modern Nevada plate is THE OUTLINE OF THE STATE OF NEVADA. It is a
+# design element occupying a separator position, not a character. Every regex
+# below therefore spells that position with the emitted SPACE, and
+# `design.serial_separator_glyph` records what is actually printed. See the
+# note on `us-nv-standard-2024`.
+#
+# WHAT IS NOT HERE (PRD-PLATES §2.5): individual special-plate DESIGNS.
+jurisdiction: us-nv
+authority:
+  name: Nevada Department of Motor Vehicles (DMV)
+  url: "https://dmv.nv.gov/platesmain.htm"
+binding: vehicle
+statute_edition: >-
+  Nevada Revised Statutes, Chapter 482 (Motor Vehicles and Trailers: Licensing,
+  Registration, Sales and Leases), the Legislative Counsel Bureau's own
+  compilation, revision stamp "[Rev. 6/29/2024 4:15:19 PM--2023]" — i.e. the
+  2023 statutes as revised to 29 June 2024. leg.state.nv.us returns 403 to
+  automated clients; the chapter was read from the Internet Archive capture of
+  28 May 2025, which preserves that revision stamp.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    NO EVIDENCE EITHER WAY WAS FOUND, AND NONE IS INVENTED. Nevada does not
+    appear in the survey of state copyright postures that the US research
+    dossier relied on — the Wikipedia article on the copyright status of works
+    by subnational governments carries an Arizona section, a Colorado section
+    and a Utah section, and its Nevada heading is EMPTY. No Nevada analogue of
+    Arizona's asserted-copyright policy page or Colorado's § 24-72-203(4)
+    authorisation was located in this pass, and no Nevada public-records
+    provision was read. Absence of a found assertion is weak evidence of
+    anything: under the governing rule (17 U.S.C. § 105 does not extend to the
+    states) the DEFAULT for a US state design is copyrighted unless that state
+    says otherwise, so Nevada must be treated as default-copyrighted until
+    researched.
+  next_step: >-
+    Read NRS Chapter 239 (Public Records) for a copyright-reservation clause of
+    the Colorado kind, and the Nevada State Library and Archives / Secretary of
+    State website policies for an assertion of the Arizona kind. Both are cheap
+    and both are exactly where the answer sat in the two states where it was
+    found.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies, and applies to more than usual
+    here: the Nevada plate's identity is carried by the STATE-OUTLINE glyph
+    between the serial groups and by the stylised mountain range along the
+    bottom. Render both as `rendered: placeholder`. Nevada state seal statutes
+    are UNRESEARCHED (standing gap, US dossier §4.5).
+  photograph_caution: >-
+    Standard finding, unchanged: a Commons CC BY-SA tag on a Nevada plate
+    photograph licenses the PHOTOGRAPH, not the design, and never reaches a
+    render generated from the spec.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): consulted, and recorded here precisely because its Nevada section is EMPTY — the negative result is the claim"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Nevada is the one state in this group whose statute
+# states a MEASURABLE retroreflectivity requirement of its own, so the AAMVA
+# row below has a live counterpart in state law.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, PAYWALLED and UNPINNED. No J686 dimension is quoted."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges."
+    jurisdiction_name_layout: "AAMVA §2.1: jurisdiction name top-centre between the bolt holes, at least 0.25 in above the plate number and 0.125 in from the top edge; jurisdiction characters 0.75-1.0 in."
+    retroreflectivity: >-
+      AAMVA §3.3 recommends readability "in both daylight and nighttime from
+      distances of at least 75 feet", with materials per ASTM D4956-19 and
+      ISO 7591:1982 clause 3 and a minimum 45 cd/lx/m2 at 0.2 degrees entrance /
+      -4 degrees observation. NEVADA LEGISLATES ITS OWN, AND MORE DEMANDING,
+      VERSION: § 482.270(4) requires plates "treated to reflect light and to be
+      at least 100 times brighter than conventional painted number plates" and,
+      when properly mounted on an unlighted vehicle and viewed from a vehicle
+      with standard headlights, VISIBLE at not less than 1,500 feet and READABLE
+      at not less than 110 feet. Nevada's readable distance exceeds AAMVA's
+      recommendation by 35 feet, and its 100x brightness ratio has no AAMVA
+      counterpart at all. This is the single most quantitative plate provision
+      found in the mountain group.
+    replacement_cycle: "AAMVA §1.1 recommends a cycle not to exceed 7 to 10 years. Nevada legislates none; instead § 482.270(3) protects pre-1982 holders from forced redesign, which is the inverse policy."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" appears in the Wikipedia Nevada
+    article footnoted to Christopher Garrish, "Reconsidering the Standard Plate
+    Size", Plates (ALPCA), October 2016 — a hobbyist magazine whose title
+    announces that it reconsiders the claim it is cited for. The US dossier
+    already found the story uncited on the parent article. COMMONLY REPEATED,
+    UNSOURCED. Nevada's own statute prescribes no dimension: § 482.270(4) says
+    "The Director may determine and vary the size, shape and form and the
+    material of which license plates are made" — a legislature expressly
+    declining to fix the size.
+
+display_rules:
+  default: >-
+    TWO plates for a motor vehicle other than a motorcycle or moped, ONE for
+    everything else. § 482.265(1): "The Department shall furnish to every owner
+    whose vehicle is registered two license plates for a motor vehicle other
+    than a motorcycle or moped and one license plate for all other vehicles
+    required to be registered hereunder." § 482.275(1) then requires one at the
+    rear and one at the front.
+  front_plate_exception: >-
+    § 482.275(2): if the vehicle "was not manufactured to include a bracket,
+    device or other contrivance to display and secure a front license plate" and
+    the manufacturer provided no other means, the rear plate must be attached
+    and the front plate MAY be attached at the owner's option. § 482.275(3) is
+    the part that matters for a dataset: the exception does NOT relieve the
+    department of the duty to issue a SET OF TWO, and does not reduce any fee —
+    the owner "shall retain the other license plate" and surrender both as a set
+    when required. So a one-plate Nevada car is still a two-plate registration.
+  mounting: "§ 482.275(4): securely fastened so as to prevent swinging, at a height not less than 12 inches from the ground measured from the bottom of the plate, clearly visible, free from foreign materials and legible"
+  displayed_content: >-
+    § 482.270(5): every plate must display (a) the registration number, or
+    combination of letters and numbers, assigned to the vehicle and owner;
+    (b) the name of this State, which MAY BE ABBREVIATED; (c) if issued for a
+    calendar year, the year; and (d) otherwise, except as provided in
+    § 482.2085, the month and year the registration expires. Note (b): Nevada
+    expressly authorises an abbreviated state name on the plate.
+  manufacture: "§ 482.267 requires production at a facility of the Department of Corrections, with an exception; the factory moved from Nevada State Prison to the Northern Nevada Correctional Center in 2012 (locator-grade for the move)"
+  sources:
+    - "https://www.leg.state.nv.us/nrs/nrs-482.html  # NRS 482.265 two-plates-or-one and the special-plate fee and threshold rules; 482.270 general specifications and redesign; 482.275 display, front-plate exception, retention duty and mounting height; 482.267 production at a Department of Corrections facility. Read via the Internet Archive capture of 28 May 2025 (leg.state.nv.us 403s automated clients)."
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE — "Home Means Nevada", current arrangements.
+  # =========================================================================
+  - id: us-nv-standard-2024
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2024 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "999 9L9"
+      regex: '\A(?:\d{3} ?\d[A-Z]\d|\d{2}[A-Z] ?\d{3})\z'
+      regex_strict: '\A(?:\d{3} ?\d[A-HJ-NP-Z]\d|\d{2}[A-HJ-NP-Z] ?\d{3})\z'
+      charset:
+        notes: >-
+          THE ALPHABET EXCLUSION IS REAL AND LONG-RUNNING: the letters I, O and
+          Q have not been used in Nevada passenger serials since the 2001 base
+          and the practice continues. That is what `regex_strict` encodes, and
+          it is why a strict twin exists here at all — the round-trip forbids
+          `regex` from carrying it (PRD-PLATES §2.7). The exclusion is
+          corroboration-grade (a collector reference reached through a locator),
+          not authority-stated, and is recorded as such; the statute is silent,
+          because § 482.2705(2) hands the Director the whole question: "the
+          Director shall determine the combinations of letters and numbers which
+          constitute the designations for license plates assigned to passenger
+          cars and trucks."
+      pattern_note: >-
+        TWO ARRANGEMENTS ARE CURRENT AT ONCE, so `regex` is their union and
+        `pattern` shows the first. Since March 2024 Nevada has issued 123 4A5
+        (from 000 0A0) and 12A 345 (resuming at 49H 000) CONCURRENTLY on the
+        same base. This is not a recall-only union of unknowns — both members
+        are attested arrangements the DMV is issuing today, so the union IS the
+        issuing grammar and `matching: strict` is correct. Compare
+        us-az-standard-2020-transitional, which is recall-only precisely because
+        its union members were NOT individually attested.
+      progression: "the Z series is reserved for issuance through dealerships, and had reached the ZZZ series on the Home Means Nevada base as of March 2024 (corroboration-grade)"
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: "NOT IN CHAPTER 482 — § 482.270(4) expressly leaves size, shape, form and material to the Director. The 12x6 figure is the North American convention from the AAMVA/SAE chain, not a Nevada claim."
+      background: { finish: retroreflective }
+      material_spec: "§ 482.270(4): treated to reflect light, at least 100 times brighter than conventional painted number plates; visible at 1,500 feet and readable at 110 feet at night from a vehicle with standard headlights; plainly readable at 100 feet in daylight"
+      colour_note: >-
+        NO HEX IS CLAIMED. Chapter 482 names no colour. The design is described
+        by a Wikipedia LOCATOR as an embossed black serial on a sky-blue plate
+        with a stylised multi-coloured mountain range along the bottom,
+        "NEVADA" screened in black at top centre and "Home Means Nevada"
+        screened in black within the mountain range. Recorded as a lead.
+      serial_separator_glyph: >-
+        THE PRINTED SEPARATOR IS THE OUTLINE OF THE STATE OF NEVADA, not a
+        hyphen, dot or space. Under PRD-PLATES §2.6 the dataset may emit only
+        '-' and ' ', so every regex here spells that position with an optional
+        SPACE and this field records the truth. The reasoning is the one already
+        set out in _meta/separators.yml's never_separator note for German and
+        Austrian coats of arms: a graphic between serial groups is a DESIGN
+        ELEMENT carried in `design`, never a serial character, and a consumer
+        deriving a separator-free twin is right to collapse "123 4A5" to
+        "1234A5". Nevada is the first US instance of that pattern in the dataset
+        and should be added to the never_separator discussion by PR.
+      legend_top: "NEVADA"
+      legend_bottom: "Home Means Nevada"
+      graphic: { present: true, rendered: placeholder, description: "stylised multi-coloured mountain range along the lower edge; state-outline glyph between serial groups — locator-grade" }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: >-
+      NONE TODAY, AND NEVADA IS THE COUNTY-LETTER STATE THAT GAVE IT UP. Nevada
+      historically encoded the county in the serial — a single letter, then a
+      two-letter code, then three-letter blocks (Clark: B, then C/CA-CF/CJ-CZ,
+      then CAA-CGZ/CJA-CZZ/TAA-TLU; Washoe: W, then W/WA, then WAA-WOZ/WRA-WRX;
+      and so on for all seventeen counties). Nothing in a modern Nevada serial
+      encodes geography. The historic county table is L4 scope and is NOT
+      reproduced here, but it is a genuine decode table and § 482.266's replica
+      programme keeps it commercially live — the DMV's own page points buyers of
+      Circa 1982 Replica plates at "county designator" plate numbers.
+    sources:
+      - "https://www.leg.state.nv.us/nrs/nrs-482.html  # NRS 482.2705(1)-(2): the Director orders preparation of passenger and truck plates in the same manner as § 482.270 and determines the letter-and-number combinations; § 482.270(4)-(5) the material, brightness and visibility requirements and the mandatory plate contents"
+      - "https://dmv.nv.gov/platesnumbers.htm  # Nevada DMV, Previously-Issued Standard Plate Numbers: 'You may obtain any standard plate number (\"123ABC\") or special counter plate number (\"Lake Tahoe 12345\")' subject to an 18-month dormancy or a release form; and '\"123ABC\" can be ordered in the Home Means Nevada or Circa 1982 styles only'"
+      - "https://dmv.nv.gov/platesmain.htm  # Nevada DMV: 'License plates are available in the standard Home Means Nevada design and more than 30 specialty designs'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nevada  # LOCATOR ONLY (PRD-PLATES §4): the March 2024 arrangement change, the two concurrent current arrangements and their ranges, the I/O/Q exclusion, the state-outline separator, the design description and the historic county-code table. None is asserted as sourced."
+    notes: >-
+      NEVADA STANDARD ISSUE, CURRENT ARRANGEMENTS. THE BASE IS OLDER THAN THE
+      SERIES: "Home Means Nevada" debuted 1 November 2016 and the March 2024
+      change was to the SERIAL ARRANGEMENT only, which is why the previous
+      arrangement has its own entry below rather than being folded in here.
+      `period_evidence: corroboration-only` because March 2024 rests on a
+      locator and a collector reference; the DMV's own November 2016 debut
+      announcement is a dead URL preserved only in the Internet Archive and was
+      not re-fetched in this pass. WHY THE UNION MATTERS: a consumer that
+      assumes one current arrangement per US state will mis-parse Nevada today,
+      and the same assumption will mis-parse New Mexico, which runs THREE
+      concurrent standard designs with three different arrangements.
+
+  # =========================================================================
+  # ONE SERIES BACK — same base, previous arrangement.
+  # =========================================================================
+  - id: us-nv-standard-2016
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2016, end: 2024 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "999 L99"
+      regex: '\A\d{3} ?[A-Z]\d{2}\z'
+      regex_strict: '\A\d{3} ?[A-HJ-NP-Z]\d{2}\z'
+      charset: { notes: "the same I/O/Q exclusion, corroboration-grade, encoded in the strict twin only; § 482.2705(2) leaves the combinations to the Director" }
+      progression: "000 A00 to 999 Z99; the parallel 123 ABC dealer-issue block ran 000 ZDK to 999 ZZZ on the same base (corroboration-grade)"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      material_spec: "§ 482.270(4), unchanged"
+      serial_separator_glyph: "the Nevada state outline, as on the current series"
+      colour_note: "identical Home Means Nevada base; no hex claimed"
+      legend_top: "NEVADA"
+      legend_bottom: "Home Means Nevada"
+      graphic: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.nv.us/nrs/nrs-482.html  # § 482.2705(2): the Director's power over the combinations, under which this arrangement was issued"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nevada  # LOCATOR ONLY: the 1 November 2016 debut of the Home Means Nevada base, the 000 A00 to 999 Z99 range and the ZDK-ZZZ dealer block"
+    notes: >-
+      THE PREVIOUS ARRANGEMENT ON THE CURRENT BASE. It is separated from
+      us-nv-standard-2024 because the format differs and PRD-PLATES §2.3 makes
+      format a series boundary, and it is kept because the two are visually
+      identical — a photograph cannot distinguish them, only the serial can.
+      That is precisely the case a format-plus-period dataset exists to resolve
+      and no competitor models.
+
+  # =========================================================================
+  # THE PREVIOUS BASE DESIGN — Sierra Nevada, 2001-2017.
+  # =========================================================================
+  - id: us-nv-standard-sierra-2001
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2001, end: 2017 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A(?:\d{3} ?[A-Z]{3}|\d{2}[A-Z] ?\d{3})\z'
+      regex_strict: '\A(?:\d{3} ?[A-HJ-NP-Z]{3}|\d{2}[A-HJ-NP-Z] ?\d{3})\z'
+      charset: { notes: "the I/O/Q exclusion begins with this base — the locator records it as first observed here and continuing to the present. Corroboration-grade." }
+      pattern_note: "two arrangements again: 123 ABC from January 2001, then 12A 345 from April 2015 as the three-letter space ran out. The union is the issuing grammar for the base, so strict."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      material_spec: "§ 482.270(4), unchanged"
+      colour_note: >-
+        NO HEX CLAIMED. Locator description: an embossed dark blue serial on a
+        graphic plate showing the Sierra Nevada mountains in light blue against a
+        yellow-and-orange gradient sky, "NEVADA" screened in dark blue at top
+        centre, "THE SILVER STATE" screened in white at bottom centre. The
+        serial became screened rather than embossed in December 2006 and
+        embossed again from July 2015 with different dies — a manufacturing
+        change inside one design, which is a sub-entry question, not a series
+        boundary.
+      serial_separator_glyph: "the Nevada state outline, adopted as the separator on the July 2015 re-embossed variant (corroboration-grade)"
+      legend_top: "NEVADA"
+      legend_bottom: "THE SILVER STATE"
+      graphic: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.nv.us/nrs/nrs-482.html  # § 482.270(1): 'the Director shall order the redesign and preparation of motor vehicle license plates' — the power under which a base change happens at all"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nevada  # LOCATOR ONLY: the January 2001 start, the December 2006 screening change, the April 2015 arrangement change, the July 2015 re-embossing and state-shape separator, and concurrent issuance with the Home Means Nevada base from 1 November 2016 until supplies were exhausted"
+    notes: >-
+      THE PREVIOUS BASE. The overlap with us-nv-standard-2016 is REAL AND
+      DELIBERATE, and is exactly the parallel-issuance case PRD-PLATES §2.2
+      anticipates: the Sierra base kept being issued from existing stock after
+      the Home Means Nevada base debuted on 1 November 2016, until supplies ran
+      out. Old stock issues on — recorded, not smoothed.
+
+  # =========================================================================
+  # THE CIRCA-1982 REPLICA — statutorily mandated reproduction of a dead design.
+  # =========================================================================
+  - id: us-nv-replica-1982
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 1997 }
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      charset: { notes: "the replica carries a CURRENT serial in the historic style, or a historic 'county designator' number reclaimed under the previously-issued-numbers rule. The DMV states the constraint precisely: '\"123ABC\" can be ordered in the Home Means Nevada or Circa 1982 styles only.'" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      manufacture_rule: >-
+        § 482.266(2), verbatim on the point that makes this series unique: the
+        Department "shall manufacture the license plates using substantially the
+        same process, dies and materials as were used to manufacture license
+        plates before January 1, 1982", and shall deliver within 180 days of
+        acceptance or payment, whichever is later.
+      colour_note: >-
+        NO HEX CLAIMED, but the colour requirement IS statutory in form:
+        § 482.266(1) defines the product as plates "substantially in the same
+        color and form as license plates manufactured before January 1, 1982".
+        The statute names no hue; it names an IDENTITY RELATION to a previous
+        design. That is a third kind of statutory colour provision, alongside
+        Florida's "distinguishing color" (a property) and Colorado's "green
+        mountains and a white sky" (a description).
+      graphic: { present: true, rendered: placeholder }
+    fee: "the manufacturing fee prescribed by the Department, capped by § 482.266(3)(b) at $25, credited to the State Highway Fund and allocated to the Revolving Account for the Issuance of Special License Plates under § 482.1805"
+    not_a_special_plate: >-
+      § 482.266(1), final flush paragraph: a request under this section "does
+      not, by itself, constitute a request for special license plates pursuant
+      to subsection 3 of NRS 482.265". The replica therefore escapes the $35
+      special-plate fee AND the 250-application threshold — a deliberate
+      legislative carve-out that keeps a nostalgia programme out of the
+      charitable-plate machinery.
+    keep_your_number: "§ 482.266(4): the requester may KEEP the plates currently registered to them if the replica carries the same letters and numbers — so the same serial can lawfully exist twice, in two styles, in one household"
+    region_encoding: "historic county-designator numbers are obtainable through this programme (Nevada DMV), which is the only live consumer of the pre-1982 county table"
+    sources:
+      - "https://www.leg.state.nv.us/nrs/nrs-482.html  # § 482.266 in full: the written-request procedure, the same-process-dies-and-materials manufacturing duty, the 180-day delivery deadline, the $25 fee cap and its destination, the not-a-special-plate carve-out and the keep-your-old-plates rule; Source note (Added to NRS by 1997, 1502)"
+      - "https://dmv.nv.gov/platesmain.htm  # Nevada DMV lists 'Circa 1982 Replica' among the MAIN NEVADA PLATES, alongside Home Means Nevada, Accessible and Exempt"
+      - "https://dmv.nv.gov/platesnumbers.htm  # Nevada DMV: 'See Circa 1982 Replica Plates for blue plates and \"county designator\" plate numbers'"
+    notes: >-
+      THE REPLICA SERIES, AND THE BEST-DATED ENTRY IN THIS FILE.
+      `period_evidence: statutory-date` with start 1997 because § 482.266's own
+      Source note reads "(Added to NRS by 1997, 1502)" — the section was created
+      in the 1997 session, so the programme cannot predate it. That is a real
+      claim, not an upper bound, and it is the model for how the rest of this
+      group's undated series should eventually be fixed: Nevada's compilation
+      prints a Source line under every section, and those lines are the primary
+      evidence for period boundaries that this whole gate is short of. WHY THE
+      SERIES MATTERS CONCEPTUALLY: it is a CURRENTLY ISSUED plate of a
+      DISCONTINUED DESIGN, which breaks the assumption that design age and issue
+      period travel together, and it sits beside a legislatively protected
+      legacy fleet of the genuine article (§ 482.270(3), § 482.2705(3)).
+
+  # =========================================================================
+  # MOTORCYCLE — its own statutory section.
+  # =========================================================================
+  - id: us-nv-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2017 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "999999"
+      regex: '\A\d{6}\z'
+      charset:
+        notes: >-
+          § 482.272(1) is the whole statutory rule and it fixes nothing: "Each
+          license plate for a motorcycle or moped may contain a number of
+          characters, including numbers and letters, as determined necessary by
+          the Director. Only one plate may be issued for a motorcycle or moped."
+          The six-digit arrangement recorded here is CORROBORATION-GRADE — it
+          comes from a collector reference through a locator, not from the
+          Department — and it is stated as strict because it is narrower than
+          what the Director may issue, not wider. If it is wrong it is wrong;
+          it is not disguised as authority.
+      progression: "sequential; the locator record has the Home Means Nevada motorcycle base starting at 288001 in 2017 and continuing"
+    design:
+      plate: { unit: in, note: "reduced motorcycle size; no dimension is stated in Chapter 482 and none was obtained (recorded gap)" }
+      background: { finish: retroreflective }
+      material_spec: "§ 482.270(4) applies to all license plates"
+      colour_note: "the motorcycle plate follows the Home Means Nevada passenger base; no hex claimed"
+      graphic: { present: true, rendered: placeholder }
+    moped_rule: >-
+      § 482.272(2) requires the moped plate to be "distinct in appearance from
+      the license plate for a motorcycle", the distinction to be made "by,
+      without limitation, the size, color or design of the plate", and exempts
+      it from displaying the month and year of expiry. A moped plate is
+      therefore a separate series by statutory command — but no moped format,
+      size or colour was obtained, so it is a RECORDED GAP rather than an
+      invented entry.
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.nv.us/nrs/nrs-482.html  # § 482.272 License plates: Motorcycles and mopeds — character count at the Director's discretion, one plate only, the moped-distinctness duty and the expiry-date exemption"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nevada  # LOCATOR ONLY: the six-digit numeric arrangement and the 2017 transition to the Home Means Nevada motorcycle base"
+    notes: >-
+      MOTORCYCLE PLATES. Included because § 482.272 gives motorcycles their own
+      section and their own issuance rule, which is the test PRD-PLATES §2.3
+      sets for a separate series. The honest weakness is the FORMAT: the statute
+      delegates the character count entirely, and the six-digit arrangement is
+      corroboration-grade. Recorded with that grade visible rather than omitted,
+      because a consumer meeting a six-digit Nevada plate should at least know
+      what it probably is.
+
+  # =========================================================================
+  # TRAILER — its own statutory section, and a two-size rule.
+  # =========================================================================
+  - id: us-nv-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "99999 L"
+      regex: '\A\d{5} ?[A-Z]\z'
+      regex_strict: '\A\d{5} ?[EFGHJKLMSUVWXY]\z'
+      charset:
+        notes: >-
+          § 482.274(3): "The Director shall determine the registration numbers
+          assigned to trailers." The five-digits-plus-suffix-letter arrangement
+          and the observed suffix set (E, F, G, H, J, K, L, M, S, U, V, W, X, Y)
+          are CORROBORATION-GRADE from a locator; the suffix set is what
+          `regex_strict` encodes, and note that it independently reproduces the
+          I/O/Q exclusion seen on passenger plates while also skipping A-D, N,
+          P-R, T and Z.
+    design:
+      plate: { w: 12, h: 6, unit: in, note: "§ 482.274(2): the Director shall order preparation of TWO SIZES of trailer plate; the smaller 'may be used for trailers with a gross vehicle weight of less than 1,000 pounds'. The smaller size's dimensions were not obtained (recorded gap)." }
+      background: { finish: retroreflective }
+      colour_note: "same design as the passenger base (corroboration-grade); no hex claimed"
+      graphic: { present: true, rendered: placeholder }
+    no_expiry_date_variant: "§ 482.274(1): a plate for a full trailer or semitrailer registered under § 482.483(3) need NOT display the month and year the registration expires — a permanent-registration trailer plate"
+    no_special_plates: "§ 482.274(5): the Department shall NOT issue a § 482.483(3) full trailer or semitrailer any special plate available under §§ 482.3667 to 482.3823 — one of the few express exclusions from the specialty programme in any state read for this gate"
+    grandfather: "§ 482.274(4): trailer plates issued before 1 July 1975 bearing a different designation remain valid for the period for which they were issued"
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.nv.us/nrs/nrs-482.html  # § 482.274 License plates: Trailers — preparation in the same manner as § 482.270, the two-size rule and the 1,000-pound threshold, the Director's power over trailer numbers, the pre-1975 grandfather clause, the permanent-registration exemption from month/year display and the express exclusion from the specialty programme"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nevada  # LOCATOR ONLY: the 12345 A arrangement and the observed suffix-letter set"
+    notes: >-
+      TRAILER PLATES. The statutory content is unusually rich for a class that
+      most states leave to administrative practice, and two provisions are worth
+      a consumer's attention: the two-size rule means a Nevada trailer plate may
+      not be 12x6 at all, and the § 482.274(5) exclusion means a permanent-
+      registration semitrailer CANNOT carry a specialty design — a negative fact
+      that a parse API can use.
+
+  # =========================================================================
+  # DEALER — the letter-prefixed business series.
+  # =========================================================================
+  - id: us-nv-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z]\d{5}\z'
+      regex_strict: '\A[DLR]\d{5}\z'
+      charset:
+        notes: >-
+          The prefix letter carries the meaning: D, L or R for the dealer,
+          lessor and rebuilder families (corroboration-grade from a locator).
+          `regex` accepts any prefix letter because the round-trip against
+          `pattern` forbids it from carrying the restriction (PRD-PLATES §2.7);
+          `regex_strict` is the sourced-as-far-as-it-goes prefix set.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "same design as the passenger base (corroboration-grade); no hex claimed"
+      graphic: { present: true, rendered: placeholder }
+    binding: business
+    statutory_basis: "§ 482.320 (Manufacturers, distributors, dealers and rebuilders: Special plates) authorises the class; § 482.320 cross-refers the display rules in §§ 482.275 and 482.330, so a dealer plate is displayed like any other"
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.nv.us/nrs/nrs-482.html  # § 482.320 Manufacturers, distributors, dealers and rebuilders: Special plates, and its cross-reference to the §§ 482.275 / 482.330 display rules"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nevada  # LOCATOR ONLY: the D/L/R prefix families and the five-digit body"
+    notes: >-
+      DEALER PLATES. `binding: business` for the same reason as Germany's rote
+      Kennzeichen and Florida's dealer plate — the plate follows the dealership,
+      not a vehicle. Note that Nevada's passenger plates ALSO do not follow the
+      vehicle in the ordinary sense, since § 482.2715 lets a registrant maintain
+      a plate code across vehicles; Nevada is closer to Arizona's owner-binding
+      than the top-level `binding: vehicle` suggests, and that tension is
+      recorded rather than resolved.
+
+  # =========================================================================
+  # GOVERNMENT / EXEMPT.
+  # =========================================================================
+  - id: us-nv-exempt
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z]\d{5}\z'
+      regex_strict: '\A[EX]\d{5}\z'
+      charset: { notes: "E or X prefix plus five digits (corroboration-grade); the prefix restriction lives in the strict twin because the round-trip forbids it in `regex`" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "same design as the passenger base (corroboration-grade); no hex claimed"
+      graphic: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://dmv.nv.gov/platesmain.htm  # Nevada DMV lists 'Exempt Plates' among the MAIN NEVADA PLATES"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nevada  # LOCATOR ONLY: the E/X prefix and five-digit body"
+    notes: >-
+      EXEMPT (GOVERNMENT FLEET) PLATES. Recorded as class `government` because
+      _meta/classes.yml defines that as "civil government fleets with distinct
+      series" and Nevada's exempt plate is exactly that. The statutory basis was
+      NOT isolated in this pass — Chapter 482 has an exempt-vehicle regime but
+      the section was not read — so the entry rests on the DMV's own plate index
+      plus a locator for the arrangement (recorded gap).
+
+  # =========================================================================
+  # PERSONALIZED — "personalized prestige" in Nevada's own words.
+  # =========================================================================
+  - id: us-nv-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 1969 }
+    period_evidence: statutory-date
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9]+\z'
+      charset:
+        notes: >-
+          NO WIDTH CLAIM IS MADE, because the width is regulatory and was not
+          obtained. § 482.3667(6): "The Department may limit by regulation the
+          number of letters and numbers used, prohibit the use of inappropriate
+          letters or combinations of letters and numbers and prohibit the
+          transfer of personalized prestige license plates from one vehicle or
+          trailer to another if such a transfer would result in an inappropriate
+          use of letters or combination of letters and numbers." The regulation
+          itself lives in the Nevada Administrative Code and was not read
+          (recorded gap), so the regex is an unbounded recall bound in the
+          us-fl-horseless-carriage style.
+        office_restriction: "§ 482.3667(7): the Department shall not assign to any person not holding the relevant office any letters and numbers denoting that the holder holds a public office"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "§ 482.3669 contemplates personalized prestige plates issued 'in lieu of the regular Nevada license plate or plates', and § 482.266 lets a personalized plate be taken in the Circa 1982 replica style"
+    eligibility: "private passenger cars, motorcycles, trucks or trailers, EXCEPT a full trailer or semitrailer registered under § 482.483(3) and EXCEPT a moped registered under § 482.2155 (§ 482.3667(2))"
+    validity: "valid for 12 months and renewable on expiration, except as provided in § 482.2065 (§ 482.3667(3))"
+    priority_rule: "§ 482.3667(5): in case of conflict, the person who first applied and has continuously renewed has priority — a first-come rule written into statute rather than left to policy"
+    fee: "$35 for the first issuance and $20 for a renewal sticker, in addition to all other licence fees and applicable taxes (§ 482.367(1)(a)-(b))"
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.nv.us/nrs/nrs-482.html  # § 482.3667 in full: the Department's duty to establish and design them, the eligible and excluded vehicle classes, the 12-month validity, transferability, the first-applicant priority rule, the regulatory power over the number of characters and the public-office restriction; § 482.3669 regulations; § 482.367(1) the $35 and $20 fees; Source note (Added to NRS by 1969, 100)"
+    notes: >-
+      PERSONALIZED PRESTIGE PLATES. `period_evidence: statutory-date` with start
+      1969 on the strength of § 482.3667's own Source line, "(Added to NRS by
+      1969, 100)" — the second properly dated series in this file and, again,
+      dated from the compilation's Source note rather than from a secondary.
+      `matching: recall-only` is the correct grade and worth stating plainly: an
+      unbounded alphanumeric regex is deliberately wider than any grammar Nevada
+      actually issues, so a match is a shape hit and nothing more, exactly as
+      PRD-PLATES §2.7 requires such a regex to be labelled.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-nv-special-plate-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9]+(?: [A-Z0-9]+)?\z'
+      charset: { notes: "Nevada specialty serials come in two shapes the DMV names itself — a standard-style number and a 'special counter plate number' such as 'Lake Tahoe 12345' — so the regex is an explicit recall bound covering one or two alphanumeric groups, and makes no width claim" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: "more than 30"
+      count_official_quote: "Nevada DMV, in its own words: 'License plates are available in the standard Home Means Nevada design and more than 30 specialty designs.'"
+      count_caveat: >-
+        The DMV's own plate index nevertheless LISTS more than thirty items in
+        the charitable-and-collegiate group alone, plus twenty-one veteran
+        plates and four main plates, so "more than 30" is plainly a floor rather
+        than a total. Both figures are recorded; neither is averaged
+        (PRD-PLATES §5.3). The veteran group as listed: Air Force, Army, Army
+        Airborne, Coast Guard, Marine Corps, National Guard - Air Force,
+        National Guard - Army, Navy, Navy Seabees, Woman Veteran, Disabled
+        Veteran, Disabled Female Veteran, Medal of Honor, Silver Star, Bronze
+        Star (with Valor), Ex-Prisoner of War, Fallen Military, Gold Star,
+        Pearl Harbor Survivor/Veteran, Purple Heart, National Guard (active
+        duty).
+      official_list_url: "https://dmv.nv.gov/platesmain.htm"
+      official_charitable_url: "https://dmv.nv.gov/platescharitable.htm"
+      statutory_range: >-
+        NEVADA AUTHORISES ITS SPECIAL PLATES BY STATUTE, one section per
+        programme, in the block NRS 482.3667 to 482.3823 inclusive — a range the
+        chapter itself cites repeatedly as a unit (see §§ 482.274(5), 482.2703,
+        482.368). A future pass can therefore enumerate the catalogue from the
+        code rather than from a web page, which is the same structural advantage
+        Colorado and New Mexico have and Arizona and Utah do not.
+      creation_threshold: >-
+        § 482.265(3)(c): "The Department shall not design, prepare or issue a
+        special license plate unless, within 4 years after the date on which the
+        measure authorizing the issuance becomes effective, it receives at least
+        250 applications for the issuance of that plate." A four-year window and
+        a 250-application floor — an order of magnitude below Colorado's
+        three-thousand-signature gate, and the reason Nevada's catalogue is
+        larger and churns faster.
+      fees: "§ 482.265(3)(a)-(b): $35 for initial issuance and $10 for renewal, in each case exclusive of any additional fee added to generate funds for a particular cause or charitable organisation. Observed charitable pricing on the DMV's own page runs $61 initial / $30 renewal for a sequential plate and $96 / $50 personalized, of which $25 initial and $20 renewal go to the cause."
+      exclusion: "§ 482.265(4): the threshold and fee rules do NOT apply to § 482.37901. § 482.2655 separately bars issuing certain special plates for 90 days after a vehicle fails an emissions test (§§ 482.381, 482.3812, 482.3814, 482.3816) — a plate programme used as an environmental enforcement lever, which is unusual enough to record."
+    region_encoding: none
+    sources:
+      - "https://www.leg.state.nv.us/nrs/nrs-482.html  # § 482.265(3) the $35/$10 special-plate fees and the 250-application / 4-year threshold, and (4) its exclusion; § 482.2655 the 90-day emissions-failure bar; the §§ 482.3667-482.3823 range as the statutory catalogue"
+      - "https://dmv.nv.gov/platesmain.htm  # Nevada DMV: 'more than 30 specialty designs', the four MAIN NEVADA PLATES and the full veteran and charitable/collegiate listings"
+      - "https://dmv.nv.gov/platescharitable.htm  # Nevada DMV charitable and collegiate plates: the sequential-versus-personalized fee structure and the per-cause allocations"
+    notes: >-
+      THE SPECIAL-PLATE PROGRAM INDEX — one entry for the whole programme, per
+      PRD-PLATES §2.5. Nevada is the most quantitatively documented specialty
+      programme in the mountain group: the threshold, the window, both fee tiers
+      and the per-cause allocation are all in statute or on the DMV's own pages,
+      and the catalogue itself is a statutory range. What is NOT here, and is
+      the obvious next capture, is issuance VOLUME — Florida publishes a monthly
+      active-plate report and Nevada does not appear to; if a Nevada equivalent
+      exists it would be the second such artefact in the dataset and worth as
+      much as the first.

--- a/plates/us-ut.yml
+++ b/plates/us-ut.yml
@@ -1,0 +1,384 @@
+# plates/us-ut.yml — Utah (PRD-PLATES gate L2, mountain group).
+#
+# READ THE SOURCING CAVEAT FIRST, BECAUSE IT SHAPES EVERY ENTRY BELOW. Utah is
+# the ONE state in the mountain group whose STATUTE could not be read in this
+# pass. le.utah.gov refused every automated client attempted (connection reset
+# on repeated tries, from two different fetchers), and the Utah Code sections
+# that ARE in the Internet Archive render their text through JavaScript, so the
+# archived captures contain the site chrome and none of the law. Utah Code
+# Title 41 Chapter 1a Part 4 is therefore PINNED BUT UNQUOTED throughout, and
+# every factual claim here rests on the Utah State Tax Commission's Division of
+# Motor Vehicles' own pages plus locators. That is a weaker evidentiary base
+# than Colorado's or Nevada's and it is stated at the top of the file rather
+# than buried in a note.
+#
+# WHAT MAKES UTAH INTERESTING ANYWAY, in three facts:
+#   1. FOUR concurrent standard-issue designs with TWO different serial
+#      arrangements between them, plus four more no longer issued but still
+#      valid — the DMV says so in its own words.
+#   2. Utah DROPPED THE FRONT PLATE for passenger vehicles on 1 January 2025,
+#      one of only a handful of US jurisdictions to move in that direction in
+#      the modern era, and consolidated its month and year decals into one.
+#   3. From 2025 Utah stopped embossing and, for the first time in its history,
+#      began RE-ISSUING SERIALS FROM A PREVIOUS RUN. A dataset that assumes a
+#      US state serial is issued once is now wrong about Utah.
+#
+# WHAT IS NOT HERE (PRD-PLATES §2.5): individual special-group DESIGNS.
+jurisdiction: us-ut
+authority:
+  name: Utah State Tax Commission, Division of Motor Vehicles (DMV)
+  url: "https://dmv.utah.gov/plates"
+binding: vehicle
+statute_edition: >-
+  NOT READ. Utah Code Title 41, Chapter 1a (Motor Vehicle Act), Part 4 (License
+  Plates and Registration Indicia) is the governing instrument and is pinned in
+  the sources below, but le.utah.gov was unreachable from this environment and
+  its archived captures are JavaScript shells. No Utah statutory text is quoted
+  anywhere in this file; where a section is named it is named as a pointer, not
+  as a source.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched-leaning-adverse
+  basis: >-
+    NO PRIMARY WAS READ, AND THE POSTURE IS NOT ASSERTED. What was found is a
+    pointer, recorded as a pointer: a secondary survey states that Utah's
+    Government Records Access and Management Act sits at Utah Code § 63G-2-101,
+    that records created or maintained by a state governmental entity are the
+    property of the state under § 63A-12-105, and that government entities "may
+    control their copyright by ordinance or policy" under § 63G-2-201. If that
+    reading is right, Utah's posture is structurally closer to Arizona's
+    (copyright assertable, exercised by policy) than to Florida's, which is why
+    the posture is recorded as leaning adverse rather than as unknown. But NONE
+    of those three sections was read in this pass and no Utah agency policy
+    asserting copyright was located, so nothing here is a sourced claim about
+    Utah's IP position.
+  next_step: >-
+    Read Utah Code §§ 63G-2-201 and 63A-12-105 directly, and look for a
+    copyright statement on the Utah State Tax Commission's or the Utah State
+    Archives' website policies — the two places the equivalent assertion was
+    found in Arizona. Both are cheap; neither was reachable here.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies, and under an unresearched posture
+    it applies at the strict end. Utah's plate identity is carried by DELICATE
+    ARCH (a named natural feature inside Arches National Park, which raises a
+    separate and unresearched federal question about depictions of national-park
+    landmarks) and by the SKIER silhouette, which the press of the day reported
+    as modelled on a specific named athlete — a personality-rights question that
+    is neither copyright nor trademark and is likewise unresearched. Render both
+    as `rendered: placeholder`. Utah state seal statutes: UNRESEARCHED (standing
+    gap, US dossier §4.5).
+  photograph_caution: >-
+    Standard finding: a Commons CC BY-SA tag on a Utah plate photograph licenses
+    the PHOTOGRAPH, not the design, and never reaches a render generated from
+    the spec.
+  sources:
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): where the § 63G-2-201 / § 63A-12-105 pointers were found. Neither section was read; nothing is asserted from this."
+
+# ---------------------------------------------------------------------------
+# The US standards chain.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, PAYWALLED and UNPINNED. No J686 dimension is quoted."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges."
+    jurisdiction_name_layout: "AAMVA §2.1: jurisdiction name top-centre between the bolt holes, at least 0.25 in above the plate number and 0.125 in from the top edge; jurisdiction characters 0.75-1.0 in."
+    retroreflectivity: "AAMVA §3.3: readable in daylight and at night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3; 45 cd/lx/m2 minimum. No Utah counterpart was read."
+    replacement_cycle: >-
+      AAMVA §1.1 recommends a rolling or full replacement cycle "not to exceed 7
+      to 10 years". Utah's practice cuts across it in an unexpected direction:
+      rather than replace plates on a cycle, Utah in 2025 began REISSUING
+      SERIALS from runs originally issued 2007-2023, which is the opposite trade
+      — retiring numbers less often, not more.
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The Wikipedia Utah article states the "1956 agreement" between the United
+    States, Canada and Mexico with the AAMVA, the Automobile Manufacturers
+    Association and the National Safety Council, and footnotes it to Christopher
+    Garrish, "Reconsidering the Standard Plate Size", Plates (ALPCA), volume 62
+    number 5, October 2016. TWO THINGS ABOUT THAT CITATION. First, it is a
+    hobbyist membership magazine, not a primary instrument, and it was not
+    obtained. Second, its title announces that it RECONSIDERS the standard-size
+    story — so the reference offered in support of the claim may well be the
+    reference that disputes it. The US dossier separately found the same story
+    carrying a `citation needed` on the parent article since 2017 and copied
+    verbatim across articles. Recorded here as COMMONLY REPEATED, UNSOURCED, and
+    flagged as the single most-repeated piece of folklore in the mountain group:
+    the identical sentence with the identical footnote appears in the Utah,
+    Nevada, Colorado and New Mexico articles.
+
+display_rules:
+  default: >-
+    ONE plate, rear, for most classes. The Utah DMV's own words: "Only rear
+    plates are required for most classes of vehicles, including motorcycles and
+    trailers. The front plate requirement was lifted for passenger vehicles on
+    January 1, 2025." All registered vehicles must display plates.
+  front_plate_change: >-
+    THE 1 JANUARY 2025 CHANGE IS THE HEADLINE UTAH FACT and it moves the
+    national tally: the US dossier recorded 23 front-and-rear jurisdictions,
+    25 rear-only and 9 mixed as of June 2026, with Utah already counted as
+    having dropped front plates in January 2025. The statutory instrument
+    effecting the change was NOT identified in this pass (recorded gap) — the
+    claim rests on the DMV's own page and a contemporaneous local-news locator.
+  decals: "month and year decals have been consolidated into a single sticker rather than two separate decals (Utah DMV)"
+  manufacture: "from 2025 Utah no longer embosses; new plates are flat screen printed (Utah DMV / locator)"
+  sources:
+    - "https://dmv.utah.gov/plates  # Utah DMV: all registered vehicles must display plates; rear-only for most classes including motorcycles and trailers; front-plate requirement lifted for passenger vehicles on 1 January 2025; decals consolidated; flat screen printing"
+    - "https://le.utah.gov/xcode/Title41/Chapter1A/  # Utah Code Title 41 Chapter 1a Part 4, License Plates and Registration Indicia — THE governing instrument. PINNED BUT NOT READ: le.utah.gov refused every automated client and its archived captures are JavaScript shells. No claim in this file is attributed to it."
+
+series:
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE (1) — the "Life Elevated" pair, Skier and Arches.
+  # =========================================================================
+  - id: us-ut-standard-life-elevated-2007
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2007 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "L99 9LL"
+      regex: '\A[A-Z]\d{2} ?\d[A-Z]{2}\z'
+      charset:
+        notes: >-
+          Six characters, printed as a three-and-three group. NO LETTER
+          EXCLUSION IS ENCODED. The locator record asserts that I, O and Q are
+          not used, but its footnote for that assertion reads, in full,
+          "Observing hundreds of plates over the past several months" — which is
+          an editor's own observation, not a source of any kind. Under
+          PRD-PLATES §4 that is below even enthusiast-corroboration grade, so it
+          is recorded here as a LEAD and deliberately kept out of
+          `regex_strict`. Contrast Nevada, where the same exclusion is
+          attributed to a published collector reference and IS encoded.
+      progression: >-
+        Two different progressions on one arrangement, which is the detail that
+        makes Utah's two Life Elevated designs distinguishable from the serial
+        alone: on the SKIER base the serial ascends normally; on the ARCH base
+        the FIRST LETTER PROGRESSES BACKWARDS (Z, then Y, then X ...). For both,
+        the fifth and sixth positions are issued alphabetically AA to ZZ before
+        the leading letter advances. Corroboration-grade.
+      reissue_warning: >-
+        FROM 2025 UTAH REUSES STAGNANT SERIALS from the original 2007-2023 runs,
+        skier plates restarting at the A series ascending and arch plates
+        restarting at the Z series descending. THIS BREAKS THE ONE-SERIAL-ONE-
+        REGISTRATION ASSUMPTION that every US plate dataset makes implicitly. A
+        Utah serial no longer identifies a registration even within one series,
+        and era inference from serial position is invalid for Utah after 2025.
+        Corroboration-grade, and the single most consequential fact in this file
+        for a parse API.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: "no Utah instrument was read; the 12x6 figure is the North American convention from the AAMVA/SAE chain and is not attributed to Utah (recorded gap)"
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO HEX IS CLAIMED and no Utah colour specification was read. Locator
+        descriptions: dark blue characters on a skier graphic (Greatest Snow on
+        Earth / Life Elevated) and dark blue characters on a Delicate Arch
+        graphic (Life Elevated). Both are recorded as leads.
+      variants_offered: ["Life Elevated - Skier (Greatest Snow on Earth)", "Life Elevated - Arches (Delicate Arch)"]
+      variants_note: >-
+        Recorded as variants of ONE series rather than two series because they
+        share the arrangement, the period and the issuing rule and differ only
+        in graphic — which is the colour-only-variant test in PRD-PLATES §2.3,
+        applied to a graphic. The progression difference noted above is the
+        argument for the other reading; it is recorded so a verifier can
+        overturn this call with evidence rather than taste.
+      legend_top: "UTAH"
+      graphic: { present: true, rendered: placeholder, description: "skier silhouette, or Delicate Arch — see artwork_risk, both carry unresearched non-copyright questions" }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://dmv.utah.gov/plates  # Utah DMV: 'Utah currently has four standard issue plates, plus four additional plates that are no longer issued, but are still valid for use on vehicles', naming In God We Trust, Life Elevated Skier, Life Elevated Arches and Off-Highway Vehicle"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Utah  # LOCATOR ONLY (PRD-PLATES §4): the 19 November 2007 introduction date, the A12 3BC arrangement, the divergent skier/arch progressions, the 2023 end of the original runs and the 2025 flat-printing and serial-reuse changes. None is asserted as sourced."
+      - "https://le.utah.gov/xcode/Title41/Chapter1A/  # Utah Code Title 41 Chapter 1a Part 4 — PINNED, NOT READ"
+    notes: >-
+      UTAH'S PRINCIPAL STANDARD ISSUE. `period_evidence: corroboration-only`:
+      19 November 2007 comes from a locator footnoted to a newspaper blog post
+      of 20 November 2007, and no Utah instrument was read. THE SERIES IS
+      DELIBERATELY LEFT OPEN (`end` absent) even though the original runs are
+      reported to have ended in 2023, because the 2025 reissue programme is
+      putting the SAME arrangement back into circulation on the SAME designs —
+      which is continuation, not revival. If a verifier reads it as two runs,
+      the honest shape is `ended: true` on a first entry plus a second dated
+      2025, and the PRD-QUALITY I-5/I-6 alias contract covers the recut.
+
+  # =========================================================================
+  # CURRENT STANDARD ISSUE (2) — In God We Trust, a specialty plate promoted
+  # to standard. Different arrangement, so its own series.
+  # =========================================================================
+  - id: us-ut-standard-igwt-2023
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2023 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "9LLL9"
+      regex: '\A\d[A-Z]{3}\d\z'
+      charset:
+        notes: >-
+          Five characters, digit-letter-letter-letter-digit, printed without a
+          separator. The locator adds a genuinely odd allocation rule for this
+          and the earlier 1A2BC arrangement: "letter combinations begin with the
+          numbers 00 instead of 01 (so 9AAA9 is followed by 0AAB0, 9AAB9 is
+          followed by 0AAC0 and so on)" — i.e. the numeric wrap happens on BOTH
+          end digits together. Corroboration-grade.
+      reissue_warning: >-
+        As with the Life Elevated series, Utah from 2025 is ALSO printing In God
+        We Trust plates in the older A123B arrangement, reusing serials from the
+        run that specialty plates used 2007-2019, apparently starting around
+        A001N and ascending. The locator states outright that what determines
+        which arrangement a given In God We Trust plate receives "is unknown".
+        Recorded because an honest unknown is more useful than a guess: a
+        five-character Utah serial in EITHER arrangement may be an In God We
+        Trust plate, and neither arrangement dates it.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "no hex claimed; no Utah colour specification was read"
+      legend_top: "UTAH"
+      legend_bottom: "In God We Trust; United We Stand"
+      graphic: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://dmv.utah.gov/plates  # Utah DMV lists In God We Trust among the four currently issued standard plates"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Utah  # LOCATOR ONLY: first issued 2013 as a specialty plate and standardized from 2017 onward (footnoted to a Deseret News report of 21 March 2016); the 1ABC2 arrangement from August 2023; the 00-not-01 wrap rule; the 2025 A123B reuse"
+      - "https://le.utah.gov/xcode/Title41/Chapter1A/  # Utah Code Title 41 Chapter 1a Part 4 — PINNED, NOT READ"
+    notes: >-
+      IN GOD WE TRUST — A SPECIALTY PLATE THAT BECAME A STANDARD ONE, which is a
+      transition no other state in the mountain group shows. It was first issued
+      in 2013 as a specialty plate and standardized from 1 January 2017; the
+      series here is dated 2023 because that is when the CURRENT arrangement
+      began, and the earlier arrangements are recorded in the charset note
+      rather than given entries of their own (no primary for their boundaries).
+      A class-vocabulary observation worth carrying to _meta/classes.yml: this
+      plate is `standard` by issuance status and `specialty` by origin, and the
+      vocabulary has no way to say that a series CHANGED CLASS. Utah is the
+      first case in the dataset that needs it.
+
+  # =========================================================================
+  # ONE BASE BACK — the 1993-2007 Arches / Ski generation.
+  # =========================================================================
+  - id: us-ut-standard-1993
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1993, end: 2007 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      charset: { notes: "three digits, group gap, three letters — the arrangement Utah used before the 2007 change to a leading letter. Corroboration-grade." }
+      progression: "on the Centennial/Arch base the first letter progressed BACKWARDS (999 ZZZ was followed by 001 YAA, 999 YZZ by 001 XAA, and so on) — the same backwards habit the modern Arch base kept"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "no hex claimed. Locator description: dark blue characters on a Delicate Arch graphic, with 'UTAH' in white on the 1992-96 issue and in blue from 1996."
+      legend_bottom: "Centennial"
+      graphic: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Utah  # LOCATOR ONLY: the 1993 to 18 November 2007 window, the 123 ABC arrangement, the backwards first-letter progression, the Centennial slogan commemorating Utah's 100 years of statehood, and concurrent issuance with the 1985 Ski base as an extra-fee base and then a no-cost base from 1997"
+      - "https://le.utah.gov/xcode/Title41/Chapter1A/  # Utah Code Title 41 Chapter 1a Part 4 — PINNED, NOT READ"
+    notes: >-
+      THE PREVIOUS BASE. Kept deliberately thin, because everything about it is
+      locator-grade and the file should not pretend otherwise. One structural
+      point is worth the entry on its own: the Centennial Arch base was issued
+      CONCURRENTLY with the 1985 Ski base — first as an extra-fee option, then
+      free from 1997 — so Utah's habit of running two standard designs at once
+      is thirty years old and is not an artefact of the modern four-design
+      catalogue.
+
+  # =========================================================================
+  # SPECIAL GROUP PLATES — Utah's specialty programme, and the ONE place the
+  # DMV states a serial format outright.
+  # =========================================================================
+  - id: us-ut-special-group-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "99LL9"
+      regex: '\A[A-Z0-9]{5}\z'
+      charset:
+        notes: >-
+          THE UTAH DMV STATES THE FORMAT ITSELF, which is rare enough to quote:
+          "Special group plates consist of a five-character combination on the
+          right with the special group sticker on the left and a descriptive
+          phrase on the bottom." FIVE CHARACTERS, from the authority, in terms.
+          The regex encodes exactly that and nothing more — five alphanumerics,
+          no separator — because the DMV states the LENGTH and not the
+          arrangement. `matching: strict` is correct: five alphanumerics is not
+          wider than what Utah issues on these plates, it is precisely the
+          stated constraint.
+      pattern_note: >-
+        `pattern` shows 99LL9 because the locator records 12AB3 as the current
+        specialty arrangement, but the pattern DSL cannot express "any five
+        alphanumerics" and the DMV constrains only the count. The regex is the
+        claim; the pattern is one instance of it. Same DSL limitation as
+        Arizona's, arrived at from the opposite direction — Arizona's authority
+        fixes one position's type and leaves the count, Utah's fixes the count
+        and leaves the types.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      layout_rule: "five-character combination at the RIGHT of the plate; special group sticker at the LEFT; descriptive phrase along the BOTTOM (Utah DMV). A stated layout, which most states do not give at all, and directly usable as render constraints."
+      note: "one design per authorised group; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_measured: 63
+      count_basis: >-
+        SIXTY-THREE distinct special group plates counted from the Utah DMV's
+        own listing as archived 29 December 2024, plus eight collegiate entries
+        counted within that total (Brigham Young, Ensign College, Salt Lake
+        Community College, Snow College, Southern Utah, Utah — two options,
+        Utah State, Utah Tech, Utah Valley, Weber State, Western Governors,
+        Westminster). A MEASURED count of one page at one instant, not a figure
+        the Division publishes, and stated that way on purpose.
+      no_longer_issued: >-
+        The DMV separately lists eight designs no longer issued but still valid:
+        four former STANDARD plates (unnamed on the page) and, among special
+        groups, Utah Centennial, Ski Utah!, Olympic, Utah Clean Fuel Clean Air,
+        Collegiate College of Eastern Utah, Wildlife Eagle and Prostate Cancer
+        Awareness. Dead designs lawfully on the road — the `ended: true` +
+        `year_end_min:` case again, and the reason a US plates dataset cannot
+        model only what is currently ORDERABLE.
+      internal_discrepancy: >-
+        RECORDED, NOT RECONCILED (PRD-PLATES §5.3). The same DMV page says in
+        one paragraph that "Utah has three standard issue plates" and in the
+        next that "Utah currently has four standard issue plates". Both
+        sentences are quoted above from the same archived capture. The four-plate
+        sentence is the one that then enumerates four plates, so it is the more
+        likely intent, but the page contradicts itself and the contradiction is
+        the record.
+      official_list_url: "https://dmv.utah.gov/plates"
+      statutory_frame: "Utah Code Title 41 Chapter 1a Part 4 governs; § 41-1a-418 is the authorized-special-group-plates section (identified by URL, NOT READ — see the file header)"
+    exempt_plates:
+      rule: >-
+        "All publicly owned vehicles and vehicles leased by public entities must
+        be registered as exempt vehicles and bear EX (exempt) plates. Plates on
+        Utah Highway Patrol vehicles are also categorized as exempt." (Utah DMV.)
+        A two-letter EX marker is a government-class series in everything but
+        name; it is NOT given its own entry because no serial format for it was
+        obtained (recorded gap).
+    region_encoding: none
+    sources:
+      - "https://dmv.utah.gov/plates  # Utah DMV: the five-character special-group format and its layout; the full special-group listing counted here; the no-longer-issued list; the EX exempt-plate rule; and the three-versus-four standard-plate contradiction"
+      - "https://le.utah.gov/xcode/Title41/Chapter1A/  # Utah Code Title 41 Chapter 1a Part 4 and § 41-1a-418 — PINNED, NOT READ"
+    notes: >-
+      THE SPECIAL-GROUP PROGRAM INDEX — one entry for the whole programme, per
+      PRD-PLATES §2.5. IT IS THE STRONGEST ENTRY IN THIS FILE despite the file's
+      weak statutory base, because the Division states the serial LENGTH and the
+      plate LAYOUT in its own words, which is more than Florida, Colorado,
+      Nevada or Arizona do for their specialty programmes. The gap that remains
+      is the creation threshold: Colorado requires three thousand signatures,
+      Nevada 250 applications, and Utah's equivalent is in Part 4 and was not
+      read.


### PR DESCRIPTION
**PRD-PLATES gate L2 (owner-directed acceleration; research parallel, application ordered — L1 landed first per §7.1).** One of eleven US regional-group PRs covering all 50 states + DC + territories (FL was the L0 pilot). Drafted to the `de.yml`/`nl.yml`/`us-fl.yml` standard: primary-law verbatim headers, instrument-dated periods, `strict`/`recall-only` matching tiers, folklore flagged not asserted, **`artwork_risk` recorded per jurisdiction with evidence** (PRD-PLATES §4).

**This PR — mountain:** CO UT NV AZ NM (5 jurisdictions, 30 pinned primary sources).

**Verification:** researcher linted green in an isolated sandbox (proof file in the group dir, archived to the pipeline program dir); the driving session then independently staged ALL 55 wave files over pristine origin/main — `plates lint: 67 files, 604 series … OK` (385 new series; the _art gate stayed green) — and this branch is linted solo pre-push; CI runs the same gate.

**For the reviewer:** the dossier below carries the gaps (marked in the YAML at point of use), folklore flags, and the artwork_risk findings. The full research dossier follows verbatim.

---

# PRD-PLATES gate L2 — MOUNTAIN group dossier (CO, UT, NV, AZ, NM)

Research date **2026-08-02**. Method: **FETCH-NEVER-ASSUME**, inherited from the
US/world dossier. Every claim in the five YAML files traces to a URL retrieved in
this session or is explicitly marked as a gap, a locator lead, or
corroboration-grade. **WebSearch was unavailable** (session budget exhausted at
the first call), so all discovery was by direct URL construction, MediaWiki
`action=raw`, the Internet Archive availability + CDX APIs, and `curl` with a
browser user-agent — the same constraint the original US/world dossier worked
under.

**Deliverables:** `us-co.yml`, `us-ut.yml`, `us-nv.yml`, `us-az.yml`, `us-nm.yml`
— **32 series**, **30 unique pinned URLs**. Lint **GREEN** in a sandbox
containing the four L0 pilot files plus these five: `9 files, 105 series`,
`matching recall-only=11 strict=94 | twins regex_statutory=11 regex_strict=52`.
A separate behaviour harness ran **53 positive/negative regex assertions**
against hand-written real-shaped serials (`ABC-D12`, `ABC 1DE`, `123 4A5`,
`12A 345`, `123-ABC`, `A12 3BC`, `1ABC2`, …) — all pass.

---

## 1. The five findings that should outlive this pass

### 1.1 Arizona's copyright assertion is now PINNED, and it is not where the PRD said to look

PRD-PLATES §4 records "AZ asserts copyright" and the US dossier traced it only to
a Wikipedia summary. The instrument is the **Arizona State Library, Archives and
Public Records** — a division of the **Arizona Secretary of State** — in its
published *Website Policies*, under "Copyright Policy", verbatim:

> **Arizona state government works:** Unlike federal works, state works are not
> in the public domain and are protected by copyright. However, public records
> laws may allow reproduction in some instances. Any user intending to obtain any
> public records information on this website for a commercial purpose is required
> under Arizona law to pay a commercial fee as established by the Secretary of
> State's office. You must follow the procedures described in A.R.S. § 39-121.03
> in order to obtain permission to use public records for a commercial purpose.

The same page states the contrast case in its own words ("Federal government
works: Information in federal publications are not protected by copyright
(17 USC 105)"), so the distinction is deliberate.

**Retrieval condition, recorded because the claim is consequential:**
`azlibrary.gov`, `azdot.gov` and `az.gov` are all behind a Cloudflare
interstitial returning **HTTP 403** to every automated client tried (WebFetch and
`curl` with a browser UA). The text above was read from the **Internet Archive
capture of 2023-09-15**. Live URL and archive URL are both cited in `us-az.yml`.
A browser-capable pass should re-verify the live text.

### 1.2 Colorado is adverse too, by statute — and this was NOT in the PRD's list

`us-co.yml` pins **C.R.S. § 24-72-203(4)**, read from the Colorado General
Assembly's own CRS 2023 Title 24 PDF:

> Nothing in this article shall preclude the state or any of its agencies,
> institutions, or political subdivisions from obtaining and enforcing trademark
> or copyright protection for any public record, and the state and its agencies,
> institutions, and political subdivisions are hereby specifically authorized to
> obtain and enforce such protection in accordance with the applicable federal
> law; except that this authorization shall not restrict public access to or fair
> use of copyrighted materials and shall not apply to writings which are merely
> lists or other compilations.

Added L. 92, p. 1104, § 3, effective 1 July 1992. **PRD-PLATES §4's adverse list
(NY/PA/WA, plus AZ) should gain Colorado.** Two carve-outs matter and are
recorded in the file: the authorisation is subject to fair use, and it expressly
does not reach "writings which are merely lists or other compilations" — which is
exactly the character of a serial-format table.

### 1.3 A state emblem sitting in a separator position — twice, and the authority says it is not a character

**New Mexico prints the Zia sun symbol between the serial groups** on both the
yellow and turquoise standard plates. **Nevada prints the outline of the state of
Nevada** in the same position on every modern plate. Neither is a character.

New Mexico's MVD settles it in the only way that really settles it, by forbidding
the Zia in a personalized serial alongside ordinary punctuation:

> Special characters such as the **Zia symbol**, hash tag, asterisk, dash,
> underscore, space, or any other special characters are not allowed.

**The state lists its own emblem among the forbidden non-characters.** This is
the cleanest authority statement anywhere in the dataset that a glyph occupying a
separator position is not part of a serial.

**Action for `_meta/separators.yml`:** its `never_separator_note` currently names
German and Austrian coats of arms as later-gate candidates and says "Nothing in
the L0 pilot". These two are the first US instances and they arrive with
authority backing. Recommend a PR adding both, with the MVD quotation as the
rationale. Encoding used in the meantime, per §2.6/§2.8: NM spells the position
as the sanctioned separator-only class `[- ]` (the `es-consular-cc-1999`
precedent — the honest encoding of a gap whose glyph the emitted set cannot
carry), NV spells it as an optional emitted space; both files carry a
`design.serial_separator_glyph` field recording what is actually printed.

### 1.4 The "1956 agreement" folklore has a citation now — and the citation may be the rebuttal

The Utah, Nevada, Colorado and New Mexico Wikipedia articles all carry the same
1956-standardisation sentence, all footnoted to the same source: **Christopher
Garrish, "Reconsidering the Standard Plate Size", *Plates* (ALPCA), vol. 62 no. 5,
October 2016.**

Two observations. (a) It is a hobbyist membership magazine, not a primary
instrument, and it was not obtained. (b) **Its title announces that it
*reconsiders* the claim it is being cited for.** The US dossier separately found
the story carrying a `citation needed` since 2017 on the parent article and
copied verbatim across articles. Status is unchanged — **COMMONLY REPEATED,
UNSOURCED** — but the finding is sharper than before: four articles cite, in
support of the story, a piece whose title suggests it disputes it. Flagged in all
five files. Acquiring that ALPCA article is a cheap, high-value follow-up.

### 1.5 Four states, four different answers to serial exhaustion

Worth the encyclopedia section on its own; all four are in this one group.

| state | exhaustion strategy | evidence |
|---|---|---|
| **Arizona** | **Add a character, then widen the alphabet.** `999 ZZZ` ran out mid-January 2008 → seven characters (`ABC1234`); that ran out April 2020 → every position alphanumeric except a digit in position 4 | contemporaneous press (*The Arizona Republic*, 2008-04-30) via locator |
| **Nevada** | **Rearrange, and run two arrangements at once.** `123 ABC` → `12A 345` (2015) → `123 A45` (2016) → `123 4A5` **and** `12A 345` concurrently since March 2024 | locator + collector reference |
| **Colorado** | **Reuse retired serials.** The 2015–18 series worked through serials left unissued in 1982–92 and then reissued 1982–92 serials outright | locator + collector reference |
| **New Mexico** | **Migrate a fixed digraph along the string.** `NM1234` → `1NM234` → `12NM34` → `123NM4` → `1234NM` on one base (1999–2010) | locator |
| **Utah** | **Reissue a previous run outright** (from 2025, skier ascending from A, arch descending from Z) | locator |

Utah's is the one with teeth for consumers: **a Utah serial no longer identifies a
registration even within a single series**, and era inference from serial position
is invalid for Utah after 2025.

---

## 2. Per-state summary

### Colorado — `us-co.yml`, 5 series, statute-rich, ADVERSE
- **Standard:** `LLL-L99` (2018–, current) and `LLL-999` (2015–2018, one back). Base design continuous since January 2000; the mountain motif since 1960.
- **Statutory serial cap:** § 42-3-201(5)(a) — "no more than a total of **six** numbers and letters", the direct cousin of Florida's seven. Encoded as `regex_statutory` on every standard series.
- **Personalized:** § 42-3-211(3)(a) — **two to seven positions**, a statutory FLOOR as well as a ceiling. Includes the street-rod carve-out: a personalized plate that must *not* look like a standard one.
- **Retired-style plates (§ 42-3-206.5, from 1 January 2023):** the only `statutory-date` series in the file, and **the only place in the group where a legislature names plate colours** — four styles described by colour in the statutory text, e.g. "White letters and numbers on a background of green mountains and a white sky".
- **Digital plates:** § 42-3-201(8) authorises electronic display plates; the authorisation **repeals itself on 1 September 2027**. Recorded in `display_rules`, not as a series (no format, colour or layout prescribed).
- **No statutory replacement cycle** — replacement is condition-triggered (§ 42-3-201(5)(b)). Plates **expire on transfer** of title (SB 21-069).
- **Specialty index:** 50 entries **counted** from the DMV's own group-special catalogue (archived 2024-01-21) — a measured count of one page, stated as such. Creation gate: **3,000 signatures collected in advance** (§ 42-3-207(6)); retirement below **3,000 vehicles** (§ 42-3-207(1)(b)(II)); the rulemaking route to new plates **closed 1 January 2001**, so the catalogue is literally a list of statute sections.

### Nevada — `us-nv.yml`, 10 series, the best-legislated system in the group
- **Standard:** the "Home Means Nevada" base (1 November 2016–). Current arrangements `123 4A5` **and** `12A 345` concurrently since March 2024, modelled as one series whose `regex` is their union — `matching: strict`, because both members are attested arrangements the DMV issues today.
- **One base back:** Sierra Nevada (2001–2017), which kept being issued from stock after the new base debuted — the parallel-issuance case PRD-PLATES §2.2 anticipates, recorded rather than smoothed.
- **The 1982 line** runs through three sections: § 482.270(3) forbids issuing redesigned plates to a pre-1982 holder without consent; § 482.2705(3) keeps pre-1982 designations valid; **§ 482.266 orders the department to manufacture REPLICAS "using substantially the same process, dies and materials"** as before 1 January 1982. `us-nv-replica-1982` carries `period_evidence: statutory-date`, start **1997**, from the compilation's own Source line "(Added to NRS by 1997, 1502)".
- **§ 482.270(4) out-specifies AAMVA:** plates "at least **100 times brighter** than conventional painted number plates", **visible at 1,500 ft** and **readable at 110 ft** at night — against AAMVA §3.3's recommended 75 ft. Most quantitative plate provision in the group.
- **Own sections for motorcycle/moped (§ 482.272) and trailer (§ 482.274)**, including a two-size trailer rule (<1,000 lb) and an express **exclusion of permanent-registration semitrailers from the entire specialty programme** (§ 482.274(5)).
- **Specialty index:** DMV's own "**more than 30** specialty designs" — recorded with the caveat that its own listing enumerates more than that in the charitable group alone. Creation gate **250 applications within 4 years** (§ 482.265(3)(c)); fees $35/$10 statutory. Catalogue is the statutory range **NRS 482.3667–482.3823**. § 482.2655 bars certain specialty plates for 90 days after an emissions-test failure — a plate programme used as an environmental lever.
- **artwork_risk: UNRESEARCHED.** The standard survey's Nevada section is **empty**; recorded as a negative result with the two next places to look (NRS ch. 239; Secretary of State / State Library policies).

### Arizona — `us-az.yml`, 5 series, the flagged state
- **Standard:** since February 2021, **six alphanumeric positions of which only the fourth is guaranteed a digit**. `regex` carries the grammar; `pattern` shows one representative arrangement (`LLL 9LL`) because **the human-pattern DSL has no alphanumeric token**. Arizona is the schema stressor for a mixed alphanumeric position — cite it when `format.fields:` is next discussed.
- **One back:** `LLL9999` (2008–2020), plus a kept nine-month transitional seven-position series (2020–2021) that is the clearest **`recall-only`** case in the group: a union whose members were not individually sourced.
- **No statutory serial constraint at all.** § 28-2351 gives the director colour and design; § 28-2406 gives the department "the number of positions allowed" on a personalized plate. The pure delegated case — contrast FL's 7 and CO's 6. `us-az-personalized` therefore carries an **unbounded** regex making no width claim (`us-fl-horseless-carriage` precedent).
- **The one prescriptive provision is typographic:** § 28-2351 (post-24 September 2022) requires the state name in capitals, **sans serif**, **three-fourths of an inch** high — i.e. exactly the bottom of AAMVA §2.1's recommended 0.75–1.0 in band, in state law. A rare checkable instance of voluntary adoption showing up in statute.
- **`binding: owner`** — the plate follows the vehicle owner (§ 28-2356 transfer-and-credit). A vehicle-keyed consumer assuming an Arizona plate identifies a *vehicle* across time will be wrong.
- **Specialty count: UNRESEARCHED, deliberately.** ADOT is unreachable (403, no archive under the tried paths). No figure is laundered from a collector site or an encyclopedia.

### New Mexico — `us-nm.yml`, 8 series, three concurrent standards
- **Three current standard designs, three arrangements:** yellow/Yucca `999-LLL` (1991–, **thirty-four years on one arrangement and not exhausted**), turquoise Centennial `LLL-999` (2010–), Chile `LLLL99` (2017–). One back: the balloon base (1999–2010) with its migrating `NM` digraph.
- **Widest letter exclusion in the group:** E, I, O, Q, U, V — encoded in `regex_strict` on all four, corroboration-grade.
- **Personalized limits are stated by the authority, six of them:** yellow 1–7 (motorcycle 1–6), turquoise 1–8 (1–6), chile 1–6 (1–5). `regex` is the sourced union `{1,8}`, `matching: strict`. Best-sourced character constraint in the group.
- **Two historic regimes side by side with different thresholds:** horseless carriage (rolling **35** years, exhibition/education only, **five-year revalidation**) and year-of-manufacture (**30** years, and the plate is the **authentic original**, inspected for condition and non-duplication). The latter is a textbook `recall-only`: its serial is the union of every historic New Mexico arrangement back to 1912 — the `nl-export` case in a US skin.
- **Specialty index is statute-per-plate and the agency does the cross-referencing:** 26 distinct NMSA 1978 sections cited across the MVD's pages, **18 of them in the 66-3-424.x block** (a floor, not a total). The Amateur Radio plate (§ 66-3-417) is **inscribed with the holder's FCC call letters** — a serial issued by a different authority entirely.
- **artwork_risk: UNRESEARCHED, with a specific extra hazard flagged.** The Zia sun symbol is the emblem of the Zia Pueblo and the subject of a long-running dispute over its use that is **not a copyright question** and would survive any favourable copyright finding. Strongest placeholder case in the group; recorded as flagged and unresearched, with no source cited for the dispute because none was fetched.
- Plates reportedly manufactured by a **foreign commercial contractor** (Waldale, Nova Scotia) rather than a prison industry — locator-grade, recorded because where a vendor designs, a vendor may claim.

### Utah — `us-ut.yml`, 4 series, and the weakest evidentiary base in the group
- **STATUTE NOT READ.** `le.utah.gov` reset the connection on every attempt from two fetchers, and its Internet Archive captures are **JavaScript shells containing site chrome and no law**. Title 41 ch. 1a pt. 4 is pinned but unquoted; every fact rests on the Utah DMV's own pages plus locators. Stated in the file header, not buried.
- **Four concurrent standard designs, two arrangements:** Life Elevated Skier + Arches `L99 9LL` (2007–) and In God We Trust `9LLL9` (2023–). One back: the 1993–2007 Arch/Centennial base `999 LLL`.
- **Front plate dropped for passenger vehicles 1 January 2025**; decals consolidated to one sticker; embossing abandoned for flat screen printing in 2025. The instrument effecting the front-plate change was not identified (gap).
- **In God We Trust is a specialty plate that became a standard one** (2013 specialty → standardised 1 January 2017). **`_meta/classes.yml` has no way to say a series changed class.** First case in the dataset that needs it.
- **The special-group programme is the strongest entry in the file**, because the DMV states the format itself: "Special group plates consist of a **five-character combination on the right** with the special group sticker on the left and a descriptive phrase on the bottom." A stated serial length *and* a stated layout, directly usable as render constraints — more than FL, CO, NV or AZ give. **63** special-group plates counted from the DMV listing (archived 2024-12-29), plus 8 designs no longer issued but still valid.
- **Recorded internal contradiction (§5.3 discipline):** the same DMV page says "Utah has three standard issue plates" in one paragraph and "Utah currently has four standard issue plates" in the next. Both quoted; neither preferred.
- **Rejected an unsourced charset:** the locator asserts I/O/Q are unused, footnoted to *"Observing hundreds of plates over the past several months"* — an editor's own observation, below even enthusiast-corroboration grade. **Kept out of `regex_strict`** and recorded as a lead. Contrast Nevada, where the same exclusion is attributed to a published collector reference and *is* encoded.

---

## 3. Sourcing grades used, and why

Beyond the PRD's `period_evidence` vocabulary this pass needed one more value and
uses it openly: **`corroboration-only`**. US states almost never legislate serial
arrangements — of 32 series here, **exactly two carry `statutory-date`** (both
Nevada, both from the compilation's own Source line) and one more is a statutory
commencement (Colorado's retired-style plates). Everything else is either
`instrument-in-force-upper-bound` (the statute edition read) or
`corroboration-only` (a locator plus a collector reference, with no primary).

Marking those honestly is the whole point: **the era boundaries in this group are
folklore-prone exactly where PRD-PLATES §9 says they will be**, and a reader can
now see at a glance which dates would survive an audit.

**Nevada's Source lines are the model for fixing this.** The NRS compilation
prints "(Added to NRS by 1997, 1502)" under every section, which is how
`us-nv-replica-1982` and `us-nv-personalized` got real dates. Colorado's CRS does
the same ("Source: L. 2021: Entire section added, (SB 21-069) …"). **A follow-up
pass that mines Source lines alone would upgrade a dozen period claims across the
group** without any new fetching.

---

## 4. Recorded gaps (the honest list)

**Blocked hosts** — all returned 403/reset to every automated client tried:
`azdot.gov`, `az.gov`, `azlibrary.gov` (Cloudflare), `dmv.nv.gov` (live),
`dmv.colorado.gov` (live), `leg.state.nv.us`, `leg.colorado.gov`, `le.utah.gov`
(connection reset), `dmv.utah.gov` (live), `www.mvd.newmexico.gov` (live),
`law.justia.com`, `nmonesource.com`. **The Internet Archive was the workaround for
all but Utah's statute and Arizona's agency**, and the archive URL is cited
alongside the live URL wherever it was used.

| gap | state | why it matters |
|---|---|---|
| **Utah Code Title 41 ch. 1a pt. 4 unread** | UT | the only state in the group with no statutory base at all; front-plate change, special-group threshold, plate contents all unsourced from law |
| **ADOT unreachable** | AZ | specialty count, personalized character limit, departmental colour/material specs, the plate-belongs-to-the-owner statement — all pinned, none fetched |
| **NMSA 1978 unread** | NM | the 66-3-424.x block is the best specialty index in the group *by structure* and could be enumerated completely if the code were reachable |
| **artwork_risk unresearched** | NV, NM, UT | three of five states; NV and NM have *empty* sections in the standard survey, UT has a pointer only |
| **Zia Pueblo emblem dispute unsourced** | NM | flagged as a real non-copyright hazard with no citation fetched — must be researched before any NM render |
| **State seal / emblem statutes** | all 5 | the standing gap from US dossier §4.5, unclosed; independent of copyright in every state |
| **Plate dimensions** | all 5 | no state in this group states a plate size in statute. All 12×6 figures come from the AAMVA/SAE convention and are attributed as such, never to a state |
| **Colour specifications** | all 5 | **no hex value is asserted anywhere in these five files.** Only Colorado § 42-3-206.5 names colours at all, and only descriptively, for *retired* styles |
| **Temporary plates** | CO | § 42-3-203(3) authorises 60-day temporary plates and dealer blocks of 25; **no format obtained → no series written** rather than an invented one |
| **Moped plates** | NV | § 482.272(2) *commands* a distinct moped plate; no format, size or colour obtained → recorded, not invented |
| **Exempt/government plates** | NV, UT | NV E/X prefix is locator-grade with no statutory section isolated; UT "EX" plates have no obtained format → no UT series |
| **Historic plates** | CO | DMV names Horseless Carriage, Collector and Street Rod series; no formats obtained → no series |
| **§ 39-121.03** | AZ | the statute the copyright policy routes commercial users through; azleg.gov returned a socket hang-up on it twice. Pinned, unread, nothing attributed to it |
| **Issuance volumes** | all 5 | Florida's monthly active-plate report has no counterpart found in this group. If a Nevada or Colorado equivalent exists it is worth as much as Florida's |
| **ALPCA "Reconsidering the Standard Plate Size"** | — | the article four Wikipedia pages cite for the 1956 story; not obtained. Cheap, high-value |

---

## 5. Recommendations to the applying session

1. **Amend PRD-PLATES §4's adverse list to include Colorado** (§ 24-72-203(4), pinned). The current list — AZ asserting, NY/PA/WA adverse — is incomplete in a way that matters, because Colorado's authorisation is *statutory* rather than policy-level.
2. **PR `_meta/separators.yml`** to add the Nevada state outline and the New Mexico Zia sun symbol to `never_separator`, quoting the NM MVD sentence as rationale. First US instances; both come with authority backing.
3. **Consider a `format.fields:` discussion trigger from Arizona**, not just Japan. Arizona needs only a third pattern token (an alphanumeric one) rather than a full field decomposition — a much cheaper amendment, and it would remove the one place in this group where `pattern` and `regex` deliberately disagree in scope.
4. **Consider whether `_meta/classes.yml` needs a way to record a class CHANGE.** Utah's In God We Trust plate went specialty → standard; the vocabulary can express neither state of affairs across time.
5. **Treat `corroboration-only` as a first-class `period_evidence` value or reject it explicitly.** It is used on 14 of the 32 series here and the alternative was to overstate.
6. **Schedule the Source-line mining pass** described in §3 — highest ratio of period-claim upgrade to effort available anywhere in this gate.
7. **Do not render New Mexico** until the Zia question is researched. Everything else in the group renders under the §3 placeholder default.
