### PR TITLE
yamaha S-5/S-6: four folds that stopped one key short, and a name nothing pinned

### DIFF
--- a/overrides/models/former_ids.yml
+++ b/overrides/models/former_ids.yml
@@ -2915,8 +2915,8 @@
 "motorcycle/yamaha/bt": "motorcycle/yamaha/bt1100" # G-1: UK Model column splits the pooled stub by displacement; single successor
 "motorcycle/yamaha/cs": "moped/yamaha/cs50" # G-1: UK Model column splits the pooled stub by displacement; single successor
 "motorcycle/yamaha/cw": "moped/yamaha/cw50" # G-1: UK Model column splits the pooled stub by displacement; single successor
-"motorcycle/yamaha/delight": "motorcycle/yamaha/delight-125" # G-1: UK Model column splits the pooled stub by displacement; single successor
-"motorcycle/yamaha/mws": "motorcycle/yamaha/mws125" # G-1: UK Model column splits the pooled stub by displacement; single successor
+"motorcycle/yamaha/delight": "motorcycle/yamaha/d-elight" # G-1: UK Model column splits the pooled stub by displacement; single successor — S-5 chain repair 2026-08-02, was delight-125
+"motorcycle/yamaha/mws": "motorcycle/yamaha/tricity-125" # G-1: UK Model column splits the pooled stub by displacement; single successor — S-5 chain repair 2026-08-02, was mws125
 "motorcycle/yamaha/ns": "moped/yamaha/aerox" # RE-CHAINED 2026-08-01 (§A fold): pointed at moped/yamaha/ns50, which this change retires into moped/yamaha/aerox. Aliases are single-pass.
 "motorcycle/yamaha/nxc": "motorcycle/yamaha/nxc125" # G-1: UK Model column splits the pooled stub by displacement; single successor
 "motorcycle/yamaha/ys": "motorcycle/yamaha/ys125" # G-1: UK Model column splits the pooled stub by displacement; single successor
@@ -6698,6 +6698,10 @@
 "motorcycle/yamaha/mtn1000d": "motorcycle/yamaha/mt-10sp"  # es,fi,lu,nl,ua — S-1 phase 2: cover "MTN1000D (MT-10 SP)"
 "motorcycle/yamaha/mtm890d": "motorcycle/yamaha/xsr900-gp"  # es,fi,lu,nl — S-1 phase 2: cover "MTM890D (XSR900 GP)"
 "motorcycle/yamaha/mtm890d-u": "motorcycle/yamaha/xsr900-gp"  # es,nl — S-1 phase 2: -U is 35 kW equipment ON the GP
+"motorcycle/yamaha/delight-125": "motorcycle/yamaha/d-elight"  # gb — S-5: UK's "DELIGHT 125" is the D'elight; one machine had two ids
+"motorcycle/yamaha/mws125": "motorcycle/yamaha/tricity-125"  # gb — S-5: bare MWS125 is not a Yamaha string
+"motorcycle/yamaha/mws125-a": "motorcycle/yamaha/tricity-125"  # es,nl — S-5: manual PBR7F8199E0E cover "TRICITY 125"
+"motorcycle/yamaha/mws150": "motorcycle/yamaha/tricity-155"  # fi,nl — S-5: MWS150 is the Tricity 155, later recoded MWS155-A
 "motorcycle/yamaha/mtm690": "motorcycle/yamaha/xsr700"  # es,fi,lu,nl
 "motorcycle/yamaha/mtm690-u": "motorcycle/yamaha/xsr700"  # es,lu,nl
 "motorcycle/yamaha/mtm690d": "motorcycle/yamaha/xsr700"  # es,nl

--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -11890,6 +11890,27 @@ Yamaha:
   "MWD300":              "Tricity 300"   # "MWD300 (Tricity 300)" — Yamaha EU manual PBEDF8199E0E
   "MWD300D":             "Tricity 300"   # "MWD300D (Tricity 300 Airbag)" — airbag is equipment
   "MWS125-C":            "Tricity 125"   # "MWS125-C (Tricity 125)" — Yamaha EU manual PBCSF8199E0E; UK "MWS 125-C TRICITY 125" n=262
