### PR TITLE
plates: us northwest — WA OR ID MT WY (L2 US wave)

### DIFF
--- a/plates/us-id.yml
+++ b/plates/us-id.yml
@@ -1,0 +1,531 @@
+# plates/us-id.yml — Idaho (PRD-PLATES gate L2, northwest group).
+#
+# READ THIS FIRST: IDAHO IS THE WEAKEST-SOURCED FILE IN THIS GROUP, AND THE
+# REASON IS ACCESS, NOT ABSENCE. legislature.idaho.gov refused the TLS
+# handshake from this environment on every single attempt — default curl,
+# --tlsv1.2, --tls-max 1.2, --tlsv1.3, --http1.1, and a raw `openssl s_client`
+# probe all failed after connecting to 164.165.66.180:443, and WebFetch
+# returned ECONNRESET. law.justia.com, the fallback the US/world dossier itself
+# used for Idaho, returned HTTP 403. adminrules.idaho.gov refused TLS the same
+# way. SO IDAHO CODE 49-443 — the section that should carry the plate design,
+# the county designator and the numbering rule — WAS NEVER READ. Every other
+# state in this group rests on statute; Idaho rests on the Idaho
+# Transportation Department's own published pages, which PRD-PLATES §4 ranks
+# as PRIMARY but second-preference, plus clearly-flagged locator material.
+# The verifier should treat re-fetching Idaho Code 49-443 from a working
+# network as the single highest-value action on this file.
+#
+# WHAT IDAHO GIVES ANYWAY, AND IT IS NOT NOTHING. ITD states the county
+# designator, the standard plate identity, the specialty programme count, a
+# real charset exclusion, and — freshest of all — a DATED STATUTORY CHANGE
+# from the 2026 legislative session: House Bill 533 killed the registration
+# sticker and House Bill 577 killed the ten-year plate replacement cycle, both
+# effective 1 July 2026. That is a live, agency-sourced, dated fact one month
+# old at the time of writing, and no competing dataset will have it.
+#
+# THE COUNTY DESIGNATOR IS THE PRIZE AND ALSO THE RISK. Idaho does not number
+# its counties the way Montana and Wyoming do. It builds a code from the
+# county's INITIAL LETTER plus an ordinal within that letter — Ada is 1A,
+# Adams 2A, Bannock 1B, Bear Lake 2B, and a county that is the only one
+# starting with its letter gets the bare letter (Elmore E, Kootenai K, Nez
+# Perce N). That mechanism is self-evidently systematic and ITD confirms that
+# a county designator exists; but the TABLE below is locator-grade and is
+# flagged as such row by row. It is included because the mechanism is the
+# valuable claim and because a flagged table a verifier can check beats an
+# omission a verifier cannot.
+jurisdiction: us-id
+authority:
+  name: Idaho Transportation Department, Division of Motor Vehicles (Idaho DMV)
+  url: "https://itd.idaho.gov/dmv/registrations-plates-titles/license-plates/"
+binding: vehicle
+statute_edition: >-
+  NONE READ. Idaho Code Title 49, Chapter 4 was NOT obtained — see the header
+  note and research_notes.reachability. Idaho Administrative Code IDAPA
+  39.02.60 (the ITD special-plate rule, cited by ITD's own page as carrying
+  "The full list of rules for special plates ... 39.02.60 202.08 on page 9")
+  was likewise unreachable. All statutory-level claims in this file are
+  ABSENT, not summarised.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4/§7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    UNRESEARCHED, AND RECORDED HONESTLY RATHER THAN GUESSED. Idaho appears
+    NOWHERE in the standing per-state copyright survey PRD-PLATES §4 works
+    from — neither in the favourable column (FL, CA, NC, NJ, MA, GA) nor in
+    the adverse column (NY, AZ, PA, WA). No {{PD-IDGov}} tag exists among the
+    state templates listed on Wikimedia Commons' US per-territory page. No
+    copyright notice was found on any Idaho page fetched in this pass: the
+    ITD plate estate's footer carries "Official Government Website / Visit
+    Idaho.gov / Accessibility / Cybersecurity / Privacy / Legal Notices /
+    Security" and NO copyright string, and www.idaho.gov/legal/ refused TLS so
+    the linked legal notices were never read. THE DEFAULT THEREFORE APPLIES
+    AND IS THE OPERATIVE POSTURE: a US state's works are copyrighted unless
+    that state says otherwise (17 U.S.C. §105 reaches federal works only and
+    does not extend to states), so Idaho plate artwork must be treated as
+    protected until Idaho says otherwise. "Unresearched" describes the
+    EVIDENCE, not the risk.
+  known_third_party_element: >-
+    ONE CONCRETE FLAG, AND IT IS NOT SPECULATIVE. Idaho's special-plate
+    catalogue as described by ITD includes college and university designs and
+    a Corvette plate; university marks and the Corvette name are third-party
+    trademarks whatever Idaho's own posture turns out to be. The
+    Appaloosa plate likewise implicates a breed-registry mark. So even a
+    favourable Idaho finding would not clear the whole catalogue.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to the scenic mountain
+    graphic, the sky gradient and every special-plate design without
+    exception. No Idaho emblem is a candidate for an upgrade at this gate:
+    upgrades require BOTH a cleared artwork_risk and a ledger entry, and Idaho
+    has neither.
+  photograph_caution: "Standard: a Commons CC BY-SA tag on a photograph of an Idaho plate is the photographer's licence on the photograph, not on the design. Our renders are generated from spec, so the obligation never attaches."
+  sources:
+    - "https://itd.idaho.gov/dmv/registrations-plates-titles/license-plates/  # fetched 2026-08-02: the ITD plate estate. Footer measured — no copyright notice present."
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: Idaho is NOT MENTIONED — a measured absence, which is why the posture is unresearched rather than favourable"
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # LOCATOR ONLY: no Idaho state PD template exists among those listed; the page's own rule is that state and local government works are generally subject to copyright"
+
+# ---------------------------------------------------------------------------
+# The US standards chain.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, which is paywalled and UNPINNED and is never quoted here. NO IDAHO DIMENSION WAS SOURCED AT ALL — Idaho Code 49-443 was unreachable — so the 12 x 6 in figure below is the North American convention as observed and carries no Idaho authority."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spacing at least 0.25 in, stroke 0.2-0.4 in, 1.25 in clear of the top and bottom edges"
+    replacement_cycle: >-
+      AAMVA §1.1 recommends a cycle "not to exceed 7 to 10 years". IDAHO RAN
+      TEN AND THEN ABOLISHED IT. ITD, in its own words: "All plates regardless
+      of design are good for 10 years with active registration", and, as of
+      2026: "House Bill 577 eliminated the requirement to replace license
+      plates every 10 years, allowing plates to remain in use as long as they
+      are readable and legible." So Idaho moved from the top of AAMVA's band
+      to Washington's position — an event-triggered rule with no clock — on
+      1 July 2026. This is the only jurisdiction in this wave observed
+      CHANGING its replacement regime, and the date is exact.
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The '1956 AMA standardization agreement' is COMMONLY REPEATED, UNSOURCED. Because no Idaho dimension was sourced at all, this file makes no dimension claim that could rest on it."
+
+# ---------------------------------------------------------------------------
+# Display rules — RECORDED GAP. Idaho Code 49-428 (display of plates) was not
+# reachable. The US/world dossier pins law.justia.com for Idaho Code 49-405;
+# that host returned 403 in this pass.
+# ---------------------------------------------------------------------------
+display_rules:
+  status: not-sourced
+  note: >-
+    NO IDAHO DISPLAY RULE IS RECORDED. Idaho is conventionally described as a
+    two-plate state, but no Idaho instrument was read in this pass and the
+    claim is therefore ABSENT rather than asserted. This is a deliberate
+    omission: every other state in this group carries its display rule
+    verbatim from statute, and a summarised or remembered Idaho rule would be
+    the only unsourced claim of its kind in the group.
+  gap: "Idaho Code 49-428 and 49-443 both unreachable; re-fetch from a working network"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES. County-designator-prefixed.
+  # =========================================================================
+  - id: us-id-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "9L 999L"
+      regex: '\A\d{0,2}[A-Z][- ]?[A-Z0-9]{3,5}\z'
+      charset:
+        notes: >-
+          IDAHO'S SERIAL GRAMMAR WAS NOT SOURCED FROM ANY INSTRUMENT. What ITD
+          states in its own words is the STRUCTURE: "The standard plate
+          includes a 'county designator' in the plate number that corresponds
+          with the county you live in." So the leading group is a county code
+          and the remainder is the plate number. The reported arrangements —
+          a one-or-two-character county designator followed by four or five
+          alphanumerics with a trailing letter that advances as the county's
+          series fills — are LOCATOR-GRADE, and the regex is deliberately
+          written as their UNION rather than as any one of them. That union is
+          wider than any grammar Idaho issues, which is exactly what
+          `matching: recall-only` means under PRD-PLATES §2.7: a match here is
+          a shape hit and nothing more.
+        personalized_exclusion_note: >-
+          ONE REAL, AGENCY-SOURCED CHARSET FACT EXISTS, though it governs
+          PERSONALIZED plates rather than this series. ITD, verbatim: "The
+          letter O and the number zero look the same on a license plate,
+          therefore only the number zero will be accepted." Idaho therefore
+          EXCLUDES THE LETTER O from owner-chosen configurations. Note the
+          delicious inconsistency this creates with the county designator
+          table, in which Oneida and Owyhee are reported as 1O and 2O — the
+          exclusion binds the owner, not the department.
+      separator_note: "The boundary between the county designator and the plate number is spelled as the separator-only class `[- ]`, sanctioned by PRD-PLATES §2.8, because it is a printed GAP and no authority text names a glyph. `pattern` shows the canonical printed form with a space."
+      progression: >-
+        LOCATOR-GRADE, NOT ASSERTED: the encyclopedia record reports the
+        trailing letter advancing as each county's block fills, with Ada
+        County reported at V and Canyon County at P. Recorded so a verifier
+        knows what to check; not claimed.
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      dimension_note: "NO IDAHO SOURCE. Idaho Code 49-443 was unreachable and no ITD dimension statement was found. 12 x 6 in is the North American convention as observed and carries no Idaho authority whatsoever."
+      background: { finish: retroreflective }
+      colour_note: >-
+        ITD, in its own words and this is the whole of the agency-sourced
+        design claim: "Idaho's standard license plate is the red, white and
+        blue scenic Idaho plate." No hex is invented from that. The
+        encyclopedia record adds a mountain scene with a red-to-white sky
+        gradient, pale blue mountains and a dark blue forest, with "IDAHO"
+        screened white at the top and "FAMOUS POTATOES" at the bottom; that
+        description is LOCATOR-GRADE and is recorded, not asserted.
+      legend_top: "IDAHO"
+      legend_bottom: "FAMOUS POTATOES"
+      legend_note: "Both legends are LOCATOR-GRADE. No Idaho instrument stating either was read. The bottom legend is famous enough that its absence from a sourced record is itself worth flagging."
+      graphic: { present: true, rendered: placeholder, description: "scenic mountain and sky design — 'the red, white and blue scenic Idaho plate' per ITD; the detail is locator-grade" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+      cost: "ITD: 'Standard plates cost $3.75 per plate.'"
+      fulfilment: "ITD: 'License plates are made to order and are shipped by the US Postal Service. Please allow 6 weeks for new plates to arrive.' Idaho does not issue over the counter — a real operational difference from Wyoming and Montana, where the county treasurer hands the plate over."
+    replacement_rule:
+      former_clock_years: 10
+      former_rule_text: "ITD, before the change: 'All plates regardless of design are good for 10 years with active registration.'"
+      abolished:
+        effective: "2026-07-01"
+        instruments: ["House Bill 577 (2026 session) — eliminated the ten-year plate replacement requirement", "House Bill 533 (2026 session) — eliminated the requirement to display registration stickers"]
+        agency_text: >-
+          ITD, verbatim: "As of July 1, 2026, the DMV will stop providing
+          registration stickers and license plates will no longer be replaced
+          every ten years." And: "House Bill 577 eliminated the requirement to
+          replace license plates every 10 years, allowing plates to remain in
+          use as long as they are readable and legible." And: "House Bill 533
+          during the 2026 legislative session eliminated the requirement to
+          display registration stickers on license plates."
+      note: >-
+        TWO CONSEQUENCES A DATASET MUST CARRY. (1) Idaho moved from a
+        ten-year clock to a legibility test on a single dated day, so plate
+        age can no longer be inferred from issue cycle for any Idaho plate
+        current after 1 July 2026. (2) THE VALIDATION STICKER IS GONE. Every
+        other state in this group affixes a decal that carries the expiry;
+        Idaho stopped. A vision system trained to find an Idaho expiry sticker
+        will find nothing, and an Idaho plate photographed after July 2026
+        carries no visible validity marker at all. The bill numbers are
+        recorded but THE BILL TEXTS WERE NOT READ — legislature.idaho.gov was
+        unreachable — so the effect is agency-sourced, not statute-sourced.
+    region_encoding:
+      mechanism: >-
+        A LETTER-ORDINAL COUNTY CODE, NOT A NUMBER. Idaho's designator is
+        built from the county's INITIAL LETTER plus an ordinal ranking among
+        the counties sharing that letter, alphabetically: Ada is 1A and Adams
+        2A because Ada precedes Adams; Bannock, Bear Lake, Benewah, Bingham,
+        Blaine, Boise, Bonner, Bonneville, Boundary and Butte run 1B to 10B in
+        alphabetical order. A county that is the ONLY one beginning with its
+        letter takes the bare letter with no ordinal — Elmore E, Idaho I,
+        Kootenai K, Nez Perce N, Shoshone S, Valley V, Washington W. This is a
+        genuinely different mechanism from Montana's and Wyoming's frozen
+        historical rankings: Idaho's is DERIVABLE FROM THE COUNTY NAME, which
+        means it is stable under demographic change and would extend
+        automatically to a new county.
+      agency_confirmation: "ITD confirms the existence and the meaning of the designator in its own words: 'The standard plate includes a \"county designator\" in the plate number that corresponds with the county you live in.' ITD does NOT publish the table."
+      decode_evidence: secondary-locator-only
+      decode_caveat: >-
+        THE TABLE BELOW IS NOT A SOURCED CLAIM. It comes from the encyclopedia
+        record and from nothing else; no ITD, IDAPA or Idaho Code publication
+        of the mapping was obtained. It is included rather than omitted for
+        three reasons: the MECHANISM is agency-confirmed, the table is
+        internally consistent with the mechanism (which is a real check — an
+        invented table would not be), and a flagged table is checkable while
+        an absence is not. A verifier must pin it to Idaho Code 49-443 or an
+        ITD publication before any consumer relies on it. TWO ROWS TO CHECK
+        FIRST: Oneida (1O) and Owyhee (2O) use the letter O, which Idaho
+        excludes from owner-chosen plates for legibility — plausible, since
+        the exclusion binds the applicant and not the department, but exactly
+        the kind of thing a locator gets wrong.
+      table:
+        Ada: "1A"
+        Adams: "2A"
+        Bannock: "1B"
+        Bear Lake: "2B"
+        Benewah: "3B"
+        Bingham: "4B"
+        Blaine: "5B"
+        Boise: "6B"
+        Bonner: "7B"
+        Bonneville: "8B"
+        Boundary: "9B"
+        Butte: "10B"
+        Camas: "1C"
+        Canyon: "2C"
+        Caribou: "3C"
+        Cassia: "4C"
+        Clark: "5C"
+        Clearwater: "6C"
+        Custer: "7C"
+        Elmore: "E"
+        Franklin: "1F"
+        Fremont: "2F"
+        Gem: "1G"
+        Gooding: "2G"
+        Idaho: "I"
+        Jefferson: "1J"
+        Jerome: "2J"
+        Kootenai: "K"
+        Latah: "1L"
+        Lemhi: "2L"
+        Lewis: "3L"
+        Lincoln: "4L"
+        Madison: "1M"
+        Minidoka: "2M"
+        Nez Perce: "N"
+        Oneida: "1O"
+        Owyhee: "2O"
+        Payette: "1P"
+        Power: "2P"
+        Shoshone: "S"
+        Teton: "1T"
+        Twin Falls: "2T"
+        Valley: "V"
+        Washington: "W"
+      table_completeness: "44 rows for Idaho's 44 counties — the count matches, which is a weak but real consistency check on a locator table."
+    sources:
+      - "https://itd.idaho.gov/dmv/registrations-plates-titles/license-plates/  # ITD, quoted throughout: 'Idaho's standard license plate is the red, white and blue scenic Idaho plate'; 'Standard plates cost $3.75 per plate'; 'All plates regardless of design are good for 10 years with active registration'; 'The standard plate includes a \"county designator\" in the plate number that corresponds with the county you live in'; the made-to-order / six-week USPS fulfilment model; the personalized-plate rules including the letter-O exclusion"
+      - "https://itd.idaho.gov/faqs/permanent-plates-and-no-registration-stickers/  # ITD FAQ: the 1 July 2026 change, House Bill 533 (registration stickers) and House Bill 577 (the ten-year replacement requirement), quoted verbatim"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Idaho  # LOCATOR ONLY (PRD-PLATES §4): the county designator table, the reported serial arrangements and trailing-letter progression, the September 1991 base introduction, the 1987-1991 Centennial predecessor, the FAMOUS POTATOES legend, and the non-passenger formats. NONE of it is asserted as sourced here."
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1 — the 7-to-10-year recommendation Idaho met and then abolished"
+    notes: >-
+      IDAHO STANDARD ISSUE. `matching: recall-only` IS THE HONEST DESCRIPTION
+      OF THIS SERIES AND NOT A HEDGE: the regex is a deliberate union of
+      several reported arrangements and is wider than anything Idaho issues,
+      so a match asserts a shape and nothing more. THE ID IS UNDATED and
+      `start: 2026` is the year ITD's estate was read — an UPPER BOUND. The
+      commonly repeated September 1991 introduction of the scenic base is
+      encyclopedia-grade and is NOT minted into the id. WHAT MAKES IDAHO WORTH
+      THE TROUBLE DESPITE THE SOURCING: it is the only state in this group
+      whose region code is DERIVABLE rather than historical — Montana and
+      Wyoming froze a 1930s ranking into law, Idaho encodes the county's own
+      name — and it is the only state observed CHANGING its replacement regime
+      and dropping its validation sticker, on a dated day, one month before
+      this pass.
+
+  # =========================================================================
+  # ONE SERIES BACK. Locator-grade in full, and marked as such.
+  # =========================================================================
+  - id: us-id-standard-centennial
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1987, end: 1991 }
+    period_evidence: secondary-locator-only
+    period_caveat: >-
+      NOT A SOURCED CLAIM. Both boundary years come from the encyclopedia
+      record and nothing else; no Idaho instrument stating either was read,
+      and Idaho's statute host was unreachable. The series is recorded because
+      Idaho's design lineage is otherwise a blank between statehood and today,
+      and because a flagged predecessor is checkable. A verifier should pin it
+      to Idaho Code 49-443's history line or an ITD publication, or drop it.
+    matching: recall-only
+    format:
+      pattern: "9L 999L"
+      regex: '\A\d{0,2}[A-Z][- ]?[A-Z0-9]{3,5}\z'
+      charset: { notes: "same county-designator structure as the current base; no instrument sourced. Union regex, hence recall-only." }
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      background: { finish: retroreflective }
+      colour_note: "reported as the same mountain scenery as the current base but with two tall dark blue trees screened at the far left and the word CENTENNIAL — Idaho's statehood centennial fell in 1990, which makes a 1987-1991 centennial base chronologically coherent. LOCATOR-GRADE."
+      legend_top: "IDAHO"
+      graphic: { present: true, rendered: placeholder, description: "centennial mountain scene with trees at left — locator-grade" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: "the same letter-ordinal county designator; see us-id-standard.region_encoding, which carries the table and its caveat"
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Idaho  # LOCATOR ONLY: the 1987-1991 Centennial base, its description, and its replacement by the scenic base. Nothing here is asserted as sourced."
+    notes: >-
+      THE PREVIOUS IDAHO BASE. This is the weakest entry in the whole
+      northwest group and it says so on its face: every claim in it is
+      locator-grade, including both period boundaries. It is retained rather
+      than dropped because Idaho's statehood centennial (1890 to 1990) gives
+      the reported dates an independent plausibility check, and because the
+      L2 brief asks for one series back — but a verifier is entitled to delete
+      it outright rather than publish it, and that would be a defensible call.
+      Distinct from us-id-standard in its reported centennial graphic and in
+      being closed.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Agency-counted.
+  # =========================================================================
+  - id: us-id-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "9L 999L"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      charset: { notes: "no per-programme grammar was sourced; individual specialty specs are L4 per PRD-PLATES §2.5. The index carries a deliberately wide union and is recall-only." }
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: "over 40"
+      count_official_quote: "ITD, in its own words: 'Idaho offers over 40 special plates with unique designs for an additional cost. Fees collected from special plate sales go to a variety of causes like educational initiatives, farm research, recreation, conservation and more.'"
+      count_secondary: "approximately 40 active designs per the encyclopedia record — LOCATOR ONLY, and consistent with ITD's own figure rather than in conflict with it. Recorded, not merged."
+      naming: "Idaho calls them SPECIAL plates, not specialty plates. The distinction is Idaho's own and is preserved here because ITD's URLs, forms and mailbox (SpecialPlates@itd.idaho.gov) all use it."
+      rules_reference: >-
+        THE AUTHORITATIVE RULE IS NAMED BUT WAS NOT READ. ITD: 'The full list
+        of rules for special plates can be found in Idaho Administrative Code
+        39.02.60 202.08 on page 9 (PDF).' adminrules.idaho.gov refused TLS
+        from this environment, so IDAPA 39.02.60 is UNREAD. It is the single
+        document that would upgrade this index from an agency blurb to a
+        sourced rule set, and it is pinned here for the next pass.
+      eligibility_gated_programmes: "ITD: 'Some special plates, including disabled plates and military plates, require additional documentation to order.' Named order-by-mail-or-in-person programmes: Classic and Old Timer, military plates, Purple Heart plates, disabled veteran plates, radio amateur plates, wrecker plates."
+      named_programmes_reported: "Agriculture, Appaloosa, Aviation, Biking, Colleges/Universities, Corvette, Fire Fighters, Lewis & Clark, National Guard, Peace Officer, Pet Friendly, Purple Heart, Rotary, Sawtooth, Ski Idaho, Snowmobile, Veterans, Wildlife (multiple designs) — LOCATOR-GRADE list, recorded to show the catalogue's shape, not as an authoritative enumeration."
+      interactive_guide_url: "https://apps.itd.idaho.gov/Apps/Fund/Dealer/InteractivePlateProgramsGuide/LaunchPlateGuide.html"
+      interactive_guide_note: >-
+        ITD PUBLISHES AN INTERACTIVE PLATE PROGRAMS GUIDE — a structured,
+        official, per-programme artefact of exactly the kind the Florida pass
+        identified as the differentiator no competitor has. It was NOT
+        machine-read in this pass (it is a JavaScript application). If it
+        exposes a JSON endpoint it is the highest-value structured Idaho
+        source in existence and should be captured before L4.
+      official_rules_url: "https://adminrules.idaho.gov/rules/current/39/390260.pdf"
+      personalized_url: "https://dmvonline.itd.idaho.gov/OpenServices/OpenVehicleServices/CheckPersonalizedPlates"
+    region_encoding: "not sourced; whether Idaho special plates retain the county designator was not established (recorded gap). Note the contrast this leaves open: Montana replaces the county number on special series by statute, Wyoming keeps it."
+    sources:
+      - "https://itd.idaho.gov/dmv/registrations-plates-titles/license-plates/  # ITD: 'over 40 special plates', the causes the fees fund, the SPECIAL (not specialty) naming, the documentation-gated programmes and their order routes, the IDAPA 39.02.60 202.08 pointer, and the interactive guide link"
+      - "https://adminrules.idaho.gov/rules/current/39/390260.pdf  # IDAPA 39.02.60 — the authoritative special-plate rule, PINNED BUT UNREAD (TLS refused). This is the next pass's first fetch."
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Idaho  # LOCATOR ONLY: the reported ~40 active designs and the programme names"
+    notes: >-
+      THE IDAHO SPECIALTY INDEX — one entry standing for the whole programme,
+      per PRD-PLATES §2.5. The count is AGENCY-SOURCED ("over 40", ITD's own
+      words), which is stronger than Oregon's (unpublished) and Wyoming's
+      (enumerated but not totalled), though weaker than Washington's
+      (a statutory table). Two follow-ups are pinned and both are cheap:
+      IDAPA 39.02.60, which is the real rule set, and the Interactive Plate
+      Programs Guide, which may be a structured endpoint.
+
+  # =========================================================================
+  # PERSONALIZED — the one Idaho series with a genuinely sourced charset rule.
+  # =========================================================================
+  - id: us-id-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        excluded: ["O"]
+        excluded_encoding_note: >-
+          THE EXCLUSION LIVES IN `charset.excluded`, NOT IN THE REGEX, AND
+          THAT IS THE SCHEMA WORKING AS DESIGNED. PRD-PLATES §2.7 makes
+          `format.regex` the round-trippable tier — it is generated against
+          `format.pattern` by the lint and therefore CANNOT carry charset
+          restrictions, which is precisely why `regex_strict` and
+          `charset.excluded` exist. A `regex_strict` of
+          '\A[A-NP-Z0-9](?: ?[A-NP-Z0-9])*\z' would lint clean, but §2.7
+          forbids a strict twin on a `recall-only` series, and this series IS
+          recall-only because the LENGTH cap is unsourced. So the exclusion is
+          carried as cited data. When the IDAPA per-plate-type character cap
+          lands, this series becomes `strict` and that regex_strict can be
+          added in the same PR.
+        excluded_source: >-
+          ITD, verbatim and this is a real agency-sourced exclusion rather
+          than an inference: "Must contain at least one character. The letter
+          O and the number zero look the same on a license plate, therefore
+          only the number zero will be accepted." The letter O is therefore
+          excluded from Idaho owner-chosen configurations, and the numeral 0
+          is the only round character accepted.
+        notes: >-
+          Further ITD rules, in ITD's own words: "Your requested plate
+          combination is subject to review"; "The maximum number of characters
+          you can use depends on the plate type you want to register. A
+          character is a letter, number, or a space. Each space counts as one
+          character"; "Must be tasteful (in any language)"; "Cannot contain any
+          punctuation or special characters"; "Must not already be in use";
+          "If you allow the registration on your personalized plates to
+          expire, the combination will become immediately available for
+          reissue to another applicant." NOTE THE SECOND RULE CAREFULLY: IDAHO
+          COUNTS A SPACE AS A CHARACTER against the cap. That is a
+          jurisdiction treating a separator as serial-significant for LENGTH
+          purposes while it remains a separator for MATCHING purposes — worth
+          recording against plates/_meta/separators.yml, though it does not
+          breach the contract, because the space is still never part of the
+          serial's identity.
+      length_note: >-
+        NO CAP IS RECORDED BECAUSE ITD STATES NONE — the maximum "depends on
+        the plate type", and the per-type table was not obtained (it is
+        presumably in the unread IDAPA 39.02.60). The regex is therefore
+        unbounded in length, which makes no width claim, and this series is
+        `recall-only`.
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      background: { finish: retroreflective }
+      note: "ITD: personalized configurations may be applied to standard plates and to some special plates for an extra fee. Vehicles with a maximum gross vehicle weight over 26,000 pounds are NOT eligible."
+      emblem: { present: true, rendered: placeholder }
+    fee: "ITD: '$25 initial Personalization Program Fee ($15 additional per registration year).' Not all plates can be personalized."
+    eligibility: "ITD: usable on passenger vehicles, commercial vehicles, motorcycles and some recreational vehicles; not all plate types can be ordered online; vehicles over 26,000 lb maximum gross vehicle weight are excluded."
+    region_encoding: "none — an owner-chosen configuration replaces the county designator entirely, so a personalized Idaho plate carries NO geographic information. This is the one place where Idaho's region encoding is defeated by owner choice, and a parse API must not attempt a county decode on it."
+    sources:
+      - "https://itd.idaho.gov/dmv/registrations-plates-titles/license-plates/  # ITD's personalized-plate rules quoted verbatim above: the letter-O exclusion, the space-counts-as-a-character rule, the per-plate-type cap, the tastefulness and punctuation rules, the availability and re-issue rules, the $25/$15 fees, the eligible vehicle classes and the 26,000 lb exclusion"
+      - "https://dmvonline.itd.idaho.gov/OpenServices/OpenVehicleServices/CheckPersonalizedPlates  # ITD's own availability checker — the service that enforces 'Must not already be in use'"
+      - "https://adminrules.idaho.gov/rules/current/39/390260.pdf  # IDAPA 39.02.60 202.08, cited by ITD as carrying the full rule set — PINNED BUT UNREAD"
+    notes: >-
+      PERSONALIZED. Modelled as its own series for the us-fl-personalized
+      reason — the SERIAL SOURCE differs, owner-chosen rather than
+      department-assigned, which is a format property — and because it carries
+      THE ONLY GENUINELY SOURCED CHARSET EXCLUSION IN THIS ENTIRE FILE. The
+      letter-O rule is worth the whole entry: it is an authority's own words
+      about its own alphabet, which is exactly what PRD-PLATES §2.7 wants, and
+      it produces the pleasing inconsistency that Idaho's own county
+      designators for Oneida and Owyhee use a letter its citizens may not
+      choose. `recall-only` only because the LENGTH cap is unsourced; if the
+      IDAPA per-type table lands, this series becomes strict with a real
+      regex_strict.
+
+# ---------------------------------------------------------------------------
+# Classes Idaho separately serializes but which are NOT given series here,
+# because the only available formats are locator-grade and this file already
+# carries two locator-grade series. Adding four more would misrepresent the
+# file's evidence quality.
+# ---------------------------------------------------------------------------
+unspecified_classes:
+  motorcycle:
+    reported_format: "M-prefixed serials, reported as embossed MAA 1 to MZZ 999 and later screened M-numeric — LOCATOR-GRADE"
+    gap: "no ITD or statutory source; Idaho Code 49-443 unreachable"
+  trailer:
+    reported_format: "U-suffixed motorcycle-sized plates, later Z-prefixed — LOCATOR-GRADE"
+    gap: "no ITD or statutory source"
+  dealer:
+    reported_format: "reported as a D/L/R marking with a numeric serial — LOCATOR-GRADE"
+    gap: "no ITD or statutory source"
+  government:
+    reported_format: "reported agency-specific markings (Idaho State Police ISP, county sheriff, fire) — LOCATOR-GRADE. ITD publishes an 'Exempt plate order form (PDF)', so the class demonstrably exists."
+    gap: "no serial grammar sourced; the exempt order form was not read"
+  historic:
+    agency_hook: "ITD publishes a 'Classic and Old Timer Application (PDF)' — so Idaho runs at least two historic tiers under those names."
+    gap: "no eligibility threshold, legend or serial grammar sourced"
+  wrecker:
+    agency_hook: "ITD publishes an 'Order wrecker plates (PDF)' form, so wrecker is a distinct Idaho plate type — matching Florida, which legislates a 'Wrecker' bottom legend. Note _meta/classes.yml has no `wrecker` or `commercial` value."
+    gap: "no serial grammar or legend sourced"
+
+# ---------------------------------------------------------------------------
+# Dead ends and open items. This section is longer than the others in the
+# group on purpose: Idaho's gaps are access gaps, and access gaps are fixable.
+# ---------------------------------------------------------------------------
+research_notes:
+  reachability:
+    - "legislature.idaho.gov: TCP connects to 164.165.66.180:443 and then the TLS handshake fails. Tried: default curl (exit 35), --tlsv1.2, --tlsv1.2 --tls-max 1.2, --tlsv1.3, --http1.1, and a bare `openssl s_client -connect legislature.idaho.gov:443 -servername legislature.idaho.gov`, which printed 'Connecting to 164.165.66.180' and then nothing. WebFetch returned ECONNRESET. IDAHO CODE 49-443 WAS THEREFORE NEVER READ."
+    - "adminrules.idaho.gov: same TLS failure (curl exit 35). IDAPA 39.02.60 unread."
+    - "www.idaho.gov/legal/: same TLS failure. The state's legal notices were never read, which is why artwork_risk is unresearched rather than resolved either way."
+    - "law.justia.com: HTTP 403 on every Idaho Code path. NOTE FOR THE SOURCE APPENDIX: the US/world dossier's pin-list cites law.justia.com for Idaho Code 49-405 as a harvested URL; that route is now blocked and the appendix should say so."
+    - "itd.idaho.gov: fully reachable and unexpectedly rich — the DMV pages carry direct quotations worth citing, and the FAQ estate carries dated legislative changes. It is slow (60 s+ for some pages) and WebFetch timed out once where curl succeeded."
+  open_items:
+    - "IDAHO CODE 49-443 — the section that should carry the plate design, dimensions, county designator and numbering rule. First fetch of the next pass. Everything structural in this file is downstream of it."
+    - "IDAPA 39.02.60 (adminrules.idaho.gov/rules/current/39/390260.pdf) — ITD's own special-plate rule, including 202.08 which ITD says carries the full personalized-plate rules and presumably the per-plate-type character caps that would make us-id-personalized strict."
+    - "House Bill 533 and House Bill 577 (2026 session) — the bill texts behind the 1 July 2026 sticker and replacement-cycle abolition. The effect is agency-sourced; the instruments are not read."
+    - "The Interactive Plate Programs Guide at apps.itd.idaho.gov — check for a JSON endpoint. Potentially the best structured Idaho artefact in existence."
+    - "The county designator table needs an official source. Idaho Code 49-443 or an ITD publication; until then it is locator-grade and flagged."
+    - "No Idaho display rule is recorded at all. Idaho Code 49-428 or equivalent."

