### PR TITLE
plates: us territories — PR GU VI AS MP (L2 US wave)

### DIFF
--- a/plates/us-as.yml
+++ b/plates/us-as.yml
@@ -1,0 +1,454 @@
+# plates/us-as.yml — American Samoa (PRD-PLATES gate L2, territories group).
+#
+# AMERICAN SAMOA CARRIES THE MOST CONSEQUENTIAL LEGAL FINDING IN THE ENTIRE US
+# PASS, AND IT IS NOT ABOUT PLATES. The United States Copyright Office states
+# that "US federal copyright law applies in the US Virgin Islands, Guam, and the
+# Northern Mariana Islands BUT NOT IN AMERICAN SAMOA", because 17 U.S.C. § 101's
+# geographical definition of "the United States" reaches the several States, the
+# District of Columbia, and the ORGANIZED territories — and American Samoa is
+# unorganized and unincorporated. American Samoa therefore sits OUTSIDE the
+# geographic scope of the Copyright Act. That is a stronger position than
+# Florida's, which rests on state constitutional law and a 2004 decision; here
+# the federal statute simply does not reach. See `artwork_risk`.
+#
+# THE PLATE LAW ITSELF IS THE THINNEST IN THE GROUP AND THIS FILE SAYS SO
+# THROUGHOUT. Title 22 of the American Samoa Code Annotated, Chapter 10
+# ("Vehicle Licensing and Registration"), is SEVEN SECTIONS LONG — 22.1001 to
+# 22.1007 — and legislates the number of tags, where they go, how they are
+# validated and what they cost. It legislates NOTHING about format, colour,
+# dimension, class prefixes or specialty programmes. Every claim below is
+# either from those seven sections or is marked as secondary.
+#
+# WHAT IS DELIBERATELY NOT HERE (PRD-PLATES §2.5): individual specialty DESIGNS.
+jurisdiction: us-as
+authority:
+  name: American Samoa Department of Public Safety — Office of Motor Vehicles (the "Commissioner" of A.S.C.A. Title 22)
+  url: "https://asbar.org/section/title-22-highways-and-motor-vehicles/chapter-10-vehicle-licensing-and-registration/"
+binding: vehicle
+statute_edition: >-
+  American Samoa Code Annotated, Title 22 ("Highways and Motor Vehicles"),
+  Chapter 10, as served by the American Samoa Bar Association — the standing
+  public host of the ASCA. The Bar's own code index is captioned "Updated
+  Annotated Code by Title (as of August 2021)", so the served text is a 2021
+  compilation and later amendments were NOT checked (recorded gap).
+authority_url_note: >-
+  American Samoa's Department of Public Safety publishes no reachable motor
+  vehicle page, and americansamoa.gov, while reachable, surfaced no plate
+  content. The authority URL therefore points at the statutory chapter itself,
+  which is the primary-source home of every claim in this file. The
+  "Commissioner" named throughout Chapter 10 is the officer the 1977 amendment
+  substituted for the "Treasurer", per the Bar's own amendment note.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4 / §7.1.
+# THIS IS THE STRONGEST POSTURE IN THE US DATASET AND IT DESERVES ITS SPACE.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: outside-us-copyright-scope
+  basis: >-
+    American Samoa is the only US jurisdiction in this dataset where the question
+    is not "does this government claim copyright?" but "does the Copyright Act
+    reach here at all?" — and the answer, from the US Copyright Office, is no.
+    Wikimedia Commons quotes the position directly: US copyright law "applies in
+    all 50 states, the District of Columbia, Puerto Rico, the US Virgin Islands,
+    Guam, and the Northern Mariana Islands, BUT DOES NOT APPLY IN AMERICAN
+    SAMOA", grounding it in 17 U.S.C. § 101's definition of "the United States"
+    in a geographical sense, which reaches the several States, DC and the
+    ORGANIZED territories under US jurisdiction. American Samoa is UNORGANIZED
+    and unincorporated and is therefore excluded. Commons operationalises this
+    with a dedicated tag, {{PD-American Samoa}}, "used for works made in American
+    Samoa so long as the work has not been copyrighted elsewhere in the United
+    States", and maintains a country-specific rules page for the territory.
+  caveat: >-
+    STATED SO THE POSTURE IS NOT OVERREAD. The exclusion is GEOGRAPHIC, and the
+    Commons tag's own condition preserves the limit: a work made in American
+    Samoa is treated as public domain "SO LONG AS THE WORK HAS NOT BEEN
+    COPYRIGHTED ELSEWHERE IN THE UNITED STATES". A plate design commissioned
+    from, or first fixed by, a mainland or Hawaii-based manufacturer could
+    therefore be protected notwithstanding the territorial exclusion, and nothing
+    in this pass establishes where American Samoa's plate artwork was authored.
+    Additionally, no American Samoa territorial copyright statute was searched for
+    successfully, so whether the territory has enacted its own protection regime
+    is UNRESEARCHED — the federal Act's silence is not the same as a legal vacuum.
+  conclusion: >-
+    Treat American Samoa as the most favourable artwork posture in the US
+    dataset, ahead of Florida, but do NOT treat it as unconditional. The
+    conditions above are real and unresolved. The practical consequence for this
+    programme is that American Samoa is the strongest candidate anywhere in the
+    US for an EMBLEM-SLOT UPGRADE under PRD-PLATES §7.1 — where artwork_risk and
+    the _art ledger must both clear, this jurisdiction clears the first test on
+    stronger grounds than any state does.
+  edicts: >-
+    Independent of all of the above, edicts of government are public domain at
+    every level ({{PD-US-GovEdict}}), so A.S.C.A. Title 22 is free to use
+    regardless of how the territorial-scope question resolves.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default STILL APPLIES for now, and deliberately:
+    the favourable copyright position does not touch the separate protection
+    regimes for flags and seals, and the caveat above is unresolved. Render
+    `emblem: {present: true, rendered: placeholder}` — but flag this jurisdiction
+    to the art-tier owner as the highest-value place to do the affirmative
+    clearance work, because the upside here is larger than anywhere else.
+  photograph_caution: >-
+    plateshack.com and worldlicenseplates.com carry no reusable licence and are
+    treated as all rights reserved; no image was copied. Note the sharp
+    distinction that matters here: even in a jurisdiction outside the Copyright
+    Act's scope, a PHOTOGRAPH taken elsewhere and uploaded by a mainland
+    contributor carries that photographer's own copyright under the law of the
+    place it was made. The territorial exclusion frees the DESIGN question, never
+    the PHOTOGRAPH question, and our own-SVG rule keeps the two apart.
+  sources:
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # THE FINDING: the US Copyright Office position that federal copyright law does NOT apply in American Samoa, quoted with its 17 U.S.C. § 101 basis; the US Territories tag list; and the pointer to Commons:Copyright rules by territory/American Samoa"
+    - "https://commons.wikimedia.org/wiki/Template:PD-American_Samoa  # the dedicated Commons tag exists and is a primary licence tag, with its 'not copyrighted elsewhere in the United States' condition"
+    - "https://asbar.org/section/title-22-highways-and-motor-vehicles/chapter-10-vehicle-licensing-and-registration/  # A.S.C.A. Title 22 ch. 10 — an edict of government, PD at every level"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. NOTHING here quotes SAE J686 (paywalled, unpinned).
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  american_samoa_position: >-
+    A.S.C.A. Title 22 references no external standard and legislates no
+    dimension. It does legislate its own LEGIBILITY DISTANCE — 22.1003(1)
+    requires the tags to be "plainly visible for a distance of 50 feet" — which
+    is the same figure the CNMI legislates and two thirds of AAMVA's recommended
+    75 feet. Two Pacific territories independently landing on 50 feet is worth
+    noting; whether that is common drafting ancestry or coincidence is unresolved.
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is PAYWALLED and was NOT obtained. No J686 dimension is quoted here."
+    retroreflectivity: "AAMVA §3.3 recommends readability from at least 75 feet in both daylight and darkness. American Samoa legislates 50 feet plus a separate ILLUMINATION duty (22.1003(2), cross-referring to 22.1101(e)), which is a different and arguably more precise way of reaching the night-time case than a reflectivity spec"
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in"
+    replacement_cycle: "AAMVA §1.1 recommends a 7-10 year replacement cycle. American Samoa legislates a REPLACEMENT TRIGGER instead of a cycle: 22.1002(f) issues two new tags only to an applicant registering a vehicle not registered in the Territory in the PRECEDING FIVE YEARS, or whose tags were lost or stolen. Tags otherwise persist indefinitely behind annual decals"
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+
+# ---------------------------------------------------------------------------
+# Display rules — statutory, and American Samoa uses the term "LICENSE TAGS"
+# rather than "license plates" throughout, which is preserved here.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: >-
+    TWO tags, front and rear. 22.1003, verbatim: "License tags shall be displayed
+    only on the vehicle for which they were issued, and in the following manner:
+    (1) ONE FIRMLY ATTACHED TO THE FRONT AND THE OTHER FIRMLY ATTACHED TO THE
+    REAR of the vehicle at all times, which shall at all times be kept clean and
+    PLAINLY VISIBLE FOR A DISTANCE OF 50 FEET; (2) the license tags shall be
+    PROPERLY ILLUMINATED in accordance with subsection (e) of 22.1101."
+  tag_issuance: >-
+    22.1002(f): the Commissioner issues TWO license tags to each applicant who is
+    either (1) registering a vehicle not registered in the Territory in the
+    preceding FIVE YEARS, or (2) whose tags have been lost or stolen, on proof.
+    Replacement of lost or stolen tags costs $22.00. So American Samoa does NOT
+    reissue tags at every registration — a returning vehicle keeps its tags, and
+    the five-year rule is the only routine trigger for new metal.
+  validation: >-
+    DECALS ON THE TAGS, not a windshield sticker. 22.1002(c): on satisfactory
+    compliance "the Commissioner shall issue 2 DECALS to the applicant WHICH
+    DECALS DENOMINATE THE PERIOD FOR WHICH REGISTRATION IS EFFECTIVE AND ARE TO BE
+    PLACED ON THE LICENSE TAGS." Two decals for two tags. Photographic evidence
+    corroborates month-and-year decals (January 2024, October 2023, August 2019,
+    January 2017 among many) and, notably, TAGS CARRYING SEVERAL YEARS' DECALS AT
+    ONCE — "August 2019 through August 21 expirations" and "January 2017 through
+    January 2023 expirations" on single plates — which is exactly what the
+    five-year reissue rule predicts.
+  expiration: "22.1004: all motor vehicle licenses expire annually at times designated by the Commissioner by rule; the Commissioner may allow up to 30 days' grace to obtain the inspection certificate"
+  registration_conditions: >-
+    22.1002(b): no license issues without (1) payment of the fee, (2) a valid
+    inspection certificate under 22.1201 et seq., (3) certification of insurance
+    effective for the licence period under 22.2001 et seq., and (4) issuance of a
+    valid motor vehicle registration. American Samoa's courts have described this
+    as effectively conditioning use of the public highways on maintaining
+    insurance (Pu'u v. Lepule, 8 A.S.R.2d 68 (1988)).
+  requirement: "22.1001: 'No motor vehicle may be operated on any highway in American Samoa without a valid registration and VEHICLE LICENSE TAGS as required by this chapter.'"
+  sources:
+    - "https://asbar.org/code-annotated/22-1003-display-of-license/  # 22.1003 (1972, PL 12-65 § 1): one tag front, one rear, at all times, clean, plainly visible at 50 feet, properly illuminated per 22.1101(e)"
+    - "https://asbar.org/code-annotated/22-1002-application-for-and-issuance-of-license-fees/  # 22.1002: (b) the four preconditions; (c) two decals denominating the registration period, placed ON the tags; (d) the fee schedule; (f) two tags on first registration or after five years' absence, or on proof of loss or theft, $22.00 replacement; (g) $7.00 of each fee to a DPS law-enforcement and production fund"
+    - "https://asbar.org/code-annotated/22-1004-expiration-of-license/  # 22.1004 (1972, PL 12-65 § 1; amended 1977, PL 15-41 § 2): annual expiry at times set by the Commissioner by rule, up to 30 days' inspection grace, and the Bar's note that the 1977 amendment substituted 'Commissioner' for 'Treasurer'"
+    - "https://asbar.org/code-annotated/22-1001-motor-vehicle-registration-and-license-required/  # 22.1001 (1972, PL 12-65 § 1): the operating prohibition, plus the annotated case notes including Pu'u v. Lepule, 8 A.S.R.2d 68 (1988) and Foma'i v. Samana, 4 A.S.R.2d 102 (1987)"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES. American Samoa is the only jurisdiction in the
+  # territories group with an ALL-NUMERIC standard serial.
+  # =========================================================================
+  - id: us-as-standard
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 1972 }
+    period_evidence: statutory-enactment-date-upper-bound
+    matching: strict
+    format:
+      pattern: "9999"
+      regex: '\A\d+\z'
+      charset:
+        notes: >-
+          A.S.C.A. TITLE 22 STATES NO SERIAL GRAMMAR AT ALL — not an alphabet, not
+          a width, not an exclusion. The all-numeric form is reported by a
+          Wikipedia locator (four digits, continuously since 1967) and
+          independently corroborated by worldlicenseplates' American Samoa plate
+          history. The regex therefore claims a FORM (numeric) and makes NO WIDTH
+          CLAIM, exactly as us-fl-horseless-carriage does for the same reason: an
+          unbounded quantifier is the honest encoding of a statute that fixes no
+          width. There is no `regex_statutory` because there is no statutory bound
+          to encode.
+      pattern_note: >-
+        The pattern shows the four-digit form the sources report. `matching:
+        strict` because an all-numeric serial lies inside the (empty) statutory
+        constraint and a match is a real claim about this series.
+      progression: "the locator reports the range 0001 to 9999 — a single flat numeric space with no block structure, which is what a territory of American Samoa's fleet size would be expected to need"
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: >-
+        NOT IN ANY AMERICAN SAMOA INSTRUMENT. 12 x 6 in aluminium is
+        locator-reported, together with the claim that American Samoa first issued
+        a 6 x 12 in plate in 1977 — i.e. that it adopted the North American
+        convention LATE, five years after the current licensing chapter was
+        enacted. That is an interesting claim and it is NOT asserted here; the
+        locator attributes it to a collector-journal article (Garrish, C.,
+        "Reconsidering the Standard Plate Size", Plates 62(5), October 2016) which
+        was not obtained. Recorded as a lead, not a fact.
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO HEX IS RECORDED. The locator describes the current base as "black on
+        reflective graphic featuring Fatu Rock" — a GRAPHIC background, not a flat
+        colour, which is precisely the case where assigning a single background hex
+        would be inventing data. The foreground is described as black but no
+        instrument states it. Both are left absent with their descriptions
+        recorded.
+      foreground_description: "black (locator-grade)"
+      legend_top: "AMERICAN SAMOA"
+      legend_slogan_reported: "Motu O Fiafiaga"
+      legend_slogan_note: >-
+        The locator glosses this as "Island of Paradise". It is Samoan and it is
+        reported, not sourced — no American Samoa instrument prescribes any legend,
+        unlike Guam, where 16 GCA § 7120(b) puts the word "Guam" on every plate by
+        law, or the CNMI, where 9 CMC § 2116(c)(1) confirms the HAFA ADAI line.
+      graphic: { present: true, rendered: placeholder, description: "Fatu Rock (Fatu ma Futi) scenic graphic across the plate face — locator-grade description, from no instrument and no drawing" }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    validation: "two decals per registration, one for each tag, denominating the registration period (22.1002(c)) — see display_rules"
+    previous_base_reported:
+      note: >-
+        DELIBERATELY NOT MINTED AS A SERIES, per PRD-PLATES §4's rule that
+        Wikipedia's era tables are not sourced years. The locator reports a 2011
+        changeover to the Fatu Rock base and, before that, "12-YY" year-indexed
+        serials 1945-1951, three digits 1952-1966, and four digits from 1967. NO
+        PRIMARY establishes any of those boundaries: A.S.C.A. Title 22 is
+        format-silent and American Samoa publishes no reachable plate instrument.
+        Rather than mint dated ids on folklore boundaries and then alias them
+        (PRD-QUALITY I-5/I-6), the boundaries are recorded here and a dated series
+        is added when a primary lands.
+      reported_boundaries: ["1945-1951 12-YY (year-indexed)", "1952-1966 three digits", "1967-present four digits", "2011-present Fatu Rock base"]
+      evidence: locator-only
+    class_prefix_table_reported:
+      note: >-
+        AMERICAN SAMOA ENCODES VEHICLE CLASS AND GOVERNMENT AGENCY IN A LETTER
+        PREFIX ON THE SERIAL, and this is the territory's single most interesting
+        plate fact. It is recorded here as a REPORTED TABLE, not as a decode
+        table, because its only source is worldlicenseplates' American Samoa page —
+        an unlicensed enthusiast site — corroborated only in part by dated
+        photographs on plateshack of plates captioned taxi, rental, dealer and
+        government. It is included because a parse API that meets an American Samoa
+        plate reading "AC 123" and has never been told that AC means Agriculture
+        will guess wrong, and because publishing the table WITH its provenance
+        grade is more useful than withholding it. IT MUST BE VERIFIED AGAINST AN
+        AMERICAN SAMOA PRIMARY BEFORE ANY CONSUMER DECODES FROM IT.
+      evidence: secondary-single-source
+      reported_prefixes:
+        AC: Agriculture
+        AP: Airport Authority
+        C: Cargo
+        CC: Community College
+        CF: Correctional Facility
+        CI: Criminal Investigation
+        CJ: Criminal Justice
+        CP: Commercial Bus
+        CT: Commercial Truck
+        DM: University
+        DOT: Coastguard
+        DPS: Department of Public Safety
+        EC: Early Childhood Department
+        ED: Education Department
+        EPA: Environmental Protection Agency
+        FA: Federal Aviation Administration
+        FD: Fire Department
+        GO: Governor
+        GS: Government Supply
+        IP: Important Person
+        MB: Motorcycle
+        MC: Medical Clinic
+        MD: Medical Doctor
+        MP: Motor Pool
+        MS: Medical Services
+        MT: Manpower Training
+        PD: Police Department
+        PS: Department of Public Safety
+        PW: Public Works
+        PWD: Public Works Department
+        R: Rental Car
+        SE: Special Education
+        SS: Social Security Administration
+        ST: School Transport
+        T: Taxi
+        TA: Territorial Auditor
+        TT: Tow Truck
+        TV: Television Station
+        US: United States Congressman
+        UT: Utility Division
+        WM: Weights and Measures
+        WP: Power Authority
+        WR: Wrecker
+      internal_inconsistencies: >-
+        RECORDED RATHER THAN CLEANED UP, because the inconsistencies are evidence
+        about the source's reliability. DPS and PS are both given as Department of
+        Public Safety; PW and PWD are both given as Public Works; and the source
+        itself marks PM and VR as unknown. A table with duplicate keys for one
+        agency and self-declared unknowns is a collector's reconstruction, not a
+        register, and its confidence should be read accordingly.
+      motorcycle_note: >-
+        NOTE THE MB PREFIX. If it is real, American Samoa serialises motorcycles
+        with a class prefix on the same numeric space rather than with a separate
+        reduced-size series, which would make it unlike most US jurisdictions. No
+        motorcycle series is minted in this file on the strength of a single table
+        row (recorded gap).
+    region_encoding: >-
+      NONE. American Samoa's prefix system encodes CLASS AND AGENCY, not
+      geography, and no source suggests any island or district coding — which is
+      consistent with a territory whose fleet is concentrated on Tutuila.
+    sources:
+      - "https://asbar.org/code-annotated/22-1002-application-for-and-issuance-of-license-fees/  # 22.1002 — the whole statutory content of an American Samoa standard registration: the four preconditions, two decals placed on the tags, the fee schedule ($32.00 motor vehicle plus $12.00 per ton, $32.00 renewal, $2.00 bicycle, $10.00 titles and transfers, $9.00 late penalty), two tags on first registration or after five years' absence, $22.00 tag replacement, and the $7.00 per-fee allocation to a DPS fund for law-enforcement costs and for PRODUCTION of driver licences and vehicle registrations"
+      - "https://asbar.org/code-annotated/22-1003-display-of-license/  # 22.1003: front and rear display, 50-foot legibility, illumination"
+      - "https://asbar.org/code-annotated/22-1001-motor-vehicle-registration-and-license-required/  # 22.1001: the 'valid registration and vehicle license tags' requirement, and the statute's own vocabulary — American Samoa says TAGS, not plates"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_American_Samoa  # LOCATOR ONLY (PRD-PLATES §4): the four-digit numeric serial from 1967 with range 0001-9999, the 2011 Fatu Rock base, the 'Motu O Fiafiaga' slogan, 12x6 in aluminium, the reported 1977 adoption of the 6x12 standard, and the AC (agriculture) and R (rental) prefixes"
+      - "http://www.worldlicenseplates.com/world/PA_AMSA.html  # CORROBORATION + GAP-FINDER (PRD-PLATES §4): the full reported class/agency prefix table transcribed above as REPORTED data, the plate history from 1927, and the separate non-passenger categories (Cargo, Commercial Bus, Commercial Truck, Government Official, Government 2020 Series, Motorcycle, Public Service Vehicle, Rental Vehicle, Taxi). No licence statement on the site — treated as all rights reserved; facts only, no text or images copied"
+      - "http://www.plateshack.com/y2k/American_Samoa/asy2k.html  # CORROBORATION: dated photographs establishing multi-year decal stacking on single tags ('August 2019 through August 21', 'January 2017 through January 2023'), which is the practical confirmation of 22.1002(f)'s five-year reissue rule; plus dated taxi, rental, dealer, government and US Congressional-delegate plates"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 geometry and the 75-foot legibility recommendation against which American Samoa's statutory 50 feet is compared"
+    notes: >-
+      AMERICAN SAMOA STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED and the period
+      is an UPPER BOUND: `start: 1972` is the enactment of PL 12-65, the act that
+      produced the current Chapter 10, and the four-digit numeric arrangement is
+      reported to predate it by five years. It is recorded as the instrument date
+      rather than invented. THREE THINGS MAKE THIS THE MOST DISTINCTIVE STANDARD
+      SERIES IN THE TERRITORIES GROUP. First, it is ALL-NUMERIC, the only one in
+      the group, which means an American Samoa plate carries no letters at all
+      unless it carries a CLASS PREFIX — so the presence of letters is itself a
+      classification signal. Second, TAGS ARE NOT REISSUED at every registration:
+      22.1002(f)'s five-year rule means a single pair of tags can accumulate half a
+      decade of decals, and the photographs prove it does. Third, the statute calls
+      them TAGS throughout, which is preserved here rather than normalised, because
+      a jurisdiction's own vocabulary is a fact about it.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES. American Samoa demonstrably serialises these
+  # separately — the reported prefix table and dated photographs agree — but
+  # NOTHING about them is in the statute. Every one is `matching: recall-only`.
+  # =========================================================================
+  - id: us-as-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: photographic-in-use-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          NO GRAMMAR IS SOURCED. The reported structure is an agency prefix of one
+          to three letters followed by a number in the ordinary numeric space —
+          DPS, PD, ED, GO (Governor), EPA, FD, PWD and about thirty more. The
+          regex is a shape catch-all and claims none of it.
+      pattern_note: "ILLUSTRATIVE PATTERN, CATCH-ALL REGEX. `matching: recall-only` — a match is a shape hit, never a claim that the string is a valid American Samoa government tag."
+    design: { plate: { note: "not sourced" }, emblem: { present: true, rendered: placeholder } }
+    reported_generations: "a distinct government series is reported as first issued in 2005 (with DHS and DOH among the photographed agency prefixes), and a further 'Government (2020 Series)' is listed separately — two generations within twenty years, neither dated by any instrument"
+    region_encoding: none
+    sources:
+      - "http://www.worldlicenseplates.com/world/PA_AMSA.html  # CORROBORATION: the 'Government, Official' and 'Government (2020 Series)' categories, and the agency prefix table transcribed under us-as-standard"
+      - "http://www.plateshack.com/y2k/American_Samoa/asy2k.html  # CORROBORATION: photographs of 'American Samoa Government vehicle plate of type first issued in 2005' with DHS and DOH prefixes read off them, 'Government Vehicle plates in recent use manufactured in 2005' with a PA prefix, and a plate for the non-voting Congressional Representative — the US prefix in the reported table"
+      - "https://asbar.org/code-annotated/22-1005-exemptions/  # 22.1005 'Exemptions' — the statutory hook under which a government fleet would sit; its text was not extracted in this pass (recorded gap)"
+    notes: >-
+      AMERICAN SAMOA GOVERNMENT TAGS. Minted because two independent secondary
+      sources agree that a distinct government series exists and photographs read
+      agency prefixes off actual plates — but with NOTHING taken from the statute,
+      because 22.1005 ("Exemptions") was not extracted and no American Samoa
+      instrument describes a government tag. `period: {start: 2026}` is a read-date
+      upper bound and carries no historical claim. THE CONGRESSIONAL-DELEGATE PLATE
+      is the curiosity worth preserving: American Samoa issues a distinct tag for
+      its non-voting Member of the US House, which is a plate class that exists in
+      only a handful of jurisdictions anywhere.
+
+  - id: us-as-taxi
+    class: taxi
+    categories: [car, van, bus]
+    period: { start: 2026 }
+    period_evidence: photographic-in-use-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "reported prefix T for taxis; CP is reported for commercial buses and is a separate reported class. No grammar is sourced" }
+      pattern_note: "illustrative pattern, catch-all regex — see us-as-government's note"
+    design: { plate: { note: "not sourced" }, emblem: { present: true, rendered: placeholder } }
+    region_encoding: none
+    sources:
+      - "http://www.plateshack.com/y2k/American_Samoa/asy2k.html  # CORROBORATION: dated photographs of American Samoa TAXI plates with August 2024, September 2015, August 2006 and June 2018 expirations — an eighteen-year run of a continuously distinct taxi tag"
+      - "http://www.worldlicenseplates.com/world/PA_AMSA.html  # CORROBORATION: 'Taxi' as its own non-passenger category, and the reported T prefix"
+    notes: >-
+      AMERICAN SAMOA TAXI TAGS. THE BEST-CORROBORATED NON-STANDARD SERIES IN THIS
+      FILE, and still only photographic: two independent enthusiast sources, one
+      of them with dated photographs spanning 2006 to 2024, agree that American
+      Samoa issues a distinct taxi tag. That is enough to assert the SERIES EXISTS
+      and not nearly enough to assert its grammar, which is why the regex is a
+      catch-all and `matching` is recall-only.
+
+  - id: us-as-agricultural
+    class: agricultural
+    categories: [truck, trailer]
+    period: { start: 2026 }
+    period_evidence: secondary-reported-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "reported prefix AC. No grammar is sourced" }
+      pattern_note: "illustrative pattern, catch-all regex — see us-as-government's note"
+    design: { plate: { note: "not sourced" }, emblem: { present: true, rendered: placeholder } }
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_American_Samoa  # LOCATOR: the 'AC 123' agriculture serial format, listed among American Samoa's non-passenger types"
+      - "http://www.worldlicenseplates.com/world/PA_AMSA.html  # CORROBORATION: 'AC Agriculture' in the reported prefix table — the one prefix on which the locator and the enthusiast table independently agree, which is why this class is minted and most of the other forty are not"
+    notes: >-
+      AMERICAN SAMOA AGRICULTURE TAGS. Minted for a narrow and explicit reason:
+      of the forty-odd prefixes in the reported table, AC is one of only two that a
+      SECOND, INDEPENDENT source also reports (the other is R for rental cars,
+      which is not minted because _meta/classes.yml has no `rental` value — see
+      the file-level gap note). Two sources agreeing on one prefix is the minimum
+      bar this file applies before giving a reported class its own series, and
+      applying that bar consistently is why the other prefixes stay in the reported
+      table under us-as-standard rather than becoming forty thin series.
+
+  - id: us-as-dealer
+    class: dealer
+    categories: [car, van, truck]
+    period: { start: 2026 }
+    period_evidence: photographic-in-use-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "no prefix is reported for dealer tags and no grammar is sourced — this series rests on a single photographed example" }
+      pattern_note: "illustrative pattern, catch-all regex — see us-as-government's note"
+    design: { plate: { note: "not sourced" }, emblem: { present: false } }
+    binding: business
+    region_encoding: none
+    sources:
+      - "http://www.plateshack.com/y2k/American_Samoa/asy2k.html  # CORROBORATION ONLY: a photograph captioned 'American Samoa dealer license plate issued in 2000' — the sole evidence that a distinct dealer tag exists"
+    notes: >-
+      AMERICAN SAMOA DEALER TAGS. THE WEAKEST-EVIDENCED SERIES IN THIS FILE and
+      flagged as such: one photograph, one source, no prefix reported, no statute.
+      It is minted rather than dropped only because PRD-PLATES §7's L2 scope names
+      dealer as a core class to spec where the jurisdiction separately serialises
+      it, and a cited placeholder with `matching: recall-only` is more useful to a
+      consumer than silence. A verifier should treat this entry as the first thing
+      to either confirm or delete.

