### PR TITLE
plates: per-jurisdiction `serial_alphabet`, declared in exact codepoints (§2.6 decision 2)

### DIFF
--- a/PRD-PLATES.md
+++ b/PRD-PLATES.md
@@ -325,6 +325,26 @@ photographs").
 |---|---|
 | Government/authority pages, statutes, gazettes (RDW, DVLA, BOE, EUR-Lex, UNECE, state DMVs) | PRIMARY. Facts extractable; cite the page per claim; archive the fetch |
 | EU/intl law (Reg. 2411/98, Vienna Convention annexes) | normative for what they mandate — quote articles, not summaries. MEASURED CAUTIONS (EU dossier): 2411/98 is a MUTUAL-RECOGNITION instrument, not a design standard — its annex is a scanned bitmap with no geometry and no per-country code list; Euroband millimetres come from NATIONAL law (ES Anexo XVIII, DE FZV Anlage 4). The 1968 Vienna Convention AS ADOPTED forbids incorporating the distinguishing sign in the plate (Annex 3 §3, UNTS 1042); the amendment permitting it is UNVERIFIED (UNECE 403s) — never state the amended rule as sourced until pinned |
+**§2.6 — PER-JURISDICTION SERIAL ALPHABET (owner ruling 2026-08-02, decision 2).**
+A jurisdiction may declare `serial_alphabet:` at the top of its dossier — a
+String of the EXACT characters its plates print. It REPLACES the dataset-wide
+set from `_meta/separators.yml` for that file, so a reader sees the whole truth
+in one place; absent, the global set applies and nothing changes. The lint
+fails any pattern literal or regex class member outside the effective set, and
+fails a declaration that collides with an emitted separator.
+
+**NO SILENT FOLDING, EVER.** Croatia prints six area codes with a caron
+(`ČK KŽ PŽ ŠI VŽ ŽU`). `ŠI` ASCII-folds to `SI`, which was itself a Croatian
+area code in the earlier system (Sisak, before SK) — unambiguous against the
+CURRENT table, ambiguous against a historic plate. That is the worst shape of
+error: current data stays self-consistent while old plates decode wrong. Record
+both forms (`code:` + `code_ascii:`, as `_decode/hr-cities.yml` does); never
+substitute one for the other.
+
+A narrower regex than the issuing grammar is still `matching: strict` (§2.7) —
+correct-but-incomplete, not wrong. Widening it is a DATA change with matching
+consequences and belongs in its own PR, never inside a schema change.
+
 | Wikipedia (the plates corpus is genuinely excellent) | **EXTRACTION AUTHORIZED — owner override, Javi, 2026-08-02.** This row read LOCATOR ONLY, never systematic text/table extraction, until the owner overrode it explicitly and on an informed basis (the CC-BY-SA ShareAlike consequence was put to him in full first). Facts — codes, indices, years, table contents — may be extracted. **FOUR conditions, and the first is the only one whose breach is defined as a violation:** (1) every Wikipedia-derived fact carries `period_evidence: secondary-wikipedia` (or the nearest accurate secondary tier) PLUS the article URL, and a rev date where cheap — an UNTAGGED Wikipedia-derived fact is the violation, because the tag is the reversibility guarantee: if the decision is ever revisited, every such fact must be enumerable in one pass. (2) FACTS IN OUR EXPRESSION — our schema, our ordering, our wording; never copied prose, never a table arrangement mirrored verbatim where the instrument orders differently. (3) EXCEPT where identity IS form: codepoints, permitted-letter sets, exact serial grammars and separators are copied EXACTLY — Greek Α (U+0391) is not Latin A (U+0041), and our-expression never licenses transliteration. (4) PRIMARY INSTRUMENT REMAINS FIRST, unchanged — not for licence reasons but because a statutory annex is better evidence and a stronger artifact than an article. The fingerprint-diff verification pass LABELS Wikipedia-shaped tables rather than rejecting them: detection is provenance now, and what fails review is Wikipedia-derived content claiming `instrument-in-force`. |
 | Enthusiast references (worldlicenseplates, olavsplates, plateshack, europlate...) | facts-uncopyrightable applies; no text copying; treat as corroboration + gap-finders, cite what was actually used; their PHOTOS are never copied |
 | Wikimedia Commons plate images | NOT copied into the dataset. License texture recorded per §6; our renders are generated, not derived |

--- a/scripts/lint_plates.rb
+++ b/scripts/lint_plates.rb
@@ -120,10 +120,10 @@ def regex_atoms(src)
 end
 
 # §2.6 + §2.8 — one regex, checked against the separator contract.
-def check_separator_contract(rel, id, key, src)
+def check_separator_contract(rel, id, key, src, alphabet = SERIAL_ALPHABET)
   literals, classes = regex_atoms(src)
   literals.uniq.each do |ch|