--- a/plates/us-mt.yml
+++ b/plates/us-mt.yml
@@ -1,0 +1,619 @@
+# plates/us-mt.yml — Montana (PRD-PLATES gate L2, northwest group).
+#
+# MONTANA IS THE BEST-SOURCED US STATE IN THIS GROUP, AND IT IS NOT CLOSE.
+# MCA 61-3-332 is a single section that legislates, in terms: the plate
+# material and finish, the state wordmark, the STATE-OUTLINE BORDER, two exact
+# plate sizes in inches, the serial grammar, the county-number prefix and its
+# separation mark, the replacement clock, the exempt-plate markings, and — in
+# subsection (7) — THE ENTIRE 56-ROW COUNTY CODE TABLE, verbatim, in the
+# statute itself. Florida's Chapter 320 is the pilot for statute-first
+# sourcing; Montana out-specifies it. Almost nothing in this file is observed.
+#
+# THE REGION-ENCODING PRIZE. MCA 61-3-332(7) assigns every Montana county a
+# number and the numbering is NOT alphabetical and NOT arbitrary: Silver Bow
+# is 1, Cascade 2, Yellowstone 3, Missoula 4 — the 1930s population order,
+# frozen in law ever since and now wildly out of date (Silver Bow/Butte was
+# Montana's largest county in 1930 and is nowhere near it today). A Montana
+# plate therefore encodes a NINETY-YEAR-OLD CENSUS RANKING, which is precisely
+# the kind of decode fact PRD-PLATES §2.4 exists to carry. The table below is
+# quoted from the statute, not from a collector site. NOTE THE FOLKLORE LINE
+# CAREFULLY: the statute states the ASSIGNMENT; it does not state the
+# RATIONALE. "Ordered by 1930 population" is commonly repeated and is recorded
+# here as COMMONLY REPEATED, NOT STATED IN LAW.
+#
+# THE ONE THING MONTANA DOES NOT HAVE: a "previous base". MCA
+# 61-3-332(3)(a)(i) provides that new plates "must be a standard license plate
+# design first issued in 1989 or later". Montana does not retire bases; it
+# accumulates them. Every standard design first issued from 1989 onward
+# remains orderable today, in parallel, forever. So the L2 "one series back"
+# requirement is INAPPLICABLE IN MONTANA'S OWN TERMS, and saying so with the
+# citation is more accurate than inventing a superseded series. See
+# `us-mt-standard.notes`.
+jurisdiction: us-mt
+authority:
+  name: Montana Motor Vehicle Division (MVD), Montana Department of Justice
+  url: "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0030/section_0320/0610-0030-0030-0320.html"
+binding: vehicle
+statute_edition: >-
+  Montana Code Annotated 2025, Title 61 (Motor Vehicles), Chapter 3, Parts 3
+  and 4, read 2026-08-02 from mca.legmt.gov. AUTHORITY URL CAVEAT: the MVD's
+  own estate (mvdmt.gov and dojmt.gov) returned HTTP 403 to every request from
+  this environment, so the `authority.url` above points at the STATUTE — which
+  is where Montana's plate facts actually live, and which is an edict of
+  government and therefore public domain. This is a deliberate choice, not an
+  oversight; see research_notes.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4/§7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: split-standard-unresearched-specialty-adverse
+  basis: >-
+    MONTANA SPLITS, AND THE SPLIT IS SOURCED FROM STATUTE RATHER THAN INFERRED.
+    (1) THE STANDARD BASE — UNRESEARCHED. Montana appears NOWHERE in the
+    standing per-state copyright survey PRD-PLATES §4 works from, no
+    {{PD-MTGov}} tag exists on Wikimedia Commons, and no copyright notice was
+    found anywhere on mt.gov as fetched. So the default applies: a US state's
+    works are copyrighted unless that state says otherwise, and Montana has
+    not said. Recorded as UNRESEARCHED for the standard base rather than
+    guessed in either direction. What IS clean is the SPEC: MCA 61-3-332 is an
+    edict of government and public domain at every level, so the wordmark
+    rule, the state-outline border, the dimensions and the county table below
+    are all freely usable even if the rendered artwork is not.
+    (2) THE SPECIALTY TIER — AFFIRMATIVELY ADVERSE, ON THE STATE'S OWN
+    ADMISSION. MCA 61-3-475(1)(e)(iv)(C) requires a sponsoring organisation to
+    prove that its name, identifying phrase or graphic does not "infringe or
+    otherwise violate a trademark, trade name, service mark, copyright, or
+    other proprietary or property right", and 61-3-475(2) lets the department
+    demand a sworn statement that the organisation "is authorized to use the
+    name, identifying phrase, and graphic ... and that no infringement or
+    violation of any property right exists, together with an agreement to
+    defend and hold harmless the state of Montana". Montana therefore states
+    in law that specialty plate GRAPHICS ARE THIRD-PARTY PROPERTY and
+    contracts out of liability for them. No clearer legislative admission that
+    plate artwork is privately owned was found in any state in this group.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies. Two Montana-specific notes.
+    First, the STATE-OUTLINE BORDER required by MCA 61-3-332(4)(a) is a
+    geographic outline — a fact, not an authored work — and is the single most
+    likely emblem-slot upgrade candidate in this group, but it is not upgraded
+    here because the artwork_risk posture for the base is unresearched and the
+    §3 default is binding until BOTH artwork_risk and the ledger clear.
+    Second, the BUFFALO SKULL used as the group separator on the current base
+    is a design element, is NOT part of the serial, and must never be treated
+    as a separator character (see `format.separator_note`).
+  photograph_caution: "Standard: a Commons CC BY-SA tag on a photograph of a Montana plate is the photographer's licence on the photograph, not on the design. Our renders are generated from the statute, so the obligation never attaches."
+  sources:
+    - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0040/section_0750/0610-0030-0040-0750.html  # MCA 61-3-475(1)(e)(iv)(C) and (2): the sponsor's non-infringement proof and the defend-and-hold-harmless agreement — Montana's own statement that specialty graphics are third-party property"
+    - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0030/section_0320/0610-0030-0030-0320.html  # MCA 61-3-332 — the design spec itself, an edict of government and public domain"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: Montana is NOT MENTIONED — a measured absence, recorded as unresearched rather than favourable"
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # LOCATOR ONLY: no Montana state PD template exists among those listed"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Montana is the group's counter-example on the
+# replacement cycle: it legislated FIVE years, BELOW AAMVA's 7-10 band.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is paywalled and UNPINNED and is never quoted here. MONTANA DOES NOT NEED IT: MCA 61-3-332(4)(b)-(d) states both plate sizes in inches, in law."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spacing at least 0.25 in, stroke 0.2-0.4 in, 1.25 in clear of top and bottom. Montana legislates the RELATIVE rule instead: MCA 61-3-332(5), 'The dimensions of the numerals and letters must be determined by the department, and all county and registration numbers must be of equal height.'"
+    replacement_cycle: >-
+      AAMVA §1.1 recommends a cycle "not to exceed 7 to 10 years". MONTANA
+      LEGISLATED FIVE — below the bottom of the recommended band — and ten for
+      combat-disabled veterans. Set against Florida's legislated ten (the top
+      of the band) and Washington's no clock at all, the three states span the
+      entire space, which is the cleanest available proof that AAMVA's cycle
+      is recommendation and not requirement.
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" is COMMONLY REPEATED, UNSOURCED
+    (a `citation needed` since 2017, copied verbatim across articles). Montana
+    needs no part of it: MCA 61-3-332(4)(b) states 6 x 12 inches in law, and
+    (4)(c) states 4 x 7 inches for motorcycles and quadricycles.
+
+# ---------------------------------------------------------------------------
+# Display and issuance.
+# ---------------------------------------------------------------------------
+display_rules:
+  issuance: "MCA 61-3-331: 'The county treasurer or an authorized agent shall, at the time of issuing a registration receipt under 61-3-322, assign the motor vehicle, trailer, semitrailer, or pole trailer a distinctive license plate number and ... deliver to the applicant ... a set of two license plates or one license plate, each of which must bear the assigned distinctive number.' NOTE THE STRUCTURE: in Montana the COUNTY TREASURER assigns the number, not the state — which is why the county code is in the serial rather than on a sticker."
+  decal_placement: "MCA 61-3-332(2)(a): 'In years when standard license plates are not reissued for a vehicle, the department shall provide a registration decal that must be affixed to the rear license plate of the vehicle.' The decal is REAR-ONLY, which is a real asymmetry between the two plates of a Montana pair."
+  permanent_registration_marking: "MCA 61-3-332(2)(c): for a travel trailer, motorcycle, quadricycle, trailer, semitrailer or pole trailer permanently registered under 61-3-313(2), 'the department may use the word or an abbreviation for the word \"permanent\" on the plate in lieu of issuing a registration decal' — a legend that encodes registration status rather than identity."
+  mounting_gap: "NO MONTANA MOUNTING-POSITION STATUTE WAS LOCATED IN THIS PASS. MCA 61-3-331 and 61-3-332 govern assignment and design; the display-position rule (height, angle, obstruction) was not found in Part 3 and is a recorded gap."
+  sources:
+    - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0030/section_0310/0610-0030-0030-0310.html  # MCA 61-3-331: county-treasurer assignment, two plates or one, each bearing the assigned distinctive number"
+    - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0030/section_0320/0610-0030-0030-0320.html  # MCA 61-3-332(2): the rear-only registration decal, the permanent-registration decal, and the 'permanent' legend option"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES. County-number-prefixed, statute-specified.
+  # =========================================================================
+  - id: us-mt-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1989 }
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "99-9999L"
+      regex: '\A\d{1,2}[- ]?\d{4,5}[A-Z]\z'
+      regex_strict: '\A(?:[1-9]|[1-4]\d|5[0-6])[- ]?\d{4,5}[A-Z]\z'
+      regex_statutory: '\A\d{1,2}[- ]?[A-Z0-9]{1,6}\z'
+      charset:
+        notes: >-
+          MCA 61-3-332(5), verbatim: "The distinctive registration numbers for
+          standard license plates must begin with a number one or with a
+          letter-number combination, such as 'A 1' or 'AA 1', or any other
+          similar combination of letters and numbers. Except for special
+          license plates, collegiate license plates, generic specialty license
+          plates, fleet license plates, and standard license plates that are 4
+          inches wide and 7 inches in length, the distinctive registration
+          number or letter-number combination assigned to the motor vehicle
+          must appear on the plate preceded by the number of the county and
+          appearing in horizontal order on the same horizontal baseline. The
+          county number must be separated from the distinctive registration
+          number by a separation mark unless a letter-number combination is
+          used." So Montana law fixes THREE things — the county number goes
+          first, a separation mark divides it from the serial, and everything
+          is on one baseline at equal height — and delegates the serial's own
+          shape to the department. No letter exclusions are stated anywhere in
+          MCA 61-3-332.
+        letter_exclusions: "NONE STATED IN LAW. No excluded-letter list appears in MCA 61-3-332; none is invented here."
+      separator_note: >-
+        MCA 61-3-332(5) requires "a separation mark" and DOES NOT NAME A
+        GLYPH. That is a genuine gap in the authority's own text, and
+        PRD-PLATES §2.8 sanctions exactly this case: the separator position is
+        spelled as the separator-only class `[- ]`, never as a bare literal,
+        so a consumer deriving a separator-free twin can detect the position
+        mechanically. `pattern` shows the canonical printed form with a
+        hyphen. SEPARATELY AND IMPORTANTLY: the current base is reported to
+        print a BUFFALO SKULL device in the separator position. A skull is not
+        punctuation. Per plates/_meta/separators.yml's never_separator note, a
+        device between serial groups is a DESIGN ELEMENT carried in
+        design.emblem and is never deleted or matched as a separator.
+      tier_note: >-
+        `regex_strict` bounds the leading group to the 56 county numbers MCA
+        61-3-332(7) actually assigns — the authority's own alphabet for that
+        position, which is what PRD-PLATES §2.7 reserves the strict twin for.
+        `regex` is the current issued arrangement (county number, separation
+        mark, four or five numerals, one trailing letter). `regex_statutory`
+        is the outer statutory bound: a county number, a separation mark, and
+        a department-determined combination of letters and numbers. Tier order
+        regex_strict subset-of regex subset-of regex_statutory holds by
+        construction.
+      progression: "MCA 61-3-332(6)(b) states the rule for EXEMPT plates explicitly — numbering 'must begin with number one and be numbered consecutively' within each county. For standard plates (5) states only that the number 'must begin with a number one or with a letter-number combination'; the department's actual progression was not sourced (recorded gap)."
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: >-
+        STATUTORY, NOT CONVENTIONAL. MCA 61-3-332(4)(b), verbatim: "Plates for
+        semitrailers, travel trailers, pole trailers, trailers with a declared
+        weight of 6,000 pounds or more, and motor vehicles, other than
+        motorcycles and quadricycles, must be 6 inches wide and 12 inches in
+        length." Note the axis wording reads oddly, exactly as Florida's does
+        — "6 inches wide and 12 inches in length" describes the conventional
+        12-across-by-6-tall American plate, and is recorded that way here.
+      material: "MCA 61-3-332(4)(a): 'All license plates must be metal and treated with a reflectorized background material according to specifications prescribed by the department.'"
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO COLOUR IS IN THE STATUTE. MCA 61-3-332(4)(a) mandates a
+        reflectorized background and names no hue. The current base is
+        reported as a white serial on reflective blue with a white
+        state-shaped border; that is LOCATOR-GRADE and no hex is invented
+        here. Contrast Wyoming, which legislates "a marked contrast" without a
+        value, and Florida, which legislates neither.
+      legend_top: "MONTANA"
+      legend_rule: "MCA 61-3-332(4)(a), verbatim: 'The word \"Montana\" must be placed on each license plate and, except for license plates that are 4 inches wide and 7 inches in length, the outline of the state of Montana must be used as a distinctive border on each standard license plate.'"
+      border:
+        shape: state-outline
+        rendered: placeholder
+        statutory: true
+        note: >-
+          THE MOST UNUSUAL SOURCED DESIGN FACT IN THE GROUP. Montana does not
+          merely permit a state-shaped motif; it REQUIRES the state outline as
+          the plate's BORDER, by statute, on every standard plate except the
+          4 x 7 inch sizes. This is a border constraint rather than a graphic
+          in a slot, and a render pipeline must model it as such: the outline
+          bounds the plate face, it does not sit inside it.
+      emblem: { present: true, rendered: placeholder, description: "buffalo skull device reported in the separator position on the current base — observed, not statutory, and NOT part of the serial" }
+      rear_differs: false
+      manufacture: "MCA 61-3-474(1)(b) has the department consult 'the department of corrections' on the most efficient plate-processing system — prison manufacture is contemplated in law for the generic specialty tier and by implication for the rest."
+    replacement_cycle:
+      years: 5
+      statutory_text: "MCA 61-3-332(3)(a)(ii)(A): 'Except as provided in subsection (3)(a)(ii)(B), license plates issued on or after January 1, 2010, must be replaced with new license plates if, upon renewal of registration under 61-3-312, the license plates are 5 or more years old or will become older than 5 years during the registration period. New license plates must be issued in accordance with the implementation schedule adopted by the department under 61-14-101.'"
+      veteran_exception: "MCA 61-3-332(3)(a)(ii)(B): 'License plates issued to a disabled veteran with a combat-related disability must be replaced with new license plates if, on renewal of registration under 61-3-312, the license plates are 10 or more years old or will become older than 10 years during the registration period.'"
+      number_retention: "MCA 61-3-332(3)(a)(iii): 'A vehicle owner may elect to keep the same license plate number from license plates issued before January 1, 2010, when replacement of those plates is required under this subsection.'"
+      exemptions: "MCA 61-3-332(3)(d): the replacement rule does NOT apply to a travel trailer, motorcycle, quadricycle, trailer, semitrailer or pole trailer at all. (3)(b): a vehicle registered for 13 to 24 months may display the design in effect at registration for the whole period. (3)(c): permanently registered light vehicles and motor homes may display the design in effect at registration for the whole permanent period — i.e. FOREVER."
+      note: >-
+        MONTANA LEGISLATED BELOW AAMVA'S FLOOR. AAMVA recommends a cycle not
+        exceeding 7 to 10 years; Montana chose 5. But read (3)(c) with it: a
+        permanently registered light vehicle keeps its design indefinitely, so
+        Montana simultaneously runs the group's shortest replacement clock and
+        an unbounded exemption from it. Any consumer inferring plate age from
+        the five-year rule will be wrong on every permanently registered
+        vehicle.
+    region_encoding:
+      mechanism: >-
+        THE COUNTY NUMBER IS THE FIRST GROUP OF THE SERIAL. MCA 61-3-332(5)
+        requires the distinctive registration number to "appear on the plate
+        preceded by the number of the county", separated by a separation mark.
+        The mapping is fixed in statute, not in a departmental list, and it
+        has not been renumbered since it was enacted — MCA 61-3-332(7) closes
+        with "Any new counties must be assigned numbers by the department as
+        they are formed, beginning with the number 57."
+      decode_evidence: statutory-verbatim
+      ordering_folklore: >-
+        COMMONLY REPEATED, NOT STATED IN LAW. The numbering is universally
+        explained as the counties' 1930 population rank (Silver Bow first,
+        Cascade second, Yellowstone third). MCA 61-3-332(7) states the
+        ASSIGNMENT and gives NO rationale, and its History line shows the
+        section originating in 1917 and being amended in 1933 — consistent
+        with the story but not evidence for it. Recorded as folklore pending a
+        Laws of Montana primary. THE STRUCTURAL POINT SURVIVES EITHER WAY: the
+        order is manifestly not alphabetical, so it encodes something
+        historical, and it is frozen — the ranking is roughly a century stale.
+      table:
+        1: Silver Bow
+        2: Cascade
+        3: Yellowstone
+        4: Missoula
+        5: Lewis and Clark
+        6: Gallatin
+        7: Flathead
+        8: Fergus
+        9: Powder River
+        10: Carbon
+        11: Phillips
+        12: Hill
+        13: Ravalli
+        14: Custer
+        15: Lake
+        16: Dawson
+        17: Roosevelt
+        18: Beaverhead
+        19: Chouteau
+        20: Valley
+        21: Toole
+        22: Big Horn
+        23: Musselshell
+        24: Blaine
+        25: Madison
+        26: Pondera
+        27: Richland
+        28: Powell
+        29: Rosebud
+        30: Deer Lodge
+        31: Teton
+        32: Stillwater
+        33: Treasure
+        34: Sheridan
+        35: Sanders
+        36: Judith Basin
+        37: Daniels
+        38: Glacier
+        39: Fallon
+        40: Sweet Grass
+        41: McCone
+        42: Carter
+        43: Broadwater
+        44: Wheatland
+        45: Prairie
+        46: Granite
+        47: Meagher
+        48: Liberty
+        49: Park
+        50: Garfield
+        51: Jefferson
+        52: Wibaux
+        53: Golden Valley
+        54: Mineral
+        55: Petroleum
+        56: Lincoln
+      table_note: "Quoted verbatim from MCA 61-3-332(7). 56 counties, numbers 1-56, no gaps, no reserved values. Kept inline rather than in plates/_decode/ because 56 rows is small enough to read in place and because the table's authority is the same statute as the rest of this series."
+      excluded_series: "MCA 61-3-332(5) exempts special, collegiate, generic specialty, fleet and 4 x 7 inch standard plates from the county-number rule; 61-3-332(8) confirms that for special plate series 'the county number must be replaced by a design that distinguishes each separate plate series'. So the ABSENCE of a county number on a Montana plate is itself information: it means the plate is not a full-size standard issue."
+    sources:
+      - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0030/section_0320/0610-0030-0030-0320.html  # MCA 61-3-332: (1) separate standard series and the dealer-distinguishability rule; (3)(a)(i) the 1989-or-later design floor; (3)(a)(ii) the 5-year and 10-year replacement clocks; (3)(a)(iii) number retention; (3)(b)-(d) the replacement exemptions; (4)(a) metal, reflectorized, the MONTANA wordmark and the state-outline border; (4)(b)-(d) the two statutory plate sizes; (5) the serial grammar, county-number prefix, separation mark and equal-height rule; (6) the exempt-plate markings; (7) the 56-row county table; (8) special series replace the county number with a distinguishing design"
+      - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0030/section_0310/0610-0030-0030-0310.html  # MCA 61-3-331: county-treasurer assignment of the distinctive number, and two plates or one"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1 — the 7-to-10-year recommendation Montana legislated BELOW"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Montana  # LOCATOR ONLY (PRD-PLATES §4): the reported current colourway, the buffalo-skull separator device, and the reported per-era serial arrangements. None is asserted as sourced here."
+    notes: >-
+      MONTANA STANDARD ISSUE. `period.start: 1989` IS A REAL STATUTORY CLAIM,
+      not an instrument-edition upper bound: MCA 61-3-332(3)(a)(i) provides
+      that new plates "must be a standard license plate design first issued in
+      1989 or later", so 1989 is the legislated floor of the currently
+      issuable standard design family. WHY THERE IS NO "ONE SERIES BACK" ENTRY
+      FOR MONTANA, and this is the file's most important structural finding:
+      Montana does not retire bases. Every standard design first issued from
+      1989 onward remains orderable in parallel, indefinitely, and 61-3-332(3)
+      extends the same rule to collegiate, generic specialty, commemorative
+      centennial and military/veteran plates. A "previous base" in the sense
+      the L2 brief means — a design that stopped — DOES NOT EXIST IN MONTANA
+      LAW. Recording that with the citation is more accurate than minting a
+      superseded series from a collector table, and it is a genuinely
+      different jurisdiction shape from Oregon (one frozen base) or Washington
+      (serial base changes with no legal marker). Distinct from
+      us-mt-motorcycle in carrying the county-number prefix, which the 4 x 7
+      inch sizes are statutorily exempt from.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES. Montana separately serializes these AND states the
+  # difference in law. Where the statute gives a bound but not a grammar, the
+  # series is `recall-only` and the regex is the STATUTORY bound — which is
+  # what recall-only means, not a hedge.
+  # =========================================================================
+  - id: us-mt-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1989 }
+    period_evidence: statutory-date
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9]+\z'
+      charset:
+        notes: >-
+          MCA 61-3-332(5) EXPRESSLY EXEMPTS 4 x 7 inch standard plates from
+          the county-number rule, so a Montana motorcycle plate carries NO
+          county prefix — the opposite of what a reader would infer from the
+          passenger plate, and the opposite of what secondary sources report.
+          MAJORITY IS NOT AUTHORITY (PRD-PLATES §5.3): the encyclopedia record
+          shows county-prefixed motorcycle serials, the statute exempts them,
+          and the statute governs. Beyond the exemption the statute states
+          only that a distinctive number "must begin with a number one or with
+          a letter-number combination", with NO WIDTH — hence the unbounded
+          quantifier, which makes no width claim at all.
+    design:
+      plate: { w: 7, h: 4, unit: in, w_mm: 177.8, h_mm: 101.6 }
+      plate_dimension_note: "STATUTORY. MCA 61-3-332(4)(c), verbatim: 'Plates for motorcycles and quadricycles must be 4 inches wide and 7 inches in length.'"
+      material: "MCA 61-3-332(4)(a): metal, reflectorized background per departmental specification"
+      background: { finish: retroreflective }
+      legend_top: "MONTANA"
+      legend_rule: "MCA 61-3-332(4)(a): the word 'Montana' is required on EVERY plate. The STATE-OUTLINE BORDER is NOT — it is expressly excepted for 4 x 7 inch plates. So Montana's smallest plates are the only standard plates without the outline."
+      border: { shape: none, statutory: true, note: "excepted by MCA 61-3-332(4)(a) for 4 x 7 inch plates" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: "none — statutorily exempted by MCA 61-3-332(5). The ABSENCE of a county number is the class signal."
+    sources:
+      - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0030/section_0320/0610-0030-0030-0320.html  # MCA 61-3-332(4)(a) the state-outline exception for 4 x 7 in plates; (4)(c) the 4 x 7 in motorcycle and quadricycle size; (5) the county-number exemption for 4 x 7 in standard plates; (3)(d) exemption from the 5-year replacement clock"
+    notes: >-
+      MOTORCYCLE (and QUADRICYCLE — Montana registers quadricycles as their
+      own vehicle kind throughout Title 61 and gives them the motorcycle
+      plate). `recall-only` is exact here rather than defensive: the regex is
+      the STATUTORY outer bound, because the statute states an alphabet and no
+      width, and a match therefore claims only that the string is a
+      well-formed Montana serial of unknown class. Distinct from
+      us-mt-standard in three sourced ways: size, no county prefix, no state
+      outline. Also exempt from the 5-year replacement clock by 61-3-332(3)(d).
+
+  - id: us-mt-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 1989 }
+    period_evidence: statutory-date
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9]+\z'
+      charset: { notes: "as for the standard series: MCA 61-3-332(5) states an alphabet and no width. Whether a given Montana trailer plate carries the county prefix depends on its SIZE, not its class — see design." }
+    design:
+      plate_size_rule: >-
+        MONTANA SIZES TRAILER PLATES BY DECLARED WEIGHT, WHICH IS UNUSUAL AND
+        HAS A DIRECT FORMAT CONSEQUENCE. MCA 61-3-332(4)(b): semitrailers,
+        travel trailers, pole trailers and trailers with a declared weight of
+        6,000 pounds or more get the 6 x 12 inch plate. (4)(d): 'The
+        department shall issue plates that are 4 inches wide and 7 inches in
+        length for trailers with a declared weight of less than 6,000 pounds
+        unless a person registering a trailer with a declared weight of less
+        than 6,000 pounds requests plates that are 6 inches wide and 12 inches
+        in length. A person registering a trailer shall pay all applicable
+        fees for the plates chosen.' Because 61-3-332(5) exempts 4 x 7 inch
+        plates from the county-number rule, A LIGHT MONTANA TRAILER'S PLATE
+        FORMAT DEPENDS ON A SIZE THE OWNER MAY ELECT AND PAY FOR. That is a
+        real modelling wrinkle: the same trailer can lawfully carry a
+        county-prefixed serial or an unprefixed one depending on which plate
+        its owner bought.
+      plate: { w: 12, h: 6, unit: in }
+      plate_variant: { w: 7, h: 4, unit: in, applies_to: "trailers with declared weight under 6,000 lb, unless the 6 x 12 in plate is requested and paid for" }
+      material: "MCA 61-3-332(4)(a): metal, reflectorized"
+      legend_top: "MONTANA"
+      border: { shape: state-outline, statutory: true, note: "required on the 6 x 12 in plate; excepted on the 4 x 7 in plate" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: "conditional — present on the 6 x 12 in plate, statutorily absent on the 4 x 7 in plate (MCA 61-3-332(5))"
+    sources:
+      - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0030/section_0320/0610-0030-0030-0320.html  # MCA 61-3-332(4)(b) and (4)(d): the 6,000 lb declared-weight size split and the owner's paid election; (5) the county-number exemption that rides on the size; (2)(c) the 'permanent' legend option; (3)(d) exemption from the 5-year clock"
+    notes: >-
+      TRAILER. Kept as its own series because Montana gives it a size rule, a
+      county-prefix consequence and a permanent-registration legend that the
+      passenger plate does not have. The declared-weight size split is the
+      single best example in this group of a US state making the PLATE FORMAT
+      depend on a vehicle attribute plus an owner election.
+
+  - id: us-mt-government-exempt
+    class: government
+    categories: [car, van, truck, bus, trailer]
+    period: { start: 1989 }
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "999"
+      regex: '\A\d+\z'
+      charset:
+        notes: >-
+          MCA 61-3-332(6)(b), verbatim: 'Distinctive registration numbers for
+          plates assigned to motor vehicles, trailers, semitrailers, or pole
+          trailers of each of the counties in the state and those of the
+          municipalities and special districts that obtain plates within each
+          county must begin with number one and be numbered consecutively.' A
+          purely numeric series with a stated origin and NO STATED WIDTH —
+          hence the unbounded quantifier, which makes no width claim.
+      progression: "strictly sequential from 1, restarting within each county"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      material: "MCA 61-3-332(4)(a): metal, reflectorized"
+      legend_top: "MONTANA"
+      legend_marking: >-
+        TWO DIFFERENT MARKINGS FOR TWO DIFFERENT OWNERS, both statutory.
+        MCA 61-3-332(6)(a) for STATE-owned vehicles: 'the department may
+        designate the prefix number for the various state departments. All
+        numbered plates issued to state departments must bear the words "State
+        Owned", and a year number may not be indicated on the plates because
+        these numbered plates are of a permanent nature'. MCA 61-3-332(6)(b)
+        for COUNTY, MUNICIPAL and SPECIAL-DISTRICT vehicles (and for civil air
+        patrol vehicles on loan from the United States or the state): 'there
+        must be placed on the standard license plates assigned, in a position
+        that the department may designate, the letter "X" or the word
+        "EXEMPT"'.
+      border: { shape: state-outline, statutory: true }
+      emblem: { present: true, rendered: placeholder }
+      no_year: "MCA 61-3-332(6)(a) and (6)(b) both provide that a year number may not be displayed, because the plates are permanent and are replaced only when their physical condition requires it."
+    region_encoding: >-
+      A DIFFERENT MECHANISM FROM THE STANDARD SERIES, AND THE DISTINCTION
+      MATTERS. State-department plates carry a DEPARTMENT prefix number the
+      department designates (61-3-332(6)(a)) — an agency code, not a county
+      code. County/municipal/special-district plates are numbered
+      consecutively from 1 WITHIN EACH COUNTY (61-3-332(6)(b)) — so the county
+      is implied by the issuing county's sequence rather than encoded in the
+      serial. Neither is the 61-3-332(7) county-number prefix.
+    sources:
+      - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0030/section_0320/0610-0030-0030-0320.html  # MCA 61-3-332(6)(a): the 'State Owned' legend, department prefix numbers, permanent nature and no year number; (6)(b): the 'X' or 'EXEMPT' marking, the per-county consecutive numbering from one, the civil air patrol case, and permanence"
+    notes: >-
+      GOVERNMENT / EXEMPT. Among the best-specified government plate rules
+      found in any US state at this gate: Montana legislates the legend, the
+      numbering origin, the numbering scope (per county), the prohibition on a
+      year number, and the replacement trigger (physical condition only).
+      Distinct from us-mt-standard in format, legend, region encoding and
+      replacement rule — four independent grounds under PRD-PLATES §2.3.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-mt-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 1989 }
+    period_evidence: statutory-date
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          MCA 61-3-474(1)(c) requires the department to 'use a numbering
+          system for generic specialty license plates that is distinctive from
+          the numbering system required under 61-3-332 or used for collegiate
+          license plates', and 61-3-332(8) requires that in each special
+          series 'the county number must be replaced by a design that
+          distinguishes each separate plate series'. So Montana specialty
+          serials are BY STATUTE unlike standard serials and unlike each
+          other. No per-programme grammar was sourced (individual specialty
+          specs are L4), so the index carries a deliberately wide union and is
+          `recall-only`.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      design_authority: "MCA 61-3-474(1)(a): 'The department shall ... design the background and general format of generic specialty license plates, including ensuring the readability of a generic specialty license plate design.' The SPONSOR supplies the name, phrase and graphic; the DEPARTMENT owns the background and format."
+      approval_rule: "MCA 61-3-474(2): 'All sponsor names, identifying phrases, and graphics intended for use on generic specialty license plates must be approved by the department prior to the manufacture of the plates.'"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      tiers: ["special license plates (legislatively approved, each its own numbered series)", "collegiate license plates (MCA 61-3-461 to 61-3-468)", "generic specialty license plates (the Montana Generic Specialty License Plate Act, MCA 61-3-472 to 61-3-481)", "fleet license plates (MCA 61-3-711 to 61-3-733)"]
+      count_official: unstated-and-request-only
+      count_official_note: >-
+        MONTANA PUBLISHES NO COUNT AND, BY STATUTE, PUBLISHES NO LIST EITHER —
+        it publishes a list ON REQUEST. MCA 61-3-474(4), verbatim: 'The
+        department shall maintain a list of the sponsors that have been
+        approved to promote the sale and issuance of generic specialty license
+        plates, the initial distribution date for sale of each sponsored
+        generic specialty license plate, and the donation fee established by
+        the sponsor for each sponsored generic specialty license plate. The
+        department shall, upon request, make copies of this list available to
+        interested members of the public.' That is a public-records duty, not
+        a publication duty. A count therefore requires a records request, and
+        the ONE INTERESTING CONSEQUENCE is that the statutory list carries the
+        INITIAL DISTRIBUTION DATE per programme — i.e. Montana's own list
+        would supply per-programme period data that no enthusiast source has.
+        Flagged as the highest-value follow-up in this file.
+      churn_rule: >-
+        MCA 61-3-474(5) obliges the department to REVOKE a sponsorship if
+        fewer than 400 sets have been sold or renewed within 3 years of
+        initial distribution, or if at any time after 3 years fewer than 400
+        sets carry a current registration, or if the sponsor stops qualifying.
+        61-3-474(6): on revocation, issuance and sale terminate, existing
+        holders may run their plates until the NEXT RENEWAL, and the
+        department may not issue replacements or duplicates. So Montana's
+        catalogue self-prunes at a numeric threshold — the exact figure
+        Florida's equivalent duty left unextracted in the L0 pass is HERE,
+        and it is 400.
+      sponsor_gates: >-
+        MCA 61-3-475(1): a sponsor must be a 501(c)(3) that has held the
+        status at least a year; its primary purpose must be community service
+        through programmes promoting public health, education or general
+        welfare (military veterans' organisations excepted); it must be a
+        Montana entity with a Montana address, a Montana bank account and a
+        listed Montana telephone number; and at least 75% of donation fees
+        must be spent in Montana. (4): an organisation may sponsor only ONE
+        design at a time, and may apply for a new one only after four years,
+        at which point the old design is discontinued from the initial
+        distribution date of the new one.
+      content_rules: "MCA 61-3-475(1)(e)(iv): the name, phrase or graphic must not invoke 'connotations offensive to good taste and decency', must not 'promote, advertise, or endorse a product, brand, or service provided for sale', must not infringe third-party rights (see artwork_risk), and must not obscure the plate letters or numbers."
+      generic_specialty_act_url: "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0040/section_0720/0610-0030-0040-0720.html"
+      collegiate_note: >-
+        MCA 61-3-461 through 61-3-468 are the collegiate plate sections. They
+        were CROSS-REFERENCED FROM 61-3-332 BUT NOT READ in this pass, so no
+        URL is pinned for them — the mca.legmt.gov section path is derivable
+        (61-3-4NN maps to part_0040/section_0<NN>0) but a derived URL is not a
+        fetched one and is not recorded as a source. Recorded gap.
+      repealed_section_note: >-
+        MCA 61-3-473 was fetched and returns "Repealed. Sec. 32, Ch. 395, L.
+        2025." The Generic Specialty License Plate Act was amended in the 2025
+        session; anyone re-reading 61-3-472 through 61-3-481 should expect
+        further 2025 movement and should not assume a stale secondary
+        description of the programme still holds.
+    region_encoding: "none — MCA 61-3-332(8) replaces the county number with a series-distinguishing design"
+    sources:
+      - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0040/section_0740/0610-0030-0040-0740.html  # MCA 61-3-474: (1)(a) departmental design of background and general format; (1)(b) corrections-department consultation on manufacture; (1)(c) the distinctive numbering requirement; (2) prior approval of names, phrases and graphics; (4) the request-only sponsor list with initial distribution dates and donation fees; (5) the 400-set revocation thresholds; (6) the run-until-renewal grace and the replacement bar"
+      - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0040/section_0750/0610-0030-0040-0750.html  # MCA 61-3-475: sponsor qualification gates, the content rules including the non-infringement requirement, the hold-harmless agreement, and the one-design-per-sponsor / four-year rule"
+      - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0040/section_0720/0610-0030-0040-0720.html  # MCA 61-3-472: 'Sections 61-3-472 through 61-3-481 may be cited as the \"Montana Generic Specialty License Plate Act\"'"
+      - "https://mca.legmt.gov/bills/mca/title_0610/chapter_0030/part_0030/section_0320/0610-0030-0030-0320.html  # MCA 61-3-332(8): each special plate series is separately numbered and the county number is replaced by a series-distinguishing design"
+    notes: >-
+      THE MONTANA SPECIALTY INDEX — one entry standing for four statutory
+      tiers, which is what PRD-PLATES §2.5 asks for at this gate. Three things
+      worth carrying forward. First, the count is not merely unpublished; MCA
+      61-3-474(4) makes the list a RECORDS-REQUEST artefact by design, so the
+      honest index value is "unstated and request-only" with the statute
+      quoted. Second, that same statutory list carries INITIAL DISTRIBUTION
+      DATES per programme — Montana would hand over per-programme period data
+      on request, which no competitor has and which is worth a records
+      request before L4. Third, the churn threshold is a hard number, 400
+      sets, with a stated grace period, so this index is a moving target in a
+      precisely specified way.
+
+# ---------------------------------------------------------------------------
+# Classes Montana separately serializes but which are NOT given series here.
+# ---------------------------------------------------------------------------
+unspecified_classes:
+  dealer:
+    statutory_hook: "MCA 61-3-332(1): 'Standard license plates issued to licensed vehicle dealers must be readily distinguishable from license plates issued to vehicles owned by other persons.' The duty and the distinguishability requirement are sourced."
+    gap: "the department's actual dealer marking and serial grammar were not located (MVD estate 403-blocked)"
+  temporary:
+    statutory_hook: "MCA 61-3-479 is cross-referenced from 61-3-332(2)(a) as an exception to the standard-plate rule; the section itself was not read."
+    gap: "not obtained"
+  personalized:
+    statutory_hook: "Montana runs personalized plates through the MVD; no MCA section was read for them in this pass."
+    gap: "character cap, alphabet and content-refusal criteria all unobtained"
+  disability:
+    statutory_hook: "MCA 61-3-332(9): a resident eligible for a disability parking permit under 49-4-301 may, and a low-speed-restricted licensee operating a low-speed electric vehicle or golf cart under 61-5-122 must, be issued 'a disability license plate with a design or decal bearing a representation of a wheelchair'. Note 61-3-332(3)(a)(i) treats wheelchair-design plates as STANDARD plates for the design-vintage rule."
+    gap: "no serial grammar; also note _meta/classes.yml carries no `disability` value, so a vocabulary PR would be needed before this could become a series"
+
+# ---------------------------------------------------------------------------
+# Dead ends and open items.
+# ---------------------------------------------------------------------------
+research_notes:
+  reachability:
+    - "leg.mt.gov/bills/mca/... 301-redirects twice, to archive.legmt.gov and then to mca.legmt.gov. Pin the FINAL host: mca.legmt.gov. The pages carry a heavy anti-bot JavaScript preamble that must be stripped before parsing, but the statutory text is fully present in the HTML."
+    - "mvdmt.gov and dojmt.gov: HTTP 403 to every request from this environment, including with a browser user agent. No Wayback capture exists for mvdmt.gov at all. Montana's AGENCY estate is therefore entirely unread in this pass — which is survivable only because MCA 61-3-332 carries so much of the spec."
+    - "plates.mt.gov, app.mt.gov/plates, svc.mt.gov/dojmvd/platesearch: all dead (connection failure or 404)."
+  open_items:
+    - "MCA 61-3-474(4) records request for the generic specialty sponsor list — it carries per-programme INITIAL DISTRIBUTION DATES and donation fees. Highest-value follow-up in this file."
+    - "No Montana plate DISPLAY-POSITION statute was located; Part 3 covers assignment and design only."
+    - "The current base's colourway and the buffalo-skull separator device are locator-grade; an MVD instrument would upgrade them."
+    - "MCA 61-3-332(7)'s numbering rationale (the 1930-population story) needs a Laws of Montana primary before it can be stated as anything but folklore."

--- a/plates/us-or.yml
+++ b/plates/us-or.yml
@@ -1,0 +1,392 @@
+# plates/us-or.yml — Oregon (PRD-PLATES gate L2, northwest group).
+#
+# THE ONE FACT THAT MAKES OREGON WORTH READING CAREFULLY. ORS 803.535 does not
+# describe the plate. It POINTS AT A DESIGN CONTEST: "The design of the
+# registration plates shall be that chosen by the commission from entries in
+# the contest held pursuant to chapter 572, Oregon Laws 1987." That is a
+# statutory instrument with a date, and it is the only era anchor in this
+# entire group that comes from the design provision itself rather than from a
+# collector table. Every other American state surveyed either fixes the design
+# in the statute (Montana, Wyoming, Florida) or delegates it wholesale to the
+# agency (Washington). Oregon does neither: it delegates the design to a
+# one-off 1987 public competition and then FREEZES THE RESULT IN LAW. The
+# Douglas-fir-and-mountains plate on the road today is, legally, the winning
+# entry of that contest, and it cannot change without amending ORS 803.535.
+#
+# CONSEQUENCE FOR PERIOD MODELLING: 1987 is a real, instrument-anchored LOWER
+# bound on the current base — plates cannot predate the contest that chose
+# them. The commonly repeated November 1989 first-issue date is
+# encyclopedia-grade and is recorded as such, never asserted. This is exactly
+# the discipline PRD-PLATES §9 asks for: primary-source-or-marked.
+#
+# SOURCE-ACCESS NOTE, RECORDED HONESTLY. www.oregonlegislature.gov refused TLS
+# from this environment on every attempt (curl exit 35, WebFetch ECONNRESET).
+# The ORS text below was therefore read from oregon.public.law, a third-party
+# reproduction. Oregon statutes are EDICTS OF GOVERNMENT and public domain at
+# every level (PRD-PLATES §4), so the reproduction carries the same text with
+# the same PD status — but the OFFICIAL citation is given first in every
+# source line, and re-verification against oregonlegislature.gov is an open
+# item for the verifier.
+jurisdiction: us-or
+authority:
+  name: Oregon Driver and Motor Vehicle Services (Oregon DMV), Oregon Department of Transportation
+  url: "https://www.oregon.gov/odot/DMV/pages/vehicle/plates.aspx"
+binding: vehicle
+statute_edition: >-
+  Oregon Revised Statutes, Chapter 803 (Vehicle Title and Registration), read
+  2026-08-02 via oregon.public.law because oregonlegislature.gov was
+  TLS-unreachable from this environment. Sections read: 803.525, 803.535,
+  803.540.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4/§7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: asserted-trademark-copyright-unresearched
+  basis: >-
+    OREGON IS NOT ON EITHER SIDE OF THE SURVEYED LEDGER, AND SAYING SO IS THE
+    HONEST ANSWER. Oregon appears NOWHERE in the standing per-state copyright
+    survey PRD-PLATES §4 works from — it is neither in the favourable column
+    (FL, CA, NC, NJ, MA, GA) nor in the adverse column (NY, AZ, PA, WA) — and
+    no {{PD-ORGov}} tag exists on Wikimedia Commons. So the DEFAULT applies:
+    a US state's works are copyrighted unless that state says otherwise
+    (17 U.S.C. §105 covers federal works only and does not extend to states).
+    What Oregon DOES say, in its own portal terms and conditions, is a
+    TRADEMARK assertion with a permission condition attached: "You may display
+    these Oregon-owned trademarks so long as the context of your use is
+    truthful and not misleading about the either services provided under that
+    trademark or the trademark's ownership." The same page runs a DMCA
+    takedown channel (egov.copyright@das.oregon.gov), which presupposes that
+    the state expects copyright claims to be actionable on its estate. Neither
+    statement is about PLATE ARTWORK specifically, and no Oregon case,
+    statute or agency policy addressing plate design ownership was located.
+    Recorded as ASSERTED ON TRADEMARK, COPYRIGHT UNRESEARCHED — not as
+    adverse, which would overclaim, and not as unresearched, which would
+    ignore the fetched assertion.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to the Douglas fir, the
+    mountain silhouette and every special-background graphic. Note the
+    additional Oregon-specific hazard: ORS 803.535 makes the design the
+    winning entry of a 1987 PUBLIC CONTEST, which means an identifiable
+    PRIVATE AUTHOR drew it. Whether the contest terms assigned copyright to
+    the state is unknown and unresearched, and it is a real question rather
+    than a theoretical one. Render placeholder.
+  photograph_caution: >-
+    Standard: a CC BY-SA tag on a Commons photograph of an Oregon plate is the
+    photographer's licence on the photograph, not a licence on the design. Our
+    renders are generated from spec, so the obligation never attaches.
+  sources:
+    - "https://www.oregon.gov/pages/terms-and-conditions.aspx  # State of Oregon terms: the Oregon-owned-trademark display condition, quoted above, and the DMCA notice channel"
+    - "https://www.oregonlegislature.gov/bills_laws/ors/ors803.html  # ORS 803.535 — the design provision itself, an edict of government and public domain; read via oregon.public.law (official host TLS-unreachable)"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: Oregon is NOT MENTIONED — a measured absence, which is why the posture is not 'favourable'"
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # LOCATOR ONLY: no Oregon state PD template exists among those listed"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Voluntary; no federal mandate; J686 never quoted.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is paywalled and UNPINNED. No J686 dimension is quoted here. Oregon law states no dimension either — ORS 803.535 leaves 'size, form and arrangement' to the department."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spacing at least 0.25 in, stroke weight 0.2-0.4 in, 1.25 in clear of top and bottom"
+    retroreflectivity: "AAMVA §3.3: readable in daylight and at night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3. Oregon legislates the REQUIREMENT ('a fully reflectorized safety plate') without the metric."
+    replacement_cycle: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. No Oregon replacement clock was located in ORS 803 (recorded gap)."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: "The 1956 AMA standardization story is COMMONLY REPEATED, UNSOURCED (a `citation needed` since 2017, copied across articles). Oregon states no dimension in law, so nothing here depends on it."
+
+# ---------------------------------------------------------------------------
+# Display rules.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates. ORS 803.525: 'The Department of Transportation shall issue two registration plates for every vehicle that is registered by the department except as otherwise provided in this section or ORS 803.530.'"
+  one_plate_vehicles: "ORS 803.525: 'Only one registration plate shall be issued' for a moped, motorcycle, trailer, antique vehicle or vehicle of special interest. A camper also receives one plate, and 'Stickers may be issued in lieu of a plate' for a camper."
+  mounting: "ORS 803.540: plates 'must be displayed on the front and rear of the vehicle if two plates are required'; on the rear only if one is required; and 'The plates must be in plain view and so as to be read easily by the public.' Oregon DMV's own plate page states the placement more concretely: 'One plate is for the foremost point of the front of the vehicle and the other is for the rearmost point of the back of the vehicle.'"
+  frames_and_alteration: "Oregon DMV, in its own words: you cannot 'Alter your plates' or 'Have a frame that covers the numbers, letters, or tags/stickers.'"
+  penalty: "ORS 803.540: violation is a CLASS D TRAFFIC VIOLATION — the lowest tier, and worth recording because the equivalent Florida offence is a nonmoving infraction and the Washington one carries a $500 transfer penalty. US display penalties are not comparable across states."
+  exceptions: "ORS 803.540 exempts operators running on temporary permits, dealer permits, or proportionally registered commercial vehicles operating in compliance with those authorisations."
+  sources:
+    - "https://www.oregonlegislature.gov/bills_laws/ors/ors803.html  # ORS 803.525 two-plate default and the one-plate list; ORS 803.540 display, plain view, Class D traffic violation, permit exceptions. Read via oregon.public.law (official host TLS-unreachable)."
+    - "https://www.oregon.gov/odot/DMV/pages/vehicle/plates.aspx  # Oregon DMV: the foremost-point/rearmost-point placement wording and the alteration/frame prohibitions"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD-ISSUE SERIES — numeral-leading arrangement on the
+  # statutory 1987-contest base.
+  # =========================================================================
+  - id: us-or-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3}[- ]?[A-Z]{3}\z'
+      charset:
+        notes: >-
+          NO CHARSET RULE IN THE STATUTE. ORS 803.535 requires only that "All
+          plates shall contain the distinctive number or characters assigned
+          to the vehicle and the word 'Oregon.'" No alphabet, no exclusions,
+          no length. The reported exclusions — the A block skipped since the
+          1950s to avoid collision with the optional Oregon Trail plates, and
+          the I and O blocks skipped since 2004 for confusion with the
+          numerals 1 and 0 — are LOCATOR-GRADE and are deliberately NOT
+          encoded as a `regex_strict`, which PRD-PLATES §2.7 reserves for the
+          authority's own alphabet.
+      pattern_note: >-
+        The group boundary is written as the separator-only class `[- ]`,
+        sanctioned by PRD-PLATES §2.8, because Oregon prints a GAP (not a
+        glyph) and no authority text names a separator character; `pattern`
+        shows the canonical printed form with a space. There is no
+        `regex_statutory`: ORS 803.535 states no outer bound to encode, which
+        is itself the finding.
+      progression: >-
+        LOCATOR-GRADE, NOT ASSERTED: the encyclopedia record reports the
+        numeral-leading block running from 001 BAA and reaching the R block by
+        mid-2026. No ODOT publication of serial ranges was located.
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      dimension_note: "NOT STATUTORY. ORS 803.535: 'Registration plates shall be in the size, form and arrangement and made of materials determined by the department.' 12 x 6 in is the North American convention as observed; the AAMVA chain delegates the dimension to the unpinned SAE J686."
+      material_rule: "ORS 803.535, verbatim: 'All plates shall be made with a reflective material, so as to be a fully reflectorized safety plate.'"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground_note: >-
+        DARK BLUE CHARACTERS, HEX UNMEASURED AND NOT INVENTED. ORS 803.535
+        states no colour at all. Rather than fabricate a hex from a JPEG the
+        colour is named with `hex_basis: unmeasured`.
+      legend_top: "Oregon"
+      legend_rule: "ORS 803.535, verbatim: 'All plates shall contain the distinctive number or characters assigned to the vehicle and the word \"Oregon.\"' That is the whole legend rule — Oregon mandates the state name and nothing else, no slogan, no county."
+      graphic: { present: true, rendered: placeholder, description: "Douglas fir at left against a mountain silhouette and sky — the winning entry of the ORS 803.535 design contest. Observed from ODOT plate imagery; the statutory text describes NO graphic, only that the design is the contest winner." }
+      emblem: { present: true, rendered: placeholder }
+      design_origin:
+        statutory_text: "ORS 803.535, verbatim: 'The design of the registration plates shall be that chosen by the commission from entries in the contest held pursuant to chapter 572, Oregon Laws 1987.'"
+        note: >-
+          THE MOST UNUSUAL DESIGN PROVISION IN THE GROUP. Oregon does not
+          describe its plate in law and does not delegate the design to the
+          department either: it incorporates by reference the winner of a
+          1987 public competition. Three consequences a dataset should carry.
+          (1) The base cannot legally change without amending ORS 803.535 —
+          which is why Oregon's plate has looked the same for a generation
+          while neighbours redesigned. (2) 1987 is an instrument-anchored
+          LOWER bound on first issue. (3) There is an identifiable private
+          author, which is an artwork_risk input, not a curiosity.
+      paired_plate_rule: "ORS 803.535: 'When a pair of registration plates is issued, each plate shall bear the same identification as the other plate of the pair.' Front and rear are identical — `rear_differs: false` is sourced here, not assumed."
+      identification_rule: "ORS 803.535: 'Means shall be provided for identifying the vehicle from the front and rear by means of characters or numerals.'"
+      rear_differs: false
+    region_encoding: "none. Oregon plates carry no county or district code and no geographic marker; the only geography on the plate is the depicted landscape, which encodes nothing."
+    sources:
+      - "https://www.oregonlegislature.gov/bills_laws/ors/ors803.html  # ORS 803.535: the 1987 contest design provision, the fully-reflectorized-safety-plate requirement, the 'distinctive number or characters ... and the word Oregon' legend rule, the size/form/arrangement delegation, and the identical-pair rule. Read via oregon.public.law (official host TLS-unreachable)."
+      - "https://www.oregon.gov/odot/DMV/pages/vehicle/plates.aspx  # Oregon DMV's own plate estate: plate-option structure, the special-background fee chart pointer, and the plate imagery the observed colours are taken from"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §2.2/§3.3 layout and retroreflectivity, adopted voluntarily; Oregon legislates the requirement without the metric"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Oregon  # LOCATOR ONLY (PRD-PLATES §4): the reported February 2004 arrangement change, the reported serial ranges, and the reported A/I/O block exclusions. None is asserted as sourced here."
+    notes: >-
+      OREGON STANDARD ISSUE, NUMERAL-LEADING. THE ID IS DELIBERATELY UNDATED
+      for the us-fl-standard reason: `start: 2026` is the year the ORS was
+      read and is an UPPER BOUND on the true start. The reported changeover to
+      the numeral-leading arrangement in February 2004 is encyclopedia-grade
+      and is NOT minted into the id. THE POINT TO CARRY: in Oregon the BASE
+      DESIGN and the SERIAL ARRANGEMENT have different lifetimes — the design
+      is frozen by ORS 803.535 since the 1987 contest, while the arrangement
+      flipped from letters-first to numerals-first when the letter blocks ran
+      out. A schema that treats "base" and "format" as one thing cannot model
+      Oregon. Distinct from us-or-standard-letters-first in that this series
+      is open and numeral-leading.
+
+  # =========================================================================
+  # ONE SERIES BACK — same statutory base, opposite arrangement.
+  # =========================================================================
+  - id: us-or-standard-letters-first
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1987, end: 2004 }
+    period_evidence: statutory-instrument-date-start-locator-end
+    period_caveat: >-
+      MIXED EVIDENCE, AND THE HALVES ARE NOT EQUAL. The START (1987) is
+      instrument-anchored: ORS 803.535 makes the design the winner of the
+      contest held pursuant to chapter 572, Oregon Laws 1987, so no plate on
+      this base can predate 1987. It is a LOWER bound on first issue, and the
+      commonly repeated November 1989 first-issue date is encyclopedia-grade
+      and is NOT asserted. The END (2004) is locator-only and NOT a sourced
+      claim; no ODOT instrument stating the arrangement changeover was
+      located. A verifier should pin the changeover to an ODOT publication or
+      downgrade the end to `ended: true` with no year.
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3}[- ]?\d{3}\z'
+      charset: { notes: "as for us-or-standard: ORS 803.535 states no alphabet. The reported A-block skip dates from the 1950s and is locator-grade." }
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      material_rule: "ORS 803.535: 'a fully reflectorized safety plate'"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground_note: "dark blue characters; hex unmeasured, not invented"
+      legend_top: "Oregon"
+      graphic: { present: true, rendered: placeholder, description: "the same ORS 803.535 contest-winning Douglas fir and mountain design — this series differs from the current one in ARRANGEMENT, not in base" }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://www.oregonlegislature.gov/bills_laws/ors/ors803.html  # ORS 803.535 — the same design provision governs this series; the base did not change, only the serial arrangement"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Oregon  # LOCATOR ONLY: the letters-first arrangement and the reported February 2004 end. The end year is not asserted as sourced."
+    notes: >-
+      THE PREVIOUS OREGON ARRANGEMENT, ON THE SAME STATUTORY BASE. Modelled as
+      its own series because PRD-PLATES §2.3's test is format OR design OR
+      period, and the FORMAT differs. A parser needs both: an Oregon plate of
+      unknown vintage on the fir base is either LLL 999 or 999 LLL. Distinct
+      from us-or-standard in that this series is closed and letter-leading
+      while the current one is open and numeral-leading; the DESIGN is
+      identical and that is the interesting part.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES. Oregon separately serializes these — ORS 803.525
+  # sources the PLATE COUNT for each, which is a real primary claim, while the
+  # serial grammars are locator-grade, hence `recall-only` with widened
+  # regexes per PRD-PLATES §2.7.
+  # =========================================================================
+  - id: us-or-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "L999999"
+      regex: '\A[A-Z]\d{4,6}\z'
+      charset:
+        notes: >-
+          ORS 803.525 sources only that a trailer receives ONE plate. The
+          letter-then-numerals shape (reported as a U prefix) is
+          encyclopedia-grade; the numeral count is widened so that a match
+          claims a SHAPE and not a grammar.
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      material_rule: "ORS 803.535 applies to all plates: 'a fully reflectorized safety plate'"
+      background: { finish: retroreflective }
+      graphic: { present: true, rendered: placeholder, description: "reported to carry the same fir base as the passenger plate" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.oregonlegislature.gov/bills_laws/ors/ors803.html  # ORS 803.525: 'Only one registration plate shall be issued' for a trailer; ORS 803.535: the reflectorization and 'word Oregon' rules apply to all plates"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Oregon  # LOCATOR ONLY: the reported U-prefixed trailer serial shape"
+    notes: >-
+      TRAILER. `recall-only` is the honest description, not a hedge: the plate
+      COUNT is statutory, the serial shape is not. Oregon groups trailers with
+      mopeds, motorcycles, campers, antiques and special-interest vehicles in
+      one statutory one-plate list, which is a cleaner rule than most states
+      manage.
+
+  - id: us-or-government-exempt
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "L999999"
+      regex: '\A[A-Z]\d{4,6}\z'
+      charset: { notes: "reported E-prefixed exempt series; letter-then-numerals shape is encyclopedia-grade and the numeral count is widened accordingly" }
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      background: { finish: retroreflective }
+      colour_note: "reported blue on gold — the pre-1989 Oregon colourway retained for exempt plates, i.e. an OLD BASE STILL IN ISSUE. Recorded because it is exactly the parallel-series case PRD-PLATES §2.2 warns about, but the claim is locator-grade."
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://www.oregonlegislature.gov/bills_laws/ors/ors803.html  # ORS 803.535: the design, reflectorization and legend rules apply to registration plates generally"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Oregon  # LOCATOR ONLY: the reported E-prefixed exempt series and its blue-on-gold colourway"
+    notes: >-
+      GOVERNMENT / EXEMPT. Modelled because Oregon separately serializes it
+      and because the reported colourway is the pre-1989 scheme — a live
+      example of a superseded base surviving inside a non-standard class. The
+      claim is locator-grade throughout, hence `recall-only`; no ODOT
+      instrument for the exempt series was located.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Count and official
+  # links only; no individual designs (those are L4).
+  # =========================================================================
+  - id: us-or-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999 LLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          Oregon calls these SPECIAL BACKGROUND plates, and the name is the
+          model: the serial arrangement is the ordinary one and only the
+          background changes. Because per-programme grammars were not sourced
+          (individual specialty specs are L4 per PRD-PLATES §2.5), the index
+          carries a deliberately wide union and is `recall-only`.
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      background: { finish: retroreflective }
+      note: "one background per authorised programme; the designs themselves are L4 scope and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: unstated
+      count_official_note: >-
+        NO OFFICIAL TOTAL IS PUBLISHED, AND THAT IS THE FINDING. Oregon DMV's
+        plate estate routes the user to a "Special Background Fees Chart" and
+        to "View your plate options" rather than to a counted catalogue, and
+        neither yields a number. Recorded as UNSTATED rather than filled in
+        from a secondary source. The encyclopedia record reports 20-plus
+        optional designs; that figure is LOCATOR-GRADE and is not adopted.
+      creation_route: >-
+        THE STRUCTURAL FACT THAT MATTERS MORE THAN THE COUNT. Oregon DMV, in
+        its own words: "Public bodies, non-profit organizations, institutes of
+        higher education, and veteran groups can apply to create a new Oregon
+        license plate", by two distinct routes — "Apply to create a new
+        special background plate" and "Apply to create a new veteran plate."
+        Oregon's catalogue is therefore APPLICANT-DRIVEN and open-ended,
+        which is the opposite of Washington's, where RCW 46.18.200(6) freezes
+        new issuance until 1 January 2029. Two neighbouring states, two
+        opposite programme architectures — this is the sort of contrast the
+        encyclopedia section exists to show.
+      official_plate_page_url: "https://www.oregon.gov/odot/DMV/pages/vehicle/plates.aspx"
+      fee_chart_note: "Oregon publishes a 'Special Background Fees Chart' as the authoritative per-programme fee list; it was not machine-read in this pass and is the natural source for an exact programme count (recorded gap)."
+      application_form_note: "DMV Form 268, 'Application for Registration, Renewal, Replacement or Transfer of Plates and/or Stickers', is the single form that carries the special-background election — one form, not one per programme."
+    region_encoding: none
+    sources:
+      - "https://www.oregon.gov/odot/DMV/pages/vehicle/plates.aspx  # Oregon DMV: the special-background structure, the two creation routes (special background plate / veteran plate) and the eligible applicant classes, the Special Background Fees Chart pointer, and Form 268"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Oregon  # LOCATOR ONLY: the reported 20-plus optional designs. NOT adopted as the count."
+    notes: >-
+      THE OREGON SPECIALTY INDEX — one entry standing for the whole programme,
+      per PRD-PLATES §2.5. The honest headline is a NEGATIVE result: Oregon
+      publishes no programme count. Recording "unstated" with the reason beats
+      importing a number from an encyclopedia, and the Special Background Fees
+      Chart is the identified path to a real figure next pass.
+
+# ---------------------------------------------------------------------------
+# Classes Oregon separately serializes but which are NOT given series here,
+# because no format was sourced and this dataset does not invent grammars.
+# ---------------------------------------------------------------------------
+unspecified_classes:
+  motorcycle:
+    statutory_hook: "ORS 803.525: 'Only one registration plate shall be issued' for a motorcycle or moped."
+    gap: "no motorcycle serial grammar sourced; the encyclopedia record's reported shape was too garbled to widen honestly"
+  dealer:
+    statutory_hook: "ORS 803.540 exempts vehicles operating under DEALER PERMITS from the ordinary display rule, so dealer issuance exists in statute."
+    gap: "no dealer plate serial grammar sourced"
+  temporary:
+    statutory_hook: "ORS 803.540 exempts operators running under TEMPORARY PERMITS. Oregon trip permits may be documents rather than plates."
+    gap: "not obtained; may fall outside the schema's plate definition entirely"
+  historic:
+    statutory_hook: "ORS 803.525 puts 'antique' vehicles and 'vehicles of special interest' in the one-plate list, so both are distinct issuance categories. Oregon DMV lists Form 6577, 'Antique/Special Interest Vehicle Certification'."
+    gap: "no serial grammar sourced for either; note Oregon distinguishes ANTIQUE from SPECIAL INTEREST, a two-tier historic regime worth modelling once sourced"
+
+# ---------------------------------------------------------------------------
+# Dead ends and open items.
+# ---------------------------------------------------------------------------
+research_notes:
+  reachability:
+    - "www.oregonlegislature.gov: TLS handshake refused from this environment on every attempt (curl exit 35 with default, --tlsv1.2, --tls-max 1.2 and --http1.1; WebFetch ECONNRESET). ORS text read from oregon.public.law instead. Oregon statutes are PD edicts so the text is the text, but official-host re-verification is an open item."
+    - "www.oregon.gov/odot/DMV/pages/vehicle/plates.aspx: 200 and fully readable. The 'View your plate options' and 'Special Background Fees Chart' targets are script-rendered and four guessed URLs all 404'd (plate_options.aspx, plates_special.aspx, plate_special.aspx, plateoptions.aspx) — the real paths must be harvested from the rendered DOM."
+  open_items:
+    - "Chapter 572, Oregon Laws 1987 — the design-contest act itself — was not fetched. It is the primary that would date the contest, name the commission and possibly settle who owns the winning artwork. HIGH VALUE for both period and artwork_risk."
+    - "The Special Background Fees Chart is the identified route to an exact Oregon specialty programme count."
+    - "No Oregon plate replacement cycle was located anywhere in ORS 803 (contrast Florida's 10 years, Montana's 5, Idaho's now-repealed 10). Whether Oregon truly has none is an unresolved negative."

--- a/plates/us-wa.yml
+++ b/plates/us-wa.yml
@@ -1,0 +1,484 @@
+# plates/us-wa.yml — Washington (PRD-PLATES gate L2, northwest group).
+#
+# WHY WASHINGTON IS THE HARD CASE OF THIS GROUP. Two independent reasons, and
+# both are sourced below rather than assumed. First, IP: Washington is one of
+# the four states PRD-PLATES §4 names as adverse, and this pass confirms it
+# from the state's own instruments — the issuing agency stamps its web estate
+# "© Washington State Department of Licensing" and the Legislature's own site
+# carries "Copyright 2025. All Rights Reserved." Second, and far more
+# decisively, RCW 46.18.200(2) enumerates Washington's special plates IN THE
+# STATUTE and describes many of them as displaying PRIVATELY OWNED marks —
+# "Displays the 'Seattle Mariners' logo", "Displays the Fred Hutch logo",
+# "Displays the name, image, and likeness of Smokey Bear", "Displays the
+# likenesses of the J.P. Patches and Gertrude characters", "Displays the '4-H'
+# logo". No theory of state public domain reaches those, because the state
+# does not own them. See `artwork_risk`.
+#
+# WHERE WASHINGTON LAW IS SILENT, AND IT IS SILENT ABOUT A LOT. RCW
+# 46.16A.200(1) hands the ENTIRE design to the director: plates "may vary in
+# background, color, and design" and "must be of a size and color ... as
+# determined by the director". So Washington — unlike Florida, Montana or
+# Wyoming — legislates NO dimension, NO colour, NO serial grammar and NO
+# replacement cycle. Everything in `design:` below is therefore observed or
+# locator-grade, and is labelled as such. What the statute DOES give is
+# unusually good: plate counts per vehicle type, display geometry, the
+# unlawful-acts list, and a replacement trigger that is not a clock.
+#
+# PERIOD DISCIPLINE (PRD-PLATES §9, and the standing rule for this wave).
+# Washington publishes no design changelog. Every era boundary below that came
+# from an enthusiast/encyclopedia table carries
+# `period_evidence: secondary-locator-only` and a `period_caveat` saying in
+# terms that it is NOT a sourced claim. The CURRENT series is instrument-dated
+# instead (`instrument-in-force-upper-bound`), exactly as us-fl-standard is,
+# so that no folklore year is ever presented as sourced.
+jurisdiction: us-wa
+authority:
+  name: Washington State Department of Licensing (DOL)
+  url: "https://dol.wa.gov/vehicles-and-boats/vehicles/license-plates"
+binding: vehicle
+statute_edition: >-
+  Revised Code of Washington, Title 46, as served by app.leg.wa.gov on
+  2026-08-02. NOTE A GENUINE TRAP: leg.wa.gov served TWO versions of RCW
+  46.16A.200 on one page — the operative text and a version "(Effective
+  January 1, 2027)" amended by 2026 c 172 s 3. The two differ only in
+  subsection (9)(b)(ii) (a defective-plate fee cross-reference to RCW
+  46.17.260). Every quotation below is identical in both versions unless
+  noted.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4/§7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: adverse
+  basis: >-
+    ADVERSE ON TWO INDEPENDENT GROUNDS. (1) State-works posture: Washington
+    does not place its works in the public domain by default; the surveyed
+    secondary analysis states "Works created by the State of Washington are
+    copyrighted. Works published by the Secretary of State of Washington are
+    voluntarily released into the public domain" — a narrow carve-out that does
+    NOT reach the Department of Licensing. That is a LOCATOR claim, but it is
+    corroborated by the state's own instruments as fetched in this pass: the
+    DOL plate estate carries the footer notice "© Washington State Department
+    of Licensing", and leg.wa.gov carries "Copyright 2025. All Rights
+    Reserved." No {{PD-WAGov}} tag exists on Wikimedia Commons; the only
+    Washington-specific tag found on the Commons per-territory page is
+    {{PD-WSRC}}, which is a single-body tag, not a state-wide one.
+    (2) THE DECISIVE GROUND, and it is statutory rather than inferential:
+    RCW 46.18.200(2) enumerates the approved special plates and describes many
+    of them as carrying THIRD-PARTY marks the state plainly does not own —
+    the "Seattle Mariners" logo, the "Seattle Seahawks" logo, the "Seattle
+    Sounders FC" logo, the "Seattle Storm" logo, the "Seattle Reign FC" logo,
+    "the logo of the Seattle NHL hockey team", the "Fred Hutch" logo, the
+    "Music Matters" logo, the "donate life" logo, "the '4-H' logo", the
+    "LeMay-America's car museum logo", "the name, image, and likeness of
+    Smokey Bear", and "the likenesses of the J.P. Patches and Gertrude
+    characters". 4-H and Smokey Bear additionally carry FEDERAL statutory
+    protection independent of copyright. So even a maximally favourable
+    reading of Washington's own posture would clear only a minority of the
+    artwork on Washington plates.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to EVERY Washington emblem and
+    graphic without exception, including the Mount Rainier motif on the
+    standard base. Render `emblem: {present: true, rendered: placeholder}` and
+    do not revisit per-emblem for the special-plate tier at all — the owners
+    are third parties, so no state-level clearance could resolve it.
+  photograph_caution: >-
+    The Commons finding from the L0 pass applies unchanged: a CC BY-SA tag on
+    a photograph of a Washington plate is the PHOTOGRAPHER's licence on the
+    PHOTOGRAPH. Because our renders are generated from spec and never derived
+    from a photograph, those obligations never attach — but in Washington the
+    underlying artwork is the live problem, not the photograph.
+  sources:
+    - "https://app.leg.wa.gov/RCW/default.aspx?cite=46.18.200  # RCW 46.18.200(2): the statutory special-plate table, quoted above, naming third-party logos and likenesses as the plate artwork"
+    - "https://app.leg.wa.gov/RCW/default.aspx?cite=46.16A.200  # RCW 46.16A.200(1)(f): 'special license plate series approved by the department and enacted into law by the legislature may display a symbol or artwork approved by the department' — the department approves; it does not thereby own"
+    - "https://dol.wa.gov/vehicles-and-boats/vehicles/license-plates  # fetched 2026-08-02; footer notice reads '© Washington State Department of Licensing'"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY (PRD-PLATES §4): 'Works created by the State of Washington are copyrighted...' — used to locate the posture, not to establish it"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Recorded per state because adoption is VOLUNTARY and
+# because the delegation trap must not be forgotten: AAMVA sends dimensions to
+# SAE J686, whose own text is PAYWALLED and UNPINNED. Nothing here quotes J686.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA writes recommendations in the declarative present; read as RECOMMENDED PRACTICE."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686. J686's own text was NOT obtained (paywalled); no J686 dimension is quoted anywhere in this dataset."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of the top and bottom edges"
+    jurisdiction_name_layout: "AAMVA §2.1: jurisdiction name in the top centre between the bolt holes, at least 0.25 in above the plate number and 0.125 in from the top edge; characters 0.75-1.0 in"
+    replacement_cycle: "AAMVA §1.1 recommends a rolling or full replacement cycle 'not to exceed 7 to 10 years'. WASHINGTON HAS NO CLOCK AT ALL — see us-wa-standard.replacement_rule. This is the strongest counter-example in the group to the idea that AAMVA's cycle is normative."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" that supposedly fixed the 6x12
+    inch plate is UNCITED in its Wikipedia source (a `citation needed` since
+    2017, copied verbatim across articles). It is recorded here as COMMONLY
+    REPEATED, UNSOURCED. Washington, unlike Florida, does not restate the
+    dimension in law at all, so this file cites NO statutory dimension.
+
+# ---------------------------------------------------------------------------
+# Display rules — the best-specified part of Washington plate law.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates, front and rear. RCW 46.16A.200(4)(a)(i): the director furnishes 'Two identical license plates each containing the license plate number'."
+  one_plate_vehicles: "RCW 46.16A.200(4)(a)(ii): 'One license plate if the vehicle is a trailer, semitrailer, camper, moped, collector vehicle, horseless carriage, or motorcycle.'"
+  mounting: "RCW 46.16A.200(5)(a): attached 'conspicuously at the front and rear of each vehicle if two license plates have been issued'; 'Attached in a horizontal position at a distance of not more than four feet from the ground'; 'kept clean and uncovered and be able to be plainly seen and read at all times'."
+  obstruction_exceptions: >-
+    RCW 46.16A.200(5)(b)(ii) is unusually specific and unusually modern: where
+    two plates are properly attached, ONE may be temporarily obstructed by a
+    trailer hitch, a wheelchair lift or carrier, a towed trailer, or a bicycle
+    / ski / luggage rack — provided the device is installed to manufacturer
+    specification and the plate can still be read from at least one accessible
+    viewing angle when parked. (5)(b)(iv) adds a forklift-carrier case for
+    trailers and expressly permits RELOCATING the trailer plate higher than
+    four feet from the ground. A dataset that models US display law as
+    "front and/or rear" loses all of this.
+  unlawful_acts: "RCW 46.16A.200(7): displaying plates not issued for the vehicle; displaying changed, altered, disfigured or illegible plates; using holders, frames or covers that conceal, obstruct, distort, alter or make a plate illegible (frames permitted only if they obscure nothing and the plate reads plainly); operating without valid plates attached; transferring plates between vehicles without application (traffic infraction, fine up to $500, plates confiscated and nullified)."
+  state_patrol_exception: "RCW 46.16A.200(5)(b)(i): the Washington State Patrol may grant exceptions where the body construction of the vehicle makes compliance impossible."
+  sources:
+    - "https://app.leg.wa.gov/RCW/default.aspx?cite=46.16A.200  # (4)(a) two plates / one-plate vehicle list; (5)(a) mounting, four-foot rule, clean-and-uncovered; (5)(b) the obstruction exceptions and the State Patrol exception; (7) unlawful acts and the transfer penalty"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES.
+  # =========================================================================
+  - id: us-wa-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL9999"
+      regex: '\A[A-Z]{3} ?\d{4}\z'
+      charset:
+        notes: >-
+          NO CHARSET RULE EXISTS IN WASHINGTON LAW. RCW 46.16A.200 says only
+          that plates "must be legible and clearly identifiable as a
+          Washington state license plate" and that the director determines
+          size and colour. There is no character cap, no alphabet and no
+          exclusion list anywhere in RCW 46.16A. The reported exclusion of
+          I, O and Q from the third letter position of the current series is
+          LOCATOR-GRADE ONLY and is deliberately NOT encoded as a
+          `regex_strict`: a strict twin is defined by PRD-PLATES §2.7 as the
+          AUTHORITY's own alphabet, and no authority has stated one.
+      progression: >-
+        LOCATOR-GRADE, NOT ASSERTED: the encyclopedia record reports the
+        current three-letter/four-numeral arrangement running from AAA0000
+        and reaching the C-block. No DOL publication of serial ranges was
+        located. Recorded so a future pass knows what to verify, not as a
+        claim.
+      pattern_note: >-
+        `regex` encodes the current three-letter/four-numeral passenger
+        arrangement, corroborated by DOL's own plate imagery and by the
+        encyclopedia record. It is written with an OPTIONAL space (` ?`)
+        because Washington prints the group boundary as a kerning gap rather
+        than a glyph — PRD-PLATES §2.6 rule 2 requires the printed form.
+        There is NO `regex_statutory`: Washington's statute states no outer
+        bound to be encoded, which is itself the finding.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4, dimension_basis: convention-observed }
+      dimension_note: >-
+        NOT STATUTORY. RCW 46.16A.200(1)(e): plates "Must be of a size and
+        color and show the registration period as determined by the
+        director." No Washington instrument fixing 12 x 6 in was located, and
+        the AAMVA chain delegates the dimension to the unpinned SAE J686, so
+        12 x 6 in is recorded as the North American convention as observed,
+        not as a sourced Washington claim.
+      material_rule: "RCW 46.16A.200(1)(d): plates 'Must be treated with fully reflectorized materials designed to increase visibility and legibility at night'. (2): plates issued before 1 January 1968 are exempt — a live carve-out, because horseless-carriage plates issued before 1987 need never be replaced (see replacement_rule)."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground_note: >-
+        NAVY / DARK BLUE CHARACTERS, HEX UNMEASURED AND DELIBERATELY NOT
+        INVENTED. Neither RCW 46.16A.200 nor any WAC located states a colour;
+        the statute says colour is "as determined by the director". Rather
+        than fabricate a hex from a JPEG, the colour is recorded by name with
+        `hex_basis: unmeasured`. A departmental specification or a measured
+        sample is the open item.
+      legend_top: "Washington"
+      legend_rule: "RCW 46.16A.200(1)(c): plates 'Must designate the name of the state of Washington without abbreviation.' That is the ONLY legend Washington law mandates."
+      graphic: { present: true, rendered: placeholder, description: "Mount Rainier motif behind the serial — observed from DOL plate imagery and the encyclopedia record; NOT from any statutory drawing" }
+      emblem: { present: true, rendered: placeholder }
+      slogan_note: >-
+        The "EVERGREEN STATE" slogan is reported on the base in issue through
+        2024. It is NOT mandated by RCW 46.16A.200, which requires only the
+        state name. Recorded as design, not law.
+      rear_differs: false
+      manufacture: "RCW 46.16A.200(1): plates 'may be obtained by the director from the metal working plant of a state correctional facility or from any source in accordance with existing state of Washington purchasing procedures' — prison manufacture is expressly contemplated in statute, but not required."
+      reported_2024_transition: >-
+        LOCATOR-GRADE, NOT ASSERTED, AND DELIBERATELY NOT MINTED AS A SERIES
+        BOUNDARY. The encyclopedia record reports an October 2024 change from
+        an embossed plate to an un-embossed (flat, digitally printed) plate
+        with navy characters, on the SAME three-letter/four-numeral
+        arrangement and with the serial block simply continuing. No DOL
+        instrument announcing it was located in this pass. Because the format
+        and the period are unchanged and only the manufacturing method and
+        hue moved, PRD-PLATES §2.3 would in any case make this a sub-entry
+        rather than a series — and on this evidence it is not even that. It
+        is recorded here so a verifier knows exactly what to chase.
+    replacement_rule:
+      clock: none
+      statutory_text: >-
+        RCW 46.16A.200(9)(a): an owner "must apply for a replacement license
+        plate or plates: (i) When taking ownership of the vehicle; (ii) if the
+        current license plate or plates assigned to the vehicle have been
+        lost, defaced, or destroyed; or (iii) if one or both plates have
+        become so illegible or are in such a condition as to be difficult to
+        distinguish."
+      transfer_rule: "RCW 46.16A.200(8)(a): 'Standard issue license plates must be replaced when ownership of the vehicle changes ... but the registered owner may retain the license plates and transfer them to a replacement vehicle of the same use.' The plate follows the OWNER on transfer, not the vehicle — while `binding: vehicle` still holds, because the plate is assigned to a vehicle at any instant."
+      transfer_exceptions: "RCW 46.16A.200(8)(d): replacement is NOT required where the ownership change is adding/removing a lienholder, a transfer between spouses or registered domestic partners, removing a deceased spouse or partner, a gift or inheritance within the registered owner's immediate family, a transfer into or out of a trust benefiting the owner or immediate family, a lease buy-out, or a name change."
+      never_replaced: "RCW 46.16A.200(10): horseless carriage plates issued under RCW 46.18.255 before 1 January 1987, Medal of Honor plates under RCW 46.18.230, and plates for commercial motor vehicles over 26,000 lb gross weight are NOT subject to the replacement duty at all."
+      note: >-
+        WASHINGTON IS THE ANTI-FLORIDA ON REPLACEMENT. Florida legislated ten
+        years, the top of AAMVA's recommended 7-10 band. Washington legislated
+        NO PERIOD WHATSOEVER: replacement is triggered by an EVENT (sale,
+        loss, illegibility), never by a clock, and three plate classes are
+        exempt even from that. Any consumer inferring plate age from a
+        replacement cycle will be wrong in Washington, and pre-1968 plates are
+        additionally exempt from the reflectorization requirement.
+    region_encoding: none
+    sources:
+      - "https://app.leg.wa.gov/RCW/default.aspx?cite=46.16A.200  # (1)(a)-(f) design delegation, state-name requirement, reflectorization, artwork approval; (2) the pre-1968 reflectorization carve-out; (4)(a) plate counts; (8) transfer and its seven exceptions; (9) the event-triggered replacement duty; (10) the three never-replaced classes; (12) tabs and emblems"
+      - "https://dol.wa.gov/vehicles-and-boats/vehicles/license-plates  # DOL's own plate estate: the standard/custom/replacement service structure and the plate imagery the observed colours are taken from"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1, the 7-10 year recommendation Washington declined to legislate"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington_(state)  # LOCATOR ONLY (PRD-PLATES §4): the reported 2010 arrangement change, the reported October 2024 flat-plate transition, the reported I/O/Q exclusion and the reported serial ranges. None is asserted as sourced here."
+    notes: >-
+      WASHINGTON STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED, for the same
+      reason us-fl-standard is: Washington law fixes no design generation, DOL
+      publishes no changelog, and the only dates available are
+      encyclopedia-grade. `start: 2026` is the year the RCW was read and is an
+      UPPER BOUND on the true start; Washington has issued three-letter /
+      four-numeral plates for well over a decade. When a departmental
+      instrument lands, a dated id is added and this id becomes its former-id
+      alias under the PRD-QUALITY I-5/I-6 contract. THE STRUCTURAL FINDING
+      WORTH CARRYING: Washington delegates the whole design to the director by
+      statute, so unlike Florida, Montana and Wyoming there is no statutory
+      design text to mine — the primary-source ceiling for Washington plate
+      DESIGN facts is a departmental rule that does not appear to exist.
+
+  # =========================================================================
+  # ONE SERIES BACK. Encyclopedia-grade boundaries, marked as such.
+  # =========================================================================
+  - id: us-wa-standard-numeric-first
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1987, end: 2010 }
+    period_evidence: secondary-locator-only
+    period_caveat: >-
+      NOT A SOURCED CLAIM. Both boundary years come from the encyclopedia
+      record and NOTHING ELSE — no Washington instrument stating either year
+      was located. They are recorded rather than omitted because the
+      ARRANGEMENT (three numerals then three letters) is independently
+      verifiable from any surviving plate, while the YEARS are not. A verifier
+      must either pin them to a DOL or Session Laws instrument or downgrade
+      them to `ended: true` with no start.
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3}[- ]?[A-Z]{3}\z'
+      charset:
+        notes: >-
+          The reported exclusion of I, O and Q from the FIRST letter position
+          in the 1987-1998 sub-range is locator-grade and is not encoded.
+      pattern_note: >-
+        The group boundary is spelled as the separator-only class `[- ]`,
+        which PRD-PLATES §2.8 sanctions, because the printed boundary on this
+        base is a gap on some issues and a dash-like element on others and no
+        authority text settles it. `pattern` shows the canonical printed form
+        with a space.
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground_note: "dark blue characters; hex unmeasured, not invented"
+      legend_top: "Washington"
+      graphic: { present: true, rendered: placeholder, description: "Mount Rainier motif — observed, not from a statutory drawing" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://app.leg.wa.gov/RCW/default.aspx?cite=46.16A.200  # the statutory frame this series was issued under is unchanged: (1)(c) state name, (1)(d) reflectorization, (1)(e) size and colour by the director"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington_(state)  # LOCATOR ONLY: the 999-LLL arrangement and both boundary years, neither asserted as sourced"
+    notes: >-
+      THE PREVIOUS WASHINGTON BASE ARRANGEMENT. Kept as its own series because
+      the FORMAT differs from the current one, which is the PRD-PLATES §2.3
+      test, and because a parser needs it: a Washington plate of unknown
+      vintage is either 999-LLL or LLL9999 and nothing else. Its period is the
+      weakest data in this file and says so on its face. Distinct from
+      us-wa-standard in that this series is closed and numeral-leading; the
+      current series is open and letter-leading.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES. Washington separately serializes these; the formats
+  # are LOCATOR-GRADE, so each is `recall-only` per PRD-PLATES §2.7 — a match
+  # is a shape hit and nothing more, and the regexes are deliberately widened
+  # so that recall-only is the honest description rather than a hedge.
+  # =========================================================================
+  - id: us-wa-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "9L9999"
+      regex: '\A\d[A-Z]\d{3,5}\z'
+      charset:
+        notes: >-
+          Washington law states no motorcycle serial grammar. RCW
+          46.16A.200(4)(a)(ii) establishes only that a motorcycle receives ONE
+          plate. The digit-letter-digits shape is locator-grade; the regex is
+          widened on the numeral count so that a match claims a SHAPE and not
+          a grammar.
+    design:
+      plate_note: "reduced size; no Washington instrument stating motorcycle plate dimensions was located (recorded gap). RCW 46.16A.200(1)(e) leaves size to the director."
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://app.leg.wa.gov/RCW/default.aspx?cite=46.16A.200  # (4)(a)(ii): one plate for a motorcycle; (1)(e): size determined by the director"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington_(state)  # LOCATOR ONLY: the reported motorcycle serial shape"
+    notes: >-
+      MOTORCYCLE. `recall-only` is the point, not a hedge: the only Washington
+      motorcycle fact with a primary source is the plate COUNT (one). The
+      serial shape is encyclopedia-grade and the regex is written wide enough
+      to say so.
+
+  - id: us-wa-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "99999LL"
+      regex: '\A\d{4,6}[A-Z]{2}\z'
+      charset: { notes: "no statutory grammar; digits-then-two-letters shape is locator-grade and the digit count is widened accordingly" }
+    design:
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://app.leg.wa.gov/RCW/default.aspx?cite=46.16A.200  # (4)(a)(ii): one plate for a trailer or semitrailer"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Washington_(state)  # LOCATOR ONLY: the reported trailer serial shape"
+    notes: >-
+      TRAILER. Washington separately serializes trailers and issues them ONE
+      plate by statute. Note the interaction with display_rules: RCW
+      46.16A.200(5)(b)(iv) expressly allows a trailer plate obstructed by a
+      forklift carrier to be RELOCATED above the four-foot limit, which is the
+      only place in the group where the mounting geometry bends for a class.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Washington is the one
+  # state in this group whose specialty programme is ENUMERATED IN STATUTE,
+  # which makes its index unusually strong and its count unusually contested.
+  # =========================================================================
+  - id: us-wa-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL9999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
+      charset:
+        notes: >-
+          Washington special plates do NOT all carry the standard passenger
+          arrangement — several run their own shorter serials. Because no
+          per-programme grammar was sourced (individual specialty specs are L4
+          per PRD-PLATES §2.5), the index carries a deliberately wide union
+          and is `recall-only`. A match says "this string could sit on some
+          Washington special plate" and nothing more.
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: convention-observed }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope and none is described here"
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_statutory: 49
+      count_statutory_note: >-
+        49 NAMED ENTRIES in the RCW 46.18.200(2) table as read on 2026-08-02.
+        The count of DESIGNS is higher: the "Armed forces collection" entry is
+        defined in the statute as including "six separate designs, each
+        containing a symbol representing a different branch of the armed
+        forces", so the statutory table describes at least 54 designs.
+      count_agency: "approximately 89 plates across eleven categories on DOL's own special-design gallery (U.S. Armed Forces, Military Services and Veterans, Charitable Organizations, Collector Vehicles, Colleges and Universities, First Responders, Parks and Nature, Special Interest, Sports, Tribal, Miscellaneous)"
+      count_discrepancy_note: >-
+        THE COUNTS ARE NOT RECONCILED AND ARE NOT AVERAGED (PRD-PLATES §5.3).
+        The statute enumerates 49; DOL's gallery shows roughly 89. The gap is
+        structural rather than an error: the DOL gallery mixes in plate types
+        authorised elsewhere in Title 46 (Medal of Honor, Former Prisoner of
+        War, Disabled American Veteran, disabled parking, personalized,
+        rideshare, collector, horseless carriage, tribal) that are not
+        "special license plates" under RCW 46.18.200(2). Both figures are
+        recorded with their sources.
+      statutory_list_url: "https://app.leg.wa.gov/RCW/default.aspx?cite=46.18.200"
+      official_gallery_url: "https://dol.wa.gov/vehicles-and-boats/vehicles/license-plates/get-custom-plates/special-design-plates"
+      moratorium: >-
+        THE FINDING NO COMPETING DATASET CARRIES. RCW 46.18.200(6): "Except for
+        special license plates created under chapter 385, Laws of 2025 and as
+        specified in this subsection, the department may not issue any new
+        special license plates until January 1, 2029." The subsection then
+        sets a PHASED issuance order for the chapter-385 plates keyed to when
+        DOL received signature sheets satisfying RCW 46.18.110(2)(f) — before
+        1 March 2025 (plus Keep Washington Evergreen and Historical Throwback)
+        first, then the later sheets in submission order. Washington's
+        specialty catalogue is therefore FROZEN by statute for the next two
+        and a half years, which makes this index unusually stable and makes
+        the date 2029-01-01 the natural re-audit trigger.
+      eligibility_gates: >-
+        RCW 46.18.200(3): professional firefighter and paramedic plates
+        require a certificate of current membership from the Washington state
+        council of firefighters. (4): volunteer firefighter plates require ten
+        years' service, or one or more years plus documentation, with
+        surrender duties on early departure and on a conviction under RCW
+        46.61.502 or a felony; maximum one set per vehicle and two sets per
+        applicant. (5): the Seattle NHL hockey plate may not issue until the
+        signature-sheet requirement is met.
+      third_party_artwork_note: >-
+        See `artwork_risk`. The statutory table itself is the evidence that
+        much of this catalogue's artwork is third-party property.
+    region_encoding: none
+    sources:
+      - "https://app.leg.wa.gov/RCW/default.aspx?cite=46.18.200  # the full statutory special-plate table (49 entries, armed forces = six designs); (3)-(4) eligibility and surrender rules; (5) the NHL signature-sheet gate; (6) the moratorium to 1 January 2029 and the chapter-385 phased issuance order"
+      - "https://dol.wa.gov/vehicles-and-boats/vehicles/license-plates/get-custom-plates/special-design-plates  # DOL's own gallery: roughly 89 plates in eleven categories — the contested count, recorded not averaged"
+      - "https://app.leg.wa.gov/RCW/default.aspx?cite=46.16A.200  # (1)(f): special series may display a symbol or artwork approved by the department"
+    notes: >-
+      THE WASHINGTON SPECIALTY INDEX — one entry standing for the whole
+      programme, which is what PRD-PLATES §2.5 asks for at this gate. Two
+      things worth carrying forward. First, Washington is the rare state whose
+      specialty catalogue is a STATUTORY TABLE rather than an agency list,
+      which means the index is citable to an edict of government and is
+      therefore public domain even though the state's posture is adverse.
+      Second, the RCW 46.18.200(6) moratorium is a hard, dated freeze to
+      1 January 2029 — a fact with real product value (the catalogue will not
+      churn) and a natural audit date.
+
+# ---------------------------------------------------------------------------
+# Classes Washington separately serializes but which are NOT given series here,
+# because no format was sourced and this dataset does not invent grammars.
+# Each carries its statutory hook so the next pass starts from a citation.
+# ---------------------------------------------------------------------------
+unspecified_classes:
+  dealer:
+    statutory_hook: "RCW 46.16A.200(3): 'License plates issued to a dealer must contain an indication that the license plates have been issued to a vehicle dealer.' The existence and the marking duty are sourced; the serial grammar is not."
+    gap: "no dealer serial format located in RCW, WAC or DOL publications"
+  personalized:
+    statutory_hook: "RCW 46.18.200(1)(a): special series 'May be issued in lieu of standard issue or personalized license plates'. DOL sells personalized plates through its custom-plate service."
+    gap: "the character cap and the content-refusal criteria were not located in RCW or WAC; DOL's availability checker was not machine-read. No series is minted rather than guess a cap."
+  government:
+    statutory_hook: "RCW 46.16A.200(8)(c) contemplates plates 'issued to the state or any county, city, town, school district, or other political subdivision entitled to exemption as provided by law'."
+    gap: "no exempt/government serial format located"
+  temporary:
+    statutory_hook: "RCW 46.16A.320 (trip permits) is referenced from DOL's plate estate as the unlicensed-vehicle instrument."
+    gap: "the trip-permit document format was not obtained; it may not be a plate in the schema's sense at all"
+
+# ---------------------------------------------------------------------------
+# Dead ends and open items, recorded so the next pass does not repeat them.
+# ---------------------------------------------------------------------------
+research_notes:
+  reachability:
+    - "app.leg.wa.gov serves the RCW as HTML and was fully readable; note it renders BOTH the operative and the 2027-effective version of 46.16A.200 on one page, which a naive scraper will concatenate."
+    - "WAC 308-96A-021 was fetched and turned out NOT to be a display rule at all — it is the REPLACEMENT-PLATE rule ('For an additional fee, you may replace them with the same number and letter combination as long as the plate meets a current approved license plate configuration and background'). The US/world dossier's pin-list cites 308-96A-021 as 'WA plate display admin code'; THAT PIN IS WRONG and should be corrected in the source appendix. Display law is in RCW 46.16A.200(5), not the WAC."
+  open_items:
+    - "No departmental instrument fixing Washington plate colours, dimensions or serial grammar was located. If none exists, that absence should itself be recorded as a sourced negative after a WAC 308-96A sweep."
+    - "The reported October 2024 flat-plate transition needs a DOL instrument before any dated series id is minted."
+    - "{{PD-WSRC}} on Commons was not resolved to its scope in this pass; it is not a state-wide Washington PD tag."