+# ── S-5, 2026-08-02 · the folds below were RIGHT and INCOMPLETE ────────────
+# `MWS125-C -> Tricity 125` and `LTS125-C -> D'elight` are correct on the
+# manufacturer's evidence. Each still left the same machine publishing as TWO
+# ids in two country sets, because only the CODE spelling was folded and the
+# register's own spelling was not.
+#
+# HOW IT GOT MISSED, from the original PR body: "1 dead (Delight -> D'elight)
+# — already folded by G-1, dropped rather than shipped inert". The
+# re-derivation check did its job and found the draft key dead; the dead key
+# was then DELETED instead of re-derived against the record it had collided
+# with. G-1 had folded the bare stub to `delight-125`, so the key that would
+# have worked is the live record's produced name — "Delight 125" — which was
+# never tried. The check looked one step upstream of where the answer was.
+  "Delight 125":         "D'elight"   # UK "DELIGHT 125 (LTS 125-C)" n=1,263 produces "Delight 125" -> delight-125 [gb], while LTS125-C's fold minted d-elight [es,fi,lu,nl,nz]. One machine, two ids, two country sets
+  "MWS125":              "Tricity 125"   # UK "MWS125" n=661 -> mws125 [gb]. The SAME register also writes "TRICITY 125" n=154, so gb was split across two ids for one scooter
+  "MWS125-A":            "Tricity 125"   # manual PBR7F8199E0E cover "TRICITY 125"; RDW "MWS125-A (TRICITY ABS)" n=6 — ABS is equipment. Bare "MWS125" is not a Yamaha string: every first-party occurrence carries a suffix
+  "MWS150":              "Tricity 155"   # 155 cm3, NOT 150 — Yamaha TH's own manual is titled "MWS150-C MWS150-A OWNER'S MANUAL" and served at /docs/owner-manual/commuter/en/tricity155-en.pdf; Yamaha JP BB8-F8199-J1 prints "MWS150-A … TRICITY 155". There has never been a "Tricity 150"
+# Yamaha later recoded the 155 as MWS155-A, which is why the digits in the old
+# code disagree with the displacement. Outside the audit's declared scope but
+# taken with it: leaving it publishes `MWS150` as a nameplate asserting a
+# displacement Yamaha never sold.
   "XVS950XR-A":          "SCR950"   # library.ymcapps.net "SCR950 - XVS950XR-A"; RDW "XVS950XR-A (SCR950)" n=33
   "XVS950CUD-A":         "XV950R"   # library.ymcapps.net "XV950R ABS - XVS950CUD-A"; RDW "XVS950CUD-A (XV950R)" n=20
   "LCG125":              "RayZR"   # "LCG125 (RayZR)" — Yamaha library BUV-F8199-E1. CREATES a missing nameplate
@@ -11993,6 +12014,9 @@ Yamaha:
   Xmax 300:                  XMAX 300               # MAX series — all-caps closed (global.yamaha-motor.com MAX-series page) (display-only)
   Yl-1:                      YL1                    # type code — closed uppercase
   Yzf-R1:                    YZF-R1                 # type code — closed uppercase (display-only)
+  "Yzf-R3":                  "YZF-R3"   # type code — closed uppercase (display-only). S-6: three produced spellings compete on this id and none was pinned
+  "Yzf R3":                  "YZF-R3"   # observed produced form; Yamaha hyphenates the R-series (YZF-R1/R3/R7)
+  "Yzf  R3":                 "YZF-R3"   # observed produced form with a DOUBLE space — real, straight out of build/observed_model_names.json
   Yzfr 1:                    YZF-R1                 # type code — closed uppercase
   "Aerox Abs":                       Aerox                      # ABS is EQUIPMENT and folds into the nameplate (NAMING.md trim policy); same class as spec-token-4w
   "Bw's":                    BW's                 # Yamaha's BW's keeps the apostrophe — confirmed via MBK's platform history, the MBK Booster being the BW's twin


### PR DESCRIPTION
Block 1 of the owner wake order, suspects **S-5** and **S-6**. Branched from `origin/main` at `fddb7f3`, independent of `data#263` (disjoint keys, disjoint ids).

## S-5 · two folds that were right and stopped one key short

`MWS125-C -> Tricity 125` and `LTS125-C -> D'elight` are correct on Yamaha's own evidence. Each still left **the same machine publishing as two ids in two country sets**, because only the *code* spelling was folded and the register's own spelling was not.

The original PR body records the near-miss and drew the wrong conclusion from it:

> **1 dead** (`Delight → D'elight`) — already folded by G-1, dropped rather than shipped inert

The re-derivation check did its job — it found the draft key dead. The dead key was then **deleted instead of re-derived against the record it had collided with.** G-1 had folded the bare stub to `delight-125`, so the key that would have worked is the live record's produced name, `"Delight 125"`, which was never tried. The check looked one step upstream of where the answer was.

