### PR TITLE
plates: pt + lu — L1 wave 2 (28 series, 2 statutory decode tables)

### DIFF
--- a/plates/_decode/lu-series-order.yml
+++ b/plates/_decode/lu-series-order.yml
@@ -1,0 +1,638 @@
+# plates/_decode/lu-series-order.yml — the Luxembourg "serie courante" ISSUANCE
+# ORDER, verbatim from the statutory annex.
+#
+# NOT a geographic decode. Luxembourg encodes no geography whatsoever in a
+# plate. What this table decodes is TIME: the two-letter prefix advances
+# through a fixed, published order, so the prefix of a Luxembourg plate is an
+# approximate-age signal and the only inferable dimension of the serial - the
+# same role the letter triple plays on a post-2000 Spanish plate.
+#
+# THE SOURCE IS PRIMARY AND THE TRANSCRIPTION IS PROVABLY COMPLETE. The table
+# is the Annexe, paragraphe 3, of the reglement grand-ducal du 17 juin 2003
+# (Memorial A n. 87 of 25-06-2003, p. 1632), printed as a 15-column grid whose
+# reading rule the annex states in terms: "L'ordre sequentiel dans lequel les
+# combinaisons de lettres se suivent repond au tableau ci-apres, evoluant de
+# haut en bas et de gauche a droite" - i.e. COLUMN-MAJOR, top to bottom then
+# left to right. The rows below are that grid re-serialised in that order.
+#
+# The completeness check is arithmetic, and it closes exactly:
+#   26 x 26                                   = 676 pairs
+#   less every pair containing I or O         = 676 - 100 = 576   (annex 2.b)
+#   less AA CD HJ KK KZ PD SA SS WC ZZ        = 576 -  10 = 566   (annex 2.a)
+#   rows in this file                                    = 566
+# and no row is a duplicate, none contains I or O, and none is an excluded
+# pair. A miscopied or dropped cell could not satisfy all four at once.
+#
+# THE DIGIT BLOCK IS PART OF THE ORDER, and it is why a bare prefix does not
+# date a plate on its own. Each prefix takes ONE thousand-block per pass:
+# "BA 4000 - BA 4999, CA 5000 - CA 5999, DA 6000 - DA 6999, etc." - so the
+# thousands digit advances with the prefix and wraps 4->9, and the whole table
+# is walked again at the next pass. 566 prefixes x 1000 = 566,000 numbers per
+# pass; 4000-9999 gives six passes, i.e. 3,396,000 current-series numbers.
+#
+# Referenced by: lu-standard-2003 (plates/lu.yml) via region_encoding.
+jurisdiction: lu
+topic: series-order
+authority:
+  name: "Reglement grand-ducal du 17 juin 2003 relatif a l'identification des vehicules routiers, a leurs plaques d'immatriculation et aux modalites d'attribution de leurs numeros d'immatriculation - Annexe"
+  url: "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf"
+sources:
+  - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # Memorial A n. 87, 25-06-2003, p. 1632: Annexe, paragraphes 1-3 - the six-position composition, the AA/CD/HJ/KK/KZ/PD/SA/SS/WC/ZZ and I/O exclusions, the 15-column order grid and its column-major reading rule. Accessed 2026-08-02"
+  - "https://data.legilux.public.lu/eli/etat/leg/rgd/2006/10/18/n1/jo/fr/pdf  # Memorial A n. 190, 06-11-2006, art. 19: replaces the annex's numeric-allocation paragraphs - 0001-0099 mopeds/light quadricycles, 0100-3999 personalised, 4000-9999 the current series - while LEAVING the paragraphe 3 order grid untouched. In force 18-12-2006. Accessed 2026-08-02"
+period: { start: 2003 }
+period_evidence: instrument-in-force
+period_note: >-
+  2003 is the in-force date of the instrument that ENACTS this order
+  (art. 20: "entre en vigueur le 1er juillet 2003"), not the date any
+  particular prefix was reached. Prefix-to-year mapping is NOT in this file
+  and is not derivable from it: it depends on registration volume, and the
+  first-issue date of each prefix is administrative allocation that Legilux
+  does not publish. A consumer may use `seq` for ORDERING two plates, never
+  for dating one.
+maximal_munch: false
+reading_rule: column-major
+excluded_pairs: [AA, CD, HJ, KK, KZ, PD, SA, SS, WC, ZZ]
+excluded_letters: [I, O]
+excluded_note: >-
+  Annexe paragraphe 2, verbatim: "les series qui impliquent une des
+  combinaisons de lettres AA, CD, HJ, KK, KZ, PD, SA, SS, WC et ZZ" and
+  "les series qui impliquent les lettres I ou O". The instrument gives no
+  reason for either list; AA, CD, P and ZZ are separately reserved as special
+  series by art. 7, which accounts for three of the ten but not for HJ, KK,
+  KZ, PD, SA, SS or WC - recorded as unexplained rather than rationalised.
+digit_block:
+  range: [4000, 9999]
+  per_prefix_span: 1000
+  note: >-
+    Annex as amended 2006: 0001-0099 are reserved to cyclomoteurs and light
+    quadricycles (and the leading two digits are NOT printed on those plates),
+    0100-3999 are available as personalised numbers, and 4000-9999 are the
+    current series. Within the current series each prefix takes one
+    thousand-block per pass in the order below.
+codes:
+  - { seq: 1  , pair: BA }
+  - { seq: 2  , pair: CA }
+  - { seq: 3  , pair: DA }
+  - { seq: 4  , pair: EA }
+  - { seq: 5  , pair: FB }
+  - { seq: 6  , pair: GB }
+  - { seq: 7  , pair: HB }
+  - { seq: 8  , pair: JB }
+  - { seq: 9  , pair: KB }
+  - { seq: 10 , pair: LC }
+  - { seq: 11 , pair: MC }
+  - { seq: 12 , pair: NC }
+  - { seq: 13 , pair: PC }
+  - { seq: 14 , pair: QC }
+  - { seq: 15 , pair: RD }
+  - { seq: 16 , pair: SD }
+  - { seq: 17 , pair: TD }
+  - { seq: 18 , pair: UD }
+  - { seq: 19 , pair: VD }
+  - { seq: 20 , pair: WE }
+  - { seq: 21 , pair: XE }
+  - { seq: 22 , pair: YE }
+  - { seq: 23 , pair: ZE }
+  - { seq: 24 , pair: ZF }
+  - { seq: 25 , pair: YF }
+  - { seq: 26 , pair: XF }
+  - { seq: 27 , pair: WF }
+  - { seq: 28 , pair: VG }
+  - { seq: 29 , pair: UG }
+  - { seq: 30 , pair: TG }
+  - { seq: 31 , pair: SG }
+  - { seq: 32 , pair: RG }
+  - { seq: 33 , pair: QH }
+  - { seq: 34 , pair: PH }
+  - { seq: 35 , pair: NH }
+  - { seq: 36 , pair: MH }
+  - { seq: 37 , pair: LH }
+  - { seq: 38 , pair: KJ }
+  - { seq: 39 , pair: JJ }
+  - { seq: 40 , pair: GJ }
+  - { seq: 41 , pair: FJ }
+  - { seq: 42 , pair: EK }
+  - { seq: 43 , pair: DK }
+  - { seq: 44 , pair: CK }
+  - { seq: 45 , pair: BK }
+  - { seq: 46 , pair: AK }
+  - { seq: 47 , pair: AL }
+  - { seq: 48 , pair: BL }
+  - { seq: 49 , pair: CL }
+  - { seq: 50 , pair: DL }
+  - { seq: 51 , pair: EL }
+  - { seq: 52 , pair: FM }
+  - { seq: 53 , pair: GM }
+  - { seq: 54 , pair: HM }
+  - { seq: 55 , pair: JM }
+  - { seq: 56 , pair: KM }
+  - { seq: 57 , pair: LN }
+  - { seq: 58 , pair: MN }
+  - { seq: 59 , pair: NN }
+  - { seq: 60 , pair: PN }
+  - { seq: 61 , pair: QN }
+  - { seq: 62 , pair: RP }
+  - { seq: 63 , pair: SP }
+  - { seq: 64 , pair: TP }
+  - { seq: 65 , pair: UP }
+  - { seq: 66 , pair: VP }
+  - { seq: 67 , pair: WQ }
+  - { seq: 68 , pair: XQ }
+  - { seq: 69 , pair: YQ }
+  - { seq: 70 , pair: ZQ }
+  - { seq: 71 , pair: ZR }
+  - { seq: 72 , pair: YR }
+  - { seq: 73 , pair: XR }
+  - { seq: 74 , pair: WR }
+  - { seq: 75 , pair: VS }
+  - { seq: 76 , pair: US }
+  - { seq: 77 , pair: TS }
+  - { seq: 78 , pair: RS }
+  - { seq: 79 , pair: QT }
+  - { seq: 80 , pair: PT }
+  - { seq: 81 , pair: NT }
+  - { seq: 82 , pair: MT }
+  - { seq: 83 , pair: LT }
+  - { seq: 84 , pair: KU }
+  - { seq: 85 , pair: JU }
+  - { seq: 86 , pair: HU }
+  - { seq: 87 , pair: GU }
+  - { seq: 88 , pair: FU }
+  - { seq: 89 , pair: EV }
+  - { seq: 90 , pair: DV }
+  - { seq: 91 , pair: CV }
+  - { seq: 92 , pair: BV }
+  - { seq: 93 , pair: AV }
+  - { seq: 94 , pair: AW }
+  - { seq: 95 , pair: BW }
+  - { seq: 96 , pair: CW }
+  - { seq: 97 , pair: DW }
+  - { seq: 98 , pair: EW }
+  - { seq: 99 , pair: FX }
+  - { seq: 100, pair: GX }
+  - { seq: 101, pair: HX }
+  - { seq: 102, pair: JX }
+  - { seq: 103, pair: KX }
+  - { seq: 104, pair: LY }
+  - { seq: 105, pair: MY }
+  - { seq: 106, pair: NY }
+  - { seq: 107, pair: PY }
+  - { seq: 108, pair: QY }
+  - { seq: 109, pair: RZ }
+  - { seq: 110, pair: SZ }
+  - { seq: 111, pair: TZ }
+  - { seq: 112, pair: UZ }
+  - { seq: 113, pair: VZ }
+  - { seq: 114, pair: WZ }
+  - { seq: 115, pair: XZ }
+  - { seq: 116, pair: YZ }
+  - { seq: 117, pair: ZY }
+  - { seq: 118, pair: YY }
+  - { seq: 119, pair: XY }
+  - { seq: 120, pair: WY }
+  - { seq: 121, pair: VX }
+  - { seq: 122, pair: UX }
+  - { seq: 123, pair: TX }
+  - { seq: 124, pair: SX }
+  - { seq: 125, pair: RX }
+  - { seq: 126, pair: QW }
+  - { seq: 127, pair: PW }
+  - { seq: 128, pair: NW }
+  - { seq: 129, pair: MW }
+  - { seq: 130, pair: LW }
+  - { seq: 131, pair: KV }
+  - { seq: 132, pair: JV }
+  - { seq: 133, pair: HV }
+  - { seq: 134, pair: GV }
+  - { seq: 135, pair: FV }
+  - { seq: 136, pair: EU }
+  - { seq: 137, pair: DU }
+  - { seq: 138, pair: CU }
+  - { seq: 139, pair: BU }
+  - { seq: 140, pair: AU }
+  - { seq: 141, pair: AT }
+  - { seq: 142, pair: BT }
+  - { seq: 143, pair: CT }
+  - { seq: 144, pair: DT }
+  - { seq: 145, pair: ET }
+  - { seq: 146, pair: FS }
+  - { seq: 147, pair: GS }
+  - { seq: 148, pair: HS }
+  - { seq: 149, pair: JS }
+  - { seq: 150, pair: KS }
+  - { seq: 151, pair: LR }
+  - { seq: 152, pair: MR }
+  - { seq: 153, pair: NR }
+  - { seq: 154, pair: PR }
+  - { seq: 155, pair: QR }
+  - { seq: 156, pair: RQ }
+  - { seq: 157, pair: SQ }
+  - { seq: 158, pair: TQ }
+  - { seq: 159, pair: UQ }
+  - { seq: 160, pair: VQ }
+  - { seq: 161, pair: WP }
+  - { seq: 162, pair: XP }
+  - { seq: 163, pair: YP }
+  - { seq: 164, pair: ZP }
+  - { seq: 165, pair: ZN }
+  - { seq: 166, pair: YN }
+  - { seq: 167, pair: XN }
+  - { seq: 168, pair: WN }
+  - { seq: 169, pair: VM }
+  - { seq: 170, pair: UM }
+  - { seq: 171, pair: TM }
+  - { seq: 172, pair: SM }
+  - { seq: 173, pair: RM }
+  - { seq: 174, pair: QL }
+  - { seq: 175, pair: PL }
+  - { seq: 176, pair: NL }
+  - { seq: 177, pair: ML }
+  - { seq: 178, pair: LL }
+  - { seq: 179, pair: JK }
+  - { seq: 180, pair: HK }
+  - { seq: 181, pair: GK }
+  - { seq: 182, pair: FK }
+  - { seq: 183, pair: EJ }
+  - { seq: 184, pair: DJ }
+  - { seq: 185, pair: CJ }
+  - { seq: 186, pair: BJ }
+  - { seq: 187, pair: AJ }
+  - { seq: 188, pair: AH }
+  - { seq: 189, pair: BH }
+  - { seq: 190, pair: CH }
+  - { seq: 191, pair: DH }
+  - { seq: 192, pair: EH }
+  - { seq: 193, pair: FG }
+  - { seq: 194, pair: GG }
+  - { seq: 195, pair: HG }
+  - { seq: 196, pair: JG }
+  - { seq: 197, pair: KG }
+  - { seq: 198, pair: LF }
+  - { seq: 199, pair: MF }
+  - { seq: 200, pair: NF }
+  - { seq: 201, pair: PF }
+  - { seq: 202, pair: QF }
+  - { seq: 203, pair: RE }
+  - { seq: 204, pair: SE }
+  - { seq: 205, pair: TE }
+  - { seq: 206, pair: UE }
+  - { seq: 207, pair: VE }
+  - { seq: 208, pair: WD }
+  - { seq: 209, pair: XD }
+  - { seq: 210, pair: YD }
+  - { seq: 211, pair: ZD }
+  - { seq: 212, pair: ZC }
+  - { seq: 213, pair: YC }
+  - { seq: 214, pair: XC }
+  - { seq: 215, pair: VB }
+  - { seq: 216, pair: UB }
+  - { seq: 217, pair: TB }
+  - { seq: 218, pair: SB }
+  - { seq: 219, pair: RB }
+  - { seq: 220, pair: QA }
+  - { seq: 221, pair: PA }
+  - { seq: 222, pair: NA }
+  - { seq: 223, pair: MA }
+  - { seq: 224, pair: LA }
+  - { seq: 225, pair: KA }
+  - { seq: 226, pair: JA }
+  - { seq: 227, pair: HA }
+  - { seq: 228, pair: GA }
+  - { seq: 229, pair: FA }
+  - { seq: 230, pair: EB }
+  - { seq: 231, pair: DB }
+  - { seq: 232, pair: CB }
+  - { seq: 233, pair: BB }
+  - { seq: 234, pair: AB }
+  - { seq: 235, pair: AC }
+  - { seq: 236, pair: BC }
+  - { seq: 237, pair: CC }
+  - { seq: 238, pair: DC }
+  - { seq: 239, pair: EC }
+  - { seq: 240, pair: FD }
+  - { seq: 241, pair: GD }
+  - { seq: 242, pair: HD }
+  - { seq: 243, pair: JD }
+  - { seq: 244, pair: KD }
+  - { seq: 245, pair: LE }
+  - { seq: 246, pair: ME }
+  - { seq: 247, pair: NE }
+  - { seq: 248, pair: PE }
+  - { seq: 249, pair: QE }
+  - { seq: 250, pair: RF }
+  - { seq: 251, pair: SF }
+  - { seq: 252, pair: TF }
+  - { seq: 253, pair: UF }
+  - { seq: 254, pair: VF }
+  - { seq: 255, pair: WG }
+  - { seq: 256, pair: XG }
+  - { seq: 257, pair: YG }
+  - { seq: 258, pair: ZG }
+  - { seq: 259, pair: ZH }
+  - { seq: 260, pair: YH }
+  - { seq: 261, pair: XH }
+  - { seq: 262, pair: WH }
+  - { seq: 263, pair: VJ }
+  - { seq: 264, pair: UJ }
+  - { seq: 265, pair: TJ }
+  - { seq: 266, pair: SJ }
+  - { seq: 267, pair: RJ }
+  - { seq: 268, pair: QK }
+  - { seq: 269, pair: PK }
+  - { seq: 270, pair: NK }
+  - { seq: 271, pair: MK }
+  - { seq: 272, pair: LK }
+  - { seq: 273, pair: KL }
+  - { seq: 274, pair: JL }
+  - { seq: 275, pair: HL }
+  - { seq: 276, pair: GL }
+  - { seq: 277, pair: FL }
+  - { seq: 278, pair: EM }
+  - { seq: 279, pair: DM }
+  - { seq: 280, pair: CM }
+  - { seq: 281, pair: BM }
+  - { seq: 282, pair: AM }
+  - { seq: 283, pair: AN }
+  - { seq: 284, pair: BN }
+  - { seq: 285, pair: CN }
+  - { seq: 286, pair: DN }
+  - { seq: 287, pair: EN }
+  - { seq: 288, pair: FP }
+  - { seq: 289, pair: GP }
+  - { seq: 290, pair: HP }
+  - { seq: 291, pair: JP }
+  - { seq: 292, pair: KP }
+  - { seq: 293, pair: LQ }
+  - { seq: 294, pair: MQ }
+  - { seq: 295, pair: NQ }
+  - { seq: 296, pair: PQ }
+  - { seq: 297, pair: QQ }
+  - { seq: 298, pair: RR }
+  - { seq: 299, pair: SR }
+  - { seq: 300, pair: TR }
+  - { seq: 301, pair: UR }
+  - { seq: 302, pair: VR }
+  - { seq: 303, pair: WS }
+  - { seq: 304, pair: XS }
+  - { seq: 305, pair: YS }
+  - { seq: 306, pair: ZS }
+  - { seq: 307, pair: ZT }
+  - { seq: 308, pair: YT }
+  - { seq: 309, pair: XT }
+  - { seq: 310, pair: WT }
+  - { seq: 311, pair: VU }
+  - { seq: 312, pair: UU }
+  - { seq: 313, pair: TU }
+  - { seq: 314, pair: SU }
+  - { seq: 315, pair: RU }
+  - { seq: 316, pair: QV }
+  - { seq: 317, pair: PV }
+  - { seq: 318, pair: NV }
+  - { seq: 319, pair: MV }
+  - { seq: 320, pair: LV }
+  - { seq: 321, pair: KW }
+  - { seq: 322, pair: JW }
+  - { seq: 323, pair: HW }
+  - { seq: 324, pair: GW }
+  - { seq: 325, pair: FW }
+  - { seq: 326, pair: EX }
+  - { seq: 327, pair: DX }
+  - { seq: 328, pair: CX }
+  - { seq: 329, pair: BX }
+  - { seq: 330, pair: AX }
+  - { seq: 331, pair: AY }
+  - { seq: 332, pair: BY }
+  - { seq: 333, pair: CY }
+  - { seq: 334, pair: DY }
+  - { seq: 335, pair: EY }
+  - { seq: 336, pair: FZ }
+  - { seq: 337, pair: GZ }
+  - { seq: 338, pair: HZ }
+  - { seq: 339, pair: JZ }
+  - { seq: 340, pair: LZ }
+  - { seq: 341, pair: MZ }
+  - { seq: 342, pair: NZ }
+  - { seq: 343, pair: PZ }
+  - { seq: 344, pair: QZ }
+  - { seq: 345, pair: RY }
+  - { seq: 346, pair: SY }
+  - { seq: 347, pair: TY }
+  - { seq: 348, pair: UY }
+  - { seq: 349, pair: VY }
+  - { seq: 350, pair: WX }
+  - { seq: 351, pair: XX }
+  - { seq: 352, pair: YX }
+  - { seq: 353, pair: ZX }
+  - { seq: 354, pair: ZW }
+  - { seq: 355, pair: YW }
+  - { seq: 356, pair: XW }
+  - { seq: 357, pair: WW }
+  - { seq: 358, pair: VV }
+  - { seq: 359, pair: UV }
+  - { seq: 360, pair: TV }
+  - { seq: 361, pair: SV }
+  - { seq: 362, pair: RV }
+  - { seq: 363, pair: QU }
+  - { seq: 364, pair: PU }
+  - { seq: 365, pair: NU }
+  - { seq: 366, pair: MU }
+  - { seq: 367, pair: LU }
+  - { seq: 368, pair: KT }
+  - { seq: 369, pair: JT }
+  - { seq: 370, pair: HT }
+  - { seq: 371, pair: GT }
+  - { seq: 372, pair: FT }
+  - { seq: 373, pair: ES }
+  - { seq: 374, pair: DS }
+  - { seq: 375, pair: CS }
+  - { seq: 376, pair: BS }
+  - { seq: 377, pair: AS }
+  - { seq: 378, pair: AR }
+  - { seq: 379, pair: BR }
+  - { seq: 380, pair: CR }
+  - { seq: 381, pair: DR }
+  - { seq: 382, pair: ER }
+  - { seq: 383, pair: FQ }
+  - { seq: 384, pair: GQ }
+  - { seq: 385, pair: HQ }
+  - { seq: 386, pair: JQ }
+  - { seq: 387, pair: KQ }
+  - { seq: 388, pair: LP }
+  - { seq: 389, pair: MP }
+  - { seq: 390, pair: NP }
+  - { seq: 391, pair: PP }
+  - { seq: 392, pair: QP }
+  - { seq: 393, pair: RN }
+  - { seq: 394, pair: SN }
+  - { seq: 395, pair: TN }
+  - { seq: 396, pair: UN }
+  - { seq: 397, pair: VN }
+  - { seq: 398, pair: WM }
+  - { seq: 399, pair: XM }
+  - { seq: 400, pair: YM }
+  - { seq: 401, pair: ZM }
+  - { seq: 402, pair: ZL }
+  - { seq: 403, pair: YL }
+  - { seq: 404, pair: XL }
+  - { seq: 405, pair: WL }
+  - { seq: 406, pair: VK }
+  - { seq: 407, pair: UK }
+  - { seq: 408, pair: TK }
+  - { seq: 409, pair: SK }
+  - { seq: 410, pair: RK }
+  - { seq: 411, pair: QJ }
+  - { seq: 412, pair: PJ }
+  - { seq: 413, pair: NJ }
+  - { seq: 414, pair: MJ }
+  - { seq: 415, pair: LJ }
+  - { seq: 416, pair: KH }
+  - { seq: 417, pair: JH }
+  - { seq: 418, pair: HH }
+  - { seq: 419, pair: GH }
+  - { seq: 420, pair: FH }
+  - { seq: 421, pair: EG }
+  - { seq: 422, pair: DG }
+  - { seq: 423, pair: CG }
+  - { seq: 424, pair: BG }
+  - { seq: 425, pair: AG }
+  - { seq: 426, pair: AF }
+  - { seq: 427, pair: BF }
+  - { seq: 428, pair: CF }
+  - { seq: 429, pair: DF }
+  - { seq: 430, pair: EF }
+  - { seq: 431, pair: FE }
+  - { seq: 432, pair: GE }
+  - { seq: 433, pair: HE }
+  - { seq: 434, pair: JE }
+  - { seq: 435, pair: KE }
+  - { seq: 436, pair: LD }
+  - { seq: 437, pair: MD }
+  - { seq: 438, pair: ND }
+  - { seq: 439, pair: QD }
+  - { seq: 440, pair: RC }
+  - { seq: 441, pair: SC }
+  - { seq: 442, pair: TC }
+  - { seq: 443, pair: UC }
+  - { seq: 444, pair: VC }
+  - { seq: 445, pair: WB }
+  - { seq: 446, pair: XB }
+  - { seq: 447, pair: YB }
+  - { seq: 448, pair: ZB }
+  - { seq: 449, pair: ZA }
+  - { seq: 450, pair: YA }
+  - { seq: 451, pair: XA }
+  - { seq: 452, pair: WA }
+  - { seq: 453, pair: VA }
+  - { seq: 454, pair: UA }
+  - { seq: 455, pair: TA }
+  - { seq: 456, pair: RA }
+  - { seq: 457, pair: QB }
+  - { seq: 458, pair: PB }
+  - { seq: 459, pair: NB }
+  - { seq: 460, pair: MB }
+  - { seq: 461, pair: LB }
+  - { seq: 462, pair: KC }
+  - { seq: 463, pair: JC }
+  - { seq: 464, pair: HC }
+  - { seq: 465, pair: GC }
+  - { seq: 466, pair: FC }
+  - { seq: 467, pair: ED }
+  - { seq: 468, pair: DD }
+  - { seq: 469, pair: BD }
+  - { seq: 470, pair: AD }
+  - { seq: 471, pair: AE }
+  - { seq: 472, pair: BE }
+  - { seq: 473, pair: CE }
+  - { seq: 474, pair: DE }
+  - { seq: 475, pair: EE }
+  - { seq: 476, pair: FF }
+  - { seq: 477, pair: GF }
+  - { seq: 478, pair: HF }
+  - { seq: 479, pair: JF }
+  - { seq: 480, pair: KF }
+  - { seq: 481, pair: LG }
+  - { seq: 482, pair: MG }
+  - { seq: 483, pair: NG }
+  - { seq: 484, pair: PG }
+  - { seq: 485, pair: QG }
+  - { seq: 486, pair: RH }
+  - { seq: 487, pair: SH }
+  - { seq: 488, pair: TH }
+  - { seq: 489, pair: UH }
+  - { seq: 490, pair: VH }
+  - { seq: 491, pair: WJ }
+  - { seq: 492, pair: XJ }
+  - { seq: 493, pair: YJ }
+  - { seq: 494, pair: ZJ }
+  - { seq: 495, pair: ZK }
+  - { seq: 496, pair: YK }
+  - { seq: 497, pair: XK }
+  - { seq: 498, pair: WK }
+  - { seq: 499, pair: VL }
+  - { seq: 500, pair: UL }
+  - { seq: 501, pair: TL }
+  - { seq: 502, pair: SL }
+  - { seq: 503, pair: RL }
+  - { seq: 504, pair: QM }
+  - { seq: 505, pair: PM }
+  - { seq: 506, pair: NM }
+  - { seq: 507, pair: MM }
+  - { seq: 508, pair: LM }
+  - { seq: 509, pair: KN }
+  - { seq: 510, pair: JN }
+  - { seq: 511, pair: HN }
+  - { seq: 512, pair: GN }
+  - { seq: 513, pair: FN }
+  - { seq: 514, pair: EP }
+  - { seq: 515, pair: DP }
+  - { seq: 516, pair: CP }
+  - { seq: 517, pair: BP }
+  - { seq: 518, pair: AP }
+  - { seq: 519, pair: AQ }
+  - { seq: 520, pair: BQ }
+  - { seq: 521, pair: CQ }
+  - { seq: 522, pair: DQ }
+  - { seq: 523, pair: EQ }
+  - { seq: 524, pair: FR }
+  - { seq: 525, pair: GR }
+  - { seq: 526, pair: HR }
+  - { seq: 527, pair: JR }
+  - { seq: 528, pair: KR }
+  - { seq: 529, pair: LS }
+  - { seq: 530, pair: MS }
+  - { seq: 531, pair: NS }
+  - { seq: 532, pair: PS }
+  - { seq: 533, pair: QS }
+  - { seq: 534, pair: RT }
+  - { seq: 535, pair: ST }
+  - { seq: 536, pair: TT }
+  - { seq: 537, pair: UT }
+  - { seq: 538, pair: VT }
+  - { seq: 539, pair: WU }
+  - { seq: 540, pair: XU }
+  - { seq: 541, pair: YU }
+  - { seq: 542, pair: ZU }
+  - { seq: 543, pair: ZV }
+  - { seq: 544, pair: YV }
+  - { seq: 545, pair: XV }
+  - { seq: 546, pair: WV }
+  - { seq: 547, pair: VW }
+  - { seq: 548, pair: UW }
+  - { seq: 549, pair: TW }
+  - { seq: 550, pair: SW }
+  - { seq: 551, pair: RW }
+  - { seq: 552, pair: QX }
+  - { seq: 553, pair: PX }
+  - { seq: 554, pair: NX }
+  - { seq: 555, pair: MX }
+  - { seq: 556, pair: LX }
+  - { seq: 557, pair: KY }
+  - { seq: 558, pair: JY }
+  - { seq: 559, pair: HY }
+  - { seq: 560, pair: GY }
+  - { seq: 561, pair: FY }
+  - { seq: 562, pair: EZ }
+  - { seq: 563, pair: DZ }
+  - { seq: 564, pair: CZ }
+  - { seq: 565, pair: BZ }
+  - { seq: 566, pair: AZ }