-    next if SERIAL_ALPHABET.include?(ch) || EMITTED.include?(ch)
+    next if alphabet.include?(ch) || EMITTED.include?(ch)
     hint = if FORGIVING.include?(ch)
              "it is in the FORGIVING set but not the EMITTED set — the dataset writes only #{EMITTED.to_a.map(&:inspect).join(' and ')}"
            else
@@ -146,7 +146,7 @@ def check_separator_contract(rel, id, key, src)
       end
     else
       members.each do |m|
-        next if m.start_with?("\\") || SERIAL_ALPHABET.include?(m)
+        next if m.start_with?("\\") || alphabet.include?(m)
         fail! "#{rel}: #{id} #{key} class [#{body}] member #{m.inspect} is outside the serial alphabet (PRD-PLATES §2.6)"
       end
     end
@@ -245,7 +245,7 @@ self_check_pattern_tokens!
 # pattern so the two cannot drift. Written against the TOKENISER, not against
 # raw characters: a `\` is grammar and never needs to be in the alphabet, while
 # the character it escapes is held to exactly the same rule as an unescaped one.
-def check_pattern_alphabet(rel, id, where, pattern)
+def check_pattern_alphabet(rel, id, where, pattern, alphabet = SERIAL_ALPHABET)
   toks = pattern_tokens(pattern)
   if toks == [[:dangling_escape]]
     fail! "#{rel}: #{id} #{where} ends in a lone backslash — an escape with nothing to escape. " \
@@ -254,7 +254,7 @@ def check_pattern_alphabet(rel, id, where, pattern)
   end
   toks.each do |kind, ch|
     next unless kind == :literal
-    next if SERIAL_ALPHABET.include?(ch) || EMITTED.include?(ch)
+    next if alphabet.include?(ch) || EMITTED.include?(ch)
     fail! "#{rel}: #{id} #{where} spells #{ch.inspect} (U+%04X) — patterns carry 9/L, escaped literals, " \
           "serial characters and emitted separators only (PRD-PLATES §2.6)" % ch.ord
   end
@@ -325,6 +325,41 @@ files.sort.each do |abs|
   fail! "#{rel}: authority {name, url} required" unless doc.dig("authority", "url").to_s.start_with?("http")
   raw = File.read(abs)
 
+  # ── PER-JURISDICTION SERIAL ALPHABET (owner ruling 2026-08-02, §2.6 dec. 2)
+  #
+  # A jurisdiction's serial alphabet is a FACT about that jurisdiction, so it is
+  # declared in that jurisdiction's own file, in exact codepoints — not folded,
+  # not inferred, not approximated by the nearest ASCII letter.
+  #
+  # WHY THIS EXISTS. Six Croatian area codes are printed with a caron
+  # (ČK KŽ PŽ ŠI VŽ ŽU) and Č/Š/Ž are outside the dataset-wide alphabet, so
+  # `plates/hr.yml` could only write `[A-Z]{2}` — NARROWER than the issuing
+  # grammar. Narrower is still `strict` under §2.7, so that is correct-but-
+  # incomplete rather than wrong; what it is NOT is a licence to fold. `ŠI`
+  # ASCII-folds to `SI`, which was itself a Croatian area code in the earlier
+  # system (Sisak, before SK) — so folding is unambiguous against the CURRENT
+  # table and AMBIGUOUS against a historic plate. That is the worst shape of
+  # error: current data stays self-consistent while old plates decode wrong,
+  # and nothing in the corpus can detect it.
+  #
+  # DEFAULT IS THE GLOBAL SET, so a file that declares nothing behaves exactly
+  # as before — this change moves no series. Declaring REPLACES rather than
+  # extends: a reader of hr.yml should see the whole truth in one place instead
+  # of mentally unioning it with separators.yml.
+  alphabet = SERIAL_ALPHABET
+  if (declared = doc["serial_alphabet"])
+    unless declared.is_a?(String) && !declared.empty?
+      fail! "#{rel}: serial_alphabet must be a non-empty String of the exact characters this jurisdiction prints"
+    else
+      alphabet = declared.chars.to_set
+      # A declaration that collides with the separator contract would make the
+      # same character mean two things in one serial.
+      clash = alphabet & EMITTED
+      fail! "#{rel}: serial_alphabet declares #{clash.to_a.inspect}, which are EMITTED separators — " \
+            "a character cannot be both a serial character and a separator" if clash.any?
+    end
+  end
+
   (doc["series"] || []).each do |s|
     series_count += 1
     id = s["id"].to_s
@@ -367,7 +402,7 @@ files.sort.each do |abs|
     # emitted separators, and nothing else. Escaped literals (`\9`, `\L`) are
     # checked against the same alphabet as everything else: the escape buys the
     # ability to SAY "9", not permission to spell characters a plate cannot show.