--- a/plates/us-gu.yml
+++ b/plates/us-gu.yml
@@ -1,0 +1,658 @@
+# plates/us-gu.yml — Guam (PRD-PLATES gate L2, territories group).
+#
+# GUAM IS THE BEST-LEGISLATED PLATE REGIME IN THIS GROUP AND ONE OF THE BEST IN
+# THE WHOLE US PASS. Title 16 of the Guam Code Annotated, Chapter 7 ("Vehicle
+# License and Registration", §§ 7101-7180) legislates the things most US states
+# leave to a department: how many plates, what words are on them, that dealer
+# and trailer numbers run in SEPARATE NUMERICAL SERIES, what a dealer-issued
+# temporary plate must say and in what letter height, and — uniquely in this
+# dataset so far — A TABLE OF RESERVED PLATE NUMBERS FOR NAMED PUBLIC OFFICES.
+# The Code is served by the Compiler of Laws at col.guamcourts.gov, updated
+# through P.L. 38-085 (Dec. 20, 2025), compilation stamp COL 2026-04-23.
+#
+# THE ONE THING GUAM DOES NOT LEGISLATE IS THE DESIGN, and it says so:
+# § 7120(c) leaves plates "such size as the Director of Revenue and Taxation may
+# determine". THE OBVIOUS PLACE TO LOOK NEXT IS THE ADMINISTRATIVE RULES — and
+# there is a clean, citable NEGATIVE there: 30 GAR Div. 2 Chapter 6, "Vehicle
+# Registration", reads in its entirety "(No rules filed.)". Guam's registration
+# regime has NO administrative regulations at all. So every design, colour and
+# serial-arrangement fact below is either statutory or is marked as
+# secondary-corroborated; there is no third layer of Guam law to go and get.
+#
+# WHAT IS DELIBERATELY NOT HERE (PRD-PLATES §2.5): individual specialty DESIGNS.
+# `us-gu-specialty-index` indexes the statutory programmes and nothing more.
+jurisdiction: us-gu
+authority:
+  name: Guam Department of Revenue and Taxation (DRT), Motor Vehicle Division
+  url: "https://col.guamcourts.gov/guam-code-annotated/guam-code-annotated"
+binding: vehicle
+statute_edition: >-
+  16 GCA (Vehicles), Chapter 7, as compiled by the Guam Compiler of Laws —
+  "UPDATED THROUGH P.L. 38-085 (DECEMBER 20, 2025)", compilation stamp
+  COL 2026-04-23. A 2026 compiler note records that under 11 GCA § 1105 all
+  references to "Department of Finance" read as "Department of Revenue and
+  Taxation" — which is why the issuing agency in a 1952-vintage section is DRT.
+authority_url_note: >-
+  DRT's own public site (guamtax.com) was UNREACHABLE from this environment on
+  every attempt (connection reset, both schemes). The authority URL therefore
+  points at the Compiler of Laws' Guam Code Annotated index, which is the
+  primary-source home of every claim in this file. Recorded as a dead end, not
+  papered over.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4 / §7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched-presumed-protected
+  basis: >-
+    NO EVIDENCE EITHER WAY WAS LOCATED, and the honest reading of that silence is
+    adverse rather than neutral. Two things are established. First, US federal
+    copyright law APPLIES IN GUAM: the US Copyright Office states that "US
+    federal copyright law applies in the US Virgin Islands, Guam, and the
+    Northern Mariana Islands but not in American Samoa", so Guam is inside the
+    Copyright Act's geographic scope. Second, the federal §105 public-domain rule
+    does not reach territorial governments any more than it reaches states, and
+    NO Commons PD tag exists for the government of Guam — Template:PD-GuamGov
+    returns 404. The tag that does exist for territories,
+    {{PD-USGov-Unincorporated}}, is expressly for UNORGANIZED territories; Guam is
+    an ORGANIZED unincorporated territory and is not covered by it.
+  conclusion: >-
+    Treat Guam plate ARTWORK as presumptively protected, in the same bucket the
+    US/world dossier assigned to Texas and Delaware: "not established — treat as
+    default (copyrighted)". No Guam statute, executive order or AG opinion on
+    government-work copyright was searched for successfully in this pass; that is
+    a recorded gap, and a real one, because the latte stone and bougainvillea
+    graphic is the whole visual identity of the current plate.
+  edicts: >-
+    The offsetting fact, and it is the one this file is built on: EDICTS OF
+    GOVERNMENT are public domain at every level ({{PD-US-GovEdict}}). 16 GCA is
+    an edict. Guam's plate is therefore legally safe to DESCRIBE in full detail
+    from the statute even though its ARTWORK is not cleared — which is exactly
+    the split PRD-PLATES §4 anticipates.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies without exception to the LATTE
+    STONE and BOUGAINVILLEA graphic and to the Seal of Guam. Render
+    `emblem: {present: true, rendered: placeholder}`. Do not upgrade until a Guam
+    government-works copyright posture is affirmatively established AND the
+    _art ledger clears the specific asset.
+  photograph_caution: >-
+    plateshack.com's Guam page carries an explicit notice — "Copyright 1997-2006.
+    Please ask permission before using any images" — which is a rarity in the
+    enthusiast landscape and is respected absolutely: no image was copied, and
+    the page was used only to corroborate which series exist.
+  sources:
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # the US Copyright Office position that federal copyright law applies in Guam; the US Territories tag list, which contains {{PD-PRGov}} and {{PD-American Samoa}} but NOTHING for Guam; and the statement that {{PD-USGov-Unincorporated}} covers UNORGANIZED territories only"
+    - "https://commons.wikimedia.org/wiki/Template:PD-GuamGov  # HTTP 404 — a measured negative: no Commons public-domain tag exists for the government of Guam"
+    - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # 16 GCA ch. 7 — an edict of government, PD at every level, and the source of every factual claim below"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. NOTHING here quotes SAE J686 (paywalled, unpinned).
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  guam_position: >-
+    Guam legislates its own plate frame and does not reference AAMVA or SAE
+    anywhere in 16 GCA ch. 7. § 7120(c)'s "such size as the Director of Revenue
+    and Taxation may determine" is an express delegation to a Guam official, not
+    an adoption of an external standard. AAMVA geometry is recorded below as
+    context only.
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is PAYWALLED and was NOT obtained. No J686 dimension is quoted here."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges"
+    jurisdiction_name_layout: "AAMVA §2.1: jurisdiction name top centre between the bolt holes — which is where 16 GCA § 7120(b)'s mandatory word 'Guam' in fact appears"
+    replacement_cycle: "AAMVA §1.1 recommends a 7-10 year replacement cycle. Guam legislates NO replacement cycle; § 7135 instead expires every plate annually with the registration and offers 'a new plate OR DEVICE indicating registration for the coming year', so Guam's plates can and do outlive many replacement cycles behind a validation device."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+
+# ---------------------------------------------------------------------------
+# Display rules — statutory, and Guam is a TWO-PLATE jurisdiction by statute.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: >-
+    TWO plates, front and rear. § 7120(a), verbatim: "Upon registering a vehicle,
+    the Department of Revenue and Taxation shall issue to the owner two (2)
+    license plates (one front and one rear) for a motor vehicle." § 7129(a) then
+    requires that they "be attached to the front and rear thereof and shall not be
+    covered with plastic or other coverings if thereby the license numbers and
+    letters are not clearly visible."
+  mounting: >-
+    § 7129(b): every plate "securely fastened to the vehicle for which it is
+    issued so as to prevent the plate from swinging, and at a minimum distance of
+    twelve (12) inches from the ground in a position to be clearly visible. Every
+    license plate shall be maintained free from foreign materials and in a
+    condition to be clearly legible." Note Guam sets a MINIMUM height only — no
+    maximum, unlike Florida's 60-inch cap.
+  mandatory_content: >-
+    § 7120(b): every plate "shall have displayed upon it the registration number
+    assigned to the vehicle for which it is issued together with THE WORD 'GUAM'
+    and THE YEAR NUMBER for which it is issued OR a suitable device issued by the
+    Department for validation purposes, which device shall contain the year
+    number for which issued." So the legend "Guam" is statutory, and the year is
+    statutory but satisfiable by a sticker.
+  shape: "§ 7120(c): 'License plates shall be rectangular in shape and such size as the Director of Revenue and Taxation may determine.' Shape legislated, size delegated."
+  devices_in_lieu: >-
+    § 7125: the Department "may issue one (1) or more stickers or other suitable
+    devices IN LIEU OF the license plates provided under this Title", and all
+    plate provisions apply to them except where physically inapplicable. A
+    jurisdiction that can lawfully replace the plate with a sticker is a genuine
+    edge case for a plate dataset and is recorded as such.
+  expiration: >-
+    § 7130(a)-(b): registration renews ANNUALLY on a STAGGERED monthly schedule
+    set by the Director, expiring at midnight on the last day of the assigned
+    month. § 7135(a): "Every license plate and special plate issued under this
+    Title expires at midnight on the last day of the month in which the
+    registration expires each year."
+  sources:
+    - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # § 7120(a) two plates front and rear; (b) the mandatory 'Guam' legend and year number or validation device; (c) rectangular shape, size at the Director's discretion; § 7125 stickers or devices in lieu of plates; § 7129(a)-(b) front-and-rear attachment, no obscuring covers, no swinging, 12-inch minimum height, legibility; § 7130 annual staggered registration; § 7135 annual plate expiry and renewal window"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES — current base, and the one before it.
+  # =========================================================================
+  - id: us-gu-standard-2009
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2009 }
+    period_evidence: secondary-corroborated
+    matching: strict
+    format:
+      pattern: "LL 9999"
+      regex: '\A[A-Z]{2} ?\d{4}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          16 GCA STATES NO SERIAL GRAMMAR AT ALL for the standard plate. § 7120(b)
+          requires only "the registration number assigned to the vehicle", and
+          § 7123(c) — the personalised-plate section — is the only place in the
+          chapter that quantifies anything, capping a personalised configuration
+          at seven positions. `regex_statutory` therefore carries no width claim.
+      pattern_note: >-
+        THE TWO-LETTER / FOUR-NUMERAL ARRANGEMENT IS NOT STATUTORY. It is
+        recorded from a Wikipedia LOCATOR and independently corroborated by
+        worldlicenseplates' Guam page, which lists a discrete "2009 Series" among
+        Guam's plate generations. `matching: strict` because the arrangement lies
+        INSIDE the (empty) statutory constraint and a match is a real claim about
+        this series; the outer bound is `regex_statutory`.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: >-
+        NOT STATUTORY. § 7120(c) makes size a decision of the Director of Revenue
+        and Taxation, and 30 GAR Div. 2 ch. 6 records that no registration rules
+        have ever been filed — so there is no Guam instrument fixing the
+        dimension. 12 x 6 in is the reported North American convention, marked as
+        reported.
+      material: "aluminium (reported)"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed-secondary }
+      foreground: "#000000"
+      colour_note: >-
+        Neither colour is in any Guam instrument. Embossed black on reflective
+        white is `hex_basis: observed-secondary`, from a Wikipedia locator
+        corroborated by worldlicenseplates' series listing.
+      legend_top: "GUAM"
+      legend_top_basis: "STATUTORY — § 7120(b) requires the word 'Guam' on every plate. This is one of the few legend claims in the whole US dataset that comes from an edict rather than from a photograph."
+      legend_bottom_reported: "Tano Y Chamorro"
+      graphic: { present: true, rendered: placeholder, description: "grey latte stone with three red bougainvillea flowers, centred — locator-grade description, NOT from any statutory or regulatory drawing" }
+      emblem: { present: true, rendered: placeholder }
+      mounting_holes_reported: "one round hole top right, horizontal slots in the other three corners — the same arrangement reported for Hawaii and the Northern Marianas; locator-grade"
+      band: { side: none }
+      rear_differs: false
+    validation: "§ 7120(b) permits a validation DEVICE bearing the year in place of an embossed year number; § 7135(a) expires it annually with the registration"
+    region_encoding: >-
+      CONTESTED, AND RECORDED RATHER THAN AVERAGED (PRD-PLATES §5.3). The
+      Wikipedia locator says the current AB 1234 serial is "coded by
+      municipality". worldlicenseplates, describing the PREVIOUS (1994) series,
+      says something materially different and narrower: "The last three letters on
+      COMMERCIAL plates designate the municipality, shown are FAP (Fort Apugan) and
+      MLL (Mount Lamlam). Others exist." Those are two different claims about two
+      different series and two different vehicle classes. NO decode table is
+      asserted here, and none should be published until a Guam primary is found.
+    sources:
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # § 7120(a)-(c): two plates, the mandatory 'Guam' legend and year/device, rectangular shape and delegated size — the entire statutory content of a Guam standard plate"
+      - "https://col.guamcourts.gov/sites/default/files/30GAR002-5_8.pdf  # 30 GAR Div. 2 ch. 6 'VEHICLE REGISTRATION — (No rules filed.)', with the rule-making-authority note citing 16 GCA §§ 7105, 7108, 7143, 7174. THE MEASURED NEGATIVE: Guam has no administrative regulations on vehicle registration or plates, so the statute is the whole of Guam's written plate law"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Guam  # LOCATOR ONLY (PRD-PLATES §4): the Feb 27 2009 issue date, the AB 1234 arrangement, the latte-stone/bougainvillea graphic, the 'Tano Y Chamorro' slogan, the 12x6 in aluminium construction, the mounting-hole arrangement, and the 'coded by municipality' claim"
+      - "http://www.worldlicenseplates.com/world/PA_GUAM.html  # CORROBORATION + GAP-FINDER: an independent listing of Guam's plate generations as '1986 Series / 1994 Series / 2009 Series', which is what makes the 2009 boundary secondary-CORROBORATED rather than single-sourced; and the finding that on the 1994 series it is the COMMERCIAL plates whose last three letters encode the municipality (FAP Fort Apugan, MLL Mount Lamlam). No licence statement on the site — treated as all rights reserved, facts only, no text or images copied"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §2.1: the top-centre jurisdiction-name placement Guam's statutory 'Guam' legend in fact occupies"
+    notes: >-
+      GUAM STANDARD ISSUE, CURRENT BASE. THE PERIOD IS THE WEAKEST CLAIM IN THIS
+      ENTRY AND IS LABELLED AS SUCH: `period_evidence: secondary-corroborated`
+      means two independent secondary sources agree on a 2009 boundary and NO
+      primary was found — Guam files no registration regulations, DRT's site was
+      unreachable, and 16 GCA is design-silent by construction. It is minted as a
+      dated series (rather than left undated as in Florida and Puerto Rico) only
+      because two independent sources agree AND because the previous base has a
+      demonstrably different serial arrangement, so the boundary is a format
+      boundary and not merely a styling change. THE STRENGTH OF THIS ENTRY IS
+      ELSEWHERE: the two-plate rule, the mandatory word "Guam", the year-or-device
+      rule and the rectangular shape are all quoted from an edict of government.
+
+  - id: us-gu-standard-1994
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1994, end: 2009 }
+    period_evidence: secondary-corroborated
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{1,3}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "no statutory grammar; the locator describes the numeric group as VARIABLE in width, which is why the quantifier is {1,3} rather than {3}" }
+      pattern_note: "the pattern shows the widest printed form; the regex admits the narrower forms the locator reports"
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+      note: "design not described here beyond its existence — the preceding base's artwork is L4 scope and its evidence is a photograph, not an instrument"
+    region_encoding: >-
+      THE ONE PLACE A GUAM DECODE CLAIM HAS ANY SPECIFICITY, and it is narrower
+      than the popular version: worldlicenseplates states that on this series the
+      LAST THREE LETTERS OF COMMERCIAL PLATES designate the municipality, giving
+      FAP (Fort Apugan) and MLL (Mount Lamlam) as examples and noting others
+      exist. That is a claim about commercial plates only. It is recorded, not
+      built into a decode table, because it is single-sourced and because the
+      surviving example codes do not obviously map to Guam's nineteen villages.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Guam  # LOCATOR ONLY: the 1994 to Feb 26 2009 window, the ABC 123 arrangement with variable digits, and the 'coded by village' claim"
+      - "http://www.worldlicenseplates.com/world/PA_GUAM.html  # CORROBORATION: an independent '1994 Series' listing, and the narrower and more specific municipality-coding claim quoted in region_encoding"
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # § 7120 — the statutory frame this series sat inside, unchanged across the boundary: the same two-plate rule, the same mandatory 'Guam' legend, the same delegated size"
+    notes: >-
+      GUAM'S PREVIOUS STANDARD BASE — the "one series back" PRD-PLATES §7 asks for
+      at L2. IT IS MINTED WITH ITS EVIDENCE GRADE ON ITS FACE. Both boundaries are
+      secondary; no Guam instrument marks either. The reason it earns a series
+      rather than a note is that the SERIAL ARRANGEMENT CHANGED at the boundary
+      (three letters and up to three numerals, versus two letters and four
+      numerals), so a parse API that treats Guam as one grammar will
+      systematically misread one generation or the other. THE FOLKLORE FLAG:
+      "coded by village" is repeated for Guam the way "1956 AMA agreement" is
+      repeated for plate sizes. The only specific evidence found says something
+      different — commercial plates, last three letters, municipality — and the two
+      claims are recorded side by side rather than merged.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES — all statutory, and several of them are specified
+  # far more tightly than the standard plate is.
+  # =========================================================================
+  - id: us-gu-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 1952 }
+    period_evidence: statutory-enactment-date
+    matching: strict
+    format:
+      pattern: "9999"
+      regex: '\A\d+\z'
+      charset:
+        notes: >-
+          § 7126, verbatim: "License plates issued for trailers, semi-trailers,
+          bicycles with motor attached, pole and pipe dollies and such vehicles as
+          are exempt from the payment of registration fees under this Title shall
+          display suitable marks or symbols, and THE REGISTRATION NUMBERS ASSIGNED
+          TO EACH SUCH CLASS OF VEHICLES SHALL RUN IN A SEPARATE NUMERICAL SERIES,
+          except that the registration numbers assigned to such vehicles as are
+          exempt from the payment of registration fees may run in several separate
+          numerical series." A separate NUMERICAL series with NO STATED WIDTH —
+          hence the unbounded quantifier, which makes no width claim.
+      progression: "separate numerical series per class of vehicle; fee-exempt vehicles may run in several such series"
+    design:
+      plate: { note: "size delegated to the Director under § 7120(c); no Guam instrument fixes it" }
+      marks: "§ 7126 requires 'suitable marks or symbols' distinguishing the class — the statute names the requirement and not the mark"
+      emblem: { present: false }
+    region_encoding: none
+    sources:
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # § 7126 (GC § 23321, enacted P.L. 1-088, Nov. 29, 1952): the separate numerical series for trailers, semi-trailers, motor bicycles, pole and pipe dollies and fee-exempt vehicles, and the 'suitable marks or symbols' requirement; § 7124 (added P.L. 14-075:4, Nov. 9, 1977, amended P.L. 29-002, May 18, 2007) separately requires DRT to register and plate a bicycle equipped with a motor at $20 initial and $20 annual"
+    notes: >-
+      TRAILERS AND THE FEE-EXEMPT FAMILY. This entry exists because § 7126 does
+      something a plate dataset can actually use: it makes the SEPARATE NUMERICAL
+      SERIES a legal fact rather than an observed practice. That is the same
+      statutory shape as Florida's "Horseless Carriage No. 1" and it deserves the
+      same treatment — an unbounded numeric regex that claims a form and not a
+      width. NOTE THE SWEEP: Guam puts trailers, semi-trailers, motorised bicycles
+      and pole/pipe dollies in one provision, and separately allows the fee-exempt
+      population to be split across SEVERAL numerical series, so "one Guam trailer
+      grammar" is not a safe assumption.
+
+  - id: us-gu-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 1952 }
+    period_evidence: statutory-enactment-date
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          § 7128(b)-(c) describes the STRUCTURE without giving the grammar: dealer
+          plates "shall be numbered in a separate numerical series and bear a
+          suitable mark or symbol"; the Department issues plates "which shall have
+          displayed thereon the general distinguishing number assigned to the
+          applicant", and "each plate or pair of plates so issued shall also
+          contain a number or symbol identifying the same from every other plate or
+          pair of plates bearing a like general distinguishing number." So the
+          serial is composite — a per-DEALER number plus a per-PLATE discriminator
+          — and no width or alphabet is stated for either part.
+      pattern_note: >-
+        ILLUSTRATIVE PATTERN, STATUTORY-BOUND REGEX. `matching: recall-only`
+        because the regex is deliberately wider than anything Guam issues: a match
+        is a shape hit and never a claim that the string is a valid Guam dealer
+        plate. The composite structure above is the thing to encode when a Guam
+        primary finally gives the grammar.
+    design:
+      plate: { note: "size delegated under § 7120(c)" }
+      marks: "§ 7128(b): 'a suitable mark or symbol'"
+      emblem: { present: false }
+    binding: business
+    eligibility: >-
+      § 7127: a dealer or distributor may operate an otherwise-registrable vehicle
+      on the highways WITHOUT REGISTERING IT "solely for the purpose of testing,
+      demonstrating, repairing, delivering, servicing, storing or selling such
+      vehicle", on condition that a special plate issued to that owner is
+      displayed. § 7128(a) requires a written application with proof of bona fide
+      dealer or distributor status; § 7128(b) requires DRT to issue a CERTIFICATE
+      listing the plates assigned.
+    fee: "§ 7170: forty dollars ($40.00) for each special plate issued to or renewed by a dealer or distributor"
+    region_encoding: none
+    sources:
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # § 7127 (GC § 23322, P.L. 1-088, Nov. 29, 1952) the seven permitted dealer uses and the display condition; § 7128 (GC § 23323, P.L. 1-088, amended P.L. 5-017:2, Mar. 13, 1959) the written application, the certificate listing assigned plates, the separate numerical series with a suitable mark or symbol, and the composite general-distinguishing-number-plus-discriminator structure; § 7170 (amended P.L. 29-002:V:I:45, May 18, 2007) the $40 fee"
+    notes: >-
+      DEALER PLATES. `binding: business` — the plate follows the licensed dealer,
+      not a vehicle. THE INTERESTING STRUCTURAL FACT is § 7128(c)'s composite
+      serial: a "general distinguishing number" identifies the DEALER and a further
+      number or symbol distinguishes each plate WITHIN that dealer's allocation.
+      That is a two-level namespace inside a single plate serial, and it is the
+      kind of thing a parse API can decode once the grammar is known — so the
+      absence of the grammar is flagged as a high-value gap rather than shrugged off.
+
+  - id: us-gu-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2014 }
+    period_evidence: statutory-enactment-date
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          NO SERIAL AT ALL IS PRESCRIBED — and that is the point. § 7179(c)
+          prescribes CONTENT instead: the dealer or distributor "shall mark or
+          stamp thereon with indelible ink IN LETTERS AT LEAST THREE-FOURTHS (3/4)
+          OF AN INCH HIGH" (1) the words "Guam Temporary Registration"; (2) the
+          dealer's or distributor's name; (3) the date of issuance; (4) the date of
+          expiration; and (5) the year, make, model and VIN of the vehicle. A Guam
+          temporary plate is a FORM, not a serial — which is why the regex is a
+          catch-all and `matching` is recall-only.
+      pattern_note: "illustrative only; there is no Guam temporary-plate serial grammar to encode"
+    design:
+      plate: { note: "size delegated; § 7179(c) fixes a MINIMUM CHARACTER HEIGHT of 0.75 in for the marked content — the only character-height figure in the whole of Guam's plate law" }
+      legend_top: "GUAM TEMPORARY REGISTRATION"
+      legend_basis: "STATUTORY — § 7179(c)(1) prescribes the exact words"
+      emblem: { present: false }
+    validity: >-
+      § 7179(e): valid for SIXTY (60) DAYS from issuance, or until a permanent
+      registration plate issues, or until the purchase contract is cancelled or
+      rescinded — whichever occurs FIRST.
+    issuer: >-
+      NOT THE DEPARTMENT. § 7179(a)-(b): DRT AUTHORISES dealers and distributors of
+      motor vehicles, motorcycles and commercial vehicles to ISSUE the plates
+      themselves, for a fee of not more than ten dollars ($10) each, to purchasers
+      of unregistered vehicles. § 7179(d) requires the dealer to keep a five-field
+      record for at least three years, open to Department inspection in business
+      hours.
+    region_encoding: none
+    sources:
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # § 7179 (added P.L. 32-156:2, May 21, 2014): dealer authorisation to issue, the $10 cap, the five mandatory marked fields, the 0.75-inch minimum letter height, the three-way 60-day validity rule, and the three-year dealer record-keeping duty; § 7104 (GC § 23303, P.L. 1-088, amended P.L. 29-002, 2007) separately empowers DRT itself to grant a temporary PERMIT pending action on a registration application, at $5 (Permit A) or $10 (Permit B)"
+    notes: >-
+      GUAM TEMPORARY REGISTRATION PLATES — and the cleanest statutory date in this
+      file. `period_evidence: statutory-enactment-date` with a real instrument
+      behind it: P.L. 32-156:2, May 21, 2014. TWO THINGS MAKE THIS SERIES WORTH
+      SPECCING. First, GUAM DELEGATES ISSUANCE TO PRIVATE DEALERS, so the "issuing
+      authority" for a Guam temporary plate is a car dealership operating under a
+      DRT authorisation — a binding that a jurisdiction-keyed schema has to be
+      told about. Second, the plate carries NO SERIAL: its identity is the dealer
+      name plus the VIN plus two dates. Any parser that expects a registration mark
+      here will find a form instead, and `matching: recall-only` is the honest
+      signal for that.
+
+  - id: us-gu-government-officials
+    class: government
+    categories: [car]
+    period: { start: 1971 }
+    period_evidence: statutory-enactment-date
+    matching: strict
+    format:
+      pattern: "9"
+      regex: '\A\d(?:-[A-Z])?\z'
+      charset:
+        notes: >-
+          THE ONLY FULLY-SPECIFIED SERIAL GRAMMAR IN GUAM'S PLATE LAW, and it is
+          specified by ENUMERATION rather than by rule. § 7122 assigns: "1" to
+          I Maga'haga/Maga'lahi (the Governor); "1-A" to I Sigundo
+          Maga'haga/Maga'lahi (the Lieutenant Governor); "2" to the Speaker; "2-A"
+          to the Vice-Speaker; "2-B" to the Legislative Secretary; "2-C through
+          2-Z" to Senators; "3" to the District Court Judge; "3-A through 3-Z" to
+          Superior Court Judges; and "4-A through 4-Z" to Mayors. The regex is that
+          table's shape exactly: a single digit, optionally followed by a hyphen
+          and one letter.
+      progression: >-
+        § 7122: within an office held by more than one person, plates issue "in
+        sequence based upon their LAST NAMES IN ALPHABETICAL ORDER" — except
+        Superior Court Judges, who are sequenced BY SENIORITY. A serial that
+        encodes alphabetical position is unusual enough to be worth recording; one
+        that switches to seniority for a single office is a genuine curiosity.
+    design:
+      plate: { note: "size delegated under § 7120(c)" }
+      emblem: { present: true, rendered: placeholder }
+    binding: office
+    eligibility: >-
+      § 7122: these are issued to the named officials FOR USE ON THEIR
+      PRIVATELY-OWNED VEHICLES, on assumption of office, and must be SURRENDERED to
+      the Department on removal from office for any cause. The section expressly
+      preserves the ordinary registration and licensing requirements for those
+      vehicles, and expressly does not prevent separate issuance of government-of-
+      Guam plates to official government-owned vehicles.
+    region_encoding: >-
+      OFFICE ENCODING, NOT GEOGRAPHIC. The leading digit is the branch/office
+      class (1 executive, 2 legislature, 3 judiciary, 4 mayors) and the letter is
+      the ordinal within it. This is a genuine, statutory, fully-enumerated decode
+      and it is the single most decode-rich fact found in the territories group.
+    sources:
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # § 7122 (GC § 23319.2, enacted P.L. 11-077:1, July 28, 1971): the complete office-to-plate-number table, the alphabetical and seniority sequencing rules, the assumption-of-office issuance and surrender-on-removal duties, and the savings clauses. Compiler notes record that 'Governor'/'Lieutenant Governor' now read as I Maga'haga/Maga'lahi and I Sigundo Maga'haga/Maga'lahi per 5 GCA § 1510, and that 'Commissioners' reads as 'Mayors' per P.L. 20-033:1 (Sept. 6, 1989)"
+    notes: >-
+      GUAM'S RESERVED OFFICIAL PLATE NUMBERS. This is the entry that justifies
+      reading territory statutes instead of territory brochures: a complete,
+      citable, government-issued decode table for a plate serial, sitting in a
+      1971 statute, that no competing dataset carries. TWO CAVEATS ON ITS FACE.
+      First, the CLASS is recorded as `government` because that is the nearest
+      value in _meta/classes.yml, but the binding is to an OFFICE and the vehicle
+      is PRIVATELY OWNED — neither the class definition nor `binding: business`
+      fits, and `binding: office` is used here as a vocabulary-growth candidate.
+      Second, the range notation "2-C through 2-Z" is a STATUTORY RANGE, not an
+      observed one; whether Guam has ever issued 2-Q or 3-X is unknown and is not
+      claimed.
+
+  - id: us-gu-government-fleet
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 1952 }
+    period_evidence: statutory-enactment-date
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "no grammar stated; § 7136(a) requires only 'a distinguishing symbol, word or letter' in place of the year number" }
+      pattern_note: "illustrative only — see us-gu-dealer's note; the same recall-only discipline applies"
+    design:
+      plate: { note: "size delegated under § 7120(c)" }
+      year_number: "§ 7136(a): a plate for a publicly-owned vehicle NEED NOT display the year number, 'but shall display a distinguishing symbol, word or letter'"
+      emblem: { present: true, rendered: placeholder }
+    validity: >-
+      PERMANENT. § 7136(b): the registration and registration card for a
+      government vehicle "shall not be renewed annually but shall remain valid
+      until the certificate of ownership for such vehicle is suspended, revoked or
+      canceled by the Department of Revenue and Taxation for cause or upon transfer
+      of any interest in such certificate of ownership." On a change of ownership
+      the vehicle is re-registered as a private vehicle and the government plates
+      are surrendered. § 7136(c) reserves DRT's power to suspend, cancel, revoke or
+      renew a permanent registration when reissue is advisable.
+    fee: "§ 7169 addresses fees for government cars separately from the general schedule"
+    region_encoding: none
+    sources:
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # § 7136 (GC § 23330, enacted P.L. 1-088, Nov. 29, 1952): the year-number exemption and the mandatory distinguishing symbol/word/letter, permanent non-renewing registration, surrender and re-registration on transfer, and DRT's reissue power"
+    notes: >-
+      GOVERNMENT FLEET PLATES. Kept separate from us-gu-government-officials
+      because the two are different animals under the same class value: § 7122
+      plates go on PRIVATE cars belonging to named office-holders and carry
+      enumerated numbers, while § 7136 plates go on PUBLICLY OWNED vehicles, carry
+      an unspecified distinguishing mark, and never expire. § 7122 itself draws
+      the line, saying nothing in it prevents "the issuance of special government
+      of Guam plates to the official government-owned vehicles assigned to any
+      public officer". THE PERMANENT-REGISTRATION FACT is the one to carry into the
+      parse layer: a Guam government plate has no year and no expiry, so
+      era-inference from a validation device silently fails on this series.
+
+  # =========================================================================
+  # PERSONALISED — and Guam is one of the few jurisdictions anywhere whose
+  # vanity-plate LENGTH CAP is in primary law.
+  # =========================================================================
+  - id: us-gu-personalized
+    class: personalized
+    categories: [car, truck, trailer]
+    period: { start: 1975 }
+    period_evidence: statutory-enactment-date
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]{1,7}\z'
+      charset:
+        notes: >-
+          § 7123(c), verbatim: a personalised plate "shall consist of numbers or
+          letters, or any combination thereof NOT EXCEEDING SEVEN (7) POSITIONS
+          provided that there are no conflicts with existing passenger, commercial,
+          trailer, motorcycle or special license plates series or with the
+          provisions of §§ 7121 and 7122." Seven positions is a hard statutory cap,
+          and the no-conflict proviso is itself a sourced fact about the shape of
+          Guam's whole serial space.
+      progression: "§ 7123(f): 'There shall be no duplication of registration numbers' — the applicant nominates the combination on a DRT form by a DRT-set date"
+    design:
+      plate: { note: "§ 7123(c): 'A personalized license plates shall be the same COLOR AND DESIGN as regular passenger vehicle, commercial vehicle or trailer license plates' — so the design question reduces exactly to the standard series' design question, and inherits its gaps" }
+      emblem: { present: true, rendered: placeholder }
+    fee: >-
+      § 7123(g): the cost of the plate plus an additional fifty dollars ($50.00)
+      on top of the regular registration fee; twenty dollars ($20.00) additional on
+      renewal. § 7123(i): a twenty-five dollar ($25.00) transfer fee. § 7123(h):
+      ALL of this revenue goes to the DRIVERS EDUCATION FUND, and § 7123(a) states
+      that funding driver education IS the section's purpose.
+    region_encoding: none
+    sources:
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # § 7123 (GC § 23319.3, enacted P.L. 13-100:1, Nov. 23, 1975; (c) amended P.L. 18-023:3, Dec. 15, 1985; (g) and (i) amended P.L. 29-002, May 18, 2007): the seven-position cap, the numbers-or-letters-or-both alphabet, the no-conflict proviso against the passenger/commercial/trailer/motorcycle/special series and against §§ 7121-7122, the same-colour-and-design rule, the no-duplication rule, the $50/$20/$25 fees and the Drivers Education Fund destination"
+    notes: >-
+      GUAM PERSONALISED PLATES. Modelled as its own series because the SERIAL
+      SOURCE differs — owner-nominated rather than department-assigned. THE
+      NO-CONFLICT PROVISO IS THE SLEEPER FACT: § 7123(c) forbids a personalised
+      combination that collides with the passenger, commercial, trailer,
+      motorcycle or special series, or with the §§ 7121-7122 call-sign and official
+      series. That single sentence is primary-source evidence that Guam runs at
+      least six distinct serial namespaces, which is far more than the two this
+      file can currently spec — and it is the best available map of what is still
+      missing.
+
+  # =========================================================================
+  # SPECIALTY — INDEX ONLY, per PRD-PLATES §2.5. Guam's specialty catalogue is
+  # statutory, and one member of it has a serial rule strange enough to spec.
+  # =========================================================================
+  - id: us-gu-amateur-radio
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 1964 }
+    period_evidence: statutory-enactment-date
+    matching: recall-only
+    format:
+      pattern: "LL9LL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          THE SERIAL IS NOT GUAM'S. § 7121(a): the holder of an unexpired amateur
+          or citizens radio station licence (other than a novice licence) may apply
+          for a plate "on which, IN LIEU OF THE NUMBER OTHERWISE PRESCRIBED, shall
+          be inscribed the OFFICIAL AMATEUR OR CITIZENS RADIO STATION CALL LETTERS
+          of the applicant AS ASSIGNED BY THE FEDERAL COMMUNICATIONS COMMISSION."
+          So the grammar belongs to the FCC, not to DRT — and the FCC call-sign
+          rules were NOT pinned in this pass. `matching: recall-only` is therefore
+          mandatory: the regex is a shape catch-all and a match says nothing.
+      pattern_note: >-
+        The pattern shows the general shape of a US amateur call sign (prefix
+        letters, a numeral, suffix letters) purely as an illustration. It is NOT a
+        sourced grammar and must not be treated as one until 47 CFR is pinned.
+    design:
+      plate: { note: "size delegated under § 7120(c); § 7121(c) issues it IN LIEU OF the regular plate, so its physical form follows the standard series" }
+      emblem: { present: true, rendered: placeholder }
+    fee: "§ 7121(b): in addition to the regular registration fee, not exceeding ten dollars ($10.00), charged again whenever the vehicle or its ownership changes"
+    limit: "§ 7121(c): 'The Department shall not issue more than one (1) special plate for any licensed amateur or citizens radio station.'"
+    region_encoding: none
+    sources:
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # § 7121 (GC § 23319.1, enacted P.L. 7-075:1, Jan. 30, 1964, amended P.L. 8-105:2, Feb. 24, 1966): the FCC call-letter serial in lieu of the ordinary number, the novice-licence exclusion, the proof requirement, the $10 fee and the one-plate-per-station limit"
+    notes: >-
+      AMATEUR AND CITIZENS RADIO PLATES. Given its own series rather than folded
+      into the specialty index because the FORMAT differs categorically: this is
+      the only Guam plate whose serial is assigned by a FEDERAL agency and merely
+      transcribed by DRT. It is the cross-jurisdictional twin of Puerto Rico's
+      Art. 2.28 radio-amateur plate, which does exactly the same thing in almost
+      the same words — two territories, two statutes, one delegation to the FCC.
+      RECORDED GAP: 47 CFR's call-sign format rules were not fetched, so no strict
+      grammar is offered; pinning them would upgrade both this series and PR's from
+      recall-only to strict in one step.
+
+  - id: us-gu-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 1995 }
+    period_evidence: statutory-enactment-date
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "specialty plates carry ordinary serials on an alternative design; § 7123(c)'s no-conflict proviso confirms 'special license plates series' is its own namespace" }
+      pattern_note: "illustrative only — this is an INDEX entry, not a spec"
+    design:
+      plate: { note: "one design per statutory programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here" }
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_statutory: 7
+      count_basis: >-
+        SEVEN PROGRAMMES ARE CREATED BY 16 GCA CH. 7 ITSELF. Like Puerto Rico and
+        unlike most US states, Guam's specialty catalogue is an EDICT rather than a
+        brochure, so the count is citable per programme.
+      statutory_programs:
+        - "§ 7120.1 — SPECIAL PLATES AND REMOVABLE WINDSHIELD PLACARDS for qualified persons with a disability, defined by five clinical criteria; uses the International Symbol of Accessibility as adopted by Rehabilitation International in 1969. Added P.L. 23-011:7 (Apr. 26, 1995); §(a)(4) amended P.L. 36-032:1 (June 11, 2021)"
+        - "§ 7120.2 — VETERAN PLATES, with a definition of 'veteran' that is Guam-specific: it expressly includes a Republic of Korea soldier who fought alongside US forces in Vietnam and acquired US citizenship, and members of the WWII Guam Combat Patrol, Wake Island Defenders, Guam Militia and Civilian Scouts. Added P.L. 24-066:2 (Sept. 30, 1997)"
+        - "§ 7120.3 — SPECIAL GOLD STAR PLATES for bereaved parents, widows and widowers, with a statutory design constraint: 'a gold star shall appear on one (1) side of the license plate'. Fee waived. Added P.L. 30-062:2 (Nov. 27, 2009); §(a) amended P.L. 32-003:1 (Mar. 6, 2013); §(b) amended P.L. 30-161:1 (July 16, 2010)"
+        - "§ 7120.4 — FIREFIGHTER PLATES, issued in lieu of regular plates, 'the same standard size and shape as a regular passenger vehicle license plate', type and style set jointly by the Director of DRT and the Chief of the Guam Fire Department; limited to two vehicles per firefighter; fees may not be subsidised. Added P.L. 33-099:1 (Dec. 1, 2015)"
+        - "§ 7120.5 — SPECIAL RECOGNITION VETERANS PLATE for recipients of the Medal of Honor, Distinguished Service Cross, Distinguished Flying Cross, Navy Cross, Air Force Cross, Silver Star, Bronze Star with 'V' device, or the Purple Heart. Added P.L. 33-185:XII:23 (Sept. 10, 2016)"
+        - "§ 7121 — AMATEUR AND CITIZENS RADIO STATION plates (specced separately as us-gu-amateur-radio because its serial grammar is categorically different)"
+        - "§ 7122 — GOVERNMENT OFFICIALS' reserved numbers (specced separately as us-gu-government-officials because it carries a full decode table)"
+      official_list_url: "https://col.guamcourts.gov/guam-code-annotated/guam-code-annotated"
+      official_list_note: >-
+        THE STATUTE IS THE CATALOGUE. DRT publishes no specialty gallery that was
+        reachable in this pass — guamtax.com refused every connection — and
+        30 GAR Div. 2 ch. 6 files no rules. Guam therefore has no
+        agency-published specialty list to index; the index above IS the complete
+        list, which is an unusually strong position for a specialty index to be in.
+      churn_note: "no discontinuation duty analogous to Florida's § 320.08056(8)(a) appears in 16 GCA ch. 7 — Guam's programmes are added by public law and, so far as the compiled chapter shows, are never automatically retired"
+    region_encoding: none
+    sources:
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # §§ 7120.1-7120.5, 7121, 7122 — the seven statutory specialty programmes with their eligibility rules, design constraints, fee rules, per-programme public-law enactment dates and amendment histories"
+      - "https://col.guamcourts.gov/sites/default/files/30GAR002-5_8.pdf  # 30 GAR Div. 2 ch. 6 'VEHICLE REGISTRATION — (No rules filed.)' — the measured negative behind the official_list_note: there is no administrative layer in which an unlisted Guam specialty programme could be hiding"
+      - "http://www.plateshack.com/guam/guam.html  # CORROBORATION ONLY: an independent Guam plate page confirming passenger issues at 1969, 1973, 1974, 1976, 1977, 1982, 1983, 1986, 1988, 1993, 1998, 2000, 2004 and 2005, plus separate motorcycle and 'oddball' sections. Carries an explicit 'Copyright 1997-2006. Please ask permission before using any images' notice, which is respected: no image or text was copied and the page informs no asserted fact"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — one entry standing for the whole programme, per
+      PRD-PLATES §2.5. THE HEADLINE IS THAT GUAM'S INDEX IS COMPLETE AND CITED,
+      which almost no US state's is: because the programmes are created by public
+      law and there is no administrative layer, the seven sections above are
+      demonstrably the whole set as of the compiled edition. `period: {start: 1995}`
+      is the enactment of the earliest surviving programme (§ 7120.1, P.L. 23-011,
+      Apr. 26, 1995) and each later programme carries its own date in the list.
+      RECORDED GAP: plateshack's Guam page shows a MOTORCYCLE section, and
+      § 7123(c) names a motorcycle series in its no-conflict proviso, so Guam
+      plainly serialises motorcycles separately — but no Guam instrument describing
+      that series was found, and it is therefore not minted. That is the largest
+      single gap in this file.