--- a/plates/us-wy.yml
+++ b/plates/us-wy.yml
@@ -1,0 +1,523 @@
+# plates/us-wy.yml — Wyoming (PRD-PLATES gate L2, northwest group).
+#
+# WYOMING IS THE ONLY STATE IN THIS GROUP WHOSE PLATE ARTWORK IS A REGISTERED
+# STATE TRADEMARK, AND THE STATUTE PUTS THAT ARTWORK INSIDE THE SERIAL LINE.
+# W.S. 31-2-204(b) requires that the plate carry "arabic numerals for the
+# county in which issued, followed by the bucking horse and rider emblem and a
+# distinctive number assigned to the vehicle". The Bucking Horse and Rider is
+# not decoration in a corner: it occupies the position where every other state
+# in this group prints a separator. And W.S. 8-3-117 directs the Secretary of
+# State to "promulgate rules regulating the licensing or other authorized use
+# of the 'Bucking Horse and Rider' and related trademarks", with licensing
+# fees and royalties deposited to a dedicated account and appropriations
+# authorised "to protect, preserve and promote" the marks. So Wyoming
+# affirmatively asserts, licenses and monetises the central element of its own
+# licence plate. That is the cleanest artwork_risk evidence found anywhere in
+# this group — better than Arizona's bare copyright assertion, because it is
+# statutory, specific to THIS mark, and revenue-generating. See artwork_risk.
+#
+# THE SEPARATOR CONSEQUENCE, WHICH IS A SCHEMA POINT AND NOT A CURIOSITY.
+# Because the emblem sits between the county number and the serial, Wyoming is
+# a live instance of plates/_meta/separators.yml's `never_separator` case: the
+# printed gap between the two groups is occupied by a DEVICE, not by
+# punctuation. A consumer deriving a separator-free twin must delete the
+# emitted separator characters and MUST NOT treat the emblem as one, because
+# it is carried in `design.emblem` and never in the serial. Recorded loudly
+# below.
+#
+# SOURCING. Wyoming publishes its statutes as per-title PDFs at wyoleg.gov;
+# Title 31 (Motor Vehicles) and Title 8 (General Provisions) were both fetched
+# and text-extracted, and every statutory quotation below is verbatim from
+# them. WYDOT's own county-prefix page was fetched and INDEPENDENTLY
+# CORROBORATES the statutory table row for row — a rare case in this wave
+# where statute and agency agree exactly and both were read.
+jurisdiction: us-wy
+authority:
+  name: Wyoming Department of Transportation (WYDOT), Motor Vehicle Services
+  url: "https://www.dot.state.wy.us/home/titles_plates_registration.html"
+binding: vehicle
+statute_edition: >-
+  Wyoming Statutes, Title 31 (Motor Vehicles) and Title 8 (General
+  Provisions), as published by the Wyoming Legislative Service Office at
+  wyoleg.gov/statutes/compress/title31.pdf and title08.pdf, fetched and
+  text-extracted 2026-08-02.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4/§7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: asserted
+  basis: >-
+    ASSERTED, ON A NAMED STATUTORY TRADEMARK, AND THE MARK IS THE PLATE'S
+    CENTREPIECE. W.S. 8-3-117, verbatim: "(a) The secretary of state shall
+    promulgate rules regulating the licensing or other authorized use of the
+    'Bucking Horse and Rider' and related trademarks. (b) Any licensing fees,
+    royalties or other revenues collected by the secretary of state under this
+    section shall be deposited into a separate account. The legislature shall
+    by appropriation authorize expenditures from the account as necessary to
+    defray administrative expenses associated with licensing of the trademark
+    and expenditures required to protect, preserve and promote the 'Bucking
+    Horse and Rider' and related trademarks on behalf of the state." Wyoming
+    therefore (i) claims the mark, (ii) licenses it for money, and (iii)
+    appropriates funds specifically to enforce it. W.S. 31-2-204(b) then puts
+    that mark ON THE PLATE, between the county number and the serial, on every
+    standard issue. Separately, Wyoming appears NOWHERE in the standing
+    per-state COPYRIGHT survey PRD-PLATES §4 works from and no {{PD-WYGov}}
+    tag exists on Wikimedia Commons, so the copyright posture is unresearched
+    and the default (state works copyrighted unless the state says otherwise)
+    applies. THE TRADEMARK POINT IS INDEPENDENT OF COPYRIGHT AND SURVIVES IT:
+    even a favourable copyright finding would not clear the Bucking Horse and
+    Rider, because trademark protection is a separate regime — exactly the
+    hazard PRD-PLATES §4 flags for state seals, here documented rather than
+    assumed.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies with unusual force. The
+    Bucking Horse and Rider MUST render as a neutral placeholder — it is a
+    live, licensed, revenue-generating state trademark, and it is not a
+    candidate for an emblem-slot upgrade at any gate absent an affirmative
+    licence from the Wyoming Secretary of State. Render `emblem: {present:
+    true, rendered: placeholder}`. NOTE ALSO that the emblem's POSITION is
+    statutory (between the county number and the serial), so a render must
+    reserve the slot even while filling it with a placeholder.
+  photograph_caution: "Standard: a Commons CC BY-SA tag on a photograph of a Wyoming plate is the photographer's licence on the photograph. Our renders are generated from the statute — but in Wyoming the underlying mark is the live problem, not the photograph."
+  trademark_reach_note: >-
+    The mark is not confined to plates. W.S. 31-3-102(a)(xxiii) and (xxiv)
+    require the annual ELECTRIC-VEHICLE and PLUG-IN-HYBRID decals to "include
+    the bucking horse and rider emblem" as well ($100 and $50 respectively).
+    Wyoming propagates the mark across its whole vehicle-credential estate.
+  sources:
+    - "https://www.wyoleg.gov/statutes/compress/title08.pdf  # W.S. 8-3-117, quoted verbatim above: Secretary of State rulemaking over licensing of the Bucking Horse and Rider and related trademarks, the royalty account, and the protect-preserve-promote appropriation"
+    - "https://www.wyoleg.gov/statutes/compress/title31.pdf  # W.S. 31-2-204(b): the emblem's mandatory place on the plate, between the county numerals and the distinctive number; W.S. 31-3-102(a)(xxiii)-(xxiv): the emblem required on EV and PHEV decals"
+    - "https://en.wikipedia.org/wiki/Copyright_status_of_works_by_subnational_governments_of_the_United_States  # LOCATOR ONLY: Wyoming is NOT MENTIONED — measured absence, so copyright posture is recorded unresearched"
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # LOCATOR ONLY: no Wyoming state PD template exists among those listed"
+
+# ---------------------------------------------------------------------------
+# The US standards chain.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, which is paywalled and UNPINNED and is never quoted here. Wyoming does not need it for length: W.S. 31-2-204(b) legislates a MINIMUM of twelve inches long, and a minimum of 3 x 6 inches for the small plates."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spacing at least 0.25 in, stroke 0.2-0.4 in. Wyoming legislates no character geometry; W.S. 31-2-204(b) leaves the distinctive number 'set forth in numerals and letters as determined by the department'."
+    retroreflectivity: "AAMVA §3.3: readable day and night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 cl.3. W.S. 31-2-204(b) legislates the requirement without the metric: 'the background of all plates shall be fully reflectorized'."
+    replacement_cycle: >-
+      AAMVA §1.1 recommends a cycle "not to exceed 7 to 10 years". WYOMING
+      LEGISLATES ANNUAL: W.S. 31-2-204(b), "License plates shall be changed or
+      validated annually." Wyoming is therefore the most aggressive of the
+      four positions this group documents — Wyoming annual, Montana five
+      years, Florida ten, Washington no clock at all.
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" is COMMONLY REPEATED, UNSOURCED.
+    Wyoming states its own minimum length in law and nothing here depends on
+    it. NOTE ALSO the Wyoming-specific folklore: the county numbers are
+    universally explained as the counties' 1930s assessed-valuation or wealth
+    ranking. W.S. 31-2-204(d) states the ASSIGNMENT and gives NO rationale.
+    Recorded as folklore; see us-wy-standard.region_encoding.
+
+# ---------------------------------------------------------------------------
+# Display rules — W.S. 31-2-205, and the nine-way front-plate exclusion list
+# is the most granular in this group.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates, front and rear. W.S. 31-2-205(a)(i): plates shall be 'Conspicuously displayed and securely fastened to be plainly visible: (A) One (1) on the front of the vehicle, excluding [nine listed classes] ... (B) One (1) on the rear of the vehicle.'"
+  issuance: "W.S. 31-2-204(a): the COUNTY TREASURER issues 'one (1) license plate or validation sticker for motorcycles, multipurpose vehicles, trailers, including house trailers, and vehicles operated with dealer license plates and two (2) license plates or proper validation stickers for any other vehicle.'"
+  front_plate_exclusions:
+    - "motorcycles"
+    - "multipurpose vehicles"
+    - "trailers, including house trailers"
+    - "vehicles operated with demo, full use or manufacturer license plates issued pursuant to W.S. 31-16-125"
+    - "street rods registered pursuant to W.S. 31-2-226"
+    - "custom vehicles registered pursuant to W.S. 31-2-227"
+    - "antique vehicles registered pursuant to W.S. 31-2-223"
+    - "a motor vehicle which was originally manufactured without a bracket, device or other means to display and secure a front license plate"
+    - "off-road recreational vehicles as defined by W.S. 31-1-101(a)(xv)(K)(II) that are registered pursuant to W.S. 31-2-232"
+  front_plate_note: >-
+    THE EIGHTH EXCLUSION IS THE INTERESTING ONE AND NO OTHER STATE IN THIS
+    GROUP HAS IT: Wyoming excuses the front plate for "a motor vehicle which
+    was originally manufactured without a bracket, device or other means to
+    display and secure a front license plate." That converts a front-plate
+    obligation into a per-MODEL fact about the vehicle's manufacture. A
+    dataset that models front-plate requirement as a per-jurisdiction boolean
+    cannot express it; a vehicle catalogue that knows factory front-bracket
+    fitment can. This is a direct hook between the plates dataset and the
+    vehicle catalogue.
+  mounting: "W.S. 31-2-205(a)(ii)-(iv): plates must be 'Secured to prevent swinging'; 'Attached in a horizontal position no less than twelve (12) inches from the ground'; and 'Maintained free from foreign materials and in a condition to be clearly legible.' NOTE the direction of the constraint — Wyoming legislates a MINIMUM height (12 in), while Washington and Florida legislate a MAXIMUM (four feet / 60 in). They are not the same rule and must not be normalised together."
+  sources:
+    - "https://www.wyoleg.gov/statutes/compress/title31.pdf  # W.S. 31-2-204(a): one plate or two by vehicle type, issued by the county treasurer; W.S. 31-2-205(a): conspicuous display, the nine front-plate exclusions, no-swinging, the twelve-inch minimum height, and the legibility duty"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES. County-number-prefixed, emblem-separated.
+  # =========================================================================
+  - id: us-wy-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "99 9999"
+      regex: '\A\d{1,2}[- ]?\d{1,6}\z'
+      regex_strict: '\A(?:[1-9]|1\d|2[0-3])[- ]?\d{1,6}\z'
+      regex_statutory: '\A\d{1,2}[- ]?[A-Z0-9]+\z'
+      charset:
+        notes: >-
+          W.S. 31-2-204(b), verbatim: "Except as otherwise provided, license
+          plates shall be of metal not less than twelve (12) inches long in
+          the left-hand end of which shall be arabic numerals for the county
+          in which issued, followed by the bucking horse and rider emblem and
+          a distinctive number assigned to the vehicle, set forth in numerals
+          and letters as determined by the department and above or underneath
+          such numerals shall be the word 'Wyoming' and arabic numerals for
+          the year of issue or validation." And (c): "The distinctive license
+          plate numbers shall begin with one (1) and be numbered consecutively
+          in each county." So Wyoming law fixes the county numerals, their
+          POSITION (left-hand end), the emblem after them, the state name, the
+          year, and the numbering origin — and delegates only the serial's own
+          shape to the department. NO WIDTH and NO EXCLUDED LETTERS are stated
+          anywhere; none is invented here.
+        vehicle_type_marker: >-
+          W.S. 31-2-204(b) also permits, but does not require, a type marker
+          in the serial line: "After the county number on the left-hand end,
+          the license plate may also contain a distinctive symbol or letters,
+          as determined by the department, indicating vehicle type." A Wyoming
+          serial may therefore carry a class token between the county number
+          and the plate number. `regex_statutory` admits it (letters are
+          allowed); `regex` does not, because the current passenger issue does
+          not use one.
+      separator_note: >-
+        CRITICAL, AND A LIVE INSTANCE OF plates/_meta/separators.yml's
+        `never_separator` CASE. The printed gap between the county numerals
+        and the distinctive number is occupied BY THE BUCKING HORSE AND RIDER
+        EMBLEM, which W.S. 31-2-204(b) places there by statute. The emblem is
+        a DESIGN ELEMENT carried in `design.emblem`; it is NOT a separator
+        character, it is NOT part of the serial, and no consumer may treat it
+        as either. The separator position is spelled as the separator-only
+        class `[- ]`, sanctioned by PRD-PLATES §2.8, because the statute names
+        no separator GLYPH at all — it names a picture. `pattern` shows the
+        canonical printed form as a space.
+      tier_note: >-
+        `regex_strict` bounds the leading group to the 23 county numbers W.S.
+        31-2-204(d) actually assigns — the authority's own alphabet for that
+        position. `regex` is the current all-numeric passenger arrangement.
+        `regex_statutory` is the outer statutory bound: county numerals, the
+        emblem gap, then a department-determined combination of numerals and
+        letters of unstated width (hence the unbounded quantifier, which makes
+        no width claim). Tier order regex_strict subset-of regex subset-of
+        regex_statutory holds by construction.
+      progression: "STATUTORY. W.S. 31-2-204(c): 'The distinctive license plate numbers shall begin with one (1) and be numbered consecutively in each county.' Wyoming's serial space is therefore PER COUNTY, restarting at 1 in each — which is why low numbers in populous Natrona (county 1) are collectible and why the same distinctive number legitimately recurs in all 23 counties."
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4, dimension_basis: statutory-minimum-length-plus-convention }
+      plate_dimension_note: >-
+        HALF STATUTORY. W.S. 31-2-204(b) legislates only a MINIMUM LENGTH:
+        plates 'shall be of metal not less than twelve (12) inches long'. No
+        height is stated for full-size plates. The 6-inch height is the North
+        American convention as observed, not a Wyoming claim; the 12-inch
+        length is a legislated floor, not a fixed value.
+      plate_variant: { w: 6, h: 3, unit: in, applies_to: "light utility trailers under 1,000 lb, motorcycles and multipurpose vehicles", statutory_text: "W.S. 31-2-204(b): 'Plates for light utility trailers under one thousand (1,000) pounds, motorcycles and multipurpose vehicles shall not be less than three (3) inches wide and six (6) inches long.' Again a MINIMUM, not a fixed size." }
+      material: "W.S. 31-2-204(b): 'license plates shall be of metal'"
+      background: { finish: retroreflective }
+      contrast_rule: >-
+        W.S. 31-2-204(b), verbatim: "There shall be a marked contrast between
+        the color of the plate and that of the numerals and letters and the
+        background of all plates shall be fully reflectorized." THE CLEANEST
+        EXAMPLE IN THIS GROUP OF A LEGISLATURE SPECIFYING A DESIGN PROPERTY
+        RATHER THAN A DESIGN VALUE — Wyoming mandates CONTRAST and
+        REFLECTORIZATION and names no colour whatsoever, exactly as Florida
+        mandates a 'distinguishing color' for its historic plates without
+        naming one. No hex is recorded here because no authority states one.
+      colour_note: "NO COLOUR IS IN THE STATUTE. Wyoming plates are conventionally described as a dark serial on a light reflective ground with the emblem in silhouette; that is observation, no hex is invented, and `contrast_rule` above is the sourced claim."
+      legend_top: "Wyoming"
+      legend_rule: "W.S. 31-2-204(b): 'above or underneath such numerals shall be the word \"Wyoming\" and arabic numerals for the year of issue or validation.' Note the statute leaves the ABOVE-OR-BELOW choice open, and (c) reserves the department's freedom to move things: 'In ordering license plates the department may from year to year change the location of the figures, words and letters or validation sticker as deemed necessary.'"
+      year_on_plate: "STATUTORY AND UNUSUAL AT THIS DATE. W.S. 31-2-204(b) requires 'arabic numerals for the year of issue or validation' ON THE PLATE ITSELF. Most US states moved the year to a sticker decades ago; Wyoming still legislates it onto the plate face, which is why Wyoming plate images are datable on sight."
+      emblem:
+        present: true
+        rendered: placeholder
+        name: "Bucking Horse and Rider"
+        statutory_position: "between the county numerals at the left-hand end and the distinctive number (W.S. 31-2-204(b))"
+        ip_note: "a registered state trademark licensed by the Secretary of State under W.S. 8-3-117 — see artwork_risk. Placeholder is mandatory, not a default."
+        substitution_rule: "W.S. 31-2-204(b): plates issued to dealers and for state or federal official forestry vehicles, motorcycles, multipurpose vehicles and trailers 'shall contain appropriate identification which may be in lieu of the bucking horse and rider emblem.' So the emblem's ABSENCE is class information."
+      rear_differs: false
+    replacement_cycle:
+      years: 1
+      statutory_text: "W.S. 31-2-204(b): 'License plates shall be changed or validated annually.'"
+      note: >-
+        THE SHORTEST CLOCK IN THE GROUP, AND IT IS A DISJUNCTION. The statute
+        says CHANGED OR VALIDATED annually, so Wyoming may satisfy it with a
+        sticker rather than new metal — which is how it operates in practice.
+        Read with the mandatory year numerals on the plate face, this means a
+        Wyoming plate always asserts a year, whether by metal or by validation.
+    registration_period: "W.S. 31-2-206(a): 'vehicle registrations expire on the last day of the annual registration month. Renewals are effective for one (1) year beginning the first day of the month following the annual registration month.' Staggered monthly registration, not a common expiry date."
+    region_encoding:
+      mechanism: >-
+        THE COUNTY NUMBER IS THE LEFTMOST GROUP OF THE SERIAL, separated from
+        the plate number by the Bucking Horse and Rider emblem. W.S.
+        31-2-204(b) fixes the position ('in the left-hand end of which shall
+        be arabic numerals for the county in which issued'); (c) makes the
+        plate number restart at 1 in each county; (d) fixes the mapping.
+      decode_evidence: statutory-verbatim-and-agency-corroborated
+      corroboration_note: >-
+        UNUSUALLY STRONG FOR THIS WAVE: the table below appears VERBATIM in
+        W.S. 31-2-204(d) AND, independently, on WYDOT's own county-prefix
+        page, which was fetched in the same pass and agrees row for row. Two
+        independent official sources, one an edict of government. WYDOT states
+        the mechanism in its own words: "Wyoming license plate numbers begin
+        with a prefix number that designates the county in which the vehicle
+        is registered."
+      ordering_folklore: >-
+        COMMONLY REPEATED, NOT STATED IN LAW. The numbering is universally
+        explained as the counties' assessed-valuation (wealth) ranking in the
+        1930s — Natrona 1, Laramie 2, Sheridan 3, Sweetwater 4. W.S.
+        31-2-204(d) states the ASSIGNMENT and gives NO rationale. Recorded as
+        folklore pending a Session Laws of Wyoming primary. THE STRUCTURAL
+        POINT SURVIVES EITHER WAY: the order is not alphabetical (Albany, the
+        alphabetically first county, is 5) and not by modern population
+        (Laramie County is the largest today but is 2), so it encodes
+        something historical and frozen. NOTE THE TELL IN THE STATUTE ITSELF:
+        Sublette is 23 and Teton is 22, both counties created after the
+        original assignment, and the section closes 'new counties shall be
+        assigned numbers by the department as they may be formed, beginning
+        with the number 24' — the tail of the sequence is chronological, not
+        ranked, which is direct textual evidence that the head was ranked
+        somehow and then frozen.
+      table:
+        1: Natrona
+        2: Laramie
+        3: Sheridan
+        4: Sweetwater
+        5: Albany
+        6: Carbon
+        7: Goshen
+        8: Platte
+        9: Big Horn
+        10: Fremont
+        11: Park
+        12: Lincoln
+        13: Converse
+        14: Niobrara
+        15: Hot Springs
+        16: Johnson
+        17: Campbell
+        18: Crook
+        19: Uinta
+        20: Washakie
+        21: Weston
+        22: Teton
+        23: Sublette
+      table_note: "Quoted verbatim from W.S. 31-2-204(d) and corroborated row for row against WYDOT's published county-prefix table. 23 counties, numbers 1-23, no gaps. Kept inline rather than in plates/_decode/ because 23 rows is trivially small and its authority is the same statute as the rest of this series."
+      county_seats: "WYDOT's county-prefix page additionally publishes the county SEAT for each number (Natrona/Casper, Laramie/Cheyenne, Sheridan/Sheridan, Sweetwater/Green River, Albany/Laramie ...), because Wyoming plates are obtained from the county treasurer in the county seat. Note the trap: the town of Laramie is the seat of ALBANY county (5), while LARAMIE county (2) seats at Cheyenne. Any geocoder keyed on the name will get this wrong."
+    sources:
+      - "https://www.wyoleg.gov/statutes/compress/title31.pdf  # W.S. 31-2-204: (a) one plate or two by vehicle type, county-treasurer issuance; (b) metal, twelve-inch minimum, county numerals at the left-hand end, the bucking horse and rider emblem, the department-determined distinctive number, the Wyoming wordmark and year numerals, the annual change-or-validate rule, the marked-contrast and fully-reflectorized rules, the 3 x 6 inch minimum for small plates, the antique 'Pioneer Wyo' legend, and the 'Farm' sticker; (c) numbering from one consecutively in each county and the department's freedom to relocate elements year to year; (d) the 23-row county table. W.S. 31-2-205: display. W.S. 31-2-206(a): staggered annual registration."
+      - "https://www.dot.state.wy.us/home/titles_plates_registration/prefixes.html  # WYDOT's own county-prefix table and county seats — independent agency corroboration of the statutory table, plus 'Wyoming license plate numbers begin with a prefix number that designates the county in which the vehicle is registered'"
+      - "https://www.dot.state.wy.us/home/titles_plates_registration.html  # WYDOT: 'Standard license plates and vehicle registrations are obtained through the local county treasurer in the county seat of the county of residence'; current passenger and truck plate imagery published as 2025 four-digit issues"
+      - "https://www.wyoleg.gov/statutes/compress/title08.pdf  # W.S. 8-3-117: the Bucking Horse and Rider trademark regime — see artwork_risk"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1 and §3.3 — the recommendations Wyoming's annual cycle and metric-free reflectorization rule sit against"
+    notes: >-
+      WYOMING STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED, and in Wyoming
+      that is not a compromise but the correct model: W.S. 31-2-204(b) makes
+      the plate change or be validated ANNUALLY and (c) lets the department
+      'from year to year change the location of the figures, words and
+      letters', so Wyoming law does not work in design generations at all. The
+      stable, statute-fixed facts are the ones recorded here — county numerals
+      left, emblem, department serial, wordmark, year — and they have held for
+      decades. `start: 2026` is the year the statute was read and is an UPPER
+      BOUND. NO "ONE SERIES BACK" ENTRY IS GIVEN: with an annual cycle and no
+      legislated design generations there is no primary-sourced predecessor
+      base to record, and inventing one from a collector table would be
+      exactly the laundering PRD-PLATES §9 warns against. Recorded as a gap.
+      Distinct from us-wy-antique in carrying the year numerals, which the
+      antique plate is statutorily forbidden to bear.
+
+  # =========================================================================
+  # HISTORIC — the one Wyoming class whose LEGEND is legislated verbatim.
+  # =========================================================================
+  - id: us-wy-antique
+    class: historic
+    categories: [car, truck]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          W.S. 31-2-204(b) states the antique plate's LEGEND and its
+          PROHIBITION but not its serial: 'Antique license plates shall bear
+          no date and shall bear the inscription "Pioneer Wyo".' The
+          department-determined serial rule of the same subsection applies by
+          default, with no stated width and no stated alphabet — hence the
+          unbounded, deliberately wide regex, which makes no width claim and
+          claims only a shape.
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: statutory-minimum-length-plus-convention }
+      material: "W.S. 31-2-204(b): metal, fully reflectorized background, marked contrast"
+      legend: "Pioneer Wyo"
+      legend_rule: "W.S. 31-2-204(b), verbatim: 'Antique license plates shall bear no date and shall bear the inscription \"Pioneer Wyo\".'"
+      no_year: "STATUTORY PROHIBITION, not merely an omission: the antique plate 'shall bear no date' — the exact inverse of the standard plate, which must bear 'arabic numerals for the year of issue or validation'. Two Wyoming series, opposite rules, same subsection."
+      emblem: { present: true, rendered: placeholder, note: "whether the Bucking Horse and Rider appears on the antique plate is not stated; the substitution clause in 31-2-204(b) names dealers, forestry, motorcycles, multipurpose vehicles and trailers, and does not name antiques (recorded gap)" }
+    display_note: "W.S. 31-2-205(a)(i)(A)(VII): antique vehicles registered under W.S. 31-2-223 are EXCLUDED from the front-plate requirement — rear only."
+    region_encoding: "not stated for this series; the county-numeral rule of W.S. 31-2-204(b) is general and is not expressly disapplied (recorded gap)"
+    sources:
+      - "https://www.wyoleg.gov/statutes/compress/title31.pdf  # W.S. 31-2-204(b): the 'Pioneer Wyo' inscription and the no-date prohibition; W.S. 31-2-205(a)(i)(A)(VII): antique vehicles excluded from the front plate; W.S. 31-2-223: the antique registration section (cross-referenced, not read in full)"
+    notes: >-
+      ANTIQUE ("Pioneer Wyo"). Worth its own series on two independent
+      PRD-PLATES §2.3 grounds: the LEGEND is legislated verbatim, and the
+      no-date rule is a statutory design prohibition the standard series
+      inverts. `recall-only` because only the legend and the date prohibition
+      are sourced — the serial grammar is not, and the regex is deliberately
+      wide enough to say so. Distinct from us-wy-standard in bearing no year
+      and in being rear-plate-only.
+
+  # =========================================================================
+  # GOVERNMENT — sourced existence and scope, unsourced grammar.
+  # =========================================================================
+  - id: us-wy-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      charset: { notes: "W.S. 31-2-207 requires 'distinctive license plates indicating public ownership' and states no grammar. The regex is a deliberately wide shape claim." }
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: statutory-minimum-length-plus-convention }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+      distinctiveness_rule: "W.S. 31-2-207: 'Upon application the department shall issue distinctive license plates indicating public ownership for vehicles owned by the United States, state of Wyoming, a county, city, town or political subdivision of Wyoming, the tribal governments of the Eastern Shoshone and Northern Arapaho tribes of the Wind River Indian Reservation or a joint powers board under W.S. 16-1-101 through 16-1-109.'"
+    covert_plate_rule: >-
+      A GENUINELY UNUSUAL STATUTORY PROVISION, AND ONE A PLATE DATASET SHOULD
+      CARRY BECAUSE IT BOUNDS WHAT ANY PARSE API CAN HONESTLY CLAIM. W.S.
+      31-2-207: 'Upon presentation of proper credentials and identification of
+      the applicant the department shall issue license plates NOT DISCLOSING
+      PUBLIC OWNERSHIP of a vehicle to investigative agencies of Wyoming and
+      the criminal investigative agencies of the department of justice,
+      department of defense and department of the treasury of the United
+      States and the records of the department shall not disclose the public
+      ownership of the vehicles.' Wyoming legislates covert plates that are
+      INDISTINGUISHABLE FROM STANDARD ISSUE and legislates that the registry
+      itself must not reveal them. Any consumer inferring "private vehicle"
+      from a standard-looking Wyoming plate is, by statute, sometimes wrong,
+      and no dataset can ever fix that.
+    region_encoding: "not stated (recorded gap)"
+    sources:
+      - "https://www.wyoleg.gov/statutes/compress/title31.pdf  # W.S. 31-2-207: the distinctive public-ownership plate, its full list of eligible public entities including the Eastern Shoshone and Northern Arapaho tribal governments and joint powers boards, and the covert-plate provision quoted above"
+    notes: >-
+      GOVERNMENT / PUBLIC OWNERSHIP. `recall-only` because the grammar is
+      unsourced. Kept because two of its facts are high-value and both are
+      statutory: the eligible-entity list expressly includes TRIBAL
+      GOVERNMENTS of the Wind River Indian Reservation alongside federal,
+      state and local bodies, and the covert-plate clause sets a hard,
+      legislated ceiling on what any plate-parse product may claim about
+      Wyoming vehicles.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-wy-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "99 9999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          Wyoming special plates generally retain the county-number-first
+          structure — the disabled plate provision, for example, specifies
+          'the arabic numerals designating the county in which issued at the
+          left, followed by the bucking horse and rider emblem and a
+          distinctive combination of up to three (3) numbers and letters ...
+          followed by the international symbol of access'. That THREE-CHARACTER
+          cap is a real sourced width for that programme, but per-programme
+          grammars are L4 scope, so the index carries a deliberately wide
+          union and is `recall-only`.
+    design:
+      plate: { w: 12, h: 6, unit: in, dimension_basis: statutory-minimum-length-plus-convention }
+      background: { finish: retroreflective }
+      note: "one design per authorised programme; the designs themselves are L4 scope and none is described here"
+      emblem: { present: true, rendered: placeholder, note: "many special series substitute their own identification for the Bucking Horse and Rider under the W.S. 31-2-204(b) substitution clause" }
+    program_index:
+      count_official: "23 named programmes, enumerated not totalled"
+      count_official_note: >-
+        WYDOT ENUMERATES RATHER THAN COUNTS, so 23 is this pass's arithmetic
+        on WYDOT's own list, not a figure WYDOT publishes. The list splits in
+        two by ISSUING ROUTE, which is the more useful structural fact.
+      county_treasurer_route: >-
+        WYDOT, in its own words: "The following special license plates are
+        processed by WYDOT in conjunction with the county treasurers' offices.
+        Some of these plates require a county treasurer to approve them prior
+        to submitting the application to WYDOT." Nineteen programmes:
+        Prestige Plates, Radio Amateur, Former POW, Pearl Harbor Survivor,
+        Disabled Veteran, National Guard, Purple Heart Recipient, Firefighter,
+        EMT, University of Wyoming, Veteran Plates, Embossed Plates, Gold Star
+        Plates, Choice Disabled Veteran Plates, Tribal Plates, Wildlife
+        Conservation Plates, Donate Life, Rodeo, Search and Rescue.
+      wydot_only_route: >-
+        WYDOT: "The following plates are issued through WYDOT-Motor Vehicles
+        Services only" — Pioneer, Street Rod and Custom Vehicle, Sample,
+        Novelty. Four programmes, no county treasurer in the loop.
+      embossed_plate_note: >-
+        WORTH RECORDING BECAUSE IT INVERTS THE USUAL DIRECTION OF TRAVEL.
+        "Embossed Plates" is a paid OPTION in Wyoming, not the default: W.S.
+        31-3-102(a)(xxii) prices 'Optional embossed license plates' at $50.
+        Everywhere else in this wave embossing is the legacy manufacturing
+        method being retired; in Wyoming it is a premium product.
+      street_rod_and_custom: "W.S. 31-2-226 (street rods) and 31-2-227 (custom vehicles) are separate statutory registration classes, both excluded from the front-plate requirement by W.S. 31-2-205(a)(i)(A)(V)-(VI)."
+      ev_decal_note: "NOT A PLATE, BUT ADJACENT AND WORTH THE ROW: W.S. 31-3-102(a)(xxiii)-(xxiv) create an annual DECAL for all-electric vehicles ($100) and plug-in hybrids ($50), each of which 'shall include the bucking horse and rider emblem'. Wyoming charges an EV fee via a plate-adjacent credential rather than via a plate series."
+      official_list_url: "https://www.dot.state.wy.us/home/titles_plates_registration/specialty_plates.html"
+      prestige_plate_url: "https://www.dot.state.wy.us/home/titles_plates_registration.html"
+    region_encoding: "generally retained — Wyoming special series typically keep the county numerals at the left-hand end (see the disabled-plate text quoted in charset.notes), unlike Montana, which replaces the county number with a series-distinguishing design"
+    sources:
+      - "https://www.dot.state.wy.us/home/titles_plates_registration/specialty_plates.html  # WYDOT's own enumerated specialty list, split into the nineteen county-treasurer-route programmes and the four WYDOT-only programmes, quoted above"
+      - "https://www.wyoleg.gov/statutes/compress/title31.pdf  # the disabled-plate serial specification (county numerals, emblem, up to three numbers and letters, international symbol of access) and the 3 x 6 inch small-plate minimum; W.S. 31-3-102(a)(xxii)-(xxiv): the optional-embossed fee and the EV/PHEV decals bearing the emblem; W.S. 31-2-226/31-2-227: street rod and custom vehicle classes"
+    notes: >-
+      THE WYOMING SPECIALTY INDEX — one entry standing for the whole
+      programme, per PRD-PLATES §2.5. Wyoming's catalogue is SMALL (23 named
+      programmes against Washington's 49 statutory entries and Idaho's
+      "over 40"), ENUMERATED rather than counted, and split by issuing route
+      in a way that matters operationally: nineteen go through the county
+      treasurer, four do not. The two facts most worth carrying forward are
+      that Wyoming special series generally KEEP the county numerals — the
+      opposite of Montana, where MCA 61-3-332(8) replaces them — and that
+      embossing is a $50 premium option rather than the legacy default.
+
+# ---------------------------------------------------------------------------
+# Classes Wyoming separately serializes but which are NOT given series here.
+# ---------------------------------------------------------------------------
+unspecified_classes:
+  motorcycle:
+    statutory_hook: "W.S. 31-2-204(a): one plate for motorcycles and multipurpose vehicles. (b): 'shall not be less than three (3) inches wide and six (6) inches long' and 'shall contain appropriate identification which may be in lieu of the bucking horse and rider emblem'. (e): 'provisions for license plates for motorcycles shall apply to autocycles.' Excluded from the front plate by 31-2-205(a)(i)(A)(I)."
+    gap: "no motorcycle serial grammar stated in statute and none located from WYDOT; a series would have to invent one"
+  trailer:
+    statutory_hook: "W.S. 31-2-204(a): one plate for trailers including house trailers. (b): light utility trailers under 1,000 lb take the 3 x 6 inch minimum size and may substitute identification for the emblem. Excluded from the front plate by 31-2-205(a)(i)(A)(III)."
+    gap: "no serial grammar sourced"
+  dealer:
+    statutory_hook: "W.S. 31-2-204(a): vehicles operated with dealer plates receive ONE plate. (b): dealer plates 'shall contain appropriate identification which may be in lieu of the bucking horse and rider emblem'. W.S. 31-16-125 issues demo, full use and manufacturer plates, all excluded from the front-plate rule by 31-2-205(a)(i)(A)(IV)."
+    gap: "no dealer serial grammar sourced; note Wyoming distinguishes DEMO from FULL USE from MANUFACTURER plates, a three-way split worth modelling once sourced"
+  agricultural:
+    statutory_hook: "W.S. 31-2-204(b): 'Distinctive license farm stickers shall be issued by the county treasurer upon request for trucks and trailers used by any farmer or rancher ... Farm stickers shall bear the inscription \"Farm\".' A STICKER on a standard plate, not a plate series — recorded here so it is not mistaken for one."
+    gap: "n/a — this is correctly not a series; it is a sourced sticker legend"
+  personalized:
+    statutory_hook: "WYDOT calls these PRESTIGE PLATES and runs an online application; W.S. 31-3-102 prices them."
+    gap: "character cap, alphabet and content-refusal criteria not obtained"
+
+# ---------------------------------------------------------------------------
+# Dead ends and open items.
+# ---------------------------------------------------------------------------
+research_notes:
+  reachability:
+    - "wyoleg.gov publishes the statutes as per-title PDFs at /statutes/compress/title<NN>.pdf — Title 31 is 542 pages, 1.7 MB, and text-extracts cleanly with pdftotext -layout. THIS IS THE BEST STATUTE-ACCESS ROUTE FOUND IN THE ENTIRE NORTHWEST GROUP and should be pinned in the source appendix; it beats scraping any HTML statute site."
+    - "www.dot.state.wy.us serves plain HTML with no bot challenge; the county-prefix and specialty-plate pages both parse trivially. Its footer carries Privacy / Contact / Disclaimer links and NO copyright notice (measured, not assumed)."
+  open_items:
+    - "The Session Laws of Wyoming enactment behind W.S. 31-2-204(d) would settle whether the county numbering is the 1930s valuation ranking. Until then it is folklore."
+    - "W.S. 31-2-223 (antique), 31-2-226 (street rod) and 31-2-227 (custom vehicle) were cross-referenced but not read in full; each may carry its own design or eligibility text."
+    - "The Secretary of State's rules under W.S. 8-3-117 governing Bucking Horse and Rider licensing were not fetched. They are the document that would say whether any use is permitted without a licence — directly relevant to any future emblem-slot decision."
+    - "No Wyoming instrument stating plate COLOURS was located; the statute mandates contrast and reflectorization only."