--- a/plates/_decode/pt-trailer-services.yml
+++ b/plates/_decode/pt-trailer-services.yml
@@ -1,0 +1,96 @@
+# plates/_decode/pt-trailer-services.yml — the Portuguese TRAILER registration
+# prefixes: the issuing regional service, one or two letters.
+#
+# This is the one place geography survives on a Portuguese plate. Car, motorcycle
+# and moped numbers carry none at all — the national car series is purely
+# sequential — but a Portuguese trailer number is, verbatim from the statute,
+# "uma ou duas letras identificadoras do serviço regional que procedeu à
+# matrícula, seguidas de um número de ordem" (Regulamento de Matrícula, art. 4.º
+# n.º 1). The letters are the district office that issued it, not the trailer's
+# home district and not the towing vehicle's.
+#
+# THE TABLE IS A STATUTORY ANNEX, and it was AMENDED ONCE, which is why this
+# file carries two vintages instead of one:
+#
+#   * Decreto-Lei n.º 54/2005, de 3 de março — ANEXO I as originally enacted.
+#     22 rows. Viseu is "VS".
+#   * Decreto-Lei n.º 106/2006, de 8 de junho, art. 1.º n.º 3 — replaces
+#     Anexo I wholesale. Same 22 districts, same 21 codes, and Viseu is "VI".
+#
+# The Viseu change is recorded, not averaged, and not treated as a misprint:
+# both readings were taken from the Diário da República page images (the 2005
+# facsimile at p. 1896 and the 2006 facsimile at p. 4054), so both are what the
+# gazette printed. From the 2006 instrument's entry into force the operative
+# code is VI; VS is on the road on every trailer plated between 2005 and 2006
+# and on every earlier one issued under the same code. A parse API must accept
+# BOTH — which is exactly the "decode tables rot" hazard PRD-PLATES §9 names,
+# caught here inside a single fourteen-month window.
+#
+# WHAT THIS TABLE IS NOT: it is not a district-code table for cars. There has
+# never been one in the modern Portuguese system. And it is not the EXPORT
+# prefix set — export numbers take a single trailing letter from a different,
+# four-member list (L / P / A / M), which is carried inline on pt-export in
+# plates/pt.yml rather than here, because it is a different statutory list in a
+# different article with different members.
+#
+# Referenced by: pt-trailer (plates/pt.yml) via region_encoding.
+jurisdiction: pt
+topic: trailer-services
+authority:
+  name: "Regulamento do Número e Chapa de Matrícula (anexo ao Decreto-Lei n.º 54/2005, de 3 de março), Anexo I — na redação do Decreto-Lei n.º 106/2006, de 8 de junho"
+  url: "https://dre.pt/application/conteudo/346124"
+sources:
+  - "https://files.diariodarepublica.pt/1s/2006/06/111a00/40524060.pdf  # Decreto-Lei n.º 106/2006 (DR I-A n.º 111, 08-06-2006), art. 1.º n.º 3 + ANEXO I, p. 4054: the CURRENT 22-row table, with Viseu = VI. Locator: https://dre.pt/application/conteudo/346124 — accessed 2026-08-02"
+  - "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # Decreto-Lei n.º 54/2005 (DR I-A n.º 44, 03-03-2005), ANEXO I 'Tabela de dígitos identificadores dos serviços emissores de matrículas de reboques (referente ao n.º 2 do artigo 4.º)', p. 1896: the SUPERSEDED table, with Viseu = VS. Locator: https://dre.pt/application/conteudo/589934 — accessed 2026-08-02"
+period: { start: 2006 }
+period_evidence: instrument-in-force
+period_note: >-
+  2006 is the vintage of the list read here (Decreto-Lei n.º 106/2006, published
+  08-06-2006; no entry-into-force clause of its own, so the general 5-day
+  vacatio of Lei n.º 74/98 applies and the operative date is 13-06-2006 —
+  DERIVED from the default rule, not stated by the instrument, and flagged as
+  such). The CODES themselves are far older than either instrument: the
+  composition "letter(s) + serial" is drawn in the pre-1992 plate model
+  (DL 54/2005 Anexo II, Modelo V, "L-10978"), so trailers were numbered this way
+  for decades before any text reachable in this pass. The instrument that first
+  enacted the list was not located — recorded gap, and the reason this file's
+  period is an instrument vintage rather than a series start.
+maximal_munch: true
+maximal_munch_note: >-
+  Single-letter codes collide with the prefixes of two-letter ones and the
+  digits that follow give no separator help, so a parser MUST take the longest
+  matching code before the serial: A (Ponta Delgada) inside AV (Aveiro) and AN
+  (Angra do Heroísmo); C (Coimbra) inside CB (Castelo Branco); L (Lisboa) inside
+  LE (Leiria); P (Porto) inside PT (Portalegre). E (Évora), H (Horta) and M
+  (Funchal) are unambiguous.
+
+codes:
+  # Mainland districts (distritos), in the order the annex prints them.
+  - { code: AV, name: "Aveiro" }
+  - { code: BE, name: "Beja" }
+  - { code: BR, name: "Braga" }
+  - { code: BN, name: "Bragança" }
+  - { code: CB, name: "Castelo Branco" }
+  - { code: C,  name: "Coimbra" }
+  - { code: E,  name: "Évora" }
+  - { code: FA, name: "Faro" }
+  - { code: GD, name: "Guarda" }
+  - { code: LE, name: "Leiria" }
+  - { code: L,  name: "Lisboa" }
+  - { code: PT, name: "Portalegre" }
+  - { code: P,  name: "Porto" }
+  - { code: SA, name: "Santarém" }
+  - { code: SE, name: "Setúbal" }
+  - { code: VC, name: "Viana do Castelo" }
+  - { code: VR, name: "Vila Real" }
+  - { code: VI, name: "Viseu", superseded_code: VS, superseded_note: "VS in the 2005 Anexo I; VI since the 2006 replacement. Both were printed by the Diário da República; both are on the road." }
+  # Autonomous regions — the annex lists the Azores by ISLAND-GROUP district
+  # (three of them) and Madeira by its single district, under the same heading.
+  - { code: AN, name: "Angra do Heroísmo", kind: autonomous-region, region: "Açores" }
+  - { code: H,  name: "Horta",             kind: autonomous-region, region: "Açores" }
+  - { code: A,  name: "Ponta Delgada",     kind: autonomous-region, region: "Açores" }
+  - { code: M,  name: "Funchal",           kind: autonomous-region, region: "Madeira" }
+
+# Sanity note for the verifier: 22 rows, and the set is complete against
+# Portugal's administrative map — 18 mainland distritos + the 3 Azorean
+# distritos + Funchal. No code is duplicated; no district is missing.