--- a/plates/us-mp.yml
+++ b/plates/us-mp.yml
@@ -1,0 +1,402 @@
+# plates/us-mp.yml — Commonwealth of the Northern Mariana Islands (PRD-PLATES L2).
+#
+# THE CNMI'S VEHICLE CODE IS REACHABLE AND WELL-STRUCTURED: Title 9 of the
+# Commonwealth Code, Division 2 ("Registration and Licenses"), served
+# section-by-section as PDFs by cnmilaw.org, the Commonwealth Law Revision
+# Commission's site. Chapter 2 establishes the Bureau of Motor Vehicles;
+# §§ 2101-2120 carry registration; § 2106 carries display.
+#
+# THE FIND THAT MAKES THIS FILE WORTH HAVING is in an unexpected place. Title 9
+# never describes the standard plate's design — but § 2116(c)(1), specifying
+# where the word "VETERAN" goes on a VETERAN plate, does it by reference:
+# "Below the line 'HAFA ADAI' will be the word 'VETERAN'...". That single
+# subordinate clause is STATUTORY CONFIRMATION that the CNMI standard plate
+# carries a HAFA ADAI legend, and it is the only instrument-grade design fact
+# available for this jurisdiction. Reading the specialty section to source the
+# standard plate is the kind of thing that only happens if you read the statute
+# rather than the brochure.
+#
+# WHAT IS DELIBERATELY NOT HERE (PRD-PLATES §2.5): individual specialty DESIGNS.
+jurisdiction: us-mp
+authority:
+  name: CNMI Bureau of Motor Vehicles, Department of Public Safety
+  url: "https://www.cnmilaw.org/cmc.php"
+binding: vehicle
+statute_edition: >-
+  9 CMC (Vehicle Code), Division 2, as served section-by-section by
+  cnmilaw.org in this pass. The served text is current at least to PL 24-23 § 2
+  (Mar. 11, 2026), which amends § 2116 — so the edition read is a 2026 edition.
+  Each section carries a Commission source line and, from roughly PL 18 onward,
+  dated amendments; earlier public laws (PL 3-61, PL 5-39, PL 6-5, PL 14-16) are
+  cited by NUMBER ONLY in the Commission's text, with no date, which is why
+  several period claims below are upper bounds rather than enactment dates.
+authority_url_note: >-
+  The Department of Public Safety's own site (dps.gov.mp) returned HTTP 401 on
+  every attempt and could not be used. The authority URL therefore points at the
+  Commonwealth Code, which is the primary-source home of every claim in this
+  file. Recorded as a dead end, not papered over.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4 / §7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched-presumed-protected
+  basis: >-
+    The same two facts that govern Guam and the US Virgin Islands govern the
+    CNMI, and they point the same way. First, US federal copyright law APPLIES:
+    the US Copyright Office states that "US federal copyright law applies in the
+    US Virgin Islands, Guam, and the Northern Mariana Islands but not in American
+    Samoa". Second, NO Commons public-domain tag exists for the CNMI government —
+    Template:PD-CNMIGov returns 404 — and {{PD-USGov-Unincorporated}} is limited
+    to UNORGANIZED territories, which the CNMI (a Commonwealth in political union
+    with the United States, with its own constitution) is emphatically not.
+  conclusion: >-
+    Treat CNMI plate ARTWORK as presumptively protected. No CNMI statute,
+    executive order or Commonwealth court decision on government-work copyright
+    was located; that is a recorded gap. Note that 9 CMC § 2116(c)(1) itself
+    requires the CNMI FLAG to appear on veteran plates alongside the US flag, and
+    flags carry protection regimes independent of copyright — so even a
+    favourable copyright finding would not clear that element.
+  edicts: >-
+    Edicts of government are public domain at every level
+    ({{PD-US-GovEdict}}), so 9 CMC — the source of every factual claim in this
+    file, including the HAFA ADAI legend — is unambiguously free to use.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to the CNMI flag, the latte stone
+    and the Commonwealth seal. Render `emblem: {present: true, rendered:
+    placeholder}`. The HAFA ADAI legend is TEXT, is stated in an edict, and is a
+    fact rather than artwork — it may be set in a substitute typeface without
+    touching the artwork question.
+  photograph_caution: >-
+    plateshack.com and worldlicenseplates.com carry no reusable licence and are
+    treated as all rights reserved; no image was copied.
+  sources:
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # the US Copyright Office position that federal copyright law applies in the Northern Mariana Islands; the US Territories tag list, which has no CNMI entry; and the UNORGANIZED-territories limit on {{PD-USGov-Unincorporated}}"
+    - "https://commons.wikimedia.org/wiki/Template:PD-CNMIGov  # HTTP 404 — a measured negative: no Commons public-domain tag exists for the CNMI government"
+    - "https://cnmilaw.org/pdf/cmc_section/T9/2116.pdf  # 9 CMC § 2116(c)(1), which requires the CNMI flag on the plate — an element outside copyright's reach either way"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. NOTHING here quotes SAE J686 (paywalled, unpinned).
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  cnmi_position: >-
+    9 CMC references no external standard. It does, however, legislate a
+    LEGIBILITY DISTANCE of its own — § 2106 requires the numbers to be "clearly
+    visible from a distance of 50 feet" — which is a Commonwealth requirement, not
+    an AAMVA one, and is a third of AAMVA's recommended 75 feet.
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is PAYWALLED and was NOT obtained. No J686 dimension is quoted here."
+    retroreflectivity: "AAMVA §3.3 recommends readability 'in both daylight and nighttime from distances of at least 75 feet'. The CNMI legislates 50 feet in § 2106 and says nothing about daylight or darkness — a materially weaker and differently-framed requirement, recorded as a real divergence"
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in"
+    replacement_cycle: "AAMVA §1.1 recommends a 7-10 year replacement cycle. The CNMI legislates none; § 2107 expires registration annually and § 2106 requires the plate to show the YEAR, so validation rather than replacement is the mechanism"
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+
+# ---------------------------------------------------------------------------
+# Display rules — statutory, and the CNMI's are unusually well-motivated: the
+# legislature published its reasoning when it tightened them in 2004.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: >-
+    TWO plates, front and rear, AT THE FACTORY-DESIGNATED POSITION. § 2106,
+    verbatim: "Every owner whose vehicle or bicycle is registered shall display
+    the plates issued by the bureau showing the registration number AND YEAR. Each
+    of these plates shall be attached properly to the front and rear of the
+    vehicle or bicycle, AT THE FACTORY DESIGNATED POSITION. The plates shall be
+    kept clean and the numbers must be clearly visible from a distance of 50 feet.
+    No vehicle or bicycle owner may display an unofficial plate at the front or
+    rear of his vehicle or bicycle."
+  bicycles_included: >-
+    NOTE THE SWEEP, which is unusual and is not a transcription artefact: § 2106
+    applies to "vehicle OR BICYCLE" throughout, and § 2107 expires bicycle
+    registrations on the same annual cycle. The CNMI registers and plates
+    bicycles, and a plate dataset scoped to motor vehicles will silently miss a
+    real CNMI series.
+  legislative_reason: >-
+    RARE AND WORTH RECORDING. PL 14-18 (July 12, 2004), which produced the
+    current § 2106, published its findings: "The Legislature finds that many
+    vehicle owners do not display both license plates on their vehicle. Many
+    vehicle owners choose to only display the plates on the rear of the vehicles.
+    This has been problematic for the Department of Public Safety, creating
+    difficulty on identifying fleeing vehicles... The legislature further finds
+    that the bureau of Motor Vehicles issues TWO license plates upon registration
+    of a vehicle." So the two-plate ISSUANCE predates 2004; what 2004 added was
+    compulsory DISPLAY of both. That distinction dates the rule precisely and is
+    the reason this file's standard series starts at 2004 rather than earlier.
+  unofficial_plates_banned: "§ 2106's final sentence bans display of an UNOFFICIAL plate at either end — a novelty-plate prohibition in primary law"
+  expiration: >-
+    § 2107: every vehicle and bicycle registration expires ANNUALLY at midnight
+    on the last day of the month designated by the bureau — a staggered scheme,
+    like Guam's. Ten business days' grace, then a $30 late fee to a DPS special
+    account for BMV supplies. Since PL 22-34 (Jan. 31, 2023) an owner of two or
+    more vehicles may align all their expiry months for $25 per vehicle.
+  seizure: "§ 1209 empowers the bureau to SEIZE documents and plates — the CNMI counterpart to Puerto Rico's Art. 2.13 'plates are Department property' rule"
+  sources:
+    - "https://cnmilaw.org/pdf/cmc_section/T9/2106.pdf  # § 2106 (PL 3-61 § 1(§ 206), amended PL 14-18, July 12, 2004): registration number AND year on the plate, front and rear at the factory-designated position, clean and legible at 50 feet, no unofficial plates; and the published PL 14-18 findings quoted above"
+    - "https://cnmilaw.org/pdf/cmc_section/T9/2107.pdf  # § 2107 (PL 3-61 § 1(§ 207), amended PL 19-18 Nov. 6 2015, repealed and reenacted PL 20-90 Feb. 18 2019, amended PL 22-34 Jan. 31 2023): annual staggered expiry, 10 business days' grace, $30 late fee to the DPS/BMV special account, the $25 multi-vehicle alignment option"
+    - "https://cnmilaw.org/pdf/cmc_section/T9/2105.pdf  # § 2105 (PL 3-61 § 1(§ 205)): the registration card's contents and the carry-in-vehicle duty"
+    - "https://cnmilaw.org/pdf/cmc_section/T9/1209.pdf  # § 1209: the bureau's power to seize documents and plates"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES.
+  # =========================================================================
+  - id: us-mp-standard
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2004 }
+    period_evidence: statutory-amendment-date-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          9 CMC STATES NO SERIAL GRAMMAR. § 2106 requires the plate to show "the
+          registration number and year" and § 2105 requires the registration card
+          to bear "the registration number", and that is the whole of it — no
+          alphabet, no width, no exclusions. `regex_statutory` therefore carries no
+          width claim. The one place the Code DOES quantify a CNMI serial is
+          § 2116(c)(2), for veteran plates, and that grammar is specced separately.
+      pattern_note: >-
+        THE THREE-LETTER / THREE-NUMERAL ARRANGEMENT IS NOT STATUTORY. It comes
+        from a Wikipedia LOCATOR, which reports ABC 123 continuously since 1989
+        across two base generations. `matching: strict` because the arrangement
+        lies INSIDE the (empty) statutory constraint and a match is a real claim
+        about this series; the outer bound is `regex_statutory`.
+      progression: "the locator reports sequential three-letter blocks (AAA 000 onward, with a reported jump to the AD-block around 2005); the specific block boundaries are NOT asserted here"
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: "NOT in any CNMI instrument; 12 x 6 in is the reported North American convention and is marked as reported. § 2116(c) confirms only that veteran plates are 'the same standard size and shape as regular passenger vehicle license plates', which fixes a RELATION without fixing a value"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed-secondary }
+      colour_note: >-
+        THE BACKGROUND IS RECORDED, THE FOREGROUND DELIBERATELY IS NOT. The
+        locator describes "dark blue embossed serials on reflective white", and
+        while "reflective white" maps to #FFFFFF without invention, "dark blue"
+        does not map to any particular hex — assigning one would be manufacturing a
+        colour value out of an adjective. The foreground is therefore left absent
+        with its description recorded, per PRD-PLATES §9's folklore discipline.
+      foreground_description: "dark blue, embossed on the older base and surface-printed on the current one (locator-grade)"
+      legend_top: "COMMONWEALTH OF THE NORTHERN MARIANA ISLANDS"
+      legend_slogan: "HAFA ADAI"
+      legend_slogan_basis: >-
+        STATUTORY, AND BY A ROUTE WORTH RECORDING. 9 CMC § 2116(c)(1) specifies
+        the veteran plate by describing where its extra text goes relative to the
+        standard plate's: "BELOW THE LINE 'HAFA ADAI' will be the word 'VETERAN' or
+        'DISABLED VETERAN' (in black lettering) bordered on the left by the United
+        States Flag and on the right by the CNMI Flag." The statute therefore takes
+        the existence and position of a HAFA ADAI line on the CNMI plate as given.
+        This is the ONLY instrument-grade design fact available for the CNMI, and it
+        was found in the specialty section, not the registration one.
+      graphic: { present: true, rendered: placeholder, description: "not described in any CNMI instrument; no graphic claim is made" }
+      emblem: { present: true, rendered: placeholder }
+      mounting_holes_reported: "one round hole top right, horizontal slots in the other three corners since 1989 — the same arrangement reported for Hawaii and Guam; locator-grade"
+      band: { side: none }
+      rear_differs: false
+    validation: "§ 2106 requires the YEAR on the plate itself, not merely on a sticker — the CNMI is one of the jurisdictions where the year is a plate property in law. Photographs of CNMI plates carrying month-and-year expirations (July 2025, March 2020, June 2013, March 2009) corroborate a per-month validation device in practice"
+    region_encoding: none
+    sources:
+      - "https://cnmilaw.org/pdf/cmc_section/T9/2106.pdf  # § 2106: the plate shows the registration number AND YEAR; front and rear at the factory-designated position; legible at 50 feet; no unofficial plates. Plus the PL 14-18 (July 12, 2004) legislative findings recording that BMV already issued TWO plates before 2004"
+      - "https://cnmilaw.org/pdf/cmc_section/T9/2116.pdf  # § 2116(c)(1): 'Below the line HAFA ADAI...' — the statutory confirmation of the standard plate's slogan line; and § 2116(c) 'the same standard size and shape as regular passenger vehicle license plates'"
+      - "https://cnmilaw.org/pdf/cmc_section/T9/2101.pdf  # § 2101: the registration application, the lawful-ownership and FMVSS-compliance evidence, and the § 2101(d) requirement that liability insurance expire in the same month as the registration"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_the_Northern_Mariana_Islands  # LOCATOR ONLY (PRD-PLATES §4): the ABC 123 arrangement since 1989, the reported 1989-2005 and 2005-present base generations and their serial blocks, the dark-blue-on-reflective-white description, the embossed-to-surface-printed change, and the mounting-hole arrangement"
+      - "http://www.plateshack.com/y2k/Northern_Marianas/cnmiy2k.html  # CORROBORATION ONLY: dated photographs of CNMI plates with July 2025, March 2020, June 2013, March 2009, 2005, 2004, 2000 and 1999 expirations, which is how the per-month validation practice was confirmed. No licence statement; no image or text copied"
+      - "http://www.worldlicenseplates.com/world/PA_NMAR.html  # CORROBORATION + GAP-FINDER: an independent CNMI page noting historical variants — plates 'with 19 embossed after the registration', the embossed 19 removed for five-digit registrations, and one plate 'Originally a government plate, repurposed and reissued as general issue DUE TO SHORTAGE'. The shortage note is the useful one: it is direct evidence that CNMI government and general serial namespaces are not hermetically separated"
+    notes: >-
+      CNMI STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED and the period is an
+      UPPER BOUND: `start: 2004` is the enactment of PL 14-18, whose published
+      findings record that BMV was ALREADY issuing two plates before that date, so
+      the true start of the current arrangement is earlier and the locator's 1989
+      figure is left in the locator where it belongs. The reported 2005 base change
+      is NOT minted as a boundary — it is a surface-printing-versus-embossing change
+      with no format consequence and no primary behind it, exactly the kind of
+      folklore boundary PRD-PLATES §9 warns against dating. THE ENTRY'S REAL VALUE
+      is the HAFA ADAI legend sourced to an edict, and the worldlicenseplates
+      shortage finding, which tells any future decode effort that CNMI government
+      plates have at least once been recycled into general issue.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES.
+  # =========================================================================
+  - id: us-mp-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "no grammar stated; § 2109 addresses only what a government plate need NOT display" }
+      pattern_note: "ILLUSTRATIVE PATTERN, CATCH-ALL REGEX. `matching: recall-only` — a match is a shape hit and never a claim that the string is a valid CNMI government plate."
+    design:
+      plate: { note: "not stated" }
+      emblem: { present: true, rendered: placeholder }
+    validity: >-
+      PERMANENT. § 2109(a)(2): the registration and registration card for a
+      Commonwealth-owned vehicle "need not be renewed annually but remains valid
+      until the certificate of ownership for the vehicle is suspended, revoked or
+      canceled by the bureau for cause or upon transfer of any interest in the
+      certificate of ownership." On a change of ownership the vehicle is
+      re-registered as a private vehicle and the special plates are surrendered.
+      § 2109(a)(3) reserves the bureau's power to suspend, cancel, revoke or renew
+      such a registration when reissue is advisable.
+    scope: "§ 2109(b): 'Each vehicle purchased from revenue of the Commonwealth government, INCLUDING ITS GOVERNMENT CORPORATIONS, AGENCIES, BOARDS OR COMMISSIONS, shall display a government license plate' — the test is the source of the purchase funds, not the identity of the registered owner"
+    textual_anomaly: >-
+      RECORDED, NOT SILENTLY CORRECTED. § 2109(a)(1) as served reads: "A license
+      plate issued for any vehicle while publicly owned NEED NOT DISPLAY A
+      DISTINGUISHING SYMBOL, WORD OR LETTER." Its evident model — Guam's 16 GCA
+      § 7136(a), which shares the provision's structure and much of its wording —
+      reads the other way round: a government plate need not display THE YEAR
+      NUMBER, "but SHALL display a distinguishing symbol, word or letter". The CNMI
+      text as compiled therefore appears to have lost the year-number exemption and
+      inverted the distinguishing-mark duty. This is flagged as a probable
+      compilation or drafting defect and is NOT relied upon in either direction;
+      PRD-PLATES §5.3 says record disagreements rather than average them, and the
+      same discipline applies to a text that disagrees with itself.
+    region_encoding: none
+    sources:
+      - "https://cnmilaw.org/pdf/cmc_section/T9/2109.pdf  # § 2109 (PL 3-61 § 1(§ 209), amended PL 6-5 § 303): the government-plate provisions in full, including the anomalous (a)(1) quoted above, permanent non-renewing registration, surrender and re-registration on transfer, the bureau's reissue power, and the (b) purchased-from-Commonwealth-revenue test"
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # Guam 16 GCA § 7136(a), cited ONLY as the comparator that makes the CNMI text's anomaly visible — the two provisions are structurally parallel and read oppositely on the same point"
+      - "http://www.worldlicenseplates.com/world/PA_NMAR.html  # CORROBORATION: a photographed 1978-series CNMI GOVERNMENT VEHICLE plate, and the note that a government plate was once repurposed and reissued as general issue during a shortage"
+    notes: >-
+      CNMI GOVERNMENT PLATES. THE PERMANENT-REGISTRATION FACT is the one to carry
+      into the parse layer: a CNMI government plate never expires, so the year that
+      § 2106 requires on every other plate cannot be relied on here, and
+      era-inference from a validation device silently fails on this series.
+      `period: {start: 2026}` is the year the Commonwealth Code was read and is an
+      upper bound; § 2109's own source line cites PL 3-61 and PL 6-5, for neither of
+      which the Commission's text supplies a date, so no earlier year could be
+      claimed without inventing it.
+
+  - id: us-mp-veteran
+    class: specialty
+    categories: [car, motorcycle]
+    period: { start: 2013 }
+    period_evidence: statutory-amendment-date-upper-bound
+    matching: strict
+    format:
+      pattern: "L999"
+      regex: '\A[A-Z]{1,2}\d{3}\z'
+      charset:
+        notes: >-
+          THE ONLY FULLY-STATED SERIAL GRAMMAR IN CNMI LAW, and it is stated by
+          example. § 2116(c)(2), verbatim: "On the next line, centered on the
+          license plate, will be the license plate number (IN BLUE LETTERING) IN
+          ALPHA NUMERIC FORMAT DESIGNATING BRANCH OF SERVICE AND NUMERICAL
+          SEQUENCE. For example, A001 (Army), NG045 (National Guard), or R610
+          (Reserves)." Three worked examples give a one- or two-letter branch code
+          followed by a three-digit sequence, which is exactly what the regex
+          encodes. The branch codes themselves are NOT enumerated in the statute —
+          A, NG and R are illustrations, not a closed set — so no decode table is
+          asserted.
+      progression: "numerical sequence within each branch code"
+    design:
+      plate: { note: "§ 2116(c): 'the same standard size and shape as regular passenger vehicle license plates' — a stated RELATION to the standard plate rather than an absolute value" }
+      legend_slogan: "HAFA ADAI"
+      legend_class: "§ 2116(c)(1): below the HAFA ADAI line, the word 'VETERAN' or 'DISABLED VETERAN' in BLACK lettering, bordered on the left by the United States Flag and on the right by the CNMI Flag"
+      foreground_class_line: "black lettering for the VETERAN / DISABLED VETERAN line (§ 2116(c)(1)); BLUE lettering for the serial (§ 2116(c)(2)) — the CNMI legislates two different ink colours on one plate, and names neither in a specifiable value"
+      accessibility_symbol: "§ 2116(c)(2): for a qualified person with a disability, the veteran plate additionally displays the International Symbol of Accessibility 'in the same size as the letters and numbers on the license plate'"
+      emblem: { present: true, rendered: placeholder }
+    eligibility: >-
+      § 2116(a): "veteran" means a person who served on active duty or in a
+      reserve component of any branch of the US Armed Forces and was discharged or
+      released under conditions other than dishonorable; "disabled veteran" adds
+      certification of at least 10% service-related disability. § 2116(b) accepts a
+      DD214, or failing that a certification from the Military and Veterans Affairs
+      Office or a VA-issued Veteran Identification Card.
+    fee: >-
+      § 2116(d): 25% LESS than the fee for a similar plate for the same class of
+      vehicle; entirely FREE for a veteran rated by the VA at 100% permanent and
+      total disability, on production of the Regional VA Office decision letter.
+    issuance_rules: >-
+      § 2116(e): issued only to the registered owner or lessee; expressly NOT
+      limited to one vehicle per veteran; not transferable to any other person,
+      except that the Commissioner "shall allow the SURVIVOR of the qualified
+      person, upon request, TO RETAIN THE FRONT LICENSE PLATE AS A MEMORIAL" —
+      which is a genuinely distinctive statutory provision, and one that only makes
+      sense in a two-plate jurisdiction. Assigned to non-commercial passenger motor
+      vehicles and non-commercial MOTORCYCLES.
+    region_encoding: none
+    sources:
+      - "https://cnmilaw.org/pdf/cmc_section/T9/2116.pdf  # § 2116 (PL 14-16 § 3; (d) amended PL 18-22 § 2, Oct. 8 2013; (g)-(h) enacted PL 19-26 § 2, Dec. 14 2015; amended PL 20-37 § 2, Jan. 18 2018; (a) and (b)(1) amended PL 24-23 § 2, Mar. 11 2026): the veteran/disabled-veteran definitions and proofs, the HAFA ADAI-relative layout, the two ink colours, the branch-code-plus-sequence serial with its three worked examples, the accessibility symbol, the 25%/100% fee rules, the multi-vehicle and non-transferability rules, and the survivor memorial provision"
+    notes: >-
+      CNMI VETERAN AND DISABLED VETERAN PLATES. SPECCED SEPARATELY FROM THE
+      SPECIALTY INDEX, and deliberately so: PRD-PLATES §2.5 excludes individual
+      specialty DESIGNS from L2, but this series carries a FORMAT — a real,
+      statutory, alpha-numeric grammar with worked examples — and a format is
+      exactly what the dataset exists to hold. PERIOD CAVEAT, STATED PLAINLY:
+      § 2116 was enacted by PL 14-16, for which the Commission's source line gives
+      NO DATE. The earliest DATED instrument in its amendment chain is PL 18-22 § 2
+      (Oct. 8, 2013), so 2013 is an UPPER BOUND on the true start, not the start.
+      CLASS CAVEAT: recorded as `specialty` because _meta/classes.yml's `military`
+      value means armed-forces REGISTRATION SYSTEMS, which this is not — it is a
+      civilian plate recognising prior service.
+
+  # =========================================================================
+  # SPECIALTY — INDEX ONLY, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-mp-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2015 }
+    period_evidence: statutory-enactment-date
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "the one CNMI specialty grammar that IS stated — the veteran branch-code format — is specced at us-mp-veteran; nothing is stated for the rest" }
+      pattern_note: "illustrative only — this is an INDEX entry, not a spec"
+    design:
+      plate: { note: "one design per programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here" }
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_statutory: 3
+      count_basis: >-
+        THREE PROGRAMMES ARE CREATED BY 9 CMC ITSELF, all of them inside a single
+        section. This is the smallest statutory specialty catalogue found anywhere
+        in the US pass, and its smallness is a finding rather than a gap: the CNMI
+        legislature has simply not built the sprawling optional-plate market that
+        Florida (over 100 programmes) or Texas (506) have.
+      statutory_programs:
+        - "§ 2116(a)-(f) — VETERAN plates (specced separately as us-mp-veteran because its serial grammar is statutory)"
+        - "§ 2116(a)-(f) — DISABLED VETERAN plates, distinguished by the class legend and by the addition of the International Symbol of Accessibility for a qualified person with a disability"
+        - "§ 2116(g)-(h) — SPECIAL GOLD STAR plates, enacted by PL 19-26 § 2 (Dec. 14, 2015): issued by BMV on application, type and style set by the Director of BMV together with the Office of Veterans Affairs, 'except that A GOLD STAR SHALL APPEAR ON ONE SIDE OF THE PLATE'; reissued to the original holder; eligibility limited to bereaved parents, stepparents, adoptive and foster parents in loco parentis, children, stepchildren and children through adoption; the fee may not exceed that for a similar plate of the same vehicle class"
+      cross_jurisdiction_note: >-
+        THE GOLD STAR PROVISION IS NEARLY WORD-FOR-WORD GUAM'S. Compare 16 GCA
+        § 7120.3 ("The type and style of the gold star license plates shall be
+        determined by the Director ... except that a gold star shall appear on one
+        (1) side of the license plate") with 9 CMC § 2116(g). Guam enacted its
+        version in P.L. 30-062 (Nov. 27, 2009); the CNMI enacted its version in
+        PL 19-26 (Dec. 14, 2015), six years later. This is a documented instance of
+        one territory's plate statute being copied by another, and it is worth
+        recording because it means the two jurisdictions' gold-star series can be
+        expected to behave identically — and because it is a warning that apparent
+        independent corroboration between Guam and CNMI sources may be common
+        ancestry rather than agreement.
+      official_list_url: "https://www.cnmilaw.org/cmc.php"
+      official_list_note: >-
+        THE STATUTE IS THE CATALOGUE. The Department of Public Safety's site
+        returned HTTP 401 throughout and BMV publishes no reachable specialty
+        gallery, so 9 CMC § 2116 is the only enumeration available. Whether the
+        CNMI Administrative Code carries BMV regulations adding further programmes
+        was NOT determined (recorded gap): the NMIAC is served by title at
+        cnmilaw.org but no motor-vehicle title was identified in this pass.
+      churn_note: "no discontinuation duty analogous to Florida's § 320.08056(8)(a) appears in 9 CMC; CNMI programmes are added by public law and are not automatically retired"
+    region_encoding: none
+    sources:
+      - "https://cnmilaw.org/pdf/cmc_section/T9/2116.pdf  # § 2116 in full — the veteran, disabled veteran and gold star programmes, with their per-programme public-law enactment and amendment dates"
+      - "https://www.cnmilaw.org/cmc.php  # the Commonwealth Code index served by the CNMI Law Revision Commission — the section-by-section source for all of Title 9 used here, and the only reachable official enumeration"
+      - "https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf  # Guam 16 GCA § 7120.3, cited as the evident source text for the CNMI gold-star provision — the common-ancestry finding recorded above"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — one entry standing for the whole programme, per
+      PRD-PLATES §2.5. TWO THINGS WORTH CARRYING FORWARD. First, THREE PROGRAMMES
+      IS THE WHOLE STATUTORY CATALOGUE, which makes the CNMI the cleanest specialty
+      index in the dataset and a useful counterexample to the assumption that every
+      US jurisdiction runs a sprawling optional-plate market. Second, THE
+      GOLD-STAR TEXT IS BORROWED FROM GUAM, which is a methodological finding as
+      much as a factual one: two territory statutes agreeing is not two
+      independent sources, and any verifier treating Guam and CNMI as
+      cross-corroborating should check for shared drafting first.

--- a/plates/us-pr.yml
+++ b/plates/us-pr.yml
@@ -1,0 +1,507 @@
+# plates/us-pr.yml — Puerto Rico (PRD-PLATES gate L2, territories group).
+#
+# WHY PUERTO RICO IS THE BEST-SOURCED TERRITORY IN THIS GROUP: its plate law is
+# a single consolidated statute — Ley Núm. 22 de 7 de enero de 2000, "Ley de
+# Vehículos y Tránsito de Puerto Rico" — served as a 210-page scan by the
+# Commonwealth's own Biblioteca Virtual (Oficina de Gerencia y Presupuesto).
+# Every format, display, class and specialty-program claim below cites an
+# ARTÍCULO of that law. The scan is image-only; it was OCR'd locally for this
+# pass, so Spanish diacritics in the quoted fragments are OCR-lossy and the
+# quotes are recorded as SUBSTANCE, not as verbatim transcription. That
+# limitation is stated once here and applies to every § quote in this file.
+#
+# THE DELEGATION TRAP, which is the single most important structural fact about
+# Puerto Rico plates: Art. 2.18 authorises the Secretary to fix "el diseño,
+# tamaño, colores, composición y otros detalles físicos de las tablillas, así
+# como la cantidad de tablillas que utilizarán los diferentes vehículos" BY
+# REGLAMENTO. So PR law fixes WHO issues, WHERE the plate goes and WHAT it
+# carries — and delegates every renderable property to a departmental
+# regulation that was NOT obtained in this pass. Design, size, colour and even
+# the NUMBER OF PLATES are therefore recorded as gaps, not guessed. This is the
+# same shape as Guam (16 GCA § 7120(c)) and it is the territory pattern.
+#
+# WHAT IS DELIBERATELY NOT HERE (PRD-PLATES §2.5): individual specialty DESIGNS.
+# `us-pr-specialty-index` indexes the SEVEN statutory programmes and nothing
+# more.
+jurisdiction: us-pr
+authority:
+  name: Departamento de Transportación y Obras Públicas (DTOP) — Directoría de Servicios al Conductor (DISCO/CESCO)
+  url: "https://www.dtop.pr.gov/"
+binding: vehicle
+statute_edition: >-
+  Ley Núm. 22 de 7 de enero de 2000, "Ley de Vehículos y Tránsito de Puerto
+  Rico", as served (210 pp, scanned) by bvirtual.ogp.pr.gov in this pass. The
+  served copy carries no amendment-currency statement, so the edition read is an
+  UPPER BOUND on nothing and a LOWER BOUND on everything: articles quoted here
+  are in the served text, and later amendments were not checked (recorded gap).
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4 / §7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: public-domain-favourable
+  basis: >-
+    Puerto Rico is the second-strongest public-domain posture found anywhere in
+    the US pass, after Florida — and it is the ONLY US territory that Wikimedia
+    Commons lists alongside the PD states. Commons' own summary row for the
+    United States reads: "Government = Federal, California, Florida, Georgia,
+    Massachusetts, PUERTO RICO: public domain / Other states: copyrighted", and
+    the tag {{PD-PRGov}} exists and is in active use for "media created by the
+    Commonwealth of Puerto Rico". The tag's cited basis is the US Copyright
+    Office's Compendium of US Copyright Office Practices (Third Edition),
+    Chapter 300.
+  caveat: >-
+    RECORDED HONESTLY RATHER THAN OVERSTATED. Commons itself flags the
+    limitation in terms: "Work of Organized Territories has less clear status;
+    the first link in this section shows strong evidence that Puerto Rico's
+    works are in the public domain, while the second link prevaricates." Puerto
+    Rico is an ORGANIZED territory, so it sits exactly in that contested space.
+    Treat the posture as favourable-but-contested, not as settled law, and note
+    that no PR statute or judicial decision on the point was located in this
+    pass (contrast Florida, where Microdecisions v. Skinner is squarely on
+    point).
+  edicts: >-
+    Independent of the above, EDICTS OF GOVERNMENT are public domain at every
+    level ({{PD-US-GovEdict}}), so Ley 22-2000 itself — the source of every
+    factual claim in this file — is unambiguously free to use. This is the
+    cleanest legal path for Puerto Rico and it is the one taken here.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies to the FORT / GARITA graphic
+    reported on the current base and to any Commonwealth coat of arms. Seals and
+    coats of arms carry protection INDEPENDENT of copyright, and Commons notes
+    for Puerto Rico that "Flags and coats of arms seem to follow the same laws
+    as the US", citing Ley Núm. 70 de 2006 — which was NOT fetched in this pass.
+    Render `emblem: {present: true, rendered: placeholder}`.
+  photograph_caution: >-
+    Plate photographs on plateshack.com and worldlicenseplates.com carry no
+    licence statement at all and are treated as all-rights-reserved; none was
+    copied. Because our renders are generated from the statute, no photographic
+    obligation attaches.
+  sources:
+    - "https://commons.wikimedia.org/wiki/Template:PD-PRGov  # the Puerto Rico PD tag exists and is in active use; its cited basis is the USCO Compendium (Third) ch. 300"
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # the summary row listing Puerto Rico with CA/FL/GA/MA as public domain; AND the countervailing 'Organized Territories has less clear status' caveat quoted above; AND the flags/coats-of-arms note citing Ley Núm. 70 de 2006"
+    - "https://copyright.gov/comp3/chap300/ch300-copyrightable-authorship.pdf  # USCO Compendium (Third) ch. 300 — the authority {{PD-PRGov}} itself points to"
+    - "https://bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf  # Ley 22-2000 itself — an edict of government, PD at every level"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. Recorded per PRD-PLATES §4. NOTHING here quotes SAE
+# J686, whose text is paywalled and unpinned (the standing rule).
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  applies_to_territories: >-
+    AAMVA's standard is a voluntary recommendation to its member jurisdictions,
+    which include the US territories. NO EVIDENCE WAS FOUND that Puerto Rico has
+    adopted it, and Ley 22-2000 does not reference it. The geometry below is
+    recorded as the North American convention Puerto Rico is REPORTED to follow,
+    not as a Puerto Rico legal requirement.
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose own text is PAYWALLED and was NOT obtained. No J686 dimension is quoted anywhere in this file."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges"
+    jurisdiction_name_layout: "AAMVA §2.1: jurisdiction name in the top centre between the bolt holes, at least 0.25 in above the plate number and 0.125 in from the top edge; jurisdiction characters 0.75-1.0 in"
+    replacement_cycle: "AAMVA §1.1 recommends a rolling or full replacement cycle not to exceed 7 to 10 years. Ley 22-2000 legislates NO replacement cycle at all — Puerto Rico plates renew annually (Art. 2.11) but the PLATE itself is not on a statutory replacement clock. Recorded as a real difference from Florida, which legislated 10 years."
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+
+# ---------------------------------------------------------------------------
+# Display rules. PUERTO RICO IS STATUTORILY REAR-ONLY — INCLUDING MOTORCYCLES —
+# and this is the single most valuable fact in the file, because the widely
+# repeated "rear plate only since 1976" claim is an enthusiast/encyclopedia
+# claim with no instrument behind it. Art. 2.18 states the rule in law.
+# ---------------------------------------------------------------------------
+display_rules:
+  default: >-
+    ONE plate, REAR. Art. 2.18, second paragraph: "Las tablillas serán fijadas
+    horizontalmente y en forma visible en la PARTE POSTERIOR de todo vehículo de
+    motor o arrastre, INCLUYENDO MOTOCICLETAS". Note the two things the sentence
+    does that matter: it fixes the position (rear) and the orientation
+    (horizontal), and it sweeps motorcycles into the same rule rather than
+    carving them out — which is unusual, and means a PR motorcycle plate is not
+    display-distinct from a car plate.
+  illumination: >-
+    Art. 2.18: the plate "deberá quedar alumbrada de noche por una luz incolora
+    colocada para ese fin en el vehículo que permita distinguir su número de
+    permiso, aun cuando el vehículo se encuentre en movimiento" — a COLOURLESS
+    lamp, and legibility required while the vehicle is IN MOTION.
+  plate_count: >-
+    NOT FIXED BY STATUTE. Art. 2.18 delegates "la cantidad de tablillas que
+    utilizarán los diferentes vehículos" to the Secretary by reglamento. The
+    single-rear-plate practice is universally reported but its instrument is the
+    unobtained reglamento, not the law (recorded gap).
+  validation: >-
+    Puerto Rico validates on a WINDSHIELD STICKER (the "marbete"), not on a
+    plate decal — corroborated by dated photographs of PR windshield
+    registration stickers for 2022, 2023 and 2024 expirations. Art. 2.11 sets a
+    STAGGERED annual renewal keyed to the month of first registration, and
+    excludes Commonwealth and municipal vehicles from the staggered system.
+  ownership: >-
+    Art. 2.13: every permiso and tablilla the Secretary issues "se considerará
+    PROPIEDAD DEL DEPARTAMENTO", and must be returned within thirty (30) days
+    when the vehicle goes to permanent private-property use, is abandoned as
+    unserviceable, or is scrapped. The plate is state property, not the owner's.
+  sources:
+    - "https://bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf  # Art. 2.18: rear-only including motorcycles, horizontal fixing, colourless illumination, and the delegation of design/size/colour/plate-count to reglamento; Art. 2.11: staggered annual renewal keyed to first-registration month, government/municipal exclusion, 30-day extension power; Art. 2.13: plates are Department property, 30-day return duty"
+    - "http://www.plateshack.com/y2k/Puerto_Rico/pry2k.html  # CORROBORATION ONLY (PRD-PLATES §4): dated photographs of PR WINDSHIELD registration stickers (Jan 2022, Jan 2023, Feb 2023, Jan 2024 expirations), which is how the marbete practice was confirmed against the statute's silence"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES.
+  # =========================================================================
+  - id: us-pr-standard
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: statutory-enactment-date-upper-bound
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          Art. 1.94 is the whole statutory constraint on the serial, and it is
+          remarkably thin: "Tablillas" significará la identificación individual
+          que como parte del permiso de un vehículo le expida el Secretario, "la
+          cual podrá contener NÚMEROS O LETRAS O COMBINACIÓN DE AMBOS". An
+          alphabet, and nothing else. NOTE WHAT IS ABSENT: Puerto Rico law fixes
+          NO MAXIMUM LENGTH. That is a genuine difference from Florida, whose
+          § 320.06(3)(a) caps the serial at seven characters, and it is why
+          `regex_statutory` here is unbounded rather than {0,6}. An unbounded
+          quantifier makes no width claim, which is the honest encoding of a
+          statute that makes none.
+      pattern_note: >-
+        `regex` encodes the CURRENT passenger arrangement — three letters, a
+        gap, three numerals. That arrangement is NOT in the statute; it is
+        reported by a Wikipedia locator and corroborated by dated plate
+        photographs, and it is recorded as `matching: strict` because it lies
+        INSIDE the statutory alphabet, never outside it (PRD-PLATES §2.7:
+        narrower is still strict). `regex_statutory` is the outer legal bound
+        from Art. 1.94 and is the honest matcher for a Puerto Rico plate of
+        unknown vintage.
+      progression: "sequential within the three-letter block; the specific block boundaries reported by locators (e.g. HEO/JVJ/KBV ranges) are NOT asserted here — see notes"
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: >-
+        THE DIMENSION IS NOT IN PUERTO RICO LAW. Art. 2.18 delegates "tamaño" to
+        the Secretary's reglamento, which was not obtained. 12 x 6 in is the
+        North American convention Puerto Rico is reported to follow and is
+        recorded as REPORTED, not sourced. Note also that Puerto Rico offers an
+        optional NARROWER plate (see `us-pr-euro-optional`), which is direct
+        evidence that PR's size is a departmental choice rather than a fixed
+        legal fact.
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed-secondary }
+      foreground: "#000000"
+      colour_note: >-
+        NEITHER COLOUR IS IN THE STATUTE — Art. 2.18 delegates "colores" to
+        reglamento in terms. The reflective-white ground with screened black
+        characters is `hex_basis: observed-secondary`, taken from a Wikipedia
+        locator description and corroborated by dated plate photographs. Treat
+        both hexes as unverified pending the DTOP reglamento.
+      legend_top: "PUERTO RICO"
+      legend_bottom_reported: "Isla del Encanto"
+      graphic: { present: true, rendered: placeholder, description: "fort / garita motif reported on the current base — locator-grade, NOT from any statutory drawing" }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    previous_base_reported:
+      note: >-
+        DELIBERATELY NOT MINTED AS A SERIES, per PRD-PLATES §4's rule that
+        Wikipedia is a LOCATOR and its era tables are not sourced years. The
+        locator reports a March 2023 changeover to the fort / "Isla del Encanto"
+        base from a 2007-2023 base, both in ABC 123. NO PRIMARY establishing
+        either boundary was obtained: DTOP publishes no plate-design instrument
+        that was reachable in this pass, and Ley 22-2000 is design-silent by
+        construction. Rather than mint a dated id on a folklore boundary and then
+        have to alias it (PRD-QUALITY I-5/I-6), the boundary is recorded here and
+        a dated series is added when a reglamento or DTOP order lands.
+      reported_boundaries: ["1987-2007 ABC 123", "2007-2023 ABC 123", "2023-present ABC 123, fort graphic"]
+      evidence: locator-only
+    region_encoding: none
+    sources:
+      - "https://bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf  # Art. 1.94: the serial alphabet ('números o letras o combinación de ambos') and the ABSENCE of any length cap; Art. 2.05: the register keys each vehicle by VIN plus 'aquel otro número que entienda apropiado el Secretario' and records the 'Identificación o tablilla concedida al vehículo'; Art. 2.17: the Secretary issues plates on registration, renewal, change of authorised use, and transfer where the acquirer holds no plate, and sets design/characteristics/issuance/renewal/use by reglamento against a $10 fee to the DISCO special account; Art. 2.18: content, delegation of design/size/colours, rear-only horizontal display including motorcycles, colourless illumination"
+      - "https://www.dtop.pr.gov/  # the issuing authority; DISCO/CESCO is the plate-issuing directorate named throughout Ley 22-2000"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Puerto_Rico  # LOCATOR ONLY (PRD-PLATES §4): the ABC 123 arrangement, the reported March 2023 fort base, the reported serial blocks, and the 'rear plate only since 1976' claim. NONE of these is asserted as sourced here; the rear-only rule is instead cited to Art. 2.18, which states it in law and needs no folklore"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 geometry, recorded as voluntary recommendation with no evidence of PR adoption"
+    notes: >-
+      PUERTO RICO STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED, for the same
+      reason us-fl-standard is: the statute is design-silent and no primary fixes
+      the base-design generations. PERIOD CAVEAT: `start: 2000` is the enactment
+      year of Ley 22-2000 and is an UPPER BOUND on the true start of the ABC 123
+      arrangement, which locators put at 1987. It is recorded as the instrument
+      date rather than invented, and the 1987 figure is left in the locator where
+      it belongs. THE BIG WIN IN THIS ENTRY is Art. 2.18: the famous "rear plate
+      only since 1976" line that every secondary source repeats is, in the
+      current law, a plain statutory rule that also sweeps in motorcycles — so
+      the dataset can assert rear-only for Puerto Rico from an edict of
+      government rather than from folklore.
+
+  - id: us-pr-euro-optional
+    class: standard
+    categories: [car, van]
+    period: { start: 2012 }
+    period_evidence: locator-reported
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "the serial is the ordinary Art. 1.94 serial on a differently-sized plate; no separate alphabet" }
+    design:
+      plate: { note: "LONGER AND NARROWER than the standard North American plate — the European proportion. No millimetre figure is sourced; DTOP's reglamento fixes size under Art. 2.18 and was not obtained." }
+      background: { finish: retroreflective }
+      shape: rectangular
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    sources:
+      - "https://bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf  # Art. 2.18 delegates 'tamaño' to the Secretary by reglamento — the legal room in which an alternative plate size can exist at all"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Puerto_Rico  # LOCATOR: optional European-size plates purchasable since 2012, offered during discrete windows (2012-2013, 2020-2021, 2022-2023)"
+      - "http://www.plateshack.com/y2k/Puerto_Rico/pry2k.html  # CORROBORATION: a photographed 'Puerto Rico Euro style plate seen in use March of 2022' — an independent attestation that the option is real and in circulation, which is why this is modelled at all"
+    notes: >-
+      THE OPTIONAL EUROPEAN-SIZE PLATE — kept as its own series because §2.3's
+      test is met on DESIGN (the plate geometry differs) while format and period
+      overlap the standard series, and because the US/world research dossier
+      singled this out as one of two North American cases that break the
+      "fixed-width alphanumeric on a 6x12 rectangle" assumption (Delaware's
+      variable-length numeric is the other). EVIDENCE GRADE IS LOW AND SAID SO:
+      `period_evidence: locator-reported`. The 2012 start and the on/off offer
+      windows come from a Wikipedia locator; the only independent confirmation is
+      a dated photograph. It is modelled rather than dropped because a parse API
+      that assumes one PR plate geometry will mis-render, and a flagged fact beats
+      a silent omission.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES. Puerto Rico serialises these separately in statute;
+  # NONE of their formats is fixed in law, because Art. 2.18 sends every
+  # physical property to a reglamento that was not obtained. Each therefore
+  # carries `matching: recall-only` and the statutory alphabet as its regex —
+  # which is the honest encoding of "we know this series exists and who issues
+  # it, and we do not know its grammar".
+  # =========================================================================
+  - id: us-pr-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: statutory-enactment-date
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "Art. 1.94's alphabet, unchanged. Art. 2.12 sends 'la expedición, características, duración y uso de los permisos provisionales y tablillas correspondientes' to a reglamento adopted with the Secretary of the Treasury, which was not obtained." }
+      pattern_note: >-
+        THE PATTERN IS ILLUSTRATIVE AND THE REGEX IS DELIBERATELY WIDE. The
+        pattern shows the printed shape of the base plate this series sits on;
+        the regex is the Art. 1.94 statutory bound. `matching: recall-only` is
+        the whole point — a match here is a shape hit, never a claim that the
+        string is a valid PR provisional plate.
+    design:
+      plate: { note: "not fixed by statute; Art. 2.12 delegates 'características' to reglamento" }
+      emblem: { present: false }
+    validity: >-
+      Art. 2.12: the provisional permit is valid for a term NOT EXCEEDING THIRTY
+      (30) DAYS from the date the vehicle was sold, must be carried in the vehicle
+      continuously, and the seller must mark the sale date in the space provided
+      and register the vehicle with the Department within those thirty days. After
+      the term expires the vehicle may not use public roads until registered.
+    eligibility: >-
+      Art. 2.12: provisional permits go ONLY to new or used motor vehicles or
+      trailers imported or destined for sale that have NOT PREVIOUSLY BEEN
+      REGISTERED IN PUERTO RICO, sold by persons in the business of selling
+      vehicles. A separate route exists for vehicles bought by a Public Service
+      Commission concessionaire for public service, where the Commission's
+      substitution authorisation itself serves as the provisional permit until the
+      Department finalises the substitution.
+    region_encoding: none
+    sources:
+      - "https://bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf  # Art. 2.12: the 30-day provisional permit and its accompanying tablillas, the sale-date marking duty, the importer/dealer-only eligibility, the Public Service Commission route, and the delegation of characteristics/duration/use to a reglamento adopted jointly with the Secretary of the Treasury"
+    notes: >-
+      PROVISIONAL PLATES. The statute is unusually precise about VALIDITY (thirty
+      days, running from the sale date, not from issuance) and unusually silent
+      about everything a renderer needs. That asymmetry — hard legal periods,
+      delegated physical properties — is the defining texture of Puerto Rico's
+      plate law and the reason this file carries so many recall-only series.
+
+  - id: us-pr-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: statutory-enactment-date
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "Art. 1.94's alphabet; no dealer-specific grammar is stated anywhere in Ley 22-2000" }
+      pattern_note: "illustrative pattern, statutory-bound regex — see us-pr-temporary's note; the same discipline applies"
+    design:
+      plate: { note: "not fixed by statute" }
+      emblem: { present: false }
+    binding: business
+    eligibility: >-
+      Art. 2.14: anyone selling motor vehicles or trailers at retail for profit
+      must obtain a "Licencia de Concesionario de Vehículos de Motor y
+      Arrastres". Art. 2.15 creates a SECOND, narrower licence — the
+      "concesionario especial" — for those who buy, rescue, salvage, repair,
+      rebuild and sell WRECKED vehicles in limited quantities, with the maximum
+      number of vehicles set by reglamento.
+    quota: >-
+      Art. 2.14(E): "El Secretario o su representante autorizado determinará la
+      CANTIDAD DE TABLILLAS ESPECIALES que asignará a todo concesionario" — the
+      dealer's plate allocation is discretionary and per-dealer, and the dealer
+      must keep an inspectable register of which vehicles carried which special
+      plate and over what dates.
+    penalty: "Art. 2.14(F): violation is a misdemeanour — up to six months' imprisonment, a fine up to $5,000, or both, at the court's discretion"
+    region_encoding: none
+    sources:
+      - "https://bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf  # Art. 2.14(A) the dealer licence and its exclusion of Art. 2.15 special concessionaires; Art. 2.14(E) the per-dealer special-plate quota and the inspectable use register; Art. 2.14(F) the penalty; Art. 2.15 the special (salvage/rebuild) concessionaire licence"
+    notes: >-
+      DEALER PLATES. `binding: business` for the same reason as Germany's rote
+      Kennzeichen and Florida's dealer plate — the plate follows the licensed
+      concessionaire, not a vehicle. The genuinely distinctive Puerto Rico fact is
+      that the ALLOCATION IS DISCRETIONARY AND LOGGED: Art. 2.14(E) makes the
+      number of dealer plates a per-dealer administrative decision and requires a
+      vehicle-by-vehicle, date-stamped use register open to Department and Police
+      inspection. Most US states issue dealer plates against a fee schedule; Puerto
+      Rico issues them against a judgement about "el desempeño adecuado y
+      responsable" of the dealer.
+
+  - id: us-pr-antique
+    class: historic
+    categories: [car]
+    period: { start: 2000 }
+    period_evidence: statutory-enactment-date
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "Art. 2.26 states no serial grammar; design/characteristics go to reglamento" }
+      pattern_note: "illustrative pattern, statutory-bound regex — see us-pr-temporary's note"
+    design:
+      plate: { note: "not fixed by statute; Art. 2.26 delegates diseño y características to reglamento" }
+      emblem: { present: true, rendered: placeholder }
+    eligibility: >-
+      Art. 2.26: a special plate is issued on application to any motor vehicle
+      classifiable as an "automóvil antiguo", meaning any car "que haya sido
+      construido por lo menos CUARENTA (40) AÑOS ANTES DE LA FECHA DE EXPEDICIÓN
+      DE LA TABLILLA" — a ROLLING forty-year threshold measured against the
+      ISSUE DATE OF THE PLATE, not against the calendar year.
+    fee: "Art. 2.26: no fee beyond that fixed by law for private-use plates"
+    region_encoding: none
+    sources:
+      - "https://bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf  # Art. 2.26: the rolling 40-year threshold measured from the plate's issue date, the no-extra-fee rule, and the delegation of design/characteristics/issuance/renewal/cancellation to reglamento"
+      - "http://www.plateshack.com/y2k/Puerto_Rico/pry2k.html  # CORROBORATION ONLY: photographs captioned 'Puerto Rico antique vehicle type plates (Current type on right)' — independent evidence that at least two antique designs have been in issue, which the statute does not record"
+    notes: >-
+      ANTIQUE PLATES. Puerto Rico sets a ROLLING threshold (40 years), the same
+      design choice as Florida's Antique series (30 years) and the opposite of
+      Florida's Horseless Carriage (fixed model year 1945). But PR does something
+      neither Florida series does: it measures the age against THE DATE THE PLATE
+      IS ISSUED rather than against the current year, which makes eligibility a
+      property of the transaction rather than of the calendar — a distinction that
+      matters to any consumer computing eligibility, and one that only appears if
+      you read the statute rather than a brochure.
+
+  - id: us-pr-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2000 }
+    period_evidence: statutory-enactment-date
+    matching: strict
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9]+\z'
+      charset:
+        notes: >-
+          Art. 2.32(a): each personalised plate carries "aquellas PALABRAS,
+          NÚMEROS O LETRAS que expresamente interese e indique la parte que la
+          solicita". NO LENGTH CAP IS STATED — hence the unbounded quantifier,
+          which makes no width claim. This is a real divergence from Florida,
+          whose § 320.06(3)(a) caps every plate at seven characters and therefore
+          caps its vanity plates too.
+      content_refusal: >-
+        Art. 2.32(a), and this is the part Florida's chapter does NOT have: the
+        Secretary "podrá, a su discreción, prohibir o restringir el uso de ciertas
+        palabras, dígitos, números, letras o combinaciones y cantidades de las
+        mismas, si entiende que éstas podrían provocar confusión, utilizarse para
+        propósitos ilícitos o de alguna manera afectar adversamente el bienestar
+        general o la sana convivencia". Puerto Rico legislates its vanity-plate
+        refusal criteria; Florida does not, and the Florida file records that as a
+        gap. Here it is a sourced fact.
+    design:
+      plate: { note: "not fixed by statute; Art. 2.32(c) delegates diseño, tamaño, colores y ubicación to reglamento" }
+      note: "Art. 2.32(c) requires the Secretary to arrange matters so that the personalised plate IS AT THE SAME TIME the official plate ('de tal forma que ésta sea a la vez la tablilla oficial') — it replaces rather than supplements"
+      emblem: { present: true, rendered: placeholder }
+    fee: "Art. 2.33: amounts for issuance and duplicates are set by reglamento; ALL revenue is deposited in a Special Fund dedicated to improving DISCO's services, facilities and mechanisation systems"
+    penalty: "Art. 2.32(f): displaying a personalised plate without authorisation is a misdemeanour, fine of $200-$500"
+    region_encoding: none
+    sources:
+      - "https://bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf  # Art. 2.32(a) owner-chosen words/numbers/letters and the Secretary's statutory content-refusal discretion; (b) the index and control records; (c) the personalised plate IS the official plate, and the delegation of design/size/colours/location; (d) validity tied to the official plate's term; (f) the $200-$500 penalty; Art. 2.33 the fee-setting delegation and the DISCO Special Fund"
+    notes: >-
+      PERSONALISED PLATES. Modelled as its own series because the SERIAL SOURCE
+      differs — owner-chosen rather than department-assigned — which is a format
+      property, exactly as in Florida. TWO FINDINGS WORTH CARRYING FORWARD. First,
+      Puerto Rico legislates the CONTENT-REFUSAL CRITERIA that Florida leaves
+      unwritten, so where us-fl-personalized records a gap this entry records a
+      sourced rule. Second, PR states NO LENGTH CAP anywhere, so the regex is
+      unbounded; a consumer that assumed the US seven-character convention would be
+      imposing Florida's law on Puerto Rico.
+
+  # =========================================================================
+  # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Puerto Rico is the rare
+  # jurisdiction where the specialty catalogue is ITSELF STATUTORY: seven
+  # programmes, each with its own article. Count and citations only; no designs.
+  # =========================================================================
+  - id: us-pr-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2000 }
+    period_evidence: statutory-enactment-date
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "specialty plates carry ordinary Art. 1.94 serials; several are DISTINTIVOS carried IN ADDITION to the official plate rather than in place of it — see the index" }
+      pattern_note: "illustrative pattern, statutory-bound regex — this is an INDEX entry, not a spec"
+    design:
+      plate: { note: "one design per statutory programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here" }
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_statutory: 7
+      count_basis: >-
+        SEVEN PROGRAMMES ARE CREATED BY LEY 22-2000 ITSELF, one article each.
+        This is a count from an edict of government, not from a brochure or a
+        press office — which makes Puerto Rico's specialty index better-sourced
+        than most US states', where the count comes from an agency web page.
+      statutory_programs:
+        - "Art. 2.20 — ACTIVE GENERAL PRESS ('miembros de la prensa general activa'), accredited by the Department of State; also for news-agency vehicles assigned to an accredited member, which must be liveried; no extra fee beyond the private-use plate fee; $20 internal-revenue stamp to the DISCO fund; surrender on loss of accreditation; $200-$500 fine for unauthorised display"
+        - "Art. 2.26 — ANTIQUE AUTOMOBILES (specced separately as us-pr-antique because its eligibility rule is substantive)"
+        - "Art. 2.27 — CAREER AND HONORARY CONSULS: plates or distintivos issued IN ADDITION to the vehicle's official plate, usable only for the official plate's term, only on the consul's vehicle, non-transferable to consulate staff"
+        - "Art. 2.28 — RADIO AMATEURS: the plate 'llevará la codificación especial asignada' by the Federal Communications Commission, is fixed to the REAR, replaces the official plate, and the amateur must obtain FCC authorisation for a replacement if it is lost or stolen; internal-revenue stamp to the DISCO Special Fund"
+        - "Art. 2.29 — LEGISLATORS: issued on certification by the Senate or House, carried IN ADDITION to the official plates, internal-revenue stamp payable"
+        - "Art. 2.30 — MAYORS AND MUNICIPAL ASSEMBLY MEMBERS: issued on certification by the Comisión Estatal de Elecciones and after taking office, carried in addition to the official plates"
+        - "Art. 2.31 — FORMER PRISONER-OF-WAR VETERANS: uniquely, the special plate may be displayed at the REAR, in which case THE OFFICIAL PLATE MOVES TO THE FRONT — the only place in Ley 22-2000 where a Puerto Rico vehicle lawfully carries a front plate"
+      also_statutory_but_not_plates: "Art. 2.21-2.24 create REMOVABLE PLACARDS ('rótulos removibles') for disabled parking — deliberately excluded from this index because a placard is not a registration mark"
+      count_secondary: >-
+        DATED PHOTOGRAPHS ATTEST AT LEAST FOUR FURTHER PROGRAMMES not named in
+        the statute — Roberto Clemente and Roberto Clemente Anniversary,
+        Make-A-Wish Foundation, San Juan 500th Anniversary, Olympic Committee, and
+        a Veteran plate first issued around 2009. The statute-versus-practice
+        discrepancy is RECORDED, NOT AVERAGED (PRD-PLATES §5.3): either these rest
+        on later amendments to Ley 22-2000 that the served scan predates, or on
+        separate special acts, or on the Secretary's reglamento power. Resolving
+        which is a recorded gap and the highest-value next step for Puerto Rico.
+      official_list_url: "https://www.cesco.pr.gov/"
+      official_list_note: "CESCO is DTOP's driver-services portal and the natural home for an official specialty catalogue; NO machine-readable or enumerated specialty list was located on it in this pass (recorded gap)"
+    region_encoding: none
+    sources:
+      - "https://bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf  # Arts. 2.20, 2.26, 2.27, 2.28, 2.29, 2.30, 2.31 — the seven statutory specialty programmes, their eligibility, fees, display rules and penalties; Art. 2.31(a) the front-plate inversion; Arts. 2.21-2.24 the disabled placards excluded from this index"
+      - "https://www.cesco.pr.gov/  # DTOP/CESCO driver-services portal — the official channel; no enumerated specialty catalogue found (gap)"
+      - "http://www.plateshack.com/y2k/Puerto_Rico/pry2k.html  # CORROBORATION + GAP-FINDER (PRD-PLATES §4): dated photographs of Roberto Clemente, Roberto Clemente Anniversary, Make-A-Wish, San Juan 500th Anniversary, Olympic Committee and Veteran plates, plus a trailer plate and a private-truck plate. This is how the statute-versus-practice discrepancy above was FOUND; no text or image was copied"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — one entry standing for the whole programme,
+      which is what PRD-PLATES §2.5 asks for at this gate. Two things worth
+      carrying forward. First, PUERTO RICO'S SPECIALTY CATALOGUE IS AN EDICT: seven
+      programmes, seven articles, all public domain and all citable per claim —
+      a materially better provenance than the agency-webpage counts most US states
+      offer, and worth saying so on the encyclopedia page. Second, THE COUNT IS
+      CONTESTED IN THE MOST INFORMATIVE WAY POSSIBLE: photographs prove programmes
+      the served statute does not create, which means the served scan is either
+      not current or not exhaustive. That is a finding about the SOURCE, not just
+      about the data, and it is recorded rather than smoothed over.

