### PR TITLE
plates: Poland (L1 wave 2) — 17 series + the 380-row powiat annex, all primary

### DIFF
--- a/plates/_decode/pl-powiats.yml
+++ b/plates/_decode/pl-powiats.yml
@@ -1,0 +1,567 @@
+# plates/_decode/pl-powiats.yml — the Polish voivodeship + powiat plate codes.
+#
+# THE SOURCE FINDING, and it is the Anlage-5d case rather than the German one:
+# THE POLISH CODE LIST IS INSIDE THE REGULATION. § 31 ust. 2 of the current
+# rozporządzenie, verbatim: "Wyróżniki województw i powiatów dla tablic
+# rejestracyjnych są określone w załączniku nr 13 do rozporządzenia." Załącznik
+# nr 13 is a closed, primary, 380-row table printed inside the instrument, so
+# every row below is authored from the instrument itself — no enthusiast list,
+# no encyclopedia table, no guesswork.
+#
+# WHICH INSTRUMENT, AND WHY IT IS NOT THE ONE MOST SOURCES CITE. The table is
+# consolidated here from three primaries, in force order:
+#   * BASE — rozporządzenie Ministra Infrastruktury z dnia 8 listopada 2024 r.
+#     w sprawie rejestracji i oznaczania pojazdów, wymagań dla tablic
+#     rejestracyjnych oraz wzorów innych dokumentów związanych z rejestracją
+#     pojazdów (Dz. U. 2024 poz. 1709), załącznik nr 13; in force 2024-11-30.
+#   * Dz. U. 2025 poz. 939 § 1 pkt 4 — three column-5 additions; 2025-07-30.
+#   * Dz. U. 2026 poz. 891 § 1 pkt 9 — three column-5 additions; 2026-07-04.
+# The widely-cited Dz. U. 2022 poz. 1847 is NOT the operative instrument: the
+# Sejm ELI register records it "uznany za uchylony" with repealDate 2024-11-30.
+# Its own annex was fetched and read in this pass as a control (its pages are
+# images, not text, in the ISAP PDF) and it differs from the 2024 table in real
+# rows — bydgoski gained BC, kielecki gained KC/KM/KP, ostródzki gained OT/OX,
+# Poznań gained X, Konin gained N, Kalisz gained A, and the tymczasowe column
+# gained the second-letter ranges (V0-V9, J0-J9, A0-A9, Y0-Y9, X0-X9, I0-I9,
+# M0-M9). Building on the repealed text would have shipped six-plus wrong rows.
+#
+# HOW THE PREFIX SPLITS, WHICH IS THE PARSE-CRITICAL FACT (see prefix_split).
+#
+# Referenced by: plates/pl.yml (pl-standard, pl-standard-preeu, pl-motorcycle,
+# pl-moped, pl-electric, pl-historic, pl-historic-moped, pl-professional) via
+# region_encoding.
+jurisdiction: pl
+topic: powiats
+authority:
+  name: "Rozporządzenie Ministra Infrastruktury z dnia 8 listopada 2024 r. w sprawie rejestracji i oznaczania pojazdów, wymagań dla tablic rejestracyjnych oraz wzorów innych dokumentów związanych z rejestracją pojazdów, załącznik nr 13 (do § 31 ust. 2)"
+  url: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709"
+sources:
+  - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # Dz. U. 2024 poz. 1709, załącznik nr 13 'WYRÓŻNIKI WOJEWÓDZTW I POWIATÓW DLA TABLIC REJESTRACYJNYCH', printed pages 79-88 — all 380 rows, all 16 voivodeship blocks, columns 4 (wyróżnik województwa), 5 (wyróżnik powiatu) and 6 (tymczasowe + indywidualne). § 31 ust. 2 is the delegation, § 31 ust. 3-5 the second-letter, merger and split rules. Accessed 2026-08-02"
+  - "https://api.sejm.gov.pl/eli/acts/DU/2025/939/text/O/D20250939.pdf  # Dz. U. 2025 poz. 939 § 1 pkt 4: 'w załączniku nr 13 do rozporządzenia w tabeli ... w kolumnie 5: a) w lp. 1 w wierszu dotyczącym powiatu wrocławskiego po literach WR dodaje się przecinek i litery WW, b) w lp. 3 ... powiatu lubelskiego po literach UB ... VB, c) w lp. 8 ... powiatu nyskiego po literach NY ... NX'; § 2 in force 14 days after publication (2025-07-15) = 2025-07-30. Accessed 2026-08-02"
+  - "https://api.sejm.gov.pl/eli/acts/DU/2026/891/text/O/D20260891.pdf  # Dz. U. 2026 poz. 891 § 1 pkt 9: column-5 additions for chełmiński (CE, CM), tarnogórski (TR, TN) and olsztyński (OZ, OP); in force 2026-07-04. Accessed 2026-08-02"
+  - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709  # the Sejm ELI register entry: status 'obowiązujący', entryIntoForce 2024-11-30, and the two amending acts above. This is also the record that shows Dz. U. 2022 poz. 1847 repealed on 2024-11-30. Accessed 2026-08-02"
+  - "https://api.sejm.gov.pl/eli/acts/DU/1999/632/text/O/D19990632.pdf  # Dz. U. 1999 nr 59 poz. 632 § 24 ('Ustala się dla tablic rejestracyjnych wyróżniki województw oraz wyróżniki powiatów, określone w załączniku nr 5') and § 49, which commences § 22-24 on 1 May 2000 — the date the voivodeship+powiat code system began. Accessed 2026-08-02"
+period: { start: 2000 }
+period_evidence: enacted-commencement
+period_note: >-
+  2000 is the commencement of the CODE SYSTEM these rows belong to, not of the
+  individual rows. § 49 of Dz. U. 1999 nr 59 poz. 632 reads, verbatim:
+  "Rozporządzenie wchodzi w życie z dniem 1 lipca 1999 r., z wyjątkiem § 16,
+  § 18 ust. 3-8, § 19, § 21 ust. 2, 4 i 5, § 22-24, § 29 i 30, które wchodzą
+  w życie z dniem 1 maja 2000 r." — § 24 is the wyróżniki annex and § 21 ust. 2
+  the serial grammar, so the voivodeship-first system began on 1 MAY 2000. Its
+  complement is in § 41 of the same instrument ("Do dnia 30 kwietnia 2000 r.
+  organ rejestrujący wydaje tablice rejestracyjne spełniające warunki określone
+  w § 39") and in § 39 ust. 2, which let stock bearing the pre-reform voivodeship
+  codes be issued "jednak nie dłużej niż do dnia 30 kwietnia 2000 r." Individual
+  rows are younger than 2000 — karkonoski replaced jeleniogórski, and the
+  multi-code rows below accumulated as pools ran out — and PER-ROW PERIODS ARE A
+  RECORDED GAP: the annex prints no dates and this pass did not diff every
+  amendment between 2000 and 2024.
+consolidated_as_of: "2026-08-02"
+
+# ---------------------------------------------------------------------------
+# THE PREFIX SPLIT — the single most parse-critical fact in this file, and it
+# is DERIVED FROM THE GRAMMAR, not from folklore.
+# ---------------------------------------------------------------------------
+prefix_split:
+  rule: >-
+    A Polish registration number begins with a wyróżnik województwa of ONE
+    letter followed by a wyróżnik powiatu of ONE OR TWO letters, so the prefix
+    is two or three characters and is NOT self-delimiting. For the ordinary
+    CAR series the boundary is nevertheless deterministic, and the reason is in
+    § 30 ust. 2 pkt 1 of the rozporządzenie: every one of the five vehicle
+    wyróżnik layouts available to a one-letter powiat (99999, 9999L, 999LL,
+    9L999, 9LL99) BEGINS WITH A DIGIT. Therefore, on a car plate, if the THIRD
+    character is a letter the prefix is three characters; if it is a digit the
+    prefix is two. Take the longest matching prefix from `codes` below and this
+    rule will agree with it.
+  worked_example: >-
+    Podlaskie is the case that looks dangerous and is not. Białystok is B + I,
+    so its prefix is the two-character "BI"; białostocki is B + IA and B + IB, so
+    its prefixes are the three-character "BIA" and "BIB". The string "BIA12345"
+    could in principle be BI + "A12345" or BIA + "12345". It is not ambiguous:
+    "A12345" is six characters and every one-letter-powiat car layout is five, so
+    only BIA + "12345" parses, and the third-character rule reaches the same
+    answer without counting. This pass checked the property MECHANICALLY across
+    all 689 prefixes and all five one-letter-powiat car layouts — zero
+    ambiguities.
+  motorcycle_caveat: >-
+    THE RULE DOES NOT HOLD FOR MOTORCYCLE AND MOPED PLATES. § 30 ust. 2 pkt 3
+    lit. a gives one-letter powiats the layouts "litera i trzy cyfry" and "dwie
+    litery i dwie cyfry", which DO begin with a letter. There the boundary is
+    resolved by LENGTH instead: a motorcycle vehicle wyróżnik is always four
+    characters, so a six-character string has a two-character prefix and a
+    seven-character string a three-character one. A consumer that does not know
+    the plate SIZE must carry both readings.
+  letters_never_a_voivodeship:
+    letters: ["H", "U"]
+    note: >-
+      The 25-letter alphabet of § 30 ust. 1 is A-Z without Q. Twenty-three of
+      those letters appear in column 4 of the annex as a wyróżnik województwa;
+      exactly TWO never do — H and U — and that is not a coincidence. H is the
+      reserved base of the six service prefixes (HB, HP, HK, HA, HW, HC:
+      § 5 ust. 3 rozporządzenia MSWiA, Dz. U. 2025 poz. 1326) and U is the
+      armed-forces wyróżnik (§ 6 ust. 3 pkt 1 rozporządzenia MON, Dz. U. 2023
+      poz. 1776, "wyróżnika Sił Zbrojnych, którym jest wielka litera U
+      umieszczana jako pierwsza"). A leading H or U therefore means the plate is
+      NOT a civil registration and must not be routed through this table.
+  second_letter_rule: >-
+    § 31 ust. 3: where the annex gives a voivodeship TWO letters, "numery
+    rejestracyjne z wykorzystaniem drugiej litery są tworzone po wyczerpaniu się
+    możliwości utworzenia numerów rejestracyjnych ... z wykorzystaniem pierwszej
+    litery" — the second letter is an overflow pool, not a parallel one, so the
+    V/J/A/Y/X/I/M prefixes are rarer on the road than their D/K/W/R/G/S/P twins
+    even though both are equally lawful. Dz. U. 2025 poz. 939 § 1 pkt 3 added
+    the one exception: the buyer of an INDIVIDUAL plate may choose which of the
+    two voivodeship letters their number is built from.
+  merger_and_split_rule: >-
+    § 31 ust. 4-5: when powiats MERGE, "na tablicach rejestracyjnych stosuje się
+    dotychczasowe wyróżniki tych powiatów" — both old codes stay in service; when
+    a powiat is SPLIT, the successor authorities keep using the existing code
+    until new ones are set, having agreed how to divide the unused pool. Codes
+    therefore outlive the units that earned them, and a code withdrawn from the
+    annex still sits on the road because a Polish plate is only exchanged on
+    re-registration (art. 73 ust. 1a Prawa o ruchu drogowym expressly lets the
+    buyer KEEP it). WITHDRAWN CODES ARE NOT IN THIS TABLE AND ARE A RECORDED GAP:
+    a prefix absent here must be treated as unresolved, never as invalid.
+
+# ---------------------------------------------------------------------------
+# The 16 voivodeships: column 4 (wyróżnik województwa, used on tablice
+# zwyczajne, zabytkowe and dyplomatyczne) and column 6 (the letter+digit
+# wyróżnik used on tablice tymczasowe and indywidualne).
+# ---------------------------------------------------------------------------
+voivodeships:
+  - { lp: 1,  name: dolnośląskie,        letters: ["D", "V"], temporary_individual: "D0-D9, V0-V9" }
+  - { lp: 2,  name: kujawsko-pomorskie,  letters: ["C"],    temporary_individual: "C0-C9" }
+  - { lp: 3,  name: lubelskie,           letters: ["L"],    temporary_individual: "L0-L9" }
+  - { lp: 4,  name: lubuskie,            letters: ["F"],    temporary_individual: "F0-F9" }
+  - { lp: 5,  name: łódzkie,             letters: ["E"],    temporary_individual: "E0-E9" }
+  - { lp: 6,  name: małopolskie,         letters: ["K", "J"], temporary_individual: "K0-K9, J0-J9" }
+  - { lp: 7,  name: mazowieckie,         letters: ["W", "A"], temporary_individual: "W0-W9, A0-A9" }
+  - { lp: 8,  name: opolskie,            letters: ["O"],    temporary_individual: "O0-O9" }
+  - { lp: 9,  name: podkarpackie,        letters: ["R", "Y"], temporary_individual: "R0-R9, Y0-Y9" }
+  - { lp: 10, name: podlaskie,           letters: ["B"],    temporary_individual: "B0-B9" }
+  - { lp: 11, name: pomorskie,           letters: ["G", "X"], temporary_individual: "G0-G9, X0-X9" }
+  - { lp: 12, name: śląskie,             letters: ["S", "I"], temporary_individual: "S0-S9, I0-I9" }
+  - { lp: 13, name: świętokrzyskie,      letters: ["T"],    temporary_individual: "T0-T9" }
+  - { lp: 14, name: warmińsko-mazurskie, letters: ["N"],    temporary_individual: "N0-N9" }
+  - { lp: 15, name: wielkopolskie,       letters: ["P", "M"], temporary_individual: "P0-P9, M0-M9" }
+  - { lp: 16, name: zachodniopomorskie,  letters: ["Z"],    temporary_individual: "Z0-Z9" }
+
+counts:
+  rows: 380
+  one_letter_powiat_codes: 92
+  two_letter_powiat_codes: 345
+  rows_with_more_than_one_code: 31
+  distinct_prefixes: 689
+counts_note: >-
+  380 rows = Poland's 314 powiats plus its 66 miasta na prawach powiatu, which
+  is the complete set; the annex has no residual or "other" row. `prefixes` on
+  each row is DERIVED, not quoted: it is the cross product of the voivodeship
+  letters with that row's powiat codes, recorded because a parse API needs the
+  concrete strings and the annex prints only the two columns. All 689 are
+  distinct — checked mechanically — so a prefix never decodes to two powiats.
+
+# ---------------------------------------------------------------------------
+# ZAŁĄCZNIK NR 13 — the 380 rows, in the annex's own order (by voivodeship Lp.,
+# then as the annex prints them: miasta na prawach powiatu first, then powiats).
+# `powiat_codes` is column 5 verbatim; `prefixes` is derived (see counts_note).
+# ---------------------------------------------------------------------------
+codes:
+  # 1. DOLNOŚLĄSKIE — wyróżnik województwa D, V | tymczasowe + indywidualne D0-D9, V0-V9
+  - { powiat: Jelenia Góra, voivodeship: dolnośląskie, powiat_codes: ["J"], prefixes: ["DJ", "VJ"], powiat_code_length: 1 }
+  - { powiat: Legnica, voivodeship: dolnośląskie, powiat_codes: ["L"], prefixes: ["DL", "VL"], powiat_code_length: 1 }
+  - { powiat: Wałbrzych, voivodeship: dolnośląskie, powiat_codes: ["B"], prefixes: ["DB", "VB"], powiat_code_length: 1 }
+  - { powiat: Wrocław, voivodeship: dolnośląskie, powiat_codes: ["W", "X"], prefixes: ["DW", "DX", "VW", "VX"], powiat_code_length: 1 }
+  - { powiat: bolesławiecki, voivodeship: dolnośląskie, powiat_codes: ["BL"], prefixes: ["DBL", "VBL"], powiat_code_length: 2 }
+  - { powiat: dzierżoniowski, voivodeship: dolnośląskie, powiat_codes: ["DZ"], prefixes: ["DDZ", "VDZ"], powiat_code_length: 2 }
+  - { powiat: głogowski, voivodeship: dolnośląskie, powiat_codes: ["GL"], prefixes: ["DGL", "VGL"], powiat_code_length: 2 }
+  - { powiat: górowski, voivodeship: dolnośląskie, powiat_codes: ["GR"], prefixes: ["DGR", "VGR"], powiat_code_length: 2 }
+  - { powiat: jaworski, voivodeship: dolnośląskie, powiat_codes: ["JA"], prefixes: ["DJA", "VJA"], powiat_code_length: 2 }
+  - { powiat: karkonoski, voivodeship: dolnośląskie, powiat_codes: ["JE"], prefixes: ["DJE", "VJE"], powiat_code_length: 2 }
+  - { powiat: kamiennogórski, voivodeship: dolnośląskie, powiat_codes: ["KA"], prefixes: ["DKA", "VKA"], powiat_code_length: 2 }
+  - { powiat: kłodzki, voivodeship: dolnośląskie, powiat_codes: ["KL"], prefixes: ["DKL", "VKL"], powiat_code_length: 2 }
+  - { powiat: legnicki, voivodeship: dolnośląskie, powiat_codes: ["LE"], prefixes: ["DLE", "VLE"], powiat_code_length: 2 }
+  - { powiat: lubański, voivodeship: dolnośląskie, powiat_codes: ["LB"], prefixes: ["DLB", "VLB"], powiat_code_length: 2 }
+  - { powiat: lubiński, voivodeship: dolnośląskie, powiat_codes: ["LU"], prefixes: ["DLU", "VLU"], powiat_code_length: 2 }
+  - { powiat: lwówecki, voivodeship: dolnośląskie, powiat_codes: ["LW"], prefixes: ["DLW", "VLW"], powiat_code_length: 2 }
+  - { powiat: milicki, voivodeship: dolnośląskie, powiat_codes: ["MI"], prefixes: ["DMI", "VMI"], powiat_code_length: 2 }
+  - { powiat: oleśnicki, voivodeship: dolnośląskie, powiat_codes: ["OL"], prefixes: ["DOL", "VOL"], powiat_code_length: 2 }
+  - { powiat: oławski, voivodeship: dolnośląskie, powiat_codes: ["OA"], prefixes: ["DOA", "VOA"], powiat_code_length: 2 }
+  - { powiat: polkowicki, voivodeship: dolnośląskie, powiat_codes: ["PL"], prefixes: ["DPL", "VPL"], powiat_code_length: 2 }
+  - { powiat: strzeliński, voivodeship: dolnośląskie, powiat_codes: ["ST"], prefixes: ["DST", "VST"], powiat_code_length: 2 }
+  - { powiat: średzki, voivodeship: dolnośląskie, powiat_codes: ["SR"], prefixes: ["DSR", "VSR"], powiat_code_length: 2 }
+  - { powiat: świdnicki, voivodeship: dolnośląskie, powiat_codes: ["SW"], prefixes: ["DSW", "VSW"], powiat_code_length: 2 }
+  - { powiat: trzebnicki, voivodeship: dolnośląskie, powiat_codes: ["TR"], prefixes: ["DTR", "VTR"], powiat_code_length: 2 }
+  - { powiat: wałbrzyski, voivodeship: dolnośląskie, powiat_codes: ["BA"], prefixes: ["DBA", "VBA"], powiat_code_length: 2 }
+  - { powiat: wołowski, voivodeship: dolnośląskie, powiat_codes: ["WL"], prefixes: ["DWL", "VWL"], powiat_code_length: 2 }
+  - { powiat: wrocławski, voivodeship: dolnośląskie, powiat_codes: ["WR", "WW"], prefixes: ["DWR", "DWW", "VWR", "VWW"], powiat_code_length: 2, amended: "Dz.U. 2025 poz. 939 § 1 pkt 4 lit. a (in force 2025-07-30)" }
+  - { powiat: ząbkowicki, voivodeship: dolnośląskie, powiat_codes: ["ZA"], prefixes: ["DZA", "VZA"], powiat_code_length: 2 }
+  - { powiat: zgorzelecki, voivodeship: dolnośląskie, powiat_codes: ["ZG"], prefixes: ["DZG", "VZG"], powiat_code_length: 2 }
+  - { powiat: złotoryjski, voivodeship: dolnośląskie, powiat_codes: ["ZL"], prefixes: ["DZL", "VZL"], powiat_code_length: 2 }
+  # 2. KUJAWSKO-POMORSKIE — wyróżnik województwa C | tymczasowe + indywidualne C0-C9
+  - { powiat: Bydgoszcz, voivodeship: kujawsko-pomorskie, powiat_codes: ["B"], prefixes: ["CB"], powiat_code_length: 1 }
+  - { powiat: Grudziądz, voivodeship: kujawsko-pomorskie, powiat_codes: ["G"], prefixes: ["CG"], powiat_code_length: 1 }
+  - { powiat: Toruń, voivodeship: kujawsko-pomorskie, powiat_codes: ["T"], prefixes: ["CT"], powiat_code_length: 1 }
+  - { powiat: Włocławek, voivodeship: kujawsko-pomorskie, powiat_codes: ["W"], prefixes: ["CW"], powiat_code_length: 1 }
+  - { powiat: aleksandrowski, voivodeship: kujawsko-pomorskie, powiat_codes: ["AL"], prefixes: ["CAL"], powiat_code_length: 2 }
+  - { powiat: brodnicki, voivodeship: kujawsko-pomorskie, powiat_codes: ["BR"], prefixes: ["CBR"], powiat_code_length: 2 }
+  - { powiat: bydgoski, voivodeship: kujawsko-pomorskie, powiat_codes: ["BY", "BC"], prefixes: ["CBC", "CBY"], powiat_code_length: 2 }
+  - { powiat: chełmiński, voivodeship: kujawsko-pomorskie, powiat_codes: ["CH", "CE", "CM"], prefixes: ["CCE", "CCH", "CCM"], powiat_code_length: 2, amended: "Dz.U. 2026 poz. 891 § 1 pkt 9 lit. a (in force 2026-07-04)" }
+  - { powiat: golubsko-dobrzyński, voivodeship: kujawsko-pomorskie, powiat_codes: ["GD"], prefixes: ["CGD"], powiat_code_length: 2 }
+  - { powiat: grudziądzki, voivodeship: kujawsko-pomorskie, powiat_codes: ["GR"], prefixes: ["CGR"], powiat_code_length: 2 }
+  - { powiat: inowrocławski, voivodeship: kujawsko-pomorskie, powiat_codes: ["IN"], prefixes: ["CIN"], powiat_code_length: 2 }
+  - { powiat: lipnowski, voivodeship: kujawsko-pomorskie, powiat_codes: ["LI"], prefixes: ["CLI"], powiat_code_length: 2 }
+  - { powiat: mogileński, voivodeship: kujawsko-pomorskie, powiat_codes: ["MG"], prefixes: ["CMG"], powiat_code_length: 2 }
+  - { powiat: nakielski, voivodeship: kujawsko-pomorskie, powiat_codes: ["NA"], prefixes: ["CNA"], powiat_code_length: 2 }
+  - { powiat: radziejowski, voivodeship: kujawsko-pomorskie, powiat_codes: ["RA"], prefixes: ["CRA"], powiat_code_length: 2 }
+  - { powiat: rypiński, voivodeship: kujawsko-pomorskie, powiat_codes: ["RY"], prefixes: ["CRY"], powiat_code_length: 2 }
+  - { powiat: sępoleński, voivodeship: kujawsko-pomorskie, powiat_codes: ["SE"], prefixes: ["CSE"], powiat_code_length: 2 }
+  - { powiat: świecki, voivodeship: kujawsko-pomorskie, powiat_codes: ["SW"], prefixes: ["CSW"], powiat_code_length: 2 }
+  - { powiat: toruński, voivodeship: kujawsko-pomorskie, powiat_codes: ["TR"], prefixes: ["CTR"], powiat_code_length: 2 }
+  - { powiat: tucholski, voivodeship: kujawsko-pomorskie, powiat_codes: ["TU"], prefixes: ["CTU"], powiat_code_length: 2 }
+  - { powiat: wąbrzeski, voivodeship: kujawsko-pomorskie, powiat_codes: ["WA"], prefixes: ["CWA"], powiat_code_length: 2 }
+  - { powiat: włocławski, voivodeship: kujawsko-pomorskie, powiat_codes: ["WL"], prefixes: ["CWL"], powiat_code_length: 2 }
+  - { powiat: żniński, voivodeship: kujawsko-pomorskie, powiat_codes: ["ZN"], prefixes: ["CZN"], powiat_code_length: 2 }
+  # 3. LUBELSKIE — wyróżnik województwa L | tymczasowe + indywidualne L0-L9
+  - { powiat: Biała Podlaska, voivodeship: lubelskie, powiat_codes: ["B"], prefixes: ["LB"], powiat_code_length: 1 }
+  - { powiat: Chełm, voivodeship: lubelskie, powiat_codes: ["C"], prefixes: ["LC"], powiat_code_length: 1 }
+  - { powiat: Lublin, voivodeship: lubelskie, powiat_codes: ["U"], prefixes: ["LU"], powiat_code_length: 1 }
+  - { powiat: Zamość, voivodeship: lubelskie, powiat_codes: ["Z"], prefixes: ["LZ"], powiat_code_length: 1 }
+  - { powiat: bialski, voivodeship: lubelskie, powiat_codes: ["BI"], prefixes: ["LBI"], powiat_code_length: 2 }
+  - { powiat: biłgorajski, voivodeship: lubelskie, powiat_codes: ["BL"], prefixes: ["LBL"], powiat_code_length: 2 }
+  - { powiat: chełmski, voivodeship: lubelskie, powiat_codes: ["CH"], prefixes: ["LCH"], powiat_code_length: 2 }
+  - { powiat: hrubieszowski, voivodeship: lubelskie, powiat_codes: ["HR"], prefixes: ["LHR"], powiat_code_length: 2 }
+  - { powiat: janowski, voivodeship: lubelskie, powiat_codes: ["JA"], prefixes: ["LJA"], powiat_code_length: 2 }
+  - { powiat: krasnostawski, voivodeship: lubelskie, powiat_codes: ["KS"], prefixes: ["LKS"], powiat_code_length: 2 }
+  - { powiat: kraśnicki, voivodeship: lubelskie, powiat_codes: ["KR"], prefixes: ["LKR"], powiat_code_length: 2 }
+  - { powiat: lubartowski, voivodeship: lubelskie, powiat_codes: ["LB"], prefixes: ["LLB"], powiat_code_length: 2 }
+  - { powiat: lubelski, voivodeship: lubelskie, powiat_codes: ["UB", "VB"], prefixes: ["LUB", "LVB"], powiat_code_length: 2, amended: "Dz.U. 2025 poz. 939 § 1 pkt 4 lit. b (in force 2025-07-30)" }
+  - { powiat: łęczyński, voivodeship: lubelskie, powiat_codes: ["LE"], prefixes: ["LLE"], powiat_code_length: 2 }
+  - { powiat: łukowski, voivodeship: lubelskie, powiat_codes: ["LU"], prefixes: ["LLU"], powiat_code_length: 2 }
+  - { powiat: opolski, voivodeship: lubelskie, powiat_codes: ["OP"], prefixes: ["LOP"], powiat_code_length: 2 }
+  - { powiat: parczewski, voivodeship: lubelskie, powiat_codes: ["PA"], prefixes: ["LPA"], powiat_code_length: 2 }
+  - { powiat: puławski, voivodeship: lubelskie, powiat_codes: ["PU"], prefixes: ["LPU"], powiat_code_length: 2 }
+  - { powiat: radzyński, voivodeship: lubelskie, powiat_codes: ["RA"], prefixes: ["LRA"], powiat_code_length: 2 }
+  - { powiat: rycki, voivodeship: lubelskie, powiat_codes: ["RY"], prefixes: ["LRY"], powiat_code_length: 2 }
+  - { powiat: świdnicki, voivodeship: lubelskie, powiat_codes: ["SW"], prefixes: ["LSW"], powiat_code_length: 2 }
+  - { powiat: tomaszowski, voivodeship: lubelskie, powiat_codes: ["TM"], prefixes: ["LTM"], powiat_code_length: 2 }
+  - { powiat: włodawski, voivodeship: lubelskie, powiat_codes: ["WL"], prefixes: ["LWL"], powiat_code_length: 2 }
+  - { powiat: zamojski, voivodeship: lubelskie, powiat_codes: ["ZA"], prefixes: ["LZA"], powiat_code_length: 2 }
+  # 4. LUBUSKIE — wyróżnik województwa F | tymczasowe + indywidualne F0-F9
+  - { powiat: Gorzów Wielkopolski, voivodeship: lubuskie, powiat_codes: ["G"], prefixes: ["FG"], powiat_code_length: 1 }
+  - { powiat: Zielona Góra, voivodeship: lubuskie, powiat_codes: ["Z"], prefixes: ["FZ"], powiat_code_length: 1 }
+  - { powiat: gorzowski, voivodeship: lubuskie, powiat_codes: ["GW"], prefixes: ["FGW"], powiat_code_length: 2 }
+  - { powiat: krośnieński, voivodeship: lubuskie, powiat_codes: ["KR"], prefixes: ["FKR"], powiat_code_length: 2 }
+  - { powiat: międzyrzecki, voivodeship: lubuskie, powiat_codes: ["MI"], prefixes: ["FMI"], powiat_code_length: 2 }
+  - { powiat: nowosolski, voivodeship: lubuskie, powiat_codes: ["NW"], prefixes: ["FNW"], powiat_code_length: 2 }
+  - { powiat: słubicki, voivodeship: lubuskie, powiat_codes: ["SL"], prefixes: ["FSL"], powiat_code_length: 2 }
+  - { powiat: strzelecko-drezdenecki, voivodeship: lubuskie, powiat_codes: ["SD"], prefixes: ["FSD"], powiat_code_length: 2 }
+  - { powiat: sulęciński, voivodeship: lubuskie, powiat_codes: ["SU"], prefixes: ["FSU"], powiat_code_length: 2 }
+  - { powiat: świebodziński, voivodeship: lubuskie, powiat_codes: ["SW"], prefixes: ["FSW"], powiat_code_length: 2 }
+  - { powiat: wschowski, voivodeship: lubuskie, powiat_codes: ["WS"], prefixes: ["FWS"], powiat_code_length: 2 }
+  - { powiat: zielonogórski, voivodeship: lubuskie, powiat_codes: ["ZI"], prefixes: ["FZI"], powiat_code_length: 2 }
+  - { powiat: żagański, voivodeship: lubuskie, powiat_codes: ["ZG"], prefixes: ["FZG"], powiat_code_length: 2 }
+  - { powiat: żarski, voivodeship: lubuskie, powiat_codes: ["ZA"], prefixes: ["FZA"], powiat_code_length: 2 }
+  # 5. ŁÓDZKIE — wyróżnik województwa E | tymczasowe + indywidualne E0-E9
+  - { powiat: Łódź, voivodeship: łódzkie, powiat_codes: ["L", "D"], prefixes: ["ED", "EL"], powiat_code_length: 1 }
+  - { powiat: Piotrków Trybunalski, voivodeship: łódzkie, powiat_codes: ["P"], prefixes: ["EP"], powiat_code_length: 1 }
+  - { powiat: Skierniewice, voivodeship: łódzkie, powiat_codes: ["S"], prefixes: ["ES"], powiat_code_length: 1 }
+  - { powiat: brzeziński, voivodeship: łódzkie, powiat_codes: ["BR"], prefixes: ["EBR"], powiat_code_length: 2 }
+  - { powiat: bełchatowski, voivodeship: łódzkie, powiat_codes: ["BE"], prefixes: ["EBE"], powiat_code_length: 2 }
+  - { powiat: kutnowski, voivodeship: łódzkie, powiat_codes: ["KU"], prefixes: ["EKU"], powiat_code_length: 2 }
+  - { powiat: łaski, voivodeship: łódzkie, powiat_codes: ["LA"], prefixes: ["ELA"], powiat_code_length: 2 }
+  - { powiat: łęczycki, voivodeship: łódzkie, powiat_codes: ["LE"], prefixes: ["ELE"], powiat_code_length: 2 }
+  - { powiat: łowicki, voivodeship: łódzkie, powiat_codes: ["LC"], prefixes: ["ELC"], powiat_code_length: 2 }
+  - { powiat: łódzki wschodni, voivodeship: łódzkie, powiat_codes: ["LW"], prefixes: ["ELW"], powiat_code_length: 2 }
+  - { powiat: opoczyński, voivodeship: łódzkie, powiat_codes: ["OP"], prefixes: ["EOP"], powiat_code_length: 2 }
+  - { powiat: pabianicki, voivodeship: łódzkie, powiat_codes: ["PA"], prefixes: ["EPA"], powiat_code_length: 2 }
+  - { powiat: pajęczański, voivodeship: łódzkie, powiat_codes: ["PJ"], prefixes: ["EPJ"], powiat_code_length: 2 }
+  - { powiat: piotrkowski, voivodeship: łódzkie, powiat_codes: ["PI"], prefixes: ["EPI"], powiat_code_length: 2 }
+  - { powiat: poddębicki, voivodeship: łódzkie, powiat_codes: ["PD"], prefixes: ["EPD"], powiat_code_length: 2 }
+  - { powiat: radomszczański, voivodeship: łódzkie, powiat_codes: ["RA"], prefixes: ["ERA"], powiat_code_length: 2 }
+  - { powiat: rawski, voivodeship: łódzkie, powiat_codes: ["RW"], prefixes: ["ERW"], powiat_code_length: 2 }
+  - { powiat: sieradzki, voivodeship: łódzkie, powiat_codes: ["SI"], prefixes: ["ESI"], powiat_code_length: 2 }
+  - { powiat: skierniewicki, voivodeship: łódzkie, powiat_codes: ["SK"], prefixes: ["ESK"], powiat_code_length: 2 }
+  - { powiat: tomaszowski, voivodeship: łódzkie, powiat_codes: ["TM"], prefixes: ["ETM"], powiat_code_length: 2 }
+  - { powiat: wieluński, voivodeship: łódzkie, powiat_codes: ["WI"], prefixes: ["EWI"], powiat_code_length: 2 }
+  - { powiat: wieruszowski, voivodeship: łódzkie, powiat_codes: ["WE"], prefixes: ["EWE"], powiat_code_length: 2 }
+  - { powiat: zduńskowolski, voivodeship: łódzkie, powiat_codes: ["ZD"], prefixes: ["EZD"], powiat_code_length: 2 }
+  - { powiat: zgierski, voivodeship: łódzkie, powiat_codes: ["ZG"], prefixes: ["EZG"], powiat_code_length: 2 }
+  # 6. MAŁOPOLSKIE — wyróżnik województwa K, J | tymczasowe + indywidualne K0-K9, J0-J9
+  - { powiat: Kraków, voivodeship: małopolskie, powiat_codes: ["R", "K"], prefixes: ["JK", "JR", "KK", "KR"], powiat_code_length: 1 }
+  - { powiat: Nowy Sącz, voivodeship: małopolskie, powiat_codes: ["N"], prefixes: ["JN", "KN"], powiat_code_length: 1 }
+  - { powiat: Tarnów, voivodeship: małopolskie, powiat_codes: ["T"], prefixes: ["JT", "KT"], powiat_code_length: 1 }
+  - { powiat: bocheński, voivodeship: małopolskie, powiat_codes: ["BC", "BA"], prefixes: ["JBA", "JBC", "KBA", "KBC"], powiat_code_length: 2 }
+  - { powiat: brzeski, voivodeship: małopolskie, powiat_codes: ["BR"], prefixes: ["JBR", "KBR"], powiat_code_length: 2 }
+  - { powiat: chrzanowski, voivodeship: małopolskie, powiat_codes: ["CH"], prefixes: ["JCH", "KCH"], powiat_code_length: 2 }
+  - { powiat: dąbrowski, voivodeship: małopolskie, powiat_codes: ["DA"], prefixes: ["JDA", "KDA"], powiat_code_length: 2 }
+  - { powiat: gorlicki, voivodeship: małopolskie, powiat_codes: ["GR"], prefixes: ["JGR", "KGR"], powiat_code_length: 2 }
+  - { powiat: krakowski, voivodeship: małopolskie, powiat_codes: ["RA", "RK"], prefixes: ["JRA", "JRK", "KRA", "KRK"], powiat_code_length: 2 }
+  - { powiat: limanowski, voivodeship: małopolskie, powiat_codes: ["LI"], prefixes: ["JLI", "KLI"], powiat_code_length: 2 }
+  - { powiat: miechowski, voivodeship: małopolskie, powiat_codes: ["MI"], prefixes: ["JMI", "KMI"], powiat_code_length: 2 }
+  - { powiat: myślenicki, voivodeship: małopolskie, powiat_codes: ["MY"], prefixes: ["JMY", "KMY"], powiat_code_length: 2 }
+  - { powiat: nowosądecki, voivodeship: małopolskie, powiat_codes: ["NS"], prefixes: ["JNS", "KNS"], powiat_code_length: 2 }
+  - { powiat: nowotarski, voivodeship: małopolskie, powiat_codes: ["NT"], prefixes: ["JNT", "KNT"], powiat_code_length: 2 }
+  - { powiat: olkuski, voivodeship: małopolskie, powiat_codes: ["OL"], prefixes: ["JOL", "KOL"], powiat_code_length: 2 }
+  - { powiat: oświęcimski, voivodeship: małopolskie, powiat_codes: ["OS"], prefixes: ["JOS", "KOS"], powiat_code_length: 2 }
+  - { powiat: proszowicki, voivodeship: małopolskie, powiat_codes: ["PR"], prefixes: ["JPR", "KPR"], powiat_code_length: 2 }
+  - { powiat: suski, voivodeship: małopolskie, powiat_codes: ["SU"], prefixes: ["JSU", "KSU"], powiat_code_length: 2 }
+  - { powiat: tarnowski, voivodeship: małopolskie, powiat_codes: ["TA"], prefixes: ["JTA", "KTA"], powiat_code_length: 2 }
+  - { powiat: tatrzański, voivodeship: małopolskie, powiat_codes: ["TT"], prefixes: ["JTT", "KTT"], powiat_code_length: 2 }
+  - { powiat: wadowicki, voivodeship: małopolskie, powiat_codes: ["WA"], prefixes: ["JWA", "KWA"], powiat_code_length: 2 }
+  - { powiat: wielicki, voivodeship: małopolskie, powiat_codes: ["WI"], prefixes: ["JWI", "KWI"], powiat_code_length: 2 }
+  # 7. MAZOWIECKIE — wyróżnik województwa W, A | tymczasowe + indywidualne W0-W9, A0-A9
+  - { powiat: Ostrołęka, voivodeship: mazowieckie, powiat_codes: ["O"], prefixes: ["AO", "WO"], powiat_code_length: 1 }
+  - { powiat: Płock, voivodeship: mazowieckie, powiat_codes: ["P"], prefixes: ["AP", "WP"], powiat_code_length: 1 }
+  - { powiat: Radom, voivodeship: mazowieckie, powiat_codes: ["R"], prefixes: ["AR", "WR"], powiat_code_length: 1 }
+  - { powiat: Siedlce, voivodeship: mazowieckie, powiat_codes: ["S"], prefixes: ["AS", "WS"], powiat_code_length: 1 }
+  - { powiat: białobrzeski, voivodeship: mazowieckie, powiat_codes: ["BR"], prefixes: ["ABR", "WBR"], powiat_code_length: 2 }
+  - { powiat: ciechanowski, voivodeship: mazowieckie, powiat_codes: ["CI"], prefixes: ["ACI", "WCI"], powiat_code_length: 2 }
+  - { powiat: garwoliński, voivodeship: mazowieckie, powiat_codes: ["G"], prefixes: ["AG", "WG"], powiat_code_length: 1 }
+  - { powiat: gostyniński, voivodeship: mazowieckie, powiat_codes: ["GS"], prefixes: ["AGS", "WGS"], powiat_code_length: 2 }
+  - { powiat: grodziski, voivodeship: mazowieckie, powiat_codes: ["GM"], prefixes: ["AGM", "WGM"], powiat_code_length: 2 }
+  - { powiat: grójecki, voivodeship: mazowieckie, powiat_codes: ["GR"], prefixes: ["AGR", "WGR"], powiat_code_length: 2 }
+  - { powiat: kozienicki, voivodeship: mazowieckie, powiat_codes: ["KZ"], prefixes: ["AKZ", "WKZ"], powiat_code_length: 2 }
+  - { powiat: legionowski, voivodeship: mazowieckie, powiat_codes: ["L"], prefixes: ["AL", "WL"], powiat_code_length: 1 }
+  - { powiat: lipski, voivodeship: mazowieckie, powiat_codes: ["LI"], prefixes: ["ALI", "WLI"], powiat_code_length: 2 }
+  - { powiat: łosicki, voivodeship: mazowieckie, powiat_codes: ["LS"], prefixes: ["ALS", "WLS"], powiat_code_length: 2 }
+  - { powiat: makowski, voivodeship: mazowieckie, powiat_codes: ["MA"], prefixes: ["AMA", "WMA"], powiat_code_length: 2 }
+  - { powiat: miński, voivodeship: mazowieckie, powiat_codes: ["M"], prefixes: ["AM", "WM"], powiat_code_length: 1 }
+  - { powiat: mławski, voivodeship: mazowieckie, powiat_codes: ["ML"], prefixes: ["AML", "WML"], powiat_code_length: 2 }
+  - { powiat: nowodworski, voivodeship: mazowieckie, powiat_codes: ["ND"], prefixes: ["AND", "WND"], powiat_code_length: 2 }
+  - { powiat: ostrołęcki, voivodeship: mazowieckie, powiat_codes: ["OS"], prefixes: ["AOS", "WOS"], powiat_code_length: 2 }
+  - { powiat: ostrowski, voivodeship: mazowieckie, powiat_codes: ["OR"], prefixes: ["AOR", "WOR"], powiat_code_length: 2 }
+  - { powiat: otwocki, voivodeship: mazowieckie, powiat_codes: ["OT"], prefixes: ["AOT", "WOT"], powiat_code_length: 2 }
+  - { powiat: piaseczyński, voivodeship: mazowieckie, powiat_codes: ["PI", "PA", "PW", "PX"], prefixes: ["APA", "API", "APW", "APX", "WPA", "WPI", "WPW", "WPX"], powiat_code_length: 2 }
+  - { powiat: płocki, voivodeship: mazowieckie, powiat_codes: ["PL"], prefixes: ["APL", "WPL"], powiat_code_length: 2 }
+  - { powiat: płoński, voivodeship: mazowieckie, powiat_codes: ["PN"], prefixes: ["APN", "WPN"], powiat_code_length: 2 }
+  - { powiat: pruszkowski, voivodeship: mazowieckie, powiat_codes: ["PR", "PP", "PS"], prefixes: ["APP", "APR", "APS", "WPP", "WPR", "WPS"], powiat_code_length: 2 }
+  - { powiat: przasnyski, voivodeship: mazowieckie, powiat_codes: ["PZ"], prefixes: ["APZ", "WPZ"], powiat_code_length: 2 }
+  - { powiat: przysuski, voivodeship: mazowieckie, powiat_codes: ["PY"], prefixes: ["APY", "WPY"], powiat_code_length: 2 }
+  - { powiat: pułtuski, voivodeship: mazowieckie, powiat_codes: ["PU"], prefixes: ["APU", "WPU"], powiat_code_length: 2 }
+  - { powiat: radomski, voivodeship: mazowieckie, powiat_codes: ["RA"], prefixes: ["ARA", "WRA"], powiat_code_length: 2 }
+  - { powiat: siedlecki, voivodeship: mazowieckie, powiat_codes: ["SI"], prefixes: ["ASI", "WSI"], powiat_code_length: 2 }
+  - { powiat: sierpecki, voivodeship: mazowieckie, powiat_codes: ["SE"], prefixes: ["ASE", "WSE"], powiat_code_length: 2 }
+  - { powiat: sochaczewski, voivodeship: mazowieckie, powiat_codes: ["SC"], prefixes: ["ASC", "WSC"], powiat_code_length: 2 }
+  - { powiat: sokołowski, voivodeship: mazowieckie, powiat_codes: ["SK"], prefixes: ["ASK", "WSK"], powiat_code_length: 2 }
+  - { powiat: szydłowiecki, voivodeship: mazowieckie, powiat_codes: ["SZ"], prefixes: ["ASZ", "WSZ"], powiat_code_length: 2 }
+  - { powiat: m.st. Warszawa, voivodeship: mazowieckie, powiat_codes: ["A", "B", "D", "E", "F", "H", "I", "J", "K", "N", "T", "U", "W", "X", "Y"], prefixes: ["AA", "AB", "AD", "AE", "AF", "AH", "AI", "AJ", "AK", "AN", "AT", "AU", "AW", "AX", "AY", "WA", "WB", "WD", "WE", "WF", "WH", "WI", "WJ", "WK", "WN", "WT", "WU", "WW", "WX", "WY"], powiat_code_length: 1 }
+  - { powiat: warszawski zachodni, voivodeship: mazowieckie, powiat_codes: ["Z"], prefixes: ["AZ", "WZ"], powiat_code_length: 1 }
+  - { powiat: węgrowski, voivodeship: mazowieckie, powiat_codes: ["WE"], prefixes: ["AWE", "WWE"], powiat_code_length: 2 }
+  - { powiat: wołomiński, voivodeship: mazowieckie, powiat_codes: ["WL", "V"], prefixes: ["AV", "AWL", "WV", "WWL"], powiat_code_length: 1/2 }
+  - { powiat: wyszkowski, voivodeship: mazowieckie, powiat_codes: ["WY"], prefixes: ["AWY", "WWY"], powiat_code_length: 2 }
+  - { powiat: zwoleński, voivodeship: mazowieckie, powiat_codes: ["ZW"], prefixes: ["AZW", "WZW"], powiat_code_length: 2 }
+  - { powiat: żuromiński, voivodeship: mazowieckie, powiat_codes: ["ZU"], prefixes: ["AZU", "WZU"], powiat_code_length: 2 }
+  - { powiat: żyrardowski, voivodeship: mazowieckie, powiat_codes: ["ZY"], prefixes: ["AZY", "WZY"], powiat_code_length: 2 }
+  # 8. OPOLSKIE — wyróżnik województwa O | tymczasowe + indywidualne O0-O9
+  - { powiat: Opole, voivodeship: opolskie, powiat_codes: ["P"], prefixes: ["OP"], powiat_code_length: 1 }
+  - { powiat: brzeski, voivodeship: opolskie, powiat_codes: ["B"], prefixes: ["OB"], powiat_code_length: 1 }
+  - { powiat: głubczycki, voivodeship: opolskie, powiat_codes: ["GL"], prefixes: ["OGL"], powiat_code_length: 2 }
+  - { powiat: kędzierzyńsko-kozielski, voivodeship: opolskie, powiat_codes: ["K"], prefixes: ["OK"], powiat_code_length: 1 }
+  - { powiat: kluczborski, voivodeship: opolskie, powiat_codes: ["KL"], prefixes: ["OKL"], powiat_code_length: 2 }
+  - { powiat: krapkowicki, voivodeship: opolskie, powiat_codes: ["KR"], prefixes: ["OKR"], powiat_code_length: 2 }
+  - { powiat: namysłowski, voivodeship: opolskie, powiat_codes: ["NA"], prefixes: ["ONA"], powiat_code_length: 2 }
+  - { powiat: nyski, voivodeship: opolskie, powiat_codes: ["NY", "NX"], prefixes: ["ONX", "ONY"], powiat_code_length: 2, amended: "Dz.U. 2025 poz. 939 § 1 pkt 4 lit. c (in force 2025-07-30)" }
+  - { powiat: oleski, voivodeship: opolskie, powiat_codes: ["OL"], prefixes: ["OOL"], powiat_code_length: 2 }
+  - { powiat: opolski, voivodeship: opolskie, powiat_codes: ["PO"], prefixes: ["OPO"], powiat_code_length: 2 }
+  - { powiat: prudnicki, voivodeship: opolskie, powiat_codes: ["PR"], prefixes: ["OPR"], powiat_code_length: 2 }
+  - { powiat: strzelecki, voivodeship: opolskie, powiat_codes: ["ST"], prefixes: ["OST"], powiat_code_length: 2 }
+  # 9. PODKARPACKIE — wyróżnik województwa R, Y | tymczasowe + indywidualne R0-R9, Y0-Y9
+  - { powiat: Krosno, voivodeship: podkarpackie, powiat_codes: ["K"], prefixes: ["RK", "YK"], powiat_code_length: 1 }
+  - { powiat: Przemyśl, voivodeship: podkarpackie, powiat_codes: ["P"], prefixes: ["RP", "YP"], powiat_code_length: 1 }
+  - { powiat: Rzeszów, voivodeship: podkarpackie, powiat_codes: ["Z"], prefixes: ["RZ", "YZ"], powiat_code_length: 1 }
+  - { powiat: Tarnobrzeg, voivodeship: podkarpackie, powiat_codes: ["T"], prefixes: ["RT", "YT"], powiat_code_length: 1 }
+  - { powiat: bieszczadzki, voivodeship: podkarpackie, powiat_codes: ["BI"], prefixes: ["RBI", "YBI"], powiat_code_length: 2 }
+  - { powiat: brzozowski, voivodeship: podkarpackie, powiat_codes: ["BR"], prefixes: ["RBR", "YBR"], powiat_code_length: 2 }
+  - { powiat: dębicki, voivodeship: podkarpackie, powiat_codes: ["DE"], prefixes: ["RDE", "YDE"], powiat_code_length: 2 }
+  - { powiat: jarosławski, voivodeship: podkarpackie, powiat_codes: ["JA"], prefixes: ["RJA", "YJA"], powiat_code_length: 2 }
+  - { powiat: jasielski, voivodeship: podkarpackie, powiat_codes: ["JS"], prefixes: ["RJS", "YJS"], powiat_code_length: 2 }
+  - { powiat: kolbuszowski, voivodeship: podkarpackie, powiat_codes: ["KL"], prefixes: ["RKL", "YKL"], powiat_code_length: 2 }
+  - { powiat: krośnieński, voivodeship: podkarpackie, powiat_codes: ["KR"], prefixes: ["RKR", "YKR"], powiat_code_length: 2 }
+  - { powiat: leski, voivodeship: podkarpackie, powiat_codes: ["LS"], prefixes: ["RLS", "YLS"], powiat_code_length: 2 }
+  - { powiat: leżajski, voivodeship: podkarpackie, powiat_codes: ["LE"], prefixes: ["RLE", "YLE"], powiat_code_length: 2 }
+  - { powiat: lubaczowski, voivodeship: podkarpackie, powiat_codes: ["LU"], prefixes: ["RLU", "YLU"], powiat_code_length: 2 }
+  - { powiat: łańcucki, voivodeship: podkarpackie, powiat_codes: ["LA"], prefixes: ["RLA", "YLA"], powiat_code_length: 2 }
+  - { powiat: mielecki, voivodeship: podkarpackie, powiat_codes: ["MI"], prefixes: ["RMI", "YMI"], powiat_code_length: 2 }
+  - { powiat: niżański, voivodeship: podkarpackie, powiat_codes: ["NI"], prefixes: ["RNI", "YNI"], powiat_code_length: 2 }
+  - { powiat: przemyski, voivodeship: podkarpackie, powiat_codes: ["PR"], prefixes: ["RPR", "YPR"], powiat_code_length: 2 }
+  - { powiat: przeworski, voivodeship: podkarpackie, powiat_codes: ["PZ"], prefixes: ["RPZ", "YPZ"], powiat_code_length: 2 }
+  - { powiat: ropczycko-sędziszowski, voivodeship: podkarpackie, powiat_codes: ["RS"], prefixes: ["RRS", "YRS"], powiat_code_length: 2 }
+  - { powiat: rzeszowski, voivodeship: podkarpackie, powiat_codes: ["ZE", "ZZ", "ZR"], prefixes: ["RZE", "RZR", "RZZ", "YZE", "YZR", "YZZ"], powiat_code_length: 2 }
+  - { powiat: sanocki, voivodeship: podkarpackie, powiat_codes: ["SA"], prefixes: ["RSA", "YSA"], powiat_code_length: 2 }
+  - { powiat: stalowowolski, voivodeship: podkarpackie, powiat_codes: ["ST"], prefixes: ["RST", "YST"], powiat_code_length: 2 }
+  - { powiat: strzyżowski, voivodeship: podkarpackie, powiat_codes: ["SR"], prefixes: ["RSR", "YSR"], powiat_code_length: 2 }
+  - { powiat: tarnobrzeski, voivodeship: podkarpackie, powiat_codes: ["TA"], prefixes: ["RTA", "YTA"], powiat_code_length: 2 }
+  # 10. PODLASKIE — wyróżnik województwa B | tymczasowe + indywidualne B0-B9
+  - { powiat: Białystok, voivodeship: podlaskie, powiat_codes: ["I"], prefixes: ["BI"], powiat_code_length: 1 }
+  - { powiat: Łomża, voivodeship: podlaskie, powiat_codes: ["L"], prefixes: ["BL"], powiat_code_length: 1 }
+  - { powiat: Suwałki, voivodeship: podlaskie, powiat_codes: ["S"], prefixes: ["BS"], powiat_code_length: 1 }
+  - { powiat: augustowski, voivodeship: podlaskie, powiat_codes: ["AU"], prefixes: ["BAU"], powiat_code_length: 2 }
+  - { powiat: białostocki, voivodeship: podlaskie, powiat_codes: ["IA", "IB"], prefixes: ["BIA", "BIB"], powiat_code_length: 2 }
+  - { powiat: bielski, voivodeship: podlaskie, powiat_codes: ["BI"], prefixes: ["BBI"], powiat_code_length: 2 }
+  - { powiat: grajewski, voivodeship: podlaskie, powiat_codes: ["GR"], prefixes: ["BGR"], powiat_code_length: 2 }
+  - { powiat: hajnowski, voivodeship: podlaskie, powiat_codes: ["HA"], prefixes: ["BHA"], powiat_code_length: 2 }
+  - { powiat: kolneński, voivodeship: podlaskie, powiat_codes: ["KL"], prefixes: ["BKL"], powiat_code_length: 2 }
+  - { powiat: łomżyński, voivodeship: podlaskie, powiat_codes: ["LM"], prefixes: ["BLM"], powiat_code_length: 2 }
+  - { powiat: moniecki, voivodeship: podlaskie, powiat_codes: ["MN"], prefixes: ["BMN"], powiat_code_length: 2 }
+  - { powiat: sejneński, voivodeship: podlaskie, powiat_codes: ["SE"], prefixes: ["BSE"], powiat_code_length: 2 }
+  - { powiat: siemiatycki, voivodeship: podlaskie, powiat_codes: ["SI"], prefixes: ["BSI"], powiat_code_length: 2 }
+  - { powiat: sokólski, voivodeship: podlaskie, powiat_codes: ["SK"], prefixes: ["BSK"], powiat_code_length: 2 }
+  - { powiat: suwalski, voivodeship: podlaskie, powiat_codes: ["SU"], prefixes: ["BSU"], powiat_code_length: 2 }
+  - { powiat: wysokomazowiecki, voivodeship: podlaskie, powiat_codes: ["WM"], prefixes: ["BWM"], powiat_code_length: 2 }
+  - { powiat: zambrowski, voivodeship: podlaskie, powiat_codes: ["ZA"], prefixes: ["BZA"], powiat_code_length: 2 }
+  # 11. POMORSKIE — wyróżnik województwa G, X | tymczasowe + indywidualne G0-G9, X0-X9
+  - { powiat: Gdańsk, voivodeship: pomorskie, powiat_codes: ["D"], prefixes: ["GD", "XD"], powiat_code_length: 1 }
+  - { powiat: Gdynia, voivodeship: pomorskie, powiat_codes: ["A"], prefixes: ["GA", "XA"], powiat_code_length: 1 }
+  - { powiat: Słupsk, voivodeship: pomorskie, powiat_codes: ["S"], prefixes: ["GS", "XS"], powiat_code_length: 1 }
+  - { powiat: Sopot, voivodeship: pomorskie, powiat_codes: ["SP"], prefixes: ["GSP", "XSP"], powiat_code_length: 2 }
+  - { powiat: bytowski, voivodeship: pomorskie, powiat_codes: ["BY"], prefixes: ["GBY", "XBY"], powiat_code_length: 2 }
+  - { powiat: chojnicki, voivodeship: pomorskie, powiat_codes: ["CH"], prefixes: ["GCH", "XCH"], powiat_code_length: 2 }
+  - { powiat: człuchowski, voivodeship: pomorskie, powiat_codes: ["CZ"], prefixes: ["GCZ", "XCZ"], powiat_code_length: 2 }
+  - { powiat: gdański, voivodeship: pomorskie, powiat_codes: ["DA"], prefixes: ["GDA", "XDA"], powiat_code_length: 2 }
+  - { powiat: kartuski, voivodeship: pomorskie, powiat_codes: ["KA", "KY", "KZ"], prefixes: ["GKA", "GKY", "GKZ", "XKA", "XKY", "XKZ"], powiat_code_length: 2 }
+  - { powiat: kościerski, voivodeship: pomorskie, powiat_codes: ["KS"], prefixes: ["GKS", "XKS"], powiat_code_length: 2 }
+  - { powiat: kwidzyński, voivodeship: pomorskie, powiat_codes: ["KW"], prefixes: ["GKW", "XKW"], powiat_code_length: 2 }
+  - { powiat: lęborski, voivodeship: pomorskie, powiat_codes: ["LE"], prefixes: ["GLE", "XLE"], powiat_code_length: 2 }
+  - { powiat: malborski, voivodeship: pomorskie, powiat_codes: ["MB"], prefixes: ["GMB", "XMB"], powiat_code_length: 2 }
+  - { powiat: nowodworski, voivodeship: pomorskie, powiat_codes: ["ND"], prefixes: ["GND", "XND"], powiat_code_length: 2 }
+  - { powiat: pucki, voivodeship: pomorskie, powiat_codes: ["PU"], prefixes: ["GPU", "XPU"], powiat_code_length: 2 }
+  - { powiat: słupski, voivodeship: pomorskie, powiat_codes: ["SL"], prefixes: ["GSL", "XSL"], powiat_code_length: 2 }
+  - { powiat: starogardzki, voivodeship: pomorskie, powiat_codes: ["ST"], prefixes: ["GST", "XST"], powiat_code_length: 2 }
+  - { powiat: sztumski, voivodeship: pomorskie, powiat_codes: ["SZ"], prefixes: ["GSZ", "XSZ"], powiat_code_length: 2 }
+  - { powiat: tczewski, voivodeship: pomorskie, powiat_codes: ["TC"], prefixes: ["GTC", "XTC"], powiat_code_length: 2 }
+  - { powiat: wejherowski, voivodeship: pomorskie, powiat_codes: ["WE", "WO"], prefixes: ["GWE", "GWO", "XWE", "XWO"], powiat_code_length: 2 }
+  # 12. ŚLĄSKIE — wyróżnik województwa S, I | tymczasowe + indywidualne S0-S9, I0-I9
+  - { powiat: Bielsko-Biała, voivodeship: śląskie, powiat_codes: ["B"], prefixes: ["IB", "SB"], powiat_code_length: 1 }
+  - { powiat: Bytom, voivodeship: śląskie, powiat_codes: ["Y"], prefixes: ["IY", "SY"], powiat_code_length: 1 }
+  - { powiat: Chorzów, voivodeship: śląskie, powiat_codes: ["H"], prefixes: ["IH", "SH"], powiat_code_length: 1 }
+  - { powiat: Częstochowa, voivodeship: śląskie, powiat_codes: ["C"], prefixes: ["IC", "SC"], powiat_code_length: 1 }
+  - { powiat: Dąbrowa Górnicza, voivodeship: śląskie, powiat_codes: ["D"], prefixes: ["ID", "SD"], powiat_code_length: 1 }
+  - { powiat: Gliwice, voivodeship: śląskie, powiat_codes: ["G"], prefixes: ["IG", "SG"], powiat_code_length: 1 }
+  - { powiat: Jastrzębie-Zdrój, voivodeship: śląskie, powiat_codes: ["JZ"], prefixes: ["IJZ", "SJZ"], powiat_code_length: 2 }
+  - { powiat: Jaworzno, voivodeship: śląskie, powiat_codes: ["J"], prefixes: ["IJ", "SJ"], powiat_code_length: 1 }
+  - { powiat: Katowice, voivodeship: śląskie, powiat_codes: ["K"], prefixes: ["IK", "SK"], powiat_code_length: 1 }
+  - { powiat: Mysłowice, voivodeship: śląskie, powiat_codes: ["M"], prefixes: ["IM", "SM"], powiat_code_length: 1 }
+  - { powiat: Piekary Śląskie, voivodeship: śląskie, powiat_codes: ["PI"], prefixes: ["IPI", "SPI"], powiat_code_length: 2 }
+  - { powiat: Ruda Śląska, voivodeship: śląskie, powiat_codes: ["RS", "L"], prefixes: ["IL", "IRS", "SL", "SRS"], powiat_code_length: 1/2 }
+  - { powiat: Rybnik, voivodeship: śląskie, powiat_codes: ["R"], prefixes: ["IR", "SR"], powiat_code_length: 1 }
+  - { powiat: Siemianowice Śląskie, voivodeship: śląskie, powiat_codes: ["I"], prefixes: ["II", "SI"], powiat_code_length: 1 }
+  - { powiat: Sosnowiec, voivodeship: śląskie, powiat_codes: ["O"], prefixes: ["IO", "SO"], powiat_code_length: 1 }
+  - { powiat: Świętochłowice, voivodeship: śląskie, powiat_codes: ["W"], prefixes: ["IW", "SW"], powiat_code_length: 1 }
+  - { powiat: Tychy, voivodeship: śląskie, powiat_codes: ["T"], prefixes: ["IT", "ST"], powiat_code_length: 1 }
+  - { powiat: Zabrze, voivodeship: śląskie, powiat_codes: ["Z"], prefixes: ["IZ", "SZ"], powiat_code_length: 1 }
+  - { powiat: Żory, voivodeship: śląskie, powiat_codes: ["ZO"], prefixes: ["IZO", "SZO"], powiat_code_length: 2 }
+  - { powiat: będziński, voivodeship: śląskie, powiat_codes: ["BE", "E", "BN"], prefixes: ["IBE", "IBN", "IE", "SBE", "SBN", "SE"], powiat_code_length: 1/2 }
+  - { powiat: bielski, voivodeship: śląskie, powiat_codes: ["BI"], prefixes: ["IBI", "SBI"], powiat_code_length: 2 }
+  - { powiat: cieszyński, voivodeship: śląskie, powiat_codes: ["CI", "CN"], prefixes: ["ICI", "ICN", "SCI", "SCN"], powiat_code_length: 2 }
+  - { powiat: częstochowski, voivodeship: śląskie, powiat_codes: ["CZ"], prefixes: ["ICZ", "SCZ"], powiat_code_length: 2 }
+  - { powiat: gliwicki, voivodeship: śląskie, powiat_codes: ["GL"], prefixes: ["IGL", "SGL"], powiat_code_length: 2 }
+  - { powiat: kłobucki, voivodeship: śląskie, powiat_codes: ["KL"], prefixes: ["IKL", "SKL"], powiat_code_length: 2 }
+  - { powiat: lubliniecki, voivodeship: śląskie, powiat_codes: ["LU"], prefixes: ["ILU", "SLU"], powiat_code_length: 2 }
+  - { powiat: mikołowski, voivodeship: śląskie, powiat_codes: ["MI"], prefixes: ["IMI", "SMI"], powiat_code_length: 2 }
+  - { powiat: myszkowski, voivodeship: śląskie, powiat_codes: ["MY"], prefixes: ["IMY", "SMY"], powiat_code_length: 2 }
+  - { powiat: pszczyński, voivodeship: śląskie, powiat_codes: ["PS"], prefixes: ["IPS", "SPS"], powiat_code_length: 2 }
+  - { powiat: raciborski, voivodeship: śląskie, powiat_codes: ["RC"], prefixes: ["IRC", "SRC"], powiat_code_length: 2 }
+  - { powiat: rybnicki, voivodeship: śląskie, powiat_codes: ["RB"], prefixes: ["IRB", "SRB"], powiat_code_length: 2 }
+  - { powiat: tarnogórski, voivodeship: śląskie, powiat_codes: ["TA", "TR", "TN"], prefixes: ["ITA", "ITN", "ITR", "STA", "STN", "STR"], powiat_code_length: 2, amended: "Dz.U. 2026 poz. 891 § 1 pkt 9 lit. b (in force 2026-07-04)" }
+  - { powiat: bieruńsko-lędziński, voivodeship: śląskie, powiat_codes: ["BL"], prefixes: ["IBL", "SBL"], powiat_code_length: 2 }
+  - { powiat: wodzisławski, voivodeship: śląskie, powiat_codes: ["WD", "WZ"], prefixes: ["IWD", "IWZ", "SWD", "SWZ"], powiat_code_length: 2 }
+  - { powiat: zawierciański, voivodeship: śląskie, powiat_codes: ["ZA"], prefixes: ["IZA", "SZA"], powiat_code_length: 2 }
+  - { powiat: żywiecki, voivodeship: śląskie, powiat_codes: ["ZY"], prefixes: ["IZY", "SZY"], powiat_code_length: 2 }
+  # 13. ŚWIĘTOKRZYSKIE — wyróżnik województwa T | tymczasowe + indywidualne T0-T9
+  - { powiat: Kielce, voivodeship: świętokrzyskie, powiat_codes: ["K"], prefixes: ["TK"], powiat_code_length: 1 }
+  - { powiat: buski, voivodeship: świętokrzyskie, powiat_codes: ["BU"], prefixes: ["TBU"], powiat_code_length: 2 }
+  - { powiat: jędrzejowski, voivodeship: świętokrzyskie, powiat_codes: ["JE"], prefixes: ["TJE"], powiat_code_length: 2 }
+  - { powiat: kazimierski, voivodeship: świętokrzyskie, powiat_codes: ["KA"], prefixes: ["TKA"], powiat_code_length: 2 }
+  - { powiat: kielecki, voivodeship: świętokrzyskie, powiat_codes: ["KI", "KC", "KM", "KP"], prefixes: ["TKC", "TKI", "TKM", "TKP"], powiat_code_length: 2 }
+  - { powiat: konecki, voivodeship: świętokrzyskie, powiat_codes: ["KN"], prefixes: ["TKN"], powiat_code_length: 2 }
+  - { powiat: opatowski, voivodeship: świętokrzyskie, powiat_codes: ["OP"], prefixes: ["TOP"], powiat_code_length: 2 }
+  - { powiat: ostrowiecki, voivodeship: świętokrzyskie, powiat_codes: ["OS"], prefixes: ["TOS"], powiat_code_length: 2 }
+  - { powiat: pińczowski, voivodeship: świętokrzyskie, powiat_codes: ["PI"], prefixes: ["TPI"], powiat_code_length: 2 }
+  - { powiat: sandomierski, voivodeship: świętokrzyskie, powiat_codes: ["SA"], prefixes: ["TSA"], powiat_code_length: 2 }
+  - { powiat: skarżyski, voivodeship: świętokrzyskie, powiat_codes: ["SK"], prefixes: ["TSK"], powiat_code_length: 2 }
+  - { powiat: starachowicki, voivodeship: świętokrzyskie, powiat_codes: ["ST"], prefixes: ["TST"], powiat_code_length: 2 }
+  - { powiat: staszowski, voivodeship: świętokrzyskie, powiat_codes: ["SZ"], prefixes: ["TSZ"], powiat_code_length: 2 }
+  - { powiat: włoszczowski, voivodeship: świętokrzyskie, powiat_codes: ["LW"], prefixes: ["TLW"], powiat_code_length: 2 }
+  # 14. WARMIŃSKO-MAZURSKIE — wyróżnik województwa N | tymczasowe + indywidualne N0-N9
+  - { powiat: Elbląg, voivodeship: warmińsko-mazurskie, powiat_codes: ["E"], prefixes: ["NE"], powiat_code_length: 1 }
+  - { powiat: Olsztyn, voivodeship: warmińsko-mazurskie, powiat_codes: ["O"], prefixes: ["NO"], powiat_code_length: 1 }
+  - { powiat: bartoszycki, voivodeship: warmińsko-mazurskie, powiat_codes: ["BA"], prefixes: ["NBA"], powiat_code_length: 2 }
+  - { powiat: braniewski, voivodeship: warmińsko-mazurskie, powiat_codes: ["BR"], prefixes: ["NBR"], powiat_code_length: 2 }
+  - { powiat: działdowski, voivodeship: warmińsko-mazurskie, powiat_codes: ["DZ"], prefixes: ["NDZ"], powiat_code_length: 2 }
+  - { powiat: elbląski, voivodeship: warmińsko-mazurskie, powiat_codes: ["EB"], prefixes: ["NEB"], powiat_code_length: 2 }
+  - { powiat: ełcki, voivodeship: warmińsko-mazurskie, powiat_codes: ["EL"], prefixes: ["NEL"], powiat_code_length: 2 }
+  - { powiat: giżycki, voivodeship: warmińsko-mazurskie, powiat_codes: ["GI"], prefixes: ["NGI"], powiat_code_length: 2 }
+  - { powiat: iławski, voivodeship: warmińsko-mazurskie, powiat_codes: ["IL"], prefixes: ["NIL"], powiat_code_length: 2 }
+  - { powiat: kętrzyński, voivodeship: warmińsko-mazurskie, powiat_codes: ["KE"], prefixes: ["NKE"], powiat_code_length: 2 }
+  - { powiat: lidzbarski, voivodeship: warmińsko-mazurskie, powiat_codes: ["LI"], prefixes: ["NLI"], powiat_code_length: 2 }
+  - { powiat: mrągowski, voivodeship: warmińsko-mazurskie, powiat_codes: ["MR"], prefixes: ["NMR"], powiat_code_length: 2 }
+  - { powiat: nidzicki, voivodeship: warmińsko-mazurskie, powiat_codes: ["NI"], prefixes: ["NNI"], powiat_code_length: 2 }
+  - { powiat: nowomiejski, voivodeship: warmińsko-mazurskie, powiat_codes: ["NM"], prefixes: ["NNM"], powiat_code_length: 2 }
+  - { powiat: olecki, voivodeship: warmińsko-mazurskie, powiat_codes: ["OE"], prefixes: ["NOE"], powiat_code_length: 2 }
+  - { powiat: gołdapski, voivodeship: warmińsko-mazurskie, powiat_codes: ["GO"], prefixes: ["NGO"], powiat_code_length: 2 }
+  - { powiat: olsztyński, voivodeship: warmińsko-mazurskie, powiat_codes: ["OL", "OZ", "OP"], prefixes: ["NOL", "NOP", "NOZ"], powiat_code_length: 2, amended: "Dz.U. 2026 poz. 891 § 1 pkt 9 lit. c (in force 2026-07-04)" }
+  - { powiat: ostródzki, voivodeship: warmińsko-mazurskie, powiat_codes: ["OS", "OT", "OX"], prefixes: ["NOS", "NOT", "NOX"], powiat_code_length: 2 }
+  - { powiat: piski, voivodeship: warmińsko-mazurskie, powiat_codes: ["PI"], prefixes: ["NPI"], powiat_code_length: 2 }
+  - { powiat: szczycieński, voivodeship: warmińsko-mazurskie, powiat_codes: ["SZ"], prefixes: ["NSZ"], powiat_code_length: 2 }
+  - { powiat: węgorzewski, voivodeship: warmińsko-mazurskie, powiat_codes: ["WE"], prefixes: ["NWE"], powiat_code_length: 2 }
+  # 15. WIELKOPOLSKIE — wyróżnik województwa P, M | tymczasowe + indywidualne P0-P9, M0-M9
+  - { powiat: Kalisz, voivodeship: wielkopolskie, powiat_codes: ["K", "A"], prefixes: ["MA", "MK", "PA", "PK"], powiat_code_length: 1 }
+  - { powiat: Konin, voivodeship: wielkopolskie, powiat_codes: ["KO", "N"], prefixes: ["MKO", "MN", "PKO", "PN"], powiat_code_length: 1/2 }
+  - { powiat: Leszno, voivodeship: wielkopolskie, powiat_codes: ["L"], prefixes: ["ML", "PL"], powiat_code_length: 1 }
+  - { powiat: Poznań, voivodeship: wielkopolskie, powiat_codes: ["O", "Y", "X"], prefixes: ["MO", "MX", "MY", "PO", "PX", "PY"], powiat_code_length: 1 }
+  - { powiat: chodzieski, voivodeship: wielkopolskie, powiat_codes: ["CH"], prefixes: ["MCH", "PCH"], powiat_code_length: 2 }
+  - { powiat: czarnkowsko-trzcianecki, voivodeship: wielkopolskie, powiat_codes: ["CT"], prefixes: ["MCT", "PCT"], powiat_code_length: 2 }
+  - { powiat: gnieźnieński, voivodeship: wielkopolskie, powiat_codes: ["GN"], prefixes: ["MGN", "PGN"], powiat_code_length: 2 }
+  - { powiat: gostyński, voivodeship: wielkopolskie, powiat_codes: ["GS"], prefixes: ["MGS", "PGS"], powiat_code_length: 2 }
+  - { powiat: grodziski, voivodeship: wielkopolskie, powiat_codes: ["GO"], prefixes: ["MGO", "PGO"], powiat_code_length: 2 }
+  - { powiat: jarociński, voivodeship: wielkopolskie, powiat_codes: ["JA"], prefixes: ["MJA", "PJA"], powiat_code_length: 2 }
+  - { powiat: kaliski, voivodeship: wielkopolskie, powiat_codes: ["KA"], prefixes: ["MKA", "PKA"], powiat_code_length: 2 }
+  - { powiat: kępiński, voivodeship: wielkopolskie, powiat_codes: ["KE"], prefixes: ["MKE", "PKE"], powiat_code_length: 2 }
+  - { powiat: kolski, voivodeship: wielkopolskie, powiat_codes: ["KL"], prefixes: ["MKL", "PKL"], powiat_code_length: 2 }
+  - { powiat: koniński, voivodeship: wielkopolskie, powiat_codes: ["KN"], prefixes: ["MKN", "PKN"], powiat_code_length: 2 }
+  - { powiat: kościański, voivodeship: wielkopolskie, powiat_codes: ["KS"], prefixes: ["MKS", "PKS"], powiat_code_length: 2 }
+  - { powiat: krotoszyński, voivodeship: wielkopolskie, powiat_codes: ["KR"], prefixes: ["MKR", "PKR"], powiat_code_length: 2 }
+  - { powiat: leszczyński, voivodeship: wielkopolskie, powiat_codes: ["LE"], prefixes: ["MLE", "PLE"], powiat_code_length: 2 }
+  - { powiat: międzychodzki, voivodeship: wielkopolskie, powiat_codes: ["MI"], prefixes: ["MMI", "PMI"], powiat_code_length: 2 }
+  - { powiat: nowotomyski, voivodeship: wielkopolskie, powiat_codes: ["NT"], prefixes: ["MNT", "PNT"], powiat_code_length: 2 }
+  - { powiat: obornicki, voivodeship: wielkopolskie, powiat_codes: ["OB"], prefixes: ["MOB", "POB"], powiat_code_length: 2 }
+  - { powiat: ostrowski, voivodeship: wielkopolskie, powiat_codes: ["OS"], prefixes: ["MOS", "POS"], powiat_code_length: 2 }
+  - { powiat: ostrzeszowski, voivodeship: wielkopolskie, powiat_codes: ["OT"], prefixes: ["MOT", "POT"], powiat_code_length: 2 }
+  - { powiat: pilski, voivodeship: wielkopolskie, powiat_codes: ["P"], prefixes: ["MP", "PP"], powiat_code_length: 1 }
+  - { powiat: pleszewski, voivodeship: wielkopolskie, powiat_codes: ["PL"], prefixes: ["MPL", "PPL"], powiat_code_length: 2 }
+  - { powiat: poznański, voivodeship: wielkopolskie, powiat_codes: ["OZ", "Z"], prefixes: ["MOZ", "MZ", "POZ", "PZ"], powiat_code_length: 1/2 }
+  - { powiat: rawicki, voivodeship: wielkopolskie, powiat_codes: ["RA"], prefixes: ["MRA", "PRA"], powiat_code_length: 2 }
+  - { powiat: słupecki, voivodeship: wielkopolskie, powiat_codes: ["SL"], prefixes: ["MSL", "PSL"], powiat_code_length: 2 }
+  - { powiat: szamotulski, voivodeship: wielkopolskie, powiat_codes: ["SZ"], prefixes: ["MSZ", "PSZ"], powiat_code_length: 2 }
+  - { powiat: średzki, voivodeship: wielkopolskie, powiat_codes: ["SR"], prefixes: ["MSR", "PSR"], powiat_code_length: 2 }
+  - { powiat: śremski, voivodeship: wielkopolskie, powiat_codes: ["SE"], prefixes: ["MSE", "PSE"], powiat_code_length: 2 }
+  - { powiat: turecki, voivodeship: wielkopolskie, powiat_codes: ["TU"], prefixes: ["MTU", "PTU"], powiat_code_length: 2 }
+  - { powiat: wągrowiecki, voivodeship: wielkopolskie, powiat_codes: ["WA"], prefixes: ["MWA", "PWA"], powiat_code_length: 2 }
+  - { powiat: wolsztyński, voivodeship: wielkopolskie, powiat_codes: ["WL"], prefixes: ["MWL", "PWL"], powiat_code_length: 2 }
+  - { powiat: wrzesiński, voivodeship: wielkopolskie, powiat_codes: ["WR"], prefixes: ["MWR", "PWR"], powiat_code_length: 2 }
+  - { powiat: złotowski, voivodeship: wielkopolskie, powiat_codes: ["ZL"], prefixes: ["MZL", "PZL"], powiat_code_length: 2 }
+  # 16. ZACHODNIOPOMORSKIE — wyróżnik województwa Z | tymczasowe + indywidualne Z0-Z9
+  - { powiat: Koszalin, voivodeship: zachodniopomorskie, powiat_codes: ["K"], prefixes: ["ZK"], powiat_code_length: 1 }
+  - { powiat: Szczecin, voivodeship: zachodniopomorskie, powiat_codes: ["S", "Z"], prefixes: ["ZS", "ZZ"], powiat_code_length: 1 }
+  - { powiat: Świnoujście, voivodeship: zachodniopomorskie, powiat_codes: ["SW"], prefixes: ["ZSW"], powiat_code_length: 2 }
+  - { powiat: białogardzki, voivodeship: zachodniopomorskie, powiat_codes: ["BI"], prefixes: ["ZBI"], powiat_code_length: 2 }
+  - { powiat: choszczeński, voivodeship: zachodniopomorskie, powiat_codes: ["CH"], prefixes: ["ZCH"], powiat_code_length: 2 }
+  - { powiat: drawski, voivodeship: zachodniopomorskie, powiat_codes: ["DR"], prefixes: ["ZDR"], powiat_code_length: 2 }
+  - { powiat: goleniowski, voivodeship: zachodniopomorskie, powiat_codes: ["GL"], prefixes: ["ZGL"], powiat_code_length: 2 }
+  - { powiat: gryficki, voivodeship: zachodniopomorskie, powiat_codes: ["GY"], prefixes: ["ZGY"], powiat_code_length: 2 }
+  - { powiat: gryfiński, voivodeship: zachodniopomorskie, powiat_codes: ["GR"], prefixes: ["ZGR"], powiat_code_length: 2 }
+  - { powiat: kamieński, voivodeship: zachodniopomorskie, powiat_codes: ["KA"], prefixes: ["ZKA"], powiat_code_length: 2 }
+  - { powiat: kołobrzeski, voivodeship: zachodniopomorskie, powiat_codes: ["KL"], prefixes: ["ZKL"], powiat_code_length: 2 }
+  - { powiat: koszaliński, voivodeship: zachodniopomorskie, powiat_codes: ["KO"], prefixes: ["ZKO"], powiat_code_length: 2 }
+  - { powiat: łobeski, voivodeship: zachodniopomorskie, powiat_codes: ["LO"], prefixes: ["ZLO"], powiat_code_length: 2 }
+  - { powiat: myśliborski, voivodeship: zachodniopomorskie, powiat_codes: ["MY"], prefixes: ["ZMY"], powiat_code_length: 2 }
+  - { powiat: policki, voivodeship: zachodniopomorskie, powiat_codes: ["PL"], prefixes: ["ZPL"], powiat_code_length: 2 }
+  - { powiat: pyrzycki, voivodeship: zachodniopomorskie, powiat_codes: ["PY"], prefixes: ["ZPY"], powiat_code_length: 2 }
+  - { powiat: sławieński, voivodeship: zachodniopomorskie, powiat_codes: ["SL"], prefixes: ["ZSL"], powiat_code_length: 2 }
+  - { powiat: stargardzki, voivodeship: zachodniopomorskie, powiat_codes: ["ST"], prefixes: ["ZST"], powiat_code_length: 2 }
+  - { powiat: szczecinecki, voivodeship: zachodniopomorskie, powiat_codes: ["SZ"], prefixes: ["ZSZ"], powiat_code_length: 2 }
+  - { powiat: świdwiński, voivodeship: zachodniopomorskie, powiat_codes: ["SD"], prefixes: ["ZSD"], powiat_code_length: 2 }
+  - { powiat: wałecki, voivodeship: zachodniopomorskie, powiat_codes: ["WA"], prefixes: ["ZWA"], powiat_code_length: 2 }

--- a/plates/pl.yml
+++ b/plates/pl.yml
@@ -1,0 +1,1296 @@
+# plates/pl.yml — Poland (PRD-PLATES gate L1, wave 2).
+#
+# EVERY format, colour, dimension and class claim here is read from a Polish
+# primary instrument fetched in this pass through the Sejm's ELI API
+# (api.sejm.gov.pl/eli), which serves the same Dziennik Ustaw PDFs as ISAP
+# without ISAP's bot wall. The instruments, in force order:
+#   * Ustawa z dnia 20 czerwca 1997 r. – Prawo o ruchu drogowym, tekst jednolity
+#     Dz. U. 2024 poz. 1251 — art. 73 (registration, number retention), art. 75a
+#     (plate manufacture), art. 76 (the four delegations).
+#   * Rozporządzenie Ministra Infrastruktury z dnia 8 listopada 2024 r.
+#     w sprawie rejestracji i oznaczania pojazdów, wymagań dla tablic
+#     rejestracyjnych oraz wzorów innych dokumentów związanych z rejestracją
+#     pojazdów (Dz. U. 2024 poz. 1709), in force 2024-11-30 — §§ 25-33 and
+#     załączniki 12 (the plate SPEC) and 13 (the CODE table); as amended by
+#     Dz. U. 2025 poz. 939 and Dz. U. 2026 poz. 891.
+#   * The predecessors that DATE the system changes: Dz. U. 1993 nr 37 poz. 164,
+#     Dz. U. 1998 nr 57 poz. 365, Dz. U. 1999 nr 59 poz. 632, Dz. U. 2002 nr 133
+#     poz. 1123, Dz. U. 2006 nr 70 poz. 489, Dz. U. 2019 poz. 1272,
+#     Dz. U. 2017 poz. 2355, Dz. U. 2022 poz. 1847.
+#   * The three SIDE regimes, each under its own delegation: professional
+#     registration (Dz. U. 2019 poz. 546, consolidated Dz. U. 2023 poz. 2616),
+#     armed forces (art. 76 ust. 2 → Dz. U. 2023 poz. 1776) and the security
+#     services (art. 76 ust. 4 → Dz. U. 2025 poz. 1326).
+#
+# THE SIX STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. THE OPERATIVE INSTRUMENT IS THE 2024 ONE, NOT THE 2022 ONE. Almost every
+#    secondary description of Polish plates still cites Dz. U. 2022 poz. 1847.
+#    The Sejm ELI register records that instrument "uznany za uchylony" with
+#    repealDate 2024-11-30, replaced by Dz. U. 2024 poz. 1709. The difference is
+#    not cosmetic: the 2024 annex adds real powiat codes (bydgoski BC, kielecki
+#    KC/KM/KP, ostródzki OT/OX, Poznań X, Konin N, Kalisz A), extends the
+#    tymczasowe/indywidualne column to the second voivodeship letter, and adds a
+#    new plate — red on YELLOW for cars built for sporting competition
+#    (§ 27 ust. 9 pkt 2). This file is built on the 2024 text throughout.
+#
+# 2. THE POWIAT CODE LIST IS INSIDE THE REGULATION, so it is authored in full,
+#    from the instrument, in plates/_decode/pl-powiats.yml — 380 rows, 689
+#    distinct prefixes, no secondary source anywhere in it. § 31 ust. 2,
+#    verbatim: "Wyróżniki województw i powiatów dla tablic rejestracyjnych są
+#    określone w załączniku nr 13 do rozporządzenia."
+#
+# 3. THE REFORM DATE IS 1 MAY 2000, AND IT IS NOT THE DATE OF ITS INSTRUMENT.
+#    The rozporządzenie that created the voivodeship-first system is dated
+#    19 June 1999 and § 49 commences it "z dniem 1 lipca 1999 r." — but the SAME
+#    sentence excepts the plate provisions: "z wyjątkiem § 16, § 18 ust. 3-8,
+#    § 19, § 21 ust. 2, 4 i 5, § 22-24, § 29 i 30, które wchodzą w życie z dniem
+#    1 maja 2000 r." § 21 ust. 2 is the serial grammar and § 24 the wyróżniki
+#    annex, so the system began on 1 MAY 2000. § 41 and § 39 ust. 2 close the
+#    other end: pre-reform stock could be issued "jednak nie dłużej niż do dnia
+#    30 kwietnia 2000 r." This file therefore carries 2000, not the 1999 of the
+#    instrument's own date and not the 2001 that circulates in secondary
+#    descriptions. It is the Spanish 1999-2000 trap in Polish dress.
+#
+# 4. THE GREEN PLATE IS 2020, NOT 2022. Rozporządzenie Ministra Infrastruktury
+#    z dnia 8 lipca 2019 r. (Dz. U. 2019 poz. 1272) inserted "barwy czarnej na
+#    zielonym tle, w przypadku tablicy rejestracyjnej wydawanej dla pojazdu
+#    elektrycznego albo pojazdu napędzanego wodorem" and § 9 commences it
+#    "z dniem 1 stycznia 2020 r.", with § 6 letting authorities ORDER the new
+#    plates from 15 December 2019. The 2022 and 2024 instruments only re-enact
+#    it. Recorded here as 2020 with the 2019 instrument cited.
+#
+# 5. THE BLUE BAND WAS THE POLISH FLAG BEFORE IT WAS THE EU STARS, and the swap
+#    is dated to the day. Dz. U. 2002 nr 133 poz. 1123 § 19 ust. 1: "Każda
+#    tablica posiada dodatkowo na niebieskim tle symbol barw Rzeczypospolitej
+#    Polskiej i litery «PL» barwy białej." Dz. U. 2006 nr 70 poz. 489 replaced
+#    that with the twelve-star EU symbol and § 6 commences it "z dniem 2 maja
+#    2006 r." — two years AFTER accession, which is the sort of gap a
+#    guessed date gets wrong. § 2 of the same instrument keeps the flag-band
+#    plates lawful indefinitely, so the two designs are genuinely parallel.
+#
+# 6. H AND U ARE THE TWO LETTERS THAT ARE NEVER A VOIVODEDSHIP. § 30 ust. 1 gives
+#    a 25-letter alphabet (A-Z without Q); 23 of those letters appear in column 4
+#    of załącznik nr 13. The two that never do are H and U, and both are spoken
+#    for elsewhere: H is the base of the six service prefixes and U is the armed
+#    forces' wyróżnik. A leading H or U is therefore a positive signal that the
+#    plate is not a civil registration — see plates/_decode/pl-powiats.yml.
+#
+# REGEX POLICY, as in plates/at.yml and plates/de.yml: `format.regex` is the
+# lint-round-trippable regex spelling § 30 ust. 2's enumerated layouts;
+# `format.regex_strict` carries the two sourced tightenings the round-trip
+# forbids — the § 30 ust. 1 exclusion of Q from the whole alphabet, and the
+# § 31 ust. 1 exclusion of B, D, I, O and Z from the VEHICLE wyróżnik only
+# (never from the prefix, where DB, DDZ, CIN and CB are all real codes).
+# There is no leading-zero rule to carry: the statutory ranges are "od 00001"
+# and "od 0001", so 0 is significant in every position but the all-zero serial.
+jurisdiction: pl
+authority:
+  name: Ministerstwo Infrastruktury — Prawo o ruchu drogowym (Dz. U. 2024 poz. 1251) i rozporządzenie w sprawie rejestracji i oznaczania pojazdów (Dz. U. 2024 poz. 1709)
+  url: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709"
+binding: vehicle
+binding_note: >-
+  art. 73 ust. 1d Prawa o ruchu drogowym: "Numer rejestracyjny na tablicach
+  (tablicy) rejestracyjnych stanowią litery i cyfry (cyfra). Numer ten składa
+  się odpowiednio z wyróżnika województwa lub powiatu i wyróżnika pojazdu albo
+  wyróżnika indywidualnego pojazdu" — and § 27 ust. 1 of the rozporządzenie:
+  "Każdemu pojazdowi przypisuje się jeden numer rejestracyjny." The number binds
+  to the VEHICLE, so vehicle-keyed consumers may join on it. The one nuance a
+  consumer must know is art. 73 ust. 1a, which since 2022 lets a BUYER keep the
+  number: "Składający wniosek o rejestrację pojazdu może wnioskować
+  o zachowanie dotychczasowego numeru rejestracyjnego, w tym tablic (tablicy)
+  rejestracyjnych, jeżeli pojazd był już zarejestrowany na terytorium
+  Rzeczypospolitej Polskiej" — the plate stays on the same vehicle across a
+  change of keeper, it never moves to a different vehicle. There is no Polish
+  analogue of the British or Swiss owner-binding.
+instrument:
+  citation: "Rozporządzenie Ministra Infrastruktury z dnia 8 listopada 2024 r. w sprawie rejestracji i oznaczania pojazdów, wymagań dla tablic rejestracyjnych oraz wzorów innych dokumentów związanych z rejestracją pojazdów (Dz. U. 2024 poz. 1709), zmienione Dz. U. 2025 poz. 939 i Dz. U. 2026 poz. 891"
+  enabling_statute: "Ustawa z dnia 20 czerwca 1997 r. – Prawo o ruchu drogowym, art. 76 ust. 1 pkt 1 lit. a, c i d (tekst jednolity Dz. U. 2024 poz. 1251)"
+  data_wydania: "2024-11-08"
+  wejscie_w_zycie: "2024-11-30"
+  wejscie_w_zycie_source: "§ 51, verbatim: 'Rozporządzenie wchodzi w życie po upływie 7 dni od dnia ogłoszenia.' The ELI register fixes the resulting date at 2024-11-30."
+  eli: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709"
+  source: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # the whole instrument, 102 pages, read in this pass. Accessed 2026-08-02"
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+common:
+  plate_types:
+    statute: >-
+      § 25 of the rozporządzenie closes the type vocabulary at FIVE, verbatim:
+      "Do oznaczania pojazdów stosuje się następujące wzory tablic
+      rejestracyjnych: 1) zwyczajne – do oznaczania wszystkich pojazdów,
+      z zastrzeżeniem pkt 2-5; 2) indywidualne – do oznaczania pojazdów
+      samochodowych; 3) zabytkowe – do oznaczania pojazdów zabytkowych;
+      4) tymczasowe – do oznaczania pojazdów czasowo zarejestrowanych;
+      5) dyplomatyczne – do oznaczania pojazdów należących do przedstawicielstw
+      dyplomatycznych, urzędów konsularnych i misji specjalnych państw obcych
+      oraz organizacji międzynarodowych, a także ich personelu." Every other
+      Polish plate — professional, military, service — exists under a DIFFERENT
+      delegation in art. 76 and a different instrument, which is why those
+      series cite different sources here.
+    sizes: >-
+      § 26 ust. 1 cuts the same plates a second way, by size: samochodowe
+      (jednorzędowe / dwurzędowe, and jednorzędowe zmniejszone for vehicles whose
+      mounting recess is undersized), motocyklowe (always two-row; also used for
+      agricultural tractors and for L6e/L7e quadricycles) and motorowerowe
+      (always two-row). A tractor may take a car plate where it has the recess
+      for one (ust. 2).
+    source: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # §§ 25-26. Accessed 2026-08-02"
+  dimensions:
+    samochodowa_jednorzedowa: { w: 520, h: 114, unit: mm }
+    samochodowa_dwurzedowa: { w: 305, h: 214, unit: mm }
+    samochodowa_jednorzedowa_zmniejszona: { w: 305, h: 114, unit: mm }
+    motocyklowa: { w: 190, h: 150, unit: mm }
+    motorowerowa: { w: 140, h: 114, unit: mm }
+    corner_radius: { r: 10, unit: mm, tolerance: "-0.5 to +1.5 mm" }
+    border_inset: { d: 7, unit: mm, note: "the embossed frame (ramka obrzeża) sits 7 mm in from the plate edge on every size" }
+    tolerance: "±1 mm on length and width (pkt 2.2); total plate thickness 1.4-3.0 mm (pkt 2.8); 1 mm aluminium strip (pkt 2.1)"
+    source: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # załącznik nr 12, Rysunek 1 'Wymiary i kształty tablic rejestracyjnych' (printed page 53) — read from the drawing, which carries the millimetre dimensions as leader-line callouts. Accessed 2026-08-02"
+    note: >-
+      520 x 114 mm, NOT the 520 x 110 mm that circulates everywhere and that
+      Germany, the Netherlands and Spain actually use. The Polish single-line
+      plate is 4 mm taller than its neighbours', and the figure is a statutory
+      dimension on Rysunek 1, not an observation. The two-row car plate is
+      305 x 214 mm, which is also not the 340 x 200 mm of the German pattern.
+  colorimetry:
+    basis: >-
+      Poland specifies COLOUR AS A CIE CHROMATICITY QUADRANGLE plus a luminance
+      factor, not as RGB or RAL. Załącznik nr 12 pkt 2.20, verbatim: "Barwa
+      biała, żółta, niebieska i zielona powierzchni odblaskowych oraz biała
+      i czarna powierzchni znaków, przy oświetleniu wzorcowym źródłem światła
+      D65 pod kątem 45º do normalnej do powierzchni i obserwacji wzdłuż normalnej
+      (geometria 45/0), powinny mieścić się w polach barwowych normalnego układu
+      trójchromatycznego CIE, określonych dla danej barwy przez punkty narożne
+      o współrzędnych trójchromatycznych podanych w tablicy 2 i odpowiadać
+      podanemu w tablicy 2 współczynnikowi luminancji." Every hex in this file
+      is therefore `hex_basis: observed`; the quadrangle is the spec and is
+      reproduced here so a renderer can do better than a guess.
+    biala:     { x: [0.355, 0.305, 0.285, 0.335], y: [0.355, 0.305, 0.325, 0.375], beta: 0.35 }
+    czerwona:  { x: [0.690, 0.595, 0.569, 0.655], y: [0.310, 0.315, 0.341, 0.345], beta: 0.05 }
+    niebieska: { x: [0.078, 0.150, 0.210, 0.137], y: [0.171, 0.220, 0.160, 0.038], beta: 0.01 }
+    zolta:     { x: [0.481, 0.444, 0.494, 0.545], y: [0.518, 0.476, 0.426, 0.454], beta: 0.27 }
+    czarna:    { x: [0.385, 0.300, 0.260, 0.345], y: [0.355, 0.270, 0.310, 0.395], beta: "<= 0.03" }
+    niebieska_pole_ue: { x: [0.176, 0.176, 0.140, 0.140], y: [0.140, 0.104, 0.104, 0.140], beta: 0.01, note: "a SECOND and much narrower blue, applying only to the field under the EU symbol and the PL letters — the plate's own blue (tablica dyplomatyczna) is the wider quadrangle above" }
+    zielona:   { x: [0.250, 0.250, 0.325, 0.325], y: [0.355, 0.500, 0.565, 0.400], beta: "0.20 <= beta <= 0.40" }
+    retroreflection: "Tablica 1 gives the minimum and maximum coefficient of retroreflection per colour and per observation/illumination angle pair — white min 50 / max 250, yellow 30/175, green 23/100, blue 3/15 cd/lx/m2 at 20' and 5°. Green and yellow are measured for DAYLIGHT only."
+    source: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # załącznik nr 12 pkt 2.18-2.21, Tablica 1 (retroreflection), Tablica 2 (daylight colour), Tablica 3 (night colour). Accessed 2026-08-02"
+  font:
+    name: null
+    statutory_basis: >-
+      NO TYPEFACE IS NAMED ANYWHERE, and the legal object is a DRAWING, exactly
+      as the EU dossier found for the UK, Germany, Spain and Austria. Załącznik
+      nr 12 pkt 2.11, in full: "Litery i cyfry na tablicach powinny być wykonane
+      zgodnie z wymiarami podanymi na rysunku 7." Rysunek 7 is a full
+      dimensioned outline drawing of all 25 letters and the 10 digits, with
+      construction radii labelled a/b/c/d per glyph. The drawn alphabet is
+      A B C D E F G H I J K L M N O P R S T U V W X Y Z — Q is absent from the
+      drawing as well as from § 30 ust. 1.
+    geometry_gap: >-
+      RECORDED GAP, and it is the one place Poland is WEAKER than Austria for a
+      renderer: the per-glyph millimetre widths live only in the drawing's
+      leader lines, not in any table, so this pass records the drawing as the
+      source without extracting numeric widths. What IS extractable in text:
+      pkt 2.10's tolerances (character height and width ±1.0 mm; spread within
+      one plate 0.8 mm on car plates and 0.5 mm elsewhere; inter-character
+      spacing ±1.5 mm; squareness 0.5 mm per 50 mm of character height) and
+      pkt 2.12's rule that layout follows Rysunki 9-25, with the substitute
+      rectangles of Rysunek 27 used for the digit 1 and the letters I, J, L and T.
+    licence: >-
+      PRD-PLATES §6 applies unchanged: the render layer derives glyphs from the
+      statutory drawing, never from a third-party TTF. Whether Poland has a
+      German-style §5 UrhG public-domain rule for designs published inside
+      statutory instruments was NOT researched in this pass — recorded gap, and
+      one more reason to derive rather than embed.
+    source: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # załącznik nr 12 pkt 2.10-2.13 and Rysunek 7 (printed page 57), Rysunek 27 (substitute rectangles). Accessed 2026-08-02"
+  euro_band:
+    side: left
+    content: eu-stars+PL
+    statute: >-
+      § 28 ust. 1, verbatim: "W skrajnej lewej części tablicy rejestracyjnej
+      umieszcza się dodatkowo na niebieskim tle symbol Unii Europejskiej
+      składający się z 12 pięcioramiennych gwiazdek barwy żółtej ułożonych na
+      obwodzie okręgu oraz znak z literami «PL» barwy białej. Wymóg ten nie
+      dotyczy tablic (tablicy) rejestracyjnych dyplomatycznych."
+    geometry: >-
+      Unlike Austria, Poland DOES publish band geometry in text. Załącznik nr 12
+      pkt 2.5: the PL letters are 20 mm high (tolerance +1 mm) with a 4 mm stroke
+      (+0.5 mm); the blue field must run into the adjoining frame so that no
+      white or yellow strip is left between the blue and the black or red border;
+      height tolerance ±2 mm on two-row plates, width tolerance ±2 mm on all.
+      Rysunek 8 tabulates the field per plate size (a/b/c/d/e/f/g in mm):
+      samochodowa jednorzędowa 30/40/-/20/6.5/24/35, samochodowa dwurzędowa
+      30/40/100/20/6.5/17/35, motocyklowa 26/35/70/17.5/4/8/21, motorowerowa
+      22.5/30/55/15/1.5/5/15.
+    note: >-
+      The band is a property of the PLATE, not of the class: it is on ordinary,
+      individual, historic, temporary and professional plates and off only the
+      diplomatic one. Poland does NOT cross-reference Reg. (EC) 2411/98 the way
+      FZV Anlage 4 does — the geometry above is purely national.
+    source: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 28 ust. 1; załącznik nr 12 pkt 2.5 and Rysunek 8. Accessed 2026-08-02"
+  eagle:
+    statute: >-
+      § 28 ust. 4 pkt 1: every plate carries a laser-etched OUTLINE of the eagle
+      of the Polish coat of arms ("grafikę obrysu wizerunku orła, o którym mowa
+      w ustawie z dnia 31 stycznia 1980 r. o godle, barwach i hymnie
+      Rzeczypospolitej Polskiej oraz o pieczęciach państwowych"), 15 mm high with
+      a 0.25 mm line, centred above the legalisation-sticker slot and 17 mm from
+      the top edge on car plates, 15 mm on motorcycle plates. § 28 ust. 6 takes
+      it OFF moped plates and temporary plates.
+    rendered: placeholder
+    render_note: >-
+      PRD-PLATES §3 placeholder rule applies. The eagle is a state emblem under
+      the 1980 ustawa o godle and its licensing posture was not researched here;
+      the render layer draws a neutral placeholder in the slot.
+    source: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 28 ust. 4 pkt 1 and ust. 6; załącznik nr 12 pkt 2.6 lit. b. Accessed 2026-08-02"
+  separator:
+    emitted: " "
+    statute: >-
+      THE REGULATION PRESCRIBES NO SEPARATOR GLYPH AT ALL — and it says what
+      occupies the position instead. Załącznik nr 12 pkt 2.6 lit. a places the
+      laser-marked slot for the legalisation sticker (18 x 30 mm, corner radius
+      3 mm, 0.25 mm line) "w poziomie – symetrycznie między ostatnim znakiem
+      wyróżnika województwa lub powiatu a pierwszym znakiem wyróżnika pojazdu",
+      42 mm down from the top edge on car plates. The gap a reader sees between
+      the prefix and the serial is therefore a STICKER WELL, exactly as the gap
+      on an Austrian plate is a coat of arms. Every `pattern` in this file
+      prints a SPACE there and every regex spells the position ` ?`, because the
+      law prescribes a physical gap and no glyph, and a written Polish plate is
+      as often set solid as spaced.
+    source: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # załącznik nr 12 pkt 2.6 lit. a; § 28 ust. 2-3, ust. 5 (no slot marking on temporary plates). Accessed 2026-08-02"
+  serial_grammar:
+    alphabet_source: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 30 ust. 1 and § 31 ust. 1. Accessed 2026-08-02"
+    alphabet: >-
+      § 30 ust. 1, verbatim: "Numery rejestracyjne są tworzone ze zbioru
+      następujących 25 liter: A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, R,
+      S, T, U, V, W, X, Y i Z oraz cyfr od 0 do 9." Q is the only Latin letter
+      excluded, and it is excluded dataset-wide, prefix included.
+    letters_excluded_everywhere: ["Q"]
+    letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"]
+    vehicle_exclusion_note: >-
+      § 31 ust. 1: "Wyróżnik pojazdu, z zastrzeżeniem § 32 ust. 2, określa organ
+      rejestrujący, posługując się zestawem cyfr i liter stanowiących pojemność
+      rejestracyjną, z wyłączeniem liter B, D, I, O i Z." The five letters are
+      the digit look-alikes and they are excluded FROM THE VEHICLE WYRÓŻNIK
+      ONLY. They remain lawful in the PREFIX, where DB (Wałbrzych), DDZ
+      (dzierżoniowski), CIN (inowrocławski), CB (Bydgoszcz) and ZSZ
+      (szczecinecki) are all real codes — a distinction every existing
+      description of Polish plates blurs and `regex_strict` here does not.
+      The "z zastrzeżeniem § 32 ust. 2" carve-out is real too: an INDIVIDUAL
+      wyróżnik is chosen by the owner, so the five letters are available there.
+    no_leading_zero_rule: false
+    no_leading_zero_note: >-
+      There is NO leading-zero rule in Polish law, unlike Austria's. The
+      statutory ranges are written "od 00001 do 99999", "od 0001 do 9999",
+      "od 001 do 999", "od 01 do 99" and "od 1 do 9" — so a zero is significant
+      in every position except that the all-zero serial is excluded, and
+      "DW 00123" is a well-formed Wrocław plate.
+    layouts_source: "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 30 ust. 2 pkt 1-7, the complete enumeration of every layout for every plate type, split by whether the powiat wyróżnik is one letter or two. Accessed 2026-08-02"
+    exhaustion_order: >-
+      § 30 ust. 2 lists the layouts "tworzony kolejno w układzie" — IN ORDER OF
+      EXHAUSTION. A layout is only reached when the previous one is used up, so
+      the list is an era-inference signal for a parse API: within one powiat, a
+      plain five-digit serial is older than a four-digit-plus-letter one, which
+      is older than three-digits-plus-two-letters. The regulation publishes the
+      ORDER but no dates, so the inference is ordinal, never calendar.
+  offensive_serials:
+    statute: "§ 32 ust. 3: an individual wyróżnik 'powinien być wyrazem, skrótem lub określeniem, które nie zawierają w swoim znaczeniu w języku polskim albo obcym treści obraźliwych lub niezgodnych z zasadami współżycia społecznego.'"
+    modelled: false
+    modelled_note: >-
+      NOT encoded as a charset exclusion, deliberately, and for the same reason
+      Austria's § 26 Abs. 8 list is not: it is a refusal standard applied at
+      assignment, it binds only INDIVIDUAL plates, and unlike Austria's the
+      Polish text enumerates nothing at all — it is a general clause, so there
+      is no list to encode even if encoding one were right.
+  absent_classes:
+    export: "No export series. § 25 closes the type list at five and none of them is an export plate; the TEMPORARY plate does that job, and has since at least 1993 — Dz. U. 1993 nr 37 poz. 164 § 13 ust. 3 gave tablice tymczasowe the express purpose of 'umożliwienia wyjazdu lub wywozu tych pojazdów za granicę'."
+    taxi: "No taxi series found in §§ 25-32 or załączniki 12-13."
+    seasonal: "No seasonal series — no Polish analogue of the German Saisonkennzeichen was found."
+    agricultural: "No agricultural series. § 26 ust. 1 pkt 2 puts agricultural tractors on the MOTORCYCLE plate, and ust. 2 lets them take a car plate where the mounting recess suits — so they are covered by pl-motorcycle and pl-standard rather than by a series of their own."
+    trailer: "No trailer series. § 26 ust. 1 pkt 1 lit. a puts trailers on ordinary car plates; załącznik nr 12 pkt 2.4 makes the trailer plate a SINGLE plate rather than a set, which is a manufacturing fact, not a format one."
+    dealer: "Superseded rather than absent — see pl-professional. The pre-2019 answer was the tablica tymczasowa badawcza."
+    research_badawcza: >-
+      ABOLISHED, and dated. Dz. U. 2002 nr 133 poz. 1123 § 18 ust. 7 and § 21
+      ust. 2 pkt 6 defined a "tablica tymczasowa badawcza" — red on white,
+      letter + digit voivodeship, two digits, then the FIXED letter B marking the
+      plate's purpose — for vehicles run under homologation and R&D testing.
+      No such type survives in § 25 of the 2024 instrument; the professional
+      registration regime of 2019 replaced it. Recorded as a class this
+      jurisdiction once had and no longer issues; the plates themselves are not
+      modelled as a series because the pass did not establish their withdrawal
+      date, which is a recorded gap.
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD SERIES — black on white, EU field since 2 May 2006.
+  # =========================================================================
+  - id: pl-standard
+    class: standard
+    categories: [car, van, truck, bus, trailer]
+    period: { start: 2006 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "LL 99999"
+      regex: '\A(?:[A-Z]{2} ?(?:\d{5}|\d{4}[A-Z]|\d{3}[A-Z]{2}|\d[A-Z]\d{3}|\d[A-Z]{2}\d{2})|[A-Z]{3} ?(?:[A-Z]\d{3}|\d{2}[A-Z]{2}|\d[A-Z]\d{2}|\d{2}[A-Z]\d|\d[A-Z]{2}\d|[A-Z]{2}\d{2}|\d{5}|\d{4}[A-Z]|\d{3}[A-Z]{2}))\z'
+      regex_strict: '\A(?:[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z] ?(?:\d{5}|\d{4}[ACEFGHJKLMNPRSTUVWXY]|\d{3}[ACEFGHJKLMNPRSTUVWXY]{2}|\d[ACEFGHJKLMNPRSTUVWXY]\d{3}|\d[ACEFGHJKLMNPRSTUVWXY]{2}\d{2})|[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z]{2} ?(?:[ACEFGHJKLMNPRSTUVWXY]\d{3}|\d{2}[ACEFGHJKLMNPRSTUVWXY]{2}|\d[ACEFGHJKLMNPRSTUVWXY]\d{2}|\d{2}[ACEFGHJKLMNPRSTUVWXY]\d|\d[ACEFGHJKLMNPRSTUVWXY]{2}\d|[ACEFGHJKLMNPRSTUVWXY]{2}\d{2}|\d{5}|\d{4}[ACEFGHJKLMNPRSTUVWXY]|\d{3}[ACEFGHJKLMNPRSTUVWXY]{2}))\z'
+      charset:
+        letters_excluded: ["Q"]
+        letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"]
+        notes: >-
+          Two DIFFERENT exclusions, and conflating them is the standard error.
+          § 30 ust. 1 excludes Q from the whole 25-letter alphabet, prefix
+          included. § 31 ust. 1 excludes B, D, I, O and Z from the VEHICLE
+          wyróżnik only — they stay lawful in the prefix, where DB, DDZ, CIN,
+          CB and ZSZ are real codes in załącznik nr 13. Hence [A-PR-Z] on the
+          prefix and [ACEFGHJKLMNPRSTUVWXY] on the serial in regex_strict.
+      progression: >-
+        § 30 ust. 2 pkt 1. For a powiat whose wyróżnik is ONE letter (prefix two
+        characters) the vehicle wyróżnik is five characters, in this exhaustion
+        order: five digits 00001-99999; four digits 0001-9999 and a letter;
+        three digits 001-999 and two letters; a digit 1-9, a letter and three
+        digits 001-999; a digit 1-9, two letters and two digits 01-99. For a
+        powiat whose wyróżnik is TWO letters (prefix three characters) it is
+        four or five: a letter and three digits; two digits and two letters; a
+        digit, a letter and two digits; two digits, a letter and a digit; a
+        digit, two letters and a digit; two letters and two digits; then five
+        digits; four digits and a letter; three digits and two letters. The list
+        is ordered "tworzony kolejno" — each layout is reached only when the
+        previous is exhausted, which makes the layout an ORDINAL age signal
+        within a powiat. The regulation publishes no dates against it.
+      prefix_split_note: >-
+        The two-or-three-letter prefix is NOT self-delimiting, but for this
+        series it is deterministic: every five-character layout begins with a
+        DIGIT, so a letter in the third position means a three-character prefix
+        and a digit there means a two-character one. See
+        plates/_decode/plates/_decode/pl-powiats.yml, prefix_split.
+      separator_note: >-
+        The printed gap between prefix and serial is the LEGALISATION-STICKER
+        WELL, not a glyph: załącznik nr 12 pkt 2.6 lit. a puts the 18 x 30 mm
+        laser-marked slot "symetrycznie między ostatnim znakiem wyróżnika
+        województwa lub powiatu a pierwszym znakiem wyróżnika pojazdu". The law
+        prescribes no separator character at all, so `pattern` prints a space
+        and the regex spells the position ` ?`.
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      plate_variants:
+        - { w: 305, h: 214, unit: mm, note: "samochodowa dwurzędowa — the two-row rear plate, used where the mounting recess requires it (§ 33 ust. 5)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, spec_note: "§ 27 ust. 2 pkt 1 names the colour as 'barwy czarnej na białym tle'; załącznik nr 12 Tablica 2 bounds white to the CIE quadrangle in common.colorimetry.biala with a luminance factor of 0.35" }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed, note: "the EU field's blue has its OWN and much narrower quadrangle (common.colorimetry.niebieska_pole_ue), distinct from the blue of the diplomatic plate" }
+      emblem: { present: true, rendered: placeholder, position: "laser-etched above the legalisation-sticker slot, 17 mm from the top edge", content: "outline of the eagle of the Polish coat of arms, 15 mm high, 0.25 mm line (§ 28 ust. 4 pkt 1)" }
+      rear_differs: false
+      display: "front and rear (§ 33 ust. 1); front is always the single-row plate (ust. 4); trailers, agricultural tractors, motorcycles and mopeds carry a rear plate only"
+      extra: "a keeper may additionally obtain a legalised DUPLICATE plate bearing the same number, to be fixed to a bicycle carrier that covers the rear plate (art. 73 ust. 1b of the ustawa; § 26 ust. 5) — a genuinely unusual provision and a trap for any consumer that assumes one plate number means at most two physical plates"
+    region_encoding: "plates/_decode/pl-powiats.yml"
+    region_encoding_mechanism: >-
+      § 30 ust. 2 pkt 1: the first letter is the voivodeship, the second — or
+      second and third — the powiat, and § 31 ust. 2 puts the whole table inside
+      the instrument as załącznik nr 13. Unlike Germany's, the list needs no
+      Bundesanzeiger hunt, so the decode file carries all 380 rows and all 689
+      prefixes from the primary.
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 27 ust. 2 (black on white), § 28 (EU field, eagle), § 30 ust. 1-2 pkt 1 (alphabet and every layout), § 31 (vehicle-wyróżnik exclusions, the annex, the second-letter rule), § 33 (mounting); załącznik nr 12 Rysunek 1 (520 x 114 mm) and Tablica 2 (colour). Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2006/489/text/O/D20060489.pdf  # Dz. U. 2006 nr 70 poz. 489: the amendment that replaced the Polish-flag band with the twelve-star EU symbol, and § 6, verbatim: 'Rozporządzenie wchodzi w życie z dniem 2 maja 2006 r.' — the period.start of this series. § 2 keeps the older plates valid, § 3 makes the swap voluntary and number-preserving. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1251/text/O/D20241251.pdf  # Prawo o ruchu drogowym art. 73 ust. 1, 1a, 1b, 1d and art. 76 ust. 1 — the enabling frame and the number-retention rule. Accessed 2026-08-02"
+    notes: >-
+      THE POLISH STANDARD SERIES. period.start 2006 is a REAL commencement and
+      not an instrument date: the EU field became mandatory on 2 May 2006 under
+      Dz. U. 2006 nr 70 poz. 489 § 6 — TWO YEARS AFTER accession, which is
+      exactly the kind of gap a plausible guess closes wrongly. The FORMAT is
+      six years older than the design: the voivodeship+powiat frame dates from
+      1 May 2000 (see pl-standard-preeu), which is why this entry and its
+      predecessor share a grammar and differ in the blue field. Both remain on
+      the road: § 2 of the 2006 amendment preserved existing plates and § 3 made
+      the swap optional and number-preserving, so flag-band plates are lawful
+      indefinitely and the two series are genuinely parallel. GRAMMAR CAVEAT,
+      stated rather than hidden: the layout list has been WIDENED inside this
+      series' period — Dz. U. 2017 poz. 2355 § 57 pkt 2 commenced six further
+      layouts on 1 July 2018, and this pass did not diff every amendment between
+      2006 and 2024, so the regex is the CURRENT union applied across the whole
+      period and is wider than what was issued in its early years. A recorded
+      gap, and the reason a per-year format claim here would be false precision.
+
+  # =========================================================================
+  # ONE SERIES BACK — the same numbers under a POLISH FLAG band, 2000-2006.
+  # =========================================================================
+  - id: pl-standard-preeu
+    class: standard
+    categories: [car, van, truck, bus, trailer]
+    period: { start: 2000, end: 2006 }
+    period_evidence: instrument-dated-both-ends
+    matching: strict
+    format:
+      pattern: "LL 99999"
+      regex: '\A(?:[A-Z]{2} ?(?:\d{5}|\d{4}[A-Z]|\d{3}[A-Z]{2})|[A-Z]{3} ?(?:\d{4}|\d{3}[A-Z]|[A-Z]\d{3}|\d{2}[A-Z]{2}|\d[A-Z]\d{2}|\d{2}[A-Z]\d|\d[A-Z]{2}\d))\z'
+      regex_strict: '\A(?:[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z] ?(?:\d{5}|\d{4}[A-PR-Z]|\d{3}[A-PR-Z]{2})|[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z]{2} ?(?:\d{4}|\d{3}[A-PR-Z]|[A-PR-Z]\d{3}|\d{2}[A-PR-Z]{2}|\d[A-PR-Z]\d{2}|\d{2}[A-PR-Z]\d|\d[A-PR-Z]{2}\d))\z'
+      charset:
+        letters_excluded: ["Q"]
+        notes: >-
+          regex_strict here carries ONLY the Q exclusion, because the B/D/I/O/Z
+          rule is younger than the series' start: it first appears as § 22
+          ust. 1 of Dz. U. 2002 nr 133 poz. 1123, in force 21 September 2002,
+          and the 1999 instrument that opened this series has no equivalent.
+          Applying today's exclusion backwards over 2000-2002 would be a claim
+          this pass cannot make.
+      grammar_widening: >-
+        THE GRAMMAR CHANGED INSIDE THIS SERIES, on a sourced date. Under
+        Dz. U. 1999 nr 59 poz. 632 § 21 ust. 2 pkt 1 (1 May 2000) a one-letter
+        powiat had five digits, then four digits and a letter, then three digits
+        and two letters; a two-letter powiat had four digits, then three digits
+        and a letter — five layouts in all. Dz. U. 2002 nr 133 poz. 1123 § 21
+        ust. 2 pkt 1 (21 September 2002) DROPPED the two bare-digit layouts for
+        two-letter powiats and added five mixed ones. The regex above is the
+        UNION of both, which is the series' own issuing grammar over its whole
+        period; `matching: strict` is therefore still correct, but a consumer
+        dating a specific plate must know that the mixed layouts cannot predate
+        21 September 2002.
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: "polish-flag+PL", hex_basis: observed }
+      band_note: >-
+        THE DIFFERENCE THAT MAKES THIS A SERIES. Dz. U. 2002 nr 133 poz. 1123
+        § 19 ust. 1, verbatim: "Każda tablica posiada dodatkowo na niebieskim tle
+        symbol barw Rzeczypospolitej Polskiej i litery «PL» barwy białej. Wymóg
+        ten nie dotyczy tablic (tablicy) dyplomatycznych." Its 1998 predecessor
+        put it more plainly still (Dz. U. 1998 nr 57 poz. 365 § 18): "Każda
+        tablica na niebieskim tle ma dodatkowo symbol flagi polskiej barwy
+        biało-czerwonej i litery «PL» barwy białej." So the band existed before
+        accession and carried the NATIONAL flag, not the EU stars, until 2 May
+        2006 — a design fact that is routinely lost.
+      emblem: { present: false, note: "the laser-etched eagle outline is a later addition; it is required by § 28 ust. 4 pkt 1 of the current instrument and was introduced by Dz. U. 2019 poz. 1272, whose § 9 gave the trade twelve further months for existing stock" }
+    region_encoding: "plates/_decode/pl-powiats.yml"
+    region_encoding_note: >-
+      Decodable through the same table, with a caution: plates/_decode/pl-powiats.yml holds the
+      codes in force in 2026, and the annex has been amended repeatedly since
+      2000. Codes added later (for example the second voivodeship letters, and
+      the extra powiat codes issued as pools ran out) cannot appear on a plate
+      from this period, and codes withdrawn since are absent from the table.
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/1999/632/text/O/D19990632.pdf  # Dz. U. 1999 nr 59 poz. 632: § 21 ust. 2 pkt 1 (the 2000 grammar), § 24 (the wyróżniki annex), § 39 (the pre-reform code tables and the stock rule), § 41 ('Do dnia 30 kwietnia 2000 r. organ rejestrujący wydaje tablice rejestracyjne spełniające warunki określone w § 39'), § 49 (commencement of §§ 21-24 on 1 May 2000). Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2002/1123/text/O/D20021123.pdf  # Dz. U. 2002 nr 133 poz. 1123: § 18 ust. 3 (black on white), § 19 ust. 1 (the Polish-flag band), § 21 ust. 2 pkt 1 (the widened grammar), § 22 ust. 1 (the first appearance of the B/D/I/O/Z exclusion). In force 21 September 2002. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2006/489/text/O/D20060489.pdf  # Dz. U. 2006 nr 70 poz. 489 § 6: the EU field from 2 May 2006 — this series' period.end. Accessed 2026-08-02"
+    notes: >-
+      THE FLAG-BAND PLATE, 1 May 2000 to 2 May 2006 — a design change at the end
+      and a system change at the beginning, both instrument-dated. period.start
+      is the commencement carved out of Dz. U. 1999 nr 59 poz. 632 § 49 for the
+      plate provisions ("§ 22-24, § 29 i 30, które wchodzą w życie z dniem
+      1 maja 2000 r."), NOT the 1 July 1999 on which the rest of that instrument
+      commenced and NOT the 2001 that secondary descriptions repeat. period.end
+      is Dz. U. 2006 nr 70 poz. 489 § 6. Distinct from pl-standard by the band
+      alone, and from pl-standard-pre2000 by the entire coding system.
+
+  # =========================================================================
+  # TWO SERIES BACK — the pre-reform system, 49 voivodeships, ends 2000-04-30.
+  # =========================================================================
+  - id: pl-standard-pre2000
+    class: standard
+    categories: [car, van, truck, bus, trailer]
+    period: { start: 1993, end: 2000 }
+    period_evidence: instrument-dated-both-ends
+    matching: strict
+    format:
+      pattern: "LLL 9999"
+      regex: '\A[A-Z]{3} ?(?:\d{4}|\d{3}[A-Z])\z'
+      regex_strict: '\A[A-PR-Z]{3} ?(?:\d{4}|\d{3}[A-PR-Z])\z'
+      charset:
+        letters_excluded: ["Q"]
+        notes: "Dz. U. 1993 nr 37 poz. 164 § 19 and Dz. U. 1998 nr 57 poz. 365 § 20 ust. 1 both give the same 25-letter set (A-Z without Q); neither carries the B/D/I/O/Z rule, which is a 2002 invention."
+      progression: >-
+        Dz. U. 1998 nr 57 poz. 365 § 20 ust. 2 pkt 1, verbatim: "na tablicach
+        zwyczajnych dwie pierwsze litery stanowią wyróżnik województwa, trzecia
+        litera i cztery cyfry w przedziale od 0001 do 9999 lub trzecia litera
+        i trzy cyfry w przedziale od 001 do 999 oraz litera stanowią wyróżnik
+        pojazdu." The 1993 instrument says the same in § 18 ust. 1. So the
+        pre-reform plate is TWO letters of voivodeship and a THREE-character
+        prefix in total — structurally the inverse of the post-2000 plate, where
+        one letter is the voivodeship and the prefix is two or three characters.
+    design:
+      plate: { w: null, h: null, unit: mm }
+      dimensions_note: "no dimensions were secured for this series: Dz. U. 1993 nr 37 poz. 164 § 16 ust. 1 delegates them entirely — 'Tablice rejestracyjne powinny odpowiadać wymaganiom określonym w obowiązującej normie' — and Dz. U. 1999 nr 59 poz. 632 § 39 ust. 5 names that norm as PN 5-73200, which was not fetched in this pass. Recorded gap."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      colour_evidence: >-
+        WHITE IS SOURCED ONLY FROM 1998 ONWARD. Dz. U. 1998 nr 57 poz. 365 § 17
+        ust. 3 is the earliest instrument read here that states a colour: "Na
+        tablicy zwyczajnej wytłoczony jest numer rejestracyjny składający się
+        z wyróżnika województwa i wyróżnika pojazdu barwy czarnej na białym
+        tle." The 1993 instrument states none at all, delegating to the norm, so
+        the transition from the black plate that preceded it IS NOT DATED HERE.
+        The widely repeated claim that Poland went from black to white in a
+        particular year is not asserted; it is a recorded gap whose answer lives
+        in PN 5-73200 and its predecessors.
+      band: { side: left, color: "#003399", content: "polish-flag+PL", hex_basis: observed, note: "sourced for 1998 onward only, from § 18 of Dz. U. 1998 nr 57 poz. 365; whether the 1993-1998 plate carried the band was not established" }
+      emblem: { present: false }
+    region_encoding: none
+    region_encoding_note: >-
+      NOT decodable through plates/_decode/pl-powiats.yml, and a parse API must
+      not route a pre-2000 string through it. This series encodes the OLD
+      49-voivodeship system in the first TWO letters, a scheme with no
+      relationship to the one-letter voivodeship codes of załącznik nr 13. The
+      code lists exist and are pinned in `sources` — Dz. U. 1993 nr 37 poz. 164
+      § 20, and the two transitional tables in Dz. U. 1999 nr 59 poz. 632 § 39
+      ust. 1 and ust. 2 — but they are NOT shipped as a decode table here,
+      deliberately: both are scanned typescript whose OCR is visibly unreliable
+      (the 1999 tables render "WS" as "W5" and "KA" as "K~"), and a code table
+      transcribed from a bad scan is worse than an honest gap. A dedicated pass
+      with page images is the fix, and this is a recorded L4 target.
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/1993/164/text/O/D19930164.pdf  # Dz. U. 1993 nr 37 poz. 164 (rozporządzenie MTiGM z 14 kwietnia 1993 r. w sprawie rejestracji, ewidencji i oznaczania pojazdów): § 13 (the four plate types), § 16 ust. 1 (dimensions delegated to the norm), § 18 ust. 1 (the two-letter voivodeship grammar), § 19 (the 25-letter alphabet), § 20 (the voivodeship code table). Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/1998/365/text/O/D19980365.pdf  # Dz. U. 1998 nr 57 poz. 365: § 17 (colours for all five plate types), § 18 (the Polish-flag band), § 20 ust. 2 (the grammar), § 21 (the 49-voivodeship code table). Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/1999/632/text/O/D19990632.pdf  # Dz. U. 1999 nr 59 poz. 632 § 39 ust. 2, the transitional stock rule that ENDS this series: plates bearing the pre-reform voivodeship codes could be issued from stock 'aż do wyczerpania się tych zapasów, jednak nie dłużej niż do dnia 30 kwietnia 2000 r.'; § 41 says the same from the other side; § 42 keeps them valid on the road indefinitely. Accessed 2026-08-02"
+    notes: >-
+      THE PRE-REFORM PLATE. period.end 2000 is SOURCED AT THE DAY, from the
+      complement of the reform: Dz. U. 1999 nr 59 poz. 632 § 41 and § 39 ust. 2
+      allow issue of the old codes only "do dnia 30 kwietnia 2000 r.", so
+      30 April 2000 is the last lawful ASSIGNMENT. HOW LONG THEY REMAIN VALID ON
+      THE ROAD IS NOT A GAP — § 42 answers it in terms ("Tablice (tablica)
+      rejestracyjne wydane na podstawie dotychczasowych przepisów ... zachowują
+      swoją ważność") and art. 73 ust. 1a of the current ustawa still lets a
+      buyer keep a conforming plate, so pre-2000 plates are lawful indefinitely
+      and are re-issued to new keepers to this day. period.start 1993 is
+      INSTRUMENT-IN-FORCE and says so: the format is certainly older than the
+      1993 rozporządzenie, whose own § 29 preserves plates issued under earlier
+      rules, but the earlier instrument was not fetched in this pass.
+
+  # =========================================================================
+  # MOTORCYCLES — and, unusually, agricultural tractors and L6e/L7e quads.
+  # =========================================================================
+  - id: pl-motorcycle
+    class: motorcycle
+    categories: [motorcycle, tractor, quadricycle]
+    period: { start: 2006 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "LL 9999"
+      regex: '\A(?:[A-Z]{2} ?(?:\d{4}|\d{3}[A-Z]|\d{2}[A-Z]\d|\d[A-Z]\d{2}|[A-Z]\d{3}|\d{2}[A-Z]{2}|\d[A-Z]{2}\d|[A-Z]{2}\d{2})|[A-Z]{3} ?(?:[A-Z]\d{3}|\d{2}[A-Z]{2}|\d[A-Z]\d{2}|\d{2}[A-Z]\d|\d[A-Z]{2}\d|[A-Z]{2}\d{2}|[A-Z]\d{2}[A-Z]|[A-Z]\d[A-Z]{2}))\z'
+      regex_strict: '\A(?:[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z] ?(?:\d{4}|\d{3}[ACEFGHJKLMNPRSTUVWXY]|\d{2}[ACEFGHJKLMNPRSTUVWXY]\d|\d[ACEFGHJKLMNPRSTUVWXY]\d{2}|[ACEFGHJKLMNPRSTUVWXY]\d{3}|\d{2}[ACEFGHJKLMNPRSTUVWXY]{2}|\d[ACEFGHJKLMNPRSTUVWXY]{2}\d|[ACEFGHJKLMNPRSTUVWXY]{2}\d{2})|[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z]{2} ?(?:[ACEFGHJKLMNPRSTUVWXY]\d{3}|\d{2}[ACEFGHJKLMNPRSTUVWXY]{2}|\d[ACEFGHJKLMNPRSTUVWXY]\d{2}|\d{2}[ACEFGHJKLMNPRSTUVWXY]\d|\d[ACEFGHJKLMNPRSTUVWXY]{2}\d|[ACEFGHJKLMNPRSTUVWXY]{2}\d{2}|[ACEFGHJKLMNPRSTUVWXY]\d{2}[ACEFGHJKLMNPRSTUVWXY]|[ACEFGHJKLMNPRSTUVWXY]\d[ACEFGHJKLMNPRSTUVWXY]{2}))\z'
+      charset: { letters_excluded: ["Q"], letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"], notes: "§ 30 ust. 1 and § 31 ust. 1, as pl-standard" }
+      progression: >-
+        § 30 ust. 2 pkt 3. The vehicle wyróżnik is ALWAYS four characters
+        whatever the prefix length, which is the structural difference from the
+        car series and the reason the prefix boundary here is resolved by total
+        length rather than by the third character.
+      prefix_split_caveat: >-
+        THE CAR RULE DOES NOT APPLY. § 30 ust. 2 pkt 3 lit. a gives one-letter
+        powiats the layouts "litera i trzy cyfry" and "dwie litery i dwie
+        cyfry", which BEGIN WITH A LETTER, so a letter in the third position no
+        longer proves a three-character prefix. Six of those eight layouts —
+        the third to eighth tirets — were added by Dz. U. 2017 poz. 2355 and
+        commenced on 1 July 2018 by its § 57 pkt 2, so the ambiguity is itself
+        younger than the series.
+      grammar_widening_note: >-
+        As pl-standard: the regex is the CURRENT union applied across the whole
+        period, and is wider than what was issued before 1 July 2018. Recorded
+        gap rather than a per-year claim.
+    design:
+      plate: { w: 190, h: 150, unit: mm, note: "always two-row (§ 26 ust. 1 pkt 2)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed, note: "the EU field on a motorcycle plate is 26 x 35 mm per Rysunek 8, against 30 x 40 mm on a car plate" }
+      emblem: { present: true, rendered: placeholder, content: "eagle outline, 15 mm from the top edge on this size" }
+      rear_differs: false
+      display: "rear only for motorcycles, mopeds, trailers and agricultural tractors (§ 33 ust. 1); L2e, L5e, L6e and L7e vehicles also carry one at the front where they have the recess (ust. 2); a tractor may carry it at the front where its construction requires (ust. 3)"
+      manufacture: "single plate, not a set (załącznik nr 12 pkt 2.4) — except that three-wheelers of class L5e and L2e and quadricycles of L7e/L6e may be given a pair"
+    region_encoding: "plates/_decode/pl-powiats.yml"
+    variants:
+      - class: motorcycle
+        format: { pattern: "LL 9999" }
+        note: >-
+          THE MOTORCYCLE-TRAILER RULE, which has no analogue in the neighbouring
+          jurisdictions and which a vehicle-keyed consumer will misread. § 33
+          ust. 6: "Z tyłu przyczepy motocyklowej umieszcza się tablicę
+          rejestracyjną motocyklową przeniesioną z motocykla, który ciągnie
+          przyczepę." The motorcycle's own plate is PHYSICALLY MOVED to the
+          trailer while towing — so one number lawfully appears on two different
+          vehicles at different moments, and never on both at once.
+        sources:
+          - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 33 ust. 6. Accessed 2026-08-02"
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 26 ust. 1 pkt 2 (motorcycle plates also carry agricultural tractors and L6e/L7e), § 27 ust. 2, § 30 ust. 2 pkt 3, § 33; załącznik nr 12 Rysunek 1 (190 x 150 mm) and Rysunek 8. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2017/2355/text/O/D20172355.pdf  # Dz. U. 2017 poz. 2355 § 57 pkt 2: § 31 ust. 2 pkt 3 lit. a tiret trzecie-ósme — the six added motorcycle layouts — enter into force 1 July 2018. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2006/489/text/O/D20060489.pdf  # § 6: the EU field from 2 May 2006, which is this series' period.start for the same reason as pl-standard. Accessed 2026-08-02"
+    notes: >-
+      MOTORCYCLE PLATES, and the class carries more than motorcycles: § 26
+      ust. 1 pkt 2 puts agricultural tractors and the "samochodowy inny" L6e and
+      L7e quadricycles on the same 190 x 150 mm two-row plate, so a Polish
+      tractor wears a motorcycle plate unless it happens to have a car-plate
+      recess (ust. 2). period.start 2006 is the EU-field commencement, as for
+      pl-standard; the format frame is again older.
+
+  # =========================================================================
+  # MOPEDS — the smallest plate, and the one with no eagle.
+  # =========================================================================
+  - id: pl-moped
+    class: moped
+    categories: [moped]
+    period: { start: 2006 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "LL 9999"
+      regex: '\A(?:[A-Z]{2} ?(?:\d{4}|\d{3}[A-Z]|\d{2}[A-Z]\d|\d[A-Z]\d{2}|[A-Z]\d{3}|\d{2}[A-Z]{2}|\d[A-Z]{2}\d|[A-Z]{2}\d{2})|[A-Z]{3} ?(?:[A-Z]\d{3}|\d{2}[A-Z]{2}|\d[A-Z]\d{2}|\d{2}[A-Z]\d|\d[A-Z]{2}\d|[A-Z]{2}\d{2}|[A-Z]\d{2}[A-Z]|[A-Z]\d[A-Z]{2}))\z'
+      regex_strict: '\A(?:[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z] ?(?:\d{4}|\d{3}[ACEFGHJKLMNPRSTUVWXY]|\d{2}[ACEFGHJKLMNPRSTUVWXY]\d|\d[ACEFGHJKLMNPRSTUVWXY]\d{2}|[ACEFGHJKLMNPRSTUVWXY]\d{3}|\d{2}[ACEFGHJKLMNPRSTUVWXY]{2}|\d[ACEFGHJKLMNPRSTUVWXY]{2}\d|[ACEFGHJKLMNPRSTUVWXY]{2}\d{2})|[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z]{2} ?(?:[ACEFGHJKLMNPRSTUVWXY]\d{3}|\d{2}[ACEFGHJKLMNPRSTUVWXY]{2}|\d[ACEFGHJKLMNPRSTUVWXY]\d{2}|\d{2}[ACEFGHJKLMNPRSTUVWXY]\d|\d[ACEFGHJKLMNPRSTUVWXY]{2}\d|[ACEFGHJKLMNPRSTUVWXY]{2}\d{2}|[ACEFGHJKLMNPRSTUVWXY]\d{2}[ACEFGHJKLMNPRSTUVWXY]|[ACEFGHJKLMNPRSTUVWXY]\d[ACEFGHJKLMNPRSTUVWXY]{2}))\z'
+      charset: { letters_excluded: ["Q"], letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"] }
+      note: "§ 30 ust. 2 pkt 3 governs 'tablice rejestracyjne zwyczajne motocyklowe i motorowerowe' together, so the grammar is identical to pl-motorcycle and the series exists because the PLATE differs."
+    design:
+      plate: { w: 140, h: 114, unit: mm, note: "always two-row; the smallest Polish plate, and almost square" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed, note: "22.5 x 30 mm on this size (Rysunek 8) — the EU field shrinks with the plate but is never dropped" }
+      emblem: { present: false, note: "§ 28 ust. 6 expressly disapplies the eagle to moped plates and to temporary plates — the only two civil plates without it" }
+      display: "rear only (§ 33 ust. 1)"
+      manufacture: "single plate (załącznik nr 12 pkt 2.4)"
+    region_encoding: "plates/_decode/pl-powiats.yml"
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 26 ust. 1 pkt 3, § 27 ust. 5, § 28 ust. 6, § 30 ust. 2 pkt 3; załącznik nr 12 Rysunek 1 (140 x 114 mm) and Rysunek 8. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2006/489/text/O/D20060489.pdf  # § 6, the EU field from 2 May 2006. Accessed 2026-08-02"
+    notes: >-
+      MOPED PLATES. Poland REGISTERS mopeds — there is no German-style
+      Versicherungskennzeichen and no annual colour cycle; a moped gets an
+      ordinary registration number from the same powiat pool as a car. The plate
+      is the jurisdiction's smallest at 140 x 114 mm and, with the temporary
+      plate, one of only two civil Polish plates that carry no eagle.
+
+  # =========================================================================
+  # THE REDUCED CAR PLATE — 305 x 114 mm, voivodeship letter ONLY.
+  # =========================================================================
+  - id: pl-standard-reduced
+    class: standard
+    categories: [car, van]
+    period: { start: 2018 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "L 999"
+      regex: '\A[A-Z] ?(?:\d{3}|\d{2}[A-Z]|\d[A-Z]\d|[A-Z]\d{2}|\d[A-Z]{2}|[A-Z]{2}\d|[A-Z]\d[A-Z])\z'
+      regex_strict: '\A[ABCDEFGIJKLMNOPRSTVWXYZ] ?(?:\d{3}|\d{2}[ACEFGHJKLMNPRSTUVWXY]|\d[ACEFGHJKLMNPRSTUVWXY]\d|[ACEFGHJKLMNPRSTUVWXY]\d{2}|\d[ACEFGHJKLMNPRSTUVWXY]{2}|[ACEFGHJKLMNPRSTUVWXY]{2}\d|[ACEFGHJKLMNPRSTUVWXY]\d[ACEFGHJKLMNPRSTUVWXY])\z'
+      charset: { letters_excluded: ["Q"], letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"] }
+      progression: >-
+        § 30 ust. 2 pkt 2, and it is the ONE Polish civil plate with NO POWIAT
+        CODE AT ALL: "dla powiatów z wyróżnikiem jednoliterowym i dwuliterowym
+        pierwsza litera stanowi wyróżnik województwa, następne cyfry lub cyfry
+        i litera, lub litery stanowią wyróżnik pojazdu" — one voivodeship letter
+        and three characters, in the exhaustion order 999, 99L, 9L9, L99, 9LL,
+        LL9, L9L. The powiat is unrecoverable from the string, by design, because
+        there is no room for it.
+    design:
+      plate: { w: 305, h: 114, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: none
+    region_encoding_note: >-
+      DELIBERATELY none, and this is the fact that makes the series worth
+      separating: the reduced plate carries only the VOIVODESHIP letter, so a
+      parse API can resolve it to one of sixteen voivodeships (or, where the
+      voivodeship has two letters, to one voivodeship exactly) and can never
+      resolve it to a powiat. Routing it through plates/_decode/pl-powiats.yml would invent a
+      district. The voivodeship letters themselves are in that file's
+      `voivodeships` block.
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 26 ust. 1 pkt 1 lit. b, § 27 ust. 3, § 30 ust. 2 pkt 2 and ust. 3; załącznik nr 12 Rysunek 1 (305 x 114 mm). Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2017/2355/text/O/D20172355.pdf  # Dz. U. 2017 poz. 2355 introduced the type (§ 27 ust. 1 pkt 1 lit. b, § 31 ust. 2 pkt 2) and § 57 pkt 2 commenced exactly those provisions 'z dniem 1 lipca 2018 r.' — the period.start here, and NOT the instrument's own 1 January 2018 general commencement. Accessed 2026-08-02"
+    notes: >-
+      THE REDUCED SINGLE-ROW PLATE, for vehicles whose mounting recess is too
+      small for a 520 mm plate — the American-import case above all. period.start
+      2018 is a genuine commencement carved out of Dz. U. 2017 poz. 2355 § 57
+      pkt 2, four provisions of which were held back to 1 July 2018 while the
+      rest of the instrument began on 1 January. Excluded from the type by
+      § 26 ust. 1 pkt 1 lit. b: motorcycles, agricultural tractors, slow vehicles
+      in tourist road-trains, and "samochodowy inny". § 30 ust. 3 pairs it with
+      the reduced TEMPORARY plate: an authority may issue both bearing the same
+      number.
+
+  # =========================================================================
+  # THE GREEN PLATE — electric and hydrogen, from 1 January 2020.
+  # =========================================================================
+  - id: pl-electric
+    class: electric
+    categories: [car, van, truck, bus, motorcycle, moped]
+    period: { start: 2020 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "LL 99999"
+      regex: '\A(?:[A-Z]{2} ?(?:\d{5}|\d{4}[A-Z]|\d{3}[A-Z]{2}|\d[A-Z]\d{3}|\d[A-Z]{2}\d{2})|[A-Z]{3} ?(?:[A-Z]\d{3}|\d{2}[A-Z]{2}|\d[A-Z]\d{2}|\d{2}[A-Z]\d|\d[A-Z]{2}\d|[A-Z]{2}\d{2}|\d{5}|\d{4}[A-Z]|\d{3}[A-Z]{2}))\z'
+      regex_strict: '\A(?:[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z] ?(?:\d{5}|\d{4}[ACEFGHJKLMNPRSTUVWXY]|\d{3}[ACEFGHJKLMNPRSTUVWXY]{2}|\d[ACEFGHJKLMNPRSTUVWXY]\d{3}|\d[ACEFGHJKLMNPRSTUVWXY]{2}\d{2})|[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z]{2} ?(?:[ACEFGHJKLMNPRSTUVWXY]\d{3}|\d{2}[ACEFGHJKLMNPRSTUVWXY]{2}|\d[ACEFGHJKLMNPRSTUVWXY]\d{2}|\d{2}[ACEFGHJKLMNPRSTUVWXY]\d|\d[ACEFGHJKLMNPRSTUVWXY]{2}\d|[ACEFGHJKLMNPRSTUVWXY]{2}\d{2}|\d{5}|\d{4}[ACEFGHJKLMNPRSTUVWXY]|\d{3}[ACEFGHJKLMNPRSTUVWXY]{2}))\z'
+      charset: { letters_excluded: ["Q"], letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"] }
+      grammar_note: >-
+        THE GREEN PLATE HAS NO GRAMMAR OF ITS OWN. § 27 ust. 2-5 make green a
+        COLOUR CONDITION on the ordinary car, reduced, individual and moped
+        plates, not a separate numbering system, so the regex above is
+        pl-standard's. A green plate on a moped follows pl-moped's grammar and a
+        green individual plate follows pl-individual's; this series exists
+        because the design and the period differ, not the format.
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      plate_variants:
+        - { w: 305, h: 214, unit: mm, note: "samochodowa dwurzędowa" }
+        - { w: 305, h: 114, unit: mm, note: "jednorzędowa zmniejszona" }
+        - { w: 140, h: 114, unit: mm, note: "motorowerowa — for a moped with an electric motor (§ 27 ust. 5 pkt 2)" }
+      background: { color: "#B5D99C", finish: retroreflective, hex_basis: observed, spec_note: "§ 27 ust. 2 pkt 2 names the colour only as 'zielonym tle'; załącznik nr 12 Tablica 2 bounds it to the CIE quadrangle in common.colorimetry.zielona, which is the WIDEST gamut in the Polish table — its luminance factor is a RANGE (0.20 to 0.40) where every other colour has a single bound, so the statutory green is deliberately a band of pale yellow-greens rather than one colour. The hex is one plausible point inside it and is marked observed." }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed }
+      emblem: { present: true, rendered: placeholder, note: "absent on the moped variant, per § 28 ust. 6" }
+    region_encoding: "plates/_decode/pl-powiats.yml"
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2019/1272/text/O/D20191272.pdf  # Dz. U. 2019 poz. 1272 (rozporządzenie MI z 8 lipca 2019 r.): inserts 'barwy czarnej na zielonym tle, w przypadku tablicy rejestracyjnej wydawanej dla pojazdu elektrycznego albo pojazdu napędzanego wodorem' into § 28 of the 2017 instrument and adds § 28 ust. 5a for electric mopeds; § 9, verbatim: 'Rozporządzenie wchodzi w życie z dniem 1 stycznia 2020 r.'; § 6 lets registering authorities ORDER green plates 'począwszy od dnia 15 grudnia 2019 r.'; §§ 4-5 give existing EV keepers a right to swap. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 27 ust. 2 pkt 2, ust. 3 pkt 2, ust. 4 pkt 2, ust. 5 pkt 2 — the current re-enactment across all four plate types; załącznik nr 12 pkt 2.1 and 2.14 (green added to the permitted retroreflective colours), Tablica 1 and Tablica 2. Accessed 2026-08-02"
+    notes: >-
+      THE GREEN PLATE, and its date is 1 JANUARY 2020 — not 2022, which is what
+      a reader gets by taking the current instrument's date for the rule's date.
+      The enabling amendment is Dz. U. 2019 poz. 1272, whose § 9 commences it on
+      1 January 2020; the 2022 and 2024 instruments merely re-enact it. Scope is
+      defined by cross-reference rather than in terms: a "pojazd elektryczny" is
+      one within art. 2 pkt 12 and a "pojazd napędzany wodorem" one within art. 2
+      pkt 15 of the ustawa o elektromobilności i paliwach alternatywnych, so a
+      plug-in hybrid does NOT qualify. The plate is optional in practice for
+      vehicles registered before 2020: §§ 4-5 of the 2019 instrument give the
+      keeper a right to swap, never a duty, so green and white plates on
+      identical electric cars are both correct.
+
+  # =========================================================================
+  # HISTORIC VEHICLES — black on yellow, with a car pictogram.
+  # =========================================================================
+  - id: pl-historic
+    class: historic
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "LL 99L"
+      regex: '\A(?:[A-Z]{2} ?(?:\d{2}[A-Z]|\d{3})|[A-Z]{3} ?(?:\d[A-Z]|\d{2}|[A-Z]\d))\z'
+      regex_strict: '\A(?:[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z] ?(?:\d{2}[ACEFGHJKLMNPRSTUVWXY]|\d{3})|[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z]{2} ?(?:\d[ACEFGHJKLMNPRSTUVWXY]|\d{2}|[ACEFGHJKLMNPRSTUVWXY]\d))\z'
+      charset: { letters_excluded: ["Q"], letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"] }
+      progression: >-
+        § 30 ust. 2 pkt 5 — the SHORTEST civil serials in the system. A one-letter
+        powiat gets two digits and a letter, then three digits; a two-letter
+        powiat gets a digit and a letter, then two digits, then a letter and a
+        digit. A historic plate is therefore five characters in total where an
+        ordinary one is seven or eight, which is the quickest way to recognise
+        one after the colour.
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      plate_variants:
+        - { w: 305, h: 214, unit: mm, note: "zabytkowa dwurzędowa" }
+        - { w: 190, h: 150, unit: mm, note: "motocyklowa zabytkowa" }
+        - { w: 305, h: 114, unit: mm, note: "zabytkowa jednorzędowa zmniejszona — takes the pl-standard-reduced grammar of § 30 ust. 2 pkt 2, not the grammar above, and carries the car pictogram as a LASER GRAPHIC rather than an embossed symbol" }
+      background: { color: "#F5D800", finish: retroreflective, hex_basis: observed, spec_note: "§ 27 ust. 6 names 'żółtym tle'; the CIE quadrangle is common.colorimetry.zolta with a luminance factor of 0.27" }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed }
+      symbol: { present: true, rendered: placeholder, content: "the pojazd zabytkowy pictogram — a stylised veteran car, embossed in black on the full-size plate (§ 27 ust. 6, 'oraz symbol pojazdu zabytkowego barwy czarnej'), and laser-etched to a 25 mm width on the reduced plate (załącznik nr 12 pkt 2.7, Rysunek 3)" }
+      emblem: { present: true, rendered: placeholder }
+    region_encoding: "plates/_decode/pl-powiats.yml"
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 25 pkt 3, § 27 ust. 6-7, § 30 ust. 2 pkt 5; załącznik nr 12 pkt 2.7 and Rysunki 3, 17-19. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/1999/632/text/O/D19990632.pdf  # Dz. U. 1999 nr 59 poz. 632 § 18 ust. 5 (black on yellow with the pictogram) and § 21 ust. 2 pkt 5 (the short grammar), commenced with the rest of the plate provisions on 1 May 2000 by § 49. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/1998/365/text/O/D19980365.pdf  # Dz. U. 1998 nr 57 poz. 365 § 17 ust. 5 and § 20 ust. 2 pkt 3 — the yellow historic plate ALREADY existed before the 2000 reform, under the old two-letter voivodeship coding. Accessed 2026-08-02"
+    notes: >-
+      THE YELLOW CLASSIC PLATE. period.start 2000 is the commencement of the
+      voivodeship+powiat coding this series' grammar depends on, not the birth
+      of the class: Dz. U. 1998 nr 57 poz. 365 § 17 ust. 5 already prescribed
+      "barwy czarnej na żółtym tle" with the pictogram in 1998, under the
+      pre-reform two-letter codes, and that earlier form is NOT modelled as a
+      separate series here — a recorded gap, and a small one, because the
+      eligible population was tiny. Eligibility is not in this instrument: it
+      runs through the entry of the vehicle in the wojewódzka ewidencja zabytków
+      or the acquisition of a rzeczoznawca's certificate, which is a heritage
+      question rather than a plate question and is out of scope for this file.
+
+  - id: pl-historic-moped
+    class: historic
+    categories: [moped]
+    period: { start: 2023 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "LL 99L"
+      regex: '\A(?:[A-Z]{2} ?(?:\d{2}[A-Z]|\d{3})|[A-Z]{3} ?(?:\d[A-Z]|\d{2}|[A-Z]\d))\z'
+      regex_strict: '\A(?:[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z] ?(?:\d{2}[ACEFGHJKLMNPRSTUVWXY]|\d{3})|[ABCDEFGIJKLMNOPRSTVWXYZ][A-PR-Z]{2} ?(?:\d[ACEFGHJKLMNPRSTUVWXY]|\d{2}|[ACEFGHJKLMNPRSTUVWXY]\d))\z'
+      charset: { letters_excluded: ["Q"], letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"] }
+    design:
+      plate: { w: 140, h: 114, unit: mm }
+      background: { color: "#F5D800", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed }
+      symbol: { present: true, rendered: placeholder, content: "a laser-etched veteran-vehicle graphic scaled to 30 mm wide (załącznik nr 12 pkt 2.7, Rysunek 4), positioned 93 mm from the left edge and 17.5 mm from the bottom" }
+      emblem: { present: false }
+      layout_note: >-
+        A LAYOUT STRESSOR worth recording. Załącznik nr 12 pkt 2.6 lit. a places
+        the legalisation slot on this plate DIFFERENTLY depending on the serial:
+        with a three-letter prefix it sits 14 mm from the left edge and 17.5 mm
+        from the bottom, with a two-letter prefix 105 mm from the left and
+        66.5 mm from the bottom. The sticker moves to a different ROW of the
+        two-row plate according to how long the prefix is — the same pressure
+        PRD-PLATES §2.2 records for Japan, and a `format.fields` case if the
+        render bundle ever needs it.
+    region_encoding: "plates/_decode/pl-powiats.yml"
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 27 ust. 8, § 28 ust. 4 pkt 5, § 30 ust. 2 pkt 5; załącznik nr 12 pkt 2.6 lit. a and pkt 2.7, Rysunek 4, Rysunek 20. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2022/1847/text/O/D20221847.pdf  # Dz. U. 2022 poz. 1847 § 53 pkt 1: '§ 27 ust. 8, § 28 ust. 4 pkt 5 oraz § 30 ust. 2 pkt 5 w zakresie tablic rejestracyjnych motorowerowych zabytkowych, które wchodzą w życie z dniem 1 maja 2023 r.'; § 49 ust. 1 opens the swap right from the same date and ust. 2 governs the 4 September 2022 - 30 April 2023 interregnum. Accessed 2026-08-02"
+    notes: >-
+      THE HISTORIC MOPED PLATE — a class Poland did not have until 1 MAY 2023,
+      and a clean example of the instrument-date rule: the provisions live in the
+      2022 instrument (which itself commenced on 4 September 2022) but § 53 pkt 1
+      held these three back to 1 May 2023, and § 49 ust. 2 says what happened in
+      between — a historic moped could take either an ordinary moped plate or a
+      historic MOTORCYCLE plate. From 1 May 2023 § 49 ust. 1 lets the keeper
+      swap: a historic motorcycle plate is exchanged keeping the number, an
+      ordinary moped plate is exchanged for a NEW number. Modelled as its own
+      series rather than a variant of pl-historic because the period and the
+      plate both differ.
+
+  # =========================================================================
+  # INDIVIDUAL (PERSONALISED) PLATES — and the one place the exclusions lift.
+  # =========================================================================
+  - id: pl-individual
+    class: personalized
+    categories: [car, van, truck, bus]
+    period: { start: 2000 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "L9 LLLLL"
+      regex: '\A[A-Z]\d ?(?:[A-Z]{3,5}|[A-Z]{2,4}\d|[A-Z]{1,3}\d{2})\z'
+      regex_strict: '\A[ABCDEFGIJKLMNOPRSTVWXYZ]\d ?(?:[A-PR-Z]{3,5}|[A-PR-Z]{2,4}\d|[A-PR-Z]{1,3}\d{2})\z'
+      charset:
+        letters_excluded: ["Q"]
+        notes: >-
+          THE EXCLUSION LIFTS HERE, and only here. § 31 ust. 1 subjects the
+          vehicle wyróżnik to the B/D/I/O/Z rule "z zastrzeżeniem § 32 ust. 2",
+          and § 32 ust. 2 hands the individual wyróżnik to the owner. So B, D, I,
+          O and Z are all available on an individual plate and regex_strict
+          carries only the dataset-wide Q exclusion. A validator that applies the
+          five-letter rule here rejects lawful plates.
+      progression: >-
+        § 30 ust. 2 pkt 4, verbatim: "litera i cyfra stanowią wyróżnik
+        województwa, zaś kolejne litery w liczbie od 3 do 5 stanowią wyróżnik
+        indywidualny pojazdu, w którym nie więcej niż dwie ostatnie litery można
+        zastąpić cyframi." The digits may only replace the LAST one or two
+        characters, so the regex is a three-way alternation rather than a mixed
+        class: letters only, letters then one digit, letters then two digits. A
+        digit followed by a letter inside the personal part is not lawful.
+      prefix_note: >-
+        The prefix here is LETTER + DIGIT, not letter + letters: individual
+        plates use column 6 of załącznik nr 13 (W0-W9, A0-A9 for mazowieckie,
+        and so on), the same pool as temporary plates, NOT the column-4 letters
+        used by ordinary plates. There is no powiat component at all — § 32
+        ust. 1 makes uniqueness a VOIVODESHIP-level test, checked against the
+        art. 73a ust. 1 pkt 1 register.
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      plate_variants:
+        - { w: 305, h: 214, unit: mm, note: "dwurzędowa" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed }
+      emblem: { present: true, rendered: placeholder }
+      green_variant: "§ 27 ust. 4 pkt 2 gives an electric or hydrogen vehicle a GREEN individual plate — the two optional regimes compose"
+    region_encoding: none
+    region_encoding_note: >-
+      Voivodeship only, and only through the letter+digit codes in
+      plates/_decode/pl-powiats.yml's `voivodeships` block. There is no powiat information on an
+      individual plate and a parse API must not invent any.
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 25 pkt 2, § 27 ust. 4, § 30 ust. 2 pkt 4, § 31 ust. 1 (the carve-out), § 32 (uniqueness, owner's choice, the decency clause). Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2025/939/text/O/D20250939.pdf  # Dz. U. 2025 poz. 939 § 1 pkt 2 and pkt 3: the second-letter overflow rule of § 31 ust. 3 is disapplied to individual plates, and § 32 ust. 2 is rewritten so that the owner 'może wskazać literę wyróżnika województwa, z którą będzie tworzony numer rejestracyjny pojazdu' — in force 2025-07-30. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/1999/632/text/O/D19990632.pdf  # Dz. U. 1999 nr 59 poz. 632 § 21 ust. 2 pkt 4 and § 22-23, commenced 1 May 2000 by § 49. Accessed 2026-08-02"
+    notes: >-
+      INDIVIDUAL PLATES — "tablice indywidualne", the Polish personalised regime,
+      restricted by § 25 pkt 2 to POJAZDY SAMOCHODOWE, so no motorcycle, moped or
+      trailer may carry one. Two facts a consumer will otherwise get wrong: the
+      five look-alike letters are LAWFUL here and nowhere else, and since
+      30 July 2025 the buyer in a two-letter voivodeship may CHOOSE which letter
+      their plate is built from (Dz. U. 2025 poz. 939 § 1 pkt 3) — the only
+      exception to the § 31 ust. 3 rule that the second letter is an overflow
+      pool. period.start 2000 is the plate provisions' commencement under
+      Dz. U. 1999 nr 59 poz. 632 § 49; individual plates existed before that
+      (Dz. U. 1998 nr 57 poz. 365 § 20 ust. 2 pkt 2 gives the same letter+digit
+      frame with 3 to 5 letters) and the pre-reform form is a recorded gap.
+
+  # =========================================================================
+  # TEMPORARY PLATES — red on white, and the plate Poland uses for export.
+  # =========================================================================
+  - id: pl-temporary
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, moped, trailer]
+    period: { start: 2000 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "L9 9999"
+      regex: '\A[A-Z]\d ?(?:\d{4}|\d{3}[A-Z])\z'
+      regex_strict: '\A[ABCDEFGIJKLMNOPRSTVWXYZ]\d ?(?:\d{4}|\d{3}[ACEFGHJKLMNPRSTUVWXY])\z'
+      charset: { letters_excluded: ["Q"], letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"] }
+      progression: >-
+        § 30 ust. 2 pkt 6, verbatim: "litera i cyfra stanowią wyróżnik
+        województwa, zaś cztery cyfry w przedziale od 0001 do 9999 stanowią
+        wyróżnik pojazdu, który po wyczerpaniu wskazanej pojemności tworzy się
+        w układzie trzy cyfry w przedziale od 001 do 999 i litera." Six
+        characters, letter+digit prefix from column 6 of załącznik nr 13, no
+        powiat component.
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      plate_variants:
+        - { w: 305, h: 214, unit: mm, note: "dwurzędowa" }
+        - { w: 190, h: 150, unit: mm, note: "motocyklowa tymczasowa" }
+        - { w: 140, h: 114, unit: mm, note: "motorowerowa tymczasowa" }
+        - { w: 305, h: 114, unit: mm, note: "tymczasowa jednorzędowa zmniejszona — added by the 2024 instrument (§ 30 ust. 2 pkt 2 and ust. 3 pkt 1); the 2022 text had no reduced temporary plate" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#CC0000"
+      foreground_spec: "§ 27 ust. 9 pkt 1: 'barwy czerwonej na białym tle'. The CIE quadrangle for czerwona is in common.colorimetry.czerwona, luminance factor 0.05 — a dark, saturated red, not a signal red."
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed }
+      emblem: { present: false, note: "§ 28 ust. 6 disapplies the eagle to temporary plates; ust. 5 also disapplies the laser-marked legalisation-slot outline, so a temporary plate is the plainest Polish plate" }
+    region_encoding: none
+    region_encoding_note: "voivodeship only, via the letter+digit codes in plates/_decode/plates/_decode/pl-powiats.yml's `voivodeships` block; no powiat component exists on a temporary plate."
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 25 pkt 4, § 27 ust. 9 pkt 1, § 28 ust. 5-6, § 30 ust. 2 pkt 6 and ust. 3; załącznik nr 12 Rysunki 21-24. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/1999/632/text/O/D19990632.pdf  # Dz. U. 1999 nr 59 poz. 632 § 18 ust. 6 and § 21 ust. 2 pkt 6, commenced 1 May 2000 by § 49. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/1993/164/text/O/D19930164.pdf  # Dz. U. 1993 nr 37 poz. 164 § 13 ust. 3: the temporary plate's statutory purposes already included 'umożliwienia wyjazdu lub wywozu tych pojazdów za granicę' — which is why Poland has no export series. Accessed 2026-08-02"
+    notes: >-
+      THE TEMPORARY PLATE, and THE REASON POLAND HAS NO EXPORT PLATE: taking a
+      vehicle permanently out of the country is one of the temporary plate's own
+      statutory purposes and has been since 1993. The 2024 instrument added a
+      REDUCED temporary plate (305 x 114 mm) that the 2022 text lacked, pairable
+      under § 30 ust. 3 with a reduced ordinary plate bearing the same number.
+      Validity is not in this instrument: it runs from art. 74 of the ustawa, and
+      the old fourteen-day cap of the 1993 rules no longer applies.
+
+  - id: pl-temporary-sport
+    class: temporary
+    categories: [car]
+    period: { start: 2024 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "L9 9999"
+      regex: '\A[A-Z]\d ?(?:\d{4}|\d{3}[A-Z])\z'
+      regex_strict: '\A[ABCDEFGIJKLMNOPRSTVWXYZ]\d ?(?:\d{4}|\d{3}[ACEFGHJKLMNPRSTUVWXY])\z'
+      charset: { letters_excluded: ["Q"], letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"] }
+      note: "§ 30 ust. 2 pkt 6 governs all temporary plates alike; only the background colour distinguishes this one."
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      background: { color: "#F5D800", finish: retroreflective, hex_basis: observed, spec_note: "common.colorimetry.zolta — the same statutory yellow as the historic plate" }
+      foreground: "#CC0000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed }
+      emblem: { present: false }
+    region_encoding: none
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 27 ust. 9, verbatim: 'Na tablicy rejestracyjnej tymczasowej jest wytłoczony numer rejestracyjny składający się z wyróżnika województwa oraz wyróżnika pojazdu: 1) barwy czerwonej na białym tle albo 2) barwy czerwonej na żółtym tle w przypadku tablicy rejestracyjnej wydawanej dla samochodu osobowego przeznaczonego do zawodów sportowych.' § 51 commences the instrument on 2024-11-30. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2022/1847/text/O/D20221847.pdf  # Dz. U. 2022 poz. 1847 § 27 ust. 9, which knows only 'barwy czerwonej na białym tle' — the pair of texts either side of 2024-11-30 IS the period evidence. Accessed 2026-08-02"
+    notes: >-
+      RED ON YELLOW, FOR COMPETITION CARS — a plate that did not exist before
+      30 November 2024 and that no secondary description of Polish plates yet
+      records, because they are all still written against the 2022 instrument.
+      The evidence is a diff: § 27 ust. 9 of Dz. U. 2022 poz. 1847 gives one
+      colour, § 27 ust. 9 of Dz. U. 2024 poz. 1709 gives two, and the second is
+      "w przypadku tablicy rejestracyjnej wydawanej dla samochodu osobowego
+      przeznaczonego do zawodów sportowych". Distinct from pl-temporary by the
+      background alone; the number grammar is identical, so a string cannot be
+      assigned between the two without knowing the colour.
+
+  # =========================================================================
+  # DIPLOMATIC — white on blue, six digits, and NO EU field.
+  # =========================================================================
+  - id: pl-diplomatic
+    class: diplomatic
+    categories: [car, van, motorcycle]
+    period: { start: 2000 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "L 999999"
+      regex: '\A[A-Z] ?\d{6}\z'
+      regex_strict: '\A[ABCDEFGIJKLMNOPRSTVWXYZ] ?\d{6}\z'
+      progression: >-
+        § 30 ust. 2 pkt 7, verbatim and complete: "na tablicach rejestracyjnych
+        dyplomatycznych – pierwsza litera stanowi wyróżnik województwa, zaś sześć
+        cyfr w przedziale od 000001 do 999999 stanowi wyróżnik pojazdu." One
+        letter and six digits, and NOTHING ELSE — the instrument publishes no
+        country-code or entitlement-class structure inside those six digits.
+      decode_gap: >-
+        A RECORDED GAP, and an important one for the Geoguessr audience: Polish
+        diplomatic serials are widely described as encoding the sending state in
+        their leading digits, and that structure is NOT in this regulation. It
+        would have to come from a Ministry of Foreign Affairs allocation list
+        that this pass did not locate. The dataset therefore claims one letter
+        and six digits and no more; a decode table for the digit blocks is an L4
+        target, and until one lands with a primary behind it a parse API must
+        return "diplomatic, voivodeship known, mission unknown".
+      voivodeship_note: >-
+        The letter is the ordinary column-4 wyróżnik województwa, not the
+        column-6 letter+digit code — so a diplomatic plate begins with the same
+        letter as an ordinary one from the same voivodeship, and in practice
+        almost always with W.
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      plate_variants:
+        - { w: 305, h: 214, unit: mm, note: "dyplomatyczna dwurzędowa" }
+        - { w: 190, h: 150, unit: mm, note: "dyplomatyczna motocyklowa" }
+        - { w: 140, h: 114, unit: mm, note: "dyplomatyczna motorowerowa" }
+      background: { color: "#003399", finish: retroreflective, hex_basis: observed, spec_note: "§ 27 ust. 10: 'barwy białej na niebieskim tle'. The quadrangle is common.colorimetry.niebieska — the WIDE blue, deliberately not the narrow EU-field blue" }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      band_note: >-
+        THE ONLY POLISH PLATE WITH NO EU FIELD, and the instrument says so twice:
+        § 28 ust. 1 ("Wymóg ten nie dotyczy tablic (tablicy) rejestracyjnych
+        dyplomatycznych") and załącznik nr 12 pkt 2.5 and pkt 2.14 lit. e. On a
+        blue plate the blue band would be invisible, which is presumably the
+        reason, but the instrument gives none.
+      emblem: { present: true, rendered: placeholder }
+      geometry: "załącznik nr 12 Rysunek 26 tabulates the diplomatic plate's own layout dimensions per size (a/b/c/d/e in mm): dwurzędowa 48/55/20/36/17, motocyklowa 24/42/14/18/20, motorowerowa 19/40/10/23/17.5"
+    region_encoding: "plates/_decode/pl-powiats.yml"
+    region_encoding_note: "voivodeship letter only — column 4 of the annex, the same letters ordinary plates use; there is no powiat component."
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1709/text/O/D20241709.pdf  # § 25 pkt 5, § 27 ust. 10, § 28 ust. 1, § 30 ust. 2 pkt 7; załącznik nr 12 pkt 2.5, pkt 2.14 lit. e, Rysunki 25-26. Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/1999/632/text/O/D19990632.pdf  # Dz. U. 1999 nr 59 poz. 632 § 21 ust. 2 pkt 8 — the same one-letter + six-digit frame, commenced 1 May 2000 by § 49. Its predecessor Dz. U. 1998 nr 57 poz. 365 § 20 ust. 2 pkt 5 used TWO letters and five digits, so the frame did change at the reform. Accessed 2026-08-02"
+    notes: >-
+      THE DIPLOMATIC PLATE, for missions, consular posts, special missions,
+      international organisations and their staff (§ 25 pkt 5). period.start 2000
+      is a real format change and not merely the reform date: the pre-reform
+      diplomatic plate under Dz. U. 1998 nr 57 poz. 365 § 20 ust. 2 pkt 5 was TWO
+      letters and five digits (four on motorcycles) and used the Warsaw
+      voivodeship code, so 1 May 2000 changed the diplomatic grammar as well as
+      the ordinary one.
+
+  # =========================================================================
+  # PROFESSIONAL REGISTRATION — the Polish dealer/trade plate, since 2019.
+  # =========================================================================
+  - id: pl-professional
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, moped, trailer]
+    period: { start: 2019 }
+    period_evidence: enacted-commencement
+    matching: strict
+    format:
+      pattern: "L99 99P99"
+      regex: '\A[A-Z]\d{2} ?\d{2}P(?:\d{2}|\d[A-Z])\z'
+      regex_strict: '\A[ABCDEFGIJKLMNOPRSTVWXYZ]\d{2} ?\d{2}P(?:\d{2}|\d[ACEFGHJKLMNPRSTUVWXY])\z'
+      charset:
+        letters_excluded: ["Q"]
+        letters_excluded_vehicle_wyroznik: ["B", "D", "I", "O", "Z"]
+        notes: "§ 14 ust. 1 of the professional-registration rozporządzenie repeats the 25-letter alphabet; § 14 ust. 2 pkt 2 excludes B, D, I, O and Z from the single trailing letter of the second layout."
+      progression: >-
+        § 14 ust. 2, verbatim: "pierwsza litera stanowi wyróżnik województwa,
+        dwie cyfry w przedziale od 01 do 99 stanowią wyróżnik powiatu,
+        następnych pięć znaków stanowi wyróżnik przydzielony dla pojazdów
+        w decyzji o profesjonalnej rejestracji pojazdów, tworzony kolejno:
+        1) z dwóch cyfr w przedziale od 00 do 99, litery P i dwóch cyfr
+        w przedziale od 01 do 99; 2) po wyczerpaniu kombinacji tych cyfr –
+        z dwóch cyfr w przedziale od 00 do 99, litery P, cyfry w przedziale od 0
+        do 9 i litery, z wyłączeniem liter B, D, I, O i Z."
+      fixed_letter_note: >-
+        The letter P in the SIXTH position is fixed and is the class marker:
+        § 12 ust. 2 calls it "stałą literę P, będącą literowym wyróżnikiem
+        tablicy przeznaczonej do profesjonalnej rejestracji pojazdów". It is the
+        only positional literal in the whole Polish system.
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      plate_variants:
+        - { w: 190, h: 150, unit: mm, note: "profesjonalna motocyklowa" }
+        - { w: 140, h: 114, unit: mm, note: "profesjonalna motorowerowa" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#00A64F"
+      foreground_spec: "§ 12 ust. 2: 'profesjonalny numer rejestracyjny barwy zielonej na białym tle'. GREEN CHARACTERS ON WHITE — the inverse of the electric plate's black on green, and a distinction a colour-only classifier will get backwards. The green is measured for daylight only, on 100 cm2 samples."
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed, note: "§ 13 ust. 1 imports the EU field by reference to the registration rozporządzenie" }
+      emblem: { present: false, note: "not established in this pass; § 13 ust. 3 forbids markings other than those in ust. 1-2 and § 14, and no eagle requirement was found. Recorded gap." }
+    region_encoding: none
+    region_encoding_note: >-
+      DO NOT ROUTE THROUGH plates/_decode/pl-powiats.yml. The professional plate's powiat
+      wyróżnik is TWO DIGITS, not letters, and its table is załącznik nr 8 to the
+      professional-registration rozporządzenie — a different annex under a
+      different delegation. That numeric table was NOT extracted in this pass and
+      is a recorded gap; the voivodeship LETTER is the same column-4 letter as on
+      an ordinary plate and can be decoded from plates/_decode/pl-powiats.yml's `voivodeships`.
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2023/2616/text/O/D20232616.pdf  # the consolidated text (obwieszczenie MI z 15 listopada 2023 r.) of rozporządzenie MI z 12 marca 2019 r. w sprawie profesjonalnej rejestracji pojazdów, stosowanych oznaczeń oraz opłat: § 12 ust. 2 (green on white, the fixed P), § 13 (EU field, legalisation mark, closed list of markings), § 14 (alphabet, the two layouts, the annex-8 delegation). Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2019/546  # the Sejm ELI entry for Dz. U. 2019 poz. 546, the original instrument: entryIntoForce 2019-07-11 — this series' period.start. Accessed 2026-08-02"
+    notes: >-
+      PROFESSIONAL REGISTRATION — Poland's dealer/trade plate, and a genuinely
+      young class: it did not exist before 11 July 2019. It is issued to a
+      BUSINESS by decision of the starosta (so `binding` differs from the
+      jurisdiction default) and covers manufacturers, distributors and research
+      units moving or testing unregistered vehicles. It replaced the "tablica
+      tymczasowa badawcza" of the 2002 regime, which is recorded in
+      common.absent_classes.research_badawcza.
+
+  # =========================================================================
+  # THE ARMED FORCES — U, under art. 76 ust. 2, a different minister.
+  # =========================================================================
+  - id: pl-military
+    class: military
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2023 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "UL 99999"
+      regex: '\AU[A-Z] ?(?:\d{5}|\d{4}T?)\z'
+      regex_strict: '\AU[A-NPR-TV-Z] ?(?:\d{5}|\d{4}T?)\z'
+      charset:
+        letters_excluded: ["O", "Q", "U"]
+        notes: >-
+          A DIFFERENT exclusion set from the civil one, and it is enumerated
+          rather than described. § 6 ust. 3 pkt 2 lit. a lists the permitted
+          second letters in full: "A, B, C, D, E, F, G, H, I, J, K, L, M, N, P,
+          R, S, T, V, W, X, Y, Z" — twenty-three letters, dropping O and U as
+          well as the dataset-wide Q. B, D, I and Z ARE permitted here, unlike on
+          a civil vehicle wyróżnik.
+      progression: >-
+        § 6 ust. 3: "wyróżnika Sił Zbrojnych, którym jest wielka litera U
+        umieszczana jako pierwsza" plus a vehicle wyróżnik of one letter and
+        then, by plate type, a five-digit number 00001-99999 for car plates and
+        for numbers painted directly on the vehicle, a four-digit number
+        0001-9999 for motorcycle plates, or a four-digit number followed by the
+        FIXED LETTER T for a tracked vehicle.
+      tracked_note: "the trailing T is the only class marker in the Polish system besides the professional plate's P, and it means gąsienicowy — tracked."
+    design:
+      plate: { w: null, h: null, unit: mm }
+      dimensions_note: >-
+        RECORDED GAP. art. 76 ust. 2 of the ustawa delegates the military plate's
+        wzór to the Minister of National Defence, but the current MON
+        rozporządzenie carries only three annexes — a registration application, a
+        military dowód rejestracyjny, and the pattern for numbers PAINTED
+        DIRECTLY on a vehicle — and none of them is a plate drawing. No
+        dimensions were secured.
+      background: { color: "#FFFFFF", finish: null, hex_basis: observed }
+      foreground: "#000000"
+      colour_evidence: >-
+        Sourced only obliquely. § 17 ust. 4 prescribes, for tracked and armoured
+        vehicles that carry no plate, "numer rejestracyjny barwy czarnej na
+        białym tle oraz symbol przynależności narodowej" applied by stencil or
+        decal; § 17 ust. 2 allows white or black for mobilisation numbers,
+        whichever contrasts with the vehicle. Black on white for the PLATE itself
+        is an inference from those provisions and is flagged as one.
+      band: { side: none, note: "not established; no EU-field requirement was found in the MON instrument. Recorded gap." }
+      emblem: { present: false }
+    region_encoding: none
+    region_encoding_note: >-
+      U is not a voivodeship letter — it is one of the two letters (with H) that
+      never appear in column 4 of załącznik nr 13, which is exactly what makes
+      the prefix unambiguous. Note § 6 ust. 1-2 however: unmarked vehicles of the
+      Żandarmeria Wojskowa, the special forces, the cyberspace-defence troops and
+      certain protected-installation units may be registered under an ORDINARY
+      voivodeship+powiat number instead, deliberately indistinguishable from a
+      civil plate. A parse API cannot detect those and its confidence model
+      should know they exist.
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2023/1776/text/O/D20231776.pdf  # rozporządzenie MON z 30 sierpnia 2023 r. w sprawie rejestracji pojazdów Sił Zbrojnych RP oraz pojazdów należących do obcych sił zbrojnych: § 6 (the U frame and the three vehicle-wyróżnik shapes), § 6 ust. 1-2 (the ordinary-number exception), § 17 (numbers applied directly), § 20 ('Rozporządzenie wchodzi w życie z dniem 4 września 2023 r.'). Accessed 2026-08-02"
+      - "https://api.sejm.gov.pl/eli/acts/DU/2024/1251/text/O/D20241251.pdf  # Prawo o ruchu drogowym art. 76 ust. 2, the delegation to the Minister of National Defence. Accessed 2026-08-02"
+    notes: >-
+      MILITARY PLATES. period.start 2023 is INSTRUMENT-IN-FORCE and means what it
+      means elsewhere in this dataset — the date of the instrument that STATES
+      the rule (§ 20 of Dz. U. 2023 poz. 1776, 4 September 2023), not the date
+      the U system began, which is certainly older: the chain of MON instruments
+      runs back through Dz. U. 2012 poz. 623, Dz. U. 2005 nr 84 poz. 723 and
+      Dz. U. 1999 nr 84 poz. 937 and was not read in this pass. A recorded gap,
+      and one worth closing because the U frame is very likely materially older
+      than 2023.
+
+  # =========================================================================
+  # THE SERVICES — H, under art. 76 ust. 4, a third minister.
+  # =========================================================================
+  - id: pl-police
+    class: police
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "HPL L999"
+      regex: '\AHP[A-Z] ?(?:[A-Z]\d{3}|\d{2}[A-Z]{2})\z'
+      regex_strict: '\AHP[A-PR-Z] ?(?:[A-PR-Z]\d{3}|\d{2}[A-PR-Z]{2})\z'
+      charset:
+        letters_excluded: ["Q"]
+        notes: >-
+          Only Q. § 5 ust. 2 pkt 1 and ust. 4 both draw on "zbiór następujących
+          25 liter" without the civil B/D/I/O/Z exclusion, which § 31 ust. 1 of
+          the transport rozporządzenie confines to plates issued under THAT
+          instrument. Applying the civil exclusion here would reject lawful
+          service plates.
+      progression: >-
+        § 5 ust. 2 pkt 1: the service wyróżnik, then ONE letter from the
+        25-letter set, then the vehicle wyróżnik, which by ust. 4 is either a
+        letter and three digits 001-999 or two digits 01-99 and two letters.
+        Seven characters in total.
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed }
+      emblem: { present: true, rendered: placeholder }
+      design_basis: >-
+        Taken from the transport rozporządzenie by cross-reference, not stated in
+        the MSWiA one: § 5 ust. 1 says "Wzory tablic rejestracyjnych, które
+        zawierają wyróżniki służb, oraz wzory umieszczanych na nich symboli są
+        określone w przepisach wydanych na podstawie art. 76 ust. 1 pkt 1 lit. a
+        ustawy" — that is Dz. U. 2024 poz. 1709. This pass did not locate a
+        service-plate wzór inside that instrument's załącznik nr 12, whose
+        drawings cover the five § 25 types only, so the colours and dimensions
+        above are an INFERENCE from the ordinary plate. Recorded gap.
+    region_encoding: none
+    region_encoding_note: >-
+      H is not a voivodeship letter — see plates/_decode/plates/_decode/pl-powiats.yml,
+      prefix_split.letters_never_a_voivodeship. But note § 5 ust. 2 pkt 2 and
+      § 6: a service may equally register a vehicle under an ORDINARY
+      voivodeship+powiat number, and must do so for vehicles that are NOT
+      liveried ("Tablic rejestracyjnych, które zawierają wyróżnik województwa
+      i powiatu, nie stosuje się do oznakowanych pojazdów służb"). So an H plate
+      implies a marked service vehicle, while an unmarked one wears a civil plate
+      that no parse can distinguish.
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2025/1326/text/O/D20251326.pdf  # rozporządzenie MSWiA z 30 września 2025 r. w sprawie rejestracji pojazdów Służby Ochrony Państwa, Policji, ABW, AW, CBA, Straży Granicznej i KAS wykorzystywanych przez Służbę Celno-Skarbową: § 5 ust. 2-4 (the number structure and the six service wyróżniki), § 6 (marked vehicles only), § 14 (in force the day after publication). Accessed 2026-08-02"
+    notes: >-
+      POLICE PLATES — the HP prefix. period.start 2025 is INSTRUMENT-IN-FORCE:
+      Dz. U. 2025 poz. 1326 is merely the latest in a chain running back through
+      Dz. U. 2023 poz. 1778, Dz. U. 2019 poz. 560, Dz. U. 2017 poz. 447,
+      Dz. U. 2011 nr 195 poz. 1160 and further, none of which was read here, so
+      2025 is the date of the instrument that STATES the rule and NOT the date
+      the HP prefix began. A recorded gap.
+
+  - id: pl-government-services
+    class: government
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2025 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "HBL L999"
+      regex: '\AH[ABCKW][A-Z] ?(?:[A-Z]\d{3}|\d{2}[A-Z]{2})\z'
+      regex_strict: '\AH[ABCKW][A-PR-Z] ?(?:[A-PR-Z]\d{3}|\d{2}[A-PR-Z]{2})\z'
+      charset: { letters_excluded: ["Q"] }
+      service_prefixes:
+        HB: "Służba Ochrony Państwa (state protection service)"
+        HK: "Agencja Bezpieczeństwa Wewnętrznego i Agencja Wywiadu (internal security and foreign intelligence — ONE prefix for two agencies)"
+        HA: "Centralne Biuro Antykorupcyjne (anti-corruption bureau)"
+        HW: "Straż Graniczna (border guard)"
+        HC: "Służba Celno-Skarbowa (customs and fiscal service)"
+      progression: "§ 5 ust. 2 pkt 1 and ust. 4, identical to pl-police; only the two-letter service wyróżnik differs."
+    design:
+      plate: { w: 520, h: 114, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#003399", content: eu-stars+PL, hex_basis: observed }
+      emblem: { present: true, rendered: placeholder }
+      design_basis: "as pl-police — inferred from the ordinary plate by the § 5 ust. 1 cross-reference; recorded gap."
+    region_encoding: none
+    sources:
+      - "https://api.sejm.gov.pl/eli/acts/DU/2025/1326/text/O/D20251326.pdf  # § 5 ust. 3, verbatim: 'Jako wyróżniki służb określa się litery: 1) HB – dla Służby Ochrony Państwa; 2) HP – dla Policji; 3) HK – dla Agencji Bezpieczeństwa Wewnętrznego i Agencji Wywiadu; 4) HA – dla Centralnego Biura Antykorupcyjnego; 5) HW – dla Straży Granicznej; 6) HC – dla Służby Celno-Skarbowej.' Accessed 2026-08-02"
+    notes: >-
+      THE FIVE NON-POLICE SERVICE PREFIXES, held as one series because they share
+      a format, a design and a period and differ only in which agency the second
+      letter names — the § 2.3 test for a class flag rather than a series. `pattern`
+      prints HB because a pattern is one canonical string; the regex carries all
+      five. The one substantive oddity is HK, which the instrument assigns to TWO
+      agencies at once (ABW and AW), so that prefix does not resolve to a single
+      body. period.start 2025 is INSTRUMENT-IN-FORCE, with the same caveat as
+      pl-police: the H system is older than this instrument and its origin is a
+      recorded gap.


### PR DESCRIPTION
## Poland — 17 series + the powiat annex, primary-sourced end to end

**The prize landed primary.** § 31 ust. 2 of the current rozporządzenie says the
code list is *inside* the instrument — "Wyróżniki województw i powiatów dla
tablic rejestracyjnych są określone w załączniku nr 13 do rozporządzenia" — so
`plates/_decode/pl-powiats.yml` is authored from **załącznik nr 13 itself**:
**380 rows, 689 distinct prefixes, 16 voivodeship blocks, zero secondary
sources**. This is the Anlage-5d case, not the German Bundesanzeiger one.

### The finding that would have sunk this PR

**The instrument almost everyone cites is repealed.** `Dz. U. 2022 poz. 1847` is
recorded in the Sejm ELI register as *uznany za uchylony*, `repealDate
2024-11-30`, replaced by **`Dz. U. 2024 poz. 1709`**. The difference is not
cosmetic — the 2024 annex carries codes the 2022 one does not (bydgoski `BC`,
kielecki `KC/KM/KP`, ostródzki `OT/OX`, Poznań `X`, Konin `N`, Kalisz `A`),
extends the tymczasowe/indywidualne column to the second voivodeship letter, and
adds a **plate that did not previously exist** (red on yellow, for competition
cars, § 27 ust. 9 pkt 2). Building on the 2022 text would have shipped six-plus
wrong rows and missed a class. Consolidated here across the 2024 base plus
`Dz. U. 2025 poz. 939` and `Dz. U. 2026 poz. 891`.

### Dates corrected away from folkloric ones

Every one is a **commencement clause**, not an instrument date:

| claim | shipped | what was wrong with the usual answer |
|---|---|---|
| the voivodeship-first reform | **1 May 2000** | its instrument is dated 19 June 1999 and generally commences 1 July 1999; § 49 *excepts* the plate provisions (§§ 22–24, 29–30) to 1 May 2000. Secondary descriptions say 2001. § 41 and § 39 ust. 2 close the other end at 30 April 2000 |
| EU band | **2 May 2006** | two years *after* accession (`Dz. U. 2006 nr 70 poz. 489 § 6`). Before it the blue band carried the **Polish flag**, not the stars |
| green EV/hydrogen plate | **1 Jan 2020** | not 2022 — the enabling amendment is `Dz. U. 2019 poz. 1272 § 9`; the 2022/2024 instruments only re-enact it |
| reduced 305 mm plate | **1 Jul 2018** | carved out of the 2017 instrument's 1 January general commencement by its § 57 pkt 2 |
| historic **moped** plate | **1 May 2023** | the provisions sit in the 2022 instrument, which § 53 pkt 1 held back |
| plate size | **520 × 114 mm** | not the 520 × 110 mm repeated everywhere — Rysunek 1 is a statutory drawing |

### Structural findings worth the reviewer's time

- **The prefix split is deterministic, and it is derived from the grammar.** All
  five one-letter-powiat car layouts begin with a *digit* (§ 30 ust. 2 pkt 1),
  so on a car plate a letter in the third position means a three-character
  prefix. Verified **mechanically** against all 689 real prefixes × all five
  layouts: **zero ambiguities**. It does *not* hold for motorcycles, and the
  file says so.
- **H and U are the only two letters that are never a voivodeship.** 23 of the
  25-letter alphabet appear in column 4; the two that never do are reserved —
  `H*` for the six services, `U` for the armed forces. A leading H or U is a
  positive signal the plate is not civil.
- **Two different letter exclusions, routinely conflated.** § 30 ust. 1 drops Q
  everywhere; § 31 ust. 1 drops B, D, I, O, Z from the **vehicle wyróżnik only**
  — they stay lawful in prefixes (`DB`, `DDZ`, `CIN`, `CB`, `ZSZ` are all real).
  And § 32 ust. 2 **lifts** that exclusion for individual plates alone.
- **The separator is a sticker well.** No glyph is prescribed anywhere; załącznik
  nr 12 pkt 2.6 lit. a puts the 18×30 mm legalisation slot exactly between
  prefix and serial — the Austrian coat-of-arms situation in Polish dress.

### Sourcing

Fetched through the **Sejm ELI API** (`api.sejm.gov.pl/eli`), which serves the
same Dziennik Ustaw PDFs as ISAP without ISAP's Imperva wall — recommended to
the other delegates. **No Wikipedia-derived fact landed in either file**, so no
`secondary-wikipedia` rows arise.

### Well-evidenced gaps, deliberately not guessed

- **No pre-2000 decode table.** The 49-voivodeship code lists exist and are
  pinned (`Dz. U. 1993 nr 37 poz. 164 § 20`; `Dz. U. 1999 nr 59 poz. 632 § 39
  ust. 1 and ust. 2`) but are scanned typescript whose OCR is visibly unreliable
  (`WS`→`W5`, `KA`→`K~`). Filed as an L4 target rather than transcribed badly.
- **Diplomatic digit blocks are not decoded.** § 30 ust. 2 pkt 7 gives one letter
  and six digits and *nothing else*; the widely-described country coding is not
  in the regulation. A parse API must return "mission unknown".
- **Professional plates use a numeric powiat code** from a different annex
  (załącznik nr 8 to `Dz. U. 2019 poz. 546`), not extracted — the file explicitly
  forbids routing them through `pl-powiats.yml`.
- Black→white transition undated (delegated to PN 5-73200); military and service
  plate *wzory* not located; per-row periods in the annex not established.

### Lint

```
$ ruby scripts/lint_plates.rb
plates lint: 73 files, 685 series
plates lint: matching recall-only=163 strict=522 | twins regex_statutory=64 regex_strict=195 | separators emitted "-"," " forgiving 18
plates lint: _art ledger 6058 rows (excluded=5355 open=410 site_only=293), 410 open assets verified
plates lint: OK
```
Exit 0. Also passes the new `_decode/` sidecar parse gate from #253.

**Plus a 95-assertion adversarial self-test** written for this PR (real-shaped
plates accepted, forbidden layouts rejected, `regex_strict ⊆ regex` on every
sample, and the prefix-split property proved over the real prefix set). It
caught a genuine defect before commit: the prefix `NO` (warmińsko-mazurskie +
Olsztyn) was being read as YAML 1.1 **boolean false**. Every code and prefix in
the decode file is now quoted, which also immunises it against a future
amendment landing `ON`, `OFF` or `YES`.

Base: `50614b9` (main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
