### PR TITLE
plates: us-fl re-dated to the Laws of Florida — 10 IRP-cycle/consolidation dates replaced; 1957/1972/1995/1997/1999 pinned; 2003 base flagged uncited

### DIFF
--- a/plates/us-fl.yml
+++ b/plates/us-fl.yml
@@ -27,12 +27,38 @@
 # WHAT IS DELIBERATELY NOT HERE (PRD-PLATES §2.5): the individual specialty
 # DESIGNS. L2 indexes the programs with official links and counts; individual
 # designs are L4. `us-fl-specialty-index` is that index entry and nothing more.
+#
+# RE-DATED TO THE L1 EVIDENCE STANDARD (pass of 2026-08-02). The L0 pilot
+# shipped every period.start as the STATUTE-EDITION year (2024/2025 —
+# instrument dates), which is exactly the disease the period_evidence
+# discipline exists to prevent: Florida standard plates obviously predate
+# 2025. This pass re-dates all ten series from primary instruments:
+#   * the History lines of §§ 320.06, 320.086, 320.0805 and 320.08056 (each
+#     History note is part of the official statute publication and lists every
+#     amending chapter law with its session year — the first entry is the
+#     section's creating act);
+#   * the 1997 ARCHIVE EDITION of the Florida Statutes (the earliest edition
+#     leg.state.fl.us serves, via the StatuteYear parameter) — presence of a
+#     legend sentence in 1997 gives a real upper bound three decades tighter
+#     than the 2025 edition;
+#   * Laws of Florida ch. 99-248 (laws.flrules.org/1999/248, the full chapter
+#     law, 142 pp, strike/underline coded: "CODING: Words stricken are
+#     deletions; words underlined are additions") — which pins the 1999
+#     historic-plate restructure and the Manufacturer legend's insertion to
+#     the sentence.
+# NEGATIVE FINDING, recorded so nobody repeats the hunt: FLHSMV has NO
+# plate-history page — the department's full WordPress sitemap (3,988 URLs)
+# was enumerated on 2026-08-02 and nothing on flhsmv.gov dates any base
+# design. The standard base's start therefore rests on a FLAGGED secondary
+# (see us-fl-standard.notes), not on an agency page, and the immediately-prior
+# base is NOT authored because no primary and no cited secondary dates it
+# (recorded gap, L4 work).
 jurisdiction: us-fl
 authority:
   name: Florida Department of Highway Safety and Motor Vehicles (FLHSMV)
   url: "https://www.flhsmv.gov/motor-vehicles-tags-titles/license-plates-registration/"
 binding: vehicle
-statute_edition: "The 2025 Florida Statutes (Title XXIII Motor Vehicles, Chapters 316 and 320) — the edition read for this pass; leg.state.fl.us serves editions back to 1997"
+statute_edition: "The 2025 Florida Statutes (Title XXIII Motor Vehicles, Chapters 316 and 320) — the current edition read; leg.state.fl.us serves archive editions back to 1997, and the 1997 editions of §§ 320.06 and 320.086 were read for the 2026-08-02 re-dating pass, together with Laws of Florida ch. 99-248 (laws.flrules.org, accessed 2026-08-02)"
 
 # ---------------------------------------------------------------------------
 # artwork_risk — required per jurisdiction by PRD-PLATES §4.
@@ -116,8 +142,11 @@ series:
   - id: us-fl-standard
     class: standard
     categories: [car, van, truck, bus, motorcycle, moped, trailer]
-    period: { start: 2025 }
-    period_evidence: instrument-in-force-upper-bound
+    period: { start: 2003 }        # the current base's reported introduction —
+                                   # December 2003 per the locator, whose table
+                                   # row carries NO footnote; see notes. NOT an
+                                   # agency or statutory date.
+    period_evidence: secondary-locator-unverified
     matching: strict
     format:
       pattern: "LLL 999"
@@ -203,19 +232,41 @@ series:
       - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(1)(a) one plate + 'letters and numerals or numerals'; (1)(b)1 the 10-year cycle, $28 fee, birth-month validation sticker; (1)(c) registration periods; (3)(a) 6x12 minimum, retroreflection, seven-character cap, FLORIDA top / county-motto-Sunshine State bottom, county opt-out"
       - "https://www.flhsmv.gov/pdf/specialtyplates/FLPB.pdf  # official FLHSMV 'Florida License Plates' brochure, 27 pp — confirms the four standard variants: Sunshine State, County Name, In God We Trust (State Motto), America 250"
       - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA Ed.3 §1.1 replacement-cycle recommendation Florida's 10 years sits at the top of"
-      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Florida  # LOCATOR ONLY (PRD-PLATES §4): the reported February 2026 rollout of the orange-blossom design and the seven historical serial arrangements. Neither is asserted as sourced here."
+      - "https://www.flhsmv.gov/2025/12/15/flhsmv-launches-america-250-license-plate/  # FLHSMV press release, 15 December 2025 (accessed 2026-08-02), verbatim: 'Unlike specialty plates, the America 250 plate serves as an alternative to the standard Florida license plate, with all regular fees applying.' — the agency's own words for the standard-variant relationship, and primary evidence the standard frame recorded here is current issue"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Florida  # LOCATOR ONLY (PRD-PLATES §4), re-checked 2026-08-02: the December 2003 introduction of the current base, the February 2026 rollout of its successor, and the seven historical serial arrangements ALL carry no footnote in the article's tables — folklore-grade. The 2003 start below is recorded as this locator's claim, flagged, not asserted as sourced."
     notes: >-