--- a/plates/us-vi.yml
+++ b/plates/us-vi.yml
@@ -1,0 +1,489 @@
+# plates/us-vi.yml — United States Virgin Islands (PRD-PLATES gate L2, territories).
+#
+# THE SOURCING SITUATION HERE IS THE INVERSE OF GUAM'S, AND IT IS STATED UP
+# FRONT BECAUSE IT SHAPES EVERY ENTRY BELOW. Guam's statute is fully reachable
+# and its agency is not; the Virgin Islands' agency is fully reachable and its
+# statute is not. Title 20 of the Virgin Islands Code (Motor Vehicles) could NOT
+# be obtained in this pass by any route attempted — law.justia.com returns HTTP
+# 403 to both curl and WebFetch, lexisnexis.com/hottopics/vicode/ and
+# advance.lexis.com serve JavaScript shells with no extractable text,
+# vicode.lexisnexis.com does not resolve, legvi.org returns 403, law.onecle.com
+# and law.resource.org have no VI tree, and the Wayback Machine holds NO
+# snapshot of the Justia VI Title 20 pages (the availability API returns an
+# empty archived_snapshots object). Those are recorded as measured dead ends.
+#
+# WHAT WE HAVE INSTEAD IS BETTER THAN USUAL FOR A DESIGN QUESTION: the VI Bureau
+# of Motor Vehicles publishes its own plate announcements, and its March 2023
+# notice gives a HARD EFFECTIVE DATE for the current base from the issuing
+# agency itself. That is a primary source of exactly the kind PRD-PLATES §4
+# ranks second only to statute — and it is why the USVI is the only jurisdiction
+# in the territories group whose current AND previous standard bases are both
+# minted as dated series.
+#
+# WHAT IS DELIBERATELY NOT HERE (PRD-PLATES §2.5): individual specialty DESIGNS.
+jurisdiction: us-vi
+authority:
+  name: United States Virgin Islands Bureau of Motor Vehicles (BMV)
+  url: "https://bmv.vi.gov/"
+binding: vehicle
+statute_edition: >-
+  NOT OBTAINED. Title 20 of the Virgin Islands Code governs motor vehicles and
+  is cited by BMV itself — see § 335 (notice of transfer, 24-hour duty) and
+  § 218a (Certificate of Title fee exemption for seniors and disabled persons),
+  both quoted on BMV's Vehicles page. Neither section's text, nor any
+  plate-format, plate-design or plate-display section, was reachable. Every
+  statutory reference in this file is therefore SECOND-HAND THROUGH BMV and is
+  marked as such.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — required per jurisdiction by PRD-PLATES §4 / §7.1.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched-presumed-protected
+  basis: >-
+    Two things are established and they point the same way. First, US federal
+    copyright law APPLIES IN THE VIRGIN ISLANDS: the US Copyright Office states
+    that "US federal copyright law applies in the US Virgin Islands, Guam, and
+    the Northern Mariana Islands but not in American Samoa". Second, NO Commons
+    public-domain tag exists for the government of the Virgin Islands —
+    Template:PD-USVIGov returns 404 — and {{PD-USGov-Unincorporated}} is
+    expressly limited to UNORGANIZED territories, which the USVI is not. There is
+    no analogue here to Florida's Microdecisions v. Skinner or to Puerto Rico's
+    {{PD-PRGov}}.
+  conclusion: >-
+    Treat USVI plate ARTWORK as presumptively protected. The exposure is
+    concrete and unusually sharp: the current base is a COMMEMORATIVE design
+    built around a "175th Emancipation" logo, and a commemorative logo is far
+    closer to a discrete authored work than a state map or a generic floral
+    motif is. Do not approximate it, do not trace it, and do not render it.
+  edicts: >-
+    Edicts of government remain public domain at every level
+    ({{PD-US-GovEdict}}), so Title 20 VIC would be freely usable — if it could be
+    obtained. It could not. That is the central irony of this file and the reason
+    its evidence grades are lower than Guam's or Puerto Rico's despite the USVI
+    having the single best-dated series in the group.
+  emblem_rule: >-
+    PRD-PLATES §3's placeholder default applies without exception to the 175TH
+    EMANCIPATION LOGO and to the Virgin Islands coat of arms. Render
+    `emblem: {present: true, rendered: placeholder}` and do not revisit until a
+    USVI government-works copyright posture is affirmatively established.
+  photograph_caution: >-
+    plateshack.com carries no extractable licence and is treated as all rights
+    reserved. No image was copied; its pages were used only to corroborate which
+    series exist and to date them.
+  sources:
+    - "https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States  # the US Copyright Office position that federal copyright law applies in the US Virgin Islands; the US Territories tag list, which contains no Virgin Islands entry; and the UNORGANIZED-territories limit on {{PD-USGov-Unincorporated}}"
+    - "https://commons.wikimedia.org/wiki/Template:PD-USVIGov  # HTTP 404 — a measured negative: no Commons public-domain tag exists for the government of the US Virgin Islands"
+    - "https://bmv.vi.gov/2023/03/03/2023-emancipation-license-plates/  # the current base is expressly a COMMEMORATIVE design, which is what sharpens the artwork risk"
+
+# ---------------------------------------------------------------------------
+# The US standards chain. NOTHING here quotes SAE J686 (paywalled, unpinned).
+# ---------------------------------------------------------------------------
+us_standards:
+  no_federal_mandate: true
+  usvi_position: "No evidence was found that the USVI has adopted the AAMVA standard, and no VI instrument was reachable in which such an adoption could be recorded. AAMVA geometry is recorded as context only."
+  aamva_edition_3:
+    dimensions_delegated: "AAMVA §3.1 delegates dimensions and bolt holes to SAE J686, whose text is PAYWALLED and was NOT obtained. No J686 dimension is quoted here."
+    character_layout: "AAMVA §2.2: characters at least 2.5 in high, spaced at least 0.25 in apart, stroke weight 0.2-0.4 in, at least 1.25 in clear of top and bottom edges"
+    replacement_cycle: >-
+      AAMVA §1.1 recommends a rolling or full replacement cycle not to exceed
+      7-10 years. THE USVI IS THE ONE TERRITORY IN THIS GROUP THAT DEMONSTRABLY
+      RAN A FULL REPLACEMENT: BMV's March 2023 notice makes the new plate
+      MANDATORY, requires the old plates to be surrendered before a registration
+      renewal can complete, and states the renewal "will not be completed until
+      the old plates have been turned in". That is a full-fleet replacement
+      executed through the renewal cycle, and it is documented by the issuing
+      agency rather than inferred.
+    source: "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf"
+
+display_rules:
+  default: >-
+    UNRESOLVED — RECORDED AS A GAP RATHER THAN GUESSED. The front/rear rule for
+    the Virgin Islands lives in Title 20 VIC, which was not obtainable, and BMV's
+    public pages do not state it. The US/world dossier's front-plate survey is a
+    Wikipedia aggregate and is a locator, not an authority. NO front/rear claim
+    is made for this jurisdiction.
+  surrender_on_transfer: >-
+    Second-hand through BMV, which paraphrases Title 20 § 335: the transferor
+    must notify BMV of a transfer within 24 hours on BMV forms; on receipt BMV
+    marks the transferor's registration licence "cancelled" and VOIDS the
+    corresponding LICENSE PLATES; the cancellation and voiding take effect 48
+    hours after the Director receives the notice; the vehicle may be operated
+    during that 48-hour window but afterwards only if the transferee has applied
+    for and received a new registration licence AND new plates.
+  cancellation: "BMV: to cancel a registration, 'the plates and sticker must be removed from the vehicle and returned to the BMV' with a signed cancellation application — so the USVI, like Puerto Rico, treats the plate as returnable state property, and validates on a separate STICKER"
+  inspection_cycle: >-
+    BMV: all vehicles require annual inspection EXCEPT private vehicles that are
+    six, eight and ten years old; private vehicles that are seven, nine and older
+    must be inspected. An alternating-year exemption keyed to even ages is an
+    oddity worth recording, and it is quoted from BMV verbatim in substance.
+  sources:
+    - "https://bmv.vi.gov/vehicles/  # BMV's own statement of the Title 20 § 335 transfer/voiding rule, the plate-and-sticker return requirement on cancellation, the annual inspection rule and its age exemptions, the dealer-only third-party/double transfer rule, and the § 218a senior/disabled title-fee exemption"
+
+series:
+
+  # =========================================================================
+  # THE STANDARD-ISSUE SERIES — and the ISLAND PREFIX, which is the best
+  # region-encoding fact in the territories group after Guam's office table.
+  # =========================================================================
+  - id: us-vi-standard-2023
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2023 }
+    period_evidence: agency-instrument-date
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_strict: '\A[CTJ][A-Z]{2} ?\d{3}\z'
+      charset:
+        notes: >-
+          The first letter is not free: it is the ISLAND CODE (see
+          region_encoding), which is why `regex_strict` exists and pins it to
+          [CTJ]. The remaining two letters and three numerals have no sourced
+          restriction — no VI instrument stating letter exclusions (the I/O/Q
+          exclusions common in US states) was obtainable, so none is claimed.
+      pattern_note: >-
+        `regex` is the round-trippable printed form and carries no charset
+        restriction, per PRD-PLATES §2.7. `regex_strict` adds the one restriction
+        that IS attested — the island prefix — and is contained in `regex` by
+        construction. There is no `regex_statutory` because Title 20 VIC could not
+        be obtained and therefore no outer legal bound is known.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4 }
+      plate_dimension_note: "12 x 6 in aluminium is locator-reported; no VI instrument fixing it was obtainable"
+      background: { finish: retroreflective }
+      colour_note: >-
+        NO HEX IS RECORDED. The reported design is a three-band composition —
+        teal top stripe, white middle stripe, gold bottom stripe, with black
+        embossed serials and the 175th Emancipation logo centred. "Teal" and
+        "gold" are colour NAMES from a locator, not values from a spec, and
+        inventing hexes for them would be exactly the laundering PRD-PLATES §9
+        warns about. Recorded as descriptions; hexes await a BMV or Title 20
+        source.
+      legend_top: "U.S. VIRGIN ISLANDS"
+      legend_slogan_reported: "175th Emancipation"
+      graphic: { present: true, rendered: placeholder, description: "175th Emancipation commemorative logo, centred — locator-grade description; the design is COMMEMORATIVE and carries the highest artwork risk in this group" }
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    validation: "a separate WINDSHIELD STICKER, not a plate decal — BMV requires 'the plates and sticker' to be surrendered together on cancellation, and dated VI windshield stickers are independently photographed"
+    mandatory_replacement:
+      effective: "2023-03-01"
+      rule: >-
+        BMV, in its own words: "Effective March 1, 2023, all vehicles with
+        TEMPORARY plates that were issued by the BMV will be exchanged at no cost
+        for the new MANDATORY VI 175th Emancipation Commemorative Plates, an
+        appointment is required. All other vehicles will only be issued the new
+        Emancipation Plates during their annual registration renewal process. In
+        order to renew the registration, the old plates must be removed and
+        returned to the BMV. The vehicle registration renewal process will not be
+        completed until the old plates have been turned in."
+      concessions: "free for registrants aged 65 and over; personalised BMV plates charged at $49; plates are collected in person and are NOT mailed even where the renewal is completed online"
+    region_encoding:
+      scheme: island-prefix
+      note: >-
+        The FIRST LETTER of the serial encodes the island of registration. This
+        is the USVI's signature plate fact and the reason its serials are
+        three-letter rather than two: the prefix is meaning, not padding.
+      table:
+        C: "Saint Croix"
+        T: "Saint Thomas (and Saint John before 1975)"
+        J: "Saint John (introduced 1975, when it was split out of the T block)"
+      evidence: >-
+        LOCATOR-GRADE, AND SAID SO. The C/T/J assignment comes from a Wikipedia
+        locator's per-era serial table and is corroborated only indirectly, by
+        photographs captioned as St. Thomas and St. Croix taxi plates. No VI
+        instrument was obtainable. It is recorded as a decode because it is
+        internally consistent across seven decades of reported serials — C-123 and
+        T-123 from 1939, J-123 appearing exactly at the reported 1975 split — but
+        it must be verified against Title 20 before any parse API decodes an
+        island from it.
+    sources:
+      - "https://bmv.vi.gov/2023/03/03/2023-emancipation-license-plates/  # THE PRIMARY DATE SOURCE: BMV's own notice — effective March 1 2023, the plates are MANDATORY, temporary-plate holders exchange at no cost by appointment, all other vehicles receive them at annual renewal, old plates must be surrendered before renewal completes, free at 65 and over, $49 for personalised, collected in person"
+      - "https://bmv.vi.gov/fees/  # BMV's published fee schedule — Personalized Plates $49.00, Registration Cancellation $12.00, Moving Permit $20.00, Certificates of Title $54.00 (free for seniors)"
+      - "https://bmv.vi.gov/vehicles/  # the plate-and-sticker surrender rule on cancellation, and the Title 20 § 335 transfer/voiding rule quoted second-hand"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_the_United_States_Virgin_Islands  # LOCATOR ONLY (PRD-PLATES §4): the CAB 123 / TAB 123 / JAB 123 arrangement, the C/T/J island prefixes and the 1975 introduction of J, the teal/white/gold banded design with the 175th Emancipation logo, and 12x6 in aluminium construction"
+      - "http://www.plateshack.com/y2k/Virgin_Islands/viy2k.html  # CORROBORATION (PRD-PLATES §4): a photograph captioned 'New Virgin Islands standard license plate issued in 2023 - 175th Anniversary of Emancipation', which independently confirms BMV's date and design name. No licence statement on the site; no image or text copied"
+    notes: >-
+      USVI STANDARD ISSUE, CURRENT BASE — AND THE BEST-DATED SERIES IN THE
+      TERRITORIES GROUP. `period_evidence: agency-instrument-date` is a real
+      claim: the issuing agency published the effective date, the mandatory
+      status, and the mechanism of changeover, and an independent photograph
+      confirms it. Compare Guam and the Northern Marianas in this same group,
+      where every base boundary is secondary. THE TRANSITION IS MODELLED HONESTLY
+      AS AN OVERLAP: because the new plates were issued at each vehicle's annual
+      renewal rather than in a single swap, the 2016 base remained lawfully on the
+      road throughout 2023 and beyond. That is precisely the parallel-issuance
+      case PRD-PLATES §2.2 sanctions, and the two series overlap deliberately.
+
+  - id: us-vi-standard-2016
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2016, end: 2023 }
+    period_evidence: mixed-locator-start-agency-end
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_strict: '\A[CTJ][A-Z]{2} ?\d{3}\z'
+      charset: { notes: "same island-prefixed grammar as the current base; the serial arrangement did NOT change at the 2023 boundary, only the artwork did" }
+    design:
+      plate: { w: 12, h: 6, unit: in }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+      note: "the preceding base's artwork is L4 scope and its evidence is photographic, not instrumental; it is not described here"
+    region_encoding:
+      scheme: island-prefix
+      note: "identical C/T/J scheme — see us-vi-standard-2023's table; the prefix long predates both bases"
+      evidence: locator-grade
+    sources:
+      - "https://bmv.vi.gov/2023/03/03/2023-emancipation-license-plates/  # THE END BOUNDARY IS PRIMARY: BMV's notice makes the successor plate mandatory from March 1 2023 and requires surrender of 'the old plates' at renewal, which is what closes this series"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_the_United_States_Virgin_Islands  # LOCATOR ONLY: the April 2016 start of this base and its February 2023 end. The START is locator-grade and is NOT corroborated by any agency source"
+      - "http://www.plateshack.com/y2k/Virgin_Islands/viy2k.html  # CORROBORATION: dated photographs of VI plates in use in 2017, 2018 and September 2019, which place a distinct base in circulation across this window without fixing either boundary"
+    notes: >-
+      THE PREVIOUS USVI STANDARD BASE — the "one series back" PRD-PLATES §7 asks
+      for at L2. ITS TWO BOUNDARIES HAVE DIFFERENT EVIDENCE GRADES AND THE FIELD
+      SAYS SO: `period_evidence: mixed-locator-start-agency-end`. The END is
+      anchored by BMV's own mandatory-replacement notice and is a real claim; the
+      START is a Wikipedia locator's April 2016 and is not corroborated anywhere.
+      A verifier should attack the 2016 figure first. NOTE ALSO that the serial
+      grammar is UNCHANGED across the boundary — same island prefix, same
+      three-plus-three shape — so unlike Guam's 1994/2009 boundary this one cannot
+      be detected from the serial at all. Only the artwork changed, which means a
+      parse API can never date a USVI plate from its number.
+
+  # =========================================================================
+  # CORE DISTINCT CLASSES. The USVI demonstrably serialises these separately —
+  # BMV publishes a distinct application form for several of them — but NO
+  # format is sourced for any, because Title 20 was unobtainable. Every one is
+  # therefore `matching: recall-only` with the shape catch-all.
+  # =========================================================================
+  - id: us-vi-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2026 }
+    period_evidence: agency-instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "no grammar sourced; Title 20 VIC unobtainable" }
+      pattern_note: "ILLUSTRATIVE PATTERN, CATCH-ALL REGEX. A match is a shape hit and nothing more — that is what `matching: recall-only` declares."
+    design: { plate: { note: "not sourced" }, emblem: { present: false } }
+    binding: business
+    eligibility: >-
+      BMV maintains a "Dealer License Plate Application Form", and separately
+      restricts THIRD-PARTY AND DOUBLE TRANSFERS to dealers holding a Power of
+      Attorney signed by the seller — so a VI dealer is a distinct regulated actor
+      with its own plate application route.
+    region_encoding: none
+    sources:
+      - "https://bmv.vi.gov/forms/  # BMV's published forms index, which lists a 'Dealer License Plate Application Form' under Vehicle Registration & Titling — direct agency evidence that a distinct dealer plate series exists"
+      - "https://bmv.vi.gov/vehicles/  # the dealer-only third-party and double-transfer rule and its Power of Attorney requirement"
+    notes: >-
+      USVI DEALER PLATES. Minted on the strength of the issuing agency publishing
+      a dedicated application form for them — which establishes the SERIES EXISTS
+      without establishing anything about its grammar. `period: {start: 2026}` is
+      the year BMV's forms index was read and is an UPPER BOUND on the true start,
+      recorded in the Florida manner rather than invented. This entry is a
+      placeholder with citations, and it is honest about being one.
+
+  - id: us-vi-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2026 }
+    period_evidence: agency-instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "no grammar sourced" }
+      pattern_note: "illustrative pattern, catch-all regex — see us-vi-dealer's note"
+    design: { plate: { note: "not sourced" }, emblem: { present: false } }
+    variants_evidenced:
+      - "DEALER TEMPORARY TAGS — BMV publishes both a 'Dealer Temporary Tag Application Form' and a 'Dealer Temporary Tag Issuance Form', the two-form structure implying dealer authorisation followed by per-tag issuance, the same shape as Guam's 16 GCA § 7179"
+      - "BMV-ISSUED TEMPORARY PLATES — the March 2023 notice refers to 'all vehicles with TEMPORARY plates that were issued by the BMV', confirming BMV issues temporaries directly and separately from the dealer channel"
+      - "MOVING PERMIT — BMV requires a first-time registrant to obtain a moving permit before presenting the vehicle for inspection; the fee is $20.00"
+    region_encoding: none
+    sources:
+      - "https://bmv.vi.gov/forms/  # the 'Dealer Temporary Tag Application Form' and 'Dealer Temporary Tag Issuance Form'"
+      - "https://bmv.vi.gov/2023/03/03/2023-emancipation-license-plates/  # BMV's reference to vehicles carrying TEMPORARY plates 'that were issued by the BMV' — evidence of a BMV-issued temporary channel distinct from the dealer one"
+      - "https://bmv.vi.gov/vehicles/  # the moving-permit requirement for first-time registration; https://bmv.vi.gov/fees/ prices it at $20.00"
+    notes: >-
+      USVI TEMPORARY PLATES — and there are demonstrably at least TWO channels,
+      dealer-issued and BMV-issued, plus a separate moving permit for the
+      pre-inspection stage. They are not split into separate series because
+      nothing distinguishes them in the evidence except the issuer, and minting
+      three format-identical placeholders would be modelling noise. The
+      two-channel structure is recorded in `variants_evidenced` so a later pass
+      knows exactly what to split.
+
+  - id: us-vi-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2026 }
+    period_evidence: photographic-in-use-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "no grammar sourced; the plate is reduced-size, which is why it is a separate series at all" }
+      pattern_note: "illustrative pattern, catch-all regex — see us-vi-dealer's note"
+    design: { plate: { note: "reduced size; no dimension sourced" }, emblem: { present: true, rendered: placeholder } }
+    region_encoding: { scheme: island-prefix, note: "presumed to share the C/T/J prefix; NOT verified for this class", evidence: unverified }
+    sources:
+      - "http://www.plateshack.com/y2k/Virgin_Islands/viy2k.html  # CORROBORATION ONLY (PRD-PLATES §4): photographs of US Virgin Islands MOTORCYCLE plates with 2014 and 2017 expirations, establishing that a separately-issued motorcycle plate exists. No format, colour or dimension is claimed from a photograph"
+    notes: >-
+      USVI MOTORCYCLE PLATES. THE WEAKEST-EVIDENCED SERIES IN THIS FILE, and
+      flagged accordingly: its entire basis is two dated photographs on an
+      enthusiast site with no licence statement. It is minted rather than dropped
+      for one reason — PRD-PLATES §7's L2 scope names motorcycle as a core class
+      to spec where the jurisdiction separately serialises it, and a series with
+      citations and an explicit `recall-only` matcher is more useful to a consumer
+      than silence. `period: {start: 2026}` is a read-date upper bound and carries
+      no historical claim whatsoever.
+
+  - id: us-vi-taxi
+    class: taxi
+    categories: [car, van, bus]
+    period: { start: 2026 }
+    period_evidence: photographic-in-use-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "no grammar sourced" }
+      pattern_note: "illustrative pattern, catch-all regex — see us-vi-dealer's note"
+    design: { plate: { note: "not sourced" }, emblem: { present: true, rendered: placeholder } }
+    quota: "BMV publishes an 'Application for Rental Vehicles Quota' form, evidence that the USVI operates numeric quotas on at least one for-hire fleet class"
+    region_encoding: { scheme: island-prefix, note: "photographs are captioned as St. Thomas and St. Croix taxi plates, consistent with the island prefix applying to this class too", evidence: weak-corroboration }
+    sources:
+      - "http://www.plateshack.com/y2k/Virgin_Islands/viy2k.html  # CORROBORATION ONLY: photographs of a '2010 issued U.S. Virgin Islands taxi plate used on St. Thomas' and a 'U.S. Virgin Islands, St. Croix taxi plate', establishing a separately-issued taxi series and its island association"
+      - "https://bmv.vi.gov/forms/  # the 'Application for Rental Vehicles Quota' form — agency evidence of quota administration over for-hire fleets"
+    notes: >-
+      USVI TAXI PLATES. Kept separate from the standard series because the
+      photographs show a distinct plate type and because the Virgin Islands'
+      economy makes for-hire vehicles a large and separately administered fleet.
+      EVIDENCE IS PHOTOGRAPHIC ONLY. The rental-quota form is included because it
+      is the one piece of AGENCY evidence that the USVI administers for-hire
+      classes numerically, which is the administrative fingerprint of a separate
+      serial namespace.
+
+  - id: us-vi-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2026 }
+    period_evidence: photographic-in-use-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "no grammar sourced" }
+      pattern_note: "illustrative pattern, catch-all regex — see us-vi-dealer's note"
+    design: { plate: { note: "not sourced" }, emblem: { present: true, rendered: placeholder } }
+    region_encoding: none
+    sources:
+      - "http://www.plateshack.com/y2k/Virgin_Islands/viy2k.html  # CORROBORATION ONLY: photographs of a 'Virgin Islands Police Department Official plate' (ca. 2017) and a 'Virgin Islands Tax Assessor plate', establishing that VI government fleets carry OFFICIAL plates distinct from standard issue"
+    notes: >-
+      USVI GOVERNMENT PLATES. Recorded as one series rather than split into
+      government and police, even though the photographic evidence shows a POLICE
+      DEPARTMENT plate specifically, because nothing in the evidence establishes
+      whether police run their own namespace or sit inside a general official
+      series — and _meta/classes.yml defines `police` as police fleets WHERE
+      DISTINCT from government, a condition that cannot be tested here. Splitting
+      on a photograph would be inventing a distinction.
+
+  - id: us-vi-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: agency-instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        notes: >-
+          NO LENGTH CAP AND NO ALPHABET RESTRICTION IS SOURCED. Title 20 VIC could
+          not be obtained, and BMV publishes a "Personalized License Plate" form
+          without stating the rules on its public pages. Contrast Guam, whose
+          seven-position cap is in statute, and Florida, whose is. The USVI's is
+          simply unknown, and an unbounded catch-all with `matching: recall-only`
+          is the only honest encoding of that.
+      pattern_note: "illustrative pattern; the regex claims nothing"
+    design: { plate: { note: "not sourced" }, emblem: { present: true, rendered: placeholder } }
+    fee: "$49.00, per BMV's published fee schedule and confirmed independently in BMV's March 2023 plate notice ('Personalized BMV plates will be charged $49')"
+    region_encoding: none
+    sources:
+      - "https://bmv.vi.gov/fees/  # 'Personalized Plates $49.00' in BMV's own published schedule"
+      - "https://bmv.vi.gov/forms/  # BMV's 'Personalized License Plate' application form"
+      - "https://bmv.vi.gov/2023/03/03/2023-emancipation-license-plates/  # independent confirmation of the $49 figure, and the distinction BMV draws between PERSONALIZED BMV plates and VANITY plates 'charged by the organization issuing the plates'"
+    notes: >-
+      USVI PERSONALISED PLATES. THE VALUABLE FACT HERE IS A DISTINCTION, NOT A
+      FORMAT: BMV's March 2023 notice separates "Personalized BMV plates", priced
+      by BMV at $49, from "Vanity plates", which "will continue to be charged BY
+      THE ORGANIZATION ISSUING THE PLATES". That is direct agency evidence that
+      the USVI runs an organisation-sponsored plate channel alongside its own
+      personalised channel — see us-vi-specialty-index — and it is the kind of
+      structural fact that a fee schedule alone would never surface.
+
+  # =========================================================================
+  # SPECIALTY — INDEX ONLY, per PRD-PLATES §2.5.
+  # =========================================================================
+  - id: us-vi-specialty-index
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2026 }
+    period_evidence: agency-instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset: { notes: "specialty plates are presumed to carry ordinary island-prefixed serials on alternative designs; not verified" }
+      pattern_note: "illustrative only — this is an INDEX entry, not a spec"
+    design:
+      plate: { note: "one design per programme; the designs themselves are L4 scope (PRD-PLATES §2.5) and none is described here" }
+      emblem: { present: true, rendered: placeholder }
+    program_index:
+      count_official: null
+      count_official_note: >-
+        NO COUNT IS PUBLISHED AND NONE IS INVENTED. BMV maintains no specialty
+        gallery, no programme list and no enumerated catalogue on its public site;
+        the only structural fact it publishes is that vanity plates are "charged by
+        the ORGANIZATION issuing the plates", which establishes the channel exists
+        without sizing it. This is the single largest gap in the USVI file and the
+        most valuable thing a follow-up pass could close.
+      channel_structure: >-
+        BMV DRAWS A TWO-CHANNEL DISTINCTION IN ITS OWN WORDS: "Personalized BMV
+        plates will be charged $49 and VANITY PLATES will continue to be charged
+        BY THE ORGANIZATION ISSUING THE PLATES." So in the USVI a sponsoring
+        organisation, not the Bureau, prices its own plate — an administrative
+        arrangement closer to Texas's vendored MyPlates model than to Florida's
+        statutory annual-use-fee model, and worth flagging for the encyclopedia.
+      programs_evidenced:
+        - "Humane Society of St. Thomas (type first issued 2006)"
+        - "Prince Hall Masons (2006)"
+        - "US Virgin Islands Olympics (2009-2010) and Paralympics (2002)"
+        - "Virgin Islands Vintage & Classic Car Club (in use 2018)"
+        - "Alpha Kappa Alpha (in use 2017)"
+      programs_evidenced_note: >-
+        PHOTOGRAPHIC EVIDENCE ONLY, from a single enthusiast site, and listed to
+        show the SHAPE of the programme — fraternal, sporting, animal-welfare and
+        car-club sponsors — not to assert a catalogue. Five attested programmes is
+        a floor, not a count.
+    region_encoding: none
+    sources:
+      - "https://bmv.vi.gov/2023/03/03/2023-emancipation-license-plates/  # BMV's own two-channel statement: personalised BMV plates at $49 versus vanity plates priced by the sponsoring organisation"
+      - "https://bmv.vi.gov/fees/  # the published fee schedule, which contains NO specialty or vanity line item — corroborating that those are priced outside BMV"
+      - "http://www.plateshack.com/y2k/Virgin_Islands/viy2k.html  # CORROBORATION + GAP-FINDER: dated photographs of the five sponsored programmes listed above. No image or text copied; used only to establish that the channel is populated"
+    notes: >-
+      THE SPECIALTY PROGRAM INDEX — one entry standing for the whole programme,
+      per PRD-PLATES §2.5. THE HONEST HEADLINE IS THAT THIS INDEX HAS NO COUNT.
+      Florida's index records a contested count from two sources; Guam's and Puerto
+      Rico's record exact statutory counts; the USVI's records that the issuing
+      agency publishes nothing at all and that the pricing sits with third-party
+      sponsors. Recording the absence, with the reason and the five photographed
+      programmes that prove the channel is live, is more useful than a number
+      invented from a photo gallery — and it tells a verifier precisely where to
+      dig.


