### PR TITLE
plates: us pacific — CA HI AK (L2 US wave)

### DIFF
--- a/plates/us-ak.yml
+++ b/plates/us-ak.yml
@@ -1,0 +1,763 @@
+# plates/us-ak.yml — Alaska (PRD-PLATES gate L2, group: pacific).
+#
+# THE SOURCING PROBLEM IN THIS FILE, STATED FIRST BECAUSE IT SHAPES EVERY
+# PERIOD CLAIM BELOW. Alaska's statutes are served by the Legislature's BASIS
+# system (akleg.gov), which is a frameset over a Folio database: the document
+# frames resolve, but the section jump does not, and a fetch of AS 28.10.161
+# returns Title 1 from the top instead. Every direct route was tried and
+# recorded: akleg.gov/basis/statutes.asp (JS shell), the folioproxy frame URLs
+# (returns the corpus from the beginning), law.justia.com (403),
+# codes.findlaw.com (403), lawserver.com (JS gate), touchngo.com live (a single
+# 24,714-byte landing page for every path). What DID work is the Internet
+# Archive's capture of the Touch N' Go Alaska Legal Resource Center, a
+# long-standing third-party reproduction of an edict of government — and its
+# own banner says the text is "current through December, 2007."
+#
+# SO: every AS quotation below is a 2007-VINTAGE TEXT, marked as such on every
+# citation, and where the live DMV contradicts it the DMV wins and the conflict
+# is recorded rather than smoothed. There is one such conflict and it is
+# material — see display_rules.conflict. A verifier with human browser access
+# to akleg.gov should re-read AS 28.10.161, 28.10.171 and 28.10.181 and either
+# confirm or replace the affected claims. This is the weakest-sourced file in
+# the pacific group and it says so in terms rather than reading as if it were
+# not.
+#
+# WHAT IS NEVERTHELESS SOLID HERE: the DMV's own live plate catalogue (fetched
+# via the Archive; dmv.alaska.gov 403s automated requests directly) enumerates
+# every plate Alaska currently issues, which gives a specialty index built from
+# the issuing agency rather than from a count; AS 28.10.181 gives sourced
+# grammar for the personalized cap, the historic series and the amateur-radio
+# plate; and AS 28.10.161(b) gives the one properly dated series boundary in
+# the file.
+jurisdiction: us-ak
+authority:
+  name: Alaska Department of Administration, Division of Motor Vehicles (DMV)
+  url: "https://dmv.alaska.gov/vehicle-services/license-plates/"
+binding: vehicle
+statute_edition: >-
+  Alaska Statutes Title 28 chapter 10, read 2026-08 from the Internet Archive
+  capture of the Touch N' Go Alaska Legal Resource Center reproduction, whose
+  own note states "This version of the Alaska Statutes is current through
+  December, 2007." Live agency practice read 2026-08 from the Archive capture
+  of dmv.alaska.gov (2025-09-14 snapshot for the plate catalogue).
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4/§7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: asserted
+  basis: >-
+    ALASKA ASSERTS COPYRIGHT ON ITS OWN PAGES. Every page of alaska.gov and of
+    dmv.alaska.gov — including the licence-plate catalogue this file cites as
+    its agency source, and the sample-plate page that offers Alaska's plate
+    designs as collector items — carries the footer "COPYRIGHT (c) STATE OF
+    ALASKA . DEPARTMENT OF ADMINISTRATION". No Commons {{PD-AKGov}} tag exists
+    (checked: the template page returns 404), and Alaska does not appear in the
+    Commons list of US states with public-domain tags. That places Alaska with
+    Arizona rather than with Florida or California: not merely "not
+    established", but affirmatively asserted on the issuing agency's own
+    artwork pages. Treat every Alaska plate GRAPHIC as protected until a
+    contrary instrument is found.
+  countervailing: >-
+    The FORMAT, CLASS, GEOMETRY and PERIOD facts in this file come from the
+    ALASKA STATUTES, which are an EDICT OF GOVERNMENT and public domain at
+    every level regardless of the website footer (PRD-PLATES §4). The
+    assertion bites on the artwork — the Kodiak bear, the state flag, the
+    fireweed-and-Denali art plate — not on the facts.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies without exception in Alaska,
+    and to more of the plate than usual: the STATE FLAG (the Big Dipper and
+    Polaris) is screened into the centre of the standard base and is therefore
+    not an emblem in a corner but the plate's central graphic. Render
+    `emblem: {present: true, rendered: placeholder}` and do not approximate the
+    flag. The ART PLATES are the sharpest case in the whole US wave: the
+    "Celebrating the Arts" designs are the copyrighted work of NAMED INDIVIDUAL
+    ARTISTS chosen by public vote (reported: Anita Laulainen for the 2018
+    northern-lights design, Sabrina Kessakorn for the 2024 fireweed design), so
+    the exposure there is a private author's copyright layered on top of the
+    state's assertion. Never render them.
+  seal_regime: >-
+    UNRESEARCHED for Alaska (recorded gap). Hawaii's HRS § 5-6 shows the regime
+    is real and criminal where it exists; no Alaska equivalent was searched
+    for in this pass. The placeholder rule covers it either way.
+  photograph_caution: >-
+    No Alaska plate photograph was licence-checked in this pass (recorded gap).
+    The standing rule holds: a Commons tag on a plate photograph is the
+    PHOTOGRAPHER's licence on the PHOTOGRAPH and never a licence on the
+    design; our renders are generated from statute and never derived from a
+    photograph, so no obligation attaches.
+  sources:
+    - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # the DMV plate catalogue, footer 'COPYRIGHT (c) STATE OF ALASKA . DEPARTMENT OF ADMINISTRATION'"
+    - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/sample-license-plates/  # the DMV sells SAMPLE plates of the Grizzly Bear and Last Frontier designs to collectors at $10 each, marked 'SAMPLE' — the state commercialising its own plate artwork, on a page carrying the same copyright footer"
+    - "https://commons.wikimedia.org/w/index.php?title=Template:PD-AKGov&action=raw  # returns 404 — there is NO Alaska public-domain tag on Commons. A negative result, recorded as one."
+
+# ---------------------------------------------------------------------------
+# The US standards chain, recorded per state.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA writes recommendations in the declarative present; read them as RECOMMENDED PRACTICE, not requirement."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is paywalled and UNPINNED; no J686 dimension is quoted anywhere in this dataset. Alaska's 12 x 6 in is LOCATOR-GRADE here — no Alaska instrument stating a plate dimension was located (recorded gap), which is a real hole given that AS 28.10.161(c) forbids adopting a plate that does not 'substantially embody the specifications of this section' and the section states no dimension at all."
+    retroreflectivity: "AAMVA §3.3: legible in daylight and at night from at least 75 feet; ASTM D4956-19 and ISO 7591:1982 clause 3. Alaska legislates reflectorization but not a standard: AS 28.10.161(a) requires 'fully reflectorized' plates, with no material specification."
+    replacement_cycle: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. NO ALASKA REPLACEMENT CYCLE WAS LOCATED. AS 28.10.161(a) says the plates 'must remain with the vehicle as long as the vehicle is subject to registration under this chapter' — the opposite instinct to a rolling replacement."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" is UNCITED in its Wikipedia source
+    (a `citation needed` since 2017, copied verbatim across articles) and is
+    NOT relied on here. The Alaska article repeats it and adds a magazine
+    citation — Christopher Garrish, "Reconsidering the Standard Plate Size",
+    Plates vol. 62 no. 5 (ALPCA, October 2016) — which is the first non-
+    circular source for the 1956 story seen anywhere in this programme. It was
+    NOT obtained. Recorded as the lead to chase if the 1956 claim is ever to be
+    promoted from folklore.
+
+# ---------------------------------------------------------------------------
+# Display rules. THE STATUTE AND THE AGENCY DISAGREE, and the disagreement is
+# recorded rather than averaged (PRD-PLATES §5.3).
+# ---------------------------------------------------------------------------
+display_rules:
+  agency_current: "Alaska DMV, its own words, 2026: 'ONE PLATE: Alaska statute AS 28.10.171 requires you to display one license plate on the back of all passenger vehicles, motorcycles, motorhomes, trucks, vans, trailers, and APV's. For Commercial vehicles that weigh over 10,001 pounds the plate is required to be displayed on the front of the vehicle. A month and year tab must be displayed on the plate.'"
+  statute_2007: "AS 28.10.171(a) as reproduced from the December 2007 text: 'When two registration plates are issued for a vehicle, they shall be attached to the vehicle for which issued, one in front and the other in the rear. When one registration plate is issued, it shall be attached to the rear of the vehicle for which issued.' AS 28.10.161(a) as of the same date: the department issues 'one fully reflectorized registration plate for a trailer or a motorcycle and two fully reflectorized registration plates for every other vehicle'."
+  conflict: >-
+    THESE CANNOT BOTH BE CURRENT. The 2007 statute has the department issuing
+    TWO plates to a passenger vehicle; the 2026 DMV says ONE plate, on the
+    rear, for passenger vehicles, motorcycles, motorhomes, trucks, vans,
+    trailers and all-purpose vehicles, with commercial vehicles over 10,001 lb
+    displaying on the FRONT. The DMV is describing current law and the
+    reproduction is fifteen years stale, so AS 28.10.161 and/or AS 28.10.171
+    were amended after 2007 and the amendment was not obtained. THE AGENCY
+    STATEMENT GOVERNS THIS FILE. Secondary sources put Alaska's move to
+    rear-only for standard passenger vehicles at 11 AUGUST 2022, but the
+    Wikipedia citation for that date is a Facebook post carrying a
+    user-generated-source flag, which is not evidence and is recorded here only
+    so the next researcher does not re-derive it. Finding the amending session
+    law is the highest-value follow-up in this file.
+  mounting: "AS 28.10.171(b) (2007 text): every plate 'shall be securely fastened to the vehicle to which it is assigned, with the upper edge of the plate horizontal, at a height of not less than 12 inches from the ground measuring from the bottom of the plate, and maintained in a location and condition so as to be clearly legible.' The commissioner may prescribe another method of installation by regulation where necessary to ensure legibility."
+  validation: "AS 28.10.161(b)(4) (2007 text): the registration year or expiration date may be on the plate itself or on a sticker or tab, but 'only one sticker or tab device may be issued for each pair of plates, and the sticker or tab device must be affixed to the rear plate.' The DMV states the same rule for two-plate vehicles today."
+  sources:
+    - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # Alaska DMV, current: one plate on the rear for passenger vehicles, motorcycles, motorhomes, trucks, vans, trailers and APVs; front display for commercial vehicles over 10,001 lb; month-and-year tab"
+    - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section171.htm  # AS 28.10.171 (reproduction, current through December 2007): front-and-rear when two are issued, rear when one, the 12-inch minimum height and horizontal-upper-edge rule"
+    - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section161.htm  # AS 28.10.161 (same reproduction and vintage): one plate for a trailer or motorcycle and two for every other vehicle; the plates remain with the vehicle; the one-sticker-per-pair rule on the rear plate"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD SERIES — the gold "Last Frontier" base, which the DMV
+  # itself calls "Standard Gold".
+  # =========================================================================
+  - id: us-ak-standard-gold
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset:
+        excluded: [I, O, Q]
+        excluded_basis: "LOCATOR-GRADE. No Alaska instrument stating a letter exclusion was located; AS 28.10.161 states none. Reported by the collector literature for the ABC 123 format since its 1976 introduction, cited through Wikipedia."
+        notes: >-
+          NO STATUTORY CHARACTER CAP EXISTS. AS 28.10.161(b) (2007 text)
+          requires only that a passenger plate display 'the registration
+          number assigned to the vehicle for which it is issued', 'the name of
+          this state, which may be abbreviated', and the registration year or
+          expiration date. Nothing about length, alphabet or arrangement. The
+          three-letter/three-numeral arrangement encoded here is OBSERVED and
+          locator-corroborated, not sourced — a recorded gap, and one that
+          matters more in Alaska than elsewhere because AS 28.10.161(c) makes
+          the section itself the constraint on any new design: 'The department
+          may not adopt a new or altered passenger vehicle registration plate
+          unless it substantially embodies the specifications of this section.'
+      progression: "The letter group advances and the numeral group cycles; reported serial ranges for the current base run through the K series (locator-grade, collector sites)."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      plate_dimension_note: "LOCATOR-GRADE. No Alaska instrument stating plate dimensions was located; 12 x 6 in is the North American convention and is recorded as observed."
+      background: { color: "#F2C94C", finish: retroreflective, hex_basis: observed }
+      foreground: "#1F3A93"
+      colour_note: >-
+        NEITHER VALUE IS IN ANY INSTRUMENT LOCATED. AS 28.10.161(a) requires
+        'fully reflectorized' plates and says nothing about hue; the
+        statehood-design mandate in (b)(1) speaks of 'a design and color' but
+        names neither. Both hexes are APPROXIMATIONS of the golden-yellow
+        ground and blue characters as depicted on DMV pages, and both should be
+        treated as unverified.
+      legend_top: "ALASKA"
+      legend_bottom: "THE LAST FRONTIER"
+      legend_note: "The state-name requirement IS statutory — AS 28.10.161(b)(3), 'the name of this state, which may be abbreviated'. The slogan is not; no instrument requiring 'THE LAST FRONTIER' was located."
+      emblem: { present: true, rendered: placeholder, description: "the Alaska state flag — the Big Dipper and Polaris — screened in the centre of the plate; not rendered (see artwork_risk)" }
+      band: { side: none }
+      rear_differs: false
+      manufacture: "LOCATOR-GRADE: Irwin-Hodson Company, Portland, Oregon. Recorded because plate manufacture is a recurring question and because an out-of-state commercial manufacturer is a different posture from Florida's or California's prison industries."
+    region_encoding: none
+    region_encoding_note: "Alaska encodes no geography in the plate string and prints no borough or city legend. Reported letter-series reservations are functional, not geographic (an 'H' series reported reserved for Disabled plates, a 'J' series for the Grizzly Bear base, 'D' series for Disabled Veteran on the 1981 base) — locator-grade, and worth noting because a naive decoder could mistake a functional block for a regional one."
+    sources:
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # the DMV's own catalogue names this design 'Standard Gold', issued at no charge with registration, $5 replacement, $30 if personalized"
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section161.htm  # AS 28.10.161 (reproduction, current through December 2007): (b)(2)-(4) the registration number, the state name 'which may be abbreviated', the year or expiration and the sticker rule; (c) the department may not adopt a new or altered passenger plate unless it substantially embodies the section"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Alaska  # LOCATOR ONLY (PRD-PLATES §4): the ABC 123 format adopted in 1976, the Last Frontier base's reported continuous issuance since 1 January 2010, the I/O/Q exclusion, the reported serial ranges and the Irwin-Hodson manufacture. None asserted as sourced."
+    notes: >-
+      ALASKA'S CURRENT STANDARD SERIES. PERIOD CAVEAT, AND IT IS A LARGE ONE:
+      `start: 2026` is the year of the instruments read and is an UPPER BOUND,
+      following the us-fl-standard convention. The true start is much earlier —
+      secondary sources put the gold Last Frontier base at July 2005 with
+      continuous issuance since 1 JANUARY 2010, after the statehood
+      commemorative base below was retired — but no agency or statutory
+      instrument stating any of those dates was obtained, and a collector-site
+      era table is exactly what this programme refuses to launder into a
+      sourced year. THE SUPERSEDED STATUTE IS THE EVIDENCE THAT SOMETHING
+      HAPPENED IN 2010: AS 28.10.161(b)(1) as of December 2007 REQUIRED every
+      passenger plate issued after 1 January 2008 to bear the statehood-50
+      design, and Alaska demonstrably does not issue that design now, so the
+      paragraph must have been amended or repealed. Finding that session law
+      would date this series properly and is the second-highest-value follow-up
+      in the file.
+
+  # =========================================================================
+  # ONE SERIES BACK — the statehood commemorative, and the ONLY series in the
+  # pacific group whose START IS WRITTEN INTO THE STATUTE AS A CALENDAR DATE.
+  # =========================================================================
+  - id: us-ak-statehood-50
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2008, ended: true, year_end_min: 2009 }
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset:
+        notes: "The format did not change at either boundary — Alaska has run ABC 123 since 1976 (locator-grade) across every base since. Only the base design changed. The pattern here omits the printed gap because secondary sources record this base's serial as set without one; the regex accepts both forms so the difference cannot cause a false negative."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "Reported as a graphic base — yellow sky, gradient orange sunburst, white mountains fading to blue — with dark blue embossed characters. LOCATOR-GRADE; no instrument states a value. No hex is recorded rather than invented."
+      legend_top: "ALASKA"
+      legend_bottom: "CELEBRATING STATEHOOD 1959-2009"
+      legend_note: "LOCATOR-GRADE legend text. What IS statutory is the requirement that produced it — see design_mandate."
+      design_mandate: >-
+        AS 28.10.161(b), verbatim from the December 2007 reproduction: "Every
+        passenger vehicle registration plate issued by the department after
+        January 1, 2008, except as specifically provided in AS 28.10.181, shall
+        have displayed upon it (1) a design and color commemorating the 50th
+        anniversary of Alaska's statehood and admittance into the United
+        States; in determining the design and color of the registration plate,
+        the commissioner shall consult with the Alaska Statehood Celebration
+        Commission". A LEGISLATURE MANDATING A COMMEMORATIVE BASE BY DATE, and
+        delegating the design to a named commission.
+      emblem: { present: true, rendered: placeholder, description: "the 'Alaska 50' logo incorporating the state flag, reported screened at left; not rendered" }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section161.htm  # AS 28.10.161(b) (reproduction, current through December 2007): the post-1-January-2008 statehood-50 design mandate and the Alaska Statehood Celebration Commission consultation duty"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Alaska  # LOCATOR ONLY: the base's reported issuance window of 1 January 2008 to 31 December 2009, its graphic description, the 'CELEBRATING STATEHOOD 1959-2009' legend and the reported serial range"
+    notes: >-
+      THE STATEHOOD COMMEMORATIVE BASE — ONE SERIES BACK, AND THE BEST-DATED
+      START IN THIS FILE. `period_evidence: statutory-date` is earned on the
+      START only: AS 28.10.161(b) says in terms that plates issued AFTER
+      1 JANUARY 2008 shall bear the statehood-50 design, so 2008 is a claim
+      about law rather than about a collector's observation. THE END IS NOT
+      SOURCED, which is why this entry uses `ended: true` with
+      `year_end_min: 2009` rather than a hard `end:` — the schema's
+      known-over-undated shape (PRD-PLATES §2.2), earning its keep exactly as
+      predicted. The series is known to be over, because Alaska visibly issues
+      the gold Last Frontier base today; 2009 is the floor because the
+      commemoration was of a 2009 anniversary and the reported end is
+      31 December 2009. A SECOND ORDER OF EVIDENCE SITS INSIDE THIS ENTRY: the
+      very existence of a superseded statutory mandate proves the statute was
+      amended after 2007, which is what licenses the display_rules.conflict
+      note above to treat the whole 2007 reproduction as provisional.
+
+  # =========================================================================
+  # THE PARALLEL STANDARD BASE — Alaska issues TWO no-cost standard designs.
+  # =========================================================================
+  - id: us-ak-grizzly
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset:
+        notes: "Same ABC 123 arrangement as the gold base. Reported issued from a reserved letter block (the 'J' series, then 'M'), which if true means the base is READABLE FROM THE SERIAL — a genuinely useful parse signal. LOCATOR-GRADE and not asserted."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "Reported as a graphic base: a standing brown Kodiak bear centred against a light blue sky, orange sunset and white mountains, with a red embossed serial and 'ALASKA' screened in dark blue at the top. LOCATOR-GRADE; no hex recorded."
+      legend_top: "ALASKA"
+      legend_bottom: null
+      legend_note: "No slogan. Reported to be based on the 1976-81 Kodiak bear base."
+      emblem: { present: true, rendered: placeholder, description: "the Kodiak bear graphic; not rendered (see artwork_risk)" }
+      rear_differs: false
+    fee: "Alaska DMV: $0 initial, $5 for replacement, $30 if personalized, $0 renewal — the same fee line as the Standard Gold plate, which is why it is modelled as a standard series and not as a specialty programme."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # the DMV lists 'Grizzly Bear' under 'Standard or Personalized License Plates' at $0 initial price, alongside 'Standard Gold'"
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/sample-license-plates/  # the DMV's collector-sample page offers exactly two designs, 'Grizzly Bear' and 'Last Frontier' — the agency's own signal that these two are the state's standard pair"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Alaska  # LOCATOR ONLY: introduced 7 May 2015; based on the 1976-81 bear base; awarded ALPCA Plate of the Year 2015; reported J and M serial blocks"
+    notes: >-
+      ALASKA RUNS TWO STANDARD BASES AT ONCE, AT THE SAME PRICE, AND THAT IS
+      THE MODELLING POINT. PRD-PLATES §2.2 says overlapping series are legal
+      where the notes distinguish them because parallel issuance is real; the
+      Grizzly Bear plate is the cleanest US example found — not old stock
+      running on, but a deliberate second no-cost standard design offered
+      concurrently with the gold base and treated by the DMV as its equal.
+      A consumer asking "what does a current Alaska plate look like?" has two
+      correct answers, and any renderer or classifier that assumes one standard
+      design per US state is wrong here. Its own series because the design
+      differs (§2.3); `start: 2026` is an upper bound on the same footing as
+      the gold base, with the reported May 2015 introduction recorded but not
+      claimed.
+
+  # =========================================================================
+  # PERSONALIZED — statutory, capped at six, with a published no-space rule.
+  # =========================================================================
+  - id: us-ak-personalized
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9]{1,6}\z'
+      charset:
+        notes: >-
+          AS 28.10.181(c), verbatim from the December 2007 reproduction:
+          "Special request plates. Upon application by the owner of a motor
+          vehicle, the department shall design and issue registration plates
+          containing a series of not more than six letters or numbers or
+          combination of letters and numbers as requested by the owner. The
+          department may, in its discretion, disapprove the issuance of
+          registration plates under this subsection when the requested symbols
+          are a duplication of an existing registration or when the symbols are
+          considered unacceptable by the department." SIX CHARACTERS is the
+          statutory cap and is what the regex encodes.
+        no_space_rule: >-
+          The DMV catalogue carries a footnote against the personalized options:
+          "*personalized plate does not have a space in the middle". THAT IS A
+          PRINTED-FORM FACT AND IT IS WHY THIS SERIES' REGEX HAS NO OPTIONAL
+          SEPARATOR while the standard series' does. An authority stating that
+          the sequential plate's printed gap disappears on the vanity plate is
+          precisely the kind of detail PRD-PLATES §2.6 exists to capture, and
+          precisely the kind a separator-forgiving consumer would otherwise
+          have to guess at.
+      refusal_rule: "The DMV cites 2 AAC 92.120: 'DMV will not issue personalized plates that display symbols in a combination that is demeaning towards a group of people, or that is otherwise a vulgar, violent, or criminal reference or term'. It also operates a RECALL: 'DMV will immediately investigate the license plate and if necessary, recall the license plate.' THE REGULATION'S OWN TEXT WAS NOT FETCHED (recorded gap — the Alaska Administrative Code shares the akleg BASIS access problem); the DMV's paraphrase is what is cited."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      note: "Available on the Standard Gold, Grizzly Bear and Celebrating the Arts bases, and on several cause and organisation plates, per the DMV catalogue; the design is that of the chosen base."
+    fee: "$30 personalization fee on most bases ($33 on Celebrating the Arts, $50 on several cause plates), per the DMV catalogue. Fees for cause plates are set by AS 28.10.421 (cited by the DMV; the section's text was not fetched)."
+    named_personalized_designs: ["Mountain", "Caribou", "In God We Trust", "Celebrating the Arts", "Honoring Fallen Police Officers"]
+    named_personalized_note: "The DMV lists five designs that are ONLY available personalized — they have no sequential series at all. That is an unusual category and is recorded because a plate with no sequential form cannot be matched by a sequential regex, and a parse API told only about Alaska's ABC 123 would silently reject every one of them."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section181.htm  # AS 28.10.181(c) (reproduction, current through December 2007): special request plates, 'not more than six letters or numbers or combination', and the departmental disapproval discretion"
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # the DMV: the no-space-in-the-middle rule, the 2 AAC 92.120 refusal standard and the recall procedure, the $30/$33/$50 personalization fees, and the five personalized-only designs"
+    notes: >-
+      ALASKA'S VANITY PLATE IS STATUTORILY A "SPECIAL REQUEST PLATE" and its
+      six-character cap is one of the few things in this file the statute
+      states outright. Two details make the entry worth more than its regex.
+      First, the DMV's no-space footnote is a rare authority statement about
+      PRINTED FORM rather than about content, and it means the vanity plate and
+      the sequential plate of the same state have different separator
+      behaviour. Second, Alaska maintains five designs that exist ONLY in
+      personalized form, which breaks the usual assumption that a personalized
+      plate is a variant of some sequential series.
+
+  # =========================================================================
+  # HISTORIC — a permanent numbered series, plus a year-of-manufacture route,
+  # both inside one statutory subsection.
+  # =========================================================================
+  - id: us-ak-historic-vehicle
+    class: historic
+    categories: [car]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "999"
+      regex: '\A\d+\z'
+      charset:
+        notes: >-
+          AS 28.10.181(b), verbatim from the December 2007 reproduction: the
+          department shall "(1) issue two permanent registration plates of
+          distinctive design and color bearing no date; vehicles qualifying for
+          registration under this paragraph shall be issued registration plates
+          numbered in a separate numerical series beginning with 'Historic
+          Vehicle No. 1'". A separate numerical series with a stated origin and
+          NO STATED WIDTH — hence the unbounded quantifier, which makes no
+          width claim.
+      progression: "strictly sequential from 1"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "AS 28.10.181(b)(1) requires plates 'of distinctive design and color BEARING NO DATE'. The statute specifies distinctness and dateleness — properties, not values — the same drafting move Florida and California make. No colour is recorded."
+      legend: "Historic Vehicle"
+      dateless_rule: "The 'bearing no date' requirement is the interesting half: Alaska legislates the ABSENCE of a validation date on this plate, which makes it the one Alaska series a date-based era heuristic cannot touch."
+    eligibility: "AS 28.10.181(b): the department registers a historic vehicle 'when satisfied that the vehicle meets the requirements for historic vehicle registration under REGULATIONS ADOPTED BY THE COMMISSIONER' — the threshold is delegated to regulation, not stated in statute. The DMV catalogue states the operative rule: 'For vehicles 30 or more years in age and driven for historical exhibitions', $10. A ROLLING threshold, which silently grows every year and must be re-audited."
+    validity: "permanent; 'Registration plates issued under this subsection remain with the vehicle as long as the vehicle is registered under this subsection' (AS 28.10.181(b))."
+    fee: "$10 initial, $0 renewal (Alaska DMV catalogue)."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section181.htm  # AS 28.10.181(b)(1) (reproduction, current through December 2007): two permanent plates, distinctive design and colour, bearing no date, 'Historic Vehicle No. 1' separate numerical series, plates remain with the vehicle"
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # Alaska DMV: Historic Vehicle plate, $10, 'For vehicles 30 or more years in age and driven for historical exhibitions'"
+    notes: >-
+      HISTORIC VEHICLE. Alaska's version of the series Florida, California and
+      Hawaii all legislate — a separate permanent numerical run — but with two
+      distinguishing choices. It numbers from "Historic Vehicle No. 1" rather
+      than "Horseless Carriage No. 1"; and it delegates the age threshold to
+      the commissioner's regulations instead of fixing it in statute, so the
+      30-year rule the DMV publishes is agency practice rather than law. Since
+      30 years is a ROLLING threshold, this is a series whose eligible fleet
+      changes annually without any instrument being amended — the exact case
+      the quarterly audit has to re-derive rather than trust.
+
+  - id: us-ak-year-of-manufacture
+    class: historic
+    categories: [car, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: >-
+          A YOM plate carries whatever serial Alaska issued in the matching
+          year, so the regex is necessarily the union of Alaska's historic
+          arrangements and a match is a shape hit only. Alaska has run at least
+          five arrangements since 1921 (locator-grade: 123, 1234, 12345, and
+          ABC 123 from 1976), and no agency table of acceptable per-era series
+          exists of the kind California publishes in VIRPM Appendix 1E
+          (recorded gap, and a direct contrast worth carrying).
+      statutory_basis: >-
+        AS 28.10.181(b)(2), verbatim: the department shall "allow the vehicle
+        to use registration plates of this state supplied by the vehicle owner
+        that correspond to the year the vehicle was manufactured if the vehicle
+        was manufactured 30 or more years before the year of application."
+        Note the elegance: Alaska puts its year-of-manufacture route INSIDE the
+        historic-vehicle subsection as an alternative to the permanent plate,
+        where California gives it a section of its own (VC § 5004.1) and
+        Florida has no equivalent at all.
+    design:
+      background: { finish: unknown }
+      design_note: "The design is that of the original year, supplied by the owner. Alaska states no restoration or authentication rules in statute (contrast California's VIRPM 21.260, which does) — recorded gap."
+    eligibility: "vehicle manufactured 30 or more years before the year of application — a ROLLING threshold, stated in statute this time rather than delegated."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section181.htm  # AS 28.10.181(b)(2): owner-supplied plates of this state corresponding to the year of manufacture, for vehicles 30 or more years old"
+    notes: >-
+      YEAR OF MANUFACTURE, ALASKA STYLE — the same edge case as California's
+      but reached by a different drafting route, and worth its own entry
+      because the two are not interchangeable: California requires DMV
+      authentication, publishes acceptable per-era series and grants full
+      operating privileges; Alaska states none of that and instead ties the
+      option to historic-vehicle registration, which the DMV describes as
+      limited to historical exhibition. `matching: recall-only` for the same
+      reason as California's: the regex is a union of eras, so a hit means
+      "this string has a shape Alaska has issued", never "this is a valid
+      registration".
+
+  # =========================================================================
+  # CORE CLASSES the state separately serializes.
+  # =========================================================================
+  - id: us-ak-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: "NO ARRANGEMENT IS PUBLISHED. AS 28.10.161(a) singles motorcycles out only to issue them ONE plate rather than two, and states nothing about serial or size. The DMV catalogue mentions motorcycles only in fee lines. Reported to share the ABC 123 arrangement on a reduced-size plate (locator-grade, and not even clearly reported). The regex is deliberately over-broad and the series is `recall-only` accordingly — a recorded gap rather than a guess."
+    design:
+      plate: { unit: in }
+      plate_dimension_note: "Not stated in any Alaska instrument located and not obtained. No measurement is recorded rather than guessed."
+      background: { finish: retroreflective }
+    display: "one plate, on the rear (AS 28.10.161(a) for issuance; the DMV's current statement of AS 28.10.171 names motorcycles expressly in the one-plate-on-the-back list)."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section161.htm  # AS 28.10.161(a): one fully reflectorized plate for a trailer or a motorcycle"
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # Alaska DMV: motorcycles are in the one-plate-on-the-back list"
+    notes: >-
+      MOTORCYCLE. Its own series because the ISSUANCE RULE differs by statute —
+      one plate rather than two — even though nothing else about it could be
+      sourced. Recorded deliberately as a thin, honest entry rather than
+      omitted: a jurisdiction-completeness detector should see that Alaska
+      serialises motorcycles separately and that the dataset does not yet know
+      how, which is more useful than silence.
+
+  - id: us-ak-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: "NO ARRANGEMENT IS PUBLISHED. As with motorcycles, AS 28.10.161(a) singles trailers out only for the one-plate rule. Recorded gap; `recall-only`."
+    design:
+      background: { finish: retroreflective }
+    display: "one plate, on the rear (AS 28.10.161(a); the DMV names trailers in the one-plate list)."
+    permanent_registration: "The DMV operates a 'Permanent registration for trailers and older vehicles' route; its terms were not fetched (recorded gap). A permanent registration is a period fact — it means a trailer plate can outlive several validation regimes."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section161.htm  # AS 28.10.161(a): one plate for a trailer"
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # Alaska DMV: trailers in the one-plate list"
+    notes: >-
+      TRAILER. Included for the same reason as the motorcycle entry — the
+      one-plate issuance rule is statutory and separates the class — and with
+      the same honest thinness. The permanent-registration route is flagged
+      because a permanently registered trailer is the kind of vehicle that
+      still carries a base two generations old, which matters to any era
+      inference built on Alaska plates.
+
+  - id: us-ak-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: "NO ARRANGEMENT IS PUBLISHED. AS 28.10.181(j) creates the plate and regulates its USE in detail while saying nothing about its face. Recorded gap; `recall-only`."
+    design:
+      background: { finish: retroreflective }
+    binding: business
+    permitted_use: >-
+      AS 28.10.181(j), from the December 2007 reproduction: a state-registered
+      and bonded vehicle dealer may apply for dealer plates, usable "only on
+      dealer-owned vehicles during the routine and normal course of the
+      dealer's business, EXCLUDING SERVICE VEHICLES, or for transporting an
+      unregistered vehicle from a port of entry to the dealer's facilities or
+      from one dealer to another or, in the case of a house trailer, from the
+      retail facility to a trailer space." A vehicle running on dealer plates
+      "must be affixed with TWO plates issued under this subsection" — which is
+      notable given that Alaska now issues one plate to ordinary passenger
+      vehicles: the dealer plate may be the state's remaining two-plate case.
+      After a sale the buyer may use the dealer plates for NOT MORE THAN FIVE
+      DAYS. The department may seize plates it believes are being used to
+      defeat the chapter.
+    plate_follows: "AS 28.10.181(a): plates issued under § 181 'remain with the person or organization to whom they are issued when vehicle ownership is transferred', except for the historic, farm and amateur-radio plates in (b), (h) and (i). Alaska legislates the plate-with-owner rule at the head of the section rather than plate by plate."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section181.htm  # AS 28.10.181(j) dealer plates: eligibility, the permitted-use list, the service-vehicle exclusion, the two-plate display rule, the five-day post-sale window and the seizure power; (a) the plate-with-owner default and its (b)/(h)/(i) exceptions"
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/  # the DMV's dealer pages, which front the dealer-plate application (form 'dealer-license-plate-application')"
+    notes: >-
+      DEALER PLATES. `binding: business` for the same reason as Florida's and
+      California's: the plate follows the firm, not the vehicle — and Alaska
+      states that as a section-wide default in AS 28.10.181(a) rather than
+      repeating it per plate type, which is cleaner drafting than either. The
+      two-plate display requirement is the fact worth carrying: if Alaska now
+      issues one plate to passenger vehicles, then a two-plate vehicle on an
+      Alaska road is a strong signal of dealer or commercial status.
+
+  - id: us-ak-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: "AS 28.10.181(e) requires only that 'Registration plates issued under this subsection must be of a DISTINCTIVE DESIGN AND NUMBERING SYSTEM' — the statute mandates that the numbering differ without saying how, which is the most that can be said. `recall-only`; recorded gap."
+    design:
+      background: { finish: retroreflective }
+      colour_note: "Distinctiveness is required, no value is stated. None recorded."
+    validity: >-
+      AS 28.10.181(e): a certificate and plate issued to the state, a
+      municipality or a charitable organization "is in effect until the vehicle
+      ... is no longer owned and operated by" that body "or until the
+      department, in its discretion, declares its expiration." An OPEN-ENDED
+      registration with a discretionary end — a period shape that no
+      year-based model captures, and worth recording as such.
+    scope: "AS 28.10.181(e) covers the State, municipalities AND 'charitable organizations of the state', defined as a nonprofit association, corporation, society or other entity organised, incorporated or headquartered in the state for educational, cultural, scientific or other charitable purposes. Each such body must keep a current list of its registered vehicles in registration-number order and provide it to the department on request."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section181.htm  # AS 28.10.181(e): state, municipal and charitable-organization plates; the distinctive design and numbering requirement; the open-ended validity and discretionary expiration; the vehicle-listing duty. Also (f), elected state officials, whose plates are numbered or designed to indicate the office and may remain only during the term"
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/charitable-exemption-for-license-plates/  # the DMV's charitable-exemption route, the live counterpart of AS 28.10.181(e)"
+    notes: >-
+      GOVERNMENT AND CHARITABLE FLEET PLATES. Alaska folds charities in with
+      the State and its municipalities, which is unusual and which means a
+      "government" classification on an Alaska plate is not a reliable
+      inference about who owns the vehicle. The elected-official plate in
+      AS 28.10.181(f) is recorded in the same citation rather than given its
+      own entry: it is numbered or designed to show the office and may remain
+      on the vehicle ONLY during the official's term, which makes it the one
+      Alaska plate whose validity is tied to an election result.
+
+  - id: us-ak-farm
+    class: agricultural
+    categories: [truck, van]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: "AS 28.10.181(h) permits a vehicle registered under it to 'be issued registration plates of a DISTINCTIVE DESIGN OR SYSTEM OF NUMBERING' — permissive, not mandatory, and unspecified either way. `recall-only`; recorded gap."
+    design:
+      background: { finish: retroreflective }
+    eligibility: >-
+      AS 28.10.181(h): a vehicle not exceeding 20,000 lb unladen total gross
+      weight, owned by a person deriving their primary livelihood from a ranch,
+      farm or dairy where they reside full-time, and used exclusively to
+      transport that person's own ranch/farm/dairy or greenhouse/nursery
+      products — "including vegetables, plants, grass seed, sod, or tree
+      seedlings" — to and from market, or supplies, commodities or equipment
+      for use on the holding.
+    fee: "$68 initial, $0 renewal (Alaska DMV catalogue, 'Farm Vehicle')."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section181.htm  # AS 28.10.181(h): the 20,000 lb ceiling, the primary-livelihood and full-time-residence tests, the exclusive-use rule and the enumerated products"
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # Alaska DMV: 'Farm Vehicle', $68, 'For vehicles used to transport products or supplies for farms'"
+    notes: >-
+      FARM VEHICLE. Included because agricultural is a controlled class and
+      because AS 28.10.181(h) is unusually specific about eligibility while
+      being unusually vague about the plate — the statute enumerates grass seed
+      and tree seedlings but will not commit to a numbering system. The
+      permissive "may be issued" is worth flagging: the statute does not
+      guarantee the plate is visually distinctive at all.
+
+  - id: us-ak-amateur-radio
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL9LLL"
+      regex: '\A[A-Z]{1,2}\d[A-Z]{1,3}\z'
+      charset:
+        notes: >-
+          THE SERIAL IS NOT A SERIES AT ALL — IT IS AN FCC CALL SIGN.
+          AS 28.10.181(i), verbatim: a licensed amateur operator who shows an
+          unexpired FCC amateur licence of any renewable class and that the
+          vehicle carries a transmitter and receiver of the applicable type
+          "may receive for the vehicle distinctive registration plates instead
+          of regular registration plates. THE NUMBER ON THE PLATES MUST BE THE
+          RADIO CALL SIGN OF THE OWNER." One vehicle may be registered per
+          radio licence held. The regex encodes the general US amateur call
+          sign shape (one or two prefix letters, a numeral, one to three suffix
+          letters); THE FCC RULE ITSELF (47 CFR part 97) WAS NOT FETCHED in
+          this pass, so the shape is not sourced to the authority that actually
+          governs it and the series is `recall-only` for that reason. Alaska
+          call signs conventionally carry AL/KL/NL/WL prefixes, which would
+          narrow it further; also unsourced here.
+    design:
+      background: { finish: retroreflective }
+      note: "'distinctive registration plates' — distinctness required, no value stated."
+    fee: "$0 initial, $0 renewal (Alaska DMV catalogue, 'Amateur Radio (Call Sign)')."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section181.htm  # AS 28.10.181(i): the FCC licence and equipment proof, one vehicle per radio licence, distinctive plates, and 'The number on the plates must be the radio call sign of the owner'"
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # Alaska DMV: 'Amateur Radio (Call Sign)', $0, 'For Amateur Radio Operators with FCC License'"
+    notes: >-
+      THE AMATEUR RADIO PLATE EARNS ITS OWN ENTRY BECAUSE ITS SERIAL COMES FROM
+      OUTSIDE THE STATE ENTIRELY. Alaska legislates that the plate number MUST
+      BE an identifier issued by a federal regulator to a person — not to the
+      vehicle, not by the DMV, and not from any Alaska series. That is a third
+      kind of plate string in this dataset, alongside department-assigned
+      serials and owner-chosen configurations, and it is the cleanest example
+      of why `matching: recall-only` exists: a match here says the string looks
+      like an amateur call sign, and the only authority that could confirm it
+      is the FCC. It also makes an amateur plate the one US plate whose holder
+      is publicly identifiable from a federal database — a privacy note worth
+      recording even though the dataset carries formats and never plates.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Alaska is small enough
+  # that the DMV's own catalogue IS the register, so this index is ENUMERATED
+  # from the agency rather than counted from a secondary source.
+  # =========================================================================
+  - id: us-ak-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset: { notes: "Specialty plates carry ordinary sequential serials on an alternative design, or a personalized configuration of up to six characters under AS 28.10.181(c). Reported letter blocks are reserved per base (locator-grade)." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+      note: "One design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here. NOTE THE ARTIST-COPYRIGHT LAYER on the Celebrating the Arts designs — see artwork_risk.emblem_rule."
+    program_index:
+      count_official: null
+      count_official_note: >-
+        ALASKA PUBLISHES NO TOTAL, but unlike California it publishes a
+        COMPLETE CATALOGUE in one table, so the index below is ENUMERATED from
+        the issuing agency rather than estimated. Counting the DMV's own rows
+        as of the 2025-09-14 capture: 3 standard/near-standard designs
+        (Standard Gold, Grizzly Bear, Celebrating the Arts), 5 personalized-only
+        designs, 7 cause plates, 3 disability plates, 4 university plates,
+        1 National Guard plate, 7 military unit designators (a generic Unit
+        Designator plus Air Force, Army, Coast Guard, Marines, Navy, Space
+        Force), 6 veteran/dependant/survivor plates, 5 fraternal-organisation
+        plates and 6 special-issue plates — 47 distinct named plates in all.
+        THE FIGURE IS OURS, DERIVED BY COUNTING THE AGENCY'S TABLE, and is
+        labelled as such rather than presented as an official count.
+      count_enumerated: 47
+      enumerated_causes: ["Alaska Children's Trust", "Blood Bank of Alaska", "Breast Cancer Awareness", "Choose Life", "National Rifle Association", "Pro-Family Pro-Choice", "Support Our Troops"]
+      enumerated_universities: ["UAA", "UAF", "UAS", "Prince William Sound Community College"]
+      enumerated_military: ["Alaska National Guard", "Unit Designator", "Air Force", "Army", "Coast Guard", "Marines", "Navy", "Space Force", "Former Prisoner of War", "Gold Star Family", "Laos Vet", "Pearl Harbor Survivor", "Purple Heart", "Veteran Commemorative"]
+      enumerated_fraternal: ["International Association of Fire Fighters (IAFF)", "Freemason", "Knights of Columbus", "Lions Club", "Pioneers of Alaska"]
+      enumerated_special_issue: ["Amateur Radio (Call Sign)", "Custom Collector", "Farm Vehicle", "Firefighter/EMS", "Historic Vehicle", "Iditarod Finisher"]
+      fee_authority: "AS 28.10.421: 'Fees for these plates are set in Alaska Statute 28.10.421 and vary by plate and cause' (Alaska DMV). The section's text was not fetched (recorded gap) — but a legislature setting each specialty fee by statute rather than by regulation is itself a structural fact, and it means Alaska's specialty catalogue can be reconstructed from the statute book, which no other state in this group allows."
+      notable_program: >-
+        THE IDITAROD FINISHER PLATE IS THE MOST UNUSUAL SERIAL RULE FOUND IN
+        THE PACIFIC GROUP. The DMV: it "Requires finisher number from the
+        Iditarod Trail Committee. One set of plates may have their finisher
+        number (Ex. IDT999) and subsequent Iditarod plates may be
+        personalized." So the serial is an identifier issued by a PRIVATE
+        SPORTING BODY, with a fixed IDT prefix — a fourth species of plate
+        string, after department-assigned, owner-chosen and federally-assigned.
+      no_free_transfer_plates: ["Disabled Veteran", "Disability - standard", "Gold Star Family", "Prisoner of War", "Pearl Harbor Survivor"]
+      no_free_transfer_note: "The DMV lists these five as carrying no transfer fee; standard-issue plates are stated to be NON-TRANSFERABLE at all ('Standard issue plates are non transferable'), while special plates move with the person under AS 28.10.181(a). A transferability rule is a period-adjacent fact: a non-transferable plate dies with the registration, a transferable one can outlive several vehicles."
+      official_list_url: "https://dmv.alaska.gov/vehicle-services/license-plates/"
+      registration_counts_url: null
+      registration_counts_note: >-
+        NO PER-PLATE ISSUANCE-VOLUME REPORT WAS FOUND, but Alaska publishes
+        something no other state in this group does: annual REGISTERED VEHICLES
+        BY CLASS and BY BOUNDARY reports (PDF, at least 2019-2024) plus
+        motor-vehicle class-code statistics running back to 1998. Those are
+        vehicle-class counts rather than plate-design counts, so they do not
+        replace Florida's monthly active-specialty-plate report — but they are
+        real official structured data from the issuing agency and are recorded
+        here as the nearest Alaskan equivalent and as a capture target.
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/license-plates/  # the Alaska DMV's complete plate catalogue: every named plate, its initial and renewal fee, its eligibility proof, the Iditarod finisher-number rule, the non-transferability of standard plates and the five no-fee-transfer plates"
+      - "https://web.archive.org/web/2023id_/http://www.touchngo.com/lglcntr/akstats/Statutes/Title28/Chapter10/Section181.htm  # AS 28.10.181: the statutory basis for the whole special-plate regime, including (a) the plate-with-owner default, (d) the disabled and disabled-veteran plate DESIGN requirements (the international symbol of accessibility, and for veterans 'the Alaska and United States flags and red, white, and blue colors' — a rare statutory colour specification), and (l) the Pearl Harbor, POW, Medal of Honor and next-of-kin plates"
+      - "https://web.archive.org/web/2025id_/https://dmv.alaska.gov/vehicle-services/sample-license-plates/  # the DMV sample-plate page ($10 collector samples marked SAMPLE)"
+    notes: >-
+      THE ALASKA SPECIALTY INDEX, AND IT IS THE ONE INDEX IN THIS WAVE THAT
+      COULD BE ENUMERATED RATHER THAN ESTIMATED — 47 distinct named plates,
+      counted off the issuing agency's own single table. That is a direct
+      consequence of scale: Florida has "over 100" and publishes a 27-page
+      brochure, California publishes three category lists and no total, and
+      Alaska publishes everything on one page. Two findings worth carrying
+      beyond this file. First, AS 28.10.181(d) specifies COLOURS IN STATUTE for
+      the disabled-veteran plate ('the Alaska and United States flags and red,
+      white, and blue colors'), which is the second statutory colour
+      specification found in the pacific group after California's Legacy
+      statute — the pattern is that legislatures specify colour when the plate
+      is about identity, and delegate it when the plate is about
+      administration. Second, Alaska sets every specialty FEE by statute
+      (AS 28.10.421), so its specialty catalogue is reconstructible from the
+      statute book alone; fetching that section is the cheapest high-value
+      follow-up in this file.

--- a/plates/us-ca.yml
+++ b/plates/us-ca.yml
@@ -1,0 +1,875 @@
+# plates/us-ca.yml — California (PRD-PLATES gate L2, group: pacific).
+#
+# WHY CALIFORNIA IS THE DEEPEST US FILE IN THIS WAVE, and what makes it
+# different from the Florida pilot: Florida's plate FACTS live in the STATUTE
+# (§ 320.06 fixes the seven-character cap, the legends and the 6x12 minimum).
+# California's do NOT. Vehicle Code § 4851 is the whole statutory design spec
+# and it is one sentence long — registration number + "California" or "Cal." +
+# the year or a validation device. There is no statutory character cap, no
+# statutory colour, no statutory legend beyond the state name.
+#
+# So the primary source for California FORMAT facts is not the code, it is the
+# DMV's own VEHICLE INDUSTRY REGISTRATION PROCEDURES MANUAL (VIRPM) — an agency
+# handbook published in full on dmv.ca.gov, which turns out to carry exactly
+# the material this dataset needs and which no competing dataset appears to
+# have found:
+#   * VIRPM Appendix 1E is a YEAR-BY-YEAR TABLE of California plate colours,
+#     character colours, sticker colours and SERIAL SERIES from 1914 to 1980,
+#     published by the issuing agency. It is the primary that dates the 1980
+#     seven-character cutover: "In 1980, seven characters were introduced in
+#     regular series license plates."
+#   * VIRPM 21.180 publishes the 144 three-letter strings "deleted from the
+#     regular series license plate configuration" — an agency-sourced
+#     charset exclusion list for the STANDARD series, not merely a vanity
+#     refusal list.
+#   * VIRPM 21.025 / 21.100 give the character counts for Legacy and
+#     Environmental (personalized) plates.
+# Where the VIRPM speaks, this file cites the VIRPM. Where only the Vehicle
+# Code speaks, it cites the Code. Wikipedia is cited as a LOCATOR only, and
+# every claim resting on it says so in terms.
+#
+# THE BIG PERIOD FACT IN THIS FILE: California exhausted the 1ABC123 format at
+# 9ZZZ999 and flipped to a MIRRORED 123ABC1 in March 2026. This file is written
+# in August 2026, i.e. inside the first year of the new series. The flip is
+# reported by news media and by Wikipedia; NO DMV instrument stating it was
+# obtained (recorded gap). The 1980 START of the format it replaced IS
+# agency-primary (Appendix 1E).
+#
+# REGEX FORM (PRD-PLATES §2.6): printed form throughout. California prints its
+# passenger serial with no separator at all, so no separator appears in any
+# regex here except in the personalized/temporary entries where the DMV's own
+# examples show none either.
+jurisdiction: us-ca
+authority:
+  name: California Department of Motor Vehicles (DMV)
+  url: "https://www.dmv.ca.gov/portal/vehicle-registration/license-plates-decals-and-placards/"
+binding: vehicle
+statute_edition: >-
+  California Vehicle Code and Government Code as served by
+  leginfo.legislature.ca.gov, read 2026-08; California DMV Vehicle Industry
+  Registration Procedures Manual (VIRPM), the edition live on dmv.ca.gov in
+  2026-08 (the manual carries no edition number; its pages footer
+  "Copyright (c) 2026 State of California").
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4/§7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: public-domain-favourable-narrower-than-florida
+  basis: >-
+    California is favourable but on a NARROWER ground than Florida. A
+    California agency may claim copyright only where the Legislature has
+    affirmatively authorised it; the Public Records Act does not supply that
+    authorisation. Wikimedia Commons maintains {{PD-CAGov}} and its own text
+    rests the tag on the California Public Records Act (Gov. Code § 7920 et
+    seq.) and on County of Santa Clara v. California First Amendment Coalition
+    (2009). Contrast Arizona, which expressly asserts copyright, and NY/PA/WA,
+    which are adverse.
+  counter_evidence: >-
+    RECORDED HONESTLY, BECAUSE IT CUTS THE OTHER WAY: every page of the DMV
+    website — including the Vehicle Industry Registration Procedures Manual
+    pages this file cites as its primary source — carries the footer
+    "Copyright (c) 2026 State of California". A blanket footer is not a
+    legislative authorisation and does not by itself defeat the PD-CAGov
+    analysis, but it IS an assertion by the issuing agency and a verifier
+    should see it rather than discover it. The tension is not resolved here.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to (a) the red "California"
+    SCRIPT WORDMARK, which is the plate's whole graphic identity and is a
+    specific lettering artwork rather than a fact, and (b) the Great Seal of
+    California where it appears on exempt/legislative plates. US doctrine that
+    TYPEFACE DESIGNS are uncopyrightable (font SOFTWARE is a different thing)
+    would tend to clear a re-drawn script, but that doctrine was not
+    independently sourced in this pass and is recorded as a gap, so the
+    placeholder stands. Render `emblem: {present: true, rendered: placeholder}`.
+  seal_regime: >-
+    SEPARATE FROM COPYRIGHT AND PARTIALLY UNRESEARCHED. Government Code § 405
+    was fetched and prescribes the COLOURS of the Great Seal when it is
+    reproduced in colour (down to Textile Color Card Association cable
+    numbers) — evidence that the Seal is regulated in its own right. The
+    MISUSE/penalty provision was NOT located in this pass and is a recorded
+    gap. Do not render the Seal.
+  photograph_caution: >-
+    Commons photographs of California plates are mixed, not uniformly
+    share-alike: the US/world dossier measured File:10851 CA.jpg as CC0 via
+    the extmetadata API. Either way the tag is the PHOTOGRAPHER's licence on
+    the PHOTOGRAPH; the uploader had no standing over the design. Our renders
+    are generated from the DMV's own published specifications and never from
+    a photograph, so no share-alike obligation attaches.
+  sources:
+    - "https://commons.wikimedia.org/w/index.php?title=Template:PD-CAGov&action=raw  # the California PD tag exists and is in active use (Category:PD California)"
+    - "https://commons.wikimedia.org/w/index.php?title=Template:PD-CAGov/en&action=raw  # the tag's own reasoning: California Public Records Act (Gov. Code § 7920 et seq.) + County of Santa Clara v. CFAC"
+    - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=GOV&sectionNum=405  # Gov. Code § 405: the statutory colour specification for the Great Seal — the seal is separately regulated"
+    - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/personalized-configurations-mandatory-refusal/  # the DMV page footer 'Copyright (c) 2026 State of California' — the counter-evidence, cited where it actually appears"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Recorded per state because adoption is VOLUNTARY and
+# because the delegation trap matters: AAMVA sends dimensions to SAE J686,
+# whose own text is PAYWALLED and UNPINNED. Nothing below quotes J686.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA writes recommendations in the declarative present; read them as RECOMMENDED PRACTICE, not requirement."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686. J686's own text is paywalled and was NOT obtained; no J686 dimension is quoted anywhere in this dataset. California's 12x6 in is taken from the DMV's own page instead, which is better sourcing than the standard would have been."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges"
+    jurisdiction_name_layout: "AAMVA §2.1: jurisdiction name in the top centre between the bolt holes, at least 0.25 in above the plate number, at least 0.125 in from the top edge, characters 0.75-1.0 in"
+    stacked_characters: "AAMVA: stacked characters are part of the official plate number; at most two stacked. DIRECTLY RELEVANT TO CALIFORNIA — the dealer, press-photographer and moped plates all print a stacked or small-format letter group beside a full-size number (see us-ca-dealer)."
+    replacement_cycle: "AAMVA §1.1 recommends a rolling or full replacement cycle 'not to exceed 7 to 10 years'. CALIFORNIA HAS NO REPLACEMENT CYCLE AT ALL: VIRPM 21.260 and the DMV's own YOM rules assume 1963 plates are still on the road, and the Vehicle Code contains no periodic-replacement duty. California is therefore the clean counter-example to Florida's legislated 10 years."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" that supposedly fixed 6x12 in is
+    UNCITED in its Wikipedia source (a `citation needed` since 2017, copied
+    verbatim across articles — circular). The California article repeats it.
+    IT IS NOT USED HERE: California's 12x6 in comes from the DMV's own
+    licence-plate page, and VIRPM Appendix 1E independently records that
+    "a standard size of 12 x 6 for autos" arrived with the 1956 issue —
+    an agency statement of the same fact without the folklore attached.
+
+# ---------------------------------------------------------------------------
+# Display rules. California is a TWO-PLATE state with a truck-tractor
+# inversion that mirrors Florida's — front only.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates, front and rear. VC § 5200(a), verbatim: 'When two license plates are issued by the department for use upon a vehicle, they shall be attached to the vehicle for which they were issued, one in the front and the other in the rear.' VC § 5200(b): where only one plate is issued it goes on the rear, 'unless the license plate is issued for use upon a truck tractor, in which case the license plate shall be displayed in accordance with Section 4850.5.'"
+  issuance_rule: "VC § 4850(a): the department issues 'two partially or fully reflectorized license plates or devices for a motor vehicle, other than a motorcycle, and one ... for all other vehicles required to be registered'. VIRPM 1.075 states the operational list: 'Trailers, motorcycles, special equipment (SE), tow dollies, and commercial truck tractors with a TR, DR, or DS body type model are issued one license plate. All other vehicle types registered in California are issued two license plates except apportioned vehicles base-plated in another state, which are issued only a sticker.'"
+  truck_tractor: "VIRPM 1.075, verbatim: 'Truck tractors must have the license plate attached to the front of the vehicle. If truck tractors are assigned special interest license plates, the license plate with the stickers must be attached to the front of the vehicle and the other license plate destroyed.' FRONT-ONLY — the same inversion Florida legislates in § 320.0706, reached here by agency rule rather than statute."
+  reflectorization: "VC § 4850(b) forbids letting any contract to a nongovernmental entity 'for the manufacturing of reflectorized safety license plates'; (c) a $1 reflectorization fee; (d) owners of NONREFLECTORIZED plates are NOT required to replace them — which is why 1963 black plates are lawfully on California roads in 2026. (e) names the section the Schrade-Belotti Act."
+  sticker_placement: "Registration validation stickers go on the REAR plate, except that truck tractors and heavy commercial vehicles display them on the front plate. LOCATOR-GRADE for the 10,001 lb threshold (Wikipedia, citing VC § 5204, which was not fetched); the truck-tractor half is VIRPM 1.075 and is sourced."
+  sources:
+    - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=5200  # § 5200(a) front and rear; (b) rear unless truck tractor"
+    - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=4850  # § 4850: two reflectorized plates (one for non-motor vehicles), the manufacturing prohibition, the $1 fee, the no-forced-replacement rule, the Schrade-Belotti Act"
+    - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/general-registration-information/license-plates/  # VIRPM 1.075: the one-plate vehicle list, the truck-tractor FRONT rule, Central License Plate Issuance"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD SERIES — the mirrored 123ABC1, new in March 2026.
+  # =========================================================================
+  - id: us-ca-standard-123abc1
+    class: standard
+    categories: [car, van]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "999LLL9"
+      regex: '\A\d{3}[A-Z]{3}\d\z'
+      regex_strict: '\A\d{3}(?!ABM|ANO|APE|ARS|ASB|ASS|BAD|BAG|BED|BRA|BUN|BUT|BVD|CHP|CIA|COC|COK|CON|COP|CQC|CQK|CQN|CUL|CUM|CUN|CUR|CUZ|DAG|DAM|DDT|DIC|DIE|DIK|DOA|DUD|DUF|DUM|DUN|FAG|FAN|FAT|FBI|FCK|FKU|FOC|FOK|FQC|FQK|FQU|FUC|FUD|FUG|FUK|FUN|FUX|FUY|GAT|GAY|GEE|GOD|GQD|GUT|HAG|HAM|HEL|HEN|HIC|HIK|HIV|HOG|HOR|HQR|JAP|JAZ|JEW|JIG|KIK|KKK|KOC|KOK|KON|KOX|KQC|KQK|KQN|KQX|KYK|LAY|LSD|MEX|NAG|NGR|NIG|NIP|NUN|OVA|PEA|PEE|PEW|PIG|PIS|POT|POW|PST|PUD|PUS|PYS|QVA|RAG|RAT|RAW|RUT|SAC|SAK|SAM|SEX|SHT|SIF|SIN|SLA|SOB|SOT|SQB|SUC|SUK|SUR|SUX|TIT|TUB|UCK|UPP|UPU|URN|URP|USB|USR|VUC|VUK|VUX|WAD|WOP|WQP|YEP|YID)[A-Z]{3}\d\z'
+      charset:
+        excluded: [ABM, ANO, APE, ARS, ASB, ASS, BAD, BAG, BED, BRA, BUN, BUT, BVD, CHP, CIA, COC, COK, CON, COP, CQC, CQK, CQN, CUL, CUM, CUN, CUR, CUZ, DAG, DAM, DDT, DIC, DIE, DIK, DOA, DUD, DUF, DUM, DUN, FAG, FAN, FAT, FBI, FCK, FKU, FOC, FOK, FQC, FQK, FQU, FUC, FUD, FUG, FUK, FUN, FUX, FUY, GAT, GAY, GEE, GOD, GQD, GUT, HAG, HAM, HEL, HEN, HIC, HIK, HIV, HOG, HOR, HQR, JAP, JAZ, JEW, JIG, KIK, KKK, KOC, KOK, KON, KOX, KQC, KQK, KQN, KQX, KYK, LAY, LSD, MEX, NAG, NGR, NIG, NIP, NUN, OVA, PEA, PEE, PEW, PIG, PIS, POT, POW, PST, PUD, PUS, PYS, QVA, RAG, RAT, RAW, RUT, SAC, SAK, SAM, SEX, SHT, SIF, SIN, SLA, SOB, SOT, SQB, SUC, SUK, SUR, SUX, TIT, TUB, UCK, UPP, UPU, URN, URP, USB, USR, VUC, VUK, VUX, WAD, WOP, WQP, YEP, YID]
+        excluded_count: 144
+        excluded_basis: >-
+          VIRPM 21.180, verbatim heading: "Restricted License Plate
+          Configurations — The following configurations are deleted from the
+          regular series license plate configuration and are not available for
+          personalized license plates". Note the two claims in that sentence:
+          these 144 three-letter strings are deleted from the REGULAR SERIES,
+          and they are separately unavailable to personalized applicants. It is
+          the first claim that makes this a `charset` fact rather than a vanity
+          rule, and it is why `regex_strict` exists on this series.
+        excluded_wrinkle: >-
+          The DMV's own worked example for the six-character automobile
+          configuration on the very same page is "123SAM" — and SAM is on the
+          restricted list. Read the example as illustrative, not as an issued
+          serial. Recorded because a naive scraper would treat it as a sample.
+        notes: >-
+          NO STATUTORY CHARACTER CAP EXISTS IN CALIFORNIA. VC § 4851 is the
+          whole statutory design rule: "Every license plate shall have
+          displayed upon it the registration number assigned to the vehicle for
+          which it is issued, together with the word 'California' or the
+          abbreviation 'Cal.' and the year number for which it is issued or a
+          suitable device issued by the department for validation purposes,
+          which device shall contain the year number for which issued." There
+          is nothing to put in `regex_statutory`; its absence here is a FACT
+          about California law, not an omission. Contrast Florida, whose
+          § 320.06(3)(a) caps the serial at seven characters.
+      progression: "Mirror of the exhausted 1ABC123 format: the three leading numerals advance and the letter group follows. REPORTED, not sourced — the DMV publishes no progression rule that was located."
+      pattern_note: >-
+        REPORTED LETTER-POSITION RULE, NOT ENCODED: secondary sources state
+        that I, O and Q are used only as the MIDDLE letter of the three-letter
+        group (the fifth character in 123ABC1, the third in 1ABC123). The
+        underlying citation chain is Wikipedia -> a San Jose Police Department
+        training PDF, which is not the issuing authority. It is deliberately
+        NOT written into `regex_strict`, because `regex_strict` is reserved for
+        the AUTHORITY's own alphabet (PRD-PLATES §2.7) and this is not it.
+        Recorded as a gap for the verifier to chase to a DMV instrument.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: "From the DMV's own licence-plate page: automobile, commercial and trailer plates 12 in x 6 in; motorcycle plates 7 in x 4 in (pre-1970 motorcycle plates 8 in x 5 in); identification plates 7 in x 4 in (pre-1981 8 in x 5 in). This is an AGENCY statement of dimensions and is used in preference to the AAMVA/SAE chain, whose own text is unpinned."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      colour_note: >-
+        NEITHER COLOUR IS IN ANY INSTRUMENT LOCATED. VC § 4850 mandates
+        reflectorization and says nothing about hue; VC § 4851 names no colour.
+        The reflective-white ground and dark-blue characters are
+        `hex_basis: observed` and both hexes are APPROXIMATIONS taken from the
+        design as depicted on DMV pages. Treat as unverified. By contrast the
+        HISTORIC colours in this file (1963 black/yellow, 1970 blue/yellow)
+        ARE agency-sourced, from VIRPM Appendix 1E and VC § 5004.3 — an
+        unusual inversion where the old designs are better sourced than the
+        current one.
+      legend_top: "California"
+      legend_top_note: "Rendered as a red SCRIPT wordmark, not as block capitals. VC § 4851 requires only 'the word \"California\" or the abbreviation \"Cal.\"' — the script treatment is departmental, not statutory."
+      legend_bottom: "dmv.ca.gov"
+      legend_bottom_note: "The DMV web address has been carried as the plate's bottom legend since 2011 per LOCATOR sources; no DMV instrument stating the date was obtained. California is one of very few jurisdictions worldwide whose standard plate advertises a URL."
+      emblem: { present: false }
+      graphic: { present: true, rendered: placeholder, description: "the red script 'California' wordmark is the plate's only graphic element; there is no seal, no state map and no scenic art on the standard base" }
+      band: { side: none }
+      rear_differs: false
+      manufacture: "California plates have been manufactured by incarcerated workers at Folsom State Prison since 1947 — LOCATOR-GRADE (Wikipedia citing the CALPIA catalogue); recorded because plate manufacture is a recurring question and because CALPIA is a state entity whose catalogue would be the primary to chase."
+    replacement_cycle:
+      years: null
+      note: >-
+        CALIFORNIA HAS NO REPLACEMENT CYCLE. No periodic-replacement duty was
+        located in the Vehicle Code, and VC § 4850(d) affirmatively provides
+        that owners of nonreflectorized plates need not replace them. VIRPM
+        21.260 and the Year of Manufacture rules take for granted that 1963
+        plates remain in service. This is the strongest single counter-example
+        in the dataset to the idea that AAMVA's 7-10 year recommendation is
+        followed: Florida legislated 10 years, California legislated nothing.
+    region_encoding: none
+    region_encoding_note: "California encodes no geography in the plate string and prints no county legend. The only county artefact is administrative (VIRPM Chart 2 - County Codes, used in DMV records, never on the plate)."
+    sources:
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/personalized-configurations-mandatory-refusal/  # VIRPM 21.180: the 144 three-letter strings 'deleted from the regular series license plate configuration'; the restricted letter/number combination table naming the automobile, commercial, CA Exempt, DP and DV configurations"
+      - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=4851  # § 4851: the entire statutory design rule — registration number + 'California' or 'Cal.' + year or validation device. No character cap, no colour, no legend."
+      - "https://www.dmv.ca.gov/portal/vehicle-registration/license-plates-decals-and-placards/license-plates/  # DMV: plate dimensions 12x6 in (auto/commercial/trailer), 7x4 in (motorcycle, pre-1970 8x5), 7x4 in (identification, pre-1981 8x5); 'Generally, license plates remain with the vehicle they were issued to.'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_California  # LOCATOR ONLY (PRD-PLATES §4): the March 2026 flip to 123ABC1 after 9ZZZ999, the 2011 dmv.ca.gov legend, the I/O/Q middle-letter rule, Folsom manufacture. None is asserted as sourced here."
+    notes: >-
+      CALIFORNIA'S CURRENT STANDARD SERIES. PERIOD CAVEAT: `start: 2026` is the
+      year of the instruments read (the live VIRPM and the 2026 Vehicle Code)
+      and is an UPPER BOUND, following the us-fl-standard convention. It
+      happens to coincide with the reported real start — secondary sources
+      (Wikipedia citing the Sacramento Bee and Fox5 San Diego) put the flip at
+      MARCH 2026, immediately after the 1ABC123 format exhausted at 9ZZZ999 —
+      but no DMV instrument stating the date was obtained, so the month is not
+      claimed and the year is claimed only as a bound. THE FLIP ITSELF is the
+      interesting structural fact: California does not redesign when a format
+      runs out, it MIRRORS the existing one, which is why the base design has
+      outlived two complete serial systems. A parse API must therefore treat
+      1ABC123 and 123ABC1 as two series of one visually identical plate.
+
+  # =========================================================================
+  # ONE SERIES BACK — 1ABC123, 1980 to 2026. The 1980 start is AGENCY-PRIMARY.
+  # =========================================================================
+  - id: us-ca-standard-1abc123
+    class: standard
+    categories: [car, van]
+    period: { start: 1980, end: 2026 }
+    period_evidence: agency-manual-dated-start
+    matching: strict
+    format:
+      pattern: "9LLL999"
+      regex: '\A\d[A-Z]{3}\d{3}\z'
+      charset:
+        excluded_ref: "us-ca-standard-123abc1 — the same 144 three-letter strings apply; VIRPM 21.180 states the deletion against the regular series as such, not against a particular arrangement of it"
+        notes: "Same absence of a statutory cap as the current series; see us-ca-standard-123abc1."
+      progression: >-
+        VIRPM Appendix 1E, verbatim: "In 1980, seven characters were
+        introduced in regular series license plates. Acceptable auto license
+        plate series for 1980 only: 1AAA000 to 1SZZ999." The reported rule
+        thereafter is that the ABC123 tail runs AAA000 -> ZZZ999 before the
+        leading digit advances — LOCATOR-GRADE beyond the 1980 block the DMV
+        itself publishes.
+      unissued_blocks_reported: >-
+        LOCATOR ONLY: 1SWD000-1TZZ999, 1WAA000-1ZYZ999, 3FMH000-3FZZ999,
+        3YAA000-3ZYZ999 and 3ZZH000-3ZZZ999 reported never issued;
+        1ZZA000-1ZZZ999 and 3ZZA000-3ZZG999 reserved for Livery;
+        1UAA000-1VZZ999 reserved for Lake Tahoe, Yosemite and Whale Tail
+        specialty plates. Not asserted as sourced. A specialty-block table like
+        this is exactly what a parse API wants and exactly what no primary
+        publishes; recorded as a research target.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      design_generations_note: >-
+        MODELLING DECISION, STATED OPENLY. This entry is cut on FORMAT, not on
+        base design, because the format boundary (1980, 2026) is the only one
+        with agency evidence at either end. Within it the base design changed
+        several times, all LOCATOR-GRADE: 1980 blue base with yellow
+        characters; 1982 "The Golden State" white base (an extra-cost option
+        that became standard in 1987); 1987 white base with an EMBOSSED red
+        state name; 1993 white base with a GRAPHIC red state name; 1998
+        "SESQUICENTENNIAL - 150 YEARS" legend; 2001 legend removed; 2011
+        "dmv.ca.gov" legend added. A future pass with a DMV instrument for any
+        of those boundaries should split this series and alias this id under
+        the PRD-QUALITY I-5/I-6 contract.
+      emblem: { present: false }
+      graphic: { present: true, rendered: placeholder }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://www.dmv.ca.gov/portal/file/vr-manual-appendix-1e/  # VIRPM Appendix 1E (PDF), California License Plate Data 1914-1980: 'In 1980, seven characters were introduced in regular series license plates. Acceptable auto license plate series for 1980 only: 1AAA000 to 1SZZ999.' Also the year-by-year colour/series table this file's historic claims rest on."
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/appendix-1e-california-license-plate-data-1914-1980/  # the VIRPM page that serves the appendix"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_California  # LOCATOR ONLY: the 2026 end of the format, the base-design generations, the unissued and reserved blocks"
+    notes: >-
+      THE FORMAT CALIFORNIA RAN FOR FORTY-SIX YEARS. Its START is properly
+      sourced — VIRPM Appendix 1E says the seven-character regular series
+      arrived in 1980 and gives the exact 1980 block — which makes this one of
+      the few US series in the dataset with an agency-dated boundary. Its END
+      is LOCATOR-GRADE (reported March 2026 on exhaustion at 9ZZZ999) and is
+      recorded as 2026 because the successor series is demonstrably in issue in
+      2026; a verifier should replace it with a DMV instrument or downgrade it.
+      DISAGREEMENT RECORDED, NOT AVERAGED (PRD-PLATES §5.3): VIRPM Appendix 1E
+      dates the blue-and-yellow base "1970-1980", Wikipedia dates it from 1969,
+      and VC § 5004.3 — a statute — describes the blue/yellow appearance as
+      that of plates "issued by the department from 1969 to 1986, inclusive".
+      Three instruments, three boundaries, no average taken.
+
+  # =========================================================================
+  # LEGACY — the 1960s black plate, back in production, WITH ITS COLOURS IN
+  # STATUTE. This is the rare case where a US plate design is specified by law.
+  # =========================================================================
+  - id: us-ca-legacy-1960s
+    class: specialty
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2015 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9]{6}\z'
+      charset:
+        notes: >-
+          VIRPM 21.025, verbatim: "Legacy License Plates are available in
+          sequential configurations of six characters and in personalized
+          configurations of two to seven characters and may be issued to
+          automobiles, commercial vehicles (excluding international
+          registration plan [IRP]), motorcycles, trailer coach (CCH), and
+          permanent trailer identification (PTI)." SIX CHARACTERS is the whole
+          published constraint — the DMV does not say WHICH six-character
+          arrangement, so the regex here is deliberately the union of all of
+          them and this series is `matching: recall-only`. A match is a shape
+          hit, not a validity claim.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#000000", finish: retroreflective, hex_basis: statutory-description }
+      foreground: "#FFC72C"
+      colour_basis: >-
+        THE COLOURS ARE IN THE STATUTE. VC § 5004.3 authorises three legacy
+        designs by colour and by reference to the period whose appearance they
+        replicate: (1) "Yellow background with black lettering per the
+        appearance of California license plates issued by the department from
+        1956 to 1962, inclusive"; (2) "Black background with yellow lettering
+        per the appearance of California license plates issued by the
+        department from 1965 to 1968, inclusive"; (3) "Blue background with
+        yellow lettering per the appearance of California license plates issued
+        by the department from 1969 to 1986, inclusive." The HEXES are still
+        approximations — the statute names colours, not values — but the
+        colour NAMES and the periods they refer to are law.
+      emblem: { present: false }
+      rear_differs: false
+      reproduction_note: "LOCATOR ONLY: the reissued plates use a modern reflective black coating rather than the original dull black paint, and the narrower character dies of the 7-character era rather than the wider 6-character dies of the originals. A collector-visible difference; recorded because a render should not claim to reproduce the 1963 artefact."
+    program_threshold: "VC § 5004.3: the department must collect 'not less than 7,500 paid applications for any one of the particular plates' before issuing it, and had 'until January 1, 2015, to receive the required number of applications', with refunds if the threshold was missed."
+    program_outcome: "LOCATOR ONLY: only the 1960s black-with-yellow design reached 7,500 before the deadline; the 1950s yellow-with-black and 1970s blue-with-yellow designs did not, and are authorised but never issued. Recorded because an authorised-but-dead design is exactly the trap PRD-PLATES §2.5 warns about — the statute lists three, the road carries one."
+    region_encoding: none
+    sources:
+      - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=5004.3  # § 5004.3: the three legacy designs with their colours and their reference periods (1956-1962, 1965-1968, 1969-1986), the 7,500 paid-application threshold, the 1 January 2015 deadline and the refund rule"
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/california-ca-1960s-legacy-license-plates/  # VIRPM 21.025: six-character sequential, two-to-seven-character personalized, the eligible vehicle types, the plate-with-owner rule"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_California  # LOCATOR ONLY: only the 1960s design met the threshold; issuance began 2015; modern coating and narrower dies"
+    notes: >-
+      THE ONE US PLATE DESIGN IN THIS WAVE WHOSE COLOURS ARE LEGISLATED.
+      Everywhere else in the US pass the statutes specify a PROPERTY
+      (Florida: "a distinguishing color") and leave the VALUE to the
+      department; VC § 5004.3 names the values. It also does something no other
+      instrument found in this programme does: it uses the state's own past
+      designs as the specification, and in doing so publishes a set of
+      historical base periods (1956-1962, 1965-1968, 1969-1986) as law. Those
+      periods disagree with both the DMV's own Appendix 1E and with the
+      collector literature, and the disagreement is recorded on
+      us-ca-standard-1abc123 rather than resolved. `start: 2015` is an upper
+      bound taken from the reported first issuance year, not from an
+      instrument.
+
+  # =========================================================================
+  # PERSONALIZED — "Environmental License Plates", the original US vanity plate.
+  # =========================================================================
+  - id: us-ca-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]{2,7}\z'
+      charset:
+        excluded_ref: "us-ca-standard-123abc1 — the same 144 restricted three-letter strings are unavailable to personalized applicants, VIRPM 21.180"
+        notes: >-
+          VIRPM 21.100, verbatim: "Environmental License Plates (ELP) are the
+          original personalized license plate. ELPs are only available
+          personalized with two to seven characters and may be issued to
+          automobiles, commercial vehicles, motorcycles, and trailers."
+          TWO TO SEVEN CHARACTERS is agency-sourced and is what the regex
+          encodes.
+      substitution_rule: >-
+        VIRPM 21.180, verbatim: "Any special license plate application which
+        contains '1' and 'I' used interchangeable or '0' and 'O' or 'Q' used
+        interchangeably must be rejected." A LOOKALIKE-COLLISION rule aimed at
+        the plate-reading problem rather than at taste, and a good example of
+        why a validator needs the authority's own alphabet rather than a
+        generic alphanumeric class.
+      conflict_table: >-
+        VIRPM 21.180 publishes the configurations unavailable to personalized
+        applicants "because they conflict with existing license plate series",
+        and in doing so publishes the CURRENT SHAPE OF SEVERAL OTHER
+        CALIFORNIA SERIES — which is why this file can spec them at all:
+        3 numbers + 2 letters (000AA-000E0, Reserved); 3 numbers + 3 letters
+        (123SAM, Automobile); 4 numbers + 2 letters (0000PH Purple Heart
+        Vessels, 1234AB, 0000DP Disabled Person, 0000DV Disabled Veteran);
+        5 numbers + 1 letter (12345R, Commercial); 5 numbers + 2 letters
+        (30000DP, 00000DV); 5 numbers + 1 letter + 1 number (11111A1,
+        Commercial); 7 numbers (1234567, CA Exempt).
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      note: "ELPs may be issued on the standard base or on most special-interest bases; the design is that of the chosen base."
+    refusal_criteria: >-
+      VIRPM 21.180 is one of the most explicit refusal standards published by
+      any US DMV, and it is quoted because the criteria themselves are the
+      fact: "DMV must refuse any personalized license plate configuration that
+      may carry connotations offensive to good taste and decency, or which
+      would be misleading" — including a configuration that has a sexual
+      connotation, is a vulgar/contemptuous/prejudicial/racially or ethnically
+      degrading term, is profane or obscene, "has been restricted (deleted)
+      from regular series license plates", has a negative connotation to a
+      specific group, misrepresents a law enforcement entity, is a foreign or
+      slang word, or "is a phonetic spelling or mirror image" of any of those.
+    statutory_hook: "VC § 5101 authorises environmental licence plates for the registered owner or lessee of 'a passenger vehicle, commercial motor vehicle, motorcycle, trailer, or semitrailer'. VC § 5105 governs refusal and cancellation of offensive or misleading configurations. NEITHER SECTION STATES A CHARACTER LIMIT — the two-to-seven rule is the DMV's, not the Legislature's."
+    region_encoding: none
+    sources:
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/environmental-license-plates/  # VIRPM 21.100: ELPs 'only available personalized with two to seven characters'; eligible vehicle types; plate-with-owner"
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/personalized-configurations-mandatory-refusal/  # VIRPM 21.180: the refusal criteria, the 1/I and 0/O/Q substitution rule, the similar-configuration rule, the 144 restricted strings, the conflicting-configuration table"
+      - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=5101  # § 5101: who may apply for environmental licence plates"
+      - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=5105  # § 5105: departmental refusal and cancellation of offensive or misleading configurations"
+    notes: >-
+      CALIFORNIA'S PERSONALIZED PLATE IS STATUTORILY CALLED AN ENVIRONMENTAL
+      LICENSE PLATE because its fees fund environmental programmes, which is
+      why a reader chasing "vanity plate" through the Vehicle Code finds
+      nothing. Modelled as its own series for the same reason as Florida's: the
+      SERIAL SOURCE differs — owner-chosen rather than department-assigned —
+      even though the character frame overlaps the standard series.
+
+  # =========================================================================
+  # HISTORIC — two permanent series, both in statute, both numbered from 1.
+  # =========================================================================
+  - id: us-ca-horseless-carriage
+    class: historic
+    categories: [car]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "999"
+      regex: '\A\d+\z'
+      charset:
+        notes: >-
+          VC § 5004, verbatim: "The special identification plates assigned to
+          motor vehicles with an engine of 16 or more cylinders manufactured
+          prior to 1965 and to any motor vehicle manufactured in the year 1922
+          and prior thereto shall run in a separate numerical series,
+          commencing with 'Horseless Carriage No. 1'." A separate numerical
+          series with a stated origin and NO STATED WIDTH — hence the unbounded
+          quantifier, which makes no width claim.
+      progression: "strictly sequential from 1"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "VC § 5004: 'Each series of plates shall have different and distinguishing colors.' The statute specifies DISTINCTNESS, not a value — the same drafting choice Florida makes in § 320.086(1). No colour is recorded."
+      legend: "Horseless Carriage"
+    eligibility: "VC § 5004(a): a motor vehicle with an engine of 16 or more cylinders manufactured prior to 1965, OR any motor vehicle manufactured in 1922 or earlier. A FIXED-CUTOFF threshold — it never moves."
+    validity: "VIRPM 21.120: the plates are PERMANENTLY assigned to the vehicle and cannot be reassigned; no additional renewal fee; the plates cannot be retained by the owner; the vehicle is subject to a fixed annual vehicle licence fee of $2 (R&TC § 10753.5) and is limited to historical exhibition, parades and club activities."
+    fee: "VC § 5004: '$25 shall be charged for the initial issuance', replacement per § 9265."
+    region_encoding: none
+    sources:
+      - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=5004  # § 5004: the 16-cylinder and 1922-or-earlier eligibility, the 'Horseless Carriage No. 1' series, 'different and distinguishing colors', the $25 initial fee"
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/historical-vehicle-and-horseless-carriage-license-plates/  # VIRPM 21.120: permanent assignment, no reassignment, no retention, the $2 fixed VLF, the exhibition-use restriction, and that these plates are NOT available personalized"
+    notes: >-
+      HORSELESS CARRIAGE. California and Florida legislate this series in
+      almost identical terms — a separate numerical run from "Horseless
+      Carriage No. 1", a distinguishing but unnamed colour, permanence — which
+      is worth recording as a genuine cross-state convergence rather than a
+      coincidence, and as a hint that the two statutes share an ancestor. The
+      eligibility rules differ: California's is a FIXED cutoff (1922, or 16+
+      cylinders pre-1965), Florida's Horseless Carriage is a fixed 1945 cutoff,
+      and California's own Historical Vehicle series below is ROLLING.
+
+  - id: us-ca-historical-vehicle
+    class: historic
+    categories: [car, truck, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "999"
+      regex: '\A\d+\z'
+      charset:
+        notes: "VC § 5004: 'The special identification plates assigned to vehicles specified in paragraph (3) of subdivision (a) shall run in a separate numerical series, commencing with \"Historical Vehicle No. 1\".' Same shape as the Horseless Carriage series, same absence of a stated width."
+      progression: "strictly sequential from 1"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      colour_note: "VC § 5004: 'Each series of plates shall have different and distinguishing colors' — the Historical Vehicle plate must therefore differ in colour from the Horseless Carriage plate, but neither value is stated."
+      legend: "Historical Vehicle"
+    eligibility: "VIRPM 21.120: a motor vehicle or trailer manufactured AFTER 1922, at least 25 YEARS OLD, and of historic interest. A ROLLING threshold — the eligible set silently grows every year, which is the kind of claim the quarterly audit has to re-derive rather than trust."
+    region_encoding: none
+    sources:
+      - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=5004  # § 5004(a)(3) and the 'Historical Vehicle No. 1' series"
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/historical-vehicle-and-horseless-carriage-license-plates/  # VIRPM 21.120: manufactured after 1922, at least 25 years old, of historic interest; the exhibition-use restriction and the $2 fixed VLF"
+    notes: >-
+      HISTORICAL VEHICLE. Its own series and not a variant of Horseless
+      Carriage because § 5004 gives it its own numerical run and requires it to
+      carry a different colour. The eligibility contrast inside a single
+      section is the modelling lesson: § 5004 carries a FIXED cutoff and a
+      ROLLING one side by side, and only the rolling one needs re-auditing.
+
+  # =========================================================================
+  # YEAR OF MANUFACTURE — the series that has no serial of its own, because it
+  # borrows a serial the department issued decades ago.
+  # =========================================================================
+  - id: us-ca-year-of-manufacture
+    class: historic
+    categories: [car, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: >-
+          A YOM plate carries whatever serial the department issued in the
+          matching year, so its regex is necessarily the UNION of California's
+          historic arrangements and a match is a shape hit only. The DMV
+          publishes the acceptable series per era, and those ARE precise:
+          VIRPM 21.260 / Appendix 1E — "1963-1969 year model automobiles must
+          have black license plates with yellow characters within the
+          alpha-numeric series of AAA000-YYY999"; 1963-1969 commercial
+          "A00000-Z99999 or 00000A-99999Z"; "1970-1980 year model automobiles
+          vehicles must have blue license plates with yellow characters within
+          the alpha-numeric series of 000AAA-999ZZZ"; 1970-1980 commercial
+          "00000A-99999Z", with 1975-1980 also "1A00001 to 3Z99999";
+          1970-1980 motorcycles "0A0000-9Z9999"; and 1980 autos may also use
+          "1AAA000 to 1SZZ999".
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: unknown }
+      design_note: "The design is that of the original year. VIRPM 21.260: plates 'May be restored/painted but cannot deviate from the original colors or configurations', and the year validation sticker corresponding to the vehicle's model year must be attached and authenticated by a DMV employee before assignment."
+    eligibility: "VC § 5004.1(a)(1): an owner of a 1980 OR OLDER model-year vehicle may use plates 'with the date of year corresponding to the model-year date when the vehicle was manufactured, if the model-year date license plate is legible and serviceable, as determined by the department'. VIRPM 21.260 narrows it operationally: 1969 or prior for autos, trailers and motorcycles; 1972 or prior for commercial vehicles. § 5004.1(a)(2) lets the department 'consult with an organization of old car hobbyists' in judging correspondence — a rare statutory delegation to a hobby community."
+    restrictions: "VIRPM 21.260: YOM vehicles have FULL operating privileges and are NOT restricted to historical activities (unlike Historical Vehicle plates); replicas, specially constructed vehicles and kit cars do not qualify; Environmental and Special Recognition plates are excluded from the programme."
+    regulatory_hook: "California Code of Regulations Title 13, Article 3.3, §§ 205.00-205.14 governs the programme. THE CCR TEXT WAS NOT FETCHED in this pass (recorded gap) — VIRPM 21.260 cites it and is used in its place."
+    region_encoding: none
+    sources:
+      - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=5004.1  # § 5004.1: 1980-or-older model year, legible and serviceable, the old-car-hobbyist consultation, the $45 application and $10 renewal fees"
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/year-of-manufacture-yom-license-plates/  # VIRPM 21.260: the 1969/1972 operational cutoffs, the sticker-equals-year rule with worked examples, the AAA000-YYY999 black-base rule, the CCR Title 13 Art. 3.3 hook"
+      - "https://www.dmv.ca.gov/portal/file/vr-manual-appendix-1e/  # VIRPM Appendix 1E: the per-era acceptable series for autos, commercial vehicles and motorcycles"
+    notes: >-
+      YEAR OF MANUFACTURE IS THE SCHEMA'S EDGE CASE AND EARNS ITS PLACE HERE
+      FOR THAT REASON: a currently-issuable registration whose plate is a
+      forty-to-a-hundred-year-old artefact supplied by the owner, authenticated
+      rather than manufactured. `matching: recall-only` is the honest reading —
+      the regex is the union of every California arrangement, so a hit says
+      "this could be a California plate of some era", never "this is a valid
+      YOM registration". The DMV's sticker arithmetic is worth carrying
+      verbatim because it is genuinely counter-intuitive: "A 1956 license plate
+      with a 1958 sticker equals a 1958 plate and must be placed on a 1958 year
+      model vehicle."
+
+  # =========================================================================
+  # CORE CLASSES the state separately serializes. The formats come from the
+  # VIRPM 21.180 conflict table where it speaks, and are LOCATOR-GRADE
+  # where it does not — each entry says which.
+  # =========================================================================
+  - id: us-ca-commercial
+    class: standard
+    categories: [truck, van, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "99999L9"
+      regex: '\A\d{5}[A-Z]\d?\z'
+      charset:
+        notes: >-
+          BOTH commercial arrangements come from VIRPM 21.180's table of
+          configurations unavailable to personalized applicants "because they
+          conflict with existing license plate series": "5 numbers; 1 letter"
+          with the example 12345R, and "5 numbers; 1 letter; 1 number" with the
+          example 11111A1, both labelled License Type "Commercial". The regex
+          is the union of exactly those two and nothing wider, so `matching`
+          is strict.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      note: "Commercial plates share the standard base design; the class is carried by the serial arrangement, not by a legend."
+    region_encoding: none
+    sources:
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/personalized-configurations-mandatory-refusal/  # VIRPM 21.180: '5 numbers; 1 letter' (12345R) and '5 numbers; 1 letter; 1 number' (11111A1), License Type Commercial"
+      - "https://www.dmv.ca.gov/portal/file/vr-manual-appendix-1e/  # VIRPM Appendix 1E .0110: the commercial series history — 1963-1969 A00000-Z99999 or 00000A-99999Z on the black base; 1970-1980 00000A-99999Z on the blue base; 1975-1980 also 1A00001-3Z99999"
+    notes: >-
+      COMMERCIAL PLATES. CLASS CAVEAT: recorded as `standard` because
+      _meta/classes.yml has no `commercial` value and the PRD's `standard`
+      definition ("the default series issued to private road vehicles") fits
+      awkwardly. The same caveat Florida records for its Wrecker plate. The
+      value of this entry is that its format is AGENCY-SOURCED — a US
+      commercial-plate format with a citation is unusual — and that it shows
+      how VIRPM 21.180's negative list (what a vanity applicant may NOT ask
+      for) is in fact a positive catalogue of California's live series.
+
+  - id: us-ca-exempt
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "9999999"
+      regex: '\A\d{7}\z'
+      charset:
+        notes: "VIRPM 21.180's conflict table: '7 numbers', example 1234567, License Type 'CA Exempt'. Seven numerals and nothing else — an all-numeric government series is unusual in the US and is the reason a validator must not assume a US plate contains a letter."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend: "CALIFORNIA EXEMPT"
+      emblem: { present: true, rendered: placeholder, description: "exempt plates carry a state-seal-derived device; NOT rendered — the Great Seal is separately regulated (see artwork_risk.seal_regime)" }
+      colour_note: "No instrument stating the exempt plate's colours was located (recorded gap)."
+    region_encoding: none
+    sources:
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/personalized-configurations-mandatory-refusal/  # VIRPM 21.180: '7 numbers' / 1234567 / CA Exempt"
+    notes: >-
+      CALIFORNIA EXEMPT — the government fleet series. Recorded because the
+      seven-numeral shape is genuinely distinctive and because it is the one
+      California series whose whole format is published in a single agency
+      line. The legend text and the emblem are LOCATOR/observation-grade and
+      are marked as such; only the format is sourced here.
+
+  - id: us-ca-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "99L9999"
+      regex: '\A\d{2}[A-Z]\d{4}\z'
+      charset:
+        notes: >-
+          LOCATOR-GRADE FORMAT. The 12A1234 arrangement and its reported start
+          in 1982 come from Wikipedia and the collector literature; no DMV
+          instrument stating the current motorcycle arrangement was located
+          (recorded gap). What IS agency-sourced is the PREVIOUS motorcycle
+          format and the plate size: VIRPM Appendix 1E gives the 1970-1980
+          motorcycle series as 0A0000-9Z9999 on the blue base with plates
+          "5 x 8", and the DMV's licence-plate page gives the current
+          motorcycle plate as 7 in x 4 in (pre-1970: 8 in x 5 in).
+    design:
+      plate: { w: 7, h: 4, unit: in }
+      plate_dimension_note: "DMV licence-plate page: motorcycle plates 7 in x 4 in; motorcycle plates issued before 1970 are 8 in x 5 in. Appendix 1E independently records the 1970-1980 motorcycle plate as 5 in x 8 in — the axes are transposed between the two agency statements and NEITHER is corrected here."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      rear_differs: false
+    display: "VC § 4850(a): a motorcycle is issued ONE plate; VC § 5200(b) puts it on the rear."
+    region_encoding: none
+    sources:
+      - "https://www.dmv.ca.gov/portal/vehicle-registration/license-plates-decals-and-placards/license-plates/  # DMV: motorcycle plate 7x4 in, pre-1970 8x5 in"
+      - "https://www.dmv.ca.gov/portal/file/vr-manual-appendix-1e/  # VIRPM Appendix 1E .0115: the 1970-1980 motorcycle series 0A0000-9Z9999 and the 5x8 plate size"
+      - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=4850  # § 4850(a): one plate for a motorcycle"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_California  # LOCATOR ONLY: the current 12A1234 arrangement, its reported 1982 start, and the reported I/O/Q exclusion"
+    notes: >-
+      MOTORCYCLE. Its own series because the format, the plate size and the
+      one-plate rule all differ from the standard passenger series. The format
+      is the weakest claim in this file and says so: the DMV publishes the
+      motorcycle plate's SIZE but not its current serial arrangement, so the
+      regex rests on collector-corroborated locator sources. A verifier should
+      either find a DMV instrument or downgrade this series to recall-only.
+
+  - id: us-ca-permanent-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "9LL9999"
+      regex: '\A\d[A-Z]{2}\d{4}\z'
+      charset:
+        notes: "LOCATOR-GRADE: the 4AB1234 arrangement of the Permanent Trailer Identification (PTI) plate and its reported 2001 start come from Wikipedia and the collector literature. No DMV instrument stating the arrangement was located (recorded gap). VIRPM 21.025 does confirm that PTI is a live plate type eligible for Legacy designs."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend_top: "California Perm Trailer"
+      legend_note: "LOCATOR-GRADE legend text."
+    display: "VC § 4850(a) / VIRPM 1.075: a trailer is issued ONE plate, displayed on the rear."
+    region_encoding: none
+    sources:
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/general-registration-information/license-plates/  # VIRPM 1.075: trailers are issued one plate"
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/california-ca-1960s-legacy-license-plates/  # VIRPM 21.025 names 'permanent trailer identification (PTI)' as a live plate type"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_California  # LOCATOR ONLY: Permanent Trailer 4AB1234 from 2001, replacing the AT-HT prefixed trailer plates of 1982-2001"
+    notes: >-
+      PERMANENT TRAILER IDENTIFICATION. Recorded because California moved
+      trailers to a PERMANENT registration in 2001 (reported) and because the
+      predecessor — trailer plates with AT through HT prefixes, 1982-2001 — is
+      a dead series still lawfully on the road, the same shape as Florida's
+      "Collectible" plate. Neither the current format nor the transition date
+      is agency-sourced; both are recorded as gaps.
+
+  - id: us-ca-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "99999"
+      regex: '\A[A-Z0-9]{1,8}\z'
+      charset:
+        notes: >-
+          THE SERIAL IS THE FIRM'S OCCUPATIONAL LICENCE NUMBER, not a plate
+          series. VIRPM 2.090, verbatim: "Special license plates bearing the
+          firm's license number are issued to licensed firms other than
+          lessor-retailers (VC §11714)." The printed plate additionally carries
+          a stacked class letter (D dealer / L lessor / R remanufacturer per
+          LOCATOR sources) and a small sequence suffix distinguishing multiple
+          sets held by one firm. Because the visible string is a licence number
+          of unstated width plus stacked decoration, the regex here is
+          deliberately over-broad and this series is `matching: recall-only`.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      stacked_characters_note: "AAMVA Ed.3 treats stacked characters as PART OF the official plate number, at most two stacked. California's dealer plate is the case that makes this bite: the class letter and the set suffix are both printed small or stacked, so a normaliser that drops them destroys the identity. The decision belongs in the parse layer."
+    binding: business
+    permitted_use: >-
+      VC § 11715 via VIRPM 2.090: special plates may be used on any vehicle
+      owned or lawfully possessed by the licensee, including to tow or
+      transport other vehicles, and by a dealer for delivery to a buyer where
+      the sale is consummated at the place of delivery. They may NOT be used on
+      work or service vehicles, on vehicles being moved under a DMV permit from
+      a vessel/railroad depot/warehouse, on an unregistered vehicle
+      transporting more than one load of vehicles for sale, or on a
+      currently-registered dealer-owned vehicle whose former owner filed a
+      release of liability and whose report of sale is displayed.
+    region_encoding: none
+    sources:
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/general-information-licensees/special-dealer-manufacturer-remanufacturer-and-distributor-license-plates/  # VIRPM 2.090: plates bear the firm's licence number (VC § 11714); the § 11715 permitted-use and prohibited-use lists; additional sets and replacements via form OL 22"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_California  # LOCATOR ONLY: the printed D/L/R + 5 numerals + small suffix arrangement and its reported generations (1970, 1987, 1993, 2011)"
+    notes: >-
+      DEALER / MANUFACTURER / REMANUFACTURER / DISTRIBUTOR PLATES.
+      `binding: business` for the same reason as Germany's rote Kennzeichen and
+      Florida's dealer plate: the plate follows the firm, not a vehicle — and
+      California makes that literal by printing the firm's OCCUPATIONAL LICENCE
+      NUMBER as the serial. That is a genuinely different kind of plate string
+      from everything else in this file: it is not drawn from a series at all,
+      which is why it is `recall-only` and why a parse API should treat a hit
+      here as "possibly a California trade plate" and nothing more.
+
+  - id: us-ca-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2019 }
+    period_evidence: statutory-operative-date
+    matching: strict
+    format:
+      pattern: "LL99L99"
+      regex: '\A[A-Z]{2}\d{2}[A-Z]\d{2}\z'
+      charset:
+        notes: >-
+          LOCATOR-GRADE ARRANGEMENT: the AB12C34 shape of the California
+          temporary paper plate is reported by Wikipedia citing VC § 4456(a)(9)
+          — but § 4456 itself, which WAS fetched, does not state a format; it
+          requires only that "the dealer or lessor-retailer shall attach the
+          temporary license plates issued by the reporting system". The
+          arrangement is therefore a property of the DMV's reporting system and
+          is recorded as unsourced. The PERIOD, by contrast, is statutory.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      material: "printed on special paper by the dealer through the DMV reporting system, not metal"
+      background: { finish: none }
+      note: "The temporary plate additionally carries the vehicle identification number and an expiry date in the published examples; not asserted as sourced."
+    validity: "Temporary plates bridge the gap between sale and arrival of the metal plates; the report-of-sale copy is attached to the vehicle before delivery (VC § 4456(a))."
+    region_encoding: none
+    sources:
+      - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=4456  # § 4456: the report-of-sale duty; (a)(9) 'the dealer or lessor-retailer shall attach the temporary license plates issued by the reporting system'; 'This section shall become operative January 1, 2019'; amended Stats. 2021 Ch. 256"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_California  # LOCATOR ONLY: the AB12C34 series, and the pre-2019 history (California was the last US state with no temporary-plate requirement; AB 516 of 2016 closed it)"
+    notes: >-
+      CALIFORNIA'S TEMPORARY PLATE IS THE NEWEST SERIES IN THIS FILE AND THE
+      ONLY ONE WITH A CLEAN STATUTORY OPERATIVE DATE: § 4456 says in terms
+      "This section shall become operative January 1, 2019", so `start: 2019`
+      is a real claim rather than an upper bound. It exists because until then
+      California was the last state in the union requiring no temporary plate
+      at all — new cars ran on dealer paper inserts, which is why the DMV's own
+      historical record and the legislative history (AB 516, 2016) are worth
+      keeping in the notes: a dataset that models only current formats cannot
+      explain why a 2018 California car has no plate in a photograph.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Count and official
+  # links only; no individual designs.
+  # =========================================================================
+  - id: us-ca-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "999LLL9"
+      regex: '\A\d{3}[A-Z]{3}\d\z'
+      charset: { notes: "Specialty plates carry ORDINARY sequential serials on an alternative design, or a personalized configuration of two to seven characters. Some programmes are issued from reserved blocks of the standard series — 1UAA000-1VZZ999 is reported reserved for Lake Tahoe, Yosemite and Whale Tail — which means a specialty plate is not always distinguishable from a standard one by its serial alone." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      design_space: >-
+        THE ONLY US SPECIALTY-PLATE GEOMETRY FOUND IN STATUTE IN THIS WAVE.
+        VC § 5060 requires that the plates permit law enforcement to readily
+        identify the letters and numbers, and prescribes for passenger vehicles
+        a 2 in x 3 in space to the LEFT of the numbers for the distinctive
+        design plus a 5/8 in high strip below the numbers for a message; for
+        motorcycles, a five-character configuration with the design space on
+        the left and sharp character contrast. That is directly renderable
+        layout data, from the Legislature rather than from an agency.
+      emblem: { present: true, rendered: placeholder }
+      note: "One design per authorised programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here."
+    program_index:
+      count_official: null
+      count_official_note: >-
+        NO OFFICIAL TOTAL IS PUBLISHED. Unlike Florida, whose FLHSMV says "over
+        100 different specialty license plates" in its own words, the
+        California DMV publishes CATEGORISED LISTS and no count. This is
+        recorded as an absence rather than filled with a secondary figure.
+      count_enumerated_special_interest: 15
+      enumerated_special_interest: ["Arts Council", "Breast Cancer Awareness", "California 1960s Legacy", "California Agriculture (CalAg)", "California Museums (Snoopy)", "Collegiate", "Environmental", "Firefighters", "Have A Heart, Be A Star, Help Our KIDS", "Lake Tahoe Conservancy", "Memorial", "Pet Lovers", "Veterans' Organizations", "Whale Tail (Coastal Protection and Access)", "Yosemite Conservancy"]
+      enumerated_special_plates: ["Amateur Radio Call Letters", "Antique Motorcycle", "Bicentennial Bill of Rights", "Citizens Band", "Disabled Person/Veteran", "Exempt", "Foreign Organization", "Historical Vehicles", "Honorary Consul Corps", "Horseless Carriages", "Livery", "Moped", "Olympic Games 1984", "Press Photographer", "Special Equipment"]
+      enumerated_recognition_occupational: ["Congressional Medal of Honor", "Gold Star Family", "Ex-Prisoner of War", "Legion of Valor", "Pearl Harbor Survivor", "Purple Heart", "Dealers", "Dismantlers", "Manufacturers", "New Vehicle Distributor", "Remanufacturers", "Transporters", "State Assembly", "State Senate", "U.S. House Representatives", "U.S. Senator", "Apportioned Power Unit"]
+      enumeration_basis: "Counted off the DMV's own Special Interest & Special License Plates index page, 2026-08. The three lists above are the DMV's own groupings, not ours. VIRPM Chapter 21 independently carries 56 sub-sections covering these types and is the deeper index."
+      official_list_url: "https://www.dmv.ca.gov/portal/vehicle-registration/license-plates-decals-and-placards/license-plates/special-interest-special-license-plates/"
+      official_manual_url: "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/"
+      program_threshold: "VC § 5060: a sponsoring organization must be tax-exempt under IRC § 501(c)(3) and submit a financial plan plus a plate design; 'No organization may be included in the program until not less than 7,500 applications for the particular special interest license plates are received', collected within 12 months of the enabling legislation, extendable once to 24 months."
+      discontinuation_rule: "VC § 5060: if outstanding valid plates fall below 7,500 the department notifies the sponsor, and if the number is still below 7,500 a year later the department 'will no longer issue or replace those special interest license plates'. Plates already issued stay valid, renewable, retainable and transferable. So California, like Florida, accumulates AUTHORISED-BUT-DEAD programmes whose plates remain on the road — the index is a moving target by design."
+      registration_counts_url: null
+      registration_counts_note: >-
+        NO EQUIVALENT OF FLORIDA'S MONTHLY ACTIVE SPECIALTY PLATES REPORT WAS
+        FOUND FOR CALIFORNIA. Florida publishes per-programme issuance volumes
+        monthly; California publishes none that was located. Recorded as a
+        negative result, because the Florida portal was the single most
+        valuable structured artefact in the US pass and the natural question is
+        whether other states match it. On this evidence, California does not.
+    region_encoding: none
+    sources:
+      - "https://www.dmv.ca.gov/portal/vehicle-registration/license-plates-decals-and-placards/license-plates/special-interest-special-license-plates/  # the DMV's own three-way grouping of special interest, special, and special recognition/occupational/legislative/apportioned plates — the 15+15+17 enumeration above"
+      - "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=VEH&sectionNum=5060  # § 5060: the 501(c)(3) sponsor requirement, the 7,500-application threshold and its 12/24-month window, the 2x3 in design space and 5/8 in message strip for passenger plates, the five-character motorcycle rule, and the below-7,500 discontinuation duty"
+      - "https://www.dmv.ca.gov/portal/handbook/vehicle-industry-registration-procedures-manual-2/special-plates/  # VIRPM Chapter 21: 56 sub-sections, the deeper official index"
+    notes: >-
+      THE CALIFORNIA SPECIALTY PROGRAM INDEX — one entry standing for the whole
+      programme, which is what PRD-PLATES §2.5 asks for at this gate. Two
+      things to carry forward. First, VC § 5060 is the best specialty-plate
+      GEOMETRY source found anywhere in the US wave: a legislature that
+      specifies a 2 x 3 inch design space and a 5/8 inch message strip is
+      handing the render layer its layout for free, and the same section
+      supplies the 7,500-in / 7,500-out lifecycle that makes the index a
+      moving target. Second, the absence of a California issuance-volume
+      report is itself a finding: Florida's monthly active-plate portal has no
+      California counterpart, so the differentiator identified in the L0 pass
+      does not generalise and must be re-checked state by state.

--- a/plates/us-hi.yml
+++ b/plates/us-hi.yml
@@ -1,0 +1,585 @@
+# plates/us-hi.yml — Hawaii (PRD-PLATES gate L2, group: pacific).
+#
+# HAWAII IS THE ONE US JURISDICTION IN THIS WAVE WHERE THE STATE DOES NOT ISSUE
+# THE PLATES. Under HRS chapter 249 the issuing officers are the four COUNTY
+# DIRECTORS OF FINANCE — City and County of Honolulu, and the Counties of
+# Hawaiʻi, Maui and Kauaʻi — and the design is settled among them, not by any
+# state agency: HRS § 249-9(a)(4) says number plates shall "Be of any shape,
+# size, and color, and with any arrangements of letters and numbers as may ...
+# be determined by the directors of finance of each county through majority
+# consent." Procurement is centralised — the Honolulu director "shall contract
+# annually on behalf of the counties" — but authority is not. A jurisdiction-
+# keyed schema therefore has to carry a jurisdiction whose "authority" is a
+# committee of four, and that is why `authority` below names the arrangement
+# rather than an agency.
+#
+# THE HEADLINE FACT, AND IT IS PROPERLY DATED: HRS § 249-9(a), as amended by
+# Act 64, Session Laws of Hawaii 2024, splits the legend requirement on a
+# calendar date. Plates issued BEFORE 1 January 2025 must bear "Hawaii";
+# plates issued ON OR AFTER 1 January 2025 must bear "Hawai`i" — with the
+# ʻokina. That is a statutory series boundary of a kind this dataset almost
+# never gets in the United States: a design change, in law, with a date, and it
+# lands squarely inside the coverage window. It is the spine of this file.
+#
+# NOTE ON THE ʻOKINA: the statute's glyph is the ʻokina (U+02BB). The
+# capitol.hawaii.gov HTML renders it as a backtick, and it is quoted below in
+# the form the instrument served. No serial in this dataset contains it — it
+# appears only in the LEGEND, never in the plate number, so PRD-PLATES §2.6's
+# serial alphabet is untouched.
+#
+# SOURCING NOTE: capitol.hawaii.gov is behind a Cloudflare challenge that
+# refuses automated fetches (403 on every attempt, including with a browser
+# user agent). Every HRS quotation below was taken from the Internet Archive's
+# capture of the official capitol.hawaii.gov HRS pages, whose snapshot date
+# (7 January 2025) is recorded with each citation. That is a mirror of an
+# edict of government, which is public domain at every level, but it is a
+# MIRROR and a verifier with human browser access should re-read the live text.
+jurisdiction: us-hi
+authority:
+  name: "The four county directors of finance (City and County of Honolulu; County of Hawaiʻi; County of Maui; County of Kauaʻi), acting under HRS chapter 249 — the Honolulu director contracts for all plates on behalf of the counties"
+  url: "https://www8.honolulu.gov/csd/motor-vehicle-license-plates/"
+binding: vehicle
+statute_edition: >-
+  Hawaii Revised Statutes chapter 249 (County Vehicular Taxes) as published at
+  capitol.hawaii.gov/hrscurrent, read 2026-08 via the Internet Archive capture
+  of the 7 January 2025 file set; § 249-9 as last amended by L 2024, c 64, § 1.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4/§7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: adverse-on-commercial-reuse
+  basis: >-
+    HAWAII IS THE FIRST STATE IN THIS PROGRAMME WITH AN EXPRESS, FETCHED,
+    ANTI-COMMERCIAL-REUSE TERM ON ITS OWN PORTAL. The State of Hawaiʻi web
+    portal's Terms of Use carries, verbatim: "Duplication or use of any content
+    from this web site for commercial purposes or in any manner likely to give
+    the impression of official approval by the State of Hawaiʻi is prohibited."
+    That is narrower than an outright copyright assertion — it targets
+    COMMERCIAL duplication and false endorsement rather than claiming copyright
+    in every state work — but it is adverse to a paid render bundle and must be
+    treated as such. No Commons {{PD-HIGov}} tag exists (checked: the template
+    page returns 404), so Hawaii has no counterpart to Florida's or
+    California's public-domain tag.
+  countervailing: >-
+    The FACTS in this file are almost entirely drawn from HRS chapter 249,
+    which is an EDICT OF GOVERNMENT and public domain at every level
+    (PRD-PLATES §4). Nothing in a terms-of-use page can reach the text of a
+    statute. So the format, geometry, legend and class facts here are clean;
+    it is the ARTWORK — the rainbow graphic — that the term bites on.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies with unusual force in Hawaii,
+    for two independent reasons. (1) The RAINBOW graphic that fills the
+    standard plate is the design's entire identity and is not described in any
+    instrument — it is departmental artwork, and the portal terms forbid
+    commercial duplication of state web content. (2) The GREAT SEAL and COAT
+    OF ARMS are separately criminalised.
+  seal_regime: >-
+    SOURCED, AND THE FIRST TIME IN THIS PROGRAMME. The US/world dossier flagged
+    state seal statutes as "the largest remaining gap in the IP analysis"
+    because none had been pinned. Hawaii's is now pinned, quoted by the State's
+    own portal: "Pursuant to Section 5-6, Hawaiʻi Revised Statutes, whoever
+    uses any representation of the great seal or the coat of arms of the State
+    in any advertisement or for any commercial purpose or in any manner likely
+    to give the impression of official State approval shall be guilty of a
+    MISDEMEANOR. The preceding sentence shall not be construed to apply to the
+    use of the seal or the coat of arms in any newspaper, periodical, book, or
+    pamphlet wherein the seal or coat of arms is printed for informational
+    purposes only." Two consequences worth carrying to every other state file:
+    the protection is CRIMINAL and independent of copyright, so a favourable
+    copyright posture does not clear a seal; and the informational-use carve-out
+    is drawn around publications, not around software or renders. Do not render
+    the seal. The § 5-6 text itself was quoted from the portal rather than from
+    the HRS page (capitol.hawaii.gov blocked); reading the statute directly is
+    a recorded follow-up.
+  photograph_caution: >-
+    No Hawaii plate photograph was licence-checked in this pass (recorded gap).
+    The standing rule applies regardless: a Commons tag on a plate photograph
+    is the PHOTOGRAPHER's licence on the PHOTOGRAPH, never a licence on the
+    design, and our renders are generated from statute so no obligation
+    attaches.
+  sources:
+    - "https://portal.ehawaii.gov/page/terms-of-use/  # State of Hawaiʻi portal Terms of Use: the commercial-duplication prohibition, and the verbatim HRS § 5-6 seal/coat-of-arms misdemeanour with its informational-use carve-out"
+    - "https://commons.wikimedia.org/w/index.php?title=Template:PD-HIGov&action=raw  # returns 404 — there is NO Hawaii public-domain tag on Commons, unlike PD-FLGov and PD-CAGov. A negative result, recorded as one."
+    - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0009.htm  # HRS § 249-9 — an edict of government, public domain, and the source of every design fact in this file"
+
+# ---------------------------------------------------------------------------
+# The US standards chain, recorded per state. Hawaii is the interesting case:
+# it is the only jurisdiction in this wave that legislates CHARACTER GEOMETRY
+# itself, and its statutory minimum EXCEEDS AAMVA's recommendation.
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  chain: "SAE J686 -> AAMVA License Plate Standard Edition 3 (September 2025) -> voluntary state adoption. AAMVA has no enforcement power; its declarative present must be read as RECOMMENDED PRACTICE."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 sends dimensions and bolt holes to SAE J686, whose text is paywalled and UNPINNED; no J686 dimension is quoted anywhere in this dataset."
+    character_layout: "AAMVA §2.2 recommends characters at least 2.5 in high with stroke weight 0.2-0.4 in."
+    hawaii_exceeds_it: >-
+      HRS § 249-9(a), verbatim: "The numerals on all number plates shall be no
+      less than three inches in height and the strokes thereof no less than
+      three-eighths inch in width, except in the case of motorcycles, in which
+      case the numerals shall be no less than one inch in height and the
+      strokes thereof no less than one-eighth inch in width." Three inches is
+      HALF AN INCH TALLER than AAMVA's recommended minimum, and 3/8 inch is
+      inside AAMVA's 0.2-0.4 in stroke band. This is the only statutory
+      character geometry found in the pacific group and one of the few in the
+      US pass — a legislature specifying renderable numbers rather than
+      delegating them.
+    replacement_cycle: "AAMVA §1.1 recommends a cycle 'not to exceed 7 to 10 years'. HAWAII HAS NO CYCLE: HRS § 249-7(b) contemplates 'the issuance of a new series of number plates as determined by the directors of finance of each county through majority consent' — an event, decided by committee, with no period attached. That is why the rainbow base ran from 1991 to 2025."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+  folklore_caution: >-
+    The "1956 AMA standardization agreement" is UNCITED in its Wikipedia source
+    and is not relied on here. Hawaii's own instrument is better: HRS § 249-12
+    "Standard size license plates" empowers each county director to issue
+    standard-size plates "in connection with the first registration of a motor
+    vehicle subsequent to September 1, 1956" — a legislated 1956 standard-size
+    cutover, in law, with a date. Where the folklore says an industry
+    association agreed something in 1956, Hawaii's statute book shows a
+    legislature acting in 1955-56. The two are not the same claim and only the
+    second is cited.
+
+# ---------------------------------------------------------------------------
+# Display rules — statutory, and unusually detailed for a US state.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: "TWO plates, front and rear. HRS § 249-7(a): the director of finance furnishes 'two number plates for the vehicle or one plate in the case of trailers, semitrailers, or motorcycles'. § 249-7(b): 'The owner shall securely fasten the number plates on the vehicle, one on the front and the other on the rear, at a location provided by the manufacturer or in the absence of such a location upon the bumpers of the vehicle and in conformance with section 291-31, in such a manner as to prevent the plates from swinging.'"
+  one_plate_vehicles: "trailers, semitrailers and motorcycles (HRS § 249-7(a)); the single plate is fastened to the rear, and for motorcycles in conformance with § 291-31 (§ 249-7(b)). Mopeds likewise get one rear plate (§ 249-14.1(c))."
+  legibility: "HRS § 249-7(b): 'Number plates shall at all times be displayed entirely unobscured and be kept reasonably clean.'"
+  validation: "HRS § 249-7(c): the annual tag or emblem is affixed 'to the top right portion of the rear number plate'. State, county, board-of-water-supply and foreign-government vehicles are issued registrations 'which need be renewed only in the new plate issue year' — so a government plate can carry no current emblem and still be valid. § 249-14.1(d) puts the moped emblem in the same top-right position."
+  case_note: "Hawaii appellate authority holds that placing safety-check emblems ON the plate can itself be an obstructed-plate infraction, and that the violation 'does not require that the license plate numbers, specifically, be obstructed' (112 H. 233 (App.), 145 P.3d 776 (2006), noted under § 249-7). Recorded because it is the only case note found on any plate-display statute in this wave."
+  penalty: "Transfer of current number plates, tag or emblem other than as authorised is punishable by a fine of not more than $50 per offence (HRS § 249-7(a)); moped registration failures up to $100 per violation (§ 249-14.1(e))."
+  sources:
+    - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0007.htm  # § 249-7: two plates (one for trailers/semitrailers/motorcycles), the front-and-rear fastening rule, the anti-swing and unobscured requirements, the top-right emblem position, the government renewal exception, the $50 transfer fine, and the 2006 obstructed-plate case note"
+    - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0014_0001.htm  # § 249-14.1: moped plates, one rear plate, top-right emblem, $27 annual fee, $100 penalty"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD SERIES — the ʻokina base, mandated from 1 Jan 2025.
+  # =========================================================================
+  - id: us-hi-standard-2025
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2025 }
+    period_evidence: statutory-date
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset:
+        excluded: [I, O, Q]
+        excluded_basis: >-
+          LOCATOR-GRADE, NOT STATUTORY. HRS § 249-9 states no letter
+          exclusions; it requires only "a distinct contrast between the color
+          of the plate and the numerals and letters thereon" and leaves the
+          arrangement to the county directors. The reported exclusion of I, O
+          and Q comes from the collector literature and from a Honolulu
+          Star-Bulletin "Kokua Line" column, both cited through Wikipedia as a
+          locator. Recorded as reported, not asserted.
+        notes: >-
+          THERE IS NO STATUTORY CHARACTER CAP AND NO STATUTORY ARRANGEMENT.
+          HRS § 249-9(a)(4) hands both to the counties: plates shall "Be of any
+          shape, size, and color, and with any arrangements of letters and
+          numbers as may, subject to sections 249-1 to 249-13, be determined by
+          the directors of finance of each county through majority consent."
+          The three-letter/three-numeral arrangement encoded here is therefore
+          OBSERVED, corroborated by the collector literature and by the
+          county's own plate illustration, and is not traceable to any
+          instrument — because the instrument that fixes it is a majority
+          consent among four county officers, which is not published anywhere
+          that was located. That is a recorded gap and a real research target:
+          the decision exists, it is just not a document we have.
+      progression: "The letter group advances; the numeral group cycles. Not published in any instrument located."
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: "12 x 6 in is the North American convention and is OBSERVED here, not statutory: HRS § 249-9(a)(4) permits 'any shape, size'. § 249-12 legislates only that 'standard size license plates' may be issued from the first registration after 1 September 1956, without stating the size."
+      character_geometry: { min_height_in: 3, min_stroke_in: 0.375, basis: "HRS § 249-9(a), verbatim; motorcycles 1 in height / 0.125 in stroke" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      colour_note: >-
+        NEITHER VALUE IS IN THE STATUTE. HRS § 249-9(a)(3) requires only "a
+        distinct contrast between the color of the plate and the numerals and
+        letters thereon" — a design PROPERTY, not a value, the same drafting
+        move Florida makes for its historic plates. Black characters on a
+        reflective white ground with a screened rainbow are OBSERVED. Attorney
+        General Opinion 67-17, noted under § 249-9, adds that "All motor
+        vehicle number plates must be uniform in all respects including the
+        reflective material" — so uniformity across the four counties is
+        itself an authority-stated requirement.
+      legend_top: "HAWAI`I"
+      legend_bottom: "Aloha State"
+      legend_rule: >-
+        HRS § 249-9(a), as amended by L 2024, c 64, verbatim: all number plates
+        shall "(1) If issued before January 1, 2025, bear the word 'Hawaii'
+        along the upper portion of the plate and the words 'Aloha State' along
+        the lower portion of the plate; (2) If issued on or after January 1,
+        2025, bear the word 'Hawai`i' along the upper portion of the plate and
+        the words 'Aloha State' along the lower portion of the plate; provided
+        that both 'Hawai`i' and 'Aloha State' may either contain all uppercase
+        or lowercase letters or have the first letter of each word be
+        uppercase". The glyph is the ʻOKINA (U+02BB); the official HTML renders
+        it as a backtick and it is transcribed here as served. Note the
+        statute's deliberate CASE PERMISSIVENESS — a legislature explicitly
+        declining to fix capitalisation is rare and is exactly the sort of
+        thing a render spec must not over-determine.
+      graphic: { present: true, rendered: placeholder, description: "a rainbow screened across the plate, unchanged in kind from the 1991 base; not described in any instrument, and covered by the portal's commercial-duplication term (see artwork_risk)" }
+      emblem: { present: false }
+      band: { side: none }
+      rear_differs: false
+      county_legend: "The issuing county's name is printed on the plate (City and County of Honolulu; County of Hawaiʻi; County of Maui; County of Kauaʻi). Like Florida's county legend it is TEXT, not code — but unlike Florida's it is not optional, because the county is the issuing authority."
+    region_encoding:
+      mechanism: "county-letter prefix in the FIRST character of the serial, plus the county name printed as a legend"
+      evidence: "LOCATOR-GRADE — reported, not sourced. No instrument publishing the allocation was located; see the charset note on the county-consent gap."
+      table_reported:
+        honolulu: ["E", "F", "G", "J", "N", "P", "R", "S", "T", "W", "Y", "A", "B", "C", "D"]
+        hawaii: ["H", "Z"]
+        maui: ["M", "L"]
+        kauai: ["K"]
+      table_note: >-
+        Reported allocation carried forward from the 1991 base. Honolulu's
+        original set was E F G J N P R S T W Y; the letters A, B, C and D were
+        reported added in late 2023 when the series was projected to exhaust at
+        W in mid-2024, which is reported to extend the rainbow series about
+        fifteen years. THE ADDITION MATTERS FOR DECODE: A-D were NOT Honolulu
+        letters on plates issued before ~2023, so a decoder keying on the first
+        letter alone must also know the era. Every element of this table is
+        locator-grade (collector literature plus a 2010 Honolulu Star-Bulletin
+        column plus a 2024 KHON2 report, all reached through Wikipedia) and
+        NONE of it is asserted as sourced.
+    sources:
+      - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0009.htm  # § 249-9(a)(1)-(4): the 1 January 2025 'Hawaii' -> 'Hawai`i' legend split (am L 2024, c 64), 'Aloha State' at the bottom, the case permissiveness, the distinct-contrast rule, the any-shape/size/color delegation to the county directors by majority consent, the 3 in / 3/8 in character geometry, the Honolulu procurement contract, and AG Op. 67-17 on uniformity"
+      - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0007.htm  # § 249-7(b): a new series of number plates is issued 'as determined by the directors of finance of each county through majority consent' — the mechanism by which a Hawaii base changes"
+      - "https://www8.honolulu.gov/csd/motor-vehicle-license-plates/  # City and County of Honolulu, the issuing authority for Oʻahu: the standard plate illustration showing Hawaii spelled with the ʻokina; the $5.00 plate replacement and $0.50 emblem replacement fees"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Hawaii  # LOCATOR ONLY (PRD-PLATES §4): the ABC 123 arrangement, the county-letter allocation table, the I/O/Q exclusion, and the 2023 addition of A-D to Honolulu. None asserted as sourced."
+    notes: >-
+      HAWAII'S CURRENT STANDARD SERIES, AND THE BEST-DATED SERIES BOUNDARY IN
+      THE ENTIRE PACIFIC GROUP. `period_evidence: statutory-date` is earned:
+      HRS § 249-9(a)(2) says in terms that plates issued ON OR AFTER 1 JANUARY
+      2025 bear "Hawai`i" with the ʻokina, and § 249-9(a)(1) says plates issued
+      before that date bear "Hawaii" without it. A legend difference is a design
+      difference and therefore its own series under PRD-PLATES §2.3, so the
+      boundary is not a curiosity — it is the cut. It also produces something a
+      parse API can actually use: two visually near-identical rainbow plates
+      whose ERA is readable from a single diacritic. THE LIMIT OF THIS ENTRY,
+      STATED PLAINLY: the legend and the geometry are law; the SERIAL
+      ARRANGEMENT is not, because Hawaii delegates it to a majority consent
+      among four county finance directors that is not published. Everything
+      format-shaped here is observed and says so.
+
+  # =========================================================================
+  # ONE SERIES BACK — the rainbow base without the ʻokina, 1991 to 2025.
+  # =========================================================================
+  - id: us-hi-rainbow-1991
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1991, end: 2025 }
+    period_evidence: statutory-date-end-secondary-start
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset:
+        excluded: [I, O, Q]
+        excluded_basis: "LOCATOR-GRADE, as on the successor series."
+        notes: "Same delegation, same absence of a statutory arrangement or cap. The format did not change at the 2025 boundary; only the legend did."
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      character_geometry: { min_height_in: 3, min_stroke_in: 0.375, basis: "HRS § 249-9(a) — unchanged across the boundary" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      legend_top: "HAWAII"
+      legend_bottom: "Aloha State"
+      legend_rule: "HRS § 249-9(a)(1): plates 'issued before January 1, 2025' bear the word 'Hawaii' — no ʻokina — at the top and 'Aloha State' at the bottom. The statute describes this base in the past tense while it is still overwhelmingly the plate on the road, which is the honest position: Hawaii has no replacement cycle, so 1991-base plates remain valid indefinitely."
+      graphic: { present: true, rendered: placeholder, description: "screened rainbow, the design that gave the base its collector name" }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding:
+      mechanism: "county-letter prefix in the first character, plus the printed county name"
+      evidence: "LOCATOR-GRADE"
+      table_reported:
+        honolulu: ["E", "F", "G", "J", "N", "P", "R", "S", "T", "W", "Y"]
+        hawaii: ["H", "Z"]
+        maui: ["M", "L"]
+        kauai: ["K"]
+      table_note: "The pre-2023 Honolulu set, before A-D were reported added. The predecessor 1981-1991 base is reported to have used a narrower Honolulu set (A, B, C, D as FIRST letter, with H, K, L and M reserved to the neighbour islands) — i.e. the letters reported re-added to Honolulu in 2023 are letters Honolulu had used forty years earlier. Locator-grade throughout."
+    sources:
+      - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0009.htm  # § 249-9(a)(1): plates issued BEFORE 1 January 2025 bear 'Hawaii' and 'Aloha State' — the statutory END of this series; and the section's history line, which records an amendment by L 1990, c 132, § 2 the year before the reported base change"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Hawaii  # LOCATOR ONLY: the 1991 start of the rainbow base, the county-letter tables, and the 2023 Honolulu letter addition"
+    notes: >-
+      THE RAINBOW BASE. ITS END IS STATUTORY AND ITS START IS NOT, and the
+      `period_evidence` value says so rather than pretending otherwise. The end
+      is HRS § 249-9(a)(1)'s "issued before January 1, 2025". The start of 1991
+      is LOCATOR-GRADE (Wikipedia and the collector literature) — but it is not
+      naked: § 249-9's own history line records "am L 1990, c 132, § 2", an
+      amendment the year before the reported base change, which is exactly
+      where a legend requirement would have entered the statute. THE ACT'S TEXT
+      WAS NOT OBTAINED (recorded gap); reading Act 132, SLH 1990 would either
+      convert this start into a statutory date or refute it, and it is the
+      single highest-value follow-up in this file. Note also that this series
+      does not stop being relevant at the boundary: Hawaii has no replacement
+      cycle, so rainbow plates without the ʻokina will outnumber ʻokina plates
+      on Hawaii roads for many years, and a parse API should weight
+      accordingly.
+
+  # =========================================================================
+  # PERSONALIZED — statutory, capped at six, and the only place in this
+  # dataset where a HYPHEN is authorised inside an owner-chosen configuration.
+  # =========================================================================
+  - id: us-hi-special-number-plates
+    class: personalized
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLLLLL"
+      regex: '\A(?=[A-Z0-9]*-?[A-Z0-9]*\z)(?:[A-Z0-9]-?){1,6}\z'
+      charset:
+        notes: >-
+          HRS § 249-9.1, verbatim: "The special number plates shall conform to
+          the requirements provided for the uniform number plates except that
+          the owner may request the choice and arrangement of letters and
+          numbers. The maximum number of letters and numbers shall be six and
+          only one hyphen will be allowed in addition to and in lieu of the six
+          letters and numerals. No other punctuation marks shall be allowed."
+          The regex encodes exactly that: one to six characters from the serial
+          alphabet, with AT MOST ONE hyphen anywhere among them. The lookahead
+          is what enforces "at most one"; the body is what enforces the
+          six-character cap on the alphanumerics themselves.
+        refusal_rule: "§ 249-9.1: the director 'shall not issue special number plates which have the letter and numeral combination of regular plates, are misleading or publicly objectionable' — a collision rule plus a taste rule, in one sentence, with no published criteria list (contrast California's VIRPM 21.180, which publishes both the criteria and the excluded strings)."
+      separator_note: >-
+        PRD-PLATES §2.6 SANCTIONS THIS AND HAWAII IS WHY THE RULE IS WRITTEN AS
+        IT IS. The hyphen here is an EMITTED SEPARATOR (U+002D), spelled as a
+        literal, never inside a character class, so a consumer deriving the
+        separator-free twin deletes it and recovers the six-character serial
+        without loss. The statute's phrase "in addition to and in lieu of" is
+        genuinely ambiguous — it reads as permitting the hyphen either as a
+        seventh printed character or as a substitute for one of the six — and
+        the regex takes the reading that the SIX-CHARACTER CAP BINDS THE
+        ALPHANUMERICS, which is the narrower and safer of the two. The
+        ambiguity is recorded, not resolved.
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      note: "Conforms to the uniform plate in every respect but the configuration (§ 249-9.1)."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+    fee: "$60 on initial application and $60 on each annual renewal, non-refundable (HRS § 249-9.1)."
+    reapplication_rule: >-
+      HRS § 249-9.1: "Re-application for special number plates must be made
+      upon a change in design of regular plates." A DESIGN CHANGE FORCES EVERY
+      VANITY HOLDER TO RE-APPLY — which means the 1 January 2025 ʻokina
+      boundary is not merely cosmetic for this series, it is a re-issuance
+      event, and it is the clearest evidence in the file that Hawaii treats a
+      legend change as a NEW SERIES in its own administrative practice. The
+      director may also "discard and allow for new applications of inactive
+      special number plates that have not been assigned or registered during
+      the preceding three years."
+    region_encoding: none
+    region_encoding_note: "An owner-chosen configuration carries no county letter, so the county name legend is the only geographic signal on a Hawaii vanity plate."
+    sources:
+      - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0009_0001.htm  # § 249-9.1: six letters and numerals maximum, one hyphen, no other punctuation, the collision and objectionability refusal rule, the $60 initial and $60 annual fees, the three-year inactivity discard, and the re-application-on-design-change duty"
+    notes: >-
+      HAWAII'S VANITY PLATE IS THE ONLY SERIES IN THIS DATASET WHOSE AUTHORITY
+      EXPRESSLY LEGISLATES A SEPARATOR INSIDE AN OWNER-CHOSEN STRING, and it
+      does so twice over: it permits exactly one hyphen and then forbids
+      everything else ("No other punctuation marks shall be allowed"). That is
+      a statutory confirmation of the separator contract from the outside — a
+      legislature independently arriving at the same closed set PRD-PLATES §2.6
+      declares. The re-application-on-design-change rule is the other keeper:
+      it is administrative proof that the counties themselves treat a legend
+      change as a break in the series, which corroborates cutting
+      us-hi-standard-2025 away from us-hi-rainbow-1991.
+
+  # =========================================================================
+  # HISTORIC — permanent, numbered from 1, and labelled by statute.
+  # =========================================================================
+  - id: us-hi-horseless-carriage
+    class: historic
+    categories: [car]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "999"
+      regex: '\A\d+\z'
+      charset:
+        notes: >-
+          HRS § 249-9(c), verbatim: "The registration numerals and special
+          number plates assigned to antique motor vehicles shall be labeled
+          'Horseless Carriage' and 'Permanent' and shall run in a separate
+          numerical series, commencing with Horseless Carriage No. 1." A
+          separate numerical series with a stated origin and NO STATED WIDTH,
+          hence the unbounded quantifier, which makes no width claim.
+      progression: "strictly sequential from 1"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      legend: "Horseless Carriage"
+      legend_secondary: "Permanent"
+      legend_rule: "§ 249-9(c) mandates BOTH labels — 'Horseless Carriage' AND 'Permanent'. Hawaii is the only jurisdiction in this wave that legislates the word 'Permanent' onto the plate face, which is a design fact and also a validity fact printed on the artefact."
+      colour_note: "No colour is stated for this plate anywhere in § 249-9 (contrast Florida and California, which at least require a 'distinguishing' colour). None is recorded."
+    eligibility: "'any antique motor vehicle' (HRS § 249-9(c)) — the section does NOT define antique, and no definition was located in chapter 249 (recorded gap). Contrast Florida's fixed 1945 model-year cutoff and California's fixed 1922 / 16-cylinder-pre-1965 rule."
+    validity: "permanent — 'valid for use on such vehicles so long as the vehicle is in existence in lieu of the uniform state number plates' (§ 249-9(c)). The director may 'discard and allow for new applications of inactive special number plates that have not been assigned or registered during the preceding three years'."
+    fee: "$10, in addition to any other fee applicable to antique motor vehicles (HRS § 249-9(c))."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0009.htm  # § 249-9(c): the $10 permanent antique plate, the 'Horseless Carriage' and 'Permanent' labels, the separate numerical series from No. 1, the three-year inactivity discard"
+    notes: >-
+      HORSELESS CARRIAGE. THE THIRD "HORSELESS CARRIAGE NO. 1" IN THIS
+      PROGRAMME — Florida § 320.086(1), California VC § 5004 and Hawaii
+      § 249-9(c) all legislate a separate numerical series commencing with
+      exactly that phrase. Three states, three statute books, one sentence
+      shape: that is no longer a coincidence and is worth recording as a
+      probable shared model act for whoever does the L4 historical pass.
+      Hawaii's differs in two ways that matter: it prints 'Permanent' on the
+      plate, and it does not define "antique motor vehicle" at all, which makes
+      its eligibility the least determinate of the three.
+
+  # =========================================================================
+  # CORE CLASSES the counties separately serialize.
+  # =========================================================================
+  - id: us-hi-moped
+    class: moped
+    categories: [moped]
+    period: { start: 2016 }
+    period_evidence: statutory-enactment-year
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9]{1,6}\z'
+      charset:
+        notes: >-
+          NO ARRANGEMENT IS PUBLISHED. HRS § 249-14.1 creates the moped plate
+          and its administration in detail — production, staggered
+          registration, the $27 annual fee, the fee structure, the rear
+          mounting, the top-right emblem — and says nothing whatever about the
+          serial. The regex is therefore deliberately over-broad and this
+          series is `matching: recall-only`: a hit is a shape observation, not
+          a validity claim. Recorded gap.
+    design:
+      plate: { unit: in }
+      plate_dimension_note: "Not stated in § 249-14.1 and not obtained. Moped plates are reduced-size in practice; no measurement is recorded rather than guessed."
+      background: { finish: unknown }
+      note: "The moped plate is not a 'number plate' under § 249-9 and is not caught by that section's legend and geometry requirements; § 249-14.1 imposes none of its own."
+    display: "one plate, fastened to the REAR of the moped at a manufacturer-provided location or otherwise on the fender, in conformance with § 291-31 and 'in such a manner as to prevent the plate from swinging' (§ 249-14.1(c)); emblem to the top right of the rear plate (§ 249-14.1(d))."
+    fee: "$27 per year registration fee, plus the plate cost and administrative cost on original registration and 50 cents for the tag or emblem (§ 249-14.1(b)-(c))."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0014_0001.htm  # § 249-14.1 (L 2016, c 200; am L 2018, c 77): moped number plates, one rear plate, staggered registration by county agreement, $27 annual fee, 50-cent emblem, top-right emblem placement, $100 penalty"
+    notes: >-
+      MOPED PLATES ARE A 2016 CREATION IN HAWAII — § 249-14.1 was enacted by
+      Act 200, Session Laws of Hawaii 2016 and amended by Act 77 of 2018, which
+      is why `start: 2016` is claimed on the enactment year rather than as an
+      upper bound. Before that mopeds carried a bicycle-style tag under the
+      neighbouring sections. The series is `recall-only` for the honest reason
+      that the statute regulates everything about the plate EXCEPT what is
+      printed on it.
+
+  - id: us-hi-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]{1,8}\z'
+      charset:
+        notes: "NO ARRANGEMENT IS PUBLISHED IN CHAPTER 249. § 249-7.5 refers the temporary plate out to HRS § 286-53, which was NOT fetched in this pass (recorded gap — capitol.hawaii.gov is Cloudflare-blocked and only the chapter 249 files were retrievable from the archive). The regex is a deliberate over-broad placeholder and the series is `recall-only` accordingly."
+    design:
+      material: "not stated in chapter 249"
+      background: { finish: unknown }
+    validity: >-
+      HRS § 249-7.5, verbatim: "Any person who has purchased a new motor
+      vehicle which has attached a temporary number plate under section 286-53
+      shall register the new motor vehicle in accordance with this chapter
+      within thirty days after taking possession of the motor vehicle." The
+      county then furnishes the permanent plates "Within thirty days of the
+      original registration", and "Upon attachment of the number plates, the
+      temporary number plate provided under section 286-53 shall be destroyed."
+      So the temporary plate has a hard THIRTY-DAY life and a statutory
+      destruction duty — an unusually explicit end-of-life rule.
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0007_0005.htm  # § 249-7.5 (L 1980, c 133; am L 1990, c 131; am L 1999, c 207): the § 286-53 temporary number plate, the thirty-day registration duty, the thirty-day plate delivery, and the destruction requirement"
+    notes: >-
+      TEMPORARY PLATES. Included because temporary issuance is a core L2 class
+      and because § 249-7.5 gives it a genuinely sourced LIFECYCLE even though
+      it gives no format: thirty days to register, thirty days to receive
+      metal, destroy the temporary on attachment. The format itself lives in
+      HRS § 286-53, which is in a chapter this pass could not retrieve, and
+      that is the honest limit of the entry.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Hawaii's programme is
+  # structurally unlike Florida's or California's: it is a DECAL regime, run
+  # by the counties, with the size of the decal fixed by statute.
+  # =========================================================================
+  - id: us-hi-organization-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset: { notes: "An organization plate is a UNIFORM plate carrying a decal, so it takes the ordinary county serial unchanged. That is the structural difference from Florida and California, whose specialty plates are separately manufactured designs." }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      decal_geometry: >-
+        THE ONLY SPECIALTY GEOMETRY IN HAWAII LAW, AND IT IS A CEILING RATHER
+        THAN A LAYOUT. HRS § 249-9.3(a): the Honolulu director of finance, "in
+        consultation with the directors of finance of the counties of Kauai,
+        Maui, and Hawaii, shall establish special design parameters and
+        restrictions for decals or graphic representations affixable to special
+        number plates; provided that the decal shall not be larger than three
+        inches wide by three inches high." The parameters themselves are
+        delegated and were not located (recorded gap); only the 3 in x 3 in
+        maximum is statutory.
+      emblem: { present: true, rendered: placeholder }
+      note: "One decal per authorised organization; the decal designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here."
+    program_index:
+      count_official: null
+      count_official_note: >-
+        NO COUNT IS PUBLISHED BY ANY OF THE FOUR COUNTIES OR BY THE STATE, and
+        none was located. That is a structural consequence of the design: the
+        programme is administered by four separate county directors under
+        § 249-9.3, so there is no single register to count. RECORDED AS AN
+        ABSENCE. Contrast Florida ("over 100", stated by FLHSMV) and California
+        (no total, but three published category lists).
+      eligibility_rule: >-
+        HRS § 249-9.3(b) defines "Organization" as (1) an IRS-recognised
+        not-for-profit "whose primary purpose is to provide the community with
+        specific programs to improve the public's health, education, or general
+        welfare"; (2) a military service veterans group; (3) a state or county
+        agency approved by the director; or (4) "Any school or accredited
+        institution of higher learning or a college or recognized program
+        thereof." All organizations "shall be headquartered in the State",
+        except that a chapter of a national or international body must be in
+        good standing and authorised in writing by its parent to use the decal.
+      revenue_rule: "§ 249-9.3(a): 'Organizations are authorized to retain the fees collected, less expenses, for the special number plates.' The organization keeps the money directly — no state trust fund intermediates, unlike California's § 5060 programme."
+      statutory_named_programs: ["Haleakala National Park and Hawaii Volcanoes National Park (§ 249-9.5)", "Polynesian Voyaging Society (§ 249-9.6)", "environmental conservation (§ 249-9.7)", "Duke Kahanamoku (§ 249-8.8, cited in the chapter index as § 249-9.8)", "Malama Puuloa (§ 249-9.9)", "military service (§ 249-9.2)", "special series number plates (§ 249-9.4)"]
+      statutory_named_programs_note: "Hawaii ALSO authorises individual programmes by their own statute sections, which no other state in this wave does — the chapter index at § 249- lists §§ 249-9.2 through 249-9.9 as separate named plate authorisations. Their texts were not all fetched (recorded gap); they are listed here because a statutorily named programme is a far stronger index entry than a brochure listing, and because they are the natural next fetch."
+      official_list_url: "https://www8.honolulu.gov/csd/motor-vehicle-license-plates/"
+      official_list_note: "The Honolulu Customer Services Department page links a 'Special License Plates' section; the linked page was not separately fetched and no count was read from it (recorded gap). The other three counties' equivalents were not located."
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-0009_0003.htm  # § 249-9.3: county issuance of organization plates, the fee-retention rule, the 3x3 in decal maximum, the delegated design parameters, and the four-part definition of 'Organization'"
+      - "https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0249/HRS_0249-.htm  # the chapter 249 index, which lists §§ 249-9.1 through 249-9.9 as separate named special-plate authorisations (military service, county design and issuance, special series, Haleakala/Hawaii Volcanoes, Polynesian Voyaging Society, environmental conservation, Duke Kahanamoku, Malama Puuloa)"
+      - "https://www8.honolulu.gov/csd/motor-vehicle-license-plates/  # City and County of Honolulu plate page, which fronts the special-plate route for Oʻahu"
+    notes: >-
+      THE HAWAII SPECIALTY INDEX, AND IT IS A DIFFERENT ANIMAL FROM THE
+      MAINLAND ONES. Three structural facts make it so, and all three are
+      statutory. FIRST, it is a DECAL regime: § 249-9.3 puts a graphic on the
+      uniform plate rather than manufacturing a distinct design, so a Hawaii
+      specialty plate carries an ordinary county serial and is not
+      distinguishable from a standard plate by its string at all — which is
+      precisely the case a parse API must be told about rather than left to
+      infer. SECOND, the money goes straight to the organization, which removes
+      the fee-trust machinery that dominates Florida's and California's
+      programmes. THIRD, there is NO COUNT and structurally cannot be one from
+      a single source, because four county directors each run their own
+      register. The honest record is the absence plus the eight named statutory
+      programmes, not an invented total.