-      FLORIDA STANDARD ISSUE. THE ID IS DELIBERATELY UNDATED. PRD-PLATES's own
-      example id is `us-fl-standard-2003`, but no primary establishing the boundary
-      between Florida base-design generations was obtained in this pass: the FLHSMV
-      brochure carries designs as images with no dates, and the reported February
-      2026 rollout of the orange-blossom base is Wikipedia-grade. Rather than mint a
-      dated id on a folklore boundary and then have to alias it, this entry is the
-      undated statutory series; when a primary lands, a dated id is added and this id
-      becomes its former-id alias under the PRD-QUALITY I-5/I-6 contract.
-      PERIOD CAVEAT: `start: 2025` is the edition of the Florida Statutes read and is
-      an UPPER BOUND on the true start — Florida has issued alphanumeric plates for
-      the better part of a century. Recorded as an upper bound rather than invented.
+      FLORIDA STANDARD ISSUE ON THE CURRENT BASE. RE-DATED 2026-08-02: the L0
+      pass shipped `start: 2025`, the statute-edition year — an instrument date,
+      not a design date, and off by two decades. The current base (orange
+      graphic over a state map between the serial groups; county / motto /
+      Sunshine State bottom legends) is reported to have entered issuance in
+      DECEMBER 2003 by the Wikipedia table, WHOSE ROW CARRIES NO FOOTNOTE —
+      so `period_evidence: secondary-locator-unverified` and 2003 is the
+      locator's claim, flagged, not asserted (PRD-PLATES §9: primary-source-or-
+      marked). What WAS verified, and why nothing better exists to pin: (1)
+      FLHSMV has NO plate-history page — the department's full sitemap (3,988
+      URLs) was enumerated on 2026-08-02 and nothing on flhsmv.gov dates any
+      base; (2) the statute never dates or describes the design — § 320.06(3)(a)
+      mandates legends and retroreflection, never artwork, and its History line
+      has no 2003 entry (the design is departmental, not legislated); (3) the
+      base demonstrably remains current issue: the FLHSMV brochure (HSMV 80003,
+      Rev. 6/2026) shows it and the department's 15 December 2025 America 250
+      launch calls that plate 'an alternative to the standard Florida license
+      plate'. The reported FEBRUARY 2026 rollout of a successor base is equally
+      uncited in the locator and is NOT asserted — if it is real, it becomes a
+      new dated series when an agency primary lands. THE ID STAYS UNDATED under
+      the id contract: minting `us-fl-standard-2003` on a folklore boundary
+      would build a dated id on sand; when a primary lands, the dated id is
+      added and this id becomes its former-id alias (PRD-QUALITY I-5/I-6).
+      THE IMMEDIATELY-PRIOR BASE (the green-serial county base the locator
+      dates to the late 1970s in several sub-forms) is deliberately NOT
+      authored: no primary and no CITED secondary dating it was found, and
+      inventing its period would be the exact disease this pass removes
+      (recorded gap, L4 work). SERIAL-ARRANGEMENT CAVEAT: `regex` encodes the
+      current three-letter/three-numeral arrangement only; the locator reports
+      several arrangements issued ON THIS SAME BASE since 2003 (A12 3BC from
+      2004, 123 ABC from 2009, ...), none with a citation — they remain inside
+      `regex_statutory` and are a recorded gap, per pattern_note.
 
   # =========================================================================
   # SPECIALTY — THE PROGRAM INDEX, per PRD-PLATES §2.5. Count and official
@@ -224,8 +275,10 @@ series:
   - id: us-fl-specialty-index
     class: specialty
     categories: [car, van, truck, motorcycle]
-    period: { start: 2025 }
-    period_evidence: instrument-in-force-upper-bound
+    period: { start: 1995 }        # s. 2, ch. 95-282 created § 320.08056, the
+                                   # specialty-plate framework — the first
+                                   # entry in the section's History line.
+    period_evidence: statutory-creation-date
     matching: strict
     format:
       pattern: "LLL 999"
@@ -256,35 +309,72 @@ series:
         so it must be snapshotted monthly or the history is lost forever.
       brochure_sections_observed: ["STANDARD", "SPECIALTY - COLLEGIATE", "SPECIAL - COMMERCIAL VEHICLE", "SPECIAL - FRONT END FOR EMERGENCY PERSONNEL", "SPECIAL - HISTORICAL VEHICLE", "SPECIAL - MISCELLANEOUS"]
       special_requirement_subtype: "FLHSMV distinguishes SPECIAL REQUIREMENT plates as 'a subtype of specialty license plates' — those needing the registrant to furnish proof before purchase (military decorations, disabled veteran, etc.). Medal of Honor, Air Force Cross, Navy Cross, Distinguished Service Cross, Silver Star, Distinguished Flying Cross and World War II Veteran plates must be ordered through the Department, not a service centre."
-      churn_note: "§ 320.08056(8)(a) obliges the department to DISCONTINUE issuance of an approved specialty plate in stated circumstances, so the index is a moving target with authorised-but-dead programs in it. The numeric threshold triggering discontinuation was not extracted in this pass (recorded gap)."
+      churn_note: >-
+        § 320.08056(8)(a), verbatim (accessed 2026-08-02, closing the L0 pass's
+        recorded gap): 'The department must discontinue the issuance of an
+        approved specialty license plate if the number of valid specialty plate
+        registrations falls below 3,000, or in the case of an out-of-state
+        college or university license plate, 4,000, for at least 12 consecutive
+        months.' So the index is a moving target with authorised-but-dead
+        programs in it, and the churn threshold is now pinned.
       gift_certificate_program: "FLHSMV authorises specialty-plate GIFT CERTIFICATES redeemable at any authorised motor-vehicle office; money passes to the sponsoring entity on purchase, so refunds are not available."
     region_encoding: none
     sources:
       - "https://www.flhsmv.gov/motor-vehicles-tags-titles/personalized-specialty-license-plates/  # FLHSMV: 'Florida offers over 100 different specialty license plates'; the special-requirement subtype; the military-plate ordering rule; the gift-certificate program"
       - "https://services.flhsmv.gov/specialtyplates/  # Monthly Active Specialty Plates report (no historical data) + Monthly Revenue Collections report (3-year history)"
       - "https://www.flhsmv.gov/pdf/specialtyplates/FLPB.pdf  # the 27-page official catalogue and its section structure"
-      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.08056.html  # § 320.08056: specialty plate authorisation, annual use fees, and the (8)(a) discontinuation duty"
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.08056.html  # § 320.08056: specialty plate authorisation, annual use fees, the (8)(a) discontinuation duty with its 3,000/4,000-registration threshold, and the History line whose first entry — 's. 2, ch. 95-282' — dates the framework to 1995 (accessed 2026-08-02)"
     notes: >-
       THE SPECIALTY PROGRAM INDEX — one entry standing for the whole program, which
-      is what PRD-PLATES §2.5 asks for at this gate. Two things worth carrying
-      forward. First, the count is CONTESTED: FLHSMV says over 100, Wikipedia says
-      over 120, and the honest record is both figures with their sources, not a
-      split. Second, the monthly active-plate report is the single most valuable
-      structured artefact found in the whole US pass and it is NOT archived by its
-      publisher — a monthly capture job should be scheduled before L2, because every
-      month not captured is permanently gone.
+      is what PRD-PLATES §2.5 asks for at this gate. RE-DATED 2026-08-02:
+      `start: 1995` is the creation year of the § 320.08056 framework — the
+      section's History line opens 's. 2, ch. 95-282' (Laws of Florida 1995),
+      and a History note is part of the official statute publication, so this
+      is a statutory-creation-date claim on the FRAMEWORK the index stands for.
+      FOLKLORE FLAGGED, NOT ASSERTED: individual Florida specialty plates are
+      commonly said to predate the framework (the mid-1980s Challenger
+      commemorative is the standard story), but the pre-1995 authorisations
+      lived in predecessor sections and Laws of Florida before 1997 are not
+      served online — the pre-1995 program history is a recorded gap, and no
+      pre-1995 start is claimed for any individual program here. Two things
+      worth carrying forward. First, the count is CONTESTED: FLHSMV says over
+      100, Wikipedia says over 120, and the honest record is both figures with
+      their sources, not a split. Second, the monthly active-plate report is
+      the single most valuable structured artefact found in the whole US pass
+      and it is NOT archived by its publisher — a monthly capture job should be
+      scheduled before L2, because every month not captured is permanently gone.
 
   - id: us-fl-personalized
     class: personalized
     categories: [car, van, truck, motorcycle]