--- a/plates/lu.yml
+++ b/plates/lu.yml
@@ -1,0 +1,842 @@
+# plates/lu.yml — Luxembourg (PRD-PLATES gate L1, EU/EEA wave 2).
+#
+# ONE INSTRUMENT, READ END TO END, CARRIES THIS ENTIRE FILE. Every format,
+# every colour, every dimension, every special series, every historic design
+# window and the sequence table in plates/_decode/lu-series-order.yml comes
+# from the REGLEMENT GRAND-DUCAL DU 17 JUIN 2003 relatif a l'identification des
+# vehicules routiers, a leurs plaques d'immatriculation et aux modalites
+# d'attribution de leurs numeros d'immatriculation — Memorial A n. 87 of
+# 25 June 2003, pages 1622-1632 — as amended by the reglement grand-ducal du
+# 18 octobre 2006 (Memorial A n. 190 of 6 November 2006, chapitre III,
+# articles 15-19). Both were fetched in full from Legilux on 2026-08-02 and
+# both are text-extractable, drawings included, which is why almost nothing in
+# this file is observed and almost nothing is secondary.
+#
+# THE START DATE IS THE INSTRUMENT'S OWN COMMENCEMENT CLAUSE, AND HERE THAT IS
+# CORRECT. The instrument-date rule says an instrument's window is not a series
+# period — but it says so because the two usually differ, not because they
+# always do. Luxembourg is the case where they coincide and the text proves it:
+# art. 20 ends "qui entre en vigueur le 1er juillet 2003", and the same date
+# is then used as the operative dividing line four more times inside the
+# instrument: art. 12 chapeau (which plate designs a vehicle may keep), art. 16
+# §1 (which NUMBERS may stay in use), §4 (which PLATES may stay in use) and §5
+# (red plates, to be exchanged by 31-12-2003). A date the instrument itself
+# uses as the dividing line for the whole subject matter is a series boundary,
+# not merely a publication fact.
+#
+# THE ACCURACY HERE IS LOAD-BEARING. `lu_snca` is a live register inside this
+# project, so a wrong Luxembourg format is not a trivia error, it is a
+# resolver error. Two things follow, and both are deliberate:
+#   * every regex has a sourced `regex_strict` twin wherever the instrument
+#     enumerates an alphabet or a numeric range, which it does far more often
+#     than most European instruments; and
+#   * the current-series letter order is shipped as a decode table
+#     (plates/_decode/lu-series-order.yml) whose transcription is checked arithmetically
+#     against the instrument's own exclusion rules — 566 pairs, and 566 is
+#     what 26x26 minus the I/O pairs minus the ten named pairs must equal.
+#
+# THE FOUR PECULIARITIES THAT SHAPE THE FILE
+#
+# 1. YELLOW IS THE ORDINARY COLOUR. Art. 11: "Le fond des plaques
+#    d'immatriculation est de couleur jaune retroreflechissante et les
+#    caracteres alphanumeriques y apposes sont de couleur noire non
+#    retroreflechissante." Not a rear-plate convention as in the UK and not a
+#    class marker as in NL — every ordinary Luxembourg plate, front and rear,
+#    is yellow, and has been since 1974.
+#
+# 2. THE SPECIAL SERIES ARE NUMBER RANGES, NOT DESIGNS. Art. 7 carves the
+#    number space into reserved blocks — 1-19 for the Grand-Ducal Court, 20-50
+#    for the government garage, P1-P99 for the Chamber of Deputies, AA and ZZ
+#    and CD prefixes for the state, limited-use vehicles and the diplomatic
+#    corps. They are authored as separate series because their GRAMMAR differs,
+#    even though most of them are printed on exactly the same yellow plate.
+#
+# 3. PERSONALISED NUMBERS ARE A REAL, REGULATED, OWNER-BOUND CLASS, and they
+#    are the one place Luxembourg's plate-to-vehicle binding breaks. Art. 8
+#    gives them a statutory waiting list, a transfer right between the holder's
+#    own vehicles, a 36-month reservation after the vehicle goes off the road,
+#    and inheritance to a first-degree relative on death. Art. 9 §2 then works
+#    out five distinct outcomes depending on who renounces what. This is not a
+#    vanity add-on bolted to the side of the system; it is written into its
+#    core.
+#
+# 4. THE HISTORIC DESIGNS ARE DATED TO THE DAY BY ART. 12, which is unusual and
+#    valuable: 340x110 black with white characters for vehicles first
+#    registered before 01-01-1974; 340x110 yellow retroreflective with black
+#    characters from 01-01-1974 to 31-12-1987; 520x110 yellow with the European
+#    emblem from 01-01-1988 to 30-06-2003. Three windows, one article, no
+#    folklore.
+jurisdiction: lu
+authority:
+  name: "Ministere de la Mobilite et des Travaux publics — reglement grand-ducal modifie du 17 juin 2003 relatif a l'identification des vehicules routiers, a leurs plaques d'immatriculation et aux modalites d'attribution de leurs numeros d'immatriculation"
+  url: "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf"
+binding: vehicle
+binding_note: >-
+  DEFAULT VEHICLE, WITH A STATUTORY OWNER-BOUND EXCEPTION — and a consumer must
+  model both. Art. 9 §1: a number granted at first registration stays attached
+  to that vehicle until it is definitively withdrawn from circulation in
+  Luxembourg, and for at least five years after the relevant trigger, after
+  which it may be re-issued. But a PERSONALISED number (art. 8) belongs to the
+  holder, transfers between that holder's vehicles, survives the vehicle by 36
+  months, and passes to a first-degree relative on death. Art. 9 §2 b) also lets
+  the holder of an ORDINARY current-series number convert it into a personalised
+  one on transfer, at which point that number changes binding mid-life. So the
+  same six-character string can be vehicle-bound or owner-bound depending on
+  history, and nothing on the plate says which.
+authority_note: >-
+  OPERATOR vs REGULATOR, worth stating because this repo ingests `lu_snca`. The
+  2003 instrument names the SNCT — Societe Nationale de Controle Technique — as
+  the body that makes red plates and export plates available to holders (art.
+  14), while the NUMBER is attributed by the minister responsible for transport
+  (art. 1). The vehicle-registration operator is today the Societe Nationale de
+  Circulation Automobile (SNCA), successor to that role; the instrument text
+  read here predates the renaming and says SNCT throughout. Recorded so that a
+  reader matching this file against the `lu_snca` register does not think the
+  two are different systems.
+
+charset_defaults:
+  excluded_letters: [I, O]
+  excluded_pairs: [AA, CD, HJ, KK, KZ, PD, SA, SS, WC, ZZ]
+  excluded_note: >-
+    Annexe, paragraphe 2, verbatim: the current series does not use "les series
+    qui impliquent une des combinaisons de lettres AA, CD, HJ, KK, KZ, PD, SA,
+    SS, WC et ZZ" nor "les series qui impliquent les lettres I ou O". Three of
+    the ten pairs are explained elsewhere in the same instrument — AA, CD and ZZ
+    are reserved as special series by art. 7 — and the remaining seven (HJ, KK,
+    KZ, PD, SA, SS, WC) are given no reason at all. Recorded as unexplained
+    rather than rationalised. I and O go for the usual 1/l and 0/O legibility
+    reason, which the instrument also does not state.
+  source: "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # Annexe, paragraphes 1-2, p. 1632"
+
+display_rules:
+  two_plates: "every registered vehicle carries a rear plate; a FRONT plate as well, except motorcycles, tricycles, mopeds, light quadricycles, trailers and towed vehicles (art. 2, first paragraph)"
+  same_number: "front and rear must carry the same number (art. 2)"
+  mounting: "as vertical as possible, legible in all circumstances; the rear plate in the location prescribed by Directive 70/222/EEC (four-wheelers) or 93/94/EC (two- and three-wheelers), failing which below 120 cm from the ground; the front plate below 120 cm (art. 15)"
+  no_perforation: "the rear plate must be fixed by means that do NOT perforate it — with a listed set of exceptions (trailers, semi-trailers, trucks, industrial and agricultural tractors, self-propelled machines) where screws or rivets are allowed; where perforation is unavoidable, the visible fixing parts must match either the plate ground or the perforated characters (art. 15)"
+  unregistered_movement: "an insured but not-yet-registered vehicle MAY carry plates on the shortest route to or from a roadworthiness test or, after a failed test, to a repair shop or the owner's home — the only lawful use of plates on an unregistered vehicle (art. 2, third paragraph)"
+  removal_duty: "the holder MUST remove the plates when the vehicle goes off the road for export or scrapping, when it is to be re-registered under another number, or when the number is transferred as a personalised number to another vehicle — and must DESTROY them unless they are immediately reused on another vehicle registered in the same name (art. 15, last two paragraphs)"
+  source: "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # arts. 2 and 15, pp. 1622-1623 and 1629"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT SERIES.
+  # =========================================================================
+  - id: lu-standard-2003
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, tricycle, quadricycle, trailer]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL 9999"
+      regex: '\A[A-Z]{2}[- ]\d{4}\z'
+      regex_strict: '\A(?!AA|CD|HJ|KK|KZ|PD|SA|SS|WC|ZZ)[A-HJ-NP-Z]{2}[- ][4-9]\d{3}\z'
+      charset:
+        notes: >-
+          `regex_strict` is the instrument's own grammar, all of it, from the
+          Annexe: six alphanumeric positions, "quatre chiffres precedes de deux
+          lettres" (para. 1); no I and no O and none of the ten named pairs
+          (para. 2); and the numeric element of the CURRENT series confined to
+          4000-9999 by the 2006 amendment, because 0001-0099 is reserved to
+          mopeds and light quadricycles and 0100-3999 to personalised numbers.
+          That last constraint is the one most likely to be missed — a
+          Luxembourg plate reading "AB 1234" is NOT a current-series number, it
+          is a personalised one, and the difference is legally and practically
+          real.
+      progression: >-
+        THE PREFIX IS THE ONLY DECODABLE DIMENSION OF A LUXEMBOURG PLATE, and it
+        decodes time, not place. The Annexe fixes the order of the 566 usable
+        letter pairs in a printed 15-column grid read COLUMN-MAJOR (see
+        plates/_decode/lu-series-order.yml), and pairs the walk with an advancing thousands
+        digit: "BA 4000 - BA 4999, CA 5000 - CA 5999, DA 6000 - DA 6999, etc."
+        So each prefix takes one thousand-block per pass, the table is walked
+        again at the next thousand, and 566 x 6000 = 3,396,000 numbers exist in
+        the current series. Ordering two plates by issue is therefore sound;
+        DATING one is not, because the instrument publishes the order and never
+        the calendar.
+      separator_note: >-
+        The instrument prescribes six alphanumeric POSITIONS and never a
+        separator glyph — art. 11 and the Annexe are silent, and art. 13
+        delegates "la disposition des caracteres alphanumeriques sur les plaques
+        d'immatriculation ainsi que leur forme, leur taille et leur emboutissage"
+        to a cahier des charges approved by the minister, which is NOT published
+        in the Memorial and was not reached. That delegation is the reason the
+        separator position is spelled as the sanctioned separator-only class
+        `[- ]` (PRD-PLATES §2.8) rather than as a literal: the gap is real, the
+        glyph is unlegislated.
+    design:
+      plate: { w: 520, h: 110, unit: mm, thickness: [1, 1.5] }
+      plate_variants:
+        - { w: 340, h: 200, unit: mm, thickness: [1, 1.5], note: "the square alternative, at the holder's choice of mounting" }
+        - { w: 270, h: 80, unit: mm, thickness: [1, 1.5], note: "motocycles" }
+        - { w: 200, h: 140, unit: mm, thickness: [1, 1.5], note: "motocycles, tall alternative" }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      foreground_note: "characters are NON-retroreflective black — the instrument specifies the negative explicitly, which a render layer should honour"
+      band:
+        side: left
+        color: "#003399"
+        hex_basis: observed
+        content: eu-stars+L
+        note: >-
+          "un aplat de couleur bleue retroreflechissante contenant, dans sa
+          partie superieure, les douze etoiles de couleur jaune
+          retroreflechissante rappelant le drapeau europeen et, dans sa partie
+          inferieure, le signe distinctif national constitue par la lettre latine
+          L en couleur blanche retroreflechissante", with the geometry taken by
+          reference from the annex to Regulation (EC) 2411/98. NOTE THE COLOUR
+          COLLISION this creates and no other EU state has: the stars are yellow
+          and so is the plate, so on a Luxembourg plate the euroband's yellow is
+          the SAME family as the ground it sits beside.
+      emblem: { present: false }
+      rear_differs: false
+      fallback_size_rule: >-
+        Where the prescribed dimensions cannot be fitted, the 2003 text sent the
+        fitter to "les criteres techniques de l'emplacement de la plaque"; the
+        2006 amendment (art. 17) replaced that with a concrete rule — the
+        MOTORCYCLE dimensions may be used instead. A rare case of an amendment
+        making a specification less discretionary rather than more.
+    region_encoding: "plates/_decode/lu-series-order.yml"
+    region_encoding_file: lu-series-order.yml
+    region_encoding_note: >-
+      NOT geography. Luxembourg encodes none, anywhere, in any series — a
+      sourced negative, since arts. 6-8 compose every number from reserved
+      ranges and a sequential table with no locational element. The referenced
+      table decodes ISSUE ORDER.
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 (Memorial A n. 87, 25-06-2003): art. 6 (first available number in the current series), art. 11 (dimensions, yellow retroreflective ground, non-retroreflective black characters, the blue EU field with 12 yellow stars and the white L), art. 20 (in force 01-07-2003), Annexe paras. 1-3 (composition, exclusions, order grid). Accessed 2026-08-02"
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2006/10/18/n1/jo/fr/pdf  # RGD 18-10-2006 (Memorial A n. 190, 06-11-2006): art. 17 (the motorcycle-dimension fallback), art. 19 (the 0001-0099 / 0100-3999 / 4000-9999 split), art. 37 (in force 18-12-2006). Accessed 2026-08-02"
+    notes: >-
+      THE CURRENT LUXEMBOURG SERIES — two letters, four digits, yellow. Started
+      by the instrument's own commencement clause on 1 July 2003, which is a
+      genuine series boundary here rather than a mere publication date (see the
+      file header). Old numbers were not recalled: art. 16 §1 lets pre-2003
+      numbers stay in use and only forces conformity on a change of owner or on
+      re-registration after the registration card lapses — with a carve-out for
+      historic vehicles holding a four- or five-character number, which the 2006
+      amendment widened again so that a re-registration after card expiry never
+      forces a historic vehicle to renumber. That is why four-digit and
+      five-digit Luxembourg plates are still legally on the road in 2026 and
+      why lu-legacy-* below are not dead entries.
+
+  - id: lu-personalized-2003
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle, tricycle, quadricycle, trailer]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A(?:[A-Z]{2}[- ]\d{1,4}|\d{4,5})\z'
+      pattern_note: >-
+        A UNION OF FOUR SHAPES, hence `recall-only`. Art. 8 §1 lets an applicant
+        request a personalised number drawn from the current series, from the
+        four-digit series 1000-9999, or from the five-digit series
+        10000-99999; the 2006 amendment adds the 0100-3999 numeric element
+        inside each letter series. So a personalised Luxembourg number may look
+        exactly like an ordinary one, may look like a bare four- or five-digit
+        number, and cannot be told apart from an ordinary current-series plate
+        by inspection alone — except in the one direction that IS decidable: a
+        two-letter plate whose digits fall below 4000 is personalised, because
+        the current series starts at 4000. A match here is a shape hit only.
+      progression: >-
+        Not sequential — chosen. The four-digit series is scarce enough to have
+        a statutory queue: "les demandes pour l'octroi d'un tel numero sont
+        inscrites, dans l'ordre sequentiel de leur entree, dans une liste
+        d'attente", one per person for life, allocated as numbers free up.
+    design:
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+L }
+      note: "no design of its own — a personalised number is printed on the ordinary plate. It is a SERIES here rather than a sub-entry because its number grammar and its binding both differ (PRD-PLATES §2.3)."
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 8 (the three series a personalised number may come from, the waiting list, transfer between the holder's vehicles, the 36-month reservation, inheritance at first degree, and the fees of 50 EUR on first grant / 24 EUR on transfer) and art. 9 §2 (the five renunciation outcomes). Accessed 2026-08-02"
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2006/10/18/n1/jo/fr/pdf  # RGD 18-10-2006 art. 19: 0100-3999 within each letter series becomes available as personalised numbers. Accessed 2026-08-02"
+    notes: >-
+      NUMEROS D'IMMATRICULATION PERSONNALISES. The fees recorded above are the
+      2003 figures and are the one field in this file known to be STALE: the
+      charge is widely reported at 200 EUR today, and no amending instrument
+      changing it was located on Legilux in this pass. Recorded as a dated gap
+      rather than updated from a secondary, because a fee is exactly the kind of
+      fact that is cheap to get wrong and expensive to be wrong about. Note also
+      the transfer mechanism in art. 16 §1 that a parse API should know: a
+      pre-2003 two-letters-three-digits number carried forward as a personalised
+      number gets AN EXTRA DIGIT INSERTED before its three ("ces trois chiffres
+      sont precedes par un chiffre supplementaire"), so some modern-looking
+      six-character Luxembourg plates are legacy numbers padded to fit.
+
+  # =========================================================================
+  # MOPEDS AND LIGHT QUADRICYCLES — the two-digit plate.
+  # =========================================================================
+  - id: lu-moped-2003
+    class: moped
+    categories: [moped, quadricycle]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL 99"
+      regex: '\A[A-Z]{2}[- ]\d{2}\z'
+      regex_strict: '\A(?!AA|CD|HJ|KK|KZ|PD|SA|SS|WC|ZZ)[A-HJ-NP-Z]{2}[- ]\d{2}\z'
+      pattern_note: >-
+        FOUR DIGITS ARE ALLOCATED AND TWO ARE PRINTED. The Annexe, last
+        paragraph: the numeric element for mopeds and light quadricycles runs
+        0010-0099 (0001-0099 after the 2006 amendment), "les deux premiers
+        chiffres de ce numero n'etant toutefois pas repris sur la plaque
+        d'immatriculation". So the register holds a six-character number and the
+        plate shows four characters. A consumer joining a printed Luxembourg
+        moped plate against a register field must left-pad the digits to four,
+        or the join silently fails — this is the single highest-value fact in
+        this file for `lu_snca` work.
+    design:
+      plate: { w: 130, h: 90, unit: mm, thickness: 1.5 }
+      plate_variants:
+        - { w: 90, h: 130, unit: mm, thickness: 1.5, note: "portrait alternative" }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band:
+        side: top
+        color: "#003399"
+        hex_basis: observed
+        content: eu-stars+L
+        note: >-
+          THE ONE BAND THAT MOVES. Art. 11, final paragraph: by derogation the
+          moped and light-quadricycle plate may carry the blue field along its
+          TOP edge instead of its left, "le signe distinctif national etant dans
+          ce cas appose a droite des douze etoiles" — so the L sits beside the
+          stars rather than beneath them. Recorded as `side: top` because that
+          is the layout the small plate actually uses.
+      design_history: >-
+        Mopeds and light quadricycles registered before 01-07-2003 may keep a
+        quite different plate (art. 12 §4): yellow retroreflective, 85 x 150 mm
+        or 150 x 85 mm, with the national sign rendered as a yellow
+        retroreflective L, 14 mm high with a 2 mm stroke, on a black
+        non-retroreflective oval of 30 x 20 mm, and the black capitals CMA to
+        its right. No European band at all.
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 Annexe final paragraph (the 0010-0099 range and the unprinted leading digits), art. 11 (130x90 / 90x130, thickness 1.5 mm, the top-edge band derogation), art. 12 §4 (the pre-2003 CMA plate), art. 17 (for mopeds and light quadricycles the 'plaque d'identite' of the 1955 arrete grand-ducal serves as the registration plate). Accessed 2026-08-02"
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2006/10/18/n1/jo/fr/pdf  # RGD 18-10-2006 art. 19: the moped range becomes 0001-0099. Accessed 2026-08-02"
+    notes: >-
+      CYCLOMOTEURS ET QUADRICYCLES LEGERS. A separate series and not a size
+      variant, because the PRINTED grammar is genuinely different — four
+      characters, not six. Art. 17 also records a legal subtlety worth keeping:
+      for these vehicles the identity plate under the arrete grand-ducal of
+      23 November 1955 "tient lieu de plaque d'immatriculation", their
+      registration record stands in for an immatriculation and their identity
+      card for a registration card. They are, strictly, registered by a
+      different mechanism that the plate rules are mapped onto.
+
+  # =========================================================================
+  # THE ART. 7 RESERVED RANGES.
+  # =========================================================================
+  - id: lu-court-2003
+    class: government
+    categories: [car, van]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "99"
+      regex: '\A(?:CD[- ])?\d{1,2}\z'
+      regex_strict: '\A(?:CD[- ])?(?:[1-9]|1\d)\z'
+      pattern_note: "art. 7 a): the numbers 1 to 19, and the same numbers prefixed CD"
+    design:
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+L }
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 7 a): 'Les vehicules de la Cour grand-ducale sont immatricules sous les numeros compris entre 1 et 19, ainsi que sous les numeros compris entre 1 et 19, precedes des lettres CD.' Accessed 2026-08-02"
+    notes: >-
+      THE GRAND-DUCAL COURT holds the nineteen lowest numbers in the country, in
+      both a plain and a CD-prefixed form — the CD form because the Court's
+      vehicles also travel under diplomatic arrangements. CLASS CAVEAT:
+      `government` is the closest member of the controlled vocabulary; the head
+      of state's household is neither a civil-government fleet nor a diplomatic
+      mission. Art. 10 §1 additionally allows the minister to grant these
+      vehicles a SECONDARY number "choisi en dehors de l'evolution normale" of
+      the current series — an unmarked ordinary-looking plate — which is a real
+      hazard for any consumer inferring officialdom from a low number.
+
+  - id: lu-government-2003
+    class: government
+    categories: [car, van, bus]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "99"
+      regex: '\A(?:CD[- ])?\d{2}\z'
+      regex_strict: '\A(?:CD[- ])?(?:[2-4]\d|50)\z'
+      pattern_note: "art. 7 b): the numbers 20 to 50, plain and CD-prefixed"
+    design:
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+L }
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 7 b): the government garage takes 20 to 50, and 20 to 50 preceded by CD. Accessed 2026-08-02"
+    notes: >-
+      LE GARAGE DU GOUVERNEMENT — thirty-one numbers, immediately above the
+      Court's nineteen, so the first fifty Luxembourg numbers are entirely
+      accounted for by the state. Same art. 10 §1 secondary-number caveat as
+      lu-court-2003. Distinct from lu-state-2003 (the AA series), which covers
+      the administrations rather than the ministerial fleet.
+
+  - id: lu-parliament-2003
+    class: government
+    categories: [car, van]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "P 99"
+      regex: '\AP[- ]\d{1,2}\z'
+      regex_strict: '\AP[- ](?:[1-9]|[1-9]\d)\z'
+      pattern_note: "art. 7 d): the numbers 1 to 99 preceded by the Latin letter P"
+    design:
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+L }
+      additional_front_plate:
+        shape: oval
+        w: 300
+        h: 180
+        unit: mm
+        background: "#FFFFFF"
+        foreground: "#CE1126"
+        hex_basis: observed
+        note: >-
+          A SECOND, NON-REGISTRATION PLATE, and one of the few non-rectangular
+          plates in this dataset. Art. 3 §2: members of the Chamber of Deputies
+          may fit, to the FRONT of a passenger or commercial vehicle registered
+          in their own name, an oval plate 300 mm wide by 180 mm high bearing a
+          red Latin P on white, the letter 100 mm high with a 16 mm stroke. It
+          is a status marker, not a registration — it carries no number, and it
+          sits on a vehicle whose ordinary plates are unchanged. Distinct from
+          the P-prefixed NUMBER in art. 7 d), which is the Chamber's own fleet.
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 7 d) (the P1-P99 fleet numbers) and art. 3 §2 (the oval red-P front plate for members, with its exact geometry). Accessed 2026-08-02"
+    notes: >-
+      LA CHAMBRE DES DEPUTES. Two quite different things share the letter P and
+      the schema keeps them apart: a reserved NUMBER RANGE for the Chamber's own
+      vehicles (this series' format) and a personal OVAL BADGE that individual
+      deputies may fit to their own cars (this series' design sub-entry). CLASS
+      CAVEAT: `government` for a legislature.
+
+  - id: lu-state-2003
+    class: government
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "AA 9999"
+      regex: '\AAA[- ]\d{4}\z'
+      regex_strict: '\AAA[- ][1-9]\d{3}\z'
+      pattern_note: "art. 7 e): the numbers 1000 to 9999 preceded by the Latin letters AA — which is exactly why AA is one of the ten pairs struck out of the current series"
+    design:
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+L }
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 7 e): 'Les vehicules de l'Etat et de ses administrations sont immatricules sous les numeros compris entre 1000 et 9999, precedes des lettres latines AA.' Accessed 2026-08-02"
+    notes: >-
+      L'ETAT ET SES ADMINISTRATIONS. Visually identical to an ordinary plate —
+      same yellow, same six characters, same band — and distinguishable only by
+      the reserved AA prefix. Note that POLICE, CUSTOMS and the Ministry of
+      State's special services are NOT given a series of their own: art. 10 §1
+      names them only as bodies that may hold an additional current-series
+      number "choisi en dehors de l'evolution normale". So Luxembourg has no
+      police plate series, and this file records none — a sourced negative, not
+      a gap.
+
+  - id: lu-limited-use-2003
+    class: agricultural
+    categories: [tractor, machine, trailer, truck]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "ZZ 9999"
+      regex: '\AZZ[- ]\d{4}\z'
+      regex_strict: '\AZZ[- ][1-9]\d{3}\z'
+      pattern_note: "art. 7 f): 1000 to 9999 preceded by ZZ, for vehicles falling under the tax regime for categories of vehicle of necessarily limited use"
+    design:
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+L }
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 7 f): the ZZ series for 'les vehicules tombant sous l'application de la reglementation fixant la taxe sur les vehicules automoteurs de certaines categories de vehicules a usage necessairement limite'. Accessed 2026-08-02"
+    notes: >-
+      THE ZZ SERIES — a TAX category wearing a plate. CLASS CAVEAT, and a
+      genuine one: the instrument defines this series by reference to a vehicle
+      TAX regulation, not by vehicle type, so its population is whatever that
+      regulation covers — in practice agricultural and works vehicles of
+      necessarily limited use. `agricultural` is the nearest member of the
+      controlled vocabulary and it is narrower than the statutory category. The
+      tax regulation itself was not fetched, so the exact population is a
+      recorded gap. This is the third file in the dataset to want a
+      works/limited-use class that does not exist (see es-special-vehicles-1999
+      and pt-machinery-2006).
+
+  # =========================================================================
+  # DIPLOMATIC.
+  # =========================================================================
+  - id: lu-diplomatic-2003
+    class: diplomatic
+    categories: [car, van, motorcycle]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "CD 99-99"
+      regex: '\ACD[- ]\d{2}-\d{2}\z'
+      pattern_note: >-
+        The instrument composes this one to the character. Art. 7 c): the number
+        is 1000-9999 preceded by CD, and "Le predit numero a quatre chiffres est
+        divise par un tiret en deux groupes a deux chiffres, le premier groupe
+        designant l'organisme diplomatique ou l'organisme international officiel
+        en question, le deuxieme groupe formant un numero courant." The hyphen
+        INSIDE the digits is statutory and is a group boundary; the gap after CD
+        is not legislated, hence the class.
+      progression: "group 1 identifies the mission or international organisation and is invariable for it; group 2 is a serial within that body"
+    design:
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+L }
+      note: "no distinctive colour — unlike Spain's red CD plate, the Luxembourg diplomatic plate is an ordinary yellow plate with a reserved prefix"
+    region_encoding: "mission prefix — the two-digit organisation codes are not published in the instrument; no decode table authored"
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 7 c): the CD series, the two-group split and what each group means, plus the exhaustive list of who qualifies. Art. 19 §3 abrogates the reglement ministeriel du 11 septembre 1995 that previously determined the eligible categories. Accessed 2026-08-02"
+    notes: >-
+      CORPS DIPLOMATIQUE. The eligibility list in art. 7 c) is unusually
+      concrete and worth preserving as a fact about Luxembourg rather than about
+      plates: beyond accredited diplomats and officials of international bodies
+      with diplomatic or analogous status, it names by office the President,
+      Vice-Presidents, political-group chairs and Secretary-General of the
+      EUROPEAN PARLIAMENT; the judges, advocates-general and registrar of the
+      COURT OF JUSTICE; the President, members and Secretary-General of the
+      COURT OF AUDITORS; the members and registrar of the COURT OF FIRST
+      INSTANCE; the President and Vice-Presidents of the EIB; the head and
+      deputy head of the EFTA Bureau; and the President and members of the
+      finance committee of the European Investment Fund. That is the European
+      institutional geography of Luxembourg City, written into a plate
+      regulation. THE DECODE TABLE IS A GAP: the instrument states the
+      MECHANISM (first group = the body) and publishes no codes, and no
+      Ministry of Foreign Affairs list was reached. PRD-PLATES puts diplomatic
+      decode tables at gate L4; this entry carries the mechanism so a table can
+      be hung off it later without an id change.
+
+  # =========================================================================
+  # RED PLATES — the dealer/trade plate, and the only non-yellow ground.
+  # =========================================================================
+  - id: lu-dealer-red-2003
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, tricycle, quadricycle, moped, trailer]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "9999 99"
+      regex: '\A\d{4}[- ]\d{2}\z'
+      regex_strict: '\A[1-9]\d{3}[- ]\d{2}\z'
+      pattern_note: >-
+        Art. 7 g): "un numero a quatre chiffres, compris entre 1000 et 9999,
+        suivi des deux derniers chiffres du millesime de l'annee a la fin de
+        laquelle expire la validite des plaques". The trailing pair is an EXPIRY
+        YEAR, not part of the serial — a red plate reading "4821 27" expires at
+        the end of 2027. It is the only Luxembourg plate that dates itself, and
+        the date it carries is a deadline, not a birthday.
+      progression: "the four-digit block is a serial; the trailing year advances with each issue cycle"
+    design:
+      plate: { w: 340, h: 110, unit: mm, thickness: [1, 1.5] }
+      background: { color: "#CE1126", finish: non-retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      foreground_note: "art. 11: red NON-retroreflective ground with white NON-retroreflective digits — the instrument specifies the absence of retroreflectivity on both, uniquely in this file"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+L, note: "red plates carry the European field too — art. 11, 'Chaque plaque d'immatriculation ET CHAQUE PLAQUE ROUGE doit arborer, a son extremite gauche, un aplat de couleur bleue'" }
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 4 (who may hold red plates, the five permitted uses, the front/rear pairing rule, the Benelux equivalence, the surrender duties), art. 7 g) (the number), art. 11 (340x110, red non-retroreflective ground, white digits, the EU field), art. 14 (supplied by the SNCT against a fee, 70% refundable within three months of expiry), art. 16 §5 (pre-2003 red plates to be exchanged by 31-12-2003). Accessed 2026-08-02"
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2006/10/18/n1/jo/fr/pdf  # RGD 18-10-2006: the fee for a pair of special or red plates set at 150 EUR. Accessed 2026-08-02"
+    notes: >-
+      PLAQUES ROUGES — Luxembourg's trade plate, held by roadworthiness-test
+      bodies and by businesses authorised to trade in or repair road vehicles.
+      Validity is fixed by statute and generous: "le dernier jour de la deuxieme
+      annee suivant l'annee de leur delivrance", so a plate issued at any point
+      in 2025 runs to 31 December 2027. THE BENELUX FACT, which no other file in
+      this dataset carries: art. 4 §4 assimilates Belgian "plaques marchandes"
+      and Dutch commercial plates to Luxembourg red plates, provided the rules
+      of Benelux Committee of Ministers decision M(92)13 of 2 December 1992 are
+      respected — so a Belgian trade plate is lawfully a Luxembourg trade plate,
+      and the corresponding Belgian or Dutch circulation documents replace the
+      Luxembourg registration card (art. 18, amending art. 92 of the 1955
+      arrete). A cross-border validation rule, in a plate regulation, sourced.
+
+  # =========================================================================
+  # EXPORT.
+  # =========================================================================
+  - id: lu-export-2003
+    class: export
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2003 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "9999 9999"
+      regex: '\A\d{4}[- ]\d{4}\z'
+      regex_strict: '\A(?:0[1-9]|1[0-2])\d{2}[- ][1-9]\d{3}\z'
+      pattern_note: >-
+        TWO ROWS, LINEARISED. Art. 7 h): the number is 1000-9999 "precede des
+        deux chiffres du mois et des deux derniers chiffres du millesime de
+        l'annee a la fin desquels expire la validite de l'immatriculation, les
+        deux groupes de chiffres ainsi constitues etant superposes et separes
+        par un trait horizontal". The plate is therefore stacked — MMYY above a
+        horizontal rule, the serial below — with the three letters EXP also
+        stacked. `pattern` writes the two rows left to right with a separator,
+        because the schema has no two-row primitive; `regex_strict` enforces the
+        month as a real month, which is what makes this shape recognisable at
+        all.
+      layout: "MM YY over a horizontal rule, serial beneath, with EXP set vertically alongside"
+    design:
+      plate: { w: 340, h: 110, unit: mm }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+L }
+      note: "art. 11, fourth paragraph, singles this plate out for a size of its own: 'les plaques d'immatriculation dont question sous h) de l'article 7 doivent avoir une largeur de 340 mm et une hauteur de 110 mm' — the only dimension in the instrument attached to a SERIES rather than to a vehicle class"
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 7 h) (the number, the stacked layout, the EXP letters, and the three-month export condition), art. 11 (the 340x110 size), art. 14 (supplied by the SNCT). Accessed 2026-08-02"
+    notes: >-
+      EXPORT PLATES. The qualifying condition is tighter than most European
+      export regimes and is worth recording: the vehicle must be "destine a etre
+      exporte dans un delai inferieur a trois mois a partir de leur date
+      d'immatriculation" — three months from registration, not from application.
+      Unlike nl-export this series does NOT reuse the vehicle's existing
+      registration, so it is `strict` rather than `recall-only`: it has a
+      grammar of its own and the grammar is enacted.
+
+  # =========================================================================
+  # ARMY.
+  # =========================================================================
+  - id: lu-army-2003
+    class: military
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2003 }
+    period_evidence: statutory-authority-undated
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,6}\z'
+      pattern_note: >-
+        NO GRAMMAR IS ENACTED AND NONE IS INVENTED — hence `recall-only` and a
+        deliberately shapeless regex. Art. 3 §1 does two things and only two:
+        it fixes the COLOURS ("un numero dont les lettres et les chiffres sont
+        peintes en couleur blanche sur fond noir") and it names the issuing
+        authority ("Les numeros d'immatriculation des vehicules de l'Armee sont
+        attribues par le Commandant de l'Armee"). Digit count, letters, ranges:
+        absent from the instrument. The pattern shows four digits only because
+        the schema requires a pattern.
+    design:
+      background: { color: "#000000", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      note: >-
+        Art. 3 §1 also permits these vehicles to carry EITHER the national
+        distinguishing sign as specified in art. 12 §6 (the black L on a white
+        oval, 175 x 115 mm) OR "un autre signe distinctif special" which the
+        instrument does not describe. `finish: painted` follows the instrument's
+        own verb — the colours are "peintes" — and no retroreflectivity is
+        required, in contrast to every civilian series here.
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 3 §1: army vehicles NOT subject to registration carry white-on-black plates, numbered by the Army Commander, optionally with the national or a special distinguishing sign. Accessed 2026-08-02"
+    notes: >-
+      L'ARMEE LUXEMBOURGEOISE. The provision governs vehicles that are NOT
+      subject to civil registration at all, which is why it sits in the
+      instrument's chapter on plate characteristics rather than in its chapter
+      on number attribution — the Army is outside the register, and this
+      regulation reaches it only to say what its plates must look like.
+      `period_evidence: statutory-authority-undated`: the 2003 instrument is
+      the authority for the colour rule and the start recorded here is that
+      instrument's commencement, but white-on-black army plates plainly predate
+      it and no earlier instrument was reached. Grammar is a recorded gap, and
+      the place to look is the Army Commander's own service orders, which are
+      not published in the Memorial.
+
+  # =========================================================================
+  # THE PRE-2003 WORLD. Three design windows, dated to the day by art. 12,
+  # carrying one shared and undated number grammar.
+  # =========================================================================
+  - id: lu-legacy-euro-1988
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 1988, end: 2003 }
+    period_evidence: statutory-date
+    matching: recall-only
+    format:
+      pattern: "LL 999"
+      regex: '\A(?:\d{2,3}|\d{2}[- ][A-Z]{2}|[A-Z]{2}[- ]\d{2}|[A-Z][- ]\d{4}|[A-Z]{2}[- ]\d{3})\z'
+      pattern_note: >-
+        THE NUMBER GRAMMAR IS SHARED ACROSS ALL THREE PRE-2003 WINDOWS AND IS
+        DATED BY NONE OF THEM. Art. 16 §1 enumerates the pre-2003 compositions
+        that may stay in use: "deux ou de trois chiffres", "deux chiffres et de
+        deux lettres", "une lettre et de quatre chiffres", "deux lettres et de
+        trois chiffres". That is a list of four shapes with no order and no
+        dates, so the regex is their union and the series is `recall-only`. The
+        two-digits-and-two-letters shape is spelled in BOTH orders here because
+        the instrument gives a composition, not an arrangement — an honest
+        widening rather than a guessed order.
+    design:
+      plate: { w: 520, h: 110, unit: mm, note: "rear, where the mounting location is 520 mm wide per Directive 70/222/EEC" }
+      plate_variants:
+        - { w: 340, h: 110, unit: mm, note: "rear where the location is only 340 mm wide, and the FRONT plate in every case — art. 12 §3 sends both back to the §2 specification" }
+        - { w: 240, h: 200, unit: mm, note: "motocycles, WITHOUT the European emblem and with the national L sign below the number on black" }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band:
+        side: left
+        color: "#003399"
+        hex_basis: observed
+        content: eu-stars
+        note: >-
+          THE EMBLEM WITHOUT THE LETTER, and the distinction is the whole point
+          of this window. Art. 12 §3 gives "l'embleme des Communautes
+          Europeennes de couleur bleu-azur NON retroreflechissante avec au
+          centre un cercle de douze etoiles de couleur jaune retroreflechissante
+          a cinq rais dont les pointes ne se touchent pas, la hauteur de
+          l'embleme etant de 80 mm et la largeur de 120 mm" — twelve stars, an
+          80 x 120 mm field, a NON-retroreflective blue, and NO national letter
+          inside it. The L had to be carried separately, on the oval sign, and
+          art. 12 §6 says so in terms: "Le signe distinctif national ne doit pas
+          etre incorpore dans la plaque d'immatriculation." Incorporating the
+          country letter into the band is precisely what the 2003 instrument
+          changed, and it is why a 1990s Luxembourg plate and a 2003 one are
+          told apart at a glance.
+      national_sign:
+        shape: oval
+        w: 175
+        h: 115
+        unit: mm
+        background: "#FFFFFF"
+        foreground: "#000000"
+        note: "art. 12 §6: a separate rear oval, black L 80 mm high with a 10 mm stroke on white, 175 x 115 mm — or the same painted or applied directly to a substantially vertical rear surface. Mandatory for every vehicle plated under art. 12 §§1-3."
+      construction: { material: aluminium, min_thickness: 1.5, character_relief: 1.5, unit: mm, note: "art. 12 §5 — embossed characters at least 1.5 mm proud, not required for mopeds and light quadricycles" }
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 12 §3 (vehicles first registered from 01-01-1988 and before 01-07-2003: the 520x110 yellow plate with the EC emblem, its exact geometry, the 340 mm fallback and the motorcycle plate), §5 (aluminium and relief), §6 (the separate oval L and the prohibition on incorporating it), art. 16 §1 (the four surviving number compositions) and §4 (pre-2003 plates may stay in use). Accessed 2026-08-02"
+    notes: >-
+      THE 1988-2003 DESIGN WINDOW. Both boundaries are calendar dates enacted in
+      one article of one instrument, which is why `statutory-date` is earned
+      here rather than asserted. The window is a PERMISSION, not a mandate — art.
+      12 opens "Par derogation aux dispositions de l'article 11, les dispositions
+      suivantes s'appliquent aux plaques d'immatriculation des vehicules
+      immatricules avant le 1er juillet 2003", and §3 says such vehicles "peuvent
+      etre munis" of this plate. So these designs are what a pre-2003 vehicle MAY
+      still lawfully carry today, and the period is an eligibility window keyed
+      to FIRST REGISTRATION rather than a manufacturing window. Conformity is
+      forced only on a change of owner or on re-registration after the
+      registration card lapses (art. 16 §4), with historic vehicles exempted.
+
+  - id: lu-legacy-yellow-1974
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 1974, end: 1988 }
+    period_evidence: statutory-date
+    matching: recall-only
+    format:
+      pattern: "LL 999"
+      regex: '\A(?:\d{2,3}|\d{2}[- ][A-Z]{2}|[A-Z]{2}[- ]\d{2}|[A-Z][- ]\d{4}|[A-Z]{2}[- ]\d{3})\z'
+      pattern_note: "the same undated union as lu-legacy-euro-1988 — see that entry's note; art. 16 §1 lists the compositions without dating them"
+    design:
+      plate: { w: 340, h: 110, unit: mm }
+      plate_variants:
+        - { w: 240, h: 200, unit: mm, note: "motocycles, with the national L sign below the number on a black field" }
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      national_sign:
+        shape: oval
+        w: 175
+        h: 115
+        unit: mm
+        background: "#FFFFFF"
+        foreground: "#000000"
+        note: "art. 12 §6 applies to this window too — the separate rear oval, black L on white"
+      construction: { material: aluminium, min_thickness: 1.5, character_relief: 1.5, unit: mm }
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 12 §2: vehicles first registered from 01-01-1974 and before 01-01-1988 may carry front and rear plates of 340 x 110 mm 'avec un fond de couleur jaune retroreflechissante sur lequel sont apposes des caracteres alphanumeriques en couleur noire non retroreflechissante'. Accessed 2026-08-02"
+    notes: >-
+      THE 1974-1988 DESIGN WINDOW — this is where Luxembourg's yellow comes
+      from, and the date is exact. No European element of any kind: the EC
+      emblem arrives with the next window and the euroband with the letter
+      arrives in 2003. So a Luxembourg plate that is yellow, 340 x 110, and
+      carries nothing at its left-hand end is a 1974-1987 first registration,
+      which makes this the most datable design in the country.
+
+  - id: lu-legacy-black
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 1955, end: 1974 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL 999"
+      regex: '\A(?:\d{2,3}|\d{2}[- ][A-Z]{2}|[A-Z]{2}[- ]\d{2}|[A-Z][- ]\d{4}|[A-Z]{2}[- ]\d{3})\z'
+      pattern_note: "the same undated union as lu-legacy-euro-1988 — see that entry's note"
+    design:
+      plate: { w: 340, h: 110, unit: mm }
+      plate_variants:
+        - { w: 240, h: 200, unit: mm, note: "motocycles, with the national L sign below the number" }
+      background: { color: "#000000", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      national_sign:
+        shape: oval
+        w: 175
+        h: 115
+        unit: mm
+        background: "#FFFFFF"
+        foreground: "#000000"
+        note: >-
+          Required at the rear like the later windows — BUT with the one
+          exemption in the instrument that lets the country letter onto the
+          plate itself: art. 12 §6's prohibition on incorporating the national
+          sign "ne s'applique toutefois ni aux motocycles ni aux vehicules qui
+          ont ete immatricules au Luxembourg au nom du proprietaire ou detenteur
+          actuel avant le premier janvier 1974". A pre-1974 plate still held by
+          the same owner may therefore carry its L, and that exemption is
+          personal to the holder — it dies with the sale.
+      construction: { material: aluminium, min_thickness: 1.5, character_relief: 1.5, unit: mm }
+    region_encoding: none
+    sources:
+      - "https://data.legilux.public.lu/eli/etat/leg/rgd/2003/06/17/n2/jo/fr/pdf  # RGD 17-06-2003 art. 12 §1: vehicles first registered before 01-01-1974 may carry 340 x 110 mm plates 'avec un fond de couleur noire non retroreflechissante, sur lequel les caracteres alphanumeriques sont reproduits en couleur blanche'; art. 12 §6 exemption. Art. 1 and the preamble cite the loi du 14 fevrier 1955 and the arrete grand-ducal du 23 novembre 1955 as the registration regime this all sits under. Accessed 2026-08-02"
+    notes: >-
+      THE BLACK ERA — white on black, and the one entry in this file whose START
+      is not a plate fact. `instrument-in-force-upper-bound` is exact about
+      that: the END, 1 January 1974, is enacted in art. 12 §1 and is solid; the
+      START, 1955, is the year of the REGISTRATION REGIME this instrument
+      descends from — the loi du 14 fevrier 1955 concernant la reglementation de
+      la circulation sur toutes les voies publiques and the arrete grand-ducal
+      du 23 novembre 1955 portant reglement de la circulation, both cited by
+      name in the 2003 instrument's preamble and art. 1. It is a regime date
+      standing in for an unknown design date, exactly as es-provincial-numeric
+      uses 1900 for a format that begins in 1907, and it is flagged here for the
+      same reason: a consumer wanting the design-instrument window should read
+      "before 1974" and treat the lower bound as unestablished. THE MISSING
+      LINK, pinned for the next pass: art. 19 §2 of the 2003 instrument
+      abrogates by name "le reglement grand-ducal modifie du 21 decembre 1991
+      sur le mode d'attribution des numeros d'immatriculation et d'identite des
+      vehicules", which is the immediate predecessor allocation rule and the
+      most likely home of the four legacy compositions. Legilux serves the
+      Memorial issue for 21-12-1991 (A n. 86 of 27-12-1991) and that issue does
+      NOT contain it — probed, ten ELI ordinals, all returning the same
+      tax-and-VAT issue — so the instrument is published under a Memorial this
+      pass could not locate. Recorded gap, with the search that failed.

--- a/plates/pt.yml
+++ b/plates/pt.yml
@@ -1,0 +1,842 @@
+# plates/pt.yml — Portugal (PRD-PLATES gate L1, EU/EEA wave 2).
+#
+# ONE INSTRUMENT CARRIES ALMOST THIS WHOLE FILE, and it is not the one the
+# secondary web cites. The Portuguese plate is governed by the REGULAMENTO DO
+# NÚMERO E CHAPA DE MATRÍCULA, annexed to Decreto-Lei n.º 54/2005, de 3 de
+# março (DR I-A n.º 44, pp. 1892-1897), amended by Decreto-Lei n.º 106/2006,
+# de 8 de junho (DR I-A n.º 111, pp. 4052-4060), Decreto-Lei n.º 112/2009, de
+# 18 de maio, Lei n.º 46/2010, de 7 de setembro, and Decreto-Lei n.º 2/2020,
+# de 14 de janeiro (DR 1.ª série n.º 9, pp. 4-12). All fetched from
+# files.diariodarepublica.pt on 2026-08-02, text AND page images.
+#
+# THE FOUR FORMAT WINDOWS ARE ENACTED LAW, NOT FOLKLORE. Regulamento art. 3.º
+# n.º 2, verbatim, in one paragraph, with the dates in the statute itself:
+#
+#     "2 — O grupo de duas letras posiciona-se da seguinte forma:
+#        a) Matrículas atribuídas até 29 de Fevereiro de 1992 — AA-00-00;
+#        b) Matrículas atribuídas a partir de 1 de Março de 1992 — 00-00-AA;
+#        c) Matrículas atribuídas a partir do fim da utilização do modelo
+#           referido na alínea anterior — 00-AA-00."
+#
+# and n.º 3 (renumbered n.º 4 by DL 2/2020) adds the fourth:
+#
+#     "Após o esgotamento dos números de matrícula correspondentes à alínea c)
+#      do número anterior, o número de matrícula ... passa a ser constituído
+#      por dois grupos de duas letras e um grupo central de dois algarismos."
+#
+# READ THAT AGAIN, BECAUSE IT IS THE WHOLE JOB. Two of the four boundaries are
+# CALENDAR DATES fixed by statute (29-02-1992 / 01-03-1992). The other two are
+# not dates at all — they are EXHAUSTION EVENTS. The statute says the next
+# format begins when the previous one runs out, and it says so twice. So:
+#
+#   * es.yml's trap does not arise here in its usual form, but its MIRROR
+#     IMAGE does. There, an instrument's own window was shipped as a series
+#     period. Here, an instrument's own in-force date would be shipped as a
+#     series START — and it would be wrong by seven weeks. DL 2/2020 entered
+#     into force on 15-01-2020 (art. 11.º, "no dia seguinte ao da sua
+#     publicação"). The AA-00-AA SERIES did not start then. Its own art. 3.º
+#     is explicit that the new models "passam a ser obrigatórios para todas as
+#     matrículas atribuídas a partir da data em que se esgotar a atual série".
+#     pt.wikipedia states "15 de janeiro de 2020" for the format change; that
+#     is the INSTRUMENT date, and it is the error this dataset exists to not
+#     make. en.wikipedia states 3 March 2020, which is a first-issue date.
+#     Both Wikipedias were read; they disagree; the disagreement is RECORDED
+#     on the series, not averaged.
+#   * The ENABLING instrument for AA-00-AA is therefore NOT DL 2/2020. It is
+#     DL 54/2005 itself, whose art. 3.º n.º 3 legislated the fourth format
+#     fifteen years before it was needed. DL 2/2020 only approved the plate
+#     MODELS for it (a new Anexo V) and removed the date strip. Every
+#     secondary source that calls DL 2/2020 "the law that created the new
+#     plates" has the mechanism backwards.
+#
+# THE SIDE LABEL IS NOT THE FORMAT, and Portugal is the country where that
+# confusion is easiest to make. From 01-01-1998 to the AA-00-AA cutover, the
+# right-hand end of a Portuguese car plate carried a YELLOW BOX with the YEAR
+# over the MONTH of first registration (Regulamento art. 5.º n.º 4). It is a
+# registration DATE, printed beside the serial, never inside it — no character
+# of a Portuguese registration number has ever encoded time or place. DL
+# 2/2020's preamble gives the reason it was abolished, and it is a good one:
+# "esta menção gera interpretações incorretas por parte das entidades
+# fiscalizadoras do trânsito de outros Estados-Membros ... uma vez que diversos
+# países utilizam a referida solução não para a indicação da data da primeira
+# matrícula do veículo, mas para inscrever a data limite de validade da
+# matrícula". Portugal's own registration date was being read abroad as an
+# EXPIRY date. The preamble also records that Portugal was alone in the Union
+# in printing it, Italy excepted.
+#
+# COLOUR POLICY, and it differs from Spain's on purpose. Anexo XVIII gave
+# Spain four-corner CIE boxes; the Portuguese Regulamento gives COLOUR NAMES
+# and nothing else — "fundo de cor branca", "a preto", "fundo amarelo", "fundo
+# vermelho", "azul retrorrefletor". A name constrains far less than a gamut,
+# so every hex in this file is `hex_basis: observed` and no `color_spec` is
+# claimed, because there is none to cite. What IS cited is the retroreflectivity
+# requirement and the colour NAME, per series.
+#
+# DIMENSIONS COME FROM THE ANNEX DRAWINGS, which are page images in the DR
+# PDF and not text-extractable. They were rendered at 150 dpi and read
+# (dl54.pdf pp. 1896-1897; dl2020.pdf pp. 10-12). Values legible at that
+# resolution are recorded with `dimension_basis: statutory-drawing`; values
+# that were not legible are ABSENT rather than guessed.
+#
+# GEOGRAPHY: there is none on a Portuguese car plate, ever, and that is a
+# sourced negative rather than a missing table — art. 3.º composes the number
+# from digits and letters with no locational element in any of the four
+# windows. Geography survives in exactly two places, both of them statutory
+# lists and both authored: the TRAILER issuing-service prefix
+# (plates/_decode/pt-trailer-services.yml) and the EXPORT customs-office letter (inline on
+# pt-export). A third, the three-letter câmara municipal code on the
+# transitional moped plate, is authored as a mechanism without its table,
+# because the table is not in the instrument.
+jurisdiction: pt
+authority:
+  name: "Instituto da Mobilidade e dos Transportes, I. P. (IMT) — Regulamento do Número e Chapa de Matrícula, anexo ao Decreto-Lei n.º 54/2005, de 3 de março, na redação atual"
+  url: "https://diariodarepublica.pt/dr/legislacao-consolidada/decreto-lei/2005-128100380"
+binding: vehicle
+binding_note: >-
+  Regulamento art. 8.º n.º 1, verbatim: "A cada veículo em condições de circular
+  só pode ser atribuído um número de matrícula." The number is the vehicle's for
+  life and does not follow an owner — the opposite of Belgium (be.yml,
+  `binding: owner`) and of Luxembourg's personalised numbers (lu.yml). Art. 8.º
+  n.os 2-4 carve out the one exception, and it is narrow and non-transferable:
+  on the request of security, military, diplomatic or judicial authorities the
+  registrar may issue up to FOUR SUPPLEMENTARY numbers to an operationally
+  sensitive vehicle, and may even issue one to a vehicle registered in another
+  country. A parse API must therefore not assume plate-to-vehicle is injective
+  in Portugal, only that vehicle-to-base-number is.
+
+charset_defaults:
+  letters: "A-Z"
+  excluded_letters_note: >-
+    NONE ARE EXCLUDED BY THE INSTRUMENT — and that is a finding, not an
+    omission. The Regulamento composes the number from "duas letras" and
+    "algarismos" and prescribes no alphabet restriction anywhere, in contrast
+    to Spain (vowels, Ñ, Q struck out by name in Anexo XVIII) and Luxembourg
+    (I and O struck out, plus ten named pairs). The only hint that Portugal
+    filters combinations at all is in DL 2/2020's own preamble, which prices
+    the AA-00-AA series at "cerca de 74 anos" of theoretical life reduced to
+    "45 anos" in practice, "nomeadamente pela não utilização de combinações que
+    possam formar palavras ou siglas que se entenda dever evitar". So an
+    avoid-list EXISTS as a matter of administrative practice and its effect is
+    quantified in a statutory preamble — but its MEMBERS are published nowhere
+    located in this pass. Recorded gap; no `regex_strict` is offered for the
+    ordinary series, because inventing the excluded set would be worse than
+    having none.
+  source: "https://files.diariodarepublica.pt/1s/2020/01/00900/0000400012.pdf  # DL 2/2020 preamble: the 74-year/45-year estimate and the reason for the difference"
+
+display_rules:
+  two_plates: "automóveis e máquinas industriais: one front, one rear (Regulamento art. 7.º n.º 1)"
+  one_plate_rear_only: "motociclos, ciclomotores, triciclos, quadriciclos, reboques e máquinas industriais rebocáveis — rear only (art. 7.º n.º 2)"
+  mounting: "principal axis horizontal, perpendicular and centred on the vehicle's median longitudinal plane or, failing that, to its LEFT; lower edge not below 200 mm and upper edge not above 1200 mm from the ground (art. 7.º n.os 3-4)"
+  machinery_exception: "on máquinas industriais where construction or function forbids it, a SINGLE plate may be mounted laterally on the RIGHT-HAND side, and removable plates may be authorised (art. 7.º n.º 7, added by DL 106/2006)"
+  minimum_character_height: "where reduced-size plates are authorised for constructive or functional reasons, characters may not fall below 60 mm (art. 9.º n.º 3, in the DL 2/2020 wording — the 2005 original set no floor, so this is a 2020 tightening)"
+  source: "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # Regulamento art. 7.º; https://files.diariodarepublica.pt/1s/2006/06/111a00/40524060.pdf  # art. 7.º n.º 7; https://files.diariodarepublica.pt/1s/2020/01/00900/0000400012.pdf  # art. 9.º n.º 3"
+
+pre_1937_history_note: >-
+  BEFORE THE 1937 NATIONAL SERIES, tagged `secondary-wikipedia` in its entirety
+  and deliberately NOT authored as series. The Portuguese-language Wikipedia
+  article dates the plate obligation itself to a Decreto de 3 de outubro de 1901
+  requiring every car to carry a metal plate at the rear, and describes an
+  intermediate 1911-1936 arrangement built on zone letters rather than a single
+  national run. Neither the 1901 decree nor any 1911 instrument was reached on
+  dre.pt in this pass — the DRE search interface is a single-page application
+  whose backend is not fetchable, and the pre-1910 Diário do Governo is not on
+  the files service under the modern path scheme. Formats for those eras are
+  therefore NOT recorded: a series entry needs a grammar, and a grammar taken
+  from an encyclopedia paragraph without an instrument behind it is exactly the
+  confident guess this dataset prefers a gap to.
+  Source (locator and sole authority for the two dates above):
+  https://pt.wikipedia.org/wiki/Matr%C3%ADculas_de_autom%C3%B3veis_em_Portugal
+
+series:
+
+  # =========================================================================
+  # THE CURRENT SERIES — AA-00-AA. Enabled 2005, modelled 2020, issued from
+  # the exhaustion of 00-AA-00.
+  # =========================================================================
+  - id: pt-national-2020
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, moped, tricycle, quadricycle]
+    period: { start: 2020 }
+    period_evidence: secondary-first-issue
+    matching: strict
+    format:
+      pattern: "LL 99 LL"
+      regex: '\A[A-Z]{2}[- ]\d{2}[- ][A-Z]{2}\z'
+      separator_note: >-
+        THE DASHES ARE GONE, and the deletion is legible in two independent
+        places in the same instrument. (1) TEXT: DL 54/2005's art. 3.º n.º 1
+        and n.º 3 both ended "sendo os grupos separados entre si por traços";
+        when DL 2/2020 rewrote n.º 3 as the new n.º 4 it reproduced the
+        composition and DROPPED that clause. (2) DRAWING: the Anexo V Modelo I
+        dimension chain prescribes only spacing — 10 mm between characters
+        inside a group and 20 mm between groups — and draws no separator glyph,
+        where the Anexo IV Modelo I drawing it replaces plainly draws one. The
+        canonical printed form in `pattern` is therefore the GAP. `regex` still
+        spells the position as the sanctioned separator-only class `[- ]`
+        (PRD-PLATES §2.8) because the instrument now prescribes millimetres and
+        no glyph, which is precisely the es-consular-cc-1999 situation: with no
+        glyph mandated, both members of the emitted set are inside the grammar,
+        so the class is `strict` rather than a widening. FLAGGED FOR THE
+        VERIFIER: this reading rests on the statutory drawing plus a deletion,
+        and a photograph of an issued plate would settle it in one look.
+      progression: >-
+        Nationally sequential and non-geographic, like every Portuguese series
+        since 1937. The known anchor is the first number, AA-01-AA, so the two
+        letter pairs and the central digits advance from there; the exact
+        odometer order (which of the three groups rolls first) is not stated by
+        the instrument and is not asserted here. DL 2/2020's preamble prices the
+        space at "cerca de 74 anos" theoretical and "45 anos" practical, and
+        notes the design deliberately leaves room to go to THREE central digits
+        later — so a future AA-000-AA is contemplated in the enacting text
+        itself and should not surprise a consumer.
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      plate_variants:
+        - { w: 340, h: 220, unit: mm, note: "Modelo II — automóveis, rear only, two rows (letters over digits+letters)" }
+        - { note: "Modelo IV — motociclos de cilindrada superior a 50 cm3 e triciclos" }
+        - { note: "Modelo V — ciclomotores, motociclos até 50 cm3 e quadriciclos" }
+        - { note: "Modelo VI — ciclomotores de três rodas e quadriciclos" }
+      dimension_basis: statutory-drawing
+      characters: { h: [75, 80], stroke: "1/7 h", gap: 10, group_gap: 20, unit: mm, note: "character height is a RANGE in the drawing (75 a 80), not a single value; widths are marked 6/7h for letters and 4/7h for digits, i.e. proportional to height rather than absolute" }
+      plate_construction: { border: 5, corner_radius: 10, unit: mm, note: "5 mm black peripheral border; R=10 corner radius; band field 45 mm wide, internally 7.5 + 30 + 7.5" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band:
+        side: left
+        color: "#003399"
+        hex_basis: observed
+        content: eu-stars+P
+        note: >-
+          Blue retroreflective field, 45 mm wide, carrying the twelve yellow
+          retroreflective stars above and the white letter P below. The annex
+          labels the three colours in words on the drawing itself — "Azul
+          retrorrefletor", "Amarelo retrorrefletor", "Branco retrorrefletor" —
+          which is the only colour specification Portuguese law gives.
+      emblem: { present: false }
+      rear_differs: false
+      date_strip: { present: false, note: "ABOLISHED with this model. See the file header." }
+    region_encoding: none
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # THE ENABLING INSTRUMENT: Regulamento art. 3.º n.º 3 as originally enacted — 'dois grupos de duas letras e um grupo central de dois algarismos', triggered by exhaustion of the 00-AA-00 series. DL 54/2005, DR I-A n.º 44, 03-03-2005. Accessed 2026-08-02"
+      - "https://files.diariodarepublica.pt/1s/2020/01/00900/0000400012.pdf  # DL 2/2020 (DR 1.ª série n.º 9, 14-01-2020): art. 3.º renumbers that rule as art. 3.º n.º 4 and drops the 'traços' clause; art. 4.º adds ANEXO V (the models drawn for this format); art. 5.º n.º 1 d) maps this window to Anexo V; art. 11.º in force 15-01-2020. Accessed 2026-08-02"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Portugal  # secondary-wikipedia: first issue AA-01-AA on 3 March 2020, and 99-ZZ-99 as the last number of the preceding series. Read 2026-08-02"
+      - "https://www.motojornal.pt/diploma-que-regula-as-matriculas-foi-publicado/  # contemporaneous Portuguese motoring press, 15-01-2020: reports the preceding series as due to run out 'at the end of next February', i.e. a March 2020 start — independent of Wikipedia and consistent with it"
+    notes: >-
+      THE CURRENT PORTUGUESE SERIES. Period start is `secondary-first-issue`
+      and not `instrument-in-force`, deliberately: the statutory trigger is the
+      EXHAUSTION of the previous series, an event no instrument dates, so the
+      only possible evidence for the start is a first-issue report. Two
+      independent secondaries agree on March 2020 — Wikipedia gives 3 March
+      2020 with the first number AA-01-AA, and the Portuguese motoring press on
+      15-01-2020 expected exhaustion at the end of February. FOLKLORE FLAG,
+      recorded not averaged: pt.wikipedia gives 15 January 2020 for the same
+      change; that is DL 2/2020's own entry into force and it is an instrument
+      date masquerading as a series start — the two Wikipedias contradict each
+      other and only one of them is describing the series. Old plates stay on
+      the road: DL 2/2020's own preamble provides that existing plates "podem
+      manter-se em uso, sem necessidade de substituição", optionally replaceable
+      at the owner's choice, and Regulamento art. 5.º n.º 12 says the same in
+      enacting terms. Vehicles of historic interest may be authorised to carry
+      the model in use at their own first registration (art. 9.º n.º 3 of DL
+      2/2020's transitional article) — Portugal has no historic-plate SERIES,
+      only a historic-plate PERMISSION, which is why no `historic` entry appears
+      in this file.
+
+  # =========================================================================
+  # 00-AA-00 — the third window.
+  # =========================================================================
+  - id: pt-national-2005
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, moped, tricycle, quadricycle]
+    period: { start: 2005, end: 2020 }
+    period_evidence: secondary-first-issue
+    matching: strict
+    format:
+      pattern: "99-LL-99"
+      regex: '\A\d{2}-[A-Z]{2}-\d{2}\z'
+      separator_note: >-
+        The hyphen IS statutory in this window: art. 3.º n.º 1, verbatim,
+        "sendo os grupos separados entre si por traços", and the Anexo IV
+        Modelo I drawing draws the glyph between groups. Contrast the 2020
+        model, where the clause was deleted.
+      progression: "sequential and non-geographic; the letter pair advances as the digit groups roll"
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      plate_variants:
+        - { w: 340, h: 220, unit: mm, note: "Modelo II — automóveis, rear only, two rows" }
+        - { note: "Modelo IV/V — motociclos de cilindrada superior a 50 cm3 e triciclos; from 01-01-2007 Modelo V, in PLASTIC (art. 5.º n.º 10). DL 106/2006 first set that date at 01-01-2006 and DL 112/2009 moved it to 01-01-2007 — a one-year slip visible only by reading both amendments" }
+      dimension_basis: statutory-drawing
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+P }
+      date_strip:
+        present: true
+        side: right
+        color: "#F9B700"
+        hex_basis: observed
+        content: year-over-month
+        note: >-
+          The yellow box at the right-hand end carries the YEAR above and the
+          MONTH below, of FIRST REGISTRATION — the Anexo IV Modelo I drawing
+          renders it as "98 / 01" (January 1998). It is not an expiry date and
+          not part of the serial. Present on Modelos I and II (cars) only;
+          the trailer model has never carried it.
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # THE ENABLING INSTRUMENT: DL 54/2005 art. 3.º n.º 2 c) — '00-AA-00' for numbers issued from the end of the use of the preceding model; preamble states the reason: 'As actuais séries de matrícula dos automóveis encontram-se praticamente esgotadas'. Art. 5.º n.º 1 c) + n.os 3-4: white retroreflective ground, black characters, plus the year/month indication at the right-hand end. Accessed 2026-08-02"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Portugal  # secondary-wikipedia: 00-AA-00 introduced 2005 and running to 99-ZZ-99 in March 2020. Read 2026-08-02"
+      - "https://www.pgdlisboa.pt/leis/lei_mostra_articulado.php?nid=1103&tabela=leis  # Decreto-Lei n.º 112/2009, de 18 de maio, as carried by the Procuradoria-Geral Distrital de Lisboa database: the amendment that moves the plastic-motorcycle-plate date from 01-01-2006 (DL 106/2006) to 01-01-2007, and that inserts the electronic-identification device into the Regulamento. Consulted as a SECONDARY carrier of the text — the Diário da República original for this one amendment was not reached. Accessed 2026-08-02"
+    notes: >-
+      THE 2005-2020 WINDOW. Both ends are exhaustion events rather than
+      instrument dates, so both are `secondary-first-issue`: this format began
+      when 99-99-ZZ ran out and ended when 99-ZZ-99 ran out. DL 54/2005 is the
+      enabling instrument and its own dates are known precisely — published
+      03-03-2005, no entry-into-force clause of its own, so the general 5-day
+      vacatio of Lei n.º 74/98 puts it in force on 08-03-2005 (DERIVED from the
+      default rule, not stated; flagged) except for Regulamento arts. 11.º,
+      15.º and 16.º, which its art. 6.º delays to 01-01-2006. NOT USED AS THE
+      SERIES START, on the instrument-date rule. THE MONTH IS THE GAP: no
+      source located in this pass gives the day, or even the month, on which
+      the first 00-AA-00 number was issued, and the enthusiast monthly-series
+      tables that would settle it are dead links. A consumer needing better than
+      year granularity here should treat 2005 as approximate.
+
+  # =========================================================================
+  # 00-00-AA — the second window. BOTH ENDS ARE CALENDAR DATES IN A STATUTE.
+  # =========================================================================
+  - id: pt-national-1992
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1992, end: 2005 }
+    period_evidence: statutory-date-start-secondary-end
+    matching: strict
+    format:
+      pattern: "99-99-LL"
+      regex: '\A\d{2}-\d{2}-[A-Z]{2}\z'
+      separator_note: "statutory hyphens (art. 3.º n.º 1, 'separados entre si por traços')"
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      plate_variants:
+        - { note: "Anexo III Modelo II — automóveis, rear, two rows; Modelo III — reboques; Modelo IV — motociclos, triciclos e quadriciclos > 50 cm3, drawn at 170 mm wide" }
+      dimension_basis: statutory-drawing
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+P }
+      band_caveat: >-
+        READ THIS BEFORE TRUSTING THE BAND ON A 1992-1997 PLATE. The band is
+        drawn on the Anexo III models — the drawing labels "AZUL
+        RETRORREFLECTOR", "AMARELO RETRORREFLECTOR" and shows the P — but
+        Anexo III as read here was published in 2005 and REPLACED again in 2006,
+        so it is a re-enactment of the 1992 model, not the 1992 instrument. The
+        EU distinguishing-sign band rests on Regulation (EC) 2411/98 of
+        3 November 1998, which postdates this window's opening by six years. So
+        either the band was on Portuguese plates before the Regulation, or the
+        2005 re-enactment modernised the drawing. This pass could not reach the
+        1992 instrument to tell them apart. The band is recorded because the
+        primary in hand draws it; the caveat is recorded because the primary in
+        hand cannot date it.
+      date_strip: { present: false, note: "the year/month box arrives with the NEXT model window, on 01-01-1998 — Anexo IV, not Anexo III" }
+    region_encoding: none
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # DL 54/2005 Regulamento art. 3.º n.º 2 a)-b): AA-00-00 for numbers issued 'até 29 de Fevereiro de 1992' and 00-00-AA 'a partir de 1 de Março de 1992' — both boundary dates enacted verbatim. Art. 5.º n.º 1 b) + n.º 3: for numbers issued between 01-01-1992 and 31-12-1997 the plate is Anexo III — retroreflective, white ground, black letters, digits, dashes and peripheral border. Accessed 2026-08-02"
+    notes: >-
+      THE 1992-2005 WINDOW, and the one place in this file where a boundary is
+      dated TO THE DAY by a statute: numbers up to 29-02-1992 are AA-00-00,
+      numbers from 01-03-1992 are 00-00-AA. Its far end is an exhaustion event
+      (see pt-national-2005). A PRECISION WORTH KEEPING, because it is a real
+      two-month seam and secondary sources collapse it: the NUMBER format
+      changed on 01-03-1992, but the PLATE MODEL changed on 01-01-1992 — art.
+      5.º n.º 1 puts Anexo II (black) on everything up to 31-12-1991 and
+      Anexo III (white retroreflective) on everything from 01-01-1992. So
+      registrations made in January and February 1992 carry an OLD-FORMAT
+      AA-00-00 number on a NEW white reflective plate, and that combination is
+      lawful, sourced, and invisible in every secondary account of the change.
+      The instrument that actually made the 1992 change was not reached: DL
+      54/2005 states the dates but revokes only arts. 1.º-3.º of Decreto
+      Regulamentar n.º 13/98, de 15 de junho and arts. 35.º and 37.º of the
+      Regulamento do Código da Estrada (Decreto n.º 39 987, de 22 de dezembro de
+      1954), so the 1992 amendment lives somewhere in the chain between those
+      two and is a recorded gap.
+
+  # =========================================================================
+  # AA-00-00 — the first modern national series.
+  # =========================================================================
+  - id: pt-national-1937
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1937, end: 1992 }
+    period_evidence: statutory-date-end-secondary-start
+    matching: strict
+    format:
+      pattern: "LL-99-99"
+      regex: '\A[A-Z]{2}-\d{2}-\d{2}\z'
+      progression: >-
+        Reported to have run from AA-10-00 to ZZ-99-99 across fifty-five years,
+        i.e. the letter pair advances as the four digits roll and the series
+        did NOT start at AA-00-00 itself. That range is `secondary-wikipedia`;
+        the STATUTE gives only the shape.
+      separator_note: "hyphens, drawn in the Anexo II models ('ML-79-08', 'MF-09-78')"
+    design:
+      plate: { w: 460, h: 100, unit: mm, note: "Anexo II Modelo I — automóveis, FRONT" }
+      plate_variants:
+        - { w: 340, h: 230, unit: mm, note: "Modelo II — automóveis, rear, two rows (letters over digits)" }
+        - { w: 520, h: 120, unit: mm, note: "Modelo III — automóveis, rear, single row" }
+        - { note: "Modelo IV — motociclos, drawn at 230 mm wide" }
+        - { w: 520, h: 120, unit: mm, note: "Modelo V — reboques" }
+      dimension_basis: statutory-drawing
+      background: { color: "#000000", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      note: >-
+        WHITE ON BLACK, and unlike Spain this is not collector folklore but
+        enacted text: Regulamento art. 5.º n.º 2, verbatim, "As chapas de
+        matrícula dos modelos constantes do anexo II têm fundo de cor preta e
+        letras, algarismos e traços de cor branca". No retroreflectivity is
+        required for this model — the requirement appears for the first time in
+        n.º 3, for Anexo III. The drawings label the two colours "BRANCO" and
+        "PRETO" and nothing else, so `finish: painted` is an inference from the
+        ABSENCE of the retroreflector requirement rather than a positive claim.
+      date_strip: { present: false }
+    region_encoding: none
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # DL 54/2005 Regulamento art. 3.º n.º 2 a) — 'Matrículas atribuídas até 29 de Fevereiro de 1992 — AA-00-00'; art. 5.º n.º 1 a) + n.º 2 — Anexo II for numbers issued up to 31-12-1991, black ground, white characters; Anexo II Modelos I-V drawings. Accessed 2026-08-02"
+      - "https://pt.wikipedia.org/wiki/Matr%C3%ADculas_de_autom%C3%B3veis_em_Portugal  # secondary-wikipedia: the second national registration system entered into force on 1 January 1937. Read 2026-08-02"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Portugal  # secondary-wikipedia: the run AA-10-00 to ZZ-99-99, and black plates with white characters through 1992. Read 2026-08-02"
+    notes: >-
+      THE FIFTY-FIVE-YEAR SERIES. Its END is enacted law, to the day
+      (29-02-1992, DL 54/2005 art. 3.º n.º 2 a)). Its START is not: 1 January
+      1937 is `secondary-wikipedia` and the instrument behind it was not
+      reached, so `period_evidence: statutory-date` describes the END only and
+      the note is where the asymmetry is declared. Anyone re-verifying should
+      start from the Regulamento do Código da Estrada (Decreto n.º 39 987, de
+      22 de dezembro de 1954) arts. 35.º and 37.º, which DL 54/2005 revokes by
+      name and which therefore carried the plate rules for the bulk of this
+      window — but 1954 is itself mid-series, so the 1937 instrument is a
+      third link back and remains unlocated. NOT the pre-1937 systems: those
+      are described in the file's `pre_1937_history_note` and are not authored.
+
+  # =========================================================================
+  # TRAILERS — the one geographic decode on a Portuguese plate.
+  # =========================================================================
+  - id: pt-trailer
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 2005 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "L-999999"
+      regex: '\A[A-Z]{1,2}[- ]\d{1,6}\z'
+      regex_strict: '\A(?:AV|BE|BR|BN|CB|FA|GD|LE|PT|SA|SE|VC|VR|VI|VS|AN|A|C|E|H|L|M|P)[- ]\d{1,6}\z'
+      charset:
+        notes: >-
+          The prefix is the ISSUING SERVICE, one or two letters, and the list is
+          enumerated twice — DL 54/2005 Anexo I and, replacing it, DL 106/2006
+          Anexo I. `regex_strict` is the UNION of both vintages (VS and VI both
+          appear, for Viseu before and after the 2006 replacement), because
+          trailers were lawfully plated under each. Longest-match first in the
+          alternation, because single-letter codes are prefixes of two-letter
+          ones. The SERIAL is "um número de ordem" with no width fixed by the
+          instrument; the 6-digit bound in `regex` is taken from the widest
+          serial the annex drawings actually print ("L-10978" in Anexo II,
+          "L 807890" in Anexo IV, "L 808970" in Anexo V) and is a narrowing, not
+          a statutory claim — which keeps the series `strict` under §2.7.
+      separator_note: "the pre-2020 drawings show a dash; the 2020 Anexo V Modelo III drawing shows a gap, as on the car plate. `[- ]` covers both vintages of this one continuing series."
+    design:
+      plate: { w: 520, h: 110, unit: mm }
+      dimension_basis: statutory-drawing
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+P }
+      date_strip: { present: false, note: "trailers never carried the year/month box — art. 5.º n.º 4 confines it to Modelos I and II, the car plates" }
+    region_encoding: "plates/_decode/pt-trailer-services.yml"
+    region_encoding_file: pt-trailer-services.yml
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # DL 54/2005 Regulamento art. 4.º n.os 1-2: 'O número de matrícula dos reboques é constituído por uma ou duas letras identificadoras do serviço regional que procedeu à matrícula, seguidas de um número de ordem', with the table at Anexo I; Anexo II Modelo V, Anexo III Modelo III and Anexo IV Modelo III drawings. Accessed 2026-08-02"
+      - "https://files.diariodarepublica.pt/1s/2006/06/111a00/40524060.pdf  # DL 106/2006 art. 1.º n.º 3: replaces Anexo I — the current code list. Accessed 2026-08-02"
+      - "https://files.diariodarepublica.pt/1s/2020/01/00900/0000400012.pdf  # DL 2/2020 Anexo, ANEXO V Modelo III — Reboques: the current trailer plate model, drawn as 'L 808970' with the EU band and no dash. Accessed 2026-08-02"
+    notes: >-
+      PORTUGUESE TRAILERS ARE DECODABLE AND PORTUGUESE CARS ARE NOT. The prefix
+      names the district office that issued the registration — not the trailer's
+      base, not the towing vehicle's plate. PERIOD HONESTY: 2005 is the vintage
+      of the instrument that ENACTS the rule read here, exactly as in
+      es-provinces.yml, and not the date the composition began. The composition
+      is demonstrably older, and the proof is inside the same instrument: Anexo
+      II Modelo V — the model governing numbers issued UP TO 31-12-1991 — is
+      drawn as "L-10978". So trailers were numbered letter-plus-serial before
+      1992 and the enacting instrument for that is a recorded gap. Contrast
+      Spain, where the trailer letter is a fixed R prefix and the province code
+      trails; here the letter IS the geography and there is no fixed prefix.
+
+  # =========================================================================
+  # EXPORT — yellow, with its own four-member customs-office letter set.
+  # =========================================================================
+  - id: pt-export
+    class: export
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2005 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "99999 L"
+      regex: '\A\d{1,6}[- ][A-Z]\z'
+      regex_strict: '\A\d{1,6}[- ][LPAM]\z'
+      charset:
+        letters: [L, P, A, M]
+        notes: >-
+          Art. 4.º n.º 3, verbatim: the export number is "um número de ordem,
+          seguido da letra inicial de Lisboa, Porto, Açores ou Madeira,
+          consoante o serviço alfandegário que a processe" — the INITIAL of the
+          customs service that processed it. Four members, inline here rather
+          than in a decode file because it is a different statutory list from
+          the trailer table, in a different article, with different members
+          (the trailer table has no Açores row at all — it splits the Azores
+          into three district codes AN/H/A).
+      progression: "sequential per customs office; the drawing prints five digits ('24783 L') but the instrument fixes no width"
+    design:
+      plate: { w: 520, h: 110, unit: mm, note: "Anexo V Modelo I as enacted in 2005; renumbered ANEXO VI by DL 2/2020 art. 7.º b) without change of content" }
+      plate_variants:
+        - { w: 340, h: 220, unit: mm, note: "Modelo II — two rows" }
+      dimension_basis: statutory-drawing
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+P }
+      expiry_box:
+        side: right
+        content: "EXP over expiry"
+        note: >-
+          The right-hand box carries the letters EXP above the validity limit —
+          the drawing renders it as "EXP / 91 5". This is the one Portuguese
+          plate that has always carried a date on its face, and it is an EXPIRY
+          date, not a registration date. Note the irony recorded in DL 2/2020's
+          preamble: foreign enforcement bodies were reading the ORDINARY plate's
+          registration strip as if it were this one.
+    region_encoding: inline
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # DL 54/2005 Regulamento art. 4.º n.º 3 (the number) and art. 6.º n.º 1 (the plate): 'Nos veículos destinados à exportação, a chapa de matrícula é de um dos modelos constantes do anexo V, tendo cor amarela e letras, algarismos, traços e rebordo periférico a preto'; Anexo V Modelos I-II drawings. Accessed 2026-08-02"
+      - "https://files.diariodarepublica.pt/1s/2020/01/00900/0000400012.pdf  # DL 2/2020 art. 7.º b): 'O anexo V é renumerado como anexo VI' — the export annex moves, its content does not. Accessed 2026-08-02"
+    notes: >-
+      EXPORT PLATES — yellow ground, black characters, EXP box. A trap for a
+      parse API and the reason this entry exists as its own series rather than a
+      colour variant: the export letter is a SUFFIX drawn from {L, P, A, M},
+      while the trailer letter is a PREFIX drawn from a 21-code table that also
+      contains L, P, A and M with DIFFERENT meanings — L is Lisboa in both, but
+      A is Ponta Delgada on a trailer and the whole of the Açores on an export
+      plate, and M is Funchal on a trailer and the whole of Madeira here.
+      Disambiguation is by POSITION, never by letter.
+
+  # =========================================================================
+  # DIPLOMATIC — a primary colour rule, a secondary number grammar.
+  # =========================================================================
+  - id: pt-diplomatic
+    class: diplomatic
+    categories: [car, van, motorcycle]
+    period: { start: 2005 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "999-CD999"
+      regex: '\A\d{1,3}-(?:CD|CC|FM)\d{1,3}\z'
+      pattern_note: >-
+        THE GRAMMAR HERE IS SECONDARY AND THE COLOUR IS PRIMARY — an unusual
+        split, and the reason this series is `recall-only`. DL 54/2005 art. 6.º
+        n.º 2 prescribes only that the CHARACTERS, dashes and border be red on
+        the plates of diplomatic-corps members, career consuls, non-resident
+        administrative and technical staff of foreign missions, and bodies
+        covered by the Protocol on the Privileges and Immunities of the European
+        Communities. It composes no number. The CD / CC / FM group letters and
+        the surrounding digit groups are taken from Wikipedia
+        (`secondary-wikipedia`); the group widths are unverified, which is why
+        the regex bounds them loosely and no `regex_strict` is offered.
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#CE1126"
+      foreground_note: >-
+        Art. 6.º n.º 2, verbatim: "os caracteres, traços e rebordo periférico das
+        chapas de matrícula são de cor vermelha". The instrument names the
+        colour and nothing more — no gamut, no RAL, no CIE. hex_basis observed.
+      band: { side: left, color: "#003399", hex_basis: observed, content: eu-stars+P }
+    region_encoding: none
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # DL 54/2005 Regulamento art. 6.º n.º 2 — the RED characters rule and the exact list of who gets them. Accessed 2026-08-02"
+      - "https://pt.wikipedia.org/wiki/Matr%C3%ADculas_de_autom%C3%B3veis_em_Portugal  # secondary-wikipedia: white plates with red characters, and the CD / CC / FM group letters with digits either side. Read 2026-08-02"
+    notes: >-
+      CORPO DIPLOMÁTICO E CONSULAR. Recorded as `diplomatic` although the
+      statutory provision is one sentence covering diplomats, career consuls,
+      mission staff AND European-institution personnel in a single breath — the
+      controlled vocabulary would split those across `diplomatic`, `consular`
+      and something it does not have. One series, because the instrument makes
+      one rule. CLASS CAVEAT flagged rather than resolved. THE REAL GAP: the
+      body that assigns the CD/CC/FM prefixes and their per-mission numbering is
+      the Ministério dos Negócios Estrangeiros, not the IMT, and no MNE
+      instrument was reached — so no mission decode table exists here and none
+      was invented. PRD-PLATES puts diplomatic decode tables at gate L4.
+
+  # =========================================================================
+  # TEMPORARY IMPORT — the blue-character plate.
+  # =========================================================================
+  - id: pt-temporary-import
+    class: temporary
+    categories: [car, van, truck, bus, trailer]
+    period: { start: 2005 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "99-99-LL"
+      regex: '\A(?:[A-Z]{2}[- ]\d{2}[- ][A-Z]{2}|\d{2}-[A-Z]{2}-\d{2}|\d{2}-\d{2}-[A-Z]{2}|[A-Z]{2}-\d{2}-\d{2})\z'
+      pattern_note: >-
+        NO NUMBER GRAMMAR IS ASSERTED, and the regex is the union of the four
+        ordinary Portuguese shapes purely so a consumer gets a shape hit — hence
+        `recall-only`, in the same spirit as nl-export. DL 54/2005 establishes
+        this plate only by penalising its absence: art. 2.º n.º 1 a) v) fines
+        "Circulação de automóvel ou de reboque importado temporariamente com
+        chapa de matrícula provisória não possuindo caracteres, traço e rebordo
+        periférico de cor azul". That sentence proves the plate exists and proves
+        its colour; it composes no number, and neither does anything else in the
+        Regulamento. `pattern` shows an ordinary shape only because the schema
+        requires one.
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003399"
+      foreground_note: "characters, dashes and peripheral border in BLUE — the only Portuguese plate so coloured. hex_basis observed; the instrument names the colour and gives no spec."
+    region_encoding: none
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # DL 54/2005 art. 2.º n.º 1 a) v): the temporarily-imported vehicle's provisional plate must carry BLUE characters, dashes and peripheral border. Accessed 2026-08-02"
+    notes: >-
+      MATRÍCULA PROVISÓRIA for temporarily imported vehicles — blue characters.
+      An honest half-entry: the colour is primary and precise, the grammar is
+      absent from the instrument, and rather than borrow a grammar from a
+      secondary this series is marked `recall-only` and says so. The entry earns
+      its place because the blue-character rule is otherwise unrecorded anywhere
+      machine-readable, and because a parse API that meets a blue Portuguese
+      plate should be able to name it.
+
+  # =========================================================================
+  # MOPEDS AND SMALL QUADRICYCLES — yellow, and conditionally commenced.
+  # =========================================================================
+  - id: pt-moped-2006
+    class: moped
+    categories: [moped, motorcycle, quadricycle, tricycle]
+    period: { start: 2006 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99-LL-99"
+      regex: '\A(?:\d{2}-[A-Z]{2}-\d{2}|[A-Z]{2}[- ]\d{2}[- ][A-Z]{2})\z'
+      pattern_note: >-
+        Mopeds carry the ORDINARY national number, not a series of their own —
+        art. 3.º n.º 1 composes one number for "automóveis, motociclos,
+        ciclomotores, triciclos e quadriciclos" together. This series exists
+        because the PLATE differs (yellow, its own models), not because the
+        serial does, and the regex is therefore the union of the two national
+        formats in force across its period.
+    design:
+      plate: { note: "Modelo VI of Anexo IV (2006-2020), replaced by Modelo V of Anexo V from the AA-00-AA cutover; Modelo VII / Modelo VI for three-wheeled mopeds and quadricycles with room for a wider plate" }
+      dimension_basis: statutory-drawing
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band:
+        side: left
+        color: "#003399"
+        hex_basis: observed
+        content: eu-stars+P
+        note: >-
+          THE BAND ARRIVED HERE IN 2020, NOT 2006, and DL 2/2020's preamble says
+          why in terms: it harmonises "os modelos das chapas de matrícula dos
+          ciclomotores e motociclos com o dos restantes veículos, no que se
+          refere à inclusão do dístico identificador do Estado-Membro de
+          matrícula, previsto no Regulamento (CE) n.º 2411/98 ... facilitando a
+          circulação internacional destes veículos". So a Portuguese moped plate
+          issued before the cutover has no EU band and one issued after does.
+    region_encoding: none
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2006/06/111a00/40524060.pdf  # DL 106/2006: extends the Regulamento to ciclomotores and quadriciclos; new art. 5.º n.º 8 — 'A chapa de matrícula dos motociclos de cilindrada não superior a 50 cm3, dos ciclomotores e dos quadriciclos ... deve obedecer às características e dimensões do modelo VI do anexo IV ..., apresentando fundo a amarelo e letras, algarismos, traços e rebordo periférico a preto'; art. 2.º n.º 1 — conditional commencement. Accessed 2026-08-02"
+      - "https://files.diariodarepublica.pt/1s/2020/01/00900/0000400012.pdf  # DL 2/2020: art. 5.º n.º 6 as amended moves this class to Modelo V of the new Anexo V from the cutover date, and the preamble states the EU-band harmonisation reason. Accessed 2026-08-02"
+    notes: >-
+      CICLOMOTORES, MOTOCICLOS ATÉ 50 cm3 E QUADRICICLOS — yellow ground, black
+      characters. `period_evidence: enabling-instrument` and NOT
+      `instrument-in-force`, because DL 106/2006's art. 2.º n.º 1 gives this
+      class a CONDITIONAL commencement and not a date: its provisions "entram em
+      vigor conjuntamente com a regulamentação relativa ao registo de propriedade
+      destes veículos". The instrument that carried that property-registration
+      regime, and therefore the real day this series began, was not reached in
+      this pass — a recorded gap, and the reason 2006 is the enabling
+      instrument's year rather than a first-issue claim. Until that condition
+      was met the transitional municipal scheme applied — see
+      pt-moped-municipal-2006, which is the series a Portuguese moped plate of
+      that era actually bears.
+
+  - id: pt-moped-municipal-2006
+    class: moped
+    categories: [moped, motorcycle]
+    period: { start: 2006, ended: true, year_end_min: 2006 }
+    period_evidence: transitional-provision
+    matching: recall-only
+    format:
+      pattern: "9-LLL-99-99"
+      regex: '\A\d{1,3}-[A-Z]{3}-\d{2}-\d{2}\z'
+      pattern_note: >-
+        THE ONLY PORTUGUESE PLATE THAT EVER ENCODED A MUNICIPALITY. DL 106/2006
+        art. 2.º n.º 1 a), in substance: the number is a group of three letters
+        standing for the CÂMARA MUNICIPAL that registered the vehicle, preceded
+        by a per-series order number starting at 1, and followed by two groups
+        of two digits giving the order of registration. The Anexo II drawings
+        render it on two rows, as "4-ETZ" over "12-30". `recall-only` because
+        the width of the leading order number is not fixed by the instrument and
+        because the three-letter municipal codes are NOT enumerated anywhere in
+        it — the mechanism is statutory, the table is not, so no decode file was
+        built and none was reconstructed from elsewhere.
+    design:
+      plate: { note: "Modelo 1 (ciclomotores) and Modelo 2 (motociclos até 50 cm3) of Anexo II to DL 106/2006, both drawn as two-row plates" }
+      dimension_basis: statutory-drawing
+      background: { color: "#F9B700", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      variant_colour_note: >-
+        TWO GROUNDS, ONE FORMAT, split by engine size — art. 2.º n.º 1 d):
+        ciclomotores get a YELLOW ground and motociclos up to 50 cm3 a WHITE
+        one, with black letters, digits, dashes and border on both. The yellow
+        is recorded as the entry's background because ciclomotores are the
+        dominant population; the white variant is a colour-only difference on
+        the same format and period, hence a note per PRD-PLATES §2.3 rather than
+        a second series.
+    region_encoding: "câmara municipal — three-letter codes not enumerated by the instrument; no decode table authored"
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2006/06/111a00/40524060.pdf  # DL 106/2006 art. 2.º n.º 1 a)-e) and ANEXO II Modelos 1-2: the transitional municipal moped number, its two grounds, the retroreflectivity requirement, and the rule that the number survives the owner's move to another concelho. Accessed 2026-08-02"
+    notes: >-
+      THE TRANSITIONAL MUNICIPAL MOPED SERIES — issued by câmaras municipais
+      while the national moped register was being stood up. `ended: true` with
+      `year_end_min: 2006` rather than a hard end, which is the schema's
+      known-over-undated shape: the scheme was expressly transitional and is
+      certainly closed, but no instrument closing it was reached, so the dataset
+      states that it ended without asserting when. Worth keeping for a parse API
+      because these plates are still on the road and nothing else in the
+      Portuguese system looks remotely like them. One human detail preserved
+      from the instrument, because it explains why the codes cannot be treated
+      as a live geography: art. 2.º n.º 1 b) freezes the number when the owner
+      moves to another municipality or sells to someone in one — so the
+      municipal code records where the moped was FIRST registered and may have
+      been wrong about its whereabouts for twenty years.
+
+  # =========================================================================
+  # INDUSTRIAL MACHINERY — where the enacted text and the enacted drawing
+  # disagree, and the disagreement is recorded rather than resolved.
+  # =========================================================================
+  - id: pt-machinery-2006
+    class: agricultural
+    categories: [machine, trailer]
+    period: { start: 2006 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99-LL-99 L"
+      regex: '\A(?:\d{2}-[A-Z]{2}-\d{2}|[A-Z]{2}[- ]\d{2}[- ][A-Z]{2})[- ][A-Z]\z'
+      charset:
+        notes: >-
+          Art. 3.º n.º 3 (added by DL 106/2006): the machinery number follows the
+          ordinary composition "sendo o número de matrícula seguido de uma letra
+          identificativa da classe de circulação definida nos termos do anexo II
+          do regulamento para atribuição de matrícula a máquinas industriais". So
+          the trailing letter is a CIRCULATION-CLASS code, and its value set
+          lives in a different regulation which was not reached — recorded gap,
+          and the reason there is no `regex_strict`. The drawings render it in
+          its own box at the right-hand end, separated by a gap rather than a
+          dash, which is why `pattern` spells that position with a space.
+    design:
+      plate: { note: "Modelos VIII (front/rear/side) and IX (rear/side) of Anexo IV; replaced by Modelos VII and VIII of Anexo V from the AA-00-AA cutover" }
+      dimension_basis: statutory-drawing
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      colour_conflict:
+        text_says: "fundo a vermelho e letras, algarismos, traços e rebordo periférico a preto — a RED ground with black characters (art. 5.º n.º 11)"
+        drawing_says: "the Anexo IV Modelo VIII and IX drawings label the plate ground BRANCO RETRORREFLECTOR and add VERMELHO RETRORREFLECTOR as a separate label, apparently for the right-hand class-letter box only"
+        recorded: >-
+          THE INSTRUMENT CONTRADICTS ITSELF and this dataset does not pick a
+          winner. Both readings are from the same Diário da República: the
+          enacting sentence in art. 5.º n.º 11 and the annexed drawing it
+          points at. `design.background` is recorded as WHITE because that is
+          what the drawing — the thing a manufacturer builds from — labels, with
+          the red confined to the class-letter field; the enacting sentence is
+          preserved verbatim here so a verifier can overturn that choice with one
+          look at a photograph. PRD-PLATES §5.3: record disagreements, never
+          average them.
+    region_encoding: none
+    sources:
+      - "https://files.diariodarepublica.pt/1s/2006/06/111a00/40524060.pdf  # DL 106/2006: art. 3.º n.º 3 (the class letter), art. 5.º n.º 11 (the red-ground sentence), ANEXO IV Modelos VIII-IX (the drawings that label the ground white), art. 2.º n.º 2 (conditional commencement: 'entram em vigor conjuntamente com a sua regulamentação'). Accessed 2026-08-02"
+      - "https://files.diariodarepublica.pt/1s/2020/01/00900/0000400012.pdf  # DL 2/2020 art. 5.º n.º 11 as amended: the same red-ground wording, models moved to Anexo V VII-VIII. Accessed 2026-08-02"
+    notes: >-
+      MÁQUINAS INDUSTRIAIS E MÁQUINAS INDUSTRIAIS REBOCÁVEIS. CLASS CAVEAT: the
+      controlled vocabulary has no works/industrial-machinery class, and
+      `agricultural` is the same compromise es-special-vehicles-1999 records for
+      the same reason — the statutory category is broader than farming. Flagged
+      as a vocabulary gap, and the second file in this dataset to flag it, which
+      is the point at which it becomes worth a vocabulary PR. Commencement is
+      conditional in the same way as the moped series ("entram em vigor
+      conjuntamente com a sua regulamentação"), hence `enabling-instrument`.
+
+  # =========================================================================
+  # STATE FLEETS — no primary reached. Authored from a secondary, tagged.
+  # =========================================================================
+  - id: pt-military
+    class: military
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2005 }
+    period_evidence: secondary-wikipedia
+    matching: recall-only
+    format:
+      pattern: "MG-99-99"
+      regex: '\A(?:MG|ME|MX|AM|AP)[- ]\d{2}[- ]\d{2}\z'
+      pattern_note: >-
+        `pattern` spells one branch of the prefix alternation (MG, the Army)
+        because the human-pattern DSL has no alternation and the lint
+        round-trips every pattern-generated serial against `regex`; the other
+        four prefixes are equally in `regex` and equally representative.
+        WHOLLY `secondary-wikipedia`. The Portuguese armed forces register
+        outside the Regulamento de Matrícula — DL 54/2005 art. 8.º n.º 2 shows
+        the civil registrar dealing with "entidades militares" as an external
+        applicant, and no Defence instrument was reached in this pass. Wikipedia
+        gives the branch prefixes as MG, ME and MX for the Army, AP for the Navy
+        and AM for the Air Force; it gives no digit grammar, so the two-by-two
+        digit shape here is this dataset's own conservative rendering and NOT a
+        claim. `recall-only`, and a match means only "this looks like a
+        Portuguese military prefix".
+    design:
+      note: "no colour, dimension or model is recorded — the Regulamento does not cover these plates and no Defence instrument was reached. Deliberately absent rather than guessed."
+    region_encoding: none
+    sources:
+      - "https://pt.wikipedia.org/wiki/Matr%C3%ADculas_de_autom%C3%B3veis_em_Portugal  # secondary-wikipedia: MG / ME / MX (Exército), AP (Marinha), AM (Força Aérea). Read 2026-08-02"
+      - "https://files.diariodarepublica.pt/1s/2005/03/044a00/18921897.pdf  # DL 54/2005 art. 8.º n.º 2 — the civil register treats military entities as external applicants for supplementary numbers, which is the primary evidence that a separate military register exists"
+    notes: >-
+      ARMED FORCES. The whole entry is a tagged secondary and it says so three
+      times, because the alternative was to omit a class every other L1
+      jurisdiction in this dataset carries. Period start 2005 is the DATASET's
+      observation window, not a claim about when military prefixes began — the
+      series is certainly far older. A verifier should treat every field here as
+      unconfirmed and start from the Ministério da Defesa Nacional's own
+      regulations, which are the missing primary.
+
+  - id: pt-police-gnr
+    class: police
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2005 }
+    period_evidence: secondary-wikipedia
+    matching: recall-only
+    format:
+      pattern: "GNR L-99"
+      regex: '\AGNR[- ][A-Z][- ]\d{2,4}\z'
+      pattern_note: >-
+        `secondary-wikipedia`: the Guarda Nacional Republicana is reported to
+        plate its vehicles as the letters GNR followed by a single letter and a
+        two-, three- or four-digit serial. No primary was reached. `recall-only`.
+    design:
+      note: "not recorded — no primary. See pt-military."
+    region_encoding: none
+    sources:
+      - "https://pt.wikipedia.org/wiki/Matr%C3%ADculas_de_autom%C3%B3veis_em_Portugal  # secondary-wikipedia: GNR plates as GNR + letter + 2-4 digits. Read 2026-08-02"
+    notes: >-
+      GUARDA NACIONAL REPUBLICANA. Same posture as pt-military: tagged
+      secondary, recall-only, design absent. Note what is NOT here — the PSP
+      (Polícia de Segurança Pública) and the municipal police forces, for which
+      no source of any tier was located. Their absence is a gap, not a claim
+      that they use ordinary plates.