-    check_pattern_alphabet(rel, id, "format.pattern", pattern)
+    check_pattern_alphabet(rel, id, "format.pattern", pattern, alphabet)
 
     if regex_s.empty?
       fail! "#{rel}: #{id} format.regex required"
@@ -375,7 +410,7 @@ files.sort.each do |abs|
       begin
         re = Regexp.new(regex_s)
         fail! "#{rel}: #{id} regex not anchored (\\A...\\z)" unless regex_s.start_with?('\A') && regex_s.end_with?('\z')
-        check_separator_contract(rel, id, "format.regex", regex_s)
+        check_separator_contract(rel, id, "format.regex", regex_s, alphabet)
         unless pattern.empty?
           srand(id.sum) # deterministic per series
           serials_from(pattern).each do |ser|
@@ -405,7 +440,7 @@ files.sort.each do |abs|
       begin
         r = Regexp.new(src)
         fail! "#{rel}: #{id} #{key} not anchored (\\A...\\z)" unless src.start_with?('\A') && src.end_with?('\z')
-        check_separator_contract(rel, id, "format.#{key}", src)
+        check_separator_contract(rel, id, "format.#{key}", src, alphabet)
         strict_re = r if key == "regex_strict"
         next if pattern.empty?
         srand(id.sum + key.sum)
@@ -432,10 +467,10 @@ files.sort.each do |abs|
     (s["variants"] || []).each_with_index do |v, vi|
       vpat = v.dig("format", "pattern").to_s
       next if vpat.empty?
-      check_pattern_alphabet(rel, id, "variant[#{vi}] pattern", vpat)
+      check_pattern_alphabet(rel, id, "variant[#{vi}] pattern", vpat, alphabet)
       %w[regex regex_strict regex_statutory].each do |key|
         vsrc = v.dig("format", key).to_s
-        check_separator_contract(rel, id, "variant[#{vi}].#{key}", vsrc) unless vsrc.empty?
+        check_separator_contract(rel, id, "variant[#{vi}].#{key}", vsrc, alphabet) unless vsrc.empty?
       end
     end
 


### PR DESCRIPTION
Owner ruling 2026-08-02, **decision 2**: a jurisdiction's serial alphabet is a *fact* about that jurisdiction — declared in its own file, exact codepoints, lint-enforced, **no silent folding ever**.

## Scope, measured before designing — one file, not 91

```
patterns across 91 dossiers containing non-ASCII:   0
decode tables whose CODES contain non-ASCII:        1   (hr-cities)
```

**The decode side was already correct before the ruling existed.** `hr-cities.yml` ships `code: "ŠI"` beside `code_ascii: "SI"` — codepoints preserved, the fold *recorded* rather than performed. Nothing to migrate. What was missing is the **serial** side being able to declare its own alphabet at all.

## I corrected my own justification

I called `ŠI`→`SI` a **live** collision, and the ruling repeats that. Measured: **zero folding collisions within the current 34-code table.** `SI` was a Croatian code in the *earlier* system (Sisak, before SK) — so the fold is unambiguous against the current table and **ambiguous against a historic plate**.

That doesn't weaken the rule. It's the worst shape of error: current data stays self-consistent while old plates decode wrong, and nothing in the corpus can detect it.

## Design

Optional `serial_alphabet:` String at the dossier root. It **replaces** the global set for that file rather than extending it, so a reader of `hr.yml` sees the whole truth in one place instead of mentally unioning two files. Absent → the global set applies.

Threaded as an **explicit parameter** through both checkers rather than a mutable global — a global not reset per file would silently inherit the previous jurisdiction's alphabet, which is exactly the class of bug this rule exists to prevent.

## Proved four ways

| | result |
|---|---|
| no file declares yet | lint output over all 91 files **byte-identical to control** — moves no series |
| undeclared `Ð` in a real `hr` regex | **FAILS**, naming series and character |
| same file **declaring** `Ð` | **PASSES** |
| declaration containing `-` | **FAILS** — a character cannot be both a serial character and an emitted separator |

## Not in this PR, deliberately

Widening `hr.yml`'s `[A-Z]{2}` area position to admit the carons. That is a **matching** change for Croatian plates, not a schema change — it would stop accepting ASCII-folded input that matches today. Narrower than the issuing grammar is still `strict` under §2.7, so the current state is *correct-but-incomplete*, not wrong. Owner's call, and it wants its own control diff.

## Two notes on my own work

`String#sub` interprets backslashes in a string replacement and silently halved `start_with?("\\")` into an unterminated literal — fixed with the block form. And my first gate test injected into a *double*-quoted regex when `hr.yml` uses single quotes, so it was a **no-op that printed nothing**; I checked rather than reading the silence as a pass.