### PR DESCRIPTION
**PRD-PLATES gate L2 (owner-directed acceleration; research parallel, application ordered — L1 landed first per §7.1).** One of eleven US regional-group PRs covering all 50 states + DC + territories (FL was the L0 pilot). Drafted to the `de.yml`/`nl.yml`/`us-fl.yml` standard: primary-law verbatim headers, instrument-dated periods, `strict`/`recall-only` matching tiers, folklore flagged not asserted, **`artwork_risk` recorded per jurisdiction with evidence** (PRD-PLATES §4).

**This PR — territories:** PR GU VI MP AS (5 jurisdictions, 46 pinned primary sources).

**Verification:** researcher linted green in an isolated sandbox (proof file in the group dir, archived to the pipeline program dir); the driving session then independently staged ALL 55 wave files over pristine origin/main — `plates lint: 67 files, 604 series … OK` (385 new series; the _art gate stayed green) — and this branch is linted solo pre-push; CI runs the same gate.

**For the reviewer:** the dossier below carries the gaps (marked in the YAML at point of use), folklore flags, and the artwork_risk findings. The full research dossier follows verbatim.

---

# PRD-PLATES gate L2 — research dossier: US TERRITORIES (PR, GU, VI, MP, AS)

Researcher pass, 2026-08-02. Method: **FETCH-NEVER-ASSUME**. `WebSearch` was
unavailable for this session (the 200-call budget was exhausted before this
subagent started), so discovery followed the US/world dossier's own fallback
method: direct `WebFetch`/`curl` against known and guessed URL schemes, MediaWiki
`action=raw`, and link-harvesting from index pages. Nothing here is recalled from
memory. Dead ends are recorded in §6 rather than silently dropped.