### PR DESCRIPTION
L1 wave 2, the **Portugal + Luxembourg** slice. 28 series, 2 decode tables, lint exit 0.

Base commit: `4a0ac42` (main at claim time). Worktree only — no writes to any primary clone.

## Lint proof

```
$ ruby scripts/lint_plates.rb
plates lint: 69 files, 634 series
plates lint: matching recall-only=159 strict=475 | twins regex_statutory=57 regex_strict=176 | separators emitted "-"," " forgiving 18
plates lint: _art ledger 6058 rows (excluded=5355 open=410 site_only=293), 410 open assets verified
plates lint: OK
```
(67 files / 606 series before; +2 files, +28 series.)

## Portugal — the four windows, and where the instrument date is NOT the series date

The brief's core deliverable. All four windows come out of one primary that no
secondary source cites: the **Regulamento do Número e Chapa de Matrícula**, annexed to
**Decreto-Lei n.º 54/2005, de 3 de março** (DR I-A n.º 44, pp. 1892-1897), as amended by
**DL 106/2006** (pp. 4052-4060), **DL 112/2009**, **Lei 46/2010** and **DL 2/2020**
(DR 1.ª série n.º 9, pp. 4-12). Fetched from `files.diariodarepublica.pt` on 2026-08-02,
text *and* page images.