-    period: { start: 2025 }
-    period_evidence: instrument-in-force-upper-bound
+    period: { start: 1972 }        # ss. 1-9, ch. 72-80 created § 320.0805,
+                                   # 'Personalized prestige license plates' —
+                                   # the first entry in its History line.
+    period_evidence: statutory-creation-date
     matching: strict
     format:
       pattern: "LLLLLLL"
       regex: '\A[A-Z]{1,7}\z'
       regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,6}\z'
-      charset: { notes: "owner-chosen inside the § 320.06(3)(a) frame: bold letters and numerals or numerals, at most seven characters. Availability is checked through FLHSMV's Personalized License Plate Inquiry before order." }
+      charset:
+        notes: >-
+          Owner-chosen inside the § 320.06(3)(a) frame, with the configuration
+          rules in § 320.0805 itself (accessed 2026-08-02), verbatim fragments:
+          'numerals from 1 to 999'; capital letters 'limited to a total of
+          seven of the same or different capital letters'; or 'no more than a
+          total of seven characters, including both numerals and capital
+          letters, in any combination, except that A HYPHEN MAY BE ADDED.'
+          Availability is checked through FLHSMV's Personalized License Plate
+          Inquiry before order.
+        hyphen_caveat: >-
+          THE STATUTORY HYPHEN IS RECORDED, NOT ENCODED. § 320.0805 permits one
+          hyphen INSIDE an owner-chosen configuration — which makes it part of
+          the plate's identity rather than a group gap, i.e. exactly the
+          glyph-inside-a-serial case PRD-PLATES §2.6 consequence 3 reserves for
+          a schema amendment (_meta/separators.yml never_separator), not a data
+          entry. No regex tier here accepts it yet; flagged for the separators
+          vocabulary owner. The closest existing precedent is the ES military
+          '-VE' note in _meta/separators.yml.
     design:
       plate: { w: 12, h: 6, unit: in }
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
@@ -293,15 +383,24 @@ series:
     fee: "$15 additional annual fee per personalized plate; HSMV form 83043 completed and presented at a local office"
     region_encoding: none
     sources:
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.0805.html  # § 320.0805 'Personalized prestige license plates' (accessed 2026-08-02): the issuance mandate, the configuration rules quoted in charset, and the History line whose first entry — 'ss. 1, 2, 3, 4, 5, 6, 7, 8, 9, ch. 72-80' — dates the series to 1972"
       - "https://www.flhsmv.gov/motor-vehicles-tags-titles/personalized-specialty-license-plates/  # personalized plates ordered in person, $15 annual fee, HSMV form 83043, the Personalized License Plate Inquiry availability service"
       - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(3)(a): the seven-character cap and alphabet a personalized configuration must fit"
       - "https://www.flhsmv.gov/pdf/specialtyplates/FLPB.pdf  # 'Note: Standard license plates listed above can be ordered as personalized.'"
     notes: >-
-      PERSONALIZED PLATES. Modelled as its own series because the SERIAL SOURCE
-      differs — owner-chosen rather than department-assigned — which is a format
-      property even though the character frame is identical. The regex given is the
-      letters-only shape most vanity configurations take; regex_statutory is the true
-      bound. Florida's content-refusal criteria are not in Chapter 320 and were not
+      PERSONALIZED PLATES. RE-DATED 2026-08-02: `start: 1972` is the creation
+      year of § 320.0805 — its History line opens 'ss. 1, 2, 3, 4, 5, 6, 7, 8,
+      9, ch. 72-80' (Laws of Florida 1972), i.e. the whole section was born as
+      that act, so the statutory-creation-date claim attaches to the series
+      itself, not merely to a section that later grew it. The L0 pass had
+      shipped the 2025 statute-edition year. Modelled as its own series because
+      the SERIAL SOURCE differs — owner-chosen rather than department-assigned
+      — which is a format property even though the character frame is
+      identical. The regex given is the letters-only shape most vanity
+      configurations take; regex_statutory is the § 320.06(3)(a) bound, and the
+      one statutory extra — the § 320.0805 hyphen — is recorded in
+      charset.hyphen_caveat as a schema question, not silently encoded.
+      Florida's content-refusal criteria are not in Chapter 320 and were not
       obtained (recorded gap).
 
   # =========================================================================
@@ -311,8 +410,10 @@ series:
   - id: us-fl-horseless-carriage
     class: historic
     categories: [car]
-    period: { start: 2025 }
-    period_evidence: instrument-in-force-upper-bound
+    period: { start: 1957 }        # s. 1, ch. 57-326 created § 320.086 — the
+                                   # first entry in its History line. Sentence-
+                                   # level caveat in notes.
+    period_evidence: statutory-creation-date
     matching: strict
     format:
       pattern: "999"
@@ -336,24 +437,49 @@ series:
         (distinctness) rather than a design VALUE.
       legend: "Horseless Carriage"
     eligibility: "motor vehicle for private use manufactured in MODEL YEAR 1945 OR EARLIER, operated on the state's streets and highways"
+    eligibility_history: >-
+      THE THRESHOLD MOVED ONCE, AND THE INSTRUMENT IS PINNED: until 1999 the
+      cutoff was 'manufactured in 1927 or earlier' (1997 edition of
+      § 320.086(1), verbatim), and ch. 99-248 s. 30, Laws of Florida, changed
+      it to 1945 — the chapter law's strike/underline text reads 'manufactured
+      in 1945 1927 or earlier' (underlined 1945, stricken 1927). Approved by
+      the Governor 8 June 1999; s. 319: 'Except as otherwise provided herein,
+      this act shall take effect upon becoming a law.' Vehicles of 1928-1945,
+      previously the separate 'Antique Vehicle' window, fold into this series
+      from 1999.
     validity: "permanent — 'valid for use without renewal so long as the vehicle is in existence'"
     region_encoding: none
     sources:
-      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.086.html  # § 320.086(1): model year 1945 or earlier, the separate numerical series from 'Horseless Carriage No. 1', distinguishing colour, permanent validity, manufacture-cost fee"
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.086.html  # § 320.086(1): model year 1945 or earlier, the separate numerical series from 'Horseless Carriage No. 1', distinguishing colour, permanent validity, manufacture-cost fee; History line opening 's. 1, ch. 57-326; s. 1, ch. 59-206; ...' (accessed 2026-08-02)"
+      - "http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=Ch0320/SEC086.HTM&StatuteYear=1997  # the 1997 ARCHIVE EDITION of § 320.086 (accessed 2026-08-02): 'Horseless Carriage No. 1' series present verbatim; eligibility then 'manufactured in 1927 or earlier'; History line then ended at ch. 97-300"
+      - "http://laws.flrules.org/1999/248  # Laws of Florida ch. 99-248 (CS/CS/SB 1270), 142 pp, accessed 2026-08-02 — s. 30 amends § 320.086: '(1) ... manufactured in 1945 1927 or earlier' (strike/underline); s. 319 effective-on-becoming-law; approved by the Governor 8 June 1999"
     notes: >-
-      HORSELESS CARRIAGE. Florida sets its historic threshold by a FIXED MODEL YEAR
-      (1945 or earlier) rather than a rolling age — the opposite design choice to the
-      Antique series below, which is rolling, and to Germany's H plate. A plates
-      dataset must model both kinds of threshold: fixed-cutoff eligibility never
-      changes, rolling eligibility silently changes every year, and only the second
-      needs re-auditing. The Netherlands' pre-1978 dark-blue rule is the fixed kind
-      too.
+      HORSELESS CARRIAGE. RE-DATED 2026-08-02: `start: 1957` is the creation
+      year of § 320.086 — the History line opens 's. 1, ch. 57-326' (Laws of
+      Florida 1957) — replacing the L0 pass's 2025 statute-edition year.
+      SENTENCE-LEVEL CAVEAT, flagged for the verifier: the History note dates
+      the SECTION, and whether the 'Horseless Carriage No. 1' series label
+      stood in the 1957 act or arrived with the 1959 amendment (s. 1, ch.
+      59-206, the second History entry) cannot be resolved online — Laws of
+      Florida before 1997 are not served by laws.flrules.org (recorded gap;
+      the 1997 edition proves the label verbatim by 1997). Florida sets this
+      historic threshold by a FIXED MODEL YEAR rather than a rolling age — the
+      opposite design choice to the Antique series below, which is rolling, and
+      to Germany's H plate. A plates dataset must model both kinds of
+      threshold: fixed-cutoff eligibility never changes silently — though this
+      one moved BY INSTRUMENT once, 1927 to 1945 in 1999, see
+      eligibility_history — while rolling eligibility changes every year and
+      needs re-auditing. The Netherlands' pre-1978 dark-blue rule is the fixed
+      kind too.
 
   - id: us-fl-antique
     class: historic
     categories: [car, truck, bus]
-    period: { start: 2025 }
-    period_evidence: instrument-in-force-upper-bound
+    period: { start: 1999 }        # ch. 99-248 s. 30 created the 'Antique'
+                                   # rolling series in its current name and
+                                   # form — by renaming the pre-1999
+                                   # 'Collectible' series. See notes.
+    period_evidence: statutory-enactment-date
     matching: strict
     format:
       pattern: "999"
@@ -370,20 +496,45 @@ series:
     superseded_variants:
       - "permanent plates issued under this section BEFORE 1 October 1999 are maintained unless the vehicle transfers to a new owner (§ 320.086(2)(b))"
       - "'Collectible' plates issued BEFORE 1 October 1999 may be retained until the next regularly scheduled replacement (§ 320.086(2)(b))"