### PR DESCRIPTION
**PRD-PLATES gate L2 (owner-directed acceleration; research parallel, application ordered — L1 landed first per §7.1).** One of eleven US regional-group PRs covering all 50 states + DC + territories (FL was the L0 pilot). Drafted to the `de.yml`/`nl.yml`/`us-fl.yml` standard: primary-law verbatim headers, instrument-dated periods, `strict`/`recall-only` matching tiers, folklore flagged not asserted, **`artwork_risk` recorded per jurisdiction with evidence** (PRD-PLATES §4).

**This PR — northwest:** WA OR ID MT WY (5 jurisdictions, 29 pinned primary sources).

**Verification:** researcher linted green in an isolated sandbox (proof file in the group dir, archived to the pipeline program dir); the driving session then independently staged ALL 55 wave files over pristine origin/main — `plates lint: 67 files, 604 series … OK` (385 new series; the _art gate stayed green) — and this branch is linted solo pre-push; CI runs the same gate.

**For the reviewer:** the dossier below carries the gaps (marked in the YAML at point of use), folklore flags, and the artwork_risk findings. The full research dossier follows verbatim.

---

# PRD-PLATES gate L2 — NORTHWEST group dossier

**States:** WA · OR · ID · MT · WY
**Researcher pass:** 2026-08-02. **Method:** FETCH-NEVER-ASSUME. Every claim in the five YAML files traces to a URL fetched in this session or is explicitly marked locator-grade. Nothing is recalled from memory. `WebSearch` was unavailable for the entire pass (session budget exhausted at the first call), so **all discovery was WebFetch and `curl` against constructed URLs** — which is why the dead-end section below is long and worth reading.