Art. 3.º n.º 2 enumerates the windows **in the statute**:

| window | boundary | how it is dated | `period_evidence` |
|---|---|---|---|
| `AA-00-00` | ends **29-02-1992** | enacted calendar date | `statutory-date-end-secondary-start` |
| `00-00-AA` | starts **01-03-1992** | enacted calendar date | `statutory-date-start-secondary-end` |
| `00-AA-00` | starts on exhaustion of the previous series | **not a date at all** | `secondary-first-issue` |
| `AA-00-AA` | starts on exhaustion of the previous series | **not a date at all** | `secondary-first-issue` |

**Three corrections that the instrument-date rule produced:**

1. **The 2020 series is not enabled by DL 2/2020.** It is enabled by DL 54/2005 art. 3.º
   n.º 3, which legislated `AA-00-AA` *fifteen years before it was needed*. DL 2/2020 only
   approved the models (a new Anexo V) and abolished the date strip. Every secondary that
   calls DL 2/2020 "the law that created the new plates" has the mechanism backwards.
2. **The folkloric date, caught.** pt.wikipedia dates the format change to *15 January
   2020* — that is DL 2/2020's own entry into force (art. 11.º, "no dia seguinte ao da sua
   publicação"), and it is wrong by seven weeks. en.wikipedia gives 3 March 2020, a
   first-issue date. Both were read, they disagree, and the disagreement is recorded on the
   series rather than averaged (PRD-PLATES §5.3).