### PR DESCRIPTION
**PRD-PLATES gate L2 (owner-directed acceleration; research parallel, application ordered — L1 landed first per §7.1).** One of eleven US regional-group PRs covering all 50 states + DC + territories (FL was the L0 pilot). Drafted to the `de.yml`/`nl.yml`/`us-fl.yml` standard: primary-law verbatim headers, instrument-dated periods, `strict`/`recall-only` matching tiers, folklore flagged not asserted, **`artwork_risk` recorded per jurisdiction with evidence** (PRD-PLATES §4).

**This PR — pacific:** CA HI AK (3 jurisdictions, 49 pinned primary sources).

**Verification:** researcher linted green in an isolated sandbox (proof file in the group dir, archived to the pipeline program dir); the driving session then independently staged ALL 55 wave files over pristine origin/main — `plates lint: 67 files, 604 series … OK` (385 new series; the _art gate stayed green) — and this branch is linted solo pre-push; CI runs the same gate.

**For the reviewer:** the dossier below carries the gaps (marked in the YAML at point of use), folklore flags, and the artwork_risk findings. The full research dossier follows verbatim.

---

# PRD-PLATES gate L2 — research dossier, group **pacific** (US-CA, US-HI, US-AK)

Researcher pass, 2026-08-02. Method: FETCH-NEVER-ASSUME. Every claim in the
three YAML files traces to a URL fetched in this session; nothing is recalled
from memory. WebSearch was UNAVAILABLE for the whole pass (the session's search
budget was exhausted before this task began), so all discovery was WebFetch and
`curl` against known or structurally-guessed URLs, plus the Internet Archive
CDX API for URL enumeration where a live host blocked automation. Dead ends are
recorded rather than dropped.