**Deliverables:** `us-wa.yml` `us-or.yml` `us-id.yml` `us-mt.yml` `us-wy.yml` + `lint-and-sample-proof.txt`, all in this directory. `/Users/javi/GitHub/vehiclesdb` was treated as read-only throughout; verification ran in a disposable sandbox copy.

**Verification:** `ruby scripts/lint_plates.rb` → **OK**, 17 files / 242 series (5 northwest files added to the current upstream, which already carries the L1 EU wave). Two checks were run *beyond* the lint and both pass: full `regex ⊆ regex_statutory` containment by random sampling over the serial+separator alphabet (the lint samples only `regex_strict ⊆ regex`), and 59 hand-written sample assertions including county-range negatives.

---

## 1. The four headline findings

### 1.1 This group splits cleanly into statute-first and agency-first states, and the split predicts data quality exactly

| state | where the plate spec actually lives | consequence |
|---|---|---|
| **MT** | **MCA 61-3-332**, one section, legislating material, wordmark, state-outline border, two exact sizes in inches, serial grammar, county prefix, separation mark, replacement clock, exempt markings **and the whole 56-row county table** | best-sourced US state in the group; almost nothing observed |
| **WY** | **W.S. 31-2-204**, legislating minimum length, county numerals at the left-hand end, the emblem's position, the wordmark, the year numerals, annual revalidation, contrast + reflectorization, the antique legend, the farm sticker, **and the 23-row county table** | second-best; agency page independently corroborates the table row-for-row |
| **OR** | **ORS 803.535**, which does not describe the plate but *incorporates the winner of a 1987 design contest by reference* | strong period anchor, weak design detail |
| **WA** | **nowhere.** RCW 46.16A.200(1) hands size, colour and design wholesale to the director; no departmental rule was found | statute gives display law and plate counts only; every design fact is observed |
| **ID** | Idaho Code 49-443 — **never read, host unreachable** | rests entirely on ITD's own pages plus flagged locator material |