3. **A two-month seam no secondary carries.** The NUMBER format changed on 01-03-1992 but
   the PLATE MODEL changed on 01-01-1992 (art. 5.º n.º 1 a)/b)) — so registrations made in
   January and February 1992 lawfully carry an **old-format `AA-00-00` number on a new
   white retroreflective plate**.

**The side label is modelled as a label, not a format.** The 1998-2020 yellow box carried
the year over the month of *first registration*, beside the serial and never inside it —
`date_strip:`, with DL 2/2020's own preamble explaining why it died (foreign enforcement
was reading Portugal's registration date as an *expiry* date).

**A self-contradicting instrument, recorded not resolved.** For máquinas industriais,
art. 5.º n.º 11 says *"fundo a vermelho"* while the Anexo IV Modelo VIII/IX drawing it
points at labels the ground `BRANCO RETRORREFLECTOR` with the red confined to the
class-letter box. Both readings are from the same Diário da República. `colour_conflict:`
carries both.

**The 2020 dashes are gone**, on two independent primary grounds: DL 2/2020 *deleted*
the "separados entre si por traços" clause when it rewrote the composition, and the Anexo V
drawing prescribes 10 mm / 20 mm spacing with no glyph. Flagged for the verifier — one
photograph settles it.

## Luxembourg — one instrument, end to end