Deliverables: `us-pr.yml`, `us-gu.yml`, `us-vi.yml`, `us-mp.yml`, `us-as.yml` —
**35 series, 46 distinct source URLs, lint green** (`plates lint: 17 files, 254
series … OK` in a sandbox copy of `plates/` + `scripts/lint_plates.rb`).

---

## 1. Headline findings (the four that should reach the PRD)

### 1.1 American Samoa is OUTSIDE the geographic scope of the US Copyright Act

The single most consequential legal finding of this pass, and it is not
plate-specific. The **US Copyright Office** position, quoted on Commons: US
copyright law "applies in all 50 states, the District of Columbia, Puerto Rico,
the US Virgin Islands, Guam, and the Northern Mariana Islands, **but does not
apply in American Samoa**" — grounded in 17 U.S.C. § 101's geographical
definition of "the United States", which reaches the several States, DC and the
**organized** territories. American Samoa is unorganized and unincorporated.
Commons operationalises this with `{{PD-American Samoa}}`.

This is a **stronger** posture than Florida's, which rests on state
constitutional law plus *Microdecisions v. Skinner* (2004). Here the Act simply
does not reach. **Recommendation:** amend PRD-PLATES §4's US state-law row to
carry the territorial-scope rule explicitly, and flag American Samoa to the
`plates/_art/` owner as the highest-value place in the entire US programme to do
affirmative emblem clearance work.