+    predecessor_regimes: >-
+      PINNED FROM THE 1997 EDITION AND THE 1999 CHAPTER LAW: before ch. 99-248
+      the section ran THREE series — 'Horseless Carriage No. 1' (1927 or
+      earlier), 'ANTIQUE VEHICLE No. 1' (manufactured 1928-1945 inclusive, a
+      FIXED window, abolished in 1999 with its vehicles folded into the
+      widened Horseless Carriage), and 'COLLECTIBLE No. 1' (20-year ROLLING,
+      this series' direct predecessor). Ch. 99-248 s. 30 struck the Antique
+      Vehicle subsection, re-labelled the rolling series' commencement —
+      chapter-law coding: 'commencing with "Antique No. 1," "Collectible
+      No. 1,"' (underlined Antique, stricken Collectible) — and raised the
+      rolling age: 'of the age of 30 20 years or more after from the date of
+      manufacture'. Three regimes became two.
     region_encoding: none
     sources:
-      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.086.html  # § 320.086(2)(a) the rolling 30-year threshold, the 'Antique No. 1' series, distinguishing colour, the regular/specialty opt-out; (2)(b) the 1 October 1999 permanent and 'Collectible' transitions; (3) firefighting apparatus, former military and other historical vehicles"
+      - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.086.html  # § 320.086(2)(a) the rolling 30-year threshold, the 'Antique No. 1' series, distinguishing colour, the regular/specialty opt-out; (2)(b) the 1 October 1999 permanent and 'Collectible' transitions; (3) firefighting apparatus, former military and other historical vehicles; History line includes 's. 30, ch. 99-248' (accessed 2026-08-02)"
+      - "http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=Ch0320/SEC086.HTM&StatuteYear=1997  # the 1997 ARCHIVE EDITION (accessed 2026-08-02): 'Antique Vehicle No. 1' fixed 1928-1945 window and 'Collectible' 20-year rolling series — the two pre-1999 regimes this series replaced and continues"
+      - "http://laws.flrules.org/1999/248  # Laws of Florida ch. 99-248 s. 30 (accessed 2026-08-02): 'Antique No. 1' inserted for 'Collectible No. 1' stricken; '30 20 years'; approved by the Governor 8 June 1999, effective upon becoming law (s. 319); the (2)(b) transition keyed to 1 October 1999 enacted in the same section"
       - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0316/Sections/0316.605.html  # § 316.605(1) cross-reference to s. 320.086(5), which EXEMPTS display of plates on described former military vehicles"
     notes: >-
-      ANTIQUE. § 320.086(2)(b) is direct evidence bearing on this series' true start:
-      it legislates for plates issued under this section BEFORE 1 OCTOBER 1999, so
-      the series demonstrably predates that date. That makes 1999 an upper bound too,
-      and a tighter one than the statute edition — but the actual start needs the
-      section's History line and the Laws of Florida, which were not pursued in this
-      pass. Recorded rather than guessed. The 'Collectible' plate is a genuinely
-      DEAD series that is still lawfully on the road — exactly the case
-      PRD-PLATES's `ended: true` + `year_end_min:` semantics exist for; it is not
-      given its own entry here because no primary for its own format was obtained.
+      ANTIQUE. RE-DATED 2026-08-02, AND THE L0 READING CORRECTED: the L0 pass
+      inferred from § 320.086(2)(b)'s 1 October 1999 transition that 'the
+      series demonstrably predates that date'. The chapter law shows the
+      OPPOSITE: the 'Antique' label is itself the 1999 novelty — ch. 99-248
+      s. 30 (approved 8 June 1999, effective upon becoming law) created this
+      series in its current name and form by RENAMING the pre-1999
+      'Collectible' rolling series and raising its age threshold from 20 to 30
+      years, while abolishing the old fixed-window 'Antique Vehicle' series
+      (see predecessor_regimes). (2)(b) grandfathers plates issued under the
+      SECTION's earlier regimes, which is why it is written around 1 October
+      1999. So `start: 1999` is an instrument-dated claim. THE PREDECESSOR
+      ROLLING SERIES ('Collectible', 20-year) demonstrably existed by 1997
+      (archive edition) but its own creation year is unresolved among the
+      pre-1997 History entries (78-363, 83-318, 87-197, 96-413 are the
+      candidates) because Laws of Florida before 1997 are not served online —
+      recorded gap, NOT guessed. The 'Collectible' plate is a genuinely DEAD
+      series that is still lawfully on the road — exactly the case PRD-PLATES's
+      `ended: true` + `year_end_min:` semantics exist for; it is still not
+      given its own entry because no primary for its own FORMAT (as opposed to
+      its existence and closure) was obtained.
 
   # =========================================================================
   # STATUTORY LEGEND SERIES. § 320.06(3)(a) mandates a specific bottom legend
@@ -393,8 +544,12 @@ series:
   - id: us-fl-apportioned
     class: standard
     categories: [truck, bus]
-    period: { start: 2024 }
-    period_evidence: statutory-date
+    period: { start: 1997 }        # UPPER BOUND: the Apportioned legend stands
+                                   # verbatim in the 1997 archive edition, the
+                                   # earliest leg.state.fl.us serves. The L0
+                                   # pass's 2024 dated the 3-year CYCLE, not
+                                   # the series — see notes.
+    period_evidence: instrument-in-force-upper-bound
     matching: strict
     format:
       pattern: "LLL 999"
@@ -414,19 +569,32 @@ series:
     region_encoding: none
     sources:
       - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(1)(b)2: the IRP 3-year plate 'Beginning July 1, 2024', the annual cab card, the $28 fee, free replacement of damaged plates; (3)(a): the 'Apportioned' bottom legend"
+      - "http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=Ch0320/SEC06.HTM&StatuteYear=1997  # the 1997 ARCHIVE EDITION of § 320.06(3)(a) (accessed 2026-08-02), verbatim: '... except that apportioned license plates shall have the word \"Apportioned\" at the bottom' — the legend series existed by 1997, the earliest edition served"
     notes: >-
-      APPORTIONED (International Registration Plan) PLATES — THE ONE FLORIDA SERIES
-      WITH A PROPERLY DATED START. § 320.06(1)(b)2 says 'Beginning July 1, 2024' in
-      terms, so `period_evidence: statutory-date` and 2024 is a real claim, not an
-      upper bound. It is also the only Florida plate on a 3-year rather than a
-      10-year cycle, and the only one whose sticker shows a month rather than the
+      APPORTIONED (International Registration Plan) PLATES. RE-DATED 2026-08-02,
+      AND THE L0 NOTE RETRACTED IN TERMS: that pass called this 'the one
+      Florida series with a properly dated start' on the strength of
+      § 320.06(1)(b)2's 'Beginning July 1, 2024' — but that date attaches to
+      the THREE-YEAR REPLACEMENT CYCLE for IRP vehicles, not to the series,
+      which the 1997 archive edition already carries verbatim. Dating a series
+      by a cycle amendment is the same instrument-date disease as dating it by
+      a statute edition. So: `start: 1997` is an UPPER BOUND (the earliest
+      edition leg.state.fl.us serves); the amendment that introduced the
+      Apportioned legend lies among the pre-1997 History entries of § 320.06
+      (Florida's IRP-era amendments — 81-151, 84-260, 85-176, 87-198 are
+      plausible candidates, none asserted) and is a recorded gap. The
+      instrument-dated cycle facts stay in replacement_cycle, where they
+      belong. Still the only Florida plate on a 3-year rather than a 10-year
+      cycle, and the only one whose sticker shows a month rather than the
       owner's birth month — apportioned vehicles are fleet-registered, so the
       birth-month scheme cannot apply.
 
   - id: us-fl-restricted
     class: standard
     categories: [truck, trailer]
-    period: { start: 2025 }
+    period: { start: 1997 }        # UPPER BOUND: legend verbatim in the 1997
+                                   # archive edition (with a wider trigger
+                                   # list — see notes).
     period_evidence: instrument-in-force-upper-bound
     matching: strict
     format:
@@ -442,17 +610,26 @@ series:
     region_encoding: none
     sources:
       - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(3)(a): the 'Restricted' bottom legend and the exact list of § 320.08 tax paragraphs it applies to"
+      - "http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=Ch0320/SEC06.HTM&StatuteYear=1997  # the 1997 ARCHIVE EDITION (accessed 2026-08-02), verbatim: 'license plates issued for vehicles taxed under s. 320.08(3)(d), (4)(m) or (n), (5)(b) or (c), (12), or (14) shall have the word \"Restricted\" at the bottom' — the legend series existed by 1997"
     notes: >-
-      RESTRICTED-USE PLATES. The class is defined ENTIRELY BY CROSS-REFERENCE to six
-      paragraphs of the vehicle-tax schedule (§ 320.08(3)(d), (4)(m), (4)(n), (5)(b),
-      (5)(c), (14)), which were not resolved to vehicle descriptions in this pass —
-      the legend and its trigger list are sourced, the underlying vehicle types are a
-      recorded gap. Categories are recorded conservatively.
+      RESTRICTED-USE PLATES. RE-DATED 2026-08-02: `start: 1997` is an UPPER
+      BOUND from the earliest archive edition served — the L0 pass had shipped
+      the 2025 edition year. TRIGGER-LIST DRIFT, recorded not resolved: the
+      1997 (and still the 1999, per ch. 99-248 s. 21) trigger list INCLUDED
+      s. 320.08(12) — the dealer/manufacturer tax paragraph — which the
+      current list omits; the amendment that carved (12) out of Restricted was
+      not identified (post-1999, recorded gap). The class is defined ENTIRELY
+      BY CROSS-REFERENCE to six paragraphs of the vehicle-tax schedule
+      (§ 320.08(3)(d), (4)(m), (4)(n), (5)(b), (5)(c), (14)), which were not
+      resolved to vehicle descriptions in this pass — the legend and its
+      trigger list are sourced, the underlying vehicle types are a recorded
+      gap. Categories are recorded conservatively.
 
   - id: us-fl-dealer
     class: dealer
     categories: [car, van, truck, bus, motorcycle, trailer]
-    period: { start: 2025 }
+    period: { start: 1997 }        # UPPER BOUND: legend verbatim in the 1997
+                                   # archive edition.
     period_evidence: instrument-in-force-upper-bound
     matching: strict
     format:
@@ -475,17 +652,30 @@ series:
     region_encoding: none
     sources:
       - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(3)(a): the 'Dealer' legend, the § 320.08(12) tax hook, and the specialty-plate exception"
+      - "http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=Ch0320/SEC06.HTM&StatuteYear=1997  # the 1997 ARCHIVE EDITION (accessed 2026-08-02): the Dealer legend sentence present verbatim — the legend series existed by 1997"
+      - "http://laws.flrules.org/1999/248  # ch. 99-248 s. 21 (accessed 2026-08-02): the Dealer sentence's then-trailing exception ', except that gross-vehicle-weight vehicles owned by a licensed motor vehicle dealer may be issued a license plate with the word \"Restricted\"' shown STRICKEN — deleted 1999; today's specialty-plate exception is a LATER insertion (unpinned, gap)"
     notes: >-
-      DEALER PLATES. `binding: business` for the same reason as Germany's rote
-      Kennzeichen: the plate follows the dealership, not a vehicle. The specialty
-      carve-out is the interesting fact and a trap for any classifier that keys off
-      the legend.
+      DEALER PLATES. RE-DATED 2026-08-02: `start: 1997` is an UPPER BOUND from
+      the earliest archive edition served — the L0 pass had shipped the 2025
+      edition year. The dealer TAX CLASS (§ 320.08(12)) is far older than the
+      legend evidence; what this series records is the legend-bearing plate,
+      and 1997 bounds that. Sentence history actually pinned: ch. 99-248 s. 21
+      (1999) DELETED the original exception letting gross-vehicle-weight
+      dealer vehicles take a 'Restricted' plate; the CURRENT exception (a
+      specialty design may displace the Dealer legend, s. 320.08056 hook) was
+      inserted by a later, unidentified amendment (recorded gap). `binding:
+      business` for the same reason as Germany's rote Kennzeichen: the plate
+      follows the dealership, not a vehicle. The specialty carve-out is the
+      interesting fact and a trap for any classifier that keys off the legend.
 
   - id: us-fl-manufacturer
     class: dealer
     categories: [car, van, truck, bus, motorcycle]
-    period: { start: 2025 }
-    period_evidence: instrument-in-force-upper-bound
+    period: { start: 1999 }        # the Manufacturer sentence is INSERTED
+                                   # (underline-coded) by ch. 99-248 s. 21 and
+                                   # absent from the 1997 edition — an exact
+                                   # birth instrument. See notes.
+    period_evidence: statutory-enactment-date
     matching: strict
     format:
       pattern: "LLL 999"
@@ -501,18 +691,27 @@ series:
     region_encoding: none
     sources:
       - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(3)(a): the 'Manufacturer' legend under the same § 320.08(12) tax hook as Dealer, without the specialty exception"
+      - "http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=Ch0320/SEC06.HTM&StatuteYear=1997  # the 1997 ARCHIVE EDITION (accessed 2026-08-02): the word 'Manufacturer' does NOT appear in § 320.06 — negative half of the birth-instrument pin"
+      - "http://laws.flrules.org/1999/248  # Laws of Florida ch. 99-248 s. 21 (accessed 2026-08-02), the sentence INSERTED (underline-coded): 'Manufacturer license plates issued for vehicles taxed under s. 320.08(12) must be imprinted with the word \"Florida\" at the top and the word \"Manufacturer\" at the bottom.' Approved by the Governor 8 June 1999; s. 319: effective upon becoming a law"
     notes: >-
-      MANUFACTURER PLATES. Its own series and not a variant of the dealer plate
-      because the statute draws the distinction itself, in adjacent sentences, and
-      because only the Dealer legend may be displaced by a specialty design. CLASS
-      CAVEAT: recorded as `dealer` — _meta/classes.yml has no `manufacturer` value,
-      and the PRD's definition of dealer ('trade/garage plates bound to a business,
-      not a vehicle') fits the binding but not the trade.
+      MANUFACTURER PLATES. RE-DATED 2026-08-02, AND THE ONE FLORIDA LEGEND WITH
+      AN EXACT BIRTH INSTRUMENT: absent from the 1997 edition of § 320.06, and
+      inserted by ch. 99-248 s. 21, Laws of Florida (underline-coded in the
+      chapter law; approved by the Governor 8 June 1999, effective upon
+      becoming law per s. 319). Both halves — the 1997 absence and the 1999
+      insertion — are cited above, so `start: 1999` is a real claim, not a
+      bound. Its own series and not a variant of the dealer plate because the
+      statute draws the distinction itself, in adjacent sentences, and because
+      only the Dealer legend may be displaced by a specialty design. CLASS
+      CAVEAT: recorded as `dealer` — _meta/classes.yml has no `manufacturer`
+      value, and the PRD's definition of dealer ('trade/garage plates bound to
+      a business, not a vehicle') fits the binding but not the trade.
 
   - id: us-fl-wrecker
     class: standard
     categories: [truck]
-    period: { start: 2025 }
+    period: { start: 1997 }        # UPPER BOUND: legend verbatim in the 1997
+                                   # archive edition.
     period_evidence: instrument-in-force-upper-bound
     matching: strict
     format:
@@ -528,9 +727,15 @@ series:
     region_encoding: none
     sources:
       - "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.06.html  # § 320.06(3)(a): the 'Wrecker' bottom legend and its § 320.08(5)(d)-(e) tax hook"
+      - "http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=Ch0320/SEC06.HTM&StatuteYear=1997  # the 1997 ARCHIVE EDITION (accessed 2026-08-02), verbatim: 'License plates issued for vehicles taxed under s. 320.08(5)(d) or (e) must be imprinted with the word \"Wrecker\" at the bottom' — the legend series existed by 1997"
     notes: >-
-      WRECKER (tow truck) PLATES. Completes the five statutory bottom legends —
-      Apportioned, Restricted, Dealer, Manufacturer, Wrecker — which together are the
-      whole of Florida's legend taxonomy and, notably, are legislated rather than left
-      to departmental design. CLASS CAVEAT: no `commercial` or `tow` class exists in
-      the vocabulary; recorded as `standard` with the legend carrying the meaning.
+      WRECKER (tow truck) PLATES. RE-DATED 2026-08-02: `start: 1997` is an
+      UPPER BOUND from the earliest archive edition served — the L0 pass had
+      shipped the 2025 edition year; the introducing amendment lies among the
+      pre-1997 History entries of § 320.06 (recorded gap). Completes the five
+      statutory bottom legends — Apportioned, Restricted, Dealer, Manufacturer,
+      Wrecker — which together are the whole of Florida's legend taxonomy and,
+      notably, are legislated rather than left to departmental design; four of
+      the five stood by 1997, and Manufacturer was born 1999 (ch. 99-248).
+      CLASS CAVEAT: no `commercial` or `tow` class exists in the vocabulary;
+      recorded as `standard` with the legend carrying the meaning.


### PR DESCRIPTION
**The instrument-date disease, cured for `us-fl.yml`** — this pre-L1 baseline carried consolidation/instrument dates as series starts (the bug a user surfaced live: es-provincial claiming 1999–2000 for a format that ran from 1971). Re-researched to the L1 evidence standard; every corrected period carries its primary, verbatim, with access date. Full-stack lint with all three redates staged: `67 files, 606 series … OK`. The dossier follows.

---

# Dossier — us-fl re-dating pass (L1 evidence standard)

*2026-08-02. Researcher pass; §5.3 verifier still owed. Scope: re-date every
series in the shipped `plates/us-fl.yml` (the pre-L1 L0 pilot baseline, which
carried statute-edition years 2024/2025 as series starts) to its true start
with instrument evidence; folklore flagged, never asserted; gaps recorded at
point of use; every existing id kept stable. No series renamed, none added,
none removed (see §4 for why the prior standard base was NOT added).*

Amended file: `plates/us-fl.yml` (this directory). Lint: GREEN, full-tree run
including the `_art` gate — `lint-proof.txt`.

## 1. The correction table — every period, before → after

| series id | before (shipped) | after | evidence value | pinned source for the new start |
|---|---|---|---|---|
| `us-fl-standard` | 2025 · instrument-in-force-upper-bound | **2003** | `secondary-locator-unverified` | Wikipedia "Vehicle registration plates of Florida" table (re-checked 2026-08-02): current base "December 2003" — **row carries no footnote; folklore-grade, flagged not asserted.** Negative primary findings recorded (§3). Corroborating primaries that the base is *current*: FLHSMV press release 2025-12-15 (America 250 is "an alternative to the standard Florida license plate"); FLHSMV brochure HSMV 80003 Rev. 6/2026 |
| `us-fl-specialty-index` | 2025 · instrument-in-force-upper-bound | **1995** | `statutory-creation-date` | § 320.08056 History line, first entry "s. 2, ch. 95-282" (Laws of Florida 1995) — leg.state.fl.us, accessed 2026-08-02 |
| `us-fl-personalized` | 2025 · instrument-in-force-upper-bound | **1972** | `statutory-creation-date` | § 320.0805 History line, first entry "ss. 1, 2, 3, 4, 5, 6, 7, 8, 9, ch. 72-80" (1972) — the whole section was born as that act, so the claim attaches to the series |
| `us-fl-horseless-carriage` | 2025 · instrument-in-force-upper-bound | **1957** | `statutory-creation-date` | § 320.086 History line, first entry "s. 1, ch. 57-326" (1957). Sentence-level caveat flagged in the file: 1957 act vs 1959 amendment (ch. 59-206) unresolvable online — pre-1997 Laws of Florida not served. 1997 archive edition proves the "Horseless Carriage No. 1" label verbatim by 1997 |
| `us-fl-antique` | 2025 · instrument-in-force-upper-bound | **1999** | `statutory-enactment-date` | Laws of Florida **ch. 99-248 s. 30** (laws.flrules.org/1999/248, full 142-pp chapter law, strike/underline coded, accessed 2026-08-02): 'commencing with ~~"Collectible No. 1,"~~ __"Antique No. 1,"__' and 'of the age of __30__ ~~20~~ years'. Approved 8 June 1999; s. 319 = effective on becoming law |
| `us-fl-apportioned` | 2024 · statutory-date | **1997** | `instrument-in-force-upper-bound` | 1997 archive edition of § 320.06(3)(a) (StatuteYear=1997, accessed 2026-08-02): "apportioned license plates shall have the word 'Apportioned' at the bottom" — verbatim, so 1997 is a real upper bound. **The shipped 2024 was an instrument date for the 3-year IRP replacement CYCLE ("Beginning July 1, 2024"), not the series start — the L0 note calling it "properly dated" is retracted in the file in terms** |
| `us-fl-restricted` | 2025 · instrument-in-force-upper-bound | **1997** | `instrument-in-force-upper-bound` | 1997 archive edition, Restricted sentence verbatim (trigger list then INCLUDED § 320.08(12) — drift recorded, see §5) |
| `us-fl-dealer` | 2025 · instrument-in-force-upper-bound | **1997** | `instrument-in-force-upper-bound` | 1997 archive edition, Dealer sentence verbatim. Bonus sentence-history pin: ch. 99-248 s. 21 DELETED the original "gross-vehicle-weight … Restricted" exception in 1999; the current specialty-plate exception is a later unidentified insertion (gap) |
| `us-fl-manufacturer` | 2025 · instrument-in-force-upper-bound | **1999** | `statutory-enactment-date` | **Both halves of an exact birth pinned:** the word "Manufacturer" is ABSENT from § 320.06 (1997 edition, checked), and the sentence is INSERTED (underline-coded) by ch. 99-248 s. 21: "Manufacturer license plates issued for vehicles taxed under s. 320.08(12) must be imprinted with the word 'Florida' at the top and the word 'Manufacturer' at the bottom." |
| `us-fl-wrecker` | 2025 · instrument-in-force-upper-bound | **1997** | `instrument-in-force-upper-bound` | 1997 archive edition, Wrecker sentence verbatim |

**10 of 10 periods corrected.** All evidence values are drawn from the
existing dataset vocabulary (`statutory-creation-date` ×2 prior uses,
`statutory-enactment-date` ×15, `instrument-in-force-upper-bound` ×172,
`secondary-locator-unverified` ×42). No new vocabulary value was invented.

## 2. The method, so the verifier can re-derive it

1. **History lines are primary.** Each Florida Statutes section ends with a
   "History.—" note that is part of the official publication and lists every
   amending chapter law with its session year; the first entry is the creating
   act. Used for §§ 320.06, 320.086, 320.0805, 320.08056.
2. **The archive editions are the bisecting instrument.** leg.state.fl.us
   serves editions back to 1997 via the `StatuteYear` parameter
   (`…URL=Ch0320/SEC06.HTM&StatuteYear=1997`). A legend sentence present in
   1997 gives an upper bound 28 years tighter than the shipped 2025.
3. **Chapter laws close the gap where they are online.** laws.flrules.org
   serves 1997+ as the enrolled PDFs with the normative coding line "CODING:
   Words stricken are deletions; words underlined are additions" — sentence-
   level attribution, not inference. Ch. 99-248 was fetched in full and
   `pdftotext`'d; it pinned three series in one document.
4. **Pre-1997 chapter laws are not served online** (neither leg.state.fl.us
   nor laws.flrules.org). Every start that lands on a pre-1997 amendment is
   therefore an upper bound or a section-creation year with the residual
   uncertainty flagged in the series notes — never silently resolved.

## 3. Negative findings (recorded so nobody repeats the hunt)

- **FLHSMV has no plate-history page.** The department's full WordPress
  sitemap (sitemap_index.xml → post/page sitemaps, 3,988 URLs) was enumerated
  on 2026-08-02; nothing on flhsmv.gov dates any base design. The guessed
  `/history-florida-license-plates/` URL is a genuine 404.
  (flhsmv.gov 403s generic fetchers; a browser User-Agent via curl works.)
- **The FLPB brochure (HSMV 80003, Rev. 6/2026) carries no design dates** —
  re-fetched and text-extracted 2026-08-02.
- **The Wikipedia article's entire dating apparatus is uncited.** The
  December 2003 current-base row, the February 2026 successor row, and all
  seven serial-arrangement rows carry **no footnotes** (checked 2026-08-02).
  Locator only, per PRD-PLATES §4.
- **web.archive.org is unreachable from this environment**, so archived
  FLHSMV press pages from ~2003 could not be pulled. Best future primary for
  the 2003 base: an archived FLHSMV/DHSMV press release or procurement notice,
  or a contemporaneous newspaper of record.

## 4. The immediately-prior standard series — deliberately NOT added

The mission allowed adding the prior standard base "if sources permit."
They do not: the green-serial county base preceding the current one is dated
only by the uncited Wikipedia table (several sub-forms, late 1970s onward),
no FLHSMV primary exists (§3), and the statute never describes designs.
Under the L1 bar (primary-or-marked; never invent a period), authoring it
would have manufactured exactly the folklore boundary this pass removes.
Recorded as an L4 gap in the file header and in `us-fl-standard.notes`.

## 5. Folklore register and open gaps (all flagged at point of use in the file)

| item | status |
|---|---|
| Current base introduced December 2003 | FOLKLORE-GRADE (uncited locator row); carried as `start: 2003` with `secondary-locator-unverified` and full flags — the one non-instrument start in the file |
| February 2026 successor base rollout | folklore, NOT asserted; becomes a new dated series when an agency primary lands |
| Serial arrangements on the current base (A12 3BC 2004, 123 ABC 2009, …) | uncited locator rows; inside `regex_statutory`; recorded gap (unchanged from L0) |
| "1956 AMA standardization agreement" | already flagged in the shipped file's `us_standards.folklore_caution`; unchanged |
| First Florida specialty plate = mid-1980s Challenger commemorative | commonly repeated; pre-1995 authorizations lived in predecessor sections; NOT asserted; gap |
| Horseless Carriage label: 1957 act vs 1959 amendment | sentence-level gap (pre-1997 session laws offline); 1957 = section-creation year, caveat flagged |
| Collectible (20-year rolling) series creation year | gap; candidates 78-363 / 83-318 / 87-197 / 96-413; existed by 1997 (archive edition) |
| Apportioned legend's introducing amendment | pre-1997 gap; IRP-era candidates (81-151, 84-260, 85-176, 87-198) listed, none asserted |
| § 320.08(12) carved out of the Restricted trigger list | post-1999 (still present in ch. 99-248 s. 21 text), amendment unidentified — recorded, not averaged |
| Dealer legend's specialty-plate exception insertion | post-1999, unidentified; the 1999 DELETION of the old Restricted exception is pinned |
| Personalized hyphen (§ 320.0805: "a hyphen may be added") | NEW FINDING this pass: a statutory glyph inside an owner-chosen serial — the §2.6-consequence-3 schema case; recorded in `charset.hyphen_caveat`, deliberately NOT encoded in any regex tier; flagged for the separators-vocabulary owner |

## 6. Bonus corrections landed in the same pass (beyond periods)

- **Specialty discontinuation threshold gap CLOSED**: § 320.08056(8)(a)
  verbatim — below **3,000** valid registrations (4,000 for out-of-state
  college/university plates) for at least 12 consecutive months.
- **Antique note's L0 inference corrected in terms**: (2)(b)'s 1 October 1999
  transition does not prove the Antique series predates 1999 — the chapter law
  shows "Antique" is the 1999 renaming of "Collectible"; the grandfather
  clause covers the section's earlier regimes. New `predecessor_regimes` key
  carries the three-regimes-became-two restructure with the strike/underline
  quotes.
- **Horseless Carriage eligibility history added**: 1927-or-earlier until
  ch. 99-248 (8 June 1999), 1945-or-earlier since — new `eligibility_history`
  key, both instruments cited.
- **Personalized configuration rules quoted from § 320.0805** (1–999
  numerals / ≤7 letters / ≤7 mixed + optional hyphen) with the new source URL.
- **America 250 standard variant pinned to an agency primary**: FLHSMV press
  release 2025-12-15, "an alternative to the standard Florida license plate,
  with all regular fees applying."

## 7. Sources pinned in this pass (exact URLs, all accessed 2026-08-02)

New to the file (5):
1. `http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=Ch0320/SEC06.HTM&StatuteYear=1997` — 1997 edition, § 320.06
2. `http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=Ch0320/SEC086.HTM&StatuteYear=1997` — 1997 edition, § 320.086
3. `http://laws.flrules.org/1999/248` — Laws of Florida ch. 99-248 (CS/CS/SB 1270), 142 pp
4. `https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0300-0399/0320/Sections/0320.0805.html` — § 320.0805 + History
5. `https://www.flhsmv.gov/2025/12/15/flhsmv-launches-america-250-license-plate/` — FLHSMV press release

Already in the file, re-fetched and newly load-bearing (3):

6. `…/Sections/0320.06.html` — current § 320.06 + complete History line (ends "s. 4, ch. 2024-272; s. 7, ch. 2025-5")
7. `…/Sections/0320.086.html` — current § 320.086 + complete History line ("s. 1, ch. 57-326; … s. 2, ch. 2023-118")
8. `…/Sections/0320.08056.html` — current § 320.08056 + History ("s. 2, ch. 95-282; …") + the (8)(a) threshold

## 8. For the verifier (§5.3): the three claims to attack first

1. **us-fl-standard 2003** — the only non-instrument start. Re-derive from an
   archived 2003–04 FLHSMV/DHSMV press page (archive.org, unreachable here) or
   a newspaper of record; if a primary gives a different year, replace the
   locator claim outright (no averaging).
2. **Horseless Carriage 1957** — pull ch. 57-326 and ch. 59-206 from the
   State Archives' Laws of Florida to resolve the sentence-level caveat.
3. **Antique 1999** — confirm my reading of the s. 30 strike/underline against
   the enrolled PDF (pdftotext flattens coding; I verified orientation via the
   "30 20"/"1945 1927" adjacency pattern and the s. 319 coding line, but the
   PDF's typography is the authority).