**Règlement grand-ducal du 17 juin 2003** (Mémorial A n° 87, pp. 1622-1632), amended by the
**RGD du 18 octobre 2006** (Mémorial A n° 190, ch. III). Both fetched in full from Legilux;
both text-extractable, drawings included — so almost nothing in `lu.yml` is `observed` and
almost nothing is secondary.

`lu_snca` is a live register here, so two things are called out explicitly:

- **The moped join-breaker.** Four digits are allocated, **two are printed**: the Annexe
  says the leading two "n'étant toutefois pas repris sur la plaque". Anyone matching a
  printed moped plate against the register must left-pad, or the join silently fails.
- **`AB 1234` is not a current-series plate.** The 2006 amendment confines the current
  series to **4000-9999**; 0001-0099 is mopeds and 0100-3999 is personalised. A
  four-digit-low Luxembourg plate is a *personalised* number, and that is legally real.

Art. 12 dates the three historic design windows **to the day** — black/white before
01-01-1974, yellow from 01-01-1974, yellow + EC emblem from 01-01-1988 — so `lu-legacy-*`
are statute-dated, not folklore. Personalised plates are authored as a first-class class
with their statutory waiting list, transfer right, 36-month reservation and inheritance.

## Decode tables (both statutory annexes, both primary)

- **`plates/_decode/pt-trailer-services.yml`** — the 22 trailer issuing-service prefixes,
  in **two vintages**: DL 106/2006 silently re-lettered **Viseu from `VS` to `VI`**. Both
  readings were taken from the DR page images, both are on the road, and `regex_strict` on
  `pt-trailer` is the union. A "decode tables rot" case (PRD-PLATES §9) caught inside a
  fourteen-month window.