The lesson for the rest of the L2 wave: **the first question per state is not "what does the plate look like" but "does this legislature specify plates at all."** Montana and Wyoming answer yes and hand over almost everything; Washington answers no and the ceiling drops to whatever the agency happens to publish.

### 1.2 The replacement cycle spans the entire possible range across five neighbouring states — and one state changed regime one month ago

AAMVA Ed.3 §1.1 recommends a cycle "not to exceed 7 to 10 years". Within this one group:

| state | cycle | instrument |
|---|---|---|
| **WY** | **annual** ("changed **or validated** annually") | W.S. 31-2-204(b) |
| **MT** | **5 years** (10 for combat-disabled veterans) | MCA 61-3-332(3)(a)(ii) |
| **ID** | **was 10 → abolished 2026-07-01** | ITD, citing House Bill 577 (2026 session) |
| **OR** | none located anywhere in ORS 803 | — (recorded negative, not asserted) |
| **WA** | **none — event-triggered only** (sale, loss, illegibility) | RCW 46.16A.200(9) |

Add Florida's legislated 10 from the L0 pilot and the five-state span covers annual → 5 → 10 → none. **AAMVA's cycle is demonstrably a recommendation and not a floor or a ceiling.** The PRD can now say that with six citations instead of one.

**The Idaho item is the freshest fact in the wave.** ITD, verbatim: *"As of July 1, 2026, the DMV will stop providing registration stickers and license plates will no longer be replaced every ten years."* Two 2026-session bills: **HB 577** killed the ten-year replacement, **HB 533** killed the registration sticker entirely. Consequences worth flagging to the parse/vision side: after 1 July 2026 an Idaho plate carries **no visible validity marker at all**, and plate age is no longer inferable from an issue cycle.