Deliverables: `us-ca.yml`, `us-hi.yml`, `us-ak.yml` (this directory).
Lint: **green** — 15 files, 253 series, `plates lint: OK`, run against a
sandbox copy of `plates/` + `scripts/lint_plates.rb` with the three drafts
added. `vehiclesdb` was never written to.

---

## 0. The four findings that should leave this group

**1. California's DMV publishes the best US plate primary found so far, and it
is not the Vehicle Code.** The *Vehicle Industry Registration Procedures Manual*
(VIRPM), served in full on dmv.ca.gov, carries: a year-by-year table of plate
colours, character colours and **serial series from 1914 to 1980** (Appendix
1E); the sentence that dates the seven-character cutover (*"In 1980, seven
characters were introduced in regular series license plates"*); and — §21.180 —
the **144 three-letter strings "deleted from the regular series license plate
configuration"**, which is an agency-sourced `charset.excluded` for a US
standard series. No competing dataset appears to carry any of this. It is
encoded as `regex_strict` on `us-ca-standard-123abc1` and verified to reject
all 144 while staying inside `regex` (tier order: 0 violations on 2,000
samples).

**2. Hawaii has a statutory series boundary dated to the day, and it is inside
the coverage window.** HRS §249-9(a), as amended by **Act 64, SLH 2024**, splits
the legend on a calendar date: plates issued **before 1 January 2025** bear
"Hawaii"; plates issued **on or after** that date bear "Hawaiʻi" **with the
ʻokina**. A legend difference is a design difference (PRD-PLATES §2.3), so this
is the cut between `us-hi-standard-2025` and `us-hi-rainbow-1991`, with
`period_evidence: statutory-date`. Hawaii's own administration corroborates the
cut: §249-9.1 requires every vanity holder to **re-apply "upon a change in
design of regular plates."**

**3. The state-seal question the US/world dossier flagged as "the largest
remaining gap in the IP analysis" is now sourced — for Hawaii, and it is
criminal.** The State of Hawaiʻi portal quotes **HRS §5-6** verbatim: using the
great seal or coat of arms "in any advertisement or for any commercial purpose
or in any manner likely to give the impression of official State approval" is a
**misdemeanor**, with a carve-out only for informational use "in any newspaper,
periodical, book, or pamphlet." Two consequences generalise: the protection is
independent of copyright, so a favourable copyright posture does not clear a
seal; and the carve-out is drawn around *publications*, not around software or
renders. PRD-PLATES §3's placeholder default is vindicated.

**4. Florida's monthly issuance-volume portal does not generalise.** The L0 pass
identified `services.flhsmv.gov/specialtyplates/` as the single most valuable
structured artefact in the US. **Neither California nor Hawaii publishes any
counterpart** (searched; recorded as a negative result). Alaska publishes the
nearest thing — annual *Registered Vehicles by Class* and *by Boundary* reports
plus motor-vehicle class-code statistics back to 1998 — but those are
vehicle-class counts, not plate-design counts. The differentiator is Florida's,
not the country's, and must be re-checked state by state rather than assumed.

---

## 1. What each state's plate facts actually rest on

| | California | Hawaii | Alaska |
|---|---|---|---|
| Issuing authority | State DMV | **Four county directors of finance** (HRS ch. 249) | State DMV |
| Statutory design spec | **One sentence** (VC §4851) | Rich: legend, contrast, geometry (HRS §249-9) | Thin (AS 28.10.161(b)) |
| Character geometry in law | none | **≥3 in high, ≥3/8 in stroke** (motorcycles 1 in / 1/8 in) | none |
| Statutory character cap | none | none (delegated to the counties) | **6, personalized only** (AS 28.10.181(c)) |
| Serial arrangement source | agency manual + locator | **nobody** — delegated to a county majority consent that is not published | locator |
| Replacement cycle | **none** (VC §4850(d) bars forced replacement) | none — a new series happens by county majority consent | none (AS 28.10.161(a): plates stay with the vehicle) |
| Best-dated boundary | **1980** (VIRPM App. 1E) | **2025-01-01** (HRS §249-9(a)(2)) | **2008-01-01** (AS 28.10.161(b)) |
| artwork_risk | PD-favourable, narrower than FL | **adverse on commercial reuse** | **asserted** |

The inversion worth naming: **in California the historic designs are better
sourced than the current one.** VC §5004.3 legislates the colours of the Legacy
plates ("Black background with yellow lettering per the appearance of California
license plates issued by the department from 1965 to 1968, inclusive"), and
VIRPM Appendix 1E gives the 1963–69 and 1970–80 series exactly. The 2026
plate's blue-on-white is `hex_basis: observed` and unverified.

### Hawaii's structural oddity, and what a jurisdiction-keyed schema does with it

HRS §249-9(a)(4): plates shall "Be of any shape, size, and color, and with any
arrangements of letters and numbers as may … be determined by the **directors of
finance of each county through majority consent**." Procurement is centralised
(the Honolulu director contracts for all four counties) but **authority is
not** — and the consent decision is not published anywhere located. So Hawaii's
`ABC 123` arrangement and its county-letter prefix table (Honolulu E F G J N P
R S T W Y + A B C D added ~2023; Hawaiʻi H Z; Maui M L; Kauaʻi K) are recorded
as `region_encoding.evidence: LOCATOR-GRADE` with the table marked reported.
**The instrument exists; it is simply not a document we have.** That is a
different and more tractable gap than "unknown", and it is the file's headline
research target alongside Act 132, SLH 1990.

---

## 2. Period claims — exactly what is claimed, and on what

`period_evidence` values used, and why each was chosen:

| value | series | basis |
|---|---|---|
| `statutory-date` | `us-hi-standard-2025` | HRS §249-9(a)(2): "issued on or after January 1, 2025" |
| `statutory-date` | `us-ak-statehood-50` | AS 28.10.161(b): "issued by the department after January 1, 2008" |
| `statutory-operative-date` | `us-ca-temporary` | VC §4456: "This section shall become operative January 1, 2019" |
| `statutory-enactment-year` | `us-hi-moped` | HRS §249-14.1 enacted by L 2016, c 200 |
| `agency-manual-dated-start` | `us-ca-standard-1abc123` | VIRPM App. 1E: seven characters introduced **1980**, with the exact 1980 block `1AAA000–1SZZ999` |
| `statutory-date-end-secondary-start` | `us-hi-rainbow-1991` | end is HRS §249-9(a)(1); **start is not sourced** and the value says so |
| `instrument-in-force-upper-bound` | all others | the us-fl-standard convention: the year of the instrument read, declared as an upper bound on the true start |

**Nothing was laundered.** Where the only date was a collector table or a news
story, the series start stays at the instrument-in-force upper bound and the
reported year lives in `notes`, loudly, with its grade. The three cases where
that costs the most are stated in the files themselves:

- `us-ak-standard-gold` — reported gold Last Frontier base from July 2005,
  continuous since **1 January 2010**. Not claimed. But the *superseded statute
  is itself evidence*: AS 28.10.161(b) required the statehood-50 design for
  every passenger plate issued after 1 Jan 2008, and Alaska plainly does not
  issue it now, so the paragraph was amended — finding that session law would
  date the series properly.
- `us-ca-standard-123abc1` — reported **March 2026** flip to `123ABC1` after
  exhaustion at `9ZZZ999`. The *year* coincides with the instrument-read year,
  so the upper bound is tight; the month is not claimed.
- `us-hi-rainbow-1991` — start reported 1991; §249-9's history line records
  `am L 1990, c 132, §2`, the year before. **Act 132, SLH 1990 was not
  obtained.** Reading it either promotes the start to statutory or refutes it.

### Folklore flagged and refused

- **The "1956 AMA standardization agreement."** Uncited in its Wikipedia source
  since 2017 and copied verbatim across state articles (circular). Repeated in
  all three of this group's Wikipedia articles. **Not used.** Better instruments
  were substituted: Hawaii legislates standard-size plates "subsequent to
  September 1, 1956" in **HRS §249-12**, and California's own VIRPM Appendix 1E
  records "a standard size of 12 x 6 for autos" arriving with the 1956 issue.
  Those are two governments acting, not an industry association agreeing, and
  only the first kind is cited. *New lead:* the Alaska article cites Christopher
  Garrish, "Reconsidering the Standard Plate Size", *Plates* 62(5), ALPCA
  (October 2016) — **the first non-circular source for the 1956 story seen
  anywhere in this programme.** Not obtained; recorded as the thing to buy or
  borrow if the claim is ever to be promoted.
- **"Alaska went rear-only on 11 August 2022."** Wikipedia's citation is a
  **Facebook post carrying a user-generated-source flag**. Recorded in
  `display_rules.conflict` purely so the next researcher does not re-derive it;
  it is not evidence and the date is not claimed.
- **California base-generation years (1987 / 1993 / 1998 / 2001 / 2011).** All
  locator-grade. Recorded inside `design_generations_note` on
  `us-ca-standard-1abc123` rather than minted as series ids on folklore
  boundaries — the same discipline `us-fl-standard` applied to its undated id.
- **Three-way disagreement, recorded not averaged (PRD-PLATES §5.3):** the blue
  California base is dated **1970–1980** by VIRPM Appendix 1E, **from 1969** by
  Wikipedia, and **"from 1969 to 1986, inclusive"** by *statute* (VC §5004.3).
  Three instruments, three boundaries, no average taken.

---

## 3. artwork_risk — one line per state, with the evidence

- **us-ca — `public-domain-favourable-narrower-than-florida`.** {{PD-CAGov}}
  exists on Commons and rests on the California Public Records Act (Gov. Code
  §7920 et seq.) plus *County of Santa Clara v. CFAC* (2009): an agency may claim
  copyright only where the Legislature has authorised it. **Counter-evidence
  recorded in the file:** every DMV page — including the VIRPM pages this
  dataset cites as primary — footers "Copyright © 2026 State of California".
  A blanket footer is not a legislative authorisation, but it *is* an agency
  assertion and the tension is left unresolved rather than argued away. Seal:
  Gov. Code §405 (fetched) prescribes the Great Seal's colours, evidencing a
  separate regime; **the misuse/penalty provision was not located** (gap).
- **us-hi — `adverse-on-commercial-reuse`.** The State portal's Terms of Use,
  verbatim: *"Duplication or use of any content from this web site for
  commercial purposes or in any manner likely to give the impression of official
  approval by the State of Hawaiʻi is prohibited."* **No {{PD-HIGov}} tag exists**
  (checked: 404). Narrower than a copyright assertion — it targets commercial
  duplication and false endorsement — but adverse to a paid render bundle.
  Countervailing and decisive for this dataset: nearly every fact in `us-hi.yml`
  comes from HRS ch. 249, an **edict of government**, which no terms-of-use page
  can reach. Seal: **HRS §5-6, misdemeanor** — see finding 3.
- **us-ak — `asserted`.** Every page of alaska.gov and dmv.alaska.gov — including
  the plate catalogue and the page that **sells $10 collector samples of the
  state's own plate designs** — footers "COPYRIGHT © STATE OF ALASKA ·
  DEPARTMENT OF ADMINISTRATION". **No {{PD-AKGov}} tag exists** (checked: 404).
  This places Alaska with Arizona, not with Florida or California: not "not
  established" but affirmatively asserted, on the artwork pages themselves.
  **Sharpest emblem case in the US wave:** the "Celebrating the Arts" plates are
  the work of *named individual artists* chosen by public vote (reported: Anita
  Laulainen 2018, Sabrina Kessakorn 2024), so a private author's copyright
  layers on top of the state's assertion. Never render them. The state flag (Big
  Dipper) is the central graphic of the standard base, not a corner emblem —
  placeholder covers the whole centre. Seal regime: **unresearched** (gap).

Photograph caution applies unchanged in all three: a Commons tag on a plate
photograph is the *photographer's* licence on the *photograph*; our renders are
generated from instruments and never derived from a photograph, so no
share-alike obligation attaches. CA has a measured CC0 example
(`File:10851 CA.jpg`, from the US/world dossier); **HI and AK photographs were
not licence-checked** (gap).

---

## 4. Geometry — AAMVA Ed.3 only, and the one state that beats it

Per the standing rule, **SAE J686 is never quoted** (paywalled, unpinned); all
geometry comes from AAMVA Ed.3, which is pinned in the US/world dossier.

The finding: **Hawaii legislates character geometry itself, and its statutory
minimum exceeds AAMVA's recommendation.** HRS §249-9(a): numerals "no less than
**three inches** in height and the strokes thereof no less than **three-eighths
inch** in width, except in the case of motorcycles … no less than **one inch** …
**one-eighth inch**." AAMVA §2.2 recommends ≥2.5 in with a 0.2–0.4 in stroke.
Three inches is half an inch taller; 3/8 in sits inside the stroke band. This is
the only statutory character geometry in the group and one of very few in the US
pass.

Second geometry find, and it is renderable: **CA VC §5060** prescribes for
passenger specialty plates a **2 in × 3 in** space to the left of the numbers for
the distinctive design plus a **5/8 in** high message strip below, and for
motorcycles a five-character configuration with the design space on the left. A
*legislature* handing the render layer its layout. **HRS §249-9.3** does the
matching thing for Hawaii with a ceiling rather than a layout: an organization
decal "shall not be larger than **three inches wide by three inches high**".

Plate dimensions: California's 12×6 in (and motorcycle 7×4 in, pre-1970 8×5 in;
identification 7×4 in, pre-1981 8×5 in) come from the **DMV's own page** — better
sourcing than the standards chain would have given. Hawaii's and Alaska's 12×6
in are **observed**, not sourced: HRS §249-9(a)(4) expressly permits "any shape,
size", and **no Alaska instrument stating a plate dimension was located** — a
real hole, given that AS 28.10.161(c) forbids adopting a plate that does not
"substantially embody the specifications of this section" and the section states
no dimension at all.