| key | target | effect |
|---|---|---|
| `"Delight 125"` | `D'elight` | `d-elight` [es,fi,lu,nl,nz] → **[es,fi,gb,lu,nl,nz]**; `delight-125` [gb] retires |
| `"MWS125"` | `Tricity 125` | gb was split across two ids for one scooter — UK writes both `MWS125` n=661 and `TRICITY 125` n=154 |
| `"MWS125-A"` | `Tricity 125` | manual PBR7F8199E0E cover `TRICITY 125`; RDW `MWS125-A (TRICITY ABS)` n=6 |
| `"MWS150"` | `Tricity 155` | **new** `tricity-155` [fi,nl] |

**`MWS150` is taken with them although it sits outside the audit's declared scope.** Two first-party sources, found independently rather than taken from the audit:

- Yamaha Thailand's manual is titled **`MWS150-C MWS150-A OWNER'S MANUAL`** and served at `.../docs/owner-manual/commuter/en/tricity155-en.pdf`
- Yamaha Japan `BB8-F8199-J1` prints **`MWS150-A … TRICITY 155`**

155 cm³, and **there has never been a "Tricity 150"** — Yamaha later recoded it `MWS155-A`, which is why the digits in the old code disagree with the displacement. Leaving it publishes `MWS150` as a nameplate asserting a displacement Yamaha never sold.

## S-6 · the audit's detail is wrong; the finding is not

The audit says the live record `motorcycle/yamaha/yzf-r3` is named **"YZF R3"** (space). **It is not** — both the released catalog and `build/out` say `YZF-R3`, the same string the fold targets. So there is no live mismatch.

What is real is the risk underneath it. `build/observed_model_names.json` for that id:

```json
"motorcycle/yamaha/yzf-r3" => ["Yzf  R3", "Yzf R3", "Yzf-R3"]
```

**Three** produced spellings — one of them with a double space — and **nothing pins which one publishes.** The hyphen wins on mass today. Mass is not a decision. Three display-only pins added, every one keyed on a form that actually occurs, so none is inert. Follows the `Yzf-R1` / `Yzfr 1` precedent five lines above.

## The lint earned its keep

The moment `mws125` and `delight-125` became aliases, `lint_curation` failed on two **CHAINs** it had been silently fine with:

```
CHAIN — "motorcycle/yamaha/mws" -> "motorcycle/yamaha/mws125", but
        "motorcycle/yamaha/mws125" is itself an alias for ".../tricity-125".
```

Both were pre-existing G-1 arms; both now point straight at the live id. This is the MISROUTE class working as designed — a consumer following one redirect must land on a live record, not on another alias.

## Verification

- Build green, **ALL GATES GREEN**, then a confirming rebuild after the chain repair — green again.
- `delta motorcycle: 5 ids removed` — `mutt/rs-13` (pre-dispositioned in `removals.yml`, unrelated) plus the four this change retires, each with a `former_ids` arm. Verified in `build/out`:
  ```
  d-elight      former: delight delight-125 lts125-c      [es,fi,gb,lu,nl,nz]
  tricity-125   former: mws mws125 mws125-a mws125-c      [es,gb,nl]
  tricity-155   former: mws150                            [fi,nl]
  yzf-r3        former: yzf-r3a yzf320-a                  [es,fi,lu,nl,nz,th,ua]
  ```
- Rename-VALUE liveness (the RESURRECT class): no rename anywhere uses `Delight 125`, `MWS125`, `MWS125-A` or `MWS150` as a **value**, so no retired display name keeps firing.
- `lint_curation` OK (109 files), `lint_overrides` OK, `rake test` 0 failures / 0 errors across all suites.

## Block 1 status after this

S-1 ✅ (`data#248` + phase 2 in `data#263`) · S-2 ✅ (`data#263`) · S-3 ✅ answered, no change (the RDW year table puts 446 of `MT09TRA`'s 583 vehicles in 2017, the MT-09 Tracer era, so the audit's retarget would move the majority onto the later name) · S-4 escalated (`data#249`) · **S-5 ✅ · S-6 ✅ here**. That closes every actionable suspect; the two CANNOT-VERIFY rows (`XVS950CUD-A`, `GPD125D-A`) stay as they are, both sound by elimination.

Next: block 2, the Kawasaki apply — 42 keys already extracted with evidence. Note the DEBT row filed in `data#263`: the 2W blocks should be re-derived after the `uk_dft` single-digit-nameplate fix lands, because that fix changes what is detectable.