### 1.3 Two of the five states put a *frozen historical ranking* in the serial; the third derives its code from the county's own name

This is the group's Geoguessr/decode gold, and **two of the three tables are quoted verbatim from statute**.

- **Montana** — MCA 61-3-332(7), 56 counties, 1–56. Silver Bow 1, Cascade 2, Yellowstone 3, Missoula 4. Not alphabetical, not modern population. New counties start at 57.
- **Wyoming** — W.S. 31-2-204(d), 23 counties, 1–23. Natrona 1, Laramie 2, Sheridan 3, Sweetwater 4. Albany (alphabetically first) is 5; Laramie County (largest today) is 2. New counties start at 24. **Independently corroborated row-for-row by WYDOT's own county-prefix page**, which also publishes county seats — and exposes a real trap: *the town of Laramie is the seat of **Albany** county (5), while **Laramie** county (2) seats at Cheyenne.* Any name-keyed geocoder gets this wrong.
- **Idaho** — a **letter-ordinal** code: initial letter + rank among counties sharing it (Ada 1A, Adams 2A, Bannock 1B … Butte 10B), with a bare letter where a county is the only one with its initial (Elmore E, Kootenai K, Nez Perce N). **Derivable from the county name**, therefore stable under demographic change — structurally different from MT/WY. ITD confirms the mechanism in its own words; **the table itself is locator-grade and flagged as such row by row.**