---

## 5. Four species of plate string (a schema observation, from this group)

This group produced the clearest evidence yet that "serial" is not one thing:

1. **Department-assigned from a series** — `us-ca-standard-123abc1`,
   `us-hi-standard-2025`, `us-ak-standard-gold`. `matching: strict`.
2. **Owner-chosen inside an official frame** — CA Environmental (2–7 chars),
   HI special number plates (≤6 + one hyphen), AK special request (≤6).
   Still `strict`, because the frame *is* the sourced grammar.
3. **Assigned by a different authority entirely** — `us-ak-amateur-radio`:
   AS 28.10.181(i), "**The number on the plates must be the radio call sign of
   the owner**" — an FCC identifier issued to a *person*. `recall-only`, because
   the governing authority (47 CFR pt 97) was not fetched.
4. **Assigned by a private body** — the **Iditarod Finisher** plate: "Requires
   finisher number from the Iditarod Trail Committee … (Ex. IDT999)". A sporting
   organisation's identifier, with a fixed `IDT` prefix, printed as a
   registration mark.

A fifth, adjacent: **`us-ca-dealer`**, whose serial is the firm's **occupational
licence number** (VIRPM 2.090, "Special license plates bearing the firm's license
number"), plus a stacked class letter and a set suffix — not drawn from a series
at all. `recall-only`, `binding: business`.

### Separator contract, exercised

**HRS §249-9.1 is a legislature independently arriving at PRD-PLATES §2.6's
closed set:** "only one hyphen will be allowed … **No other punctuation marks
shall be allowed.**" `us-hi-special-number-plates` encodes it as
`\A(?=[A-Z0-9]*-?[A-Z0-9]*\z)(?:[A-Z0-9]-?){1,6}\z` — hyphen as an emitted
literal, never inside a class, so the separator-free twin derives soundly.
Verified: `ALOHA` ✓, `ALOHA-1` ✓, `AB-CDEF` ✓ (6 alphanumerics + 1 hyphen),
`A-B-C` ✗, `ABCDEFG` ✗. The statute's "in addition to and in lieu of" is
genuinely ambiguous; the **narrower** reading (the six-cap binds the
alphanumerics) was taken and the ambiguity recorded, not resolved.

Counterpart on the other side: the **Alaska DMV's own footnote**, "*personalized
plate does not have a space in the middle*" — an authority statement about
**printed form**, which is why `us-ak-personalized` has no optional separator
while `us-ak-standard-gold` does.

---

## 6. Dead ends and blocks (skipped-beats-assumed)

| target | outcome |
|---|---|
| **WebSearch** | **Unavailable for the entire pass** — session budget exhausted before the task began. All discovery was WebFetch/`curl` on known or guessed URLs plus the Wayback **CDX API** for URL enumeration. |
| `capitol.hawaii.gov` (all HRS pages) | **403 Cloudflare** on WebFetch *and* on `curl` with a browser UA. **Workaround that worked:** `https://web.archive.org/web/2024id_/https://www.capitol.hawaii.gov/hrscurrent/...` — served the official HTML cleanly, snapshot 2025-01-07. The directory listing at `.../HRS0249/` is also archived and enumerates every section file, which is how §§249-7.5, 249-9.1, 249-9.3, 249-12 and 249-14.1 were found. |
| `dmv.alaska.gov` (all pages) | **403** on WebFetch and `curl`. **Workaround:** Wayback CDX (`url=dmv.alaska.gov*`) to enumerate paths, then `web/<ts>id_/` to fetch. Note the `id_` payloads are **gzip-encoded** and must be `gunzip`ed before text extraction. |
| **Alaska Statutes, current text** | **NOT OBTAINED — the biggest gap in the group.** `akleg.gov/basis/statutes.asp` is a JS shell; the underlying Folio frames (`folioproxy.asp?url=…folioisa.dll/stattx13/query=[jump!3A!27as2810161!27]…`) resolve but **ignore the jump and return Title 1 from the beginning**; `stattx25` returns "could not read from pipe". `law.justia.com` 403, `codes.findlaw.com` 403 (and not in Wayback), `lawserver.com` JS gate, `alaska.public.law` **DNS does not resolve**, `touchngo.com` live serves one 24,714-byte landing page for every path. **What worked:** the Internet Archive's capture of Touch N' Go's deep links (`/lglcntr/akstats/Statutes/Title28/Chapter10/Section161.htm` etc.), whose own banner says **"current through December, 2007."** Every AS quotation in `us-ak.yml` carries that vintage on its citation. |
| **Alaska statute-vs-agency conflict** | The 2007 text has the department issuing **two** plates to a passenger vehicle; the 2026 DMV says **one, on the rear**, with commercial >10,001 lb on the **front**. Both cannot be current. **The agency statement governs the file** and the conflict is recorded in `display_rules.conflict`. Finding the amending session law is the highest-value follow-up in `us-ak.yml`. |
| `www8.honolulu.gov/csd/motor-vehicle-license-plates/` | 301 to the `http://www.honolulu.gov` host; fetched at the redirect target. Confirms the ʻokina spelling on the current plate illustration and the $5.00 plate / $0.50 emblem replacement fees. **No serial-format or county-letter information on it** — the county-letter table stays locator-grade. |
| Honolulu "Special License Plates" sub-page | Linked from the CSD page, **not separately fetched**; no Hawaii specialty count was read (gap). The other three counties' equivalents were not located. |
| `HRS §5-6` (seal) direct text | capitol.hawaii.gov blocked and the Vol01 path was not archived under the guessed filename. **Quoted instead from the State portal's Terms of Use, which reproduces it verbatim.** Reading the statute directly is a recorded follow-up. |
| `HRS §286-53` (temporary plates) | **Not fetched** — only the ch. 249 file set was retrievable from the archive. `us-hi-temporary` therefore has a sourced *lifecycle* (30 days to register, 30 days to receive metal, destroy on attachment — §249-7.5) and **no format**. |
| `HRS §§249-9.2, 249-9.4–249-9.9` | Individual statutorily-named Hawaii plate programmes; **texts not fetched**, listed in the index entry from the chapter TOC. The cheapest high-value follow-up in `us-hi.yml`. |
| `AS 28.10.421` (specialty fees) | Cited by the Alaska DMV, **text not fetched**. Because Alaska sets *every* specialty fee by statute, this one section would let the whole specialty catalogue be reconstructed from the statute book. Cheapest high-value follow-up in `us-ak.yml`. |
| `2 AAC 92.120` (AK offensive plates) | **Not fetched** — the Alaska Administrative Code shares the BASIS access problem. The DMV's paraphrase is what `us-ak-personalized` cites. |
| CA CCR Title 13, Art. 3.3, §§205.00–205.14 (YOM regs) | **Not fetched**; VIRPM 21.260 cites them and is used in their place. |
| `dmv.ca.gov/.../california-legacy-license-plates/` and several guessed DMV paths | **404.** Correct paths found by Wayback CDX against `dmv.ca.gov/portal/vehicle-registration/license-plates-decals-and-placards*`; the live tree is `…/license-plates/…`, not `…/california-license-plates/…`. |
| CA VC §5101 / §5105 character limits | Fetched — **neither states a character limit.** The 2–7 rule is the **DMV's**, from VIRPM 21.100, not the Legislature's. Recorded as such. |
| `codes.findlaw.com` (AK) | 403 live, **not archived**. |

**Environment notes for follow-up runs.** Wayback `id_` payloads from
`dmv.alaska.gov` are gzip-compressed — `gunzip -c` before any text extraction or
you get silent empty output. `tr` and `grep` need `LC_ALL=C` on this machine for
UTF-8 captures (ʻokina, Hawaiian macrons) or they abort with "Illegal byte
sequence". `archive.org/wayback/available` returns `{}` for un-archived URLs
while the **CDX** endpoint enumerates whole hosts — use CDX to discover paths,
`available`/`web/<ts>id_/` to fetch.

---

## 7. Verification record

Sandbox: `plates/` + `scripts/lint_plates.rb` copied from `vehiclesdb`
(READ-ONLY, never written), three drafts added, `ruby scripts/lint_plates.rb`
run after each file.

```
baseline (12 files, 219 series)                       plates lint: OK
+ us-ca.yml (13 files, 233 series)                    plates lint: OK
+ us-hi.yml (14 files, 240 series)                    plates lint: OK
+ us-ak.yml (15 files, 253 series)                    plates lint: OK
plates lint: matching recall-only=27 strict=226 | twins regex_statutory=32 regex_strict=133
```

Additional checks run beyond the lint (all pass):

- `us-ca-standard-123abc1.charset.excluded` — **144 entries, 144 unique**,
  matching the declared `excluded_count`.
- `regex_strict` rejects **all 144** excluded triples in position
  (`123KKK4` ✗, `123SAM7` ✗, `123DIE0` ✗) while accepting ordinary serials
  (`123ABC4` ✓, `999ZZZ9` ✓).
- Tier order `regex_strict ⊆ regex`: **0 violations** on 2,000
  pattern-generated serials (independent of the lint's own sampling).
- HI vanity regex behaviour verified against the statutory rule (see §5).
- `us-ak-statehood-50` round-trips both printed forms (`ABC123`, `ABC 123`).
- `us-ak-amateur-radio` accepts `KL7ABC` / `AL1A` / `WL7XY`, rejects a
  4-letter suffix.

**Series delivered:** us-ca 14 · us-hi 7 · us-ak 13 = **34**.
**Unique source URLs pinned:** us-ca 28 · us-hi 12 · us-ak 11 = **49 distinct**.

---

## 8. Recommended follow-ups, in value order

1. **Alaska: the amending session law for AS 28.10.161/28.10.171.** Resolves the
   statute-vs-agency conflict *and* dates `us-ak-standard-gold` properly. Needs
   human browser access to akleg.gov.
2. **Hawaii: Act 132, SLH 1990.** Promotes or refutes `us-hi-rainbow-1991`'s
   start. Also worth reading Act 64, SLH 2024 for the ʻokina amendment's own
   effective-date language.
3. **Hawaii: the county-directors' majority-consent decision** fixing the serial
   arrangement and the county-letter allocation. It exists under
   HRS §249-9(a)(4); it is simply not a document we have. Would convert the
   entire `region_encoding` table from locator-grade to sourced — the single
   biggest quality jump available in this group.
4. **AS 28.10.421** — reconstructs Alaska's whole specialty catalogue from statute.
5. **HRS §§249-9.2, 249-9.4–249-9.9 and §286-53** — statutorily-named Hawaii
   programmes plus the temporary-plate format.
6. **A DMV instrument for California's March 2026 format flip** — currently the
   only news-grade claim load-bearing on a *current* series in this group.
7. **Christopher Garrish, "Reconsidering the Standard Plate Size", *Plates*
   62(5), ALPCA (Oct 2016)** — the first non-circular lead on the 1956 story;
   would settle programme-wide folklore, not just this group.
8. **CA Gov. Code seal-misuse provision** and **an Alaska seal statute** — the
   §5-6 finding shows the regime is real and criminal; two of three states in
   this group are still unresearched on it.
