### PR TITLE
plates: ie — Ireland (L1 wave 2), 7 series + the county index decode table

### DIFF
--- a/plates/_decode/ie-counties.yml
+++ b/plates/_decode/ie-counties.yml
@@ -1,0 +1,227 @@
+# plates/_decode/ie-counties.yml — Irish index marks (the county/city identifier
+# in the middle group of an Irish registration).
+#
+# THE SOURCE FINDING, and it is the Austrian result rather than the German one:
+# THE IRISH INDEX-MARK LIST IS IN THE INSTRUMENTS, TWICE OVER, AND NOTHING BELOW
+# COMES FROM A SECONDARY SOURCE. Two independent statutory tables enumerate it:
+#
+#   * THE REGISTRATION TABLE — S.I. No. 445 of 1986 inserted "Part II" into the
+#     Schedule to the Road Vehicles (Index Marks) Regulations, 1958, allotting
+#     the new two-letter/one-letter marks to each licensing authority, and its
+#     new article 3 dates them to the day: "the index marks in Part I of the
+#     Schedule ... shall not be assigned to vehicles first registered on or
+#     after the 1st day of January, 1987 and the index marks in Part II ...
+#     shall be assigned to vehicles first registered on or after the 1st day of
+#     January, 1987." That table was then re-enacted, with the IRISH-LANGUAGE
+#     PLACENAME beside each mark, as the Table to paragraph 4 of the First
+#     Schedule to the Vehicle Registration and Taxation Regulations, 1992
+#     (S.I. No. 318 of 1992), and again in the First Schedule as substituted by
+#     S.I. No. 432 of 1999.
+#   * THE TRADE-LICENCE TABLE — Article 6(3)(a) of S.I. No. 409 of 1992 as
+#     substituted by S.I. No. 328 of 2013 and again by S.I. No. 243 of 2014.
+#     This is the ONLY instrument located in this pass that carries the
+#     POST-MERGER identifiers T (Tipperary), L (Limerick City and County) and
+#     W (Waterford City and County).
+#
+# THE DISCREPANCY IS REAL AND IS RECORDED, NOT AVERAGED (PRD-PLATES §5.3): the
+# VRT First Schedule table still reads TN / TS / LK / L / WD / W and has never
+# been amended to add T or to merge LK into L and WD into W, while the
+# trade-licence table WAS amended for exactly that reason — S.I. 328/2013's own
+# explanatory note: "These Regulations provide for a single identifier for trade
+# licences issued in Limerick, Tipperary and Waterford." Every row below
+# therefore carries `instruments:` naming which table it comes from, and the
+# post-2014 rows carry `registration_plate_authority: trade-licence-table-only`
+# so a consumer can see precisely how far the evidence reaches.
+#
+# Referenced by: plates/ie.yml (ie-standard-1987, ie-standard-1991,
+# ie-standard-2013, ie-trade-1993) via region_encoding.
+#
+# PERIOD DISCIPLINE (PRD-PLATES §2.4): these are the marks assignable to
+# vehicles FIRST REGISTERED on or after 1 January 1987. The pre-1987 marks are a
+# different, disjoint set and are handled in `historic_pre_1987` below — they are
+# NOT in `codes:` and a pre-1987 plate must never be decoded through it. Marks
+# are not withdrawn from plates already issued: a 1988 TS plate stays a TS plate
+# forever, which is why TN/TS/LK/WD remain decodable long after 2014.
+jurisdiction: ie
+topic: counties
+authority:
+  name: "Road Vehicles (Index Marks) Regulations, 1958, Schedule Part II (inserted by S.I. No. 445 of 1986); Vehicle Registration and Taxation Regulations, 1992, First Schedule paragraph 4"
+  url: "https://www.irishstatutebook.ie/eli/1992/si/318/made/en/print"
+sources:
+  - "https://www.irishstatutebook.ie/eli/1986/si/445/made/en/print  # S.I. No. 445 of 1986, Road Vehicles (Index Marks) (Amendment) (No. 2) Regulations, 1986 — inserts Schedule Part II (the new marks, per licensing authority) and the new art. 3 dating them to first registrations on or after 01-01-1987; sealed 20-12-1986. Accessed 2026-08-02"
+  - "https://www.irishstatutebook.ie/eli/1992/si/318/made/en/print  # S.I. No. 318 of 1992, First Schedule para. 4 TABLE 'INDEX MARKS AND CORRESPONDING PLACENAMES' — the same 29 marks with the Irish placename each plate must exhibit. Accessed 2026-08-02"
+  - "https://www.irishstatutebook.ie/eli/1999/si/432/made/en/print  # S.I. No. 432 of 1999 — substitutes the whole First Schedule; the para. 4 table is re-enacted unchanged except the Offaly placename spelling (Úibh Fhailí -> Uibh Fhailí). Accessed 2026-08-02"
+  - "https://www.irishstatutebook.ie/eli/2013/si/328/made/en/print  # S.I. No. 328 of 2013 — substitutes Art. 6(3)(a) of S.I. 409/1992 with a table giving T to BOTH Tipperary ridings, L to both Limerick authorities and W to both Waterford authorities; 'shall apply to trade licences issued for 2014 and subsequent years'. Accessed 2026-08-02"
+  - "https://www.irishstatutebook.ie/eli/2014/si/243/made/en/print  # S.I. No. 243 of 2014 — substitutes that table again for the merged authority names (Limerick City and County, Tipperary, Waterford City and County); 'shall apply to trade licences issued on or after 01 June 2014'. Accessed 2026-08-02"
+  - "https://www.irishstatutebook.ie/eli/1958/si/14/made/en/print  # S.I. No. 14 of 1958, Road Vehicles (Index Marks) Regulations, 1958 — the PRE-1987 Schedule (later Part I), quoted in historic_pre_1987 below. In operation 01-02-1958. Accessed 2026-08-02"
+period: { start: 1987 }
+period_evidence: instrument-in-force
+period_note: >-
+  1987 is not the date of the instrument (sealed 20 December 1986) but the date
+  the marks became assignable, stated in the instrument's own new article 3:
+  marks in Part II "shall be assigned to vehicles first registered on or after
+  the 1st day of January, 1987". Rows added later carry their own `since:`.
+
+# A parse API needs this, and unlike Austria the Irish answer is clean.
+maximal_munch: true
+maximal_munch_note: >-
+  Take the LONGEST matching code — L vs LK vs LD vs LH vs LM vs LS, C vs CE vs
+  CN vs CW, T vs TN vs TS, W vs WD vs WH vs WW vs WX, D vs DL, K-prefixed KE/KK/
+  KY, M-prefixed MH/MN/MO. The split is nevertheless UNAMBIGUOUS even on
+  separator-stripped input, because the index mark is a pure letter run bounded
+  by digits on both sides: "121D12345" splits at the letter run "D" and nowhere
+  else. Irish marks are self-delimiting; the maximal-munch rule matters only for
+  the mark itself, never for finding its boundaries.
+
+# The placename is not decoration: First Schedule para. 4 requires the plate to
+# "exhibit the placename set out in the Table ... opposite the mention in the
+# Table of the index mark on the plate". The spelling below is the CURRENT
+# instrument's spelling; `placename_variants` records where instruments differ,
+# because they do and a render layer has to pick one.
+codes:
+  - { code: C,  placename: "Corcaigh",          county: "Cork",             licensing_authority: "Cork County Council and the Lord Mayor, Aldermen and Burgesses of Cork", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: CE, placename: "An Clár",           county: "Clare",            licensing_authority: "Clare County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: CN, placename: "An Cabhán",         county: "Cavan",            licensing_authority: "Cavan County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: CW, placename: "Ceatharlach",       county: "Carlow",           licensing_authority: "Carlow County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: D,  placename: "Baile Átha Cliath", county: "Dublin",           licensing_authority: "Dublin County Council and the Right Honourable the Lord Mayor, Aldermen and Burgesses of Dublin", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014], placename_variants: ["Baile Atha Cliath (S.I. 328/2013 and S.I. 243/2014 print it without the fada on Atha)"] }
+  - { code: DL, placename: "Dún na nGall",      county: "Donegal",          licensing_authority: "Donegal County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: G,  placename: "Gaillimh",          county: "Galway",           licensing_authority: "Galway County Council and the Mayor, Aldermen and Burgesses of Galway", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: KE, placename: "Cill Dara",         county: "Kildare",          licensing_authority: "Kildare County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: KK, placename: "Cill Chainnigh",    county: "Kilkenny",         licensing_authority: "Kilkenny County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: KY, placename: "Ciarraí",           county: "Kerry",            licensing_authority: "Kerry County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: L,  placename: "Luimneach",         county: "Limerick",         licensing_authority: "The Mayor, Aldermen and Burgesses of Limerick (1986); Limerick City and County (from S.I. 243/2014)", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014], note: "L was the LIMERICK CITY mark from 1987 (LK was the county). S.I. 328/2013 gave L to both Limerick authorities for trade licences and S.I. 243/2014 renamed the holder 'Limerick City and County'. The VRT First Schedule table still carries L and LK as separate rows." }
+  - { code: LD, placename: "An Longfort",       county: "Longford",         licensing_authority: "Longford County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: LH, placename: "Lú",                county: "Louth",            licensing_authority: "Louth County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014], placename_variants: ["Lughbhaidh appears in some non-statutory usage; every instrument read in this pass prints Lú"] }
+  - { code: LK, placename: "Luimneach",         county: "Limerick",         licensing_authority: "Limerick County Council", instruments: [si-445-1986, si-318-1992, si-432-1999], superseded_by: L, superseded_note: "absent from the trade-licence table as substituted by S.I. 328/2013; still in the un-amended VRT First Schedule table. Plates issued under LK stay valid and decodable." }
+  - { code: LM, placename: "Liatroim",          county: "Leitrim",          licensing_authority: "Leitrim County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: LS, placename: "Laois",             county: "Laois",            licensing_authority: "Laoighis County Council (so spelled in S.I. 445/1986)", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: MH, placename: "An Mhí",            county: "Meath",            licensing_authority: "Meath County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: MN, placename: "Muineachán",        county: "Monaghan",         licensing_authority: "Monaghan County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: MO, placename: "Maigh Eo",          county: "Mayo",             licensing_authority: "Mayo County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: OY, placename: "Uíbh Fhailí",       county: "Offaly",           licensing_authority: "Offaly County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014], placename_variants: ["Úibh Fhailí (S.I. 318/1992)", "Uibh Fhailí (S.I. 432/1999)", "UÍBH FHAILÍ (S.I. 287/1990)", "Uíbh Fhailí (S.I. 328/2013, S.I. 243/2014)"] }
+  - { code: RN, placename: "Ros Comáin",        county: "Roscommon",        licensing_authority: "Roscommon County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: SO, placename: "Sligeach",          county: "Sligo",            licensing_authority: "Sligo County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: T,  placename: "Tiobraid Árann",    county: "Tipperary",        licensing_authority: "Tipperary North / Tipperary South (S.I. 328/2013); Tipperary (S.I. 243/2014)", since: 2014, instruments: [si-328-2013, si-243-2014], registration_plate_authority: trade-licence-table-only, note: "THE ONLY MARK IN THIS TABLE WITH NO VRT INSTRUMENT. T is prescribed for TRADE LICENCE plates by S.I. 328/2013 (for licences issued for 2014 onwards) and S.I. 243/2014. No amendment adding T to the Table to paragraph 4 of the First Schedule to S.I. 318/1992 — the table that governs ordinary REGISTRATION plates — was located in a title-level sweep of the Irish Statute Book's annual S.I. indexes for 1990 to 2025 (by title, not full text; see plates/ie.yml, ie-standard-2013.notes for the grading). Its use on registration plates is therefore NOT established from an instrument here; see plates/ie.yml, ie-standard-2013.notes." }
+  - { code: TN, placename: "Tiobraid Árann",    county: "Tipperary North Riding", licensing_authority: "Tipperary North Riding County Council", instruments: [si-445-1986, si-318-1992, si-432-1999], superseded_by: T, superseded_note: "absent from the trade-licence table as substituted by S.I. 328/2013; still in the un-amended VRT First Schedule table." }
+  - { code: TS, placename: "Tiobraid Árann",    county: "Tipperary South Riding", licensing_authority: "Tipperary South Riding County Council", instruments: [si-445-1986, si-318-1992, si-432-1999], superseded_by: T, superseded_note: "as TN" }
+  - { code: W,  placename: "Port Láirge",       county: "Waterford",        licensing_authority: "The Mayor, Aldermen and Burgesses of Waterford (1986); Waterford City and County (from S.I. 243/2014)", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014], note: "W was the WATERFORD CITY mark from 1987 (WD was the county), on the same pattern as L/LK." }
+  - { code: WD, placename: "Port Láirge",       county: "Waterford",        licensing_authority: "Waterford County Council", instruments: [si-445-1986, si-318-1992, si-432-1999], superseded_by: W, superseded_note: "as LK" }
+  - { code: WH, placename: "An Iarmhí",         county: "Westmeath",        licensing_authority: "Westmeath County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: WW, placename: "Cill Mhantáin",     county: "Wicklow",          licensing_authority: "Wicklow County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+  - { code: WX, placename: "Loch Garman",       county: "Wexford",          licensing_authority: "Wexford County Council", instruments: [si-445-1986, si-318-1992, si-432-1999, si-328-2013, si-243-2014] }
+
+instrument_key:
+  si-445-1986: "S.I. No. 445 of 1986 — Road Vehicles (Index Marks) (Amendment) (No. 2) Regulations, 1986, Schedule Part II. Marks assignable to vehicles first registered on or after 01-01-1987."
+  si-318-1992: "S.I. No. 318 of 1992 — Vehicle Registration and Taxation Regulations, 1992, First Schedule para. 4 Table. Reg. 9 in operation 01-01-1993 (Reg. 3)."
+  si-432-1999: "S.I. No. 432 of 1999 — Vehicle Registration and Taxation (Amendment) Regulations, 1999, substituting the First Schedule; sealed 22-12-1999."
+  si-328-2013: "S.I. No. 328 of 2013 — trade-licence table, applying to trade licences issued for 2014 and subsequent years."
+  si-243-2014: "S.I. No. 243 of 2014 — trade-licence table, applying to trade licences issued on or after 01-06-2014."
+
+not_in_this_table:
+  - "ZV — the vintage-vehicle mark (S.I. 318/1992 Reg. 9(1)(d), re-enacted as Reg. 9(1A)(e) by S.I. 542/2012). It is an index mark in the statute's own words but it encodes AGE, not geography, and carries no placename."
+  - "ZZ — the temporary registration mark for non-residents. Not geographic; no instrument prescribing it was located (see plates/ie.yml, ie-temporary-zz)."
+  - "Galway city, Dún Laoghaire, and the post-2014 city/county councils generally: Ireland allots ONE mark per licensing authority AREA, and city/county pairs share a mark (C, D, G) or held adjacent marks (L/LK, W/WD). There is no separate city code beyond that pair."
+
+# ---------------------------------------------------------------------------
+# THE PRE-1987 SYSTEM. A different, disjoint set of marks, and deliberately NOT
+# authored row-by-row — what is authored is the base table plus the expansion
+# RULE, which is stronger than a partial list.
+# ---------------------------------------------------------------------------
+historic_pre_1987:
+  period: { start: 1958, end: 1987 }
+  period_evidence: instrument-in-force
+  period_note: >-
+    1958 dates the CONSOLIDATED LIST read below (S.I. No. 14 of 1958, in
+    operation 1 February 1958), not the system: the marks themselves descend
+    from registrations under the Motor Car Act, 1903 and the Roads Act, 1920,
+    and the 1958 regulations' own explanatory note says they "replace a number
+    of orders (now revoked)". Those pre-1958 orders were not fetched — recorded
+    gap. The end is exact: S.I. 445/1986's new art. 3 stops these marks being
+    assigned to vehicles first registered on or after 1 January 1987.
+  base_table_source: "https://www.irishstatutebook.ie/eli/1958/si/14/made/en/print  # S.I. No. 14 of 1958, Schedule (later renamed Part I by S.I. 445/1986). Accessed 2026-08-02"
+  stems:
+    - { marks: [IC], authority: "Carlow County Council" }
+    - { marks: [ID], authority: "Cavan County Council" }
+    - { marks: [IE], authority: "Clare County Council" }
+    - { marks: [IF, ZB, ZK, ZT], authority: "Cork County Council" }
+    - { marks: [IH, ZP], authority: "Donegal County Council" }
+    - { marks: [IK, RI, YI, Z, ZA, ZC, ZE, ZI, ZD, ZH, ZJ, ZL, ZO, ZU], authority: "Dublin County Council and The Right Honourable the Lord Mayor, Aldermen and Burgesses of Dublin" }
+    - { marks: [IM, ZM], authority: "Galway County Council" }
+    - { marks: [IN, ZX], authority: "Kerry County Council" }
+    - { marks: [IO, ZW], authority: "Kildare County Council" }
+    - { marks: [IP], authority: "Kilkenny County Council" }
+    - { marks: [CI], authority: "Laoighis County Council" }
+    - { marks: [IT], authority: "Leitrim County Council" }
+    - { marks: [IU], authority: "Limerick County Council" }
+    - { marks: [IX], authority: "Longford County Council" }
+    - { marks: [IY, ZY], authority: "Louth County Council" }
+    - { marks: [IZ], authority: "Mayo County Council" }
+    - { marks: [AI, ZN], authority: "Meath County Council" }
+    - { marks: [BI], authority: "Monaghan County Council" }
+    - { marks: [IR], authority: "Offaly County Council" }
+    - { marks: [DI], authority: "Roscommon County Council" }
+    - { marks: [EI], authority: "Sligo County Council" }
+    - { marks: [FI], authority: "Tipperary, North Riding County Council" }
+    - { marks: [HI], authority: "Tipperary, South Riding County Council" }
+    - { marks: [KI], authority: "Waterford County Council" }
+    - { marks: [LI], authority: "Westmeath County Council" }
+    - { marks: [MI, ZR], authority: "Wexford County Council" }
+    - { marks: [NI], authority: "Wicklow County Council" }
+    - { marks: [PI, ZF], authority: "The Lord Mayor, Aldermen and Burgesses of Cork" }
+    - { marks: [TI], authority: "The Mayor, Aldermen and Burgesses of Limerick" }
+    - { marks: [WI], authority: "The Mayor, Aldermen and Burgesses of Waterford" }
+  stems_added_later:
+    - { marks: [SI, ZG, ZS, ZV], authority: "Dublin County Council and the Lord Mayor, Aldermen and Burgesses of Dublin", instrument: "S.I. No. 6 of 1986, sealed 19-01-1986", note: "ZV here is the pre-1987 DUBLIN ordinary mark. The post-1992 ZV vintage series re-uses the same two letters for a different purpose entirely — a collision a parse API must carry. Note also the ORDER: S.I. 231/1981 allotted the three-letter expansions ASI..ZSI, AZG..YZG, AZS..YZS and AZV..YZV five years BEFORE S.I. 6/1986 allotted the two-letter stems SI, ZG, ZS and ZV themselves. The expansion rule below is a decode rule, not a chronology." }
+    - { marks: [ZZP], authority: "Donegal County Council", instrument: "S.I. No. 28 of 1982, sealed 23-02-1982", note: "the one four-character outlier: a leading Z on the ZP stem, i.e. the expansion rule applied to a two-letter stem that itself begins with Z." }
+  three_letter_expansion_rule: >-
+    THE THREE-LETTER MARKS ARE STEM + ONE LEADING LETTER, AND THAT IS HOW TO
+    DECODE THEM. Every three-letter mark in the fourteen amending instruments
+    listed below is formed by prefixing a single letter to a two-letter stem
+    already allotted to the same authority: AIC..ZIC to Carlow's IC, AZA..YZA
+    and AZC..YZC and AZE..YZE and AZH..YZH and AZI..YZI and AZJ..YZJ and
+    AZL..YZL and AZO..YZO and AZU..YZU and AZG/AZS/AZV series to Dublin's ZA/ZC/
+    ZE/ZH/ZI/ZJ/ZL/ZO/ZU/ZG/ZS/ZV, KPI..ZPI and AZF..LZF to Cork City's PI/ZF,
+    ATI..ZTI to Limerick City's TI, AWI..JWI to Waterford City's WI, and so on
+    for every county. So: STRIP THE LEADING LETTER, LOOK UP THE REMAINING TWO
+    (or, for a two-letter mark, look it up directly).
+    EPISTEMIC LABEL, stated because it matters: this rule is an INDUCTION over
+    the fourteen instruments read in this pass, every one of which conforms
+    without exception. NO INSTRUMENT STATES IT. It is not law, it is a reliable
+    regularity, and a parse API must treat a non-conforming mark as unresolved
+    rather than forcing it.
+  exhaustive_list_status: not-authored
+  exhaustive_list_note: >-
+    The complete pre-1987 mark list is the 1958 Schedule as amended fourteen
+    times, and merging those fourteen insertions row-by-row is gate-L4 work
+    (PRD-PLATES §7). It is deliberately NOT half-done here: a partial list read
+    as complete would make a parse API declare real plates invalid, which is
+    worse than declaring them unresolved. The amending instruments, all read and
+    all conforming to the expansion rule above, are pinned so the merge can be
+    done later without re-discovery.
+  amending_instruments:
+    - "https://www.irishstatutebook.ie/eli/1959/si/8/made/en/print    # S.I. 8/1959 — Clare"
+    - "https://www.irishstatutebook.ie/eli/1959/si/107/made/en/print  # S.I. 107/1959 — Dublin, Westmeath"
+    - "https://www.irishstatutebook.ie/eli/1959/si/136/made/en/print  # S.I. 136/1959 — Limerick City, Galway, Sligo"
+    - "https://www.irishstatutebook.ie/eli/1960/si/46/made/en/print   # S.I. 46/1960 — Laoighis, Offaly, Monaghan"
+    - "https://www.irishstatutebook.ie/eli/1960/si/244/made/en/print  # S.I. 244/1960 — Dublin, Waterford, Wexford"
+    - "https://www.irishstatutebook.ie/eli/1961/si/283/made/en/print  # S.I. 283/1961 — ten authorities"
+    - "https://www.irishstatutebook.ie/eli/1963/si/69/made/en/print   # S.I. 69/1963 — Dublin"
+    - "https://www.irishstatutebook.ie/eli/1964/si/8/made/en/print    # S.I. 8/1964 — Dublin, Cork City, Carlow, Louth"
+    - "https://www.irishstatutebook.ie/eli/1965/si/30/made/en/print   # S.I. 30/1965 — eight authorities"
+    - "https://www.irishstatutebook.ie/eli/1967/si/128/made/en/print  # S.I. 128/1967 — Dublin, Tipperary North Riding"
+    - "https://www.irishstatutebook.ie/eli/1968/si/121/made/en/print  # S.I. 121/1968 — Dublin, Cork City, Limerick City, Kerry, Westmeath"
+    - "https://www.irishstatutebook.ie/eli/1970/si/101/made/en/print  # S.I. 101/1970 — the largest single amendment, thirteen or more authorities"
+    - "https://www.irishstatutebook.ie/eli/1981/si/231/made/en/print  # S.I. 231/1981 — Dublin, Limerick, Mayo, Tipperary South Riding"
+    - "https://www.irishstatutebook.ie/eli/1982/si/28/made/en/print   # S.I. 28/1982 — Donegal (ZZP)"
+    - "https://www.irishstatutebook.ie/eli/1986/si/6/made/en/print    # S.I. 6/1986 — Dublin (SI, ZG, ZS, ZV)"
+  skipped_letters_folklore: >-
+    FOLKLORE FLAG, recorded not repeated: the widely circulated claim that the
+    letters G, S and V were "skipped, as these were intended for Scotland" is
+    NOT stated in any instrument read in this pass. What the instruments show is
+    narrower and different: the 1958 Schedule contains no TWO-letter mark
+    beginning with G, S or V — but it is full of THREE-letter marks that do
+    (GYI, SYI, VYI, all Dublin), and S.I. No. 6 of 1986 later allotted the
+    two-letter mark SI to Dublin outright. So no permanent reservation is
+    observable in the primary record. The claim is recorded here as unverified
+    and is not asserted by this file; establishing or refuting it needs the
+    pre-1958 orders the 1958 regulations revoked, which were not fetched.

--- a/plates/ie.yml
+++ b/plates/ie.yml
@@ -1,0 +1,775 @@
+# plates/ie.yml — Ireland (PRD-PLATES gate L1, wave 2).
+#
+# EVERY format, colour, dimension and period claim in this file is read off an
+# instrument on irishstatutebook.ie, fetched 2026-08-02. Wikipedia was used as a
+# FINDING AID to learn which S.I. numbers to chase and for nothing else; the two
+# facts in this file that rest on it are tagged `secondary-wikipedia` at point of
+# use and are both recorded as GAPS rather than as data (diplomatic CD marks,
+# Defence Forces plates). No table, infobox or list here was taken from it.
+#
+# THE INSTRUMENT CHAIN, in the order it actually happened — and note that not
+# one of these dates is the date of the instrument that carries it:
+#
+#   1921-01-01  ROADS ACT 1920 (c. 72) s. 6 — county councils register vehicles
+#               and assign "a mark indicating the registered number of the
+#               vehicle and the council with which the vehicle is registered".
+#               Its proviso fixes the handover date verbatim: "any number which
+#               has been assigned to a motor car under section two of the Motor
+#               Car Act, 1903, and which is the registered number of that car on
+#               the first day of January, nineteen hundred and twenty-one, shall
+#               be treated as having been assigned to the car under the
+#               provisions of this section and no new number shall be assigned".
+#   1958-02-01  S.I. No. 14 of 1958 — the consolidated index-mark list (IC, ID,
+#               IE, IF, IK, Z, ZA ...), amended fourteen times to 1986.
+#   1983-02-01  S.I. No. 311 of 1982 — the pre-1987 plate spec (Third Schedule):
+#               black ground with white/silver/light grey characters, or the
+#               reflective alternative with a WHITE front and a RED rear.
+#   1987-01-01  S.I. No. 441 of 1986, art. 1(3): "These Regulations shall come
+#               into operation on the 1st day of January, 1987." THE YEAR-COUNTY
+#               SYSTEM IS BORN — art. 25(3) of the 1982 Regulations is
+#               substituted to add "the third and fourth numerals of the year in
+#               which the vehicle is first registered", and a new Third Schedule
+#               Part II gives the plate: "87 D 99999", "87 CW 9999", white
+#               reflective, black characters, NO EU flag, NO placename, and the
+#               groups separated by SPACE, not by a hyphen.
+#               S.I. No. 445 of 1986 art. 3 does the other half: the old marks
+#               "shall not be assigned to vehicles first registered on or after
+#               the 1st day of January, 1987" and the new ones shall.
+#   1991-01-01  S.I. No. 287 of 1990 — Third Schedule Part III, "in respect of
+#               vehicles registered on or after the 1st day of January, 1991",
+#               and Part II is simultaneously capped "but not later than the
+#               31st day of December, 1990". THE MODERN IRISH PLATE ARRIVES
+#               WHOLE: 520 x 110, black border, the flag of the European
+#               Communities with IRL, the Irish-language placename above the
+#               mark, and the HYPHEN as the prescribed separator.
+#   1993-01-01  S.I. No. 318 of 1992 (Reg. 3 commences Reg. 9) — the Revenue
+#               Commissioners take the register over from the county councils
+#               under Finance Act 1992 s. 131. Reg. 9(1) re-enacts the mark and
+#               the First Schedule re-enacts the plate. FORMAT UNCHANGED — this
+#               is an administrative transfer, not a new series, and it is the
+#               single most tempting wrong series boundary in the Irish record.
+#               S.I. No. 409 of 1992 (same date) prescribes the trade licence.
+#   1999-12-22  S.I. No. 432 of 1999 substitutes the First Schedule: character
+#               width becomes a RANGE (36-50 mm, was fixed 36) and the hyphen a
+#               range (13-22 mm, was fixed 22). Its own explanatory note gives
+#               the reason: "to allow additional characters to be displayed ...
+#               necessary to cater for increases in the number of car
+#               registrations". A design amendment, NOT a new series.
+#   2013-01-01  S.I. No. 542 of 2012, art. 2: "These Regulations come into
+#               operation on 1 January 2013." THE HALF-YEAR REFORM — new Reg.
+#               9(1A) inserts "(b)(i) the numeral '1' for vehicles first brought
+#               into use during the period 1 January to 30 June in any year, or
+#               (ii) the numeral '2' for vehicles first brought into use during
+#               the period 1 July to 31 December". 131 and 132 are law, dated to
+#               the day, from a Revenue instrument sealed 20 December 2012.
+#   2025-07-01  S.I. No. 268 of 2025, art. 2 — the optional green stripe for
+#               zero-tailpipe-CO2 vehicles, plus a further relaxation of the
+#               character metrics (height 65-70, stroke 9-10, width 33-50).
+#
+# WHAT THE HALF-YEAR REFORM ACTUALLY KEYS ON, because everyone gets this wrong:
+# NOT the date of registration. Reg. 9(1) as amended applies to a vehicle "first
+# brought into use on or before 31 December 2012"; Reg. 9(1A) to one "first
+# brought into use on or after 1 January 2013". So the TWO-DIGIT SERIES IS STILL
+# BEING ISSUED TODAY — an imported car built in 2011 and registered in Ireland
+# in 2026 gets an 11- mark. Revenue states it in terms with a worked example:
+# "A car imported in 2017 that was first registered in the UK in 2011 will be
+# registered as 11-xx-xxxx." ie-standard-1991 therefore has NO end date, and it
+# overlaps ie-standard-2013 permanently and legally.
+#
+# COLOUR POLICY, the Irish variant of the Spanish gamut problem: IRELAND
+# PRESCRIBES NO COLORIMETRY AT ALL. There is no CIE box, no RAL, no luminance
+# factor — the instruments say "white reflex reflective material", "black
+# characters", "a colour shade generally known as royal blue", "twelve gold
+# stars", and that is the whole of it. Every hex below is therefore
+# `hex_basis: observed`. The ONE exception is the 2025 green stripe, and it is a
+# NAMED INK rather than a hex: "shall be colour Pantone 7481c or a colour match
+# that is as close as possible to this colour" — carried as `color_spec`, with
+# the hex still marked observed because a Pantone-to-sRGB conversion is a
+# rendering decision, not a sourced value.
+#
+# FOUR SOURCED NEGATIVES. Searched for in the 1982, 1986, 1990, 1992, 1999, 2012
+# and 2025 instruments and NOT FOUND, so recorded as absent rather than invented:
+#   * NO TRAILER SERIES. Reg. 9(8): "Where one or more trailers of any kind are
+#     attached to a vehicle, a duplicate of the identification mark of the
+#     vehicle shall be exhibited on the back of the rearmost trailer." An Irish
+#     trailer carries the towing vehicle's mark and has no mark of its own.
+#   * NO MOTORCYCLE SERIES. A motorcycle carries the ordinary mark; Reg. 9(7)
+#     only relieves it of the front plate ("in the case of a vehicle which has
+#     only one front wheel, on the back of the vehicle"). Note the Irish
+#     drafting trap: "bicycle" in these regulations MEANS a motorcycle —
+#     S.I. 357/1991 defines it as "a mechanically propelled bicycle (including
+#     a motor scooter ...)", and S.I. 268/2025 arts. 5(o) and 5(q)(i) finally
+#     substitute the word "motorcycle" for "bicycle" in First Schedule paras. 18
+#     and 19 — a thirty-three-year-old drafting artefact corrected in 2025.
+#   * NO PERSONALISED SERIES. Ireland sells RESERVATION, not vanity: s. 131(5A)
+#     Finance Act 1992, EUR 1,000 (S.I. 396/2008 raised it from EUR 315), and
+#     Revenue states the constraint — the number "must be in the normal
+#     registration number format", must match the year and half-year, and must
+#     match where the applicant resides. There is no owner-chosen string.
+#   * NO SEPARATE TAXI, EXPORT, SEASONAL, ELECTRIC, MOPED OR AGRICULTURAL
+#     SERIES. The 2025 green stripe is a variant of the standard plate, not a
+#     series: same mark, same format, optional, retrofittable.
+jurisdiction: ie
+authority:
+  name: Revenue Commissioners — Vehicle Registration and Taxation Regulations, 1992 (S.I. No. 318 of 1992), made under s. 141 Finance Act 1992
+  url: "https://www.irishstatutebook.ie/eli/1992/si/318/made/en/print"
+binding: vehicle
+binding_note: >-
+  Reg. 9(4), verbatim: "The identification mark of a vehicle shall remain
+  assigned to the vehicle and no other such marks shall be assigned to the
+  vehicle save in such circumstances as may be determined by the Commissioners
+  or where the owner of the vehicle requests that the identification mark
+  assigned to a vehicle which reaches 30 years of age be replaced by a mark in
+  the ZV series." Vehicle-keyed consumers may join on it: the mark does not
+  follow the owner, and the ONE statutory route to a different mark is the
+  thirty-year ZV swap. The trade licence (ie-trade-1993) is the exception and
+  carries its own `binding: business`.
+
+instrument:
+  enabling_statute: "Finance Act 1992 (No. 9 of 1992), Chapter IV of Part II — s. 131 (registration and assignment of identification marks), s. 131(5A) (reservation), s. 135 (temporary exemption), s. 136 (authorised persons), s. 141 (regulation-making power)"
+  predecessor_statute: "Roads Act 1920 (c. 72) ss. 5, 6 and 12 — the county-council registration regime the Revenue regime replaced on 1 January 1993"
+  source: "https://www.irishstatutebook.ie/eli/1920/act/72/enacted/en/print  # Roads Act 1920 s. 6 'Registration and identification marks', including the Motor Car Act 1903 carry-over proviso. Accessed 2026-08-02"
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+common:
+  colour_basis: >-
+    NO COLORIMETRIC SPECIFICATION EXISTS IN IRISH LAW. The First Schedule to
+    S.I. 318/1992 (as substituted 1999, amended 2012 and 2025) names colours in
+    words only: para. 9 "black characters ... exhibited on white reflex
+    reflective material"; para. 10 "twelve gold stars against a blue background
+    (of a colour shade generally known as royal blue)"; para. 11 "the letters
+    IRL ... in white letters". Contrast Spain's Anexo XVIII Cuadro 3 and
+    Austria's Anlage 5e Tabelle 2, both of which fix a CIE quadrangle. Every hex
+    in this file is `hex_basis: observed` and none of them is a sourced claim.
+  colour_spec_exception:
+    green_stripe: "Pantone 7481 C"
+    text: >-
+      First Schedule para. 12A, inserted by S.I. 268/2025, verbatim: "The green
+      stripe for an eligible vehicle shall be colour Pantone 7481c or a colour
+      match that is as close as possible to this colour and shall be formed of
+      reflex reflective material." The only named colour standard in the Irish
+      plate law, and it is an ink reference, not a coordinate.
+    source: "https://www.irishstatutebook.ie/eli/2025/si/268/made/en/print  # art. 5(d) inserting First Schedule para. 12A. Accessed 2026-08-02"
+  separator_finding: >-
+    THE HYPHEN IS STATUTORY FROM 1991 AND WAS NOT BEFORE. Third Schedule Part II
+    (1987-1990) prescribes only a GAP — para. 7(c), verbatim: "the space between
+    the index mark and adjoining figures shall be three times the space between
+    the nearest part of adjoining figures." Third Schedule Part III (from 1991)
+    and the First Schedule that re-enacts it prescribe the glyph and its size —
+    para. 16(d), verbatim: "the index mark shall be separated from adjoining
+    figures on each side of the index mark by a hyphen with a stroke width of 10
+    millimetres which shall extend horizontally for a distance of not less than
+    13 millimetres and not more than 22 millimetres." So `ie-standard-1987`
+    spells a space and `ie-standard-1991`/`ie-standard-2013` spell a hyphen, and
+    both are the printed form the instrument itself prescribes (PRD-PLATES §2.6
+    rule 2).
+  no_nought_rule: >-
+    First Schedule para. 3(b), verbatim: "The identification mark shall not
+    incorporate the figure nought unless such figure forms part of the
+    identification mark assigned to the vehicle by the Commissioners." This is
+    the Irish no-leading-zero rule: the sequence number is printed as assigned,
+    never padded, so "121-D-7" is a whole registration and "121-D-0007" is not
+    one. It is carried in `regex_strict`, never in `regex`, because the
+    round-trip (PRD-PLATES §2.7) forbids `regex` from carrying charset rules.
+    NOTE THE PERIOD: this paragraph is in Third Schedule Part III (1991) and the
+    First Schedule (1992 onward). Part II (1987-1990) has no equivalent, so
+    ie-standard-1987 makes no leading-zero claim.
+  display_rules:
+    two_plates: "Reg. 9(7): front and back, 'in a vertical or nearly vertical position', except a vehicle 'which has only one front wheel' which carries the rear plate only"
+    trailers: "Reg. 9(8): the rearmost trailer displays a DUPLICATE of the towing vehicle's mark — Ireland issues no trailer registration"
+    obstruction: "Reg. 9(9): 'Figures, letters, designs, ornamentation's, fittings or structures shall not be placed on a vehicle or trailer in such a position as to render more difficult the reading or distinguishing of the identification mark'"
+    display_deadline: "Reg. 9(5): where the declaration is made by a person who is not an authorised person, the mark must be displayed 'as on and from a day not more than 3 working days after the registration of the vehicle'"
+    source: "https://www.irishstatutebook.ie/eli/1992/si/318/made/en/print  # Reg. 9(5)-(9). Accessed 2026-08-02"
+  large_psv_exception: >-
+    First Schedule para. 22 exempts a large public service vehicle whose mark is
+    "illuminated by transparency or translucency": its characters "shall appear
+    white when the mark is so illuminated and shall appear at all other times
+    white against a black background". A white-on-black Irish bus plate is
+    lawful and is the ONLY inverted standard-series plate in Irish law.
+  tolerance_rule: >-
+    First Schedule para. 21: a plate is not in contravention by reason only of a
+    dimension error of up to 1 mm where the prescribed dimension is 70 mm or
+    less, or up to 3 mm where it is greater. A renderer should treat every
+    millimetre in this file as a nominal with that tolerance.
+  penalty: "Finance Act 1992 s. 139 — summary conviction; Revenue states the maximum as EUR 5,000 for a non-conforming plate"
+  not_authored:
+    note: >-
+      Two Irish plate types are REPORTED to exist and are NOT authored as series
+      here, because no instrument prescribing either was located and the only
+      description available is secondary. They are recorded so a later pass
+      starts from a named gap rather than from nothing, and each carries its
+      evidence grade at point of use.
+    diplomatic:
+      status: not-established
+      evidence: secondary-wikipedia
+      reported: "a plate in the ordinary format with a small 'CD' between the index mark and the sequence number"
+      searched: >-
+        Not in S.I. 318/1992 (First Schedule read in full, paras. 1-23), not in
+        S.I. 287/1990 Part III, not in S.I. 441/1986 Part II, and not in any
+        Vehicle Registration and Taxation amendment 1993-2025 found by the
+        title-level sweep. Reg. 9(1) admits no letter group other than the index
+        mark, so a CD element has no visible statutory basis in the instruments
+        read.
+      source: "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ireland  # read as a locator 2026-08-02; the article names no instrument for this claim, and none was found"
+    defence_forces:
+      status: not-established
+      evidence: secondary-wikipedia
+      reported: "silver characters on a black ground, without the Irish-language placename"
+      searched: >-
+        S.I. 311/1982 art. 25(2) does contemplate military vehicles — "On the
+        first licensing of a military vehicle the appropriate licensing
+        authority shall, on receipt of an application from a duly authorised
+        officer of the Department of Defence, assign to it an identification
+        mark complying with the provisions of sub-article (3)" — but sub-article
+        (3) is the ORDINARY composition, so the 1982 regime gave military
+        vehicles ordinary marks. No instrument prescribing a distinct Defence
+        Forces format or design was located.
+      source: "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ireland  # read as a locator 2026-08-02"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT SERIES — three-digit year with the half-year digit.
+  # =========================================================================
+  - id: ie-standard-2013
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "999-LL-9999"
+      regex: '\A\d{3}-[A-Z]{1,2}-\d{1,6}\z'
+      regex_strict: '\A\d{2}[12]-(?:CE|CN|CW|DL|KE|KK|KY|LD|LH|LK|LM|LS|MH|MN|MO|OY|RN|SO|TN|TS|WD|WH|WW|WX|C|D|G|L|T|W)-[1-9]\d{0,5}\z'
+      composition:
+        - "Reg. 9(1A)(a) — 'the third and fourth numerals of the year in which the vehicle is first brought into use'"
+        - "Reg. 9(1A)(b) — the half-year numeral: '1' for 1 January to 30 June, '2' for 1 July to 31 December"
+        - "Reg. 9(1A)(c) — 'an index mark, as provided for in the table to paragraph 4 of the First Schedule ... corresponding to the functional area of the licensing authority in which the owner at the time of registration ordinarily resides'"
+        - "Reg. 9(1A)(d) — 'a number which when combined with the appropriate numerals and mark aforesaid produces a unique combination'"
+      pattern_note: >-
+        The four digits in the pattern's last group are REPRESENTATIVE ONLY. No
+        instrument fixes the width of the sequence number: Reg. 9(3) says only
+        that numbers "shall be assigned sequentially to each index mark, but the
+        Commissioners may omit any numbers from a sequence". The 1987 diagrams
+        drew five digits behind a one-letter mark ("87 D 99999") and four behind
+        a two-letter mark ("87 CW 9999"), which is a drafting illustration and
+        not a limit. `regex` bounds the group at six digits as an outer bound
+        and makes no claim inside it.
+      progression: >-
+        Sequential per index mark PER HALF-YEAR, restarting at 1 each time the
+        year group changes — which is exactly why the year group is a hard age
+        signal and Ireland is the easiest plate in Europe to date. The sequence
+        also makes the number a rough within-county volume signal, since
+        "121-D-90000" and "121-LD-300" are the same six months in two counties
+        of very different size.
+      charset:
+        letters: "index marks only; see the decode table"
+        notes: "no leading zero on the sequence number (First Schedule para. 3(b) — see common.no_nought_rule); the index-mark group is a closed enumerated list, not a free alphabet"
+      separator_note: "hyphen, prescribed with its stroke width and length by First Schedule para. 16(d) — see common.separator_finding"
+    design:
+      plate: { w: 520, h: 110, unit: mm, note: "Diagram No. 3, First Schedule para. 2A + para. 16(a)" }
+      plate_variants:
+        - { w: 340, h: 220, unit: mm, note: "Diagram No. 4 — the two-line plate, para. 17(a)" }
+        - { note: "para. 18: on a motorcycle, an invalid carriage or a pedestrian-controlled vehicle every prescribed dimension may be HALVED and the plate need not be rectangular" }
+        - { note: "para. 20: where the vehicle has an indented plate recess too small for either prescribed size, the dimensions may be reduced to comply 'as nearly as possible'" }
+      characters: { h: [65, 70], stroke: [9, 10], w: [33, 50], gap_min: 8, unit: mm, note: "the 2025 ranges (para. 14 as substituted by S.I. 268/2025). Before 2025-07-01 the height was exactly 70 and the stroke exactly 10, with width 36-50 from 1999 and exactly 36 from 1990." }
+      border: { color: "#000000", stroke: 5, unit: mm, note: "para. 5: 'The periphery of the plate shall be marked all around by a black border having a stroke width of 5 millimetres' — a black KEYLINE inside the plate edge, which is a distinctively Irish feature and is statutory, not decorative" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band:
+        side: left
+        color: "#003399"
+        hex_basis: observed
+        content: eu-stars+IRL
+        w: [40, 45]
+        unit: mm
+        note: >-
+          para. 10-12: twelve gold stars whose centrepoints lie on a circle of
+          radius 15 mm with 4 mm star apexes, "against a blue background (of a
+          colour shade generally known as royal blue)"; IRL below them in white,
+          20 mm high, 4 mm stroke, R and L each 12 mm wide; all of it
+          retroreflective. The band width was exactly 40 mm until S.I. 268/2025
+          made it 40-45.
+      placename:
+        content: irish-language-county-name
+        position: above-the-mark
+        h_min: 12
+        stroke_min: 3
+        unit: mm
+        note: >-
+          para. 4 and para. 13. THE PLACENAME IS PART OF THE PLATE, not a
+          sticker: "The plate shall exhibit the placename set out in the Table to
+          this paragraph opposite the mention in the Table of the index mark on
+          the plate". It is in IRISH ONLY, it is black on the white ground, and
+          its accents are dimensioned ("Where an accented vowel occurs in the
+          placename the length accent character shall have a height of 2
+          millimetres above the letter"). Ireland is the only EU jurisdiction in
+          this dataset that prints the region NAME rather than only its code.
+      no_other_marks: "para. 3(a): the plate 'shall not contain any words, letters, numbers, emblems or other marks of any kind other than those required under this Schedule' — which is why Ireland has no emblem slot and no dealer branding on plates"
+      emblem: { present: false }
+      rear_differs: false
+      construction: "para. 6-8: metal plates carry EMBOSSED characters raised above the surface and forming part of the plate; plastic plates are transparent, at least 2.5 mm thick, with the mark adhered to the REAR so it reads through the front"
+    region_encoding: "ie-counties.yml"
+    variants:
+      - class: electric
+        design:
+          stripe: { side: right, color: "#009639", hex_basis: observed, color_spec: "Pantone 7481 C", w: 30, unit: mm, finish: retroreflective }
+        note: >-
+          THE GREEN FLASH, from 1 July 2025 (S.I. 268/2025 art. 2). A sub-entry
+          and not a series, on the PRD-PLATES §2.3 test: same format, same
+          period, same mark — only the design differs, and only optionally. New
+          Reg. 9(10): "an eligible vehicle MAY display a plate which contains a
+          stripe which is green in colour", where "eligible vehicle" is defined
+          as one "which emits no CO2 tailpipe emissions". On the long plate the
+          stripe is 30 mm at the RIGHT-hand edge (para. 16(ba)); on the two-line
+          plate it is 45 mm at the LEFT, running from the bottom of the EU flag
+          to the bottom border (para. 17(ba)) — the two layouts put it on
+          opposite sides, which a renderer must not average. Revenue confirms it
+          is optional and retrofittable to an existing EV.
+        sources:
+          - "https://www.irishstatutebook.ie/eli/2025/si/268/made/en/print  # arts. 2, 4(a)(ii), 4(c), 5(c), 5(d), 5(h), 5(l): in operation 01-07-2025; 'eligible vehicle'; Reg. 9(10) permissive 'may'; Diagrams 5 and 6; Pantone 7481c; the 30 mm right stripe and the 45 mm left stripe. Accessed 2026-08-02"
+          - "https://www.revenue.ie/en/vrt/vehicle-registration-tax/registration-plates-and-format-standards.aspx  # Revenue: 'Since 1 July 2025, all vehicles that do not emit CO2 tailpipe emissions are eligible for a green \"flash\" registration plate ... not mandatory ... you can retrofit'. Accessed 2026-08-02"
+    sources:
+      - "https://www.irishstatutebook.ie/eli/2012/si/542/made/en/print  # S.I. No. 542 of 2012: art. 2 'These Regulations come into operation on 1 January 2013'; art. 4(b) inserting Reg. 9(1A) with the half-year numerals verbatim; art. 5(b) inserting First Schedule para. 2A with Diagrams 3 and 4; sealed 20-12-2012; notice published in Iris Oifigiúil of 01-01-2013. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/1992/si/318/made/en/print  # S.I. No. 318 of 1992: Reg. 9(3) sequential assignment; First Schedule paras. 3-22 (the plate spec this series inherits); para. 4 Table (index marks and placenames). Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/1999/si/432/made/en/print  # S.I. No. 432 of 1999: substitutes the First Schedule — character width range 36-50 mm, hyphen length range 13-22 mm. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/2025/si/268/made/en/print  # S.I. No. 268 of 2025: art. 5(e) substituting para. 14 with the 65-70 mm / 9-10 mm / 33-50 mm ranges; art. 5(g) the 40-45 mm band. Accessed 2026-08-02"
+      - "https://www.revenue.ie/en/vrt/vehicle-registration-tax/registration-plates-and-format-standards.aspx  # Revenue (the issuing authority): 'The format YY[1 or 2] - County - sequential number will apply to all vehicles registered since 1 January 2013'; the plate must carry black on white reflective, the Irish county name at the top, and the EU flag with IRL on the left. Accessed 2026-08-02"
+    notes: >-
+      THE CURRENT IRISH SERIES, and the half-year reform is the best-dated plate
+      change in this dataset: S.I. 542/2012 was sealed on 20 December 2012 and
+      commences on 1 January 2013 by its own article 2. The commonly repeated
+      motive — that 131 exists to avoid an unlucky "13" and to move sales into
+      the second half of the year — is NOT in the instrument, which as usual
+      states no reason at all; it is recorded here as commentary, not as
+      sourced fact. WHAT IS IN THE INSTRUMENT is the thing secondary sources
+      usually get wrong: the half-year digit follows FIRST BROUGHT INTO USE, not
+      the date of Irish registration, so this series does not supersede
+      ie-standard-1991 — the two run in parallel for as long as pre-2013 vehicles
+      are still being imported. THE ONE OPEN QUESTION IS THE LETTER T: Tipperary
+      merged its two ridings in 2014 and the single mark T is prescribed by the
+      TRADE-LICENCE table (S.I. 328/2013, S.I. 243/2014), but a TITLE-LEVEL
+      sweep of the Irish Statute Book's annual S.I. indexes for every year from
+      1990 to 2025, followed by reading each of the eleven instruments so found
+      whose title touched vehicle registration, produced NO amendment adding T
+      (or merging LK into L, or WD into W) in the Table to paragraph 4 of the
+      First Schedule, which is the table Reg. 9(1A)(c) actually points at. The
+      sweep was by TITLE, not by full text, so an amendment hidden in a
+      differently-named instrument would have been missed — the negative is
+      strong but not exhaustive, and it is graded that way. T is
+      carried in `regex_strict` because refusing a plate that is certainly issued
+      would be the worse error, and the evidential shortfall is recorded here and
+      per-row in the decode table rather than papered over.
+
+  # =========================================================================
+  # THE TWO-DIGIT YEAR SERIES — 1991 onward, STILL ISSUED.
+  # =========================================================================
+  - id: ie-standard-1991
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1991 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "99-LL-9999"
+      regex: '\A\d{2}-[A-Z]{1,2}-\d{1,6}\z'
+      regex_strict: '\A\d{2}-(?:CE|CN|CW|DL|KE|KK|KY|LD|LH|LK|LM|LS|MH|MN|MO|OY|RN|SO|TN|TS|WD|WH|WW|WX|C|D|G|L|T|W)-[1-9]\d{0,5}\z'
+      composition:
+        - "1991-1992: art. 25(3) of S.I. 311/1982 as substituted by S.I. 441/1986 — registration number, index mark of the licensing authority, and 'the third and fourth numerals of the year in which the vehicle is first registered'"
+        - "1993 onward: Reg. 9(1) of S.I. 318/1992 — 'the third and fourth numerals of the year in which the vehicle is first brought into use', the index mark of the authority where the owner ordinarily resides, and a unique number"
+      pattern_note: "sequence-number width is representative only — see ie-standard-2013.format.pattern_note, which applies verbatim"
+      progression: "sequential per index mark per YEAR (not per half-year, which arrives only in 2013); Reg. 9(3) permits the Commissioners to omit numbers from a sequence"
+      separator_note: "hyphen, prescribed from 1991 by Third Schedule Part III para. 17(d) and re-enacted as First Schedule para. 16(d) — see common.separator_finding"
+    design:
+      plate: { w: 520, h: 110, unit: mm, note: "Diagram No. 9 (1991-1992) / Diagram No. 1 (1993 onward)" }
+      plate_variants:
+        - { w: 340, h: 220, unit: mm, note: "Diagram No. 10 / Diagram No. 2 — the two-line plate" }
+      characters: { h: 70, stroke: 10, w: [36, 50], gap_min: 8, unit: mm, note: "width was exactly 36 mm from 1991 (S.I. 287/1990 Part III para. 15) and became the range 36-50 on 22-12-1999 (S.I. 432/1999). Height 70 and stroke 10 were exact until S.I. 268/2025." }
+      border: { color: "#000000", stroke: 5, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+IRL, w: 40, unit: mm, note: "identical wording to the current series; introduced by S.I. 287/1990 Part III paras. 11-13, so the EU flag on an Irish plate is a 1991 fact and not a 1993 one" }
+      placename: { content: irish-language-county-name, position: above-the-mark, h_min: 12, stroke_min: 3, unit: mm }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: "ie-counties.yml"
+    sources:
+      - "https://www.irishstatutebook.ie/eli/1990/si/287/made/en/print  # S.I. No. 287 of 1990: art. 3(d) adds Third Schedule PART III, 'Provisions to be complied with in respect of vehicles registered on or after the 1st day of January, 1991' — the EU flag, IRL, the Irish placename, the 520x110 and 340x220 plates, the black border, and the HYPHEN; art. 3(b) caps Part II at 31-12-1990. Sealed 05-12-1990. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/1992/si/318/made/en/print  # S.I. No. 318 of 1992: Reg. 3 puts Reg. 9 into operation on 01-01-1993; Reg. 9(1) re-enacts the two-digit mark; the First Schedule re-enacts the Part III plate almost word for word. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/2012/si/542/made/en/print  # S.I. No. 542 of 2012 art. 4(a): confines Reg. 9(1) to a vehicle 'first brought into use on or before 31 December 2012 and' entered in the register — the provision that keeps this series ALIVE rather than closing it. Accessed 2026-08-02"
+      - "https://www.revenue.ie/en/vrt/vehicle-registration-tax/registration-plates-and-format-standards.aspx  # Revenue's worked example: 'A car imported in 2017 that was first registered in the UK in 2011 will be registered as 11-xx-xxxx.' Accessed 2026-08-02"
+    notes: >-
+      THE MODERN IRISH PLATE AS IT FIRST APPEARED, and an open-ended series that
+      a naive reading would have closed in 2012. Two boundary facts are worth
+      stating because both are routinely misdated. FIRST, the design boundary is
+      1 JANUARY 1991, not 1993: S.I. 287/1990 introduced the EU flag, the IRL
+      sign, the Irish placename and the hyphen while vehicles were still
+      registered by county councils under the Roads Act 1920, and the Revenue
+      takeover on 1 January 1993 changed the registering authority and not one
+      character of the plate. Modelling 1993 as a series start would record an
+      administrative transfer as a design change. SECOND, this series has no end:
+      S.I. 542/2012 did not close it, it CONFINED it to vehicles first brought
+      into use on or before 31 December 2012 — and those vehicles are still being
+      imported and registered, so two-digit marks are still being issued in 2026.
+      The overlap with ie-standard-2013 is permanent, legal and stated.
+      TRANSITION DETAIL: S.I. 287/1990 art. 3(c) also let 1987-1990 vehicles
+      adopt the new plate voluntarily ("The provisions of this Part of this
+      Schedule shall be deemed to be complied with if the identification mark
+      exhibited on the vehicle complies with the provisions of Part III"), which
+      is why an 88-D plate seen today usually carries the EU band it was never
+      issued with.
+
+  # =========================================================================
+  # THE ORIGINAL 1987 PLATE — no EU band, no placename, no hyphen.
+  # =========================================================================
+  - id: ie-standard-1987
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1987, end: 1990 }
+    period_evidence: instrument-dated-both-ends
+    matching: strict
+    format:
+      pattern: "99 LL 9999"
+      regex: '\A\d{2} [A-Z]{1,2} \d{1,6}\z'
+      regex_strict: '\A\d{2} (?:CE|CN|CW|DL|KE|KK|KY|LD|LH|LK|LM|LS|MH|MN|MO|OY|RN|SO|TN|TS|WD|WH|WW|WX|C|D|G|L|W) \d{1,6}\z'
+      pattern_note: >-
+        The 1986 instrument's own diagrams are the evidence for the shape and
+        they are printed in the text: "87 D 99999" (Diagram No. 6, one-letter
+        mark) and "87 CW 9999" (Diagram No. 8, two-letter mark), with Diagrams
+        No. 5 and No. 7 as the two-line versions. Digit widths are illustrative;
+        no instrument fixes them.
+      composition:
+        - "art. 25(3)(a) — 'the number under which the vehicle is registered with the licensing authority'"
+        - "art. 25(3)(b) — 'an index mark allotted to that licensing authority'"
+        - "art. 25(3)(c) — 'in respect of vehicles first registered on or after the 1st day of January, 1987 ... the third and fourth numerals of the year in which the vehicle is first registered'"
+        - "art. 25(3)(d) — for a vehicle previously registered abroad, 'the third and fourth numerals of the year in which the vehicle was first registered in that State'"
+      separator_note: >-
+        SPACE, NOT HYPHEN, and this is the whole difference between an Irish
+        plate of 1988 and one of 1991. Third Schedule Part II para. 7(c) fixes
+        only a proportional gap: "the space between the index mark and adjoining
+        figures shall be three times the space between the nearest part of
+        adjoining figures", with para. 7(a) setting the base gap at 8 mm. No
+        glyph is prescribed anywhere in Part II.
+      leading_zero_note: "Part II has NO equivalent of the later para. 3(b) no-nought rule, so unlike the 1991 and 2013 series this one makes no leading-zero claim and `regex_strict` does not carry one"
+    design:
+      plate: { note: "NO PLATE DIMENSIONS ARE PRESCRIBED IN PART II — a recorded gap, and a real one: Part II fixes character sizes and margins but never an overall plate size. The 520 x 110 / 340 x 220 pair arrives only with S.I. 287/1990." }
+      characters: { h_min: 81, stroke_min: 12, w_min: 48, gap_min: 8, unit: mm, note: "para. 5: 'all letters and figures of an identification mark shall be at least 81 millimetres high ... every part of every letter and figure shall be at least 12 millimetres broad and the total width of the space taken by every letter or figure, except in the case of the letter \"I\" or the figure \"1\", shall be at least 48 millimetres'. MINIMA, not exact values — the opposite drafting style to the 1990 spec, and 81 mm is TALLER than the 70 mm the modern plate uses." }
+      margins: { edge_min: 8, unit: mm, note: "para. 6: at least 8 mm from any character to the top, bottom or sides of the reflective surface" }
+      line_gap_min: { v: 13, unit: mm, note: "para. 8, two-line layouts (Diagrams 5 and 7)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none, note: "NO EU FLAG AND NO IRL. Ireland's plates carried no EU band until 1 January 1991." }
+      placename: { present: false, note: "NO IRISH-LANGUAGE COUNTY NAME either — that too is a 1991 addition. The 1987 plate shows the mark and nothing else." }
+      border: { present: false, note: "the 5 mm black border is a 1991 addition; Part II prescribes none" }
+      emblem: { present: false }
+      rear_differs: false
+      construction: "para. 3: on metal, black embossed characters raised above WHITE reflex reflective material; para. 4: on plastic, at least 2.5 mm transparent material with the mark adhered to the rear reading through as black on white"
+      psv_note: "para. 4(4): on a large public service vehicle the illuminated mark shows WHITE at the front as well as the rear — a change from the 1982 regime, where the front had to be white and the rear could be white OR RED"
+    region_encoding: "ie-counties.yml"
+    sources:
+      - "https://www.irishstatutebook.ie/eli/1986/si/441/made/en/print  # S.I. No. 441 of 1986: art. 1(3) 'These Regulations shall come into operation on the 1st day of January, 1987'; art. 2(c) substituting art. 25(3) with the year numerals; art. 2(e) inserting Third Schedule PART II with Diagrams 5-8 and paras. 1-9. Sealed 19-12-1986. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/1986/si/445/made/en/print  # S.I. No. 445 of 1986: the matching index-mark half — new art. 3, 'the index marks in Part I ... shall not be assigned to vehicles first registered on or after the 1st day of January, 1987 and the index marks in Part II ... shall be assigned to vehicles first registered on or after the 1st day of January, 1987'. Sealed 20-12-1986. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/1990/si/287/made/en/print  # S.I. No. 287 of 1990 art. 3(b): inserts into Part II's heading 'but not later than the 31st day of December, 1990' — the instrument that CLOSES this series, dated by its own words. Accessed 2026-08-02"
+    notes: >-
+      THE FIRST YEAR-COUNTY PLATE, and it looks almost nothing like the plate
+      people picture when they think of Ireland: white reflective, black
+      characters at least 81 mm tall, groups separated by a wide SPACE, and no
+      EU band, no black border and no Irish county name anywhere on it. It ran
+      for exactly four years. Cutting it as its own series rather than as the
+      early stretch of ie-standard-1991 is the PRD-PLATES §2.3 test applied
+      literally: the design differs (no band, no placename, no border), the
+      printed format differs (space versus hyphen) and the period is closed by
+      an instrument — three of three. START DATE PRECISION: both halves of the
+      reform are dated to 1 January 1987 by their own instruments, and both were
+      sealed in the week before Christmas 1986 (the 19th and the 20th), which is
+      the kind of gap that produces "1986" in secondary sources. The system
+      dates from 1987; the instruments date from 1986.
+
+  # =========================================================================
+  # THE PRE-1987 COUNTY-COUNCIL INDEX-MARK ERA. One recall-only series for six
+  # decades of one continuous scheme.
+  # =========================================================================
+  - id: ie-index-mark-pre1987
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1921, end: 1987 }
+    period_evidence: enabling-instrument
+    matching: recall-only
+    format:
+      pattern: "LLL 9999"
+      regex: '\A(?:[A-Z]{1,3}[- ]\d{1,6}|\d{1,6}[- ][A-Z]{1,3})\z'
+      pattern_note: >-
+        DELIBERATELY WIDE, hence recall-only. Two independent reasons. FIRST, THE
+        ORDER IS THE OWNER'S CHOICE: Third Schedule para. 1 of S.I. 311/1982,
+        verbatim, "(a) Where the identification mark of a vehicle consists of an
+        index mark followed by a registration number it shall at the option of
+        the owner be arranged in conformity with either Diagram No. 1 or Diagram
+        No. 2 ... (b) Where the identification mark of a vehicle consists of a
+        registration number followed by an index mark it shall at the option of
+        the owner be arranged in conformity with either Diagram No. 3 or Diagram
+        No. 4" — so "IK 1234" and "1234 IK" are both lawful arrangements of the
+        same registration, and the regex is the union. SECOND, the index mark is
+        one, two or three letters drawn from an enumerated list that grew through
+        fifteen instruments, and the number has no prescribed width at all. A hit
+        on this regex is a shape claim about Ireland before 1987 and nothing
+        more.
+      composition:
+        - "S.I. 311/1982 art. 25(3): 'the number under which the vehicle is registered with the licensing authority' and 'an index mark allotted to that licensing authority' — and nothing else. No year, no half-year, no age signal of any kind."
+      progression: >-
+        Sequential within an index mark, and when a mark ran out the Minister
+        allotted the authority another by regulation — which is why Dublin holds
+        eighty-odd marks and Carlow started with one. The three-letter marks are
+        a single leading letter prefixed to an existing two-letter stem
+        (AIC..ZIC on Carlow's IC), so the letters carry no year information but
+        DO carry a rough vintage, since an authority's marks were exhausted in
+        the order they were allotted. See ie-counties.yml,
+        historic_pre_1987.three_letter_expansion_rule.
+      separator_note: >-
+        A GAP, never a glyph. S.I. 311/1982 Third Schedule para. 7(b) requires
+        only "that the index mark appears as a separate unit from the
+        registration number", and para. 8 sets the minimum gap at 38 mm on
+        one-line layouts. The regex spells the position as the separator-only
+        class `[- ]` (PRD-PLATES §2.8) because the instrument prescribes a
+        separation and no character to make it with.
+    design:
+      background: { color: "#000000", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      rear_differs: true
+      colour_note: >-
+        TWO LAWFUL SCHEMES AT ONCE, and the second one is the surprise. Third
+        Schedule para. 2, verbatim: unless illuminated or reflective, the mark
+        "shall be formed of white, silver or light grey letters and figures upon
+        a black surface". Para. 4 gives the reflective alternative and it is
+        FRONT/REAR ASYMMETRIC: "(a) the identification mark displayed on the
+        front of the vehicle shall be formed of black letters and figures upon a
+        WHITE surface constructed of reflex reflecting material ... (b) the
+        identification mark displayed on the back of the vehicle or on any
+        trailer attached thereto shall be formed of black letters and figures
+        upon a RED surface constructed of reflex reflecting material". A RED REAR
+        PLATE is the pre-1987 Irish signature and it is prescribed, not
+        folklore — the recorded hex pair above is the black/silver default, and
+        the reflective pair is carried in `reflective_variant`.
+      reflective_variant:
+        front: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000" }
+        rear:  { background: { color: "#CC0000", finish: retroreflective, hex_basis: observed }, foreground: "#000000" }
+      illuminated_variant: "para. 3: an illuminated mark shows WHITE at the front and 'either white or red' at the rear during lighting-up hours, and white on black at all other times"
+      characters: { h: 89, stroke: 16, w: 63, gap: 13, unit: mm, note: "para. 5, and these are EXACT values, not minima: 'all letters and figures must be 89 millimetres high, every part of every letter and figure must be 16 millimetres broad, and the total width of the space taken by every letter or figure, except in the case of the letter \"I\" or the figure \"1\", must be 63 millimetres'. The pre-1987 Irish plate carried the largest characters in this dataset." }
+      margins: { top_bottom_min: 13, sides_min: 24, unit: mm, note: "para. 6" }
+      line_gap: { v: 19, unit: mm, note: "para. 8, two-line layouts; on one-line layouts the index-to-number gap is at least 38 mm" }
+      plate: { note: "no overall plate size is prescribed — the 1982 Schedule dimensions characters and margins and lets the plate follow. Recorded gap." }
+      band: { side: none }
+      placename: { present: false }
+      emblem: { present: false }
+    region_encoding: "ie-counties.yml"
+    region_encoding_note: >-
+      DECODE THROUGH `historic_pre_1987` IN THAT FILE, NEVER THROUGH `codes:`.
+      The two mark sets are disjoint and a pre-1987 mark run through the modern
+      table gives a confidently wrong county. The historic table ships the 1958
+      base list plus the three-letter expansion RULE rather than an exhaustive
+      merge of fifteen instruments; a mark that resolves through neither must be
+      returned as unresolved, not as invalid.
+    sources:
+      - "https://www.irishstatutebook.ie/eli/1920/act/72/enacted/en/print  # Roads Act 1920 s. 6(1): the county council 'shall assign a separate number to every vehicle registered with them, and a mark indicating the registered number of the vehicle and the council with which the vehicle is registered shall be fixed on the vehicle'; the proviso carries Motor Car Act 1903 s. 2 numbers over as at 01-01-1921. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/1982/si/311/made/en/print  # S.I. No. 311 of 1982, Road Vehicles (Registration and Licensing) Regulations, 1982: art. 1(2) in operation 01-02-1983; art. 25(3) the mark's composition; Third Schedule paras. 1-9 the plate spec quoted above. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/1958/si/14/made/en/print  # S.I. No. 14 of 1958, Road Vehicles (Index Marks) Regulations, 1958: the consolidated mark list, in operation 01-02-1958; its explanatory note records that it replaced 'a number of orders (now revoked)'. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/1986/si/445/made/en/print  # S.I. No. 445 of 1986 art. 3: the marks in Part I 'shall not be assigned to vehicles first registered on or after the 1st day of January, 1987' — the instrument that ends the era, and its explanatory note adds 'Index marks used before that date continue to remain in force'. Accessed 2026-08-02"
+    notes: >-
+      THE COUNTY-COUNCIL INDEX-MARK ERA — one recall-only series for the whole of
+      it, on the plates/es.yml `es-provincial-numeric` precedent: it is one
+      continuous per-authority sequential scheme whose surface rules were revised
+      instrument by instrument, and a vehicle registered in 1930 kept its mark
+      under every later regulation. THE START DATE IS A DELIBERATE UNDER-CLAIM
+      AND IS FLAGGED AS ONE. 1921 is the date the Roads Act 1920 regime takes the
+      scheme over, fixed by that Act's own proviso ("the first day of January,
+      nineteen hundred and twenty-one"); marks of exactly this shape were being
+      assigned earlier under s. 2 of the Motor Car Act 1903, which the 1920 Act
+      names and preserves. The 1903 Act is PDF-only on legislation.gov.uk and is
+      not text-extractable, and the Irish Statute Book's pre-1922 collection does
+      not serve it at /eli/1903/act/36/ — so its commencement was NOT established
+      in this pass and the series is dated from the instrument actually held.
+      A consumer wanting the true first year should read "1903 or 1904, not
+      established" and both statements are pinned above. END DATE, by contrast,
+      is exact to the day: 1 January 1987, by S.I. 445/1986 art. 3. Plates
+      already issued were never recalled — the same explanatory note says so —
+      so pre-1987 marks remained on Irish roads for decades afterwards and remain
+      lawful today.
+
+  # =========================================================================
+  # THE VINTAGE SERIES — ZV.
+  # =========================================================================
+  - id: ie-vintage-zv
+    class: historic
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1993 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "ZV 9999"
+      regex: '\AZV[- ]\d{1,6}\z'
+      composition:
+        - "Reg. 9(1)(d) of S.I. 318/1992, verbatim: 'in the case of a vehicle which the Commissioners are satisfied was constructed or first brought into use more than 30 years prior to the time of registration, and the person applying for registration so requests, an index mark ZV and a unique number'"
+        - "re-enacted for post-2012 vehicles as Reg. 9(1A)(e) by S.I. 542/2012 art. 4(b), in identical words"
+      pattern_note: >-
+        NO YEAR GROUP AT ALL — that is what makes ZV its own series rather than a
+        variant. The statute says "an index mark ZV and a unique number" and
+        fixes no width; Revenue's own worked example is "ZV 4723". The four
+        digits in the pattern follow that example and the regex allows one to
+        six, claiming nothing.
+      separator_note: >-
+        Spelled as the separator-only class `[- ]` (PRD-PLATES §2.8) because the
+        instrument leaves the position genuinely open: First Schedule para. 16(d)
+        would prescribe a hyphen, but para. 23 expressly lets a ZV mark comply
+        instead with the OLD 1982 Part I spec, which prescribes a gap and no
+        glyph. Revenue prints a space. Both forms are lawful and the class is the
+        honest encoding of that.
+      eligibility: "thirty years from construction or first use, assessed by the Commissioners; Reg. 9(2) lets them weigh 'any previous registration documents, the distance which the vehicle has travelled, and any other matters which are, in the opinion of the Commissioners, fair and reasonable'"
+    design:
+      background: { color: "#000000", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      rear_differs: false
+      note: >-
+        THE ONE PLACE IRISH LAW LETS A MODERN REGISTRATION WEAR A PERIOD PLATE.
+        First Schedule para. 23, verbatim: "The provisions of this Schedule shall
+        be deemed to be complied with in relation to an identification mark which
+        incorporates the index mark ZV if the identification mark exhibited on
+        the vehicle complies with the provisions of Part I of the Third Schedule
+        to the Road Vehicles (Registration and Licensing) Regulations, 1982." Part
+        I is the pre-1987 spec — so a ZV plate may lawfully be silver-on-black
+        with 89 mm characters and no EU band, which is why the hexes recorded
+        here are the historic pair rather than the modern one. It may EQUALLY be
+        an ordinary modern white plate with the EU band and the county placename,
+        since para. 23 is permissive. A renderer must offer both.
+      band: { side: none, note: "in the Part I form. In the modern form the standard left EU band applies." }
+      emblem: { present: false }
+    region_encoding: none
+    region_encoding_note: "ZV encodes AGE, not geography: it replaces the county mark rather than qualifying it, so a ZV plate says nothing about where the vehicle is registered. Note the collision recorded in ie-counties.yml — ZV was also a pre-1987 DUBLIN ordinary mark (S.I. 6/1986), so 'ZV 4723' is ambiguous between a Dublin plate of the mid-1980s and a modern vintage plate, and nothing in the string resolves it."
+    sources:
+      - "https://www.irishstatutebook.ie/eli/1992/si/318/made/en/print  # S.I. No. 318 of 1992: Reg. 9(1)(d) the ZV mark; Reg. 9(4) the owner's right to swap an ordinary mark for a ZV one at thirty years; First Schedule para. 23 the Part I compliance route. Reg. 9 in operation 01-01-1993 (Reg. 3). Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/2012/si/542/made/en/print  # S.I. No. 542 of 2012 art. 4(b): Reg. 9(1A)(e) re-enacts ZV verbatim for vehicles first brought into use on or after 01-01-2013 — a provision that will not bite until 2043 and is recorded because it dates the series' continuation. Accessed 2026-08-02"
+      - "https://www.revenue.ie/en/vrt/vehicle-registration-tax/zz-registrations-vintage-vehicles-and-zv-plates.aspx  # Revenue: 'A typical registration plate in this series would be ZV 4723. There is no additional cost to obtain \"ZV\" series plates.' Applications on Form VRT 35. Accessed 2026-08-02"
+    notes: >-
+      VINTAGE VEHICLES, thirty years and older, on request and free of charge.
+      Structurally the mirror image of Spain's H-prefix historic series: Spain
+      gives its historic vehicles a distinct SERIAL on an otherwise ordinary
+      plate, Ireland gives them a distinct serial AND lets them keep a period
+      DESIGN. Two facts worth carrying into a parse API. First, ZV is optional
+      in both directions — a thirty-year-old car may keep its original mark
+      indefinitely, and Reg. 9(4) lets an owner convert to ZV at any time after
+      the threshold, so the presence of ZV dates the APPLICATION and not the
+      vehicle. Second, the thirty years run from construction or first use, not
+      from Irish registration, so a ZV plate can sit on a car that has been in
+      Ireland since new or on one imported last week.
+
+  # =========================================================================
+  # TEMPORARY REGISTRATION FOR NON-RESIDENTS — ZZ.
+  # =========================================================================
+  - id: ie-temporary-zz
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1993 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "ZZ 99999"
+      regex: '\AZZ[- ]\d{5}\z'
+      evidence: agency-page
+      composition:
+        - "Revenue, verbatim: 'A ZZ registration consists of the letters ZZ followed by a unique five-digit number.'"
+      pattern_note: >-
+        FIVE DIGITS EXACTLY, on the authority's own statement — the one series in
+        this file whose digit width IS pinned, and pinned by Revenue rather than
+        by an instrument. The separator is spelled `[- ]` because no source
+        prescribes a glyph.
+    design:
+      note: >-
+        NO DESIGN IS SPECIFIED HERE, DELIBERATELY. No instrument located in this
+        pass prescribes a ZZ plate, and Revenue's page describes the scheme
+        without describing the plate. Colours and dimensions are therefore ABSENT
+        rather than guessed — the same discipline plates/es.yml applies to the
+        Spanish state series that Anexo XVIII leaves uncoloured. Recorded gap.
+      band: { side: none, note: "not established" }
+    region_encoding: none
+    sources:
+      - "https://www.revenue.ie/en/vrt/vehicle-registration-tax/zz-registrations-vintage-vehicles-and-zv-plates.aspx  # Revenue (the authority): 'The ZZ system of temporary registration is administered by the Automobile Association (AA) of Ireland on behalf of Revenue. A vehicle which is not permanently registered can use a ZZ registration for up to one month prior to its exportation. A ZZ registration consists of the letters ZZ followed by a unique five-digit number.' Qualifying conditions: the vehicle temporarily in Ireland, the applicant established outside Ireland, all taxes paid. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/1993/si/60/made/en/print  # S.I. No. 60 of 1993, Temporary Exemption from Registration of Vehicles Regulations, 1993 — deemed in operation 01-01-1993, made under s. 141(3) Finance Act 1992. READ IN FULL AND IT DOES NOT MENTION ZZ: it sets the conditions for exemption under s. 135(a)-(c) and says nothing about a mark. Pinned as a negative result so the next researcher does not re-chase it. Accessed 2026-08-02"
+    notes: >-
+      TEMPORARY REGISTRATION FOR NON-RESIDENTS, one month, exportation-bound,
+      administered by the AA of Ireland on Revenue's behalf. PERIOD HONESTY, and
+      this is the weakest date in the file, stated plainly: 1993 is the year the
+      Revenue registration regime commenced and under which Revenue describes ZZ
+      as operating. NO INSTRUMENT PRESCRIBING THE ZZ MARK WAS LOCATED — not in
+      S.I. 318/1992, not in S.I. 60/1993 (read in full), and not in any
+      Vehicle Registration and Taxation amendment 1993-2025 in a year-by-year
+      sweep of the Irish Statute Book. THE TRUE FIRST-ISSUE YEAR IS NOT
+      ESTABLISHED and 1993 must not be read as one; `period_evidence:
+      corroboration-only` says exactly that. The format is nevertheless firm,
+      because the authority states it in terms. CLASS CAVEAT: recorded as
+      `temporary`; `export` would fit the exportation condition equally well and
+      _meta/classes.yml offers no "temporary-import" category.
+
+  # =========================================================================
+  # TRADE PLATES.
+  # =========================================================================
+  - id: ie-trade-1993
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1993 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    binding: business
+    format:
+      pattern: "999-LL-99"
+      regex: '\A(?:\d{1,6}[- ][A-Z]{1,2}[- ]\d{2}|\d{2}[- ][A-Z]{1,2}[- ]\d{1,6})\z'
+      composition:
+        - "Art. 6(3) of S.I. 409/1992: each trade licence plate carries (a) 'the appropriate placename corresponding to the index mark allocated to the licensing authority', (b) 'the serial number assigned to the licence by the licensing authority', (c) the index mark, (d) 'the third and fourth numerals of the year to which the licence applies' and (e) a hologram"
+        - "art. 6(3)(c) was DELETED and (e)'s wording changed by S.I. 328/2013; (a) was replaced with an explicit index-mark/placename table by S.I. 328/2013 and again by S.I. 243/2014"
+      pattern_note: >-
+        RECALL-ONLY, AND THE REASON IS A PICTURE. Art. 6(3) enumerates the four
+        data items but the ARRANGEMENT lives in "Diagram No. 1 or Diagram No. 2
+        of the Schedule to these Regulations", and those diagrams are IMAGES in
+        the Irish Statute Book's rendering — not text-extractable, so the order
+        of the groups is NOT ESTABLISHED from the primary. The regex is the union
+        of both plausible orders (serial-county-year and year-county-serial) and
+        a hit on it is a shape claim only. The commonly repeated description —
+        that a trade plate reverses the ordinary order, showing the trader's
+        serial first and the year last — is recorded as
+        `secondary-wikipedia` below and is NOT relied on for the pattern.
+      layout_evidence: secondary-wikipedia
+      layout_secondary: "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ireland  # 'Trade plates have plates with white letters on a dark green background, but with the reverse style of the normal plates: the trader's number for that year is displayed first, the county second, and the applicable year last.' Read as a LOCATOR 2026-08-02; the underlying diagrams were not obtained, so both the reversed order AND the green colour are unverified against the instrument."
+      annual: "the plate carries the year to which the LICENCE applies, so a trade plate is re-issued annually — art. 6(3)(d)"
+    design:
+      note: >-
+        COLOURS AND DIMENSIONS NOT ESTABLISHED. The Schedule to S.I. 409/1992 is
+        two diagrams and no prose: unlike the registration plate, whose every
+        millimetre is spelled out in the First Schedule to S.I. 318/1992, the
+        trade plate's appearance exists only as artwork. The white-on-dark-green
+        description that circulates is tagged `secondary-wikipedia` above and is
+        deliberately NOT recorded as a colour claim here. Recorded gap.
+      display: "art. 7: on a motorcycle, one plate at the rear; on any other vehicle with front and rear windows, one plate INSIDE each window; on a vehicle with no rear window, affixed to the rear. Art. 7(2): a registered vehicle must still show its own mark, unobscured."
+      hologram: { present: true, note: "art. 6(3)(e): 'a hologram bearing the words \"Department of the Environment\" and \"VALID\"', updated by S.I. 328/2013 to 'Department of the Environment, Community and Local Government'" }
+      band: { side: none, note: "not established" }
+      emblem: { present: false, note: "not established; the hologram is the security feature" }
+    region_encoding: "ie-counties.yml"
+    region_encoding_note: "the trade-licence table is the SECOND enumeration of Irish index marks and the only one carrying T, L and W in their post-merger sense — see ie-counties.yml, which cites both tables per row"
+    sources:
+      - "https://www.irishstatutebook.ie/eli/1992/si/409/made/en/print  # S.I. No. 409 of 1992, Road Vehicles (Registration and Licensing) (Amendment) (No. 2) Regulations, 1992: art. 2 'These Regulations shall come into operation on the 1st day of January, 1993'; arts. 6-9 the trade licence, its plate's contents, its display and the eight lawful uses. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/2013/si/328/made/en/print  # S.I. No. 328 of 2013: substitutes art. 6(3)(a) with the index-mark/placename table, deletes art. 6(3)(c), and applies 'to trade licences issued for 2014 and subsequent years'. Explanatory note: 'These Regulations provide for a single identifier for trade licences issued in Limerick, Tipperary and Waterford.' Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/2014/si/243/made/en/print  # S.I. No. 243 of 2014: substitutes that table again for the merged authority names; 'shall apply to trade licences issued on or after 01 June 2014'. Accessed 2026-08-02"
+      - "https://www.irishstatutebook.ie/eli/1982/si/311/made/en/print  # S.I. No. 311 of 1982: the definition the trade licence hangs on — 'trade licence' means a general licence issued under section 9 of the Roads Act, 1920, as amended by section 15 of the Finance Act, 1922 — and the 1982 Regulations' express carve-out of trade licences, which is why the trade plate was still governed by the 1958 regime until 1993. Accessed 2026-08-02"
+    notes: >-
+      THE IRISH TRADE PLATE — bound to a motor dealer, not to a vehicle, and the
+      only entry in this file with `binding: business`. It is also the file's
+      clearest example of an evidence ceiling: the statute is completely explicit
+      about WHAT the plate must say and completely silent about what it must LOOK
+      LIKE, because the look is delegated to two diagrams that exist only as
+      artwork. The composition, the annual re-issue, the display rules and the
+      lawful uses are all primary; the group order and the colours are not, and
+      both are marked. WORTH KNOWING for a parse API: art. 7(2) means a trade
+      plate NEVER replaces a registration on an already-registered vehicle — it
+      sits in the window alongside the real plate — so a photograph can lawfully
+      show two different marks on one car. And the trade table is the reason the
+      Tipperary "T" exists in Irish law at all: it entered through trade licences
+      in 2013, not through the registration regulations, which have never been
+      amended to carry it.


### PR DESCRIPTION
Ireland for PRD-PLATES gate L1, wave 2. `plates/ie.yml` (7 series) and
`plates/_decode/ie-counties.yml`.

**Sourcing.** Every period, format, colour and dimension claim is read off an
instrument on irishstatutebook.ie or off the issuing authority's own pages
(revenue.ie), all fetched 2026-08-02. Sixteen statutory instruments plus the
Roads Act 1920 were read in full. Wikipedia was used as a finding aid to learn
which S.I. numbers to chase, and for nothing else — the two facts in the file
that rest on it are tagged `secondary-wikipedia` at point of use, and both are
recorded as **gaps** rather than as data (the trade plate's group order/colour,
and the diplomatic/Defence-Forces schemes). No table was taken from it; the
decode table is primary twice over.

## The instrument chain — and not one of these dates is its instrument's date

| in force | instrument | what it actually did |
|---|---|---|
| 1987-01-01 | S.I. 441/1986 art. 1(3), sealed 19-12-1986 | the year-county system is born; new art. 25(3)(c) adds "the third and fourth numerals of the year" |
| 1987-01-01 | S.I. 445/1986 art. 3, sealed 20-12-1986 | old index marks "shall not be assigned to vehicles first registered on or after the 1st day of January, 1987"; new ones shall |
| 1991-01-01 | S.I. 287/1990 Part III | EU flag + IRL + the Irish placename + the black border + **the hyphen** |
| 1993-01-01 | S.I. 318/1992 Regs. 3 and 9 | Revenue takes the register over from the county councils — **administrative transfer, format unchanged** |
| 1999-12-22 | S.I. 432/1999 | character width becomes a range; a design amendment, not a series |
| 2013-01-01 | S.I. 542/2012 art. 2 + new Reg. 9(1A) | **the half-year reform** |
| 2025-07-01 | S.I. 268/2025 art. 2 | the optional Pantone 7481c green EV stripe |

The 2013 reform, verbatim from Reg. 9(1A): *"(b)(i) the numeral '1' for vehicles
first brought into use during the period 1 January to 30 June in any year, or
(ii) the numeral '2' for vehicles first brought into use during the period
1 July to 31 December."* 131/132 is law, dated to the day, from an instrument
sealed 20 December 2012.

## Two findings that changed the shape of the data

**1. The two-digit series has no end.** The half-year rule keys on *first
brought into use*, not on registration date — S.I. 542/2012 art. 4(a) *confined*
Reg. 9(1) to vehicles "first brought into use on or before 31 December 2012"
rather than repealing it. Pre-2013 imports still get two-digit marks in 2026,
and Revenue states it with a worked example. `ie-standard-1991` therefore has
`period: { start: 1991 }` with no end and overlaps `ie-standard-2013`
permanently and legally.

**2. 1987–1990 is its own series.** No EU band, no placename, no border,
characters at least **81 mm** tall (the modern plate is 70), and the groups
separated by a **space**: Part II para. 7(c) prescribes only *"the space between
the index mark and adjoining figures shall be three times the space between the
nearest part of adjoining figures"*, while the hyphen and its millimetres appear
only in Part III para. 17(d) from 1991. Three of three on the §2.3 test.

The corresponding trap avoided: **1993 is not a series boundary.** Cutting one
there would record the Revenue takeover — which changed the registering
authority and not one character of the plate — as a design change.

## Colour policy

Ireland prescribes **no colorimetry at all**: no CIE box, no RAL, no luminance
factor, just *"white reflex reflective material"*, *"black characters"* and
*"a colour shade generally known as royal blue"*. Every hex is
`hex_basis: observed`. The single exception is a **named ink**, not a
coordinate — para. 12A: *"shall be colour Pantone 7481c or a colour match that
is as close as possible to this colour"* — carried as `color_spec` with the hex
still marked observed, on the es.yml gamut-not-a-value principle.

## The decode table

`ie-counties.yml`, 30 codes, primary twice over: S.I. 445/1986 Schedule Part II
and the Table to para. 4 of the S.I. 318/1992 First Schedule (re-enacted 1999),
**plus** the trade-licence table of S.I. 328/2013 / S.I. 243/2014 — the only
instrument located that carries **T** (Tipperary), **L** and **W** in their
post-merger sense. The discrepancy is real and is recorded per row rather than
averaged: the VRT table still reads TN/TS/LK/WD and has never been amended,
while the trade table was, for exactly that reason. Every row names which table
it comes from; the T row carries
`registration_plate_authority: trade-licence-table-only`.

Also in the file: the pre-1987 table as the 1958 base list **plus the
three-letter expansion rule** (three-letter marks are one leading letter on a
two-letter stem — AIC..ZIC on Carlow's IC), which is labelled honestly as an
*induction over the fourteen amending instruments, stated by none of them*.
Shipping the rule beats shipping a half-merged list that would make a parse API
call real plates invalid.

## Sourced negatives (searched for, not found, recorded as absent)

- **No trailer series** — Reg. 9(8): the rearmost trailer shows *"a duplicate of
  the identification mark of the vehicle"*.
- **No motorcycle series** — the ordinary mark; Reg. 9(7) only drops the front
  plate for a one-front-wheel vehicle. (Drafting trap: "bicycle" in these
  regulations *means* a motorcycle, finally corrected by S.I. 268/2025.)
- **No personalised series** — Ireland sells *reservation*, not vanity: the
  number "must be in the normal registration number format".
- **No taxi, export, seasonal, electric, moped or agricultural series.**

## Recorded gaps — deliberately not filled

- **ZZ** has no locating instrument. S.I. 60/1993 was read in full and does not
  mention it; the title-level sweep found nothing. Format is firm (Revenue
  states five digits); the period is graded `corroboration-only` and the notes
  say the true first-issue year **is not established**.
- **The trade plate's group order and colours** live in Diagrams 1 and 2, which
  are images. Composition, annual re-issue, display rules and lawful uses are
  primary; the layout is `recall-only` with the union of both orders.
- **The pre-1987 start is an under-claim at 1921**, fixed by the Roads Act 1920's
  own proviso. Marks of the same shape were assigned earlier under Motor Car Act
  1903 s. 2, but that Act is PDF-only on legislation.gov.uk and ISB does not
  serve it — flagged in terms so a reader knows to read "1903 or 1904, not
  established".
- **The Tipperary T on registration plates.** The sweep was by title, not full
  text; the negative is graded as strong but not exhaustive.
- **Diplomatic and Defence Forces plates** — no instrument located; not authored.

## Folklore corrected

- *"The modern Irish plate dates from 1993"* → **1991**, S.I. 287/1990 Part III.
- *"G, S and V were skipped for Scotland"* → not in any instrument read, and the
  1958 Schedule is full of three-letter marks beginning G, S and V (GYI, SYI,
  VYI), with SI later allotted outright. Recorded as unverified.
- *"131 exists because of unlucky 13"* → not in the instrument, which as usual
  gives no reason. Recorded as commentary, not fact.

## Lint

```
$ ruby scripts/lint_plates.rb
plates lint: 68 files, 613 series
plates lint: matching recall-only=151 strict=462 | twins regex_statutory=57 regex_strict=168 | separators emitted "-"," " forgiving 18
plates lint: _art ledger 6058 rows (excluded=5355 open=410 site_only=293), 410 open assets verified
plates lint: OK
```

Base: data `4a0ac42`, pipeline `af7cdf3`. Beyond the lint, the regexes were
exercised against real Irish plate strings across all seven series (both tiers,
positive and negative cases, plus tier-order containment) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)