Two conditions keep it from being unconditional, and both are in the data: the
Commons tag's own limit ("so long as the work has not been copyrighted elsewhere
in the United States" — a mainland-authored design could still be protected), and
the fact that no American Samoa **territorial** copyright statute was searched for
successfully.

### 1.2 The territories split cleanly into two IP buckets, and only PR is favourable

| jurisdiction | posture recorded | evidence |
|---|---|---|
| **AS** | `outside-us-copyright-scope` | USCO: the Act does not apply; `{{PD-American Samoa}}` exists |
| **PR** | `public-domain-favourable` | `{{PD-PRGov}}` exists; Commons' US summary row lists Puerto Rico **with** CA/FL/GA/MA as public domain; basis = USCO Compendium (Third) ch. 300 |
| **GU** | `unresearched-presumed-protected` | USCO: the Act **applies**; `Template:PD-GuamGov` → **HTTP 404** |
| **VI** | `unresearched-presumed-protected` | USCO: the Act **applies**; `Template:PD-USVIGov` → **HTTP 404** |
| **MP** | `unresearched-presumed-protected` | USCO: the Act **applies**; `Template:PD-CNMIGov` → **HTTP 404** |

The 404s are *measured negatives*, fetched this pass, not assumptions. One trap
worth carrying: `{{PD-USGov-Unincorporated}}` looks like it should cover
territories but is expressly limited to **unorganized** territories — it does not
reach Guam, the USVI or the CNMI, all of which are organized.

Puerto Rico's favourable posture carries a caveat quoted verbatim in the file:
Commons itself says "Work of Organized Territories has less clear status; the
first link … shows strong evidence that Puerto Rico's works are in the public
domain, while the second link **prevaricates**." Recorded as
favourable-but-contested, not as settled.

### 1.3 The territory pattern: statutes legislate procedure, delegate design

Every territory in this group legislates *how many plates, where they go, who
issues them, what they cost, when they expire* — and delegates *design, size,
colour* to an administrative instrument. Three of the five delegations are
explicit in the same words:

- **PR**, Ley 22-2000 **Art. 2.18**: the Secretary determines by reglamento "el
  diseño, tamaño, colores, composición y otros detalles físicos de las tablillas,
  así como **la cantidad de tablillas** que utilizarán los diferentes vehículos".
- **GU**, 16 GCA **§ 7120(c)**: plates are "rectangular in shape and **such size
  as the Director of Revenue and Taxation may determine**".
- **MP/AS**: silent entirely.

**And in Guam the delegated instrument demonstrably does not exist.** 30 GAR
Div. 2 Chapter 6, "Vehicle Registration", reads in its entirety **"(No rules
filed.)"** with a note citing the rule-making authority (16 GCA §§ 7105, 7108,
7143, 7174) that was never exercised. That is a clean, citable negative: Guam's
plate design has *no* written legal basis at any level. It is the cleanest
example this programme has of why `hex_basis: observed` exists.

### 1.4 Two genuinely first-class decode facts, both statutory

- **Guam 16 GCA § 7122** reserves plate numbers **by named office**, in a table:
  `1` Governor, `1-A` Lieutenant Governor, `2` Speaker, `2-A` Vice-Speaker,
  `2-B` Legislative Secretary, `2-C`–`2-Z` Senators, `3` District Court Judge,
  `3-A`–`3-Z` Superior Court Judges, `4-A`–`4-Z` Mayors — issued on assumption
  of office, surrendered on removal, sequenced **alphabetically by surname**
  except Superior Court Judges, who are sequenced **by seniority**. A complete,
  government-issued, citable serial decode from a 1971 statute. No competing
  dataset carries it.