- **`plates/_decode/lu-series-order.yml`** — the 566 current-series letter pairs in
  statutory order, read column-major per the annex's own rule. **The transcription is
  checked arithmetically, not by eye**: 26×26 = 676, less 100 pairs containing I or O,
  less the ten named pairs = **566**, which is exactly the row count, with no duplicate, no
  I/O and no excluded pair. A dropped or miscopied cell could not satisfy all four at once.

## Recorded gaps (not guessed)

- The instruments that made the **1992** and **1998** Portuguese changes. DL 54/2005 names
  its casualties (Decreto Regulamentar n.º 13/98 arts. 1.º-3.º; Regulamento do Código da
  Estrada, Decreto n.º 39 987/1954, arts. 35.º and 37.º) but the amending texts were not
  reached — the DRE search UI is a SPA whose backend is not fetchable.
- The **1937** start and everything before it: `secondary-wikipedia`, no series authored.
- The Portuguese **avoid-list** of banned letter combinations — its *existence* and its
  cost are quantified in DL 2/2020's preamble ("74 anos" → "45 anos"); its members are
  unpublished. No `regex_strict` invented for the ordinary series.
- Portuguese **military / GNR**: no primary reached. Authored `recall-only` and tagged
  `secondary-wikipedia` in every field. PSP and municipal police: no source of any tier,
  and their absence is stated as a gap rather than implied to be ordinary plates.
- The Luxembourg **RGD of 21 December 1991** (named in the 2003 abrogation clause) — the
  Mémorial issue Legilux serves for that date does not contain it. The failed search is
  recorded in the file.
- Luxembourg **personalised-plate fee**: the 2003 figures (50 € / 24 €) are recorded and
  flagged stale; no amending instrument located. Not updated from a secondary.

## Provenance discipline

Primary claims are tagged `instrument-in-force` / `statutory-date` / `enabling-instrument` /
`transitional-provision` / `instrument-in-force-upper-bound`. Every Wikipedia-derived fact
carries **`secondary-wikipedia`** plus its article URL, and no Wikipedia-derived row claims
`instrument-in-force`. Facts are expressed in this dataset's own schema and wording; no
table arrangement is mirrored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