**FOLKLORE FLAGGED, NOT LAUNDERED.** The MT and WY orderings are universally explained as 1930s population / assessed-valuation rankings. **Neither statute states any rationale** — they state the assignment only. Both files record the story as *commonly repeated, not stated in law*. Wyoming's statute contains its own tell, which is recorded: Teton is 22 and Sublette is 23 (both later-created counties) and new counties continue from 24, so the tail is chronological while the head is ranked-then-frozen — textual evidence *that* something was ranked, not evidence of *what*.

### 1.4 `artwork_risk`: Wyoming is the strongest adverse evidence found in any state so far — stronger than Arizona's

PRD-PLATES §4 names AZ as the most adverse posture found (a bare copyright assertion). **Wyoming beats it, from statute:**

> **W.S. 8-3-117** — *"(a) The secretary of state shall promulgate rules regulating the licensing or other authorized use of the 'Bucking Horse and Rider' and related trademarks. (b) Any licensing fees, royalties or other revenues collected … shall be deposited into a separate account. The legislature shall by appropriation authorize expenditures … required to protect, preserve and promote the 'Bucking Horse and Rider' and related trademarks on behalf of the state."*

Wyoming **claims the mark, licenses it for money, and appropriates funds to enforce it** — and **W.S. 31-2-204(b) puts that mark on every standard plate**, between the county numerals and the serial. The mark also rides the EV/PHEV decals (W.S. 31-3-102(a)(xxiii)–(xxiv)). This is a *trademark* regime and therefore **survives any copyright finding**, which is exactly the seal/emblem hazard §4 flags as unresearched — here documented instead.

Washington is confirmed adverse on grounds better than the general state-works rule: **RCW 46.18.200(2) is a statutory table of special plates describing the artwork as third-party marks** — the Seattle Mariners / Seahawks / Sounders / Storm / Reign logos, the Fred Hutch logo, "the name, image, and likeness of Smokey Bear", "the likenesses of the J.P. Patches and Gertrude characters", "the '4-H' logo". 4-H and Smokey Bear carry *federal* protection independent of copyright. No theory of state PD reaches any of it.

Montana **splits, on its own admission**: MCA 61-3-475(1)(e)(iv)(C) makes a sponsor prove its graphic does not "infringe or otherwise violate a trademark, trade name, service mark, copyright, or other proprietary or property right", and (2) lets the department demand a sworn statement plus an "agreement to defend and hold harmless the state of Montana". **Montana legislates that its specialty artwork is third-party property and contracts out of liability for it.**

Full per-state postures are in §3.

---

## 2. Per-state summary

### WA — `us-wa.yml` (5 series)
`us-wa-standard` (LLL9999, undated, instrument-in-force) · `us-wa-standard-numeric-first` (999 LLL, 1987–2010, **locator-only period**) · `us-wa-motorcycle` · `us-wa-trailer` (both recall-only) · `us-wa-specialty-index`.
- **Display law is the best part**: RCW 46.16A.200(5)(b) enumerates *which devices may obstruct one plate* — trailer hitch, wheelchair lift/carrier, towed trailer, bike/ski/luggage rack — with an installed-to-spec and readable-from-one-angle-when-parked test, and (5)(b)(iv) lets an obstructed **trailer** plate be *relocated above* the four-foot limit.
- **Transfer, not a clock**: standard plates must be replaced on ownership change, but the owner may keep and transfer them; seven enumerated exceptions (lien, spouse, death, family gift, trust, lease buy-out, name change). Three plate classes are never replaced at all.
- **Specialty count is contested and recorded, not averaged**: **49 statutory entries** (RCW 46.18.200(2); ≥54 designs because "Armed forces collection" is defined as six) vs **~89** on DOL's gallery. The gap is structural (the gallery mixes in plates authorised elsewhere in Title 46).
- **A hard dated freeze**: RCW 46.18.200(6) — *"the department may not issue any new special license plates until January 1, 2029"* except the chapter-385 (2025) plates, in a phased order keyed to signature-sheet dates. Natural re-audit trigger.
- **Correction to the source appendix** — see §5.

### OR — `us-or.yml` (5 series)
`us-or-standard` (999 LLL) · `us-or-standard-letters-first` (LLL 999, **start instrument-anchored to 1987, end locator-only**) · `us-or-trailer` · `us-or-government-exempt` (both recall-only) · `us-or-specialty-index`.
- **ORS 803.535 is the find of the pass for period discipline**: the design is *"that chosen by the commission from entries in the contest held pursuant to chapter 572, Oregon Laws 1987."* An instrument with a date, a real **lower** bound on first issue, and the reason Oregon's plate has outlived every neighbour's redesign — it cannot change without amending the statute.
- **Base and arrangement have different lifetimes.** The fir base is frozen since 1987; the serial flipped letters-first → numerals-first when the letter blocks ran out. A schema conflating "base" and "format" cannot model Oregon. Modelled as two series on one design.
- **Specialty count: `unstated`.** Oregon publishes no total — recorded as a negative with the reason, not filled from an encyclopedia. What *is* sourced is the architecture: applicant-driven creation by "Public bodies, non-profit organizations, institutes of higher education, and veteran groups", via two routes. **Exactly opposite to Washington's statutory freeze** — two neighbours, two opposite programme designs.
- Class D traffic violation for display breach (cf. FL nonmoving infraction, WA $500 transfer fine): **US display penalties are not comparable across states** and must not be normalised.

### ID — `us-id.yml` (4 series) — the weakest file, and it says so on its face
`us-id-standard` (recall-only union) · `us-id-standard-centennial` (1987–1991, **entirely locator-grade**) · `us-id-specialty-index` · `us-id-personalized`.
- **Idaho Code 49-443 was never read.** TLS handshake refused on every variant tried; Justia 403; IDAPA host refused too. Everything rests on ITD's own pages. `display_rules.status: not-sourced` — Idaho is conventionally a two-plate state and the file **declines to say so**, because no instrument was read.
- **The one genuinely sourced charset rule in the file** is ITD's: *"The letter O and the number zero look the same on a license plate, therefore only the number zero will be accepted."* Carried as `charset.excluded: ["O"]` (not in a regex — §2.7 makes `regex` the round-trippable tier, and `recall-only` forbids a strict twin). Pleasing consequence recorded: Idaho's own county designators for **Oneida (1O)** and **Owyhee (2O)** use a letter its citizens may not choose.
- **Idaho counts a space as a character** against the personalized cap — a jurisdiction treating a separator as length-significant while it stays a separator for matching. Recorded against `_meta/separators.yml`; **it does not breach the contract** (the space is still never part of serial identity).
- ITD publishes an **Interactive Plate Programs Guide** (a JS app). If it has a JSON endpoint it is the best structured Idaho artefact in existence. Pinned, not captured.

### MT — `us-mt.yml` (5 series) — the best-sourced state
`us-mt-standard` (99-9999L, **`period.start: 1989`, `statutory-date`**, with `regex_strict` bounding the county to 1–56 and `regex_statutory` the outer bound) · `us-mt-motorcycle` · `us-mt-trailer` · `us-mt-government-exempt` (strict, numeric-from-1) · `us-mt-specialty-index`.
- **`start: 1989` is a real statutory claim**, not an edition upper bound: MCA 61-3-332(3)(a)(i) requires new plates to be "a standard license plate design first issued in **1989 or later**".
- **THERE IS NO "ONE SERIES BACK" IN MONTANA, and that is the finding.** Montana does not retire bases; it accumulates them. Every standard design first issued from 1989 onward stays orderable in parallel, indefinitely, and the rule extends to collegiate, generic specialty, commemorative centennial and military/veteran plates. Recording that with the citation beats minting a superseded series from a collector table. **The L2 "one series back" requirement is inapplicable in Montana's own terms.**
- **Statutory design spec**: metal, reflectorized, "Montana" on every plate, and *"the outline of the state of Montana must be used as a **distinctive border**"* — a border constraint, not a graphic in a slot; a renderer must bound the face with it. Excepted for 4×7 in plates.
- **Format depends on plate SIZE, which the owner can buy.** 4×7 in plates are statutorily exempt from the county-number rule; a trailer under 6,000 lb declared weight gets a 4×7 in plate **unless the owner requests and pays for** the 6×12 in. So the same trailer can lawfully carry a county-prefixed or unprefixed serial depending on which plate its owner bought.
- **MAJORITY IS NOT AUTHORITY, applied**: secondary sources show county-prefixed *motorcycle* serials; MCA 61-3-332(5) exempts 4×7 in plates from the county rule. The statute governs; the discrepancy is recorded.
- **Specialty index = `unstated-and-request-only`, by statute.** MCA 61-3-474(4) makes the sponsor list a *records-request* artefact, not a publication. **That list carries per-programme initial distribution dates** — i.e. Montana would hand over period data no competitor has, on request. Highest-value follow-up in the group. Churn threshold is exact: **400 sets** (61-3-474(5)), with a run-until-next-renewal grace.

### WY — `us-wy.yml` (4 series)
`us-wy-standard` (99 9999, `regex_strict` bounding the county to 1–23) · `us-wy-antique` ("Pioneer Wyo") · `us-wy-government` · `us-wy-specialty-index` (all recall-only where grammar is unsourced).
- **The emblem sits in the separator position** — a live instance of `_meta/separators.yml`'s `never_separator` case. Recorded loudly in `format.separator_note`: the gap holds a *picture*, the separator class `[- ]` is the honest encoding of a statute that names no glyph, and no consumer may treat the emblem as a separator or as serial.
- **Serial space is per county** (W.S. 31-2-204(c): "begin with one (1) and be numbered consecutively **in each county**"), so the same distinctive number legitimately recurs 23 times statewide. A parse API must not treat a Wyoming distinctive number as globally unique.
- **The year is on the plate face by statute**, not on a sticker — Wyoming plate photos are datable on sight.
- **The eighth front-plate exclusion is a hook into the vehicle catalogue**: no front plate for *"a motor vehicle which was originally manufactured without a bracket, device or other means to display and secure a front license plate."* That is a per-**model** fact. A per-jurisdiction boolean cannot express it; a vehicle catalogue that knows factory front-bracket fitment can.
- **Height constraint runs the opposite way from its neighbours**: Wyoming legislates a **minimum** 12 in from the ground; WA and FL legislate **maxima** (4 ft / 60 in). Not the same rule; must not be normalised together.
- **Covert plates are legislated** (W.S. 31-2-207): plates "not disclosing public ownership" for investigative agencies, *and* the registry itself must not disclose it. A hard, statutory ceiling on what any plate-parse product may claim.
- **Embossing is a $50 premium option** (W.S. 31-3-102(a)(xxii)), inverting the usual direction of travel.
- **No "one series back"**: with annual change-or-validation and no legislated design generations there is no primary-sourced predecessor. Recorded as a gap rather than invented.

---

## 3. `artwork_risk` ledger

| state | posture | evidence class | key evidence |
|---|---|---|---|
| **WY** | **asserted** | **statutory trademark, licensed for royalties** | W.S. 8-3-117 (SoS licensing rules, royalty account, protect-preserve-promote appropriation) + W.S. 31-2-204(b) putting the mark on every plate + W.S. 31-3-102(a)(xxiii)–(xxiv) putting it on EV/PHEV decals |
| **WA** | **adverse** | **statutory table naming third-party marks** + agency/legislature © notices | RCW 46.18.200(2) (Mariners/Seahawks/Sounders/Storm/Reign, Fred Hutch, Smokey Bear, J.P. Patches, 4-H); "© Washington State Department of Licensing" (fetched); leg.wa.gov "Copyright 2025. All Rights Reserved." (fetched); no state PD tag on Commons |
| **MT** | **split** — standard base **unresearched**, specialty tier **adverse** | **statute, on the state's own admission** | MCA 61-3-475(1)(e)(iv)(C) non-infringement proof + 61-3-475(2) sworn statement and defend-and-hold-harmless. MCA 61-3-332 itself is a PD edict, so the *spec* is clean even if the artwork is not |
| **OR** | **asserted (trademark); copyright unresearched** | state portal terms | oregon.gov T&C: "You may display these Oregon-owned trademarks so long as the context of your use is truthful and not misleading…" + DMCA channel. Extra hazard recorded: ORS 803.535 makes the design a **1987 contest winner**, i.e. an identifiable private author — whether the contest assigned copyright is unknown |
| **ID** | **unresearched** | measured absences | not in the §4 state survey; no Commons ID tag; **no copyright notice found on any Idaho page fetched**; idaho.gov/legal TLS-refused. Default applies (state works © unless the state says otherwise). One concrete flag: university, Corvette and Appaloosa marks in the special catalogue are third-party regardless |

**Emblem rule:** PRD-PLATES §3 placeholder default applies to **all five states, all emblems, no exceptions.** The one plausible future upgrade candidate anywhere in this group is Montana's **state-outline border** — a geographic outline, arguably a fact rather than an authored work — and it is *not* upgraded here because §7.1 requires *both* `artwork_risk` and the ledger to clear, and Montana's base posture is unresearched.

---

## 4. Method notes the wave should adopt

**`period_evidence` values used**, extending the two the FL pilot established. All are declared in-file; a verifier may rename them, but the *distinctions* should survive:
- `statutory-date` — the year is in the instrument (MT 1989).
- `statutory-instrument-date-start-locator-end` — halves with different strength (OR letters-first: 1987 anchored, 2004 not).
- `instrument-in-force-upper-bound` — the FL pilot's value; the statute edition read, as an upper bound (WA/OR/ID/WY current series).
- **`secondary-locator-only`** — *new, and the important one.* Used where a boundary comes from an encyclopedia and nothing else, **always paired with a `period_caveat` that says "NOT A SOURCED CLAIM" in terms**. Used on `us-wa-standard-numeric-first` and `us-id-standard-centennial`. This is the alternative to either laundering collector years or dropping predecessor series entirely; the verifier should ratify or reject it as a wave-wide convention.

**`matching: recall-only` as an evidence signal.** 31 of the 242 series in the linted set are recall-only; 16 of the 23 northwest series are. The rule applied: *a format sourced only from a locator gets a deliberately **widened** regex and `recall-only`, so the schema's own vocabulary carries the evidence quality* — a match is a shape hit, exactly as §2.7 defines it. Where a statute gives an outer bound but no grammar (MT motorcycle/trailer, WY antique/government), the regex **is** the statutory bound, which is recall-only in the purest sense.

**Widths are never invented.** Where a statute states an alphabet and no width, the quantifier is unbounded (`\A[A-Z0-9]+\z`) — following `us-fl-horseless-carriage`. Unbounded makes *no* width claim; a guessed `{1,6}` would make a false one.

**No hexes were fabricated.** Only `#FFFFFF` (reflective white) is recorded, `hex_basis: observed`. Where the real colour is known by name but not measured — WA navy, OR dark blue, MT blue — a `foreground_note` / `colour_note` records the name with `hex_basis: unmeasured` and **no hex at all**. Deriving a hex from a JPEG and labelling it "observed" would be the same laundering as a folklore year.

---

## 5. Correction to the pinned source appendix

`aux/research/plates-2026-07/plates-research-us-world.md` §1.2 and pin-list #8 cite
`http://app.leg.wa.gov/wac/default.aspx?cite=308-96A-021` as **"WA plate display admin code."**

**That pin is wrong.** WAC 308-96A-021 was fetched in this pass and is the **replacement-plate rule** — when you must apply for replacements, the affidavit-of-loss requirement, and *"For an additional fee, you may replace them with the same number and letter combination as long as the plate meets a current approved license plate configuration and background."* It contains **no display rule at all**.

Washington display law is **RCW 46.16A.200(5)**. The appendix should be corrected and the correct citation substituted. (The pin was harvested from Wikipedia wikitext and never independently fetched — noted in the dossier's own fetch-status column as "harvested, not fetched." This is a small vindication of that column's existence.)

Also worth adding to the appendix: **`wyoleg.gov/statutes/compress/title<NN>.pdf`** is the best statute-access route found in this group — whole titles as clean PDFs that `pdftotext -layout` handles perfectly. Title 31 is 542 pp / 1.7 MB. It beats scraping any HTML statute site and should be the first thing tried for Wyoming at any future gate.

---

## 6. Dead ends — recorded so nobody repeats them

**TLS-refused (connect succeeds, handshake fails; not a bot block):**
| host | what was lost | attempts |
|---|---|---|
| `legislature.idaho.gov` | **Idaho Code 49-443 and 49-428** — the whole Idaho statutory layer | default curl (exit 35), `--tlsv1.2`, `--tlsv1.2 --tls-max 1.2`, `--tlsv1.3`, `--http1.1`; WebFetch ECONNRESET; raw `openssl s_client` connected to 164.165.66.180 then hung |
| `adminrules.idaho.gov` | **IDAPA 39.02.60** — ITD's own special-plate rule, incl. 202.08 (personalized rules, per-type character caps) | curl exit 35; WebFetch ECONNRESET |
| `www.idaho.gov/legal/` | Idaho's legal notices → why `artwork_risk` is unresearched rather than resolved | curl exit 35 |
| `www.oregonlegislature.gov` | official ORS host; **worked around** via `oregon.public.law` (PD edicts, so the text is the text) | curl exit 35 on all variants; WebFetch ECONNRESET |

**HTTP-blocked:**
- `law.justia.com` → **403 on every Idaho path.** The US/world dossier pins Justia for Idaho Code 49-405 as a harvested URL; **that route is now closed** and the appendix should say so.
- `mvdmt.gov` and `dojmt.gov` → **403 on everything**, including with a browser UA. **No Wayback capture of `mvdmt.gov` exists at all.** Montana's entire *agency* estate is unread — survivable only because MCA 61-3-332 carries so much of the spec.
- `plates.mt.gov`, `app.mt.gov/plates`, `svc.mt.gov/dojmvd/platesearch` → dead (connection failure / 404).

**404 / wrong guesses:** `oregon.gov/odot/DMV/Pages/Vehicle/plate_options.aspx`, `plates_special.aspx`, `plate_special.aspx`, `plateoptions.aspx` (all 404 — the real targets are script-rendered and must be harvested from the DOM); `itd.idaho.gov/itddmv/*` (the working prefix is `/dmv/`, not `/itddmv/`); `dol.wa.gov/vehicles-and-boats/license-plates` 301s to `…/vehicles/license-plates`.

**Parsing gotchas:** `leg.mt.gov` 301s **twice** (→ `archive.legmt.gov` → **`mca.legmt.gov`**; pin the final host) and serves a heavy anti-bot JS preamble that must be stripped before the statutory text is reachable. `app.leg.wa.gov` renders **two versions of RCW 46.16A.200 on one page** — operative and "(Effective January 1, 2027)", amended by 2026 c 172 s 3 — which a naive scraper will concatenate; they differ only in (9)(b)(ii).

**Environment:** `WebSearch` was unavailable for this entire pass (budget exhausted at the first call). Every source above was reached by constructing a URL and fetching it.

---

## 7. Ranked follow-ups

1. **Idaho Code 49-443** from a working network. Everything structural in `us-id.yml` is downstream of it: design, dimensions, the county-designator table, the numbering rule, display.
2. **Montana MCA 61-3-474(4) records request** for the generic specialty sponsor list — it carries **per-programme initial distribution dates and donation fees**. Period data no competitor has, available for the asking.
3. **IDAPA 39.02.60** — would likely make `us-id-personalized` strict with a real `regex_strict` (per-plate-type character caps).
4. **Chapter 572, Oregon Laws 1987** — the design-contest act. Would date the contest, name the commission, and possibly settle **who owns the winning artwork** (period *and* artwork_risk).
5. **ITD Interactive Plate Programs Guide** — check for a JSON endpoint.
6. **WA**: any WAC 308-96A rule fixing colours/dimensions/serial grammar. If none exists, record the absence as a *sourced negative* after a full sweep.
7. **WY Secretary of State rules under W.S. 8-3-117** — the document that would say whether any Bucking Horse use is permitted unlicensed. Gates any future emblem decision.
8. **Session Laws** for the MT and WY county orderings — to convert the 1930s-ranking story from folklore into a citation, or to kill it.
9. **HB 533 / HB 577 (Idaho 2026)** bill texts — the sticker and replacement-cycle abolition is currently agency-sourced, not statute-sourced.