- **CNMI 9 CMC § 2116(c)(2)** gives the veteran-plate serial *by worked example*:
  "in alpha numeric format designating **branch of service and numerical
  sequence**. For example, **A001** (Army), **NG045** (National Guard), or
  **R610** (Reserves)." Encoded as `\A[A-Z]{1,2}\d{3}\z`, `matching: strict`.

A third, weaker but high-value: **USVI island prefixes** — `C` St. Croix, `T`
St. Thomas, `J` St. John (split out of the T block in 1975). Encoded as
`regex_strict: \A[CTJ][A-Z]{2} ?\d{3}\z`. Locator-grade; see §4.

---

## 2. Per-jurisdiction summary

| file | series | primary-source spine | strongest claim | weakest claim |
|---|---|---|---|---|
| `us-pr.yml` | 7 | **Ley 22-2000**, 210 pp, from the Commonwealth's own Biblioteca Virtual (OGP) | Art. 2.18: **rear-only display, statutorily, including motorcycles** | current base start (locator-only; not minted) |
| `us-gu.yml` | 10 | **16 GCA ch. 7**, Compiler of Laws, updated through P.L. 38-085 (Dec 20 2025) | § 7122 office decode; § 7179 temporary plates (P.L. 32-156, May 21 2014) | 2009/1994 base boundaries (`secondary-corroborated`) |
| `us-vi.yml` | 9 | **BMV's own plate notice** — statute unobtainable | "Effective March 1, 2023 … **mandatory** VI 175th Emancipation Commemorative Plates" | six of nine series rest on photographs |
| `us-mp.yml` | 4 | **9 CMC** Div. 2, current to PL 24-23 (Mar 11 2026) | § 2116(c)(1) confirms the **HAFA ADAI** legend on the standard plate | § 2109's text is internally anomalous (§3.3) |
| `us-as.yml` | 5 | **A.S.C.A. Title 22 ch. 10** — seven sections total | 22.1002(f): tags reissued only after **five years' absence** | the 40-row class-prefix table (single source) |

Class coverage across the group: `standard` 8, `specialty` 6, `government` 5,
`dealer` 4, `temporary` 3, `personalized` 3, `taxi` 2, plus one each of
`historic`, `trailer`, `motorcycle`, `agricultural`.
`matching`: **22 recall-only, 13 strict** — an unusually recall-heavy file set,
and deliberately so (§4.2).

---

## 3. Findings worth reading in full

### 3.1 Puerto Rico: the "rear-only since 1976" folklore has a statute behind it

Every secondary source repeats "rear plate only since 1976" for Puerto Rico with
no instrument. **Art. 2.18 states the rule in current law** — "Las tablillas
serán fijadas horizontalmente y en forma visible en la **parte posterior** de
todo vehículo de motor o arrastre, **incluyendo motocicletas**" — plus a
colourless-lamp illumination duty and a legibility-in-motion requirement. So the
dataset can assert rear-only for PR **from an edict of government** and leave the
1976 date in the locator where it belongs. This is the single clearest
folklore-to-primary upgrade of the pass.

Related PR wins: **Art. 2.32(a)** legislates the *vanity-plate content-refusal
criteria* that Florida's Chapter 320 does not (where `us-fl-personalized` records
a gap, `us-pr-personalized` records a sourced rule); **Art. 2.26** sets a rolling
40-year antique threshold measured **against the plate's issue date**, not the
calendar year; **Art. 2.13** makes plates Department property returnable in 30
days; and **PR states no length cap anywhere**, so PR regexes are unbounded — a
consumer applying Florida's seven-character convention to Puerto Rico would be
imposing the wrong jurisdiction's law.

**PR specialty index is an edict**: seven programmes, one article each (2.20
press, 2.26 antique, 2.27 consuls, 2.28 radio amateurs, 2.29 legislators, 2.30
mayors, 2.31 ex-POW veterans). Art. 2.31 contains the only lawful PR front plate:
the ex-POW plate may go on the rear, in which case *the official plate moves to
the front*.

### 3.2 Guam: the best-legislated regime in the group

16 GCA ch. 7 legislates what most US states delegate: two plates front and rear
(§ 7120(a)); the mandatory word **"Guam"** and a year number *or* validation
device (§ 7120(b)); rectangular shape (§ 7120(c)); separate numerical series for
trailers/semi-trailers/motor bicycles/pole-and-pipe dollies (§ 7126); a composite
dealer serial — a per-dealer "general distinguishing number" plus a per-plate
discriminator (§ 7128(c)); and a **seven-position cap** on personalised plates
whose no-conflict proviso (§ 7123(c)) is itself primary evidence that Guam runs
at least **six distinct serial namespaces** (passenger, commercial, trailer,
motorcycle, special, plus §§ 7121–7122).

**§ 7179 temporary plates are delegated to private dealers**: DRT authorises
dealers to *issue* them at ≤$10, and the plate carries **no serial at all** —
its identity is the words "Guam Temporary Registration", the dealer's name, two
dates and the VIN, in indelible ink, letters ≥¾ inch. Valid 60 days or until
permanent plates issue or the sale is rescinded, whichever first. Enacted
P.L. 32-156:2, **May 21, 2014** — the cleanest statutory date in the group.

### 3.3 CNMI: a probable compilation defect, recorded not corrected

9 CMC § 2109(a)(1) as served reads: "A license plate issued for any vehicle while
publicly owned **need not display a distinguishing symbol, word or letter**."
Its evident model — Guam 16 GCA § 7136(a), structurally parallel and largely
identical in wording — reads the other way: a government plate need not display
**the year number**, "but **shall** display a distinguishing symbol, word or
letter". The CNMI text appears to have lost the year-number exemption and
inverted the distinguishing-mark duty. **Flagged in the data, relied on in
neither direction** (PRD-PLATES §5.3).

**A methodological finding attaches to this.** The CNMI gold-star provision
(9 CMC § 2116(g), PL 19-26, Dec 14 2015) is near word-for-word Guam's 16 GCA
§ 7120.3 (P.L. 30-062, Nov 27 2009) — *"except that a gold star shall appear on
one side of the license plate"*. **Guam and CNMI statutes agreeing is not two
independent sources; it is common drafting ancestry.** Any verifier
cross-checking these two territories must test for shared text first. This
recurs: both territories legislate permanent, non-renewing government
registrations in parallel language.

### 3.4 USVI: agency-primary where statute is unreachable

Title 20 VIC could not be obtained by any route (§6). What saved the file is that
**BMV publishes its own plate announcements**. Its 2023-03-03 notice gives a hard
effective date, mandatory status, and the changeover mechanism — old plates
surrendered at annual renewal, renewal not completing until they are turned in;
free at 65+; personalised at $49; collected in person, never mailed. That is a
**documented full-fleet replacement executed through the renewal cycle**, and it
is why the USVI is the only jurisdiction in this group whose current *and*
previous bases are both minted as dated series.

BMV also draws a structural distinction no fee schedule would surface:
"Personalized BMV plates will be charged $49 and **Vanity plates will continue to
be charged by the organization issuing the plates**" — i.e. the USVI runs a
sponsor-priced specialty channel alongside its own, closer to Texas's vendored
MyPlates model than to Florida's statutory annual-use-fee model. **No specialty
count is published and none was invented**; five sponsored programmes are
attested photographically and recorded as a floor.

Note the parse consequence recorded in the file: the USVI serial grammar is
**unchanged** across the 2016→2023 boundary. Only artwork changed. **A USVI plate
can never be dated from its number.**

### 3.5 American Samoa: tags, not plates; and no routine reissue

A.S.C.A. Title 22 ch. 10 is seven sections. It says **"license tags"** throughout
(preserved in the data, not normalised — a jurisdiction's own vocabulary is a
fact about it). Two tags, front and rear, legible at **50 feet**, illuminated
(22.1003). Two **decals** per registration, placed *on the tags* (22.1002(c)).
And the fact with the most downstream consequence: **22.1002(f) issues new tags
only** to an applicant registering a vehicle not registered in the Territory in
the **preceding five years**, or on proof of loss/theft ($22.00). Photographs
confirm the prediction — single tags carrying "August 2019 through August 21" and
"January 2017 through January 2023" decal stacks.

American Samoa is also the only all-numeric standard serial in the group, which
makes **the presence of letters itself a classification signal**.

---

## 4. Methodological calls a verifier should scrutinise

### 4.1 "One series back" was minted only where evidence allowed

PRD-PLATES §7 asks L2 for the previous standard base. The evidence did not
support that uniformly, and the files diverge deliberately:

| jurisdiction | previous base | call | why |
|---|---|---|---|
| VI | **minted** (`us-vi-standard-2016`) | series | its **end** boundary is agency-primary (BMV mandatory replacement); start is locator, and `period_evidence: mixed-locator-start-agency-end` says so |
| GU | **minted** (`us-gu-standard-1994`) | series | two *independent* secondary sources agree on 2009, **and** the serial arrangement changes at the boundary (LLL 999 → LL 9999), so it is a format boundary, not a styling change |
| PR, MP, AS | **not minted** | `previous_base_reported:` block | Wikipedia-only boundaries; minting a dated id on folklore would force a former-id alias later (PRD-QUALITY I-5/I-6) |

This is the judgement call most likely to be contested. The alternative — mint
everything with a low evidence grade — was rejected because PRD-PLATES §4 makes
Wikipedia a **locator**, and a period claim resting only on a locator is not a
verified fact. **If the maintainer prefers uniform minting, the `previous_base_reported`
blocks contain everything needed to promote them in one edit.**

### 4.2 Why 22 of 35 series are `recall-only`

Because the territories delegate format to instruments that were not obtained.
For those series the honest encoding is: illustrative `pattern` (the printed
shape of the base plate the class sits on), a **statutory-alphabet catch-all**
`regex`, and `matching: recall-only` — which is exactly PRD-PLATES §2.7's
declaration that *"a match is a shape hit and nothing more"*. Every such series
carries a `pattern_note` saying the pattern is illustrative. This is the
mechanism §2.7 exists for and it is being used as designed rather than as an
escape hatch: where a grammar **is** sourced (GU officials, GU personalized, GU
trailer, MP veteran, AS standard, PR personalized, VI island prefix) the series is
`strict`.

### 4.3 Evidence-grade vocabulary used in `period_evidence`

Beyond `us-fl.yml`'s `instrument-in-force-upper-bound` and `statutory-date`, this
group needed finer distinctions. All are free-text (the lint does not constrain
the field) and all are defined on use:
`statutory-enactment-date`, `statutory-enactment-date-upper-bound`,
`statutory-amendment-date-upper-bound`, `agency-instrument-date`,
`agency-instrument-in-force-upper-bound`, `mixed-locator-start-agency-end`,
`secondary-corroborated`, `secondary-reported-upper-bound`, `locator-reported`,
`photographic-in-use-upper-bound`, `instrument-in-force-upper-bound`.
**Recommendation:** if this proliferation is unwelcome, collapse to a small
controlled vocabulary in `_meta/` and lint it — but do not collapse
`agency-instrument-date` into `secondary-*`, because the USVI case is genuinely a
primary-source date.

### 4.4 Where enthusiast sites were used, and the bar applied

`plateshack.com` and `worldlicenseplates.com` were used as **corroboration and
gap-finders only**, cited where used, **no text or image copied**. plateshack's
Guam page carries an explicit *"Copyright 1997-2006. Please ask permission before
using any images"* notice — respected absolutely.

The bar applied before a reported class became its own series: **two independent
sources**. That is why `us-as-agricultural` exists (locator *and*
worldlicenseplates both report `AC`) while the other ~40 rows of the American
Samoa prefix table stay inside `us-as-standard.class_prefix_table_reported`
rather than becoming forty thin series. `us-as-dealer` is the one deliberate
exception (single photograph) and is flagged in its own notes as "the first thing
to either confirm or delete".

---

## 5. Folklore flagged / debunked

1. **"PR rear-only since 1976."** Repeated everywhere, uncited. Superseded: the
   rule is in **Ley 22-2000 Art. 2.18** and sweeps in motorcycles. The *1976
   date* remains unsourced and is left in the locator.
2. **"Guam plates are coded by village."** The Wikipedia locator says the current
   `AB 1234` serial is "coded by municipality". worldlicenseplates says something
   narrower and different about a *different* series: on the **1994** series it is
   the **last three letters of COMMERCIAL plates** that designate the municipality
   (`FAP` Fort Apugan, `MLL` Mount Lamlam). **Two different claims about two
   different series and two different vehicle classes.** Recorded side by side;
   **no Guam decode table is asserted** (PRD-PLATES §5.3 — record, don't average).
3. **The "1956 AMA standardization agreement"** for 6×12 in. Uncited upstream and
   copied verbatim into the Puerto Rico article specifically (the US/world dossier
   already caught the circularity). **No territory file cites it**; every 12×6
   figure in this group is marked as *reported North American convention*, because
   not one of the five territories legislates a dimension.
4. **CNMI 2005 "base change."** The locator splits 1989–2005 and 2005–present. The
   only described difference is embossed → surface-printed serials, with no format
   consequence and no primary. **Not minted as a boundary.**
5. **American Samoa "first 6×12 plate in 1977."** Attributed by the locator to a
   collector-journal article (Garrish, *Plates* 62(5), Oct 2016) that was not
   obtained. Recorded as a **lead, not a fact**.
6. **Guam/CNMI cross-corroboration.** Not folklore but a trap of the same shape:
   their gold-star and government-plate provisions share drafting. **Apparent
   agreement between these two territories must be tested for common ancestry.**

---

## 6. Dead ends (skipped-beats-assumed)

**Blocked / unreachable**

| target | outcome |
|---|---|
| **Virgin Islands Code, Title 20** | ⚠️ **The largest single gap in this group.** `law.justia.com` → **403** to both curl and WebFetch; `lexisnexis.com/hottopics/vicode/` and `advance.lexis.com/container?...` → **200 but JavaScript shells**, zero extractable text; `vicode.lexisnexis.com` → does not resolve; `legvi.org` → **403**; `law.onecle.com/virgin-islands/` and `law.resource.org/pub/us/code/vi/` → **404**; Wayback availability API returns **empty `archived_snapshots`** for the Justia VI Title 20 paths. VI statutory text reaches this dataset only second-hand through BMV (§ 335, § 218a). |
| `guamtax.com` (Guam DRT) | **connection reset**, both schemes, every attempt. Guam's issuing agency has no reachable web presence from here; the file's authority URL points at the Compiler of Laws instead. |
| `dps.gov.mp` (CNMI Dept. of Public Safety) | **HTTP 401** on every attempt. |
| `www.guamcourts.org/CompilerofLaws/...` | connection reset on the old path; **workaround that worked:** the site redirects to `guamcourts.gov`, whose Compiler-of-Laws page links out to **`col.guamcourts.gov`**, where Title 16 chapter PDFs live at `/sites/default/files/16gc0NN.pdf`. |
| `lexjuris.com` consolidated Ley de Tránsito | **members-only paywall**; the site's own `Leyes2000` deep links are broken `file://` paths. **Workaround that worked:** `bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf` — the Commonwealth's own virtual library, 47 MB, HTTP 200. |
| `www.oslpr.org/download/{es,en}/2000/A-0022-2000.pdf` | 404 both languages. |
| **WebSearch** | budget exhausted (200/200) before this pass began — all discovery was URL-guessing and link-harvesting. |

**Sought but not present / not extracted**

- **PR reglamento under Arts. 2.12, 2.17, 2.18, 2.26, 2.32.** The instrument that
  actually fixes PR plate design, size, colours *and the number of plates per
  vehicle*. Not located on dtop.pr.gov or cesco.pr.gov. **Highest-value single
  target for a follow-up pass.**
- **PR statute currency.** The served scan carries no amendment-currency
  statement, and photographs attest ≥4 specialty programmes (Roberto Clemente,
  Make-A-Wish, San Juan 500th, Olympic Committee) that the served text does not
  create. Either the scan is not current, or those rest on separate acts or on the
  reglamento. **Unresolved and recorded in the data.**
- **PR OCR quality.** The 210-page scan is image-only (`Producer: PyPDF2`,
  `pdftotext` yields zero lines). OCR'd locally with tesseract 5.5.1 — **`eng`
  only; no `spa` model available**. Spanish diacritics are lossy in every quoted
  fragment. Quotes are recorded as **substance, not verbatim transcription**, and
  the file says so at the top. **A verifier with a Spanish OCR model should re-read
  Arts. 1.94, 2.12–2.20 and 2.26–2.33.**
- **CNMI Administrative Code / NMIAC motor-vehicle title.** Served by title at
  cnmilaw.org but no BMV/motor-vehicle title was identified. Whether CNMI
  regulations add specialty programmes beyond § 2116's three is **undetermined**.
- **A.S.C.A. 22.1005 ("Exemptions")** text not extracted — the likely statutory
  hook for American Samoa's government fleet.
- **Guam motorcycle series.** § 7123(c)'s no-conflict proviso names a motorcycle
  series and plateshack shows a motorcycle section, so Guam plainly serialises
  motorcycles separately — **no Guam instrument describing it was found.** The
  largest gap in `us-gu.yml`.
- **47 CFR amateur call-sign format.** Not pinned. Both Guam (§ 7121) and Puerto
  Rico (Art. 2.28) delegate a plate serial to FCC call letters; pinning 47 CFR
  would upgrade **both** series from `recall-only` to `strict` in one step.
- **Territorial copyright statutes** for GU, VI, MP, AS. None searched for
  successfully. The three `unresearched-presumed-protected` postures could each
  move on one primary source.
- **Front/rear rule for the USVI.** Lives in Title 20 VIC (unobtainable); BMV does
  not state it. **No front/rear claim is made for the USVI** — the only
  jurisdiction in the group where that basic fact is absent.

---

## 7. PIN-LIST — the primary sources that carry this group

**Statutes and codes (edicts of government — PD at every level)**
1. `https://bvirtual.ogp.pr.gov/ogp/Bvirtual/leyesreferencia/PDF/2/0022-2000.pdf` — **Ley 22-2000**, PR Vehicle & Traffic Act, 210 pp scanned, HTTP 200, 47 MB. Arts. 1.94, 2.05, 2.11–2.20, 2.26–2.34.
2. `https://col.guamcourts.gov/sites/default/files/16gc007_0.pdf` — **16 GCA ch. 7**, §§ 7101–7180. The richest plate statute in the group.
3. `https://col.guamcourts.gov/sites/default/files/30GAR002-5_8.pdf` — **30 GAR Div. 2 ch. 6 "(No rules filed.)"** — the measured negative.
4. `https://col.guamcourts.gov/sites/default/files/16gc_TOC_0.pdf` — Title 16 TOC; the edition stamp (P.L. 38-085, COL 2026-04-23).
5. `https://cnmilaw.org/pdf/cmc_section/T9/2106.pdf` — 9 CMC § 2106 + the PL 14-18 legislative findings.
6. `https://cnmilaw.org/pdf/cmc_section/T9/2116.pdf` — 9 CMC § 2116: **the HAFA ADAI confirmation** and the veteran serial grammar.
7. `https://cnmilaw.org/pdf/cmc_section/T9/2109.pdf` — 9 CMC § 2109, incl. the anomaly in §3.3.
8. `https://cnmilaw.org/pdf/cmc_section/T9/2107.pdf` · `/2105.pdf` · `/2101.pdf` · `/1209.pdf` — expiry, cards, application, seizure.
9. `https://www.cnmilaw.org/cmc.php` — the Commonwealth Code index (section-PDF scheme `/pdf/cmc_section/T{n}/{sec}.pdf`).
10. `https://asbar.org/code-annotated/22-1002-application-for-and-issuance-of-license-fees/` — A.S.C.A. 22.1002, the whole of American Samoa's registration content.
11. `https://asbar.org/code-annotated/22-1003-display-of-license/` · `/22-1004-…/` · `/22-1001-…/` — display, expiry, requirement.
12. `https://asbar.org/section/title-22-highways-and-motor-vehicles/chapter-10-vehicle-licensing-and-registration/` — the chapter index (7 sections).

**Issuing-agency primaries**
13. `https://bmv.vi.gov/2023/03/03/2023-emancipation-license-plates/` — **the best-dated fact in the group**: effective 2023-03-01, mandatory, surrender-at-renewal, 65+ free, $49 personalised, sponsor-priced vanity.
14. `https://bmv.vi.gov/vehicles/` — Title 20 § 335 and § 218a second-hand; plate-and-sticker surrender; inspection age exemptions.
15. `https://bmv.vi.gov/fees/` · `https://bmv.vi.gov/forms/` — fee schedule; dealer plate / dealer temporary tag / personalised / rental-quota forms.
16. `https://www.dtop.pr.gov/` · `https://www.cesco.pr.gov/` — PR issuing authority (no enumerated specialty catalogue found).

**IP / licensing**
17. `https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/United_States` — **the territorial-scope finding** (USCO: the Act does not apply in American Samoa); the US Territories tag list; the organized-territories caveat for PR; the unorganized-only limit on `{{PD-USGov-Unincorporated}}`.
18. `https://commons.wikimedia.org/wiki/Template:PD-PRGov` — exists; basis = USCO Compendium ch. 300.
19. `https://commons.wikimedia.org/wiki/Template:PD-American_Samoa` — exists, with its "not copyrighted elsewhere in the United States" condition.
20. `https://commons.wikimedia.org/wiki/Template:PD-GuamGov` · `…PD-USVIGov` · `…PD-CNMIGov` — **all HTTP 404**; measured negatives.
21. `https://copyright.gov/comp3/chap300/ch300-copyrightable-authorship.pdf` — USCO Compendium (Third) ch. 300.

**Standards**
22. `https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf` — AAMVA Ed.3 §§1.1, 2.1, 2.2, 3.1, 3.3. **SAE J686 never quoted** (paywalled, unpinned — standing rule).

**Locators / corroboration (cited where used; no text or images copied)**
23. `https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Puerto_Rico` · `…_of_Guam` · `…_of_the_United_States_Virgin_Islands` · `…_of_the_Northern_Mariana_Islands` · `…_of_American_Samoa` — locators only.
24. `http://www.plateshack.com/y2k/Puerto_Rico/pry2k.html` · `/Virgin_Islands/viy2k.html` · `/Northern_Marianas/cnmiy2k.html` · `/American_Samoa/asy2k.html` · `http://www.plateshack.com/guam/guam.html` (explicit © notice, respected).
25. `http://www.worldlicenseplates.com/world/PA_GUAM.html` · `/PA_NMAR.html` · `/PA_AMSA.html` — the Guam series list, the CNMI shortage note, the American Samoa prefix table. (`NA_US{GU,PR,VI}.html` → **404**; the Pacific tree is the working scheme for GU/MP/AS and there is **no worldlicenseplates page for PR or VI**.)

---

## 8. Verification protocol handoff

Per PRD-PLATES §5.3 (researcher ≠ verifier), the independent verifier should
re-derive, in this priority order:

1. **`us-vi-standard-2016`'s 2016 start** — the only *locator-only boundary
   inside a minted series* in the whole group.
2. **PR Arts. 1.94 / 2.18 / 2.26 / 2.32** with a Spanish OCR model, to confirm the
   substance-quoted fragments (esp. the *absence* of a length cap, on which four
   PR regexes depend).
3. **Guam's 2009/1994 boundaries** — `secondary-corroborated`, and the basis for
   two minted series.
4. **CNMI § 2109(a)(1)** against the CNMI session laws, to confirm or refute the
   suspected compilation defect (§3.3).
5. **The American Samoa 40-row prefix table** — single-source; nothing in the
   dataset decodes from it yet, and nothing should until this is done.
6. **The three `unresearched-presumed-protected` artwork postures** (GU, VI, MP) —
   each could move on one territorial primary.

Nothing in this group was applied to `/Users/javi/GitHub/vehiclesdb`, which was
treated as read-only throughout. Verification ran in a sandbox copy
(`…/plates-l2/territories/sandbox/`).
