### PR TITLE
plates L3: cn — cn (S5W)

### DIFF
--- a/plates/_decode/cn-issuing-offices.yml
+++ b/plates/_decode/cn-issuing-offices.yml
@@ -1,0 +1,463 @@
+# plates/_decode/cn-issuing-offices.yml — China's 发牌机关代号 (issuing-authority
+# letter codes), the second element of every civil Chinese registration number.
+#
+# THE SOURCE FINDING, and it is the reason this file can exist at all.
+# GA 36 《中华人民共和国机动车号牌》 is the mandatory public-security industry
+# standard that defines Chinese plates. The CURRENT edition, GA 36-2018, is
+# recorded in the national standards register (发布 2018-04-20, 实施 2018-05-01,
+# 代替 GA 36-2014) but its TEXT IS NOT PUBLIC: the register's own reader returns
+# "您所查询的标准在本系统尚未公开" and its download endpoint returns zero bytes.
+# The SUPERSEDED edition GA 36-2007 (发布 2007-09-28, 实施 2007-11-01, 代替
+# GA 36-1992) is, however, republished IN FULL by a Chinese municipal
+# government — 巩义市人民政府 (www.hngy.gov.cn), 2012-11-15 — and every row
+# below is its 附录 A（规范性附录）发牌机关代号, 表 A.1, read off that copy in
+# its own printed order. Nothing here comes from Wikipedia: the en/zh
+# "Vehicle registration plates of China" articles were used only as a finding
+# aid, and their CC BY-SA prefix tables were never opened for extraction.
+#
+# WHAT THE CODES ARE (GA 36-2007 § 5.8.1, verbatim):
+#   "发牌机关即车辆登记机关，为省、自治区、直辖市公安厅、局和地、市、州、盟公安
+#    局、处车辆管理所。发牌机关代号见附录A。"
+#   ("The issuing authority is the vehicle registration authority, namely the
+#    vehicle management offices of the provincial/autonomous-region/
+#    municipality public security departments and bureaux and of the
+#    prefecture, city, prefecture-level and league public security bureaux and
+#    divisions. The issuing-authority codes are given in Annex A." — translation
+#    ours; the Chinese is the sourced text.)
+#
+# TWO ALLOCATION RULES, BOTH VERBATIM, AND THEY ARE WHY THIS TABLE ROTS:
+#   § 5.8.2 "直辖市公安机关交通管理部门车辆管理所的发牌机关代号为A至Z，报公安部
+#            交通管理局备案后，可依次使用。"
+#            — the four DIRECTLY-ADMINISTERED MUNICIPALITIES (北京 京, 天津 津,
+#            上海 沪, 重庆 渝) are allocated the WHOLE ALPHABET A-Z, used in
+#            order after filing with the MPS Traffic Management Bureau. Annex A
+#            prints exactly that: one row per municipality carrying "A B C ...
+#            Z" and no city breakdown. Those four rows therefore carry
+#            `code_range: "A-Z"` here and NO per-letter meaning: a Beijing
+#            letter is a batch marker, not a place. A decoder that reads 京B as
+#            a Beijing district is inventing.
+#   § 5.8.3 "设区的市或者相当于同级的公安机关交通管理部门车辆管理所报经公安部
+#            交通管理局批准同意后可启用新的发牌机关代号。"
+#            — a new code can be brought into use by MPS approval AT ANY TIME.
+#            So this table is a 2007 SNAPSHOT of an open, growing allocation,
+#            not a closed list. The sourced example of a post-2007 addition is
+#            豫V (Zhengzhou), announced by 郑州市人民政府 for 2020-09-16 and
+#            cited below — it is NOT in Annex A because Annex A predates it.
+#
+# PERIOD DISCIPLINE (PRD-PLATES § 2.4). Rows are the 2007 state and are never
+# deleted: a plate issued under an old code stays on the road, and several of
+# the place names below have since been renamed or reorganised (襄樊市 →
+# 襄阳市 2010; 巢湖市 dissolved 2011; 铜仁地区/毕节地区/海东地区/吐鲁番地区/
+# 哈密地区 and the Tibetan 地区 became 市; 三沙市 and 儋州市 were created after
+# 2007 and are absent). Those changes are NOT applied here — this file records
+# what the standard printed, and the L4 pass re-sources the current allocation
+# from GA 36-2018's Annex A if it ever becomes public.
+#
+# CAUTIONS A PARSE API MUST CARRY:
+#   * The code is the ISSUING OFFICE, not the owner's address and not where the
+#     vehicle is. It is fixed at registration.
+#   * Several cities hold MORE THAN ONE code (佛山市 E X Y; 青岛市 B U; 烟台市
+#     F Y; 潍坊市 G V; 哈尔滨市 A L; 南昌市 A M; 福州市 A K; 长沙市 A S;
+#     桂林市 C H; 伊犁哈萨克自治州 D F). Each is a separate row.
+#   * "O" is a NATIONAL code, not a provincial one: Annex A gives it to the
+#     "省、自治区公安厅交通管理局、处车辆管理所" (the provincial public security
+#     department's own vehicle office) in EVERY province. It is the code behind
+#     the "O 牌" controversy. Several provinces have since stopped issuing it;
+#     no primary for any withdrawal was secured, so no row is closed here.
+#   * "Z" appears twice with different meanings: as an ordinary prefecture code
+#     in provinces that have got that far, and — per Annex A footnote 9 — as
+#     the code 广东省公安厅交通管理局车辆管理所 uses for 港澳入出境车号牌
+#     (粤Z, the Hong Kong / Macau cross-boundary plates).
+#   * The issuing-office letter uses the FULL alphabet, "I" and "O" included
+#     (GA 36-2007 前言 records "增加了发牌机关代号"I"" as a 2007 change). The
+#     I/O exclusion in Chinese plates applies to the SERIAL only
+#     (GA 36-2007 § 5.9.1) — the single most-missed fact about this format.
+jurisdiction: cn
+topic: issuing-offices
+authority:
+  name: 公安部交通管理局 (Traffic Management Bureau, Ministry of Public Security)
+  url: "https://www.mps.gov.cn/"
+  url_status: >-
+    www.mps.gov.cn returned HTTP 521 on every attempt from this workstation on
+    2026-08-02; the ministry's pages were read through the Internet Archive and
+    are cited with their archive URLs where used.
+sources:
+  - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 《中华人民共和国机动车号牌》 FULL TEXT as republished by 巩义市人民政府 (published 2012-11-15): § 5.8 发牌机关代号 and 附录 A 表 A.1 — every row below; accessed 2026-08-02"
+  - "https://hbba.sacinfo.org.cn/stdDetail/12b7710b682f0e13dfc423a325751920  # 全国标准信息公共服务平台 register entry for GA 36-2007: 发布 2007-09-28, 实施 2007-11-01, 代替 GA 36-1992, status 废止 — the provenance of the text above; accessed 2026-08-02"
+  - "https://hbba.sacinfo.org.cn/stdDetail/328b77ee80fdee1dee33d20e83d01d2ad128f380aa93c7dbe5c58c67d9d2075e  # register entry for the CURRENT GA 36-2018: 发布 2018-04-20, 实施 2018-05-01, 代替 GA 36-2014, 技术归口 公安部道路交通管理标准化技术委员会 — metadata only; the text is withheld ('尚未公开'); accessed 2026-08-02"
+  - "https://web.archive.org/web/20201104173257/http://www.zhengzhou.gov.cn/news1/3941801.jhtml  # 郑州市人民政府, 2020-09-11: 豫V 号牌 in use from 2020-09-16, 前期经报请公安部交通管理局、河南省公安厅交警总队批准 — the sourced example of the § 5.8.3 mechanism adding a code after 2007; accessed 2026-08-02"
+period: { start: 2007 }
+period_evidence: instrument-in-force
+period_note: >-
+  2007 is the year GA 36-2007 came into force (实施 2007-11-01), NOT the year
+  these codes began: most of them were already allocated under GA 36-1992 and
+  the 1992-format plates that carry them were issued from 1992 onward. This is
+  the instrument-in-force case in PRD-PLATES § 2.4 exactly — a consolidation
+  documenting an older practice. The 2014 and 2018 editions each reissued
+  Annex A and neither text is public, so no row here can be dated later than
+  2007 and none can be shown to have been withdrawn.
+offices:
+  - { province: 北京市, province_char: 京, iso_3166_2: CN-BJ, code_range: "A-Z", office: "北京市车辆管理所", rule: "GA 36-2007 5.8.2" }
+  - { province: 天津市, province_char: 津, iso_3166_2: CN-TJ, code_range: "A-Z", office: "天津市车辆管理所", rule: "GA 36-2007 5.8.2" }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: A, office: 石家庄市 }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: B, office: 唐山市 }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: C, office: 秦皇岛市 }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: D, office: 邯郸市 }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: E, office: 邢台市 }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: F, office: 保定市 }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: G, office: 张家口市 }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: H, office: 承德市 }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: J, office: 沧州市 }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: R, office: 廊坊市 }
+  - { province: 河北省, province_char: 冀, iso_3166_2: CN-HE, code: T, office: 衡水市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: A, office: 太原市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: B, office: 大同市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: C, office: 阳泉市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: D, office: 长治市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: E, office: 晋城市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: F, office: 朔州市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: H, office: 忻州市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: J, office: 吕梁市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: K, office: 晋中市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: L, office: 临汾市 }
+  - { province: 山西省, province_char: 晋, iso_3166_2: CN-SX, code: M, office: 运城市 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: A, office: 呼和浩特市 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: B, office: 包头市 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: C, office: 乌海市 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: D, office: 赤峰市 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: E, office: 呼伦贝尔市 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: F, office: 兴安盟 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: G, office: 通辽市 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: H, office: 锡林郭勒盟 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: J, office: 乌兰察布市 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: K, office: 鄂尔多斯市 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: L, office: 巴彦淖尔市 }
+  - { province: 内蒙古自治区, province_char: 蒙, iso_3166_2: CN-NM, code: M, office: 阿拉善盟 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: A, office: 沈阳市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: B, office: 大连市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: C, office: 鞍山市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: D, office: 抚顺市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: E, office: 本溪市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: F, office: 丹东市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: G, office: 锦州市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: H, office: 营口市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: J, office: 阜新市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: K, office: 辽阳市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: L, office: 盘锦市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: M, office: 铁岭市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: N, office: 朝阳市 }
+  - { province: 辽宁省, province_char: 辽, iso_3166_2: CN-LN, code: P, office: 葫芦岛市 }
+  - { province: 吉林省, province_char: 吉, iso_3166_2: CN-JL, code: A, office: 长春市 }
+  - { province: 吉林省, province_char: 吉, iso_3166_2: CN-JL, code: B, office: 吉林市 }
+  - { province: 吉林省, province_char: 吉, iso_3166_2: CN-JL, code: C, office: 四平市 }
+  - { province: 吉林省, province_char: 吉, iso_3166_2: CN-JL, code: D, office: 辽源市 }
+  - { province: 吉林省, province_char: 吉, iso_3166_2: CN-JL, code: E, office: 通化市 }
+  - { province: 吉林省, province_char: 吉, iso_3166_2: CN-JL, code: F, office: 白山市 }
+  - { province: 吉林省, province_char: 吉, iso_3166_2: CN-JL, code: G, office: 白城市 }
+  - { province: 吉林省, province_char: 吉, iso_3166_2: CN-JL, code: H, office: 延边朝鲜族自治州 }
+  - { province: 吉林省, province_char: 吉, iso_3166_2: CN-JL, code: J, office: 松原市 }
+  - { province: 吉林省, province_char: 吉, iso_3166_2: CN-JL, code: K, office: 长白山保护开发区, note: "吉林省公安厅交通警察总队长白山保护开发区车辆管理所" }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: A, office: 哈尔滨市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: L, office: 哈尔滨市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: B, office: 齐齐哈尔市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: C, office: 牡丹江市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: D, office: 佳木斯市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: E, office: 大庆市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: F, office: 伊春市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: G, office: 鸡西市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: H, office: 鹤岗市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: J, office: 双鸭市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: K, office: 七台河市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: M, office: 绥化市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: N, office: 黑河市 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: P, office: 大兴安岭地区 }
+  - { province: 黑龙江省, province_char: 黑, iso_3166_2: CN-HL, code: R, office: 垦区, note: "黑龙江省垦区公安局交通警察支队车辆管理所" }
+  - { province: 上海市, province_char: 沪, iso_3166_2: CN-SH, code_range: "A-Z", office: "上海市车辆管理所", rule: "GA 36-2007 5.8.2" }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: A, office: 南京市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: B, office: 无锡市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: C, office: 徐州市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: D, office: 常州市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: E, office: 苏州市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: F, office: 南通市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: G, office: 连云港市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: H, office: 淮安市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: J, office: 盐城市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: K, office: 扬州市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: L, office: 镇江市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: M, office: 泰州市 }
+  - { province: 江苏省, province_char: 苏, iso_3166_2: CN-JS, code: N, office: 宿迁市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: A, office: 杭州市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: B, office: 宁波市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: C, office: 温州市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: D, office: 绍兴市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: E, office: 湖州市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: F, office: 嘉兴市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: G, office: 金华市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: H, office: 衢州市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: J, office: 台州市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: K, office: 丽水市 }
+  - { province: 浙江省, province_char: 浙, iso_3166_2: CN-ZJ, code: L, office: 舟山市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: A, office: 合肥市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: B, office: 芜湖市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: C, office: 蚌埠市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: D, office: 淮南市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: E, office: 马鞍山市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: F, office: 淮北市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: G, office: 铜陵市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: H, office: 安庆市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: J, office: 黄山市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: K, office: 阜阳市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: L, office: 宿州市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: M, office: 滁州市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: N, office: 六安市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: P, office: 宣城市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: Q, office: 巢湖市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: R, office: 池州市 }
+  - { province: 安徽省, province_char: 皖, iso_3166_2: CN-AH, code: S, office: 亳州市 }
+  - { province: 福建省, province_char: 闽, iso_3166_2: CN-FJ, code: A, office: 福州市 }
+  - { province: 福建省, province_char: 闽, iso_3166_2: CN-FJ, code: K, office: 福州市 }
+  - { province: 福建省, province_char: 闽, iso_3166_2: CN-FJ, code: B, office: 莆田市 }
+  - { province: 福建省, province_char: 闽, iso_3166_2: CN-FJ, code: C, office: 泉州市 }
+  - { province: 福建省, province_char: 闽, iso_3166_2: CN-FJ, code: D, office: 厦门市 }
+  - { province: 福建省, province_char: 闽, iso_3166_2: CN-FJ, code: E, office: 漳州市 }
+  - { province: 福建省, province_char: 闽, iso_3166_2: CN-FJ, code: F, office: 龙岩市 }
+  - { province: 福建省, province_char: 闽, iso_3166_2: CN-FJ, code: G, office: 三明市 }
+  - { province: 福建省, province_char: 闽, iso_3166_2: CN-FJ, code: H, office: 南平市 }
+  - { province: 福建省, province_char: 闽, iso_3166_2: CN-FJ, code: J, office: 宁德市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: A, office: 南昌市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: M, office: 南昌市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: B, office: 赣州市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: C, office: 宜春市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: D, office: 吉安市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: E, office: 上饶市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: F, office: 抚州市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: G, office: 九江市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: H, office: 景德镇市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: J, office: 萍乡市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: K, office: 新余市 }
+  - { province: 江西省, province_char: 赣, iso_3166_2: CN-JX, code: L, office: 鹰潭市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: A, office: 济南市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: B, office: 青岛市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: U, office: 青岛市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: C, office: 淄博市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: D, office: 枣庄市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: E, office: 东营市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: F, office: 烟台市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: Y, office: 烟台市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: G, office: 潍坊市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: V, office: 潍坊市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: H, office: 济宁市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: J, office: 泰安市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: K, office: 威海市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: L, office: 日照市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: M, office: 滨州市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: N, office: 德州市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: P, office: 聊城市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: Q, office: 临沂市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: R, office: 菏泽市 }
+  - { province: 山东省, province_char: 鲁, iso_3166_2: CN-SD, code: S, office: 莱芜市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: A, office: 郑州市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: B, office: 开封市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: C, office: 洛阳市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: D, office: 平顶山市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: E, office: 安阳市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: F, office: 鹤壁市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: G, office: 新乡市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: H, office: 焦作市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: J, office: 濮阳市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: K, office: 许昌市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: L, office: 漯河市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: M, office: 三门峡市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: N, office: 商丘市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: P, office: 周口市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: Q, office: 驻马店市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: R, office: 南阳市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: S, office: 信阳市 }
+  - { province: 河南省, province_char: 豫, iso_3166_2: CN-HA, code: U, office: 济源市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: A, office: 武汉市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: B, office: 黄石市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: C, office: 十堰市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: D, office: 荆州市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: E, office: 宜昌市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: F, office: 襄樊市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: G, office: 鄂州市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: H, office: 荆门市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: J, office: 黄冈市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: K, office: 孝感市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: L, office: 咸宁市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: M, office: 仙桃市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: N, office: 潜江市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: P, office: 神农架林区 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: Q, office: 恩施土家族苗族自治州 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: R, office: 天门市 }
+  - { province: 湖北省, province_char: 鄂, iso_3166_2: CN-HB, code: S, office: 随州市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: A, office: 长沙市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: S, office: 长沙市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: B, office: 株洲市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: C, office: 湘潭市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: D, office: 衡阳市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: E, office: 邵阳市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: F, office: 岳阳市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: G, office: 张家界市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: H, office: 益阳市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: J, office: 常德市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: K, office: 娄底市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: L, office: 郴州市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: M, office: 永州市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: N, office: 怀化市 }
+  - { province: 湖南省, province_char: 湘, iso_3166_2: CN-HN, code: U, office: 湘西土家族苗族自治州 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: A, office: 广州市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: B, office: 深圳市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: C, office: 珠海市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: D, office: 汕头市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: E, office: 佛山市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: X, office: 佛山市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: Y, office: 佛山市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: F, office: 韶关市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: G, office: 湛江市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: H, office: 肇庆市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: J, office: 江门市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: K, office: 茂名市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: L, office: 惠州市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: M, office: 梅州市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: N, office: 汕尾市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: P, office: 河源市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: Q, office: 阳江市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: R, office: 清远市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: S, office: 东莞市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: T, office: 中山市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: U, office: 潮州市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: V, office: 揭阳市 }
+  - { province: 广东省, province_char: 粤, iso_3166_2: CN-GD, code: W, office: 云浮市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: A, office: 南宁市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: B, office: 柳州市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: C, office: 桂林市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: H, office: 桂林市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: D, office: 梧州市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: E, office: 北海市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: F, office: 崇左市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: G, office: 来宾市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: J, office: 贺州市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: K, office: 玉林市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: L, office: 百色市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: M, office: 河池市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: N, office: 钦州市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: P, office: 防城港市 }
+  - { province: 广西壮族自治区, province_char: 桂, iso_3166_2: CN-GX, code: R, office: 贵港市 }
+  - { province: 海南省, province_char: 琼, iso_3166_2: CN-HI, code: A, office: 海口市 }
+  - { province: 海南省, province_char: 琼, iso_3166_2: CN-HI, code: B, office: 三亚市 }
+  - { province: 海南省, province_char: 琼, iso_3166_2: CN-HI, code: C, office: 琼北, note: "海南省公安厅交通警察总队琼北车辆管理所" }
+  - { province: 海南省, province_char: 琼, iso_3166_2: CN-HI, code: D, office: 琼南, note: "海南省公安厅交通警察总队琼南车辆管理所" }
+  - { province: 海南省, province_char: 琼, iso_3166_2: CN-HI, code: E, office: 洋浦经济开发区, note: "海南省公安厅交通警察总队车辆管理所代管的洋浦经济开发区公安局交通警察支队车辆管理所" }
+  - { province: 重庆市, province_char: 渝, iso_3166_2: CN-CQ, code_range: "A-Z", office: "重庆市车辆管理所", rule: "GA 36-2007 5.8.2" }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: A, office: 成都市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: B, office: 绵阳市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: C, office: 自贡市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: D, office: 攀枝花市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: E, office: 泸州市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: F, office: 德阳市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: H, office: 广元市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: J, office: 遂宁市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: K, office: 内江市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: L, office: 乐山市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: M, office: 资阳市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: Q, office: 宜宾市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: R, office: 南充市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: S, office: 达州市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: T, office: 雅安市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: U, office: 阿坝藏族羌族自治州 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: V, office: 甘孜藏族自治州 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: W, office: 凉山彝族自治州 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: X, office: 广安市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: Y, office: 巴中市 }
+  - { province: 四川省, province_char: 川, iso_3166_2: CN-SC, code: Z, office: 眉山市 }
+  - { province: 贵州省, province_char: 贵, iso_3166_2: CN-GZ, code: A, office: 贵阳市 }
+  - { province: 贵州省, province_char: 贵, iso_3166_2: CN-GZ, code: B, office: 六盘水市 }
+  - { province: 贵州省, province_char: 贵, iso_3166_2: CN-GZ, code: C, office: 遵义市 }
+  - { province: 贵州省, province_char: 贵, iso_3166_2: CN-GZ, code: D, office: 铜仁地区 }
+  - { province: 贵州省, province_char: 贵, iso_3166_2: CN-GZ, code: E, office: 黔西南布依族苗族自治州 }
+  - { province: 贵州省, province_char: 贵, iso_3166_2: CN-GZ, code: F, office: 毕节地区 }
+  - { province: 贵州省, province_char: 贵, iso_3166_2: CN-GZ, code: G, office: 安顺市 }
+  - { province: 贵州省, province_char: 贵, iso_3166_2: CN-GZ, code: H, office: 黔东南苗族侗族自治州 }
+  - { province: 贵州省, province_char: 贵, iso_3166_2: CN-GZ, code: J, office: 黔南布依族苗族自治州 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: A, office: 昆明市 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: C, office: 昭通市 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: D, office: 曲靖市 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: E, office: 楚雄彝族自治州 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: F, office: 玉溪市 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: G, office: 红河哈尼族彝族自治州 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: H, office: 文山壮族苗族自治州 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: J, office: 普洱市 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: K, office: 西双版纳傣族自治州 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: L, office: 大理白族自治州 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: M, office: 保山市 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: N, office: 德宏傣族景颇族自治州 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: P, office: 丽江市 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: Q, office: 怒江傈僳族自治州 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: R, office: 迪庆藏族自治州 }
+  - { province: 云南省, province_char: 云, iso_3166_2: CN-YN, code: S, office: 临沧市 }
+  - { province: 西藏自治区, province_char: 藏, iso_3166_2: CN-XZ, code: A, office: 拉萨市 }
+  - { province: 西藏自治区, province_char: 藏, iso_3166_2: CN-XZ, code: B, office: 昌都地区 }
+  - { province: 西藏自治区, province_char: 藏, iso_3166_2: CN-XZ, code: C, office: 山南地区 }
+  - { province: 西藏自治区, province_char: 藏, iso_3166_2: CN-XZ, code: D, office: 日喀则地区 }
+  - { province: 西藏自治区, province_char: 藏, iso_3166_2: CN-XZ, code: E, office: 那曲地区 }
+  - { province: 西藏自治区, province_char: 藏, iso_3166_2: CN-XZ, code: F, office: 阿里地区 }
+  - { province: 西藏自治区, province_char: 藏, iso_3166_2: CN-XZ, code: G, office: 林芝地区 }
+  - { province: 西藏自治区, province_char: 藏, iso_3166_2: CN-XZ, code: H, office: 四川双流, note: "西藏自治区公安厅驻四川双流车辆管理所" }
+  - { province: 西藏自治区, province_char: 藏, iso_3166_2: CN-XZ, code: J, office: 青海格尔木, note: "西藏自治区公安厅驻青海格尔木交通警察支队车辆管理所" }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: A, office: 西安市 }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: B, office: 铜川市 }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: C, office: 宝鸡市 }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: D, office: 咸阳市 }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: E, office: 渭南市 }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: F, office: 汉中市 }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: G, office: 安康市 }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: H, office: 商洛市 }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: J, office: 延安市 }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: K, office: 榆林市 }
+  - { province: 陕西省, province_char: 陕, iso_3166_2: CN-SN, code: V, office: 杨凌, note: "陕西省公安厅车辆管理所杨凌分所" }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: A, office: 兰州市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: B, office: 嘉峪关市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: C, office: 金昌市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: D, office: 白银市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: E, office: 天水市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: F, office: 酒泉市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: G, office: 张掖市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: H, office: 武威市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: J, office: 定西市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: K, office: 陇南市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: L, office: 平凉市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: M, office: 庆阳市 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: N, office: 临夏回族自治州 }
+  - { province: 甘肃省, province_char: 甘, iso_3166_2: CN-GS, code: P, office: 甘南藏族自治州 }
+  - { province: 青海省, province_char: 青, iso_3166_2: CN-QH, code: A, office: 西宁市 }
+  - { province: 青海省, province_char: 青, iso_3166_2: CN-QH, code: B, office: 海东地区 }
+  - { province: 青海省, province_char: 青, iso_3166_2: CN-QH, code: C, office: 海北藏族自治州 }
+  - { province: 青海省, province_char: 青, iso_3166_2: CN-QH, code: D, office: 黄南藏族自治州 }
+  - { province: 青海省, province_char: 青, iso_3166_2: CN-QH, code: E, office: 海南藏族自治州 }
+  - { province: 青海省, province_char: 青, iso_3166_2: CN-QH, code: F, office: 果洛藏族自治州 }
+  - { province: 青海省, province_char: 青, iso_3166_2: CN-QH, code: G, office: 玉树藏族自治州 }
+  - { province: 青海省, province_char: 青, iso_3166_2: CN-QH, code: H, office: 海西蒙古族藏族自治州 }
+  - { province: 宁夏回族自治区, province_char: 宁, iso_3166_2: CN-NX, code: A, office: 银川市 }
+  - { province: 宁夏回族自治区, province_char: 宁, iso_3166_2: CN-NX, code: B, office: 石嘴山市 }
+  - { province: 宁夏回族自治区, province_char: 宁, iso_3166_2: CN-NX, code: C, office: 吴忠市 }
+  - { province: 宁夏回族自治区, province_char: 宁, iso_3166_2: CN-NX, code: D, office: 固原市 }
+  - { province: 宁夏回族自治区, province_char: 宁, iso_3166_2: CN-NX, code: E, office: 中卫市 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: A, office: 乌鲁木齐市 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: B, office: 昌吉回族自治州 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: C, office: 石河子市 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: E, office: 博尔塔拉蒙古自治州 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: D, office: 伊犁哈萨克自治州 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: F, office: 伊犁哈萨克自治州 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: G, office: 塔城地区 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: H, office: 阿勒泰地区 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: J, office: 克拉玛依市 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: K, office: 吐鲁番地区 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: L, office: 哈密地区 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: M, office: 巴音郭楞蒙古自治州 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: N, office: 阿克苏地区 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: P, office: 克孜勒苏柯尔克孜自治州 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: Q, office: 喀什地区 }
+  - { province: 新疆维吾尔自治区, province_char: 新, iso_3166_2: CN-XJ, code: R, office: 和田地区 }
+  - { scope: national, code: O, office: "省、自治区公安厅交通管理局、处车辆管理所" }
+  - { scope: national, code: Z, office: "广东省公安厅交通管理局车辆管理所", note: "广东省公安厅交通管理局车辆管理所核发的港澳入出境车号牌使用的发牌机关代号为“Z”" }

--- a/plates/_decode/cn-provinces.yml
+++ b/plates/_decode/cn-provinces.yml
@@ -1,0 +1,614 @@
+# plates/_decode/cn-provinces.yml — the leading Han character of a Chinese
+# registration number: 省、自治区、直辖市简称, the abbreviation of the province,
+# autonomous region or directly-administered municipality.
+#
+# THE SOURCE FINDING, and it is the same one that makes
+# plates/_decode/cn-issuing-offices.yml possible: THE LIST IS INSIDE THE
+# STANDARD, AND ONE EDITION OF THE STANDARD IS READABLE. GA 36
+# 《中华人民共和国机动车号牌》 is the mandatory public-security industry standard
+# that defines Chinese plates. The CURRENT edition, GA 36-2018, is registered
+# (发布 2018-04-20, 实施 2018-05-01, 代替 GA 36-2014) and its TEXT IS WITHHELD —
+# the register's own reader answers "您所查询的标准在本系统尚未公开，不公开理由
+# 如下：无". The immediately preceding edition GA 36-2007 (发布 2007-09-28,
+# 实施 2007-11-01, 代替 GA 36-1992) is republished IN FULL by a Chinese
+# municipal government, 巩义市人民政府 (www.hngy.gov.cn, 2012-11-15), and that
+# copy survives in the Internet Archive. Every row below is
+# GA 36-2007 § 5.7 表 2《省、自治区、直辖市简称》, read off that copy.
+#
+# § 5.7, verbatim and complete: "省、自治区、直辖市的简称应符合表2的要求。"
+# ("The abbreviations of provinces, autonomous regions and municipalities shall
+# conform to the requirements of Table 2." — translation ours; the Chinese is
+# the sourced text.) Table 2 is printed in two columns of numbered rows, 1 to
+# 31, each row 序号 / 地区名称 / 简称. The rows below are in TABLE 2's OWN
+# NUMBERING, recovered by parsing the two interleaved columns and sorting on
+# 序号 — they are NOT re-ordered alphabetically and NOT taken from any
+# encyclopaedia.
+#
+# NOTHING HERE WAS TYPED BY HAND THAT COULD HAVE BEEN PARSED. The characters,
+# the subdivision names and the row numbers were extracted mechanically from
+# the archived GA 36-2007 text (which is GB18030-encoded and mis-declares
+# itself as UTF-8 — decode it as GB18030 or you will get mojibake and think the
+# page is broken); the codepoints were computed with `ch.ord`. The only
+# hand-added columns are ISO 3166-2, GB/T 2260, pinyin, the English name and
+# the customary-alternate flags.
+#
+# ============================================================================
+# WHY THIS IS A DECODE FILE AND NOT PART OF A REGEX
+# ============================================================================
+# plates/_meta/separators.yml fixes the dataset's serial alphabet, normatively
+# and dataset-wide, as "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", and
+# scripts/lint_plates.rb enforces it on every pattern and regex. A Chinese mark
+# opens with a Han character, and — unlike the Greek case (plates/gr.yml),
+# where Α U+0391 and A U+0041 are the same picture and the Latin form is
+# lossless — there is NO Latin form of 京. "jing" is a reading, not a glyph;
+# no plate, no registry and no ANPR camera ever emits it. So the Han elements
+# are modelled as DATA here and in plates/cn.yml's `format.han`, and the
+# regexes match the Latin-and-digit remainder. plates/cn.yml's header states
+# that division once for the whole jurisdiction.
+#
+# ============================================================================
+# THE TRAP: SIX SUBDIVISIONS HAVE TWO CUSTOMARY ABBREVIATIONS AND TABLE 2
+# PICKS ONE
+# ============================================================================
+# 中国政府网's own 《中华人民共和国行政区划》 page says the abbreviations are
+# customary rather than statutory — "在历史上和习惯上，各省级行政区都有简称"
+# ("historically and by custom, every provincial-level administrative division
+# has an abbreviation") — and custom produced doublets. Table 2 chose:
+#
+#     四川省  川 (Table 2)  /  蜀       贵州省  贵 (Table 2)  /  黔
+#     云南省  云 (Table 2)  /  滇       陕西省  陕 (Table 2)  /  秦
+#     甘肃省  甘 (Table 2)  /  陇       上海市  沪 (Table 2)  /  申
+#
+# A consumer that decodes 蜀, 黔, 滇, 秦, 陇 or 申 as a plate prefix is decoding
+# a character no plate carries. Each is recorded on its row as
+# `customary_alternate_not_on_plates` so the wrong answer cannot be reached
+# from this file and the right one is stated. Note what this costs: the plate
+# character is NOT always the character a Chinese speaker would reach for
+# first, and a translation pipeline that maps 简称 to province by dictionary
+# rather than by this table will disagree with the road.
+#
+# ============================================================================
+# PERIOD DISCIPLINE (PRD-PLATES § 2.4) — ONE ROW IS YOUNGER THAN THE OTHERS
+# ============================================================================
+# GA 36-2007's 前言 lists, among the changes that edition made to GA 36-1992,
+# verbatim: "――增加了重庆的简称；" and "――增加了"渝"、"港"、"澳"、"使"、"警"、
+# "超"等省、自治区、直辖市简称及号牌分类用汉字；" — the 2007 edition ADDED
+# Chongqing's abbreviation 渝, together with the classification characters 港,
+# 澳, 使, 警 and 超. That is exactly what the administrative history predicts:
+# Chongqing was separated from Sichuan and made a directly-administered
+# municipality in 1997, five years after GA 36-1992, so 渝 could not have been
+# in the 1992 table. It is the ONLY row in this file with a different start
+# year, and it is dated on the standard's own foreword rather than on the
+# constitutional change.
+#
+# The other 30 rows run from GA 36-1992 — `period.start: 1992` on this file —
+# and none has been withdrawn: no provincial-level division has been created,
+# merged or abolished since 1997, and the 2014 and 2018 editions' change lists
+# are not public, so no row here can be shown to have changed after 2007.
+jurisdiction: cn
+topic: provinces
+authority:
+  name: 公安部 (Ministry of Public Security) — GA 36 《中华人民共和国机动车号牌》 § 5.7 表 2；技术归口 公安部道路交通管理标准化技术委员会
+  url: "https://hbba.sacinfo.org.cn/stdDetail/328b77ee80fdee1dee33d20e83d01d2ad128f380aa93c7dbe5c58c67d9d2075e"
+sources:
+  - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 《中华人民共和国机动车号牌》 FULL TEXT as republished by 巩义市人民政府 (published 2012-11-15): § 5.7 and 表 2 省、自治区、直辖市简称 — all 31 rows below, in the table's own 序号 order; § 5.10 号牌分类用汉字 — the classification characters listed under `classification_han`; § 5.11 间隔符; the 前言 change list carrying the 渝 addition. Note the page is GB18030 mis-declared as UTF-8. Accessed 2026-08-02"
+  - "https://hbba.sacinfo.org.cn/stdDetail/12b7710b682f0e13dfc423a325751920  # 全国标准信息公共服务平台 register entry for GA 36-2007: 发布 2007-09-28, 实施 2007-11-01, 代替 GA 36-1992, 状态 废止 — the provenance of the text above, and the evidence that GA 36-1992 existed. Accessed 2026-08-02"
+  - "https://hbba.sacinfo.org.cn/stdDetail/328b77ee80fdee1dee33d20e83d01d2ad128f380aa93c7dbe5c58c67d9d2075e  # register entry for the CURRENT GA 36-2018: 发布 2018-04-20, 实施 2018-05-01, 代替 GA 36-2014. Metadata only — the text is withheld ('尚未公开')， so this table cannot be re-verified against the edition actually in force. Accessed 2026-08-02"
+  - "https://web.archive.org/web/20240222001221/https://www.gov.cn/test/2005-06/15/content_18253.htm  # 中国政府网 《中华人民共和国行政区划》: the 34 provincial-level divisions and, verbatim, '在历史上和习惯上，各省级行政区都有简称' — the abbreviations are CUSTOMARY, which is why they live in a public-security standard and in no statute. Live URL 404s; read from the Internet Archive. Accessed 2026-08-02"
+  - "https://www.gov.cn/zhengce/content/2018-12/11/content_5347765.htm  # 国办发〔2018〕114号 附件 一（一）: the worked examples '京·12345应急' and '京·X2345应急', glossing the second as 北京市应急管理部门 — an independent instrument showing a Table 2 character IN USE on a plate with its subdivision named. Accessed 2026-08-02"
+period: { start: 1992 }
+period_evidence: enabling-instrument
+period_note: >-
+  1992 is GA 36-1992, the edition that created the 92-pattern mark this table
+  belongs to; its existence is evidenced by GA 36-2007's 前言 ("本标准代替
+  GA36-1992") and by the register's 代替标准 field, and no 发布/实施 date for it
+  could be pinned because it predates the industry-standard filing database.
+  ONE ROW IS YOUNGER: 渝 (Chongqing) was added by the 2007 edition and carries
+  `row_period_start: 2007` with the foreword quoted on it. The widely repeated
+  claim that the 92-pattern was trialled in 1992 and rolled out nationwide in
+  July 1994 is NOT asserted here or in plates/cn.yml — see the dossier's
+  folklore section.
+decode_direction: "leading Han character -> the provincial-level division whose vehicle-management office issued the mark"
+split_note: >-
+  FIXED WIDTH, AND THE CLEANEST SPLIT IN THIS DATASET. The province character
+  is always exactly ONE character and always the FIRST character of the mark,
+  immediately followed by the single Latin issuing-office letter. A consumer
+  takes `mark[0]`, looks it up here, and hands the remainder to
+  plates/cn.yml's regexes — there is no greedy-match problem and no ambiguity
+  with the Latin tail, because the two alphabets are disjoint by construction.
+  TWO EXCEPTIONS, both instrument-sourced and both recorded below in
+  `classification_han`: the embassy mark opens with 使 instead of a province
+  character (GA 36-2007 § 5.10), and the emergency-rescue MOTORCYCLE mark opens
+  with the two-character pair 应急 before its province character
+  (国办发〔2018〕114号 附件 一（二）).
+scope_note: >-
+  HONG KONG, MACAU AND TAIWAN HAVE NO ROW, and their absence is the standard's,
+  not ours: Table 2 has exactly 31 rows and stops at 新疆维吾尔自治区. 港 and 澳
+  DO appear in GA 36-2007 — but as CLASSIFICATION characters under § 5.10, on
+  the mainland-side plate a Hong Kong or Macau cross-boundary vehicle carries,
+  not as province prefixes. They are recorded under `classification_han` for
+  that reason, and Hong Kong (ISO 3166-1 HK) and Macau (MO) are separate
+  jurisdictions in this dataset with their own files.
+
+# ---------------------------------------------------------------------------
+# GA 36-2007 § 5.7 表 2《省、自治区、直辖市简称》 — all 31 rows, in the
+# table's own 序号 order. Characters, names and row numbers parsed from the
+# archived instrument text; codepoints computed with ch.ord.
+# ---------------------------------------------------------------------------
+rows:
+  - table2_row: 1
+    char: "京"
+    codepoint: "U+4EAC"
+    pinyin: jing
+    subdivision_zh: "北京市"
+    subdivision_en: "Beijing Municipality"
+    subdivision_type: municipality
+    iso_3166_2: CN-BJ
+    gbt_2260: "110000"
+  - table2_row: 2
+    char: "津"
+    codepoint: "U+6D25"
+    pinyin: jin
+    subdivision_zh: "天津市"
+    subdivision_en: "Tianjin Municipality"
+    subdivision_type: municipality
+    iso_3166_2: CN-TJ
+    gbt_2260: "120000"
+  - table2_row: 3
+    char: "冀"
+    codepoint: "U+5180"
+    pinyin: ji
+    subdivision_zh: "河北省"
+    subdivision_en: "Hebei Province"
+    subdivision_type: province
+    iso_3166_2: CN-HE
+    gbt_2260: "130000"
+  - table2_row: 4
+    char: "晋"
+    codepoint: "U+664B"
+    pinyin: jin
+    subdivision_zh: "山西省"
+    subdivision_en: "Shanxi Province"
+    subdivision_type: province
+    iso_3166_2: CN-SX
+    gbt_2260: "140000"
+  - table2_row: 5
+    char: "蒙"
+    codepoint: "U+8499"
+    pinyin: meng
+    subdivision_zh: "内蒙古自治区"
+    subdivision_en: "Inner Mongolia Autonomous Region"
+    subdivision_type: autonomous-region
+    iso_3166_2: CN-NM
+    gbt_2260: "150000"
+  - table2_row: 6
+    char: "辽"
+    codepoint: "U+8FBD"
+    pinyin: liao
+    subdivision_zh: "辽宁省"
+    subdivision_en: "Liaoning Province"
+    subdivision_type: province
+    iso_3166_2: CN-LN
+    gbt_2260: "210000"
+  - table2_row: 7
+    char: "吉"
+    codepoint: "U+5409"
+    pinyin: ji
+    subdivision_zh: "吉林省"
+    subdivision_en: "Jilin Province"
+    subdivision_type: province
+    iso_3166_2: CN-JL
+    gbt_2260: "220000"
+  - table2_row: 8
+    char: "黑"
+    codepoint: "U+9ED1"
+    pinyin: hei
+    subdivision_zh: "黑龙江省"
+    subdivision_en: "Heilongjiang Province"
+    subdivision_type: province
+    iso_3166_2: CN-HL
+    gbt_2260: "230000"
+  - table2_row: 9
+    char: "沪"
+    codepoint: "U+6CAA"
+    pinyin: hu
+    subdivision_zh: "上海市"
+    subdivision_en: "Shanghai Municipality"
+    subdivision_type: municipality
+    iso_3166_2: CN-SH
+    gbt_2260: "310000"
+    customary_alternate_not_on_plates:
+      - { char: "申", codepoint: "U+7533" }
+  - table2_row: 10
+    char: "苏"
+    codepoint: "U+82CF"
+    pinyin: su
+    subdivision_zh: "江苏省"
+    subdivision_en: "Jiangsu Province"
+    subdivision_type: province
+    iso_3166_2: CN-JS
+    gbt_2260: "320000"
+  - table2_row: 11
+    char: "浙"
+    codepoint: "U+6D59"
+    pinyin: zhe
+    subdivision_zh: "浙江省"
+    subdivision_en: "Zhejiang Province"
+    subdivision_type: province
+    iso_3166_2: CN-ZJ
+    gbt_2260: "330000"
+  - table2_row: 12
+    char: "皖"
+    codepoint: "U+7696"
+    pinyin: wan
+    subdivision_zh: "安徽省"
+    subdivision_en: "Anhui Province"
+    subdivision_type: province
+    iso_3166_2: CN-AH
+    gbt_2260: "340000"
+  - table2_row: 13
+    char: "闽"
+    codepoint: "U+95FD"
+    pinyin: min
+    subdivision_zh: "福建省"
+    subdivision_en: "Fujian Province"
+    subdivision_type: province
+    iso_3166_2: CN-FJ
+    gbt_2260: "350000"
+  - table2_row: 14
+    char: "赣"
+    codepoint: "U+8D63"
+    pinyin: gan
+    subdivision_zh: "江西省"
+    subdivision_en: "Jiangxi Province"
+    subdivision_type: province
+    iso_3166_2: CN-JX
+    gbt_2260: "360000"
+  - table2_row: 15
+    char: "鲁"
+    codepoint: "U+9C81"
+    pinyin: lu
+    subdivision_zh: "山东省"
+    subdivision_en: "Shandong Province"
+    subdivision_type: province
+    iso_3166_2: CN-SD
+    gbt_2260: "370000"
+  - table2_row: 16
+    char: "豫"
+    codepoint: "U+8C6B"
+    pinyin: yu
+    subdivision_zh: "河南省"
+    subdivision_en: "Henan Province"
+    subdivision_type: province
+    iso_3166_2: CN-HA
+    gbt_2260: "410000"
+  - table2_row: 17
+    char: "鄂"
+    codepoint: "U+9102"
+    pinyin: e
+    subdivision_zh: "湖北省"
+    subdivision_en: "Hubei Province"
+    subdivision_type: province
+    iso_3166_2: CN-HB
+    gbt_2260: "420000"
+  - table2_row: 18
+    char: "湘"
+    codepoint: "U+6E58"
+    pinyin: xiang
+    subdivision_zh: "湖南省"
+    subdivision_en: "Hunan Province"
+    subdivision_type: province
+    iso_3166_2: CN-HN
+    gbt_2260: "430000"
+  - table2_row: 19
+    char: "粤"
+    codepoint: "U+7CA4"
+    pinyin: yue
+    subdivision_zh: "广东省"
+    subdivision_en: "Guangdong Province"
+    subdivision_type: province
+    iso_3166_2: CN-GD
+    gbt_2260: "440000"
+  - table2_row: 20
+    char: "桂"
+    codepoint: "U+6842"
+    pinyin: gui
+    subdivision_zh: "广西壮族自治区"
+    subdivision_en: "Guangxi Zhuang Autonomous Region"
+    subdivision_type: autonomous-region
+    iso_3166_2: CN-GX
+    gbt_2260: "450000"
+  - table2_row: 21
+    char: "琼"
+    codepoint: "U+743C"
+    pinyin: qiong
+    subdivision_zh: "海南省"
+    subdivision_en: "Hainan Province"
+    subdivision_type: province
+    iso_3166_2: CN-HI
+    gbt_2260: "460000"
+  - table2_row: 22
+    char: "渝"
+    codepoint: "U+6E1D"
+    pinyin: yu
+    subdivision_zh: "重庆市"
+    subdivision_en: "Chongqing Municipality"
+    subdivision_type: municipality
+    iso_3166_2: CN-CQ
+    gbt_2260: "500000"
+    row_period_start: 2007
+    row_period_note: "GA 36-2007 前言, verbatim: “――增加了重庆的简称；” — 渝 was ADDED by the 2007 edition, which is what the administrative history predicts: Chongqing was separated from Sichuan and made a directly-administered municipality in 1997, five years after GA 36-1992. The only row in this table with a start year of its own."
+  - table2_row: 23
+    char: "川"
+    codepoint: "U+5DDD"
+    pinyin: chuan
+    subdivision_zh: "四川省"
+    subdivision_en: "Sichuan Province"
+    subdivision_type: province
+    iso_3166_2: CN-SC
+    gbt_2260: "510000"
+    customary_alternate_not_on_plates:
+      - { char: "蜀", codepoint: "U+8700" }
+  - table2_row: 24
+    char: "贵"
+    codepoint: "U+8D35"
+    pinyin: gui
+    subdivision_zh: "贵州省"
+    subdivision_en: "Guizhou Province"
+    subdivision_type: province
+    iso_3166_2: CN-GZ
+    gbt_2260: "520000"
+    customary_alternate_not_on_plates:
+      - { char: "黔", codepoint: "U+9ED4" }
+  - table2_row: 25
+    char: "云"
+    codepoint: "U+4E91"
+    pinyin: yun
+    subdivision_zh: "云南省"
+    subdivision_en: "Yunnan Province"
+    subdivision_type: province
+    iso_3166_2: CN-YN
+    gbt_2260: "530000"
+    customary_alternate_not_on_plates:
+      - { char: "滇", codepoint: "U+6EC7" }
+  - table2_row: 26
+    char: "藏"
+    codepoint: "U+85CF"
+    pinyin: zang
+    subdivision_zh: "西藏自治区"
+    subdivision_en: "Xizang (Tibet) Autonomous Region"
+    subdivision_type: autonomous-region
+    iso_3166_2: CN-XZ
+    gbt_2260: "540000"
+  - table2_row: 27
+    char: "陕"
+    codepoint: "U+9655"
+    pinyin: shan
+    subdivision_zh: "陕西省"
+    subdivision_en: "Shaanxi Province"
+    subdivision_type: province
+    iso_3166_2: CN-SN
+    gbt_2260: "610000"
+    customary_alternate_not_on_plates:
+      - { char: "秦", codepoint: "U+79E6" }
+  - table2_row: 28
+    char: "甘"
+    codepoint: "U+7518"
+    pinyin: gan
+    subdivision_zh: "甘肃省"
+    subdivision_en: "Gansu Province"
+    subdivision_type: province
+    iso_3166_2: CN-GS
+    gbt_2260: "620000"
+    customary_alternate_not_on_plates:
+      - { char: "陇", codepoint: "U+9647" }
+  - table2_row: 29
+    char: "青"
+    codepoint: "U+9752"
+    pinyin: qing
+    subdivision_zh: "青海省"
+    subdivision_en: "Qinghai Province"
+    subdivision_type: province
+    iso_3166_2: CN-QH
+    gbt_2260: "630000"
+  - table2_row: 30
+    char: "宁"
+    codepoint: "U+5B81"
+    pinyin: ning
+    subdivision_zh: "宁夏回族自治区"
+    subdivision_en: "Ningxia Hui Autonomous Region"
+    subdivision_type: autonomous-region
+    iso_3166_2: CN-NX
+    gbt_2260: "640000"
+  - table2_row: 31
+    char: "新"
+    codepoint: "U+65B0"
+    pinyin: xin
+    subdivision_zh: "新疆维吾尔自治区"
+    subdivision_en: "Xinjiang Uygur Autonomous Region"
+    subdivision_type: autonomous-region
+    iso_3166_2: CN-XJ
+    gbt_2260: "650000"
+
+# ---------------------------------------------------------------------------
+# 号牌分类用汉字 — THE CLASSIFICATION CHARACTERS
+#
+# GA 36-2007 § 5.10, verbatim and complete (one sentence, nine clauses):
+#
+#   "领馆汽车号牌和摩托车号牌的机动车登记编号中使用汉字简称"领"字；使馆汽车
+#    号牌和摩托车号牌的机动车登记编号中使用汉字简称"使"字；警用汽车号牌和摩托车
+#    号牌的机动车登记编号使用汉字简称"警"字；教练汽车号牌和摩托车号牌的机动车
+#    登记编号中使用汉字简称"学"字；挂车号牌的机动车登记编号使用汉字简称"挂"字；
+#    香港特别行政区入出内地车辆号牌的机动车登记编号使用汉字简称"港"字；澳门
+#    特别行政区入出内地车辆号牌的机动车登记编号使用汉字简称"澳"字；试验车的临时
+#    行驶车号牌的机动车登记编号中使用汉字简称"试"字；特型车的临时行驶车号牌的
+#    机动车登记编号中使用汉字简称"超"字。"
+#
+# Nine characters, each bound to a named plate class by the standard itself.
+# This is the fourth element of GA 36-2007 § 3.2's four-element registration
+# number, and it is why a Chinese mark can be bracketed by Han characters at
+# both ends. The 应急 pair is NOT in this list — it postdates GA 36-2007 by
+# eleven years and comes from a State Council instrument instead.
+#
+# POSITION IS NOT UNIFORM AND § 5.10 DOES NOT STATE IT. The standard says which
+# character each class uses and not where it sits; 使 leads and the rest trail,
+# which is recorded per row from plates/cn.yml's series and flagged where it
+# rests on anything weaker than an instrument.
+# ---------------------------------------------------------------------------
+classification_han:
+  - char: "领"
+    codepoint: "U+9886"
+    pinyin: ling
+    position: trailing
+    class_zh: 领馆汽车号牌和摩托车号牌
+    class_en: "consular post — car and motorcycle plates"
+    evidence: enabling-instrument
+    row_period_start: 1992
+  - char: "使"
+    codepoint: "U+4F7F"
+    pinyin: shi
+    position: leading
+    position_note: >-
+      THE ONE CLASSIFICATION CHARACTER THAT REPLACES THE PROVINCE CHARACTER
+      rather than following the serial: an embassy mark carries no geography at
+      all. § 5.10 does not say so in terms; the position is taken from
+      GA 36-2007's own 附录 C 号牌效果图 and from plates/cn.yml's embassy series.
+    class_zh: 使馆汽车号牌和摩托车号牌
+    class_en: "diplomatic mission (embassy) — car and motorcycle plates"
+    evidence: enabling-instrument
+    row_period_start: 2007
+    row_period_note: >-
+      GA 36-2007 前言, verbatim: "――增加了"渝"、"港"、"澳"、"使"、"警"、"超"等
+      省、自治区、直辖市简称及号牌分类用汉字；" — 使 was ADDED by the 2007
+      edition. A pre-2007 embassy mark used a different construction and this
+      pass located no primary describing it.
+  - char: "警"
+    codepoint: "U+8B66"
+    pinyin: jing
+    position: trailing
+    class_zh: 警用汽车号牌和摩托车号牌
+    class_en: "police — car and motorcycle plates"
+    evidence: enabling-instrument
+    row_period_start: 2007
+    row_period_note: >-
+      Added by the 2007 edition, and the foreword says so twice: the change list
+      carries both "――增加了警用汽车号牌和警用摩托车号牌式样；" and the 警
+      character in the classification-character line quoted above. The class and
+      its character arrived together in GA 36-2007.
+  - char: "学"
+    codepoint: "U+5B66"
+    pinyin: xue
+    position: trailing
+    class_zh: 教练汽车号牌和摩托车号牌
+    class_en: "driving-school (learner) — car and motorcycle plates"
+    evidence: enabling-instrument
+    row_period_start: 1992
+  - char: "挂"
+    codepoint: "U+6302"
+    pinyin: gua
+    position: trailing
+    class_zh: 挂车号牌
+    class_en: "trailer"
+    evidence: enabling-instrument
+    row_period_start: 1992
+  - char: "港"
+    codepoint: "U+6E2F"
+    pinyin: gang
+    position: trailing
+    class_zh: 香港特别行政区入出内地车辆号牌
+    class_en: "Hong Kong SAR vehicle entering and leaving the mainland — mainland-side plate"
+    evidence: enabling-instrument
+    row_period_start: 2007
+    row_period_note: "added by the 2007 edition (前言, the same change line as 使 and 警) — which fits: the Hong Kong SAR was established in 1997, after GA 36-1992"
+  - char: "澳"
+    codepoint: "U+6FB3"
+    pinyin: ao
+    position: trailing
+    class_zh: 澳门特别行政区入出内地车辆号牌
+    class_en: "Macau SAR vehicle entering and leaving the mainland — mainland-side plate"
+    evidence: enabling-instrument
+    row_period_start: 2007
+    row_period_note: "added by the 2007 edition; the Macau SAR was established in 1999, after GA 36-1992"
+  - char: "试"
+    codepoint: "U+8BD5"
+    pinyin: shi
+    position: trailing
+    class_zh: 试验车的临时行驶车号牌
+    class_en: "temporary-movement plate for a test vehicle"
+    evidence: enabling-instrument
+    row_period_start: 1992
+  - char: "超"
+    codepoint: "U+8D85"
+    pinyin: chao
+    position: trailing
+    class_zh: 特型车的临时行驶车号牌
+    class_en: "temporary-movement plate for an over-dimension vehicle"
+    evidence: enabling-instrument
+    row_period_start: 2007
+    row_period_note: "added by the 2007 edition (前言, same change line)"
+  - token: "应急"
+    chars: ["应", "急"]
+    codepoints: ["U+5E94", "U+6025"]
+    pinyin: yingji
+    position: "trailing on the car plate, LEADING on the motorcycle plate"
+    class_zh: 应急救援专用号牌
+    class_en: "emergency rescue — national comprehensive fire-and-rescue force"
+    evidence: enabling-instrument
+    row_period_start: 2018
+    row_period_note: >-
+      NOT IN GA 36-2007 § 5.10 — it postdates that edition by eleven years and
+      arrives from a State Council instrument rather than from the standard.
+      国办发〔2018〕114号 附件 一（一）, verbatim: "字符共8位，依次为省（自治区、
+      直辖市）汉字简称、所属救援队伍代号、四位序号和汉字"应急"组成"; 附件 一（二）
+      for the motorcycle: "字符共7位，依次为汉字"应急"、省（自治区、直辖市）汉字
+      简称、三位序号和所属救援队伍代号组成". It is the only TWO-character
+      classification token in the system and the only one that leads on one
+      plate and trails on another.
+    source: "https://www.gov.cn/zhengce/content/2018-12/11/content_5347765.htm  # 国办发〔2018〕114号, 成文 2018-12-04, 发布 2018-12-11. Accessed 2026-08-02"
+classification_han_source: "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 § 5.10 for the nine standard characters and 前言 for the 2007 additions. Accessed 2026-08-02"
+
+# ---------------------------------------------------------------------------
+# What this table does NOT decode, said plainly so no consumer assumes it does.
+# ---------------------------------------------------------------------------
+limits:
+  not_a_location: >-
+    The character names the provincial-level division of the ISSUING vehicle-
+    management office, fixed at registration. It is not where the vehicle is,
+    not where the keeper lives now, and not where the vehicle was built. A
+    Geoguessr-style or insurance use that reads it as a current-location signal
+    is reading it wrong, and a parse API must say so.
+  not_a_city: >-
+    The city lives in the SECOND character — the 发牌机关代号 — and that table
+    is plates/_decode/cn-issuing-offices.yml, which is a 2007 snapshot of an
+    open allocation (GA 36-2007 § 5.8.3 lets a new code be brought into use at
+    any time with MPS approval). Decoding a province from this file is safe;
+    decoding a city needs that file and its cautions.
+  no_date: >-
+    A Chinese mark encodes NO date anywhere. There is no age identifier, no
+    six-month letter, no year block — and since 《机动车登记规定》第四十三条
+    lets an owner self-compose the serial inside the published rules, even
+    serial-order era inference is unsafe. This is the sharpest contrast in the
+    dataset with the British mark, which names the six-month period of first
+    registration to 2050.
+  cross_file_divergences: >-
+    RECORDED, NOT AVERAGED (PRD-PLATES § 5.3). Two `row_period_start` values in
+    `classification_han` above disagree with the period on the plates/cn.yml
+    series that uses the same character, and the disagreement is left standing
+    for the verifier rather than reconciled by one file overwriting the other.
+    (1) 使 — this file dates it 2007 on GA 36-2007's 前言, which lists 使 among
+    the classification characters that edition ADDED; plates/cn.yml dates
+    `cn-embassy-car-1992` and `cn-embassy-motorcycle-1992` to 1992 with
+    `period_evidence: instrument-in-force`. Both can be true at once — an
+    embassy plate almost certainly existed before 2007 in a construction the
+    2007 edition then standardised — but nothing secured by either pass proves
+    it, and the foreword is the harder evidence. (2) 超 — this file dates it
+    2007 on the same foreword line; plates/cn.yml carries it as one of the two
+    suffixes on `cn-temporary-travel-1992`, whose other suffix 试 is a 1992
+    character. A verifier resolving these should either split the affected
+    series or move the starts, and should say which in the PR.
+  edition_caveat: >-
+    Every row is GA 36-2007's Table 2. GA 36-2014 and GA 36-2018 each reissued
+    the standard and neither text is public, so this table cannot be re-verified
+    against the edition actually in force. No provincial-level division has been
+    created, merged or abolished since 1997, so the risk of a stale row is
+    genuinely low — but it is a risk, and it is stated rather than assumed away.

--- a/plates/cn.yml
+++ b/plates/cn.yml
@@ -1,0 +1,1431 @@
+# plates/cn.yml — People's Republic of China (mainland), PRD-PLATES gate L3.
+#
+# ============================================================================
+# 1. THE SOURCE SITUATION, STATED FIRST BECAUSE IT SHAPES EVERY CLAIM HERE
+# ============================================================================
+# Chinese plates are defined by ONE mandatory instrument: GA 36
+# 《中华人民共和国机动车号牌》, a 强制性 (mandatory) public-security industry
+# standard issued by 公安部 (the Ministry of Public Security). Its authority is
+# delegated by ministerial rule: 《机动车登记规定》(公安部令第164号) 第八十五条,
+# verbatim — "机动车登记证书、号牌、行驶证、检验合格标志的式样由公安部统一制定并
+# 监制。机动车登记证书、号牌、行驶证、检验合格标志的制作应当符合有关标准。"
+# ("The forms of the vehicle registration certificate, number plates, driving
+# licence and inspection mark are uniformly formulated and supervised by the
+# Ministry of Public Security. Their manufacture shall conform to the relevant
+# standards." — translation ours.)
+#
+# THE EDITION PROBLEM, AND THE ONE PIECE OF LUCK.
+#   * The CURRENT edition is GA 36-2018: 发布 2018-04-20, 实施 2018-05-01,
+#     代替 GA 36-2014, 技术归口 公安部道路交通管理标准化技术委员会, 起草单位
+#     公安部交通管理科学研究所. All of that is PINNED from the national standards
+#     register. Its TEXT IS WITHHELD: the register's reader answers
+#     "您所查询的标准在本系统尚未公开，不公开理由如下：无" and its download
+#     endpoint returns zero bytes. GA 36-2014 and GA 36-2007 answer
+#     "废止标准不提供标准文本阅读服务".
+#   * The luck: GA 36-2007 — the immediately preceding edition, 发布 2007-09-28,
+#     实施 2007-11-01, 代替 GA 36-1992 — is republished IN FULL by a Chinese
+#     municipal government, 巩义市人民政府 (www.hngy.gov.cn), 2012-11-15, and
+#     that copy survives in the Internet Archive. Clauses 3 to 7 and Annexes A
+#     and B of that text are the backbone of this file, quoted verbatim.
+#   * CONSEQUENCE, and it is recorded on every affected series: claims taken
+#     from GA 36-2007 describe the 92-pattern system AS IT STOOD IN 2007. The
+#     2014 and 2018 revisions' change lists are not public. Where a 2018 fact is
+#     needed and only GA 36-2007 has it (colours, dimensions, serial grammar),
+#     the claim is made with `standard_edition: GA 36-2007` on the series and is
+#     a named verifier target. Where 2018 changed something we CAN see — the new
+#     energy vehicle plates — the Ministry's own announcements are the source.
+#   * The Wikipedia articles (en + zh) were used as a MANDATORY FINDING AID and
+#     nothing else: their citations were mined, the instruments they name were
+#     fetched, and those instruments are what is cited. Their CC BY-SA prefix
+#     tables and text were never extracted. Everything the finding aid asserted
+#     that no instrument confirmed is in the dossier's folklore section, and
+#     three of those claims are named in the notes below so a verifier can see
+#     what was DELIBERATELY not asserted.
+#
+# ============================================================================
+# 2. THE HAN LINE — where the dataset's serial alphabet stops (PRD-PLATES §2.6)
+# ============================================================================
+# GA 36-2007 § 3.2 defines the thing a plate carries, verbatim:
+#   "机动车登记编号 registration number of motor vehicle
+#    按照不同类型的机动车号牌，机动车登记编号包含省、自治区、直辖市的汉字简称、
+#    用英文字母表示发牌机关的代号、由阿拉伯数字和英文字母组成的序号和有特殊性质的
+#    机动车使用的号牌分类用汉字简称。"
+#   ("Depending on the type of plate, the registration number comprises the
+#    Chinese-character abbreviation of the province / autonomous region /
+#    municipality, the issuing-authority code expressed as a Latin letter, a
+#    serial composed of Arabic numerals and Latin letters, and — for vehicles of
+#    special character — a Chinese-character classification abbreviation."
+#    Translation ours; the Chinese is the sourced text.)
+#
+# So a Chinese registration number has FOUR elements, two of them Han. The
+# dataset's serial alphabet is A-Z and 0-9 and PRD-PLATES § 2.6 says a
+# jurisdiction that prints a glyph inside the serial "is a schema amendment,
+# not a data entry". This file does NOT smuggle Han characters into any
+# `format.pattern`, `format.regex`, `format.regex_strict` or
+# `format.regex_statutory`. Instead:
+#
+#   format.pattern / format.regex  cover the MACHINE-READABLE LATIN+DIGIT
+#                                  remainder — the issuing-authority letter and
+#                                  the serial. This is precisely the substring
+#                                  an ALPR, a car-park barrier or a validation
+#                                  library matches on, so the regex layer stays
+#                                  useful rather than decorative.
+#   format.han                     carries the Han elements as structured data:
+#                                  `prefix` (always the province character,
+#                                  decoded by plates/_decode/cn-provinces.yml),
+#                                  `suffix` (the classification character, when
+#                                  the class has one), `printed`, `script: Han`
+#                                  and an INFORMATIONAL Han-aware regex that is
+#                                  explicitly outside the § 2.6 contract and is
+#                                  NOT lint-validated.
+#
+# A consumer validating "京A·12345" therefore: (1) splits the leading Han
+# character and looks it up in cn-provinces.yml; (2) splits a trailing Han
+# character if present and looks it up in `common.classification_han` below;
+# (3) matches what is left — "A12345" — against `format.regex`. The two decode
+# files make steps 1 and 2 mechanical. The schema amendment PRD-PLATES § 2.6
+# anticipates (a `never_separator` / non-Latin-element ruling in
+# _meta/separators.yml) is REQUESTED in the dossier; until it lands, this is the
+# honest encoding and it is stated here once rather than guessed per series.
+#
+# THE SEPARATOR. GA 36-2007 § 5.11, verbatim: "间隔符对机动车登记编号进行有效
+# 分割。间隔符可以和机动车登记编号同样冲压并着色。" ("The separator effectively
+# divides the registration number. The separator may be embossed and coloured in
+# the same way as the registration number.") It is the raised mid-dot printed
+# between the issuing-authority letter and the serial. U+00B7 MIDDLE DOT is in
+# _meta/separators.yml's FORGIVING set but NOT in its EMITTED set, so this file
+# may not spell it; every regex here accepts an OPTIONAL emitted separator
+# `[- ]?` at that position instead, exactly as plates/gb.yml does for the
+# statutory millimetre gap. Nothing is lost: the dot is forgiving-strippable by
+# construction.
+#
+# ============================================================================
+# 3. THE SERIAL GRAMMAR — the best-sourced thing in this file
+# ============================================================================
+# GA 36-2007 § 5.9.1 序号编码规则, verbatim:
+#   "a) 序号的每一位都使用阿拉伯数字；
+#    b) 序号的每一位可单独使用英文字母，26个英文字母中O和I不能使用；
+#    c) 序号中允许出现2位英文字母，26个英文字母中O和I不能使用。"
+# — the serial is all digits, or carries ONE letter, or carries AT MOST TWO
+# letters, and O and I are never letters in a serial. § 5.9.2 a) then fixes
+# WHICH positions those letters may occupy, in 表 3 "序号用字母和数字组合方式",
+# with two serial widths (四位数 / 五位数) and eleven combinations; the sourced
+# rule for release order is verbatim: "序号用数字和字母组合方式的使用应按表3的
+# 规定依次有序使用。序号的使用率超过60％后，应经省级公安机关交通管理部门批准并报
+# 公安部交通管理局备案后，依次启用下一种组合方式。" Table 3, transcribed:
+#
+#   #   letters at positions      4-position   5-position
+#   1   (none, all digits)            yes          yes
+#   2   1                             yes          yes
+#   3   1,2                           yes          yes
+#   4   2                             yes          yes
+#   5   3                             yes          yes
+#   6   4                             yes          yes
+#   7   5                             NO           yes
+#   8   1,5                           NO           yes
+#   9   4,5                           NO           yes
+#   10  1,3                           yes          yes
+#   11  2,3                           yes          yes
+#
+# EVERY `regex_strict` in this file is that table, mechanically. It is the
+# tightest sourced serial grammar this programme has secured outside the UK's
+# Schedule 3 Table A, and it is why `regex` (which the lint round-trips against
+# `pattern`, and which therefore cannot carry the O/I exclusion or the position
+# rule) has a strict twin nearly everywhere.
+#
+# THE I/O ASYMMETRY, WHICH ALMOST EVERY OTHER DATASET GETS WRONG. The O and I
+# exclusion is a rule about the SERIAL. The ISSUING-AUTHORITY LETTER uses the
+# full alphabet: GA 36-2007's 前言 lists "增加了发牌机关代号"I"" among the
+# changes that edition made, and Annex A gives "O" to the
+# "省、自治区公安厅交通管理局、处车辆管理所" in every province (the famous
+# "O 牌"). So `[A-Z]` for the office letter and `[0-9A-HJ-NP-Z]` for the serial,
+# in the same regex, is not an inconsistency — it is the sourced rule.
+#
+# ============================================================================
+# 4. PERIOD POLICY (PRD-PLATES §2.4, the instrument-date rule)
+# ============================================================================
+# The system in force is the "92-pattern" (92式) created by GA 36-1992, whose
+# existence and designation year are evidenced by GA 36-2007's own 前言 ("本标准
+# 代替GA36-1992") and by the national register's 代替标准 field for GA 36-2007.
+# GA 36-1992 itself PREDATES the industry-standard filing database, so no
+# 发布/实施 date for it could be pinned; series that GA 36-2007 shows unchanged
+# therefore carry `period: { start: 1992 }` with
+# `period_evidence: enabling-instrument` and say so. Where GA 36-2007's 前言
+# records that this edition ADDED a class or its classification character, the
+# series is dated 2007 instead, with the foreword quoted on the series.
+# The much-repeated claim that the 92-pattern was trialled in 乌鲁木齐/大庆 in
+# 1992 and rolled out nationwide in July 1994 is NOT asserted here: no primary
+# was secured for either date (dossier folklore F-1).
+jurisdiction: cn
+authority:
+  name: 公安部交通管理局 (Traffic Management Bureau, Ministry of Public Security)
+  url: "https://www.mps.gov.cn/"
+  url_status: >-
+    www.mps.gov.cn returned HTTP 521 on every request from this workstation on
+    2026-08-02 (the ministry's origin, not a block we could route around); every
+    ministry page used here is cited through the Internet Archive with its
+    archive URL and its original URL, and the archived captures were read in
+    full.
+binding: vehicle
+binding_note: >-
+  The registration number belongs to the VEHICLE, not the keeper: GA 36-2007
+  § 3.1 defines 机动车号牌 as "准予机动车在中华人民共和国境内道路上行驶的法定
+  标志，其号码是机动车登记编号" — "the legal mark permitting a motor vehicle to
+  travel on roads within the People's Republic of China; its number is the
+  vehicle registration number". 《机动车登记规定》(公安部令第164号) 第四十四条
+  lets a former owner re-apply for the OLD number on a new vehicle only if they
+  held the vehicle and used that number for at least a year, and 第四十五条
+  extends it to a spouse after a year of marriage — the exceptions prove the
+  rule. 第四十三条: the number is chosen "通过计算机随机选取或者按照选号规则自行
+  编排的方式" (computer random draw or owner self-composition inside the
+  published rules), through a single national number-selection system.
+
+instrument:
+  standard:
+    citation: "GA 36-2018 《中华人民共和国机动车号牌》 (mandatory public-security industry standard)"
+    issued: "2018-04-20"
+    in_force: "2018-05-01"
+    replaces: "GA 36-2014"
+    ccs: R82
+    ics: "43.040.60"
+    technical_committee: 公安部道路交通管理标准化技术委员会
+    approving_body: 公安部
+    drafting_units: 公安部交通管理科学研究所、公安部交通安全产品质量监督检测中心、常州华日升反光材料股份有限公司
+    filing: "备案号 66154-2019, 备案日期 2019-06-06"
+    text_status: >-
+      NOT PUBLIC. hbba.sacinfo.org.cn's online reader returns "您所查询的标准在
+      本系统尚未公开，不公开理由如下：无" and /portal/download/ returns 0 bytes.
+      Every format, colour and dimension claim in this file is therefore sourced
+      to GA 36-2007 (full text, government-republished) or to a Ministry
+      announcement, and each series records which.
+    source: "https://hbba.sacinfo.org.cn/stdDetail/328b77ee80fdee1dee33d20e83d01d2ad128f380aa93c7dbe5c58c67d9d2075e  # every field above; accessed 2026-08-02"
+  lineage:
+    - { code: "GA 36-1992", note: "the 92-pattern's creating edition; evidenced only by GA 36-2007's 前言 ('本标准代替GA36-1992') and the register's 代替标准 field — it predates the filing database and no dates for it were secured" }
+    - { code: "GA 36-2007", issued: "2007-09-28", in_force: "2007-11-01", replaces: "GA 36-1992", status: 废止, note: "THE READABLE EDITION — full text republished by 巩义市人民政府" }
+    - { code: "GA 36-2014", issued: "2014-01-24", in_force: "2014-01-24", replaces: "GA 36-2007", status: 废止, repealed: "2019-03-11", note: "text withheld; change list unknown — a recorded gap between the readable 2007 text and the current 2018 edition" }
+    - { code: "GA 36-2018", issued: "2018-04-20", in_force: "2018-05-01", replaces: "GA 36-2014", status: 现行 }
+  lineage_source: "https://hbba.sacinfo.org.cn/stdQueryList  # 全国标准信息公共服务平台 (行业标准) query for GA 36 — all four editions with 发布/实施/废止 dates and 代替标准; accessed 2026-08-02"
+  enabling_rule:
+    citation: "《机动车登记规定》, 公安部令第164号 — 2021年12月4日第8次部务会议审议通过, 公布 2021-12-17 (部长 赵克志), 施行 2022-05-01"
+    relevant_articles: "第四十三条 (number selection), 第四十四条-第四十五条 (retaining a number), 第四十六条-第四十八条 (临时行驶车号牌 and its validity ladder), 第四十九条 (临时入境机动车号牌), 第五十条 (uniform national plate management system), 第八十五条 (the MPS sets the FORM of the plate; manufacture follows the relevant standards)"
+    source: "https://www.gov.cn/gongbao/content/2022/content_5682413.htm  # State Council Gazette 2022 No. 9, full text; accessed 2026-08-02"
+  related:
+    - "GA 666-2018 《机动车号牌用反光膜》 (发布/实施 2018-05-01, 代替 GA 666-2006) — the retroreflective-film standard GA 36 defers colour and retroreflection to; text not public"
+    - "GA/T 804-2024 《机动车号牌专用固封装置》 (实施 2024-12-31, 代替 GA 804-2008) — the anti-theft plate fastener GA 36-2007 § 7.1 c) requires, two per plate face"
+    - "GA/T 16.7-2012 《道路交通管理信息代码 第7部分：机动车号牌种类代码》 — the closed CODE LIST for plate types; text not public and a named verifier target"
+    - "NY 345.1-2005 《拖拉机号牌》 (农业部, 发布/实施 2005-01-17, 现行) — GA 36-2007 表 1 row 19 delegates tractor plates to it in terms ('按 NY 345.1-2005 执行'). Its PDF is downloadable from the register but is a scanned image with no text layer, so no tractor series is modelled here (recorded gap)"
+    - "《警车管理规定》, 公安部令第89号 (2007), as amended by 公安部令第174号 (公布 2025-11-25, 施行 2025-12-29) — police plates"
+    - "《临时入境机动车和驾驶人管理规定》, 公安部令第90号 (通过 2006-11-08, 公布 2006-12-01, 施行 2007-01-01, replacing 公安部令第4号 of 1989-05-01) — temporary-entry plates"
+    - "《国务院办公厅关于国家综合性消防救援车辆悬挂应急救援专用号牌有关事项的通知》, 国办发〔2018〕114号 (成文 2018-12-04, 发布 2018-12-11) — the emergency-rescue plates, and the only Chinese plate whose full encoding rule is published in an accessible instrument"
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+common:
+  registration_number_elements:
+    order: [province_han, office_letter, serial, classification_han]
+    note: >-
+      GA 36-2007 § 3.2, quoted in full in the header. The fourth element appears
+      only on the classes GA 36-2007 § 5.10 lists. The emergency-rescue plates
+      (国办发〔2018〕114号) are the one class that departs from this order: the
+      motorcycle plate puts its TWO-character classification pair 应急 FIRST.
+    source: "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 § 3.2; accessed 2026-08-02"
+  province_han:
+    decode: "plates/_decode/cn-provinces.yml"
+    count: 31
+    note: "GA 36-2007 § 5.7 表 2 — 31 rows, one character each, closed and primary. Hong Kong, Macau and Taiwan have no row."
+  office_letter:
+    alphabet: "A-Z"
+    includes_i_and_o: true
+    decode: "plates/_decode/cn-issuing-offices.yml"
+    rules: >-
+      GA 36-2007 § 5.8.1-5.8.3 (quoted in the decode file): the code identifies
+      the vehicle-management office; the four directly-administered
+      municipalities hold the whole alphabet A-Z in sequence; anywhere else a
+      new code needs MPS Traffic Management Bureau approval, so the allocation
+      is OPEN and Annex A is a 2007 snapshot.
+    source: "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 § 5.8 + 附录 A 表 A.1; accessed 2026-08-02"
+  serial:
+    letters_excluded: [I, O]
+    max_letters: 2
+    widths_defined: [4, 5]
+    combinations_source: "GA 36-2007 § 5.9.2 a) 表 3 — transcribed in this file's header and encoded in every regex_strict below"
+    release_rule: >-
+      "序号的使用率超过60％后，应经省级公安机关交通管理部门批准并报公安部交通管理
+      局备案后，依次启用下一种组合方式" — a combination is opened only once the
+      previous ones are 60% consumed, in Table 3's order. This is the Chinese
+      equivalent of an age identifier and the reason a letter-bearing serial
+      implies a LATER issue than an all-digit one within the same office code.
+      It is a one-sided inference and this dataset makes no year claim from it.
+    recycling_rule: "GA 36-2007 § 5.9.2 b): '机动车登记中收回的号牌，其机动车登记编号6个月后可重新使用。' — a surrendered number returns to the pool after six months"
+    source: "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 § 5.9; accessed 2026-08-02"
+  classification_han:
+    note: >-
+      GA 36-2007 § 5.10, verbatim and complete: "领馆汽车号牌和摩托车号牌的机动车
+      登记编号中使用汉字简称"领"字；使馆汽车号牌和摩托车号牌的机动车登记编号中使用
+      汉字简称"使"字；警用汽车号牌和摩托车号牌的机动车登记编号使用汉字简称"警"字；
+      教练汽车号牌和摩托车号牌的机动车登记编号中使用汉字简称"学"字；挂车号牌的机动车
+      登记编号使用汉字简称"挂"字；香港特别行政区入出内地车辆号牌的机动车登记编号使用
+      汉字简称"港"字；澳门特别行政区入出内地车辆号牌的机动车登记编号使用汉字简称"澳"
+      字；试验车的临时行驶车号牌的机动车登记编号中使用汉字简称"试"字；特型车的临时
+      行驶车号牌的机动车登记编号中使用汉字简称"超"字。"
+    characters:
+      - { han: 领, script: Han, pinyin: "lǐng", meaning: "consular corps (驻华领事馆)" }
+      - { han: 使, script: Han, pinyin: "shǐ",  meaning: "diplomatic corps (驻华使馆)" }
+      - { han: 警, script: Han, pinyin: "jǐng", meaning: "police vehicle (警车)" }
+      - { han: 学, script: Han, pinyin: "xué",  meaning: "driving-instruction vehicle (教练车)" }
+      - { han: 挂, script: Han, pinyin: "guà",  meaning: "trailer / semi-trailer (挂车)" }
+      - { han: 港, script: Han, pinyin: "gǎng", meaning: "Hong Kong vehicle entering/leaving the mainland" }
+      - { han: 澳, script: Han, pinyin: "ào",   meaning: "Macau vehicle entering/leaving the mainland" }
+      - { han: 试, script: Han, pinyin: "shì",  meaning: "test vehicle, on a temporary-travel plate" }
+      - { han: 超, script: Han, pinyin: "chāo", meaning: "over-dimension/over-mass special vehicle, on a temporary-travel plate" }
+      - { han: 应急, script: Han, pinyin: "yìngjí", meaning: "national comprehensive fire-and-rescue vehicle", source_note: "NOT in GA 36-2007 § 5.10 — created later by 国办发〔2018〕114号, and the only TWO-character classification element" }
+    source: "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 § 5.10; accessed 2026-08-02"
+  materials:
+    metal: "GA 36-2007 § 6.1.1.1: aluminium of at least 1.0 mm (1.2 mm, or steel, for the large-vehicle rear plate and the trailer plate), to GB/T 3880.1 / GB/T 3880.2; surface film to GA 666-2006"
+    paper: "§ 6.1.1.2: temporary-ENTRY plates are printed on 200-220 g watermarked paper and laminated. § 6.1.1.3: the domestic temporary-travel plate is 125 g white card"
+    service_life: "§ 6.3: '金属材料号牌的使用寿命不得少于四年。' — a metal plate's service life shall be not less than four years"
+    embossing: "§ 6.6.3: characters and the separator stand proud of the plate face by more than 1 mm, inside a stiffening rib of more than 1 mm"
+    fastening: "§ 7.1 c): every plate face except the temporary-entry and temporary-travel plates is fixed with at least two uniform anti-theft fasteners embossed with the issuing-authority code (GA/T 804)"
+    enlarged_number: "§ 7.3: heavy and medium goods vehicles and their trailers carry the registration number painted on the body at 2.5x plate size"
+    source: "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 §§ 6, 7; accessed 2026-08-02"
+  colour_basis:
+    note: >-
+      GA 36 NAMES colours and never numbers them for the metal plates: § 6.8.2
+      and § 6.8.3 defer the day and night chromaticity coordinates to
+      GA 666-2006 § 4.4, a standard whose text is not public. Only two colours
+      are numbered anywhere in the readable text, and both are on the PAPER
+      plates and the red characters: § 6.8.1 fixes the red paint as GB/T
+      3181-1995 大红 (R03); § 6.4 fixes the temporary plates' ground tints as
+      GB/T 3181-1995 天(酞)蓝 (PB09) and 棕黄 (YR06). EVERY hex value in this
+      file is therefore `hex_basis: observed` — a rendering convenience, not a
+      sourced fact — and re-sourcing them from GA 666 is a named verifier
+      target.
+    named_colours_source: "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 §§ 6.4, 6.8, and 表 1's colour column; accessed 2026-08-02"
+
+series:
+
+  # =========================================================================
+  # THE CIVIL 92-PATTERN CORE. GA 36-2007 表 1 "号牌的分类、规格、颜色及适用
+  # 范围" is the closed classification; rows 1-19 of that table are the source
+  # for every dimension, colour and scope claim in this block, and each series
+  # quotes its own row.
+  # =========================================================================
+
+  - id: cn-small-car-1992
+    class: standard
+    categories: [car, van]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 3 (format/design); GA 36-1992 (period)"
+    matching: strict
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{5}\z'
+      regex_strict: '\A[A-Z][- ]?(?:\d{5}|[A-HJ-NP-Z]\d{4}|[A-HJ-NP-Z]{2}\d{3}|\d[A-HJ-NP-Z]\d{3}|\d{2}[A-HJ-NP-Z]\d{2}|\d{3}[A-HJ-NP-Z]\d|\d{4}[A-HJ-NP-Z]|[A-HJ-NP-Z]\d{3}[A-HJ-NP-Z]|\d{3}[A-HJ-NP-Z]{2}|[A-HJ-NP-Z]\d[A-HJ-NP-Z]\d{2}|\d[A-HJ-NP-Z]{2}\d{2})\z'
+      charset:
+        office_letter: "A-Z (I and O included — see the header's I/O asymmetry note)"
+        serial_letters_excluded: [I, O]
+        notes: "regex_strict is GA 36-2007 表 3's five-position column, all eleven rows"
+      progression: "combinations open in 表 3 order once the previous is 60% consumed (§ 5.9.2 a)); the inference is one-sided and no year claim is made from it"
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: none
+        printed: "<province>·<office letter><5-position serial>"
+        printed_example: "京A·12345"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{5}\z'
+        regex_informational_note: >-
+          NOT part of the PRD-PLATES § 2.6 contract, NOT lint-validated, and NOT
+          a substitute for format.regex — provided because a consumer holding a
+          whole Chinese plate string needs one expression to split it. The Han
+          class is the 31 characters of cn-provinces.yml in Table 2's order.
+    design:
+      plate: { w: 440, h: 140, unit: mm }
+      count: 2
+      background: { color: "#1C3F94", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      border: { color: "#FFFFFF", note: "白框线 — the white keyline is part of the sourced colour description" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      note: >-
+        GA 36-2007 表 1 row 3, verbatim: 小型汽车号牌 / 440×140 / 蓝底白字白框线
+        / 2 / 中型以下的载客、载货汽车和专项作业车。 § 6.5 b) adds that on the
+        small-car plate BOTH the ground colour and the characters are
+        retroreflective ("小型汽车号牌和轻便摩托车号牌底色和字符均为反光") —
+        which is not true of the yellow plates, whose ground is retroreflective
+        but whose black characters are not.
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+      note: >-
+        Two independent geographic elements: the Han character gives the
+        province-level jurisdiction (closed, 31 values); the Latin letter gives
+        the issuing vehicle-management office within it (open list, MPS-approved
+        additions). For the four directly-administered municipalities the letter
+        is a BATCH marker with no place meaning at all (§ 5.8.2).
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 3 (dimensions, colours, count, scope); § 5.1.1 (the 440x140 layout group); § 5.9 (serial grammar, regex_strict); § 6.5 b) (both ground and characters retroreflective); accessed 2026-08-02"
+      - "https://web.archive.org/web/20161122160811/http://www.mps.gov.cn/n2254098/n4904352/c5550094/content.html  # 公安部交通管理局, 2016-11-21: '与普通汽车号牌相比，新能源汽车号牌号码由5位升为6位' — the primary that fixes the ORDINARY car serial at FIVE positions; accessed 2026-08-02"
+      - "https://hbba.sacinfo.org.cn/stdDetail/12b7710b682f0e13dfc423a325751920  # GA 36-2007 register entry: 代替 GA 36-1992 — the evidence for period.start 1992; accessed 2026-08-02"
+    notes: >-
+      The ordinary blue plate: light passenger and goods vehicles and special
+      operating vehicles below medium size, two plates per vehicle, 440x140 mm,
+      white on blue with a white keyline. period.start 1992 is the designation
+      year of GA 36-1992, the edition that created the 92-pattern; that
+      standard's own issue and in-force dates could not be pinned (it predates
+      the industry-standard filing database), and the widely repeated
+      "trial 1992, nationwide July 1994" pair has NO primary and is not asserted
+      (dossier folklore F-1). The five-position serial is sourced twice over —
+      GA 36-2007 表 3's 五位数 column and the Ministry's 2016 NEV announcement,
+      which contrasts the ordinary plate's five positions with the NEV plate's
+      six. Colours are named, not numbered, in the readable text; the hex is
+      observed (see common.colour_basis).
+
+  - id: cn-large-car-1992
+    class: standard
+    categories: [truck, bus]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 1"
+    matching: strict
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{5}\z'
+      regex_strict: '\A[A-Z][- ]?(?:\d{5}|[A-HJ-NP-Z]\d{4}|[A-HJ-NP-Z]{2}\d{3}|\d[A-HJ-NP-Z]\d{3}|\d{2}[A-HJ-NP-Z]\d{2}|\d{3}[A-HJ-NP-Z]\d|\d{4}[A-HJ-NP-Z]|[A-HJ-NP-Z]\d{3}[A-HJ-NP-Z]|\d{3}[A-HJ-NP-Z]{2}|[A-HJ-NP-Z]\d[A-HJ-NP-Z]\d{2}|\d[A-HJ-NP-Z]{2}\d{2})\z'
+      charset: { serial_letters_excluded: [I, O], notes: "GA 36-2007 表 3, five-position column" }
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: none
+        printed: "<province>·<office letter><5-position serial>"
+        printed_example: "沪A·12345"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{5}\z'
+    design:
+      plate: { w: 440, h: 140, unit: mm, position: front }
+      plate_variants:
+        - { w: 440, h: 220, unit: mm, position: rear, note: "the two-line rear plate" }
+      count: 2
+      background: { color: "#FFD500", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      border: { color: "#000000", note: "黑框线" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: true
+      rear_differs_note: >-
+        Not a colour or format difference — a SHAPE difference. GA 36-2007
+        表 1 row 1 gives 前：440×140 / 后：440×220, and § 5.2 assigns the
+        440x220 layout to "大型汽车后号牌和挂车号牌". China is the dataset's
+        clearest case of front/rear asymmetry by dimension rather than by
+        colour (contrast the UK, where the asymmetry is colour).
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 1: 大型汽车号牌 / 前 440x140 后 440x220 / 黄底黑字黑框线 / 2 / 中型（含）以上载客、载货汽车和专项作业车；半挂牵引车；电车; §§ 5.1.1, 5.2; accessed 2026-08-02"
+      - "https://web.archive.org/web/20161122160811/http://www.mps.gov.cn/n2254098/n4904352/c5550094/content.html  # the five-position ordinary-car serial; accessed 2026-08-02"
+    notes: >-
+      The yellow plate: medium and larger passenger and goods vehicles and
+      special operating vehicles, semi-trailer tractors, and TROLLEYBUSES
+      (电车 — named in the table's scope column and easy to miss). Same
+      registration-number grammar as the small-car plate; different colour and a
+      taller rear plate. Note the scope boundary is the vehicle SIZE CLASS, not
+      commercial use: a privately owned medium bus is yellow-plated.
+
+  - id: cn-trailer-1992
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 2"
+    # RECALL-ONLY (PRD-PLATES §2.7): the readable text fixes the trailer plate's
+    # DESIGN and its classification character but never states which of the two
+    # serial widths 表 3 defines applies to it — that lives in Annex C's
+    # figures, which the government republication reproduces as headings only.
+    # The regex therefore spans both widths and a match is a SHAPE hit.
+    matching: recall-only
+    format:
+      pattern: "L9999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      width_note: >-
+        GA 36-2007 表 3 defines four-position and five-position serials and does
+        not say which classes take which. On a trailer plate the trailing 挂
+        occupies a character cell, which is why the four-position reading is the
+        likely one; it is NOT asserted. Pin it and this series becomes strict
+        with 表 3's four-position column as its regex_strict.
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: { han: 挂, script: Han, pinyin: "guà", role: classification }
+        printed: "<province>·<office letter><serial>挂"
+        printed_example: "京A·1234挂"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}挂\z'
+    design:
+      plate: { w: 440, h: 220, unit: mm }
+      count: 1
+      background: { color: "#FFD500", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      note: "ONE plate only (表 1 row 2's 数量 column), the same 440x220 two-line layout as the large-vehicle rear plate (§ 5.2). Base material is at least 1.2 mm aluminium or steel (§ 6.1.1.1 b))."
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 2: 挂车号牌 / 440x220 / 黄底黑字黑框线 / 1 / 全挂车和不与牵引车固定使用的半挂车; § 5.10 (the 挂 character); § 6.1.1.1 b); accessed 2026-08-02"
+      - "https://www.gov.cn/gongbao/content/2022/content_5682413.htm  # 《机动车登记规定》(公安部令第164号) 第九条: '车辆管理所办理注册登记时，应当对牵引车和挂车分别核发机动车登记证书、号牌、行驶证和检验合格标志' — tractor and trailer are separately registered and separately plated; accessed 2026-08-02"
+    notes: >-
+      Full trailers and semi-trailers not permanently coupled to their tractor.
+      The scope wording matters: a semi-trailer that IS permanently coupled is
+      not separately plated. 《机动车登记规定》第九条 confirms the separate
+      registration at rule level. One plate, rear only, on the tall 440x220
+      layout it shares with the large-vehicle rear plate.
+
+  - id: cn-motorcycle-1992
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 9"
+    # RECALL-ONLY: as with the trailer plate, the serial WIDTH for this class is
+    # in Annex C's figures and not in the readable text.
+    matching: recall-only
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: none
+        printed: "<province><office letter><serial>"
+        printed_example: "京A12345"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}\z'
+    design:
+      plate: { w: 220, h: 95, unit: mm, position: front }
+      plate_variants:
+        - { w: 220, h: 140, unit: mm, position: rear, note: "the two-line rear plate" }
+      count: 2
+      background: { color: "#FFD500", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: true
+      rear_differs_note: "220x95 single-line front, 220x140 two-line rear (表 1 row 9; §§ 5.3, 5.4.1)"
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 9: 普通摩托车号牌 / 前 220x95 后 220x140 / 黄底黑字黑框线 / 普通二轮摩托车和普通三轮摩托车; §§ 5.3, 5.4.1; accessed 2026-08-02"
+    notes: >-
+      Ordinary two-wheel and three-wheel motorcycles. THE FRONT PLATE IS A
+      2007 FACT AND MAY NOT BE A 2018 ONE: GA 36-2007 表 1 gives this class a
+      front plate of 220x95 mm as well as the rear 220x140, and the count
+      column reads 2. Whether GA 36-2014 or GA 36-2018 withdrew the front
+      motorcycle plate cannot be checked — neither text is public — and this is
+      a named verifier target. The dataset records what the readable edition
+      says and flags the exposure rather than quietly modernising it.
+
+  - id: cn-moped-1992
+    class: moped
+    categories: [moped]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 10"
+    matching: recall-only
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: none
+        printed: "<province><office letter><serial>"
+        printed_example: "沪A12345"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}\z'
+    design:
+      plate: { w: 220, h: 95, unit: mm, position: front }
+      plate_variants:
+        - { w: 220, h: 140, unit: mm, position: rear }
+      count: 2
+      background: { color: "#1C3F94", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      border: { color: "#FFFFFF" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: true
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 10: 轻便摩托车号牌 / 蓝底白字白框线 / 轻便摩托车 (dimensions merged with row 9); § 6.5 b) (ground AND characters retroreflective, as on the small-car plate); accessed 2026-08-02"
+    notes: >-
+      轻便摩托车 (light motorcycle / moped) plates are the motorcycle plate in
+      the SMALL-CAR colourway — blue ground, white characters, white keyline —
+      and GA 36-2007 § 6.5 b) names them alongside the small-car plate as the
+      two classes whose ground AND characters are both retroreflective. The
+      dimensions cell of 表 1 row 10 is merged with row 9's, which is how the
+      220x95 front / 220x140 rear pair is read here. Same width caveat as the
+      motorcycle plate, hence recall-only.
+
+  - id: cn-lowspeed-1992
+    class: agricultural
+    categories: [truck, machine]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 15"
+    matching: recall-only
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: none
+        printed: "<province><office letter><serial>"
+        printed_example: "冀A12345"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}\z'
+    design:
+      plate: { w: 300, h: 165, unit: mm }
+      count: 2
+      background: { color: "#FFD500", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 15: 低速车号牌 / 300x165 / 黄底黑字黑框线 / 2 / 低速载货汽车、三轮汽车和轮式自行机械车; § 5.5; accessed 2026-08-02"
+    notes: >-
+      低速车号牌 — low-speed goods vehicles, three-wheeled vehicles and wheeled
+      self-propelled machinery. The 300x165 mm plate is unique to this class and
+      is the squarest metal plate in the Chinese range. CLASS CAVEAT: the
+      dataset's _meta/classes.yml has no term for a low-speed-vehicle regime;
+      `agricultural` is the closest existing term because this is the plate on
+      rural three-wheelers and wheeled machinery, and the dossier requests a
+      `low-speed` vocabulary addition rather than leaving the choice implicit.
+      Tractors proper are NOT this class: 表 1 row 19 sends them to
+      NY 345.1-2005, whose text is a scanned image, so no tractor series is
+      modelled (recorded gap).
+
+  - id: cn-driving-school-car-1992
+    class: standard
+    class_note: >-
+      教练汽车号牌 is a distinct legal issuance category in GA 36-2007 表 1
+      (row 7) with its own classification character, but _meta/classes.yml has
+      no term for a driving-instruction regime. `standard` is used because the
+      vehicle is an ordinary civil registration whose plate carries a
+      permitted-use marker, and the dossier requests a `driving-school`
+      vocabulary addition. A consumer must read class_note, not just class.
+    categories: [car, bus]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 7"
+    matching: recall-only
+    format:
+      pattern: "L9999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: { han: 学, script: Han, pinyin: "xué", role: classification }
+        printed: "<province>·<office letter><serial>学"
+        printed_example: "京A·1234学"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}学\z'
+    design:
+      plate: { w: 440, h: 140, unit: mm }
+      count: 2
+      background: { color: "#FFD500", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      note: "表 1 row 7: 黄底黑字，黑'学'字黑框线 — the 学 character is BLACK like the rest, unlike the red 使/领/警 of the diplomatic and police plates"
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 7: 教练汽车号牌 / 黄底黑字，黑'学'字黑框线 / 教练用汽车 (dimensions and count merged from row 3's 440x140 / 2); § 5.1.1 (the 440x140 layout group includes 教练汽车号牌); § 5.10 (the 学 character); accessed 2026-08-02"
+    notes: >-
+      Driving-instruction cars. The class shares the 440x140 layout group with
+      the small-car, consular and cross-boundary plates (§ 5.1.1 names all of
+      them together), which is how the dimensions and the count of 2 are read
+      from 表 1's merged cells. recall-only for the serial-width reason given on
+      the trailer series.
+
+  - id: cn-driving-school-motorcycle-1992
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 13"
+    matching: recall-only
+    format:
+      pattern: "L9999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: { han: 学, script: Han, pinyin: "xué", role: classification }
+        printed: "<province><office letter><serial>学"
+        printed_example: "京A1234学"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}学\z'
+    design:
+      plate: { w: 220, h: 95, unit: mm, position: front }
+      plate_variants:
+        - { w: 220, h: 140, unit: mm, position: rear }
+      count: 2
+      background: { color: "#FFD500", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: true
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 13: 教练摩托车号牌 / 黄底黑字，黑'学'字黑框线 / 教练用摩托车; §§ 5.3, 5.4.1 name 教练摩托车前/后号牌 in the 220x95 and 220x140 layout groups; accessed 2026-08-02"
+    notes: >-
+      Driving-instruction motorcycles — the motorcycle plate carrying 学. Listed
+      separately from the car version because the standard lists it separately
+      and because the plate dimensions differ, which is the § 2.3 test.
+
+  - id: cn-police-car-2007
+    class: police
+    categories: [car, van, truck, bus]
+    period: { start: 2007 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 8"
+    matching: recall-only
+    format:
+      pattern: "L9999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: { han: 警, script: Han, pinyin: "jǐng", role: classification, colour: red }
+        printed: "<province>·<office letter><serial>警"
+        printed_example: "京A·1234警"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}警\z'
+    design:
+      plate: { w: 440, h: 140, unit: mm }
+      count: 2
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      accent: { color: "#D7000F", element: "the 警 character", hex_basis: observed, named_colour: "GB/T 3181-1995 大红 (R03), per GA 36-2007 § 6.8.1" }
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: true
+      rear_differs_note: "GA 36-2007 § 5.1.3 gives the police car plate SEPARATE front and rear layouts (图 3 / 图 4) at the same 440x140 size — the drawings are not reproduced in the government republication, so what differs is a recorded gap"
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 8: 警用汽车号牌 / 白底黑字，红'警'字黑框线 / 汽车类警车; § 5.1.3 (separate front and rear layouts); 前言 '增加了警用汽车号牌和警用摩托车号牌式样' — the evidence for period.start 2007; accessed 2026-08-02"
+      - "https://www.gov.cn/gongbao/2026/issue_12586/202602/content_7059934.html  # 《警车管理规定》 as republished with 公安部令第174号 (公布 2025-11-25, 施行 2025-12-29): 第七条 '警车号牌分为汽车、摩托车两种。均为铝质材，底色为白底反光。号牌应当符合《警车号牌式样》和机动车号牌的行业标准。'; 第十一条 (car: one plate front and one rear; motorcycle: one at the rear); 第十条 (issued by PROVINCIAL-level traffic management, not the local office); accessed 2026-08-02"
+    notes: >-
+      Police cars. period.start 2007 is instrument-dated on GA 36-2007's own
+      前言, which lists "增加了警用汽车号牌和警用摩托车号牌式样" among that
+      edition's changes — the police plate LAYOUTS are a 2007 addition to the
+      standard. 《警车管理规定》第七条 independently confirms the white
+      retroreflective ground and the two-type split, and 第十条 adds a fact GA 36
+      does not carry: police plates are issued by the PROVINCIAL public security
+      department's traffic management arm, so the issuing-office letter on a
+      police plate does not decode the way a civil one does. The 《警车号牌式样》
+      annex to 公安部令第174号 is marked "（以上附件略，详情请登录公安部网站）" in
+      the Gazette and www.mps.gov.cn was unreachable — the exact serial grammar
+      is therefore a recorded gap and this series is recall-only.
+      NOT ASSERTED: the widely repeated claim that police-adjacent civil plates
+      use the office letter "O" as a de-facto police segment. GA 36-2007
+      Annex A does give O to the provincial department's own vehicle office in
+      every province, which is a real and sourced fact recorded in the decode
+      file; every further claim about O is folklore (dossier F-3).
+
+  - id: cn-police-motorcycle-2007
+    class: police
+    categories: [motorcycle]
+    period: { start: 2007 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 14"
+    matching: recall-only
+    format:
+      pattern: "L9999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: { han: 警, script: Han, pinyin: "jǐng", role: classification, colour: red }
+        printed: "<province><office letter><serial>警"
+        printed_example: "京A1234警"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}警\z'
+    design:
+      plate: { w: 220, h: 140, unit: mm }
+      count: 1
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      accent: { color: "#D7000F", element: "the 警 character", hex_basis: observed }
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      note: "ONE plate, at the rear — 表 1 row 14's count column reads 1, and 《警车管理规定》第十一条 says '摩托车号牌应当在车身后部安装一面'. The police motorcycle is the one motorcycle class with no front plate in the 2007 text."
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 14: 警用摩托车号牌 / 220x140 / 白底黑字，红'警'字黑框线 / 1 / 摩托车类警车; § 5.4.3; 前言 (2007 addition); accessed 2026-08-02"
+      - "https://www.gov.cn/gongbao/2026/issue_12586/202602/content_7059934.html  # 《警车管理规定》第七条 and 第十一条; accessed 2026-08-02"
+    notes: >-
+      Police motorcycles. The only class in 表 1 whose count column reads 1 among
+      the motorcycle rows, and the rule-level confirmation is in the police
+      regulation itself. Same serial-width gap as the police car plate.
+
+  - id: cn-embassy-car-1992
+    class: diplomatic
+    categories: [car, van]
+    period: { start: 1992 }
+    period_evidence: instrument-in-force
+    standard_edition: "GA 36-2007 表 1 row 4"
+    # RECALL-ONLY, and this one is the most deliberate in the file. GA 36-2007
+    # § 5.1.2 gives the EMBASSY car plate a layout of its own (图 2), separate
+    # from the single layout (图 1) that every other 440x140 class shares. That
+    # separation is the strongest evidence in the readable text that the embassy
+    # registration number is NOT built on the province + office-letter pattern —
+    # and the readable text never says what it IS built on. The regex is
+    # therefore a deliberately wide digits-only shape and a match is a shape hit.
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A\d{4,6}\z'
+      han:
+        prefix: none
+        prefix_note: >-
+          NO province character. This is the one civil class where the leading
+          element of GA 36-2007 § 3.2's structure is absent — § 5.1.2's separate
+          layout is the evidence, and Annex C.4's drawing (not reproduced) would
+          settle it.
+        suffix: { han: 使, script: Han, pinyin: "shǐ", role: classification, colour: red }
+        printed: "<digits>使"
+        printed_example: "123456使"
+        regex_informational: '\A\d{4,6}使\z'
+    design:
+      plate: { w: 440, h: 140, unit: mm }
+      count: 2
+      background: { color: "#000000", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      accent: { color: "#D7000F", element: "the 使 character", hex_basis: observed, named_colour: "GB/T 3181-1995 大红 (R03)" }
+      border: { color: "#FFFFFF", note: "白框线" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: none
+    region_encoding_note: "No province character and no issuing-office letter — an embassy plate encodes no Chinese geography at all."
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 4: 使馆汽车号牌 / 黑底白字，红'使'、'领'字白框线 / 驻华使馆的汽车 (dimensions and count merged from row 3); § 5.1.2 (the embassy plate has its OWN 440x140 layout, 图 2); § 5.10 (the 使 character); 前言 (the 使 glyph was ADDED in this edition); accessed 2026-08-02"
+    notes: >-
+      Embassy cars. Black ground, white characters, a RED 使, white keyline,
+      440x140, two plates. Everything in the previous sentence is sourced;
+      the SERIAL GRAMMAR IS NOT. The commonly repeated form — a three-digit
+      mission/country code followed by a three-digit serial — has no primary in
+      the accessible record and is NOT asserted here (dossier folklore F-2);
+      the regex is a deliberately wide four-to-six-digit shape so that a
+      consumer gets recall without being told a lie about validity.
+      period_evidence is instrument-in-force, not enabling-instrument: China had
+      diplomatic plates long before 2007, but GA 36-2007's 前言 records the 使
+      glyph as an addition to that edition's character annex, so the only
+      instrument date available documents an older practice.
+
+  - id: cn-embassy-motorcycle-1992
+    class: diplomatic
+    categories: [motorcycle]
+    period: { start: 1992 }
+    period_evidence: instrument-in-force
+    standard_edition: "GA 36-2007 表 1 row 11"
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A\d{4,6}\z'
+      han:
+        prefix: none
+        suffix: { han: 使, script: Han, pinyin: "shǐ", role: classification, colour: red }
+        printed: "<digits>使"
+        regex_informational: '\A\d{4,6}使\z'
+    design:
+      plate: { w: 220, h: 95, unit: mm, position: front }
+      plate_variants:
+        - { w: 220, h: 140, unit: mm, position: rear, note: "§ 5.4.2 gives the embassy motorcycle REAR plate its own layout (图 8), separate from the other motorcycle rear plates (图 7)" }
+      count: 2
+      background: { color: "#000000", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      accent: { color: "#D7000F", element: "the 使 character", hex_basis: observed }
+      border: { color: "#FFFFFF" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: true
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 11: 使馆摩托车号牌 / 黑底白字，红'使'、'领'字白框线 / 驻华使馆的摩托车; §§ 5.3, 5.4.2; accessed 2026-08-02"
+    notes: >-
+      Embassy motorcycles. Same grammar gap as the embassy car plate, hence
+      recall-only. Modelled separately because § 5.4.2 gives it a distinct rear
+      layout and the dimensions differ.
+
+  - id: cn-consulate-car-1992
+    class: consular
+    categories: [car, van]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 5"
+    matching: recall-only
+    format:
+      pattern: "L9999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: { han: 领, script: Han, pinyin: "lǐng", role: classification, colour: red }
+        printed: "<province>·<office letter><serial>领"
+        printed_example: "沪A·1234领"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}领\z'
+    design:
+      plate: { w: 440, h: 140, unit: mm }
+      count: 2
+      background: { color: "#000000", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      accent: { color: "#D7000F", element: "the 领 character", hex_basis: observed, named_colour: "GB/T 3181-1995 大红 (R03)" }
+      border: { color: "#FFFFFF" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+      note: >-
+        THE STRUCTURAL DIFFERENCE FROM THE EMBASSY PLATE, and it is sourced:
+        § 5.1.1 puts 领馆汽车号牌 in the SHARED 440x140 layout group (图 1)
+        together with the small-car, cross-boundary and driving-school plates,
+        while § 5.1.2 gives 使馆汽车号牌 a layout of its OWN (图 2). Consular
+        plates therefore carry the province character and the issuing-office
+        letter and decode geographically; embassy plates do not.
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 5: 领馆汽车号牌 / 黑底白字，红'使'、'领'字白框线 / 驻华领事馆的汽车; § 5.1.1 (shared layout group — the geographic decode); § 5.10 (the 领 character); accessed 2026-08-02"
+    notes: >-
+      Consular cars. The consulate's host city is decodable because the plate is
+      built on the ordinary province + office-letter frame — § 5.1.1's layout
+      grouping is the evidence, and it is the single most useful sourced fact
+      about Chinese diplomatic plates. Serial width unpinned, hence recall-only.
+      Unlike 使, the 领 character is NOT in GA 36-2007's list of characters that
+      edition added, so this class is dated to the 1992 enabling instrument.
+
+  - id: cn-consulate-motorcycle-1992
+    class: consular
+    categories: [motorcycle]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 12"
+    matching: recall-only
+    format:
+      pattern: "L9999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: { han: 领, script: Han, pinyin: "lǐng", role: classification, colour: red }
+        printed: "<province><office letter><serial>领"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}领\z'
+    design:
+      plate: { w: 220, h: 95, unit: mm, position: front }
+      plate_variants:
+        - { w: 220, h: 140, unit: mm, position: rear }
+      count: 2
+      background: { color: "#000000", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      accent: { color: "#D7000F", element: "the 领 character", hex_basis: observed }
+      border: { color: "#FFFFFF" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: true
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 12: 领馆摩托车号牌; §§ 5.3, 5.4.1 (the consular motorcycle sits in the SHARED motorcycle layout groups, unlike the embassy motorcycle); accessed 2026-08-02"
+    notes: >-
+      Consular motorcycles. Note the parallel with the cars: § 5.4.1 puts the
+      consular motorcycle rear plate in the shared layout (图 7) while § 5.4.2
+      gives the embassy motorcycle its own (图 8).
+
+  - id: cn-hkmacau-crossborder-2007
+    class: standard
+    class_note: >-
+      港澳入出境车号牌 is a cross-boundary regime for vehicles registered in Hong
+      Kong or Macau that enter the mainland; _meta/classes.yml has no term for
+      it (`temporary` is wrong — these are multi-year permits; `export` and
+      `transit` are wrong in the opposite direction). `standard` is used and the
+      dossier requests a `cross-border` vocabulary addition.
+    categories: [car, van, truck, bus]
+    period: { start: 2007 }
+    period_evidence: instrument-in-force
+    standard_edition: "GA 36-2007 表 1 row 6"
+    matching: recall-only
+    format:
+      pattern: "Z9999"
+      regex: '\AZ[- ]?[A-Z0-9]{4,5}\z'
+      charset:
+        office_letter: [Z]
+        notes: >-
+          The office letter is FIXED at Z by Annex A footnote 9, verbatim:
+          "表示广东省公安厅交通管理局车辆管理所核发的港澳入出境车号牌使用的发牌机关
+          代号为"Z"。" This is the only class in the file whose issuing-office
+          letter is a literal, which is why it is written into the pattern.
+      han:
+        prefix: { han: 粤, role: province, script: Han, fixed: true, note: "always Guangdong — the plates are issued by 广东省公安厅交通管理局车辆管理所" }
+        suffix: { han: [港, 澳], script: Han, role: classification, note: "港 for a Hong Kong vehicle, 澳 for a Macau vehicle (§ 5.10); the printed Latin/digit portion is identical, which is why one series carries both" }
+        printed: "粤Z·<serial>港  or  粤Z·<serial>澳"
+        printed_example: "粤Z·1234港"
+        regex_informational: '\A粤Z[·\- ]?[A-Z0-9]{4,5}[港澳]\z'
+    design:
+      plate: { w: 440, h: 140, unit: mm }
+      count: 2
+      background: { color: "#000000", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      accent: { color: "#FFFFFF", element: "the 港/澳 character", hex_basis: observed, note: "WHITE, not red — 表 1 row 6 reads 黑底白字，白'港'、'澳'字白框线, which is exactly how this class is told apart from the diplomatic plates that share its black ground" }
+      border: { color: "#FFFFFF" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding:
+      type: fixed
+      note: "粤 + Z always; the plate encodes the ISSUING regime, not a Guangdong location."
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 6: 港澳入出境车号牌 / 黑底白字，白'港'、'澳'字白框线 / 港澳地区入出内地的汽车; § 5.1.1 (shared 440x140 layout); § 5.10 (the 港/澳 characters); 附录 A footnote 9 (the Z code); 前言 ('增加了...'港'、'澳'...' — the evidence for period.start 2007); accessed 2026-08-02"
+    notes: >-
+      Hong Kong and Macau vehicles entering the mainland. period.start 2007 is
+      an instrument-in-force date: GA 36-2007's 前言 lists 港 and 澳 among the
+      characters that edition added, but the regime itself is older — the widely
+      repeated claim that 粤Z港/粤Z澳 replaced the 86-pattern "广东02"/"广东03"
+      plates in 2001 has no primary and is NOT asserted (dossier folklore F-4).
+      Mainland-registered vehicles crossing the OTHER way are outside GA 36
+      entirely. Serial width unpinned, hence recall-only; the fixed Z is
+      sourced, and it makes this the most identifiable Chinese plate of all.
+
+  # =========================================================================
+  # NEW ENERGY VEHICLES. The one part of the current standard whose creation is
+  # documented by accessible primaries — the Ministry's own announcements —
+  # because GA 36-2018's text is withheld.
+  # =========================================================================
+
+  - id: cn-nev-small-2016
+    class: electric
+    categories: [car, van]
+    period:
+      start: 2016
+      rollout:
+        pilot: "2016-12-01 — 上海、南京、无锡、济南、深圳"
+        expansion_1: "2017-11 — plus 河北保定、吉林长春、福建福州、山东青岛、河南郑州、广东中山、广西柳州、重庆、四川成都、云南昆明"
+        expansion_2: "by end 2017 — every municipality, provincial capital and autonomous-region capital, plus at least one or two further cities per province"
+        national: "first half of 2018 — '全国所有城市全面启用新号牌'"
+        national_note: >-
+          The Ministry's August 2017 announcement gives the national step as a
+          HALF-YEAR, not a date. The specific date 2018-06-15 that circulates
+          widely has no primary in the accessible record and is not asserted
+          (dossier folklore F-5).
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2018 incorporates the NEV plates; its text is withheld, so every claim here is the Ministry's own announcements"
+    matching: strict
+    format:
+      pattern: "L999999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{6}\z'
+      regex_strict: '\A[A-Z][- ]?[0-9A-HJ-NP-Z]{6}\z'
+      regex_strict_note: >-
+        The strict twin carries ONLY the I/O exclusion, and that is carried
+        forward from GA 36-2007 § 5.9.1 b)/c) — it is NOT verified against
+        GA 36-2018, whose text is withheld. It deliberately does NOT encode a
+        letter POSITION: see the powertrain note below.
+      charset:
+        serial_positions: 6
+        serial_letters_excluded: [I, O]
+        notes: "six positions is sourced verbatim; the position rule is not"
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: none
+        printed: "<province><office letter><6-position serial>"
+        printed_example: "京AD12345"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{6}\z'
+    design:
+      background:
+        color: "#A9D8A0"
+        gradient: { from: "#F5FAF2", to: "#57B948", note: "渐变绿 — a graded green; the Ministry names the colour and numbers nothing" }
+        finish: retroreflective
+        hex_basis: observed
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: false }
+      marking: { note: "'增加了专用标识' — the Ministry's announcement records a dedicated NEV identifier mark on the plate; the readable sources do not describe or place it" }
+      rear_differs: false
+      dimensions_status: >-
+        DELIBERATELY ABSENT. GA 36-2007 predates this class and GA 36-2018's
+        text is withheld, so no plate size for the NEV plate is sourced. The
+        480x140 mm figure that circulates is not asserted (dossier folklore
+        F-6). Note that the emergency-rescue CAR plate, created two years later
+        by 国办发〔2018〕114号, IS 480x140 mm and IS sourced — which makes the
+        NEV figure plausible and still unproven.
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20161122160811/http://www.mps.gov.cn/n2254098/n4904352/c5550094/content.html  # 公安部交通管理局, 2016-11-21, '新能源汽车专用号牌将在5城市试点启用': '自2016年12月1日起，上海、南京、无锡、济南、深圳5个城市将率先试点启用新能源汽车号牌'; '小型新能源汽车号牌底色采用渐变绿色，大型新能源汽车号牌底色采用黄绿双拼色'; '与普通汽车号牌相比，新能源汽车号牌号码由5位升为6位'; '字母“D”代表纯电动汽车，字母“F”代表非纯电动汽车（包括插电式混合动力和燃料电池汽车等）'; original www.mps.gov.cn URL now HTTP 521; accessed via archive 2026-08-02"
+      - "https://web.archive.org/web/20181024152732/http://www.mps.gov.cn/n2253534/n2253535/n2253537/c5757013/content.html  # 公安部交通管理局, 2017-08-13, '公安部将在全国逐步推广新能源汽车专用号牌': the full rollout ladder quoted in period.rollout, verbatim, including '2018年上半年，全国所有城市全面启用新号牌'; also '新号牌签注唯一的生产序列标识' and the 50-选-1 random draw; accessed 2026-08-02"
+      - "https://hbba.sacinfo.org.cn/stdDetail/328b77ee80fdee1dee33d20e83d01d2ad128f380aa93c7dbe5c58c67d9d2075e  # GA 36-2018 register entry — the standard that carries the NEV plate into the mandatory standard, 实施 2018-05-01, text withheld; accessed 2026-08-02"
+    notes: >-
+      The small new-energy vehicle plate — the graded-green plate. FOUR THINGS
+      ARE SOURCED VERBATIM and they are the four that matter: the serial went
+      from five positions to SIX; the small-vehicle ground is 渐变绿 (graded
+      green) while the large-vehicle ground is 黄绿双拼 (a yellow-green split);
+      the letter D means 纯电动 (battery electric) and F means 非纯电动
+      (plug-in hybrid, fuel cell and the rest); and the plate carries a
+      dedicated identifier mark. THE POSITION OF THAT LETTER IS NOT SOURCED.
+      Every popular account says the letter is the FIRST serial position on a
+      small NEV plate and the LAST on a large one; no Ministry document, no
+      instrument and no standard text in the accessible record says so, and this
+      dataset does not assert it (dossier folklore F-7). It is the single
+      highest-value verifier target for China: pin it, and this series' regex
+      tightens to a genuinely diagnostic expression in one line. period.start
+      2016 is the enabling instrument — the Ministry's announcement creating the
+      pilot — with the whole rollout ladder recorded in period.rollout rather
+      than averaged into one date, which is exactly the Mercosur pattern
+      PRD-PLATES § 2.2 anticipates.
+
+  - id: cn-nev-large-2016
+    class: electric
+    categories: [truck, bus]
+    period:
+      start: 2016
+      rollout:
+        pilot: "2016-12-01 — 上海、南京、无锡、济南、深圳"
+        national: "first half of 2018"
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L999999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{6}\z'
+      regex_strict: '\A[A-Z][- ]?[0-9A-HJ-NP-Z]{6}\z'
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: none
+        printed: "<province><office letter><6-position serial>"
+        printed_example: "京A12345D"
+        printed_example_note: "illustrative only — the example places the powertrain letter last because that is the reported convention for large NEV plates, and the convention is NOT asserted as fact anywhere in this record"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{6}\z'
+    design:
+      background:
+        color: "#57B948"
+        split: { left: "#FFD500", right: "#57B948", note: "黄绿双拼色 — a two-tone yellow/green ground; the proportions are not sourced" }
+        finish: retroreflective
+        hex_basis: observed
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      dimensions_status: "absent for the same reason as the small NEV plate"
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20161122160811/http://www.mps.gov.cn/n2254098/n4904352/c5550094/content.html  # 公安部交通管理局, 2016-11-21: '大型新能源汽车号牌底色采用黄绿双拼色'; the six-position serial; the D/F meanings; accessed 2026-08-02"
+      - "https://web.archive.org/web/20181024152732/http://www.mps.gov.cn/n2253534/n2253535/n2253537/c5757013/content.html  # 公安部交通管理局, 2017-08-13: national rollout; accessed 2026-08-02"
+    notes: >-
+      The large new-energy vehicle plate — the yellow-and-green split plate,
+      for the vehicle sizes that would otherwise take the yellow large-vehicle
+      plate. Modelled as its own series rather than a colour variant because the
+      Ministry names the two grounds separately and because the two are scoped
+      to different vehicle sizes; the split proportions and the plate dimensions
+      are unsourced. The powertrain-letter position caveat on
+      cn-nev-small-2016 applies here identically and with the opposite reported
+      convention, which is precisely why neither is asserted.
+
+  # =========================================================================
+  # TEMPORARY REGIMES. Paper plates, and the only Chinese classes whose ground
+  # colours are NUMBERED in a public standard (GB/T 3181-1995 designations).
+  # =========================================================================
+
+  - id: cn-temporary-travel-1992
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, moped, trailer, machine]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 16 (the 式样 was MODIFIED in that edition — 前言: '修改了临时行驶车号牌式样')"
+    matching: recall-only
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      derivation_note: >-
+        The registration number's ELEMENTS come from GA 36-2007 § 3.2 and the
+        widths from § 5.9's four- and five-position serial types; the class's own
+        grammar lives in Annex C.16's drawings, which the government
+        republication reproduces as headings only. The regex is therefore a
+        derivation, not a transcription, and the series is recall-only.
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: { han: [试, 超], script: Han, role: classification, optional: true, note: "试 on a TEST vehicle's temporary plate, 超 on an over-dimension/over-mass special vehicle's; absent on the two ordinary variants" }
+        printed: "<province><office letter><serial>[试|超]"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}[试超]?\z'
+    design:
+      plate: { w: 220, h: 140, unit: mm }
+      count: 1
+      background: { color: "#CFE4F5", finish: paper, hex_basis: observed, named_colour: "GB/T 3181-1995 天(酞)蓝 PB09 — the ground TINT of the within-jurisdiction variant, per GA 36-2007 § 6.4 c)" }
+      foreground: "#000000"
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      material: "125 g white card (§ 6.1.1.3), placed inside the windscreen on the right (§ 7.1 e)) — not fixed, not fastened"
+    variants:
+      - class: temporary
+        design: { background: { color: "#E3C08A", finish: paper, hex_basis: observed, named_colour: "GB/T 3181-1995 棕黄 YR06" }, foreground: "#000000" }
+        note: >-
+          BROWN-YELLOW TINT, three uses distinguished only by the classification
+          character: cross-jurisdiction movement (no character), a TEST vehicle
+          (试), and an over-dimension/over-mass special vehicle (超). The blue
+          tint above is for movement WITHIN one administrative jurisdiction.
+          A tint-and-character variant of one format and period, so a sub-entry
+          per PRD-PLATES § 2.3.
+        sources:
+          - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 16 (all four uses and their tints); § 6.4 c)-d) (the two GB/T 3181-1995 colour designations); accessed 2026-08-02"
+    validity:
+      note: >-
+        Set by rule, not by standard. 《机动车登记规定》(公安部令第164号)
+        第四十七条: 30 days for an unsold vehicle, a newly acquired but
+        unregistered vehicle, or a new vehicle for export sale; SIX MONTHS for
+        research and type testing; 90 days for the over-dimension special
+        vehicles that cannot be registered at all; and 15 days where the plate
+        itself cannot be made in time. No more than three temporary plates for
+        the first two cases, one for the export case; never longer than the
+        compulsory insurance; and void three days after the permanent plates
+        arrive. 第四十八条 adds a separate temporary plate for intelligent
+        connected vehicle road testing and demonstration, matching the test
+        permit and capped at six months.
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 16: 临时行驶车号牌 / 220x140 / 天(酞)蓝底纹黑字黑框线 (行政辖区内) and 棕黄底纹黑字黑框线 (跨行政辖区 / 试 / 超) / 1; §§ 5.4.5, 6.1.1.3, 6.4 c)-d), 7.1 e); § 5.10 (试 and 超); accessed 2026-08-02"
+      - "https://www.gov.cn/gongbao/content/2022/content_5682413.htm  # 《机动车登记规定》第四十六条-第四十八条: the five qualifying situations and the whole validity ladder quoted above; accessed 2026-08-02"
+    notes: >-
+      The domestic temporary-travel plate: a printed card, one per vehicle,
+      behind the windscreen. It is the only Chinese class whose colours are
+      NUMBERED in a public standard, because paper printing is specified against
+      GB/T 3181-1995 rather than against the withheld retroreflective-film
+      standard — which is why its two hexes are the only ones in this file with a
+      named colour designation behind them. Its serial grammar is derived rather
+      than transcribed, so it is recall-only. GA 36-2007's 前言 records that this
+      edition MODIFIED the temporary plate's 式样, so the 2007 description is not
+      necessarily the 1992 one and certainly not necessarily the 2018 one.
+
+  - id: cn-temporary-entry-car-1992
+    class: temporary
+    categories: [car, van, truck, bus]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 17 (式样 MODIFIED in that edition per its 前言)"
+    matching: recall-only
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      derivation_note: "as on cn-temporary-travel-1992 — elements from § 3.2, widths from § 5.9, class grammar in Annex C.17's drawings which are not reproduced"
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: none
+        printed: "<province><office letter><serial>, with the permitted area/route and expiry printed on the plate"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}\z'
+    design:
+      plate: { w: 220, h: 140, unit: mm }
+      count: 1
+      background: { color: "#CFE4F5", finish: paper, hex_basis: observed, named_colour: "GB/T 3181-1995 天(酞)蓝 PB09 for the WITHIN-AREA variant (§ 6.4 a)); 棕黄 YR06 for the cross-area variant (§ 6.4 b))" }
+      foreground: "#000000"
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      material: "200-220 g watermarked paper, laminated (§ 6.1.1.2); placed inside the windscreen on the right (§ 7.1 e))"
+      note: "表 1 row 17's colour cell reads 白底棕蓝色专用底纹，黑字黑边框 — a white ground carrying a dedicated brown/blue security tint"
+    validity:
+      note: >-
+        《临时入境机动车和驾驶人管理规定》(公安部令第90号) 第五条, verbatim:
+        "临时入境机动车号牌为纸质号牌，载明允许行驶的区域、线路和有效期。临时入境
+        机动车号牌背面为临时入境机动车行驶证，签注车辆类型、号牌号码、厂牌型号、行驶
+        区域或者线路、有效期等信息。" — the plate IS the vehicle licence, printed
+        on its back. 第六条: validity matches the entry approval and never
+        exceeds three months, and may not be extended. 第七条: the car plate goes
+        inside the windscreen on the right; the motorcycle plate is carried with
+        the vehicle. 第二十二条: printed centrally by the Ministry.
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+      note: "issued by the municipal or prefecture-level traffic management department at the point of entry or the point of departure (公安部令第90号 第三条)"
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 17: 临时入境汽车号牌 / 220x140 / 白底棕蓝色专用底纹，黑字黑边框 / 临时入境汽车; §§ 5.4.4, 6.1.1.2, 6.4 a)-b), 7.1 e); accessed 2026-08-02"
+      - "http://www.gov.cn/gongbao/content/2007/content_772748.htm  # 《临时入境机动车和驾驶人管理规定》 (公安部令第90号, 施行 2007-01-01, replacing 公安部令第4号 of 1989-05-01): 第三条, 第五条, 第六条, 第七条, 第二十二条, and 第二十一条 (Hong Kong, Macau and Taiwan vehicles are handled 参照 this rule); accessed 2026-08-02"
+    notes: >-
+      The temporary-entry plate for a foreign-registered car. It is a laminated
+      watermarked card whose REVERSE is the vehicle licence, it states the area
+      or route the vehicle may use, and it never lasts more than three months.
+      Two ground tints, distinguished by whether the vehicle stays inside one
+      area or crosses between areas — the same blue/brown-yellow logic as the
+      domestic temporary plate, and sourced to the same clause of GA 36-2007.
+      Hong Kong, Macau and Taiwan vehicles on organised trips are handled by
+      reference to this rule (公安部令第90号 第二十一条), which is a different
+      regime from the 粤Z 港/澳 cross-boundary plates above.
+
+  - id: cn-temporary-entry-motorcycle-1992
+    class: temporary
+    categories: [motorcycle]
+    period: { start: 1992 }
+    period_evidence: enabling-instrument
+    standard_edition: "GA 36-2007 表 1 row 18"
+    matching: recall-only
+    format:
+      pattern: "L99999"
+      regex: '\A[A-Z][- ]?[A-Z0-9]{4,5}\z'
+      derivation_note: "as on the temporary-entry car plate"
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: none
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}\z'
+    design:
+      plate: { w: 88, h: 60, unit: mm }
+      count: 1
+      background: { color: "#CFE4F5", finish: paper, hex_basis: observed, named_colour: "GB/T 3181-1995 天(酞)蓝 PB09 / 棕黄 YR06 as for the car plate" }
+      foreground: "#000000"
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      note: >-
+        THE SMALLEST PLATE IN THE CHINESE RANGE at 88x60 mm, and the only one
+        whose dimensional tolerance the standard states in absolute terms
+        (§ 6.6.1: +/-0.5 mm, where every other size gets +/-0.5%). Annex B.5
+        makes the reason plain: its characters are the temporary-entry car
+        plate's glyphs reduced 2.5 times. Carried with the vehicle rather than
+        displayed (§ 7.1 e); 公安部令第90号 第七条).
+    validity: { note: "as for the temporary-entry car plate — 公安部令第90号 第六条, maximum three months, not extendable" }
+    region_encoding:
+      type: province-and-office
+      decode: ["plates/_decode/cn-provinces.yml", "plates/_decode/cn-issuing-offices.yml"]
+    sources:
+      - "https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html  # GA 36-2007 表 1 row 18: 临时入境摩托车号牌 / 88x60; §§ 5.6, 6.6.1, 附录 B.5 (the 2.5x reduction); accessed 2026-08-02"
+      - "http://www.gov.cn/gongbao/content/2007/content_772748.htm  # 公安部令第90号 第六条, 第七条; accessed 2026-08-02"
+    notes: >-
+      The temporary-entry motorcycle plate. Modelled separately from the car
+      plate purely because of the dimensions — a 20-fold difference in area is
+      the clearest possible § 2.3 design difference.
+
+  # =========================================================================
+  # EMERGENCY RESCUE. Created outside GA 36 by a State Council instrument, and
+  # for that reason the ONLY Chinese plate whose complete encoding rule is
+  # published in text this programme could read.
+  # =========================================================================
+
+  - id: cn-emergency-rescue-car-2018
+    class: government
+    class_note: >-
+      The national comprehensive fire-and-rescue force is a civil state service
+      (it moved out of the armed police in 2018), so `government` is the right
+      term in _meta/classes.yml; it is not `police` and not `military`.
+    categories: [car, van, truck, bus]
+    period: { start: 2018 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L9999"
+      regex: '\A(?:[A-Z]\d{4}|\d{5})\z'
+      regex_strict: '\A(?:[XS]\d{4}|\d{5})\z'
+      charset:
+        force_codes: { X: 消防救援 (fire and rescue), S: 森林消防 (forest fire) }
+        no_letter_form: "a serial with NO force letter and five digits marks a vehicle belonging to the Ministry of Emergency Management itself"
+      han:
+        prefix: { role: province, script: Han, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: { han: 应急, script: Han, pinyin: "yìngjí", role: classification, colour: red, note: "the only TWO-character classification element in the Chinese range" }
+        printed: "<province>·<force letter><4 digits>应急  or  <province>·<5 digits>应急"
+        printed_example: "京·X2345应急"
+        regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][·\- ]?(?:[XS]\d{4}|\d{5})应急\z'
+        total_characters: 8
+    design:
+      plate: { w: 480, h: 140, unit: mm }
+      count: 2
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      accent: { color: "#D7000F", element: "the 应急 pair, and — on the FRONT plate only — the force letter", hex_basis: observed }
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: true
+      rear_differs_note: >-
+        Verbatim: "汽车号牌分为前牌和后牌，前牌的所属救援队伍代号为红色，后牌的所属
+        救援队伍代号为黑色。" — the force letter is RED on the front plate and
+        BLACK on the rear. The dataset has no other series where front and rear
+        differ by the colour of a single character.
+    region_encoding:
+      type: province-only
+      decode: "plates/_decode/cn-provinces.yml"
+      note: >-
+        There is NO issuing-office letter on this plate: the second position is
+        the force code, not an office code. A parse API that reaches for
+        cn-issuing-offices.yml on an 应急 plate will produce confident nonsense.
+    sources:
+      - "https://www.gov.cn/zhengce/zhengceku/2018-12/11/content_5347765.htm  # 《国务院办公厅关于国家综合性消防救援车辆悬挂应急救援专用号牌有关事项的通知》 国办发〔2018〕114号 (成文 2018-12-04, 发布 2018-12-11), 二 and 附件 一（一）: '字符共8位，依次为省（自治区、直辖市）汉字简称、所属救援队伍代号、四位序号和汉字“应急”组成。其中，所属救援队伍代号用X代表消防救援、S代表森林消防。应急部的专用号牌不用英文字母，以与地方的专用号牌区别，如“京·12345应急”表示车辆归属应急部，“京·X2345应急”表示车辆归属北京市应急管理部门。'; 附件 二 '汽车号牌规格为480毫米×140毫米'; 附件 三 (front/rear colour difference); 二 '专用号牌为白底黑字，配以红色汉字“应急”'; accessed 2026-08-02"
+    notes: >-
+      The emergency-rescue plate, and the best-documented Chinese plate in this
+      file: a State Council General Office notice publishes the complete
+      encoding rule, the dimensions and the front/rear difference in TEXT, which
+      GA 36 does only in withheld drawings. Eight characters: province, force
+      code, four digits, 应急 — or, for the Ministry of Emergency Management's
+      own vehicles, province, FIVE digits, 应急, with no letter at all, and the
+      notice gives both worked examples itself. The scope is set by the same
+      notice: fire engines, aerial platforms, special-duty and logistics fire
+      vehicles, fire motorcycles, rescue command vehicles, rescue transport,
+      fire publicity vehicles and fire-scene survey vehicles, with the Ministry
+      of Emergency Management as issuing authority. Vehicles moved to these
+      plates from military plates get a one-off vehicle-and-vessel tax
+      exemption in the year of the change, which is how the notice quietly dates
+      the transfer of the force out of the armed police.
+
+  - id: cn-emergency-rescue-motorcycle-2018
+    class: government
+    categories: [motorcycle]
+    period: { start: 2018 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "999L"
+      regex: '\A\d{3}[A-Z]\z'
+      regex_strict: '\A\d{3}[XS]\z'
+      han:
+        prefix: { han: 应急, script: Han, role: classification, colour: red, note: "THE ONLY CHINESE PLATE WHOSE CLASSIFICATION CHARACTERS COME FIRST" }
+        province: { role: province, script: Han, position: 3, decode: "plates/_decode/cn-provinces.yml" }
+        suffix: none
+        printed: "应急<province><3 digits><force letter>"
+        printed_example: "应急京123X"
+        regex_informational: '\A应急[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新]\d{3}[XS]\z'
+        total_characters: 7
+    design:
+      plate: { w: 220, h: 140, unit: mm }
+      count: 1
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      accent: { color: "#D7000F", element: "the 应急 pair", hex_basis: observed }
+      border: { color: "#000000" }
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      note: "one plate, at the rear; the force letter is BLACK (the front/rear red-letter rule applies only to the car plate)"
+    region_encoding:
+      type: province-only
+      decode: "plates/_decode/cn-provinces.yml"
+      note: "the province character is the THIRD character, not the first — the 应急 pair leads"
+    sources:
+      - "https://www.gov.cn/zhengce/zhengceku/2018-12/11/content_5347765.htm  # 国办发〔2018〕114号 附件 一（二）: '字符共7位，依次为汉字“应急”、省（自治区、直辖市）汉字简称、三位序号和所属救援队伍代号组成。其中，所属救援队伍代号用X代表消防救援、S代表森林消防。'; 附件 二 '摩托车号牌规格为220毫米×140毫米'; 附件 三（二）(single rear plate, black force letter); accessed 2026-08-02"
+    notes: >-
+      The emergency-rescue motorcycle plate, and the one Chinese registration
+      number that inverts the § 3.2 element order: the two-character 应急 pair
+      leads, the province character follows it, and the force letter closes.
+      Seven characters against the car plate's eight. Any parser that assumes
+      "first character = province" for China is wrong exactly here, which is
+      why the rule is spelled out on the series rather than left to the header.


### PR DESCRIPTION
**PRD-PLATES gate L3 (S5W; manifest branch s4w-plates/l3-manifest).** Researcher-drafted to the L1/L2 standard: primary instruments quoted verbatim (native-language gazettes read in the original), instrument-dated periods with honest period_evidence, folklore flagged not asserted, non-Latin scripts modelled as decode/field facts with the ASCII projection stated. Independent staged lint over origin/main with ALL 28 wave files: `plates lint: 123 files, 1360 series ... OK`.

**cn**: 22 series, 17 pinned sources, lint green.

---

# Research dossier — cn (People's Republic of China, mainland)

PRD-PLATES gate L3. Deliverables in this directory:

| file | applies to | status |
|---|---|---|
| `cn.yml` | `plates/cn.yml` | 22 series, lint green |
| `cn-provinces.yml` | `plates/_decode/cn-provinces.yml` | 31 Table-2 rows + 10 classification characters |
| `cn-issuing-offices.yml` | `plates/_decode/cn-issuing-offices.yml` | GA 36-2007 Annex A, Table A.1 |
| `lint-proof.txt` | — | isolated run: `92 files, 967 series … OK` (baseline 91/945) |

Nothing in `/Users/javi/GitHub/vehiclesdb` was touched. Verification ran in a
copy of `plates/` (excluding `_art/`) plus `scripts/lint_plates.rb`.

---

## 0. Read this first — a repair record, because this pass was not the first

This directory already held `cn.yml` and `cn-issuing-offices.yml` from an
earlier pass in the same wave (file timestamps 18:02 and 18:12). **This pass
overwrote `cn-provinces.yml` before discovering them.** The loss is stated
plainly rather than papered over, together with what was done about it:

1. The destroyed file was **rebuilt from the same primary the earlier pass
   used** — GA 36-2007 § 5.7 表 2, read out of the 巩义市人民政府 republication
   via the Internet Archive — and to the same evidentiary standard. The 31 rows
   are *parsed* out of the instrument text and sorted on the table's own 序号,
   not transcribed; the codepoints are computed with `ch.ord`. An interim draft
   of this pass had tiered 19 of the 31 rows `secondary-wikipedia` off gov.cn
   省情 pages, and that draft was **discarded entirely** once the instrument
   turned up: everything now on the file is instrument-evidenced.
2. `cn.yml` was **not rewritten**. This pass's own draft of it — thinner, with
   `recall-only` on every series and no sourced serial grammar — was discarded
   in favour of the earlier one, which is materially better. What was done to
   `cn.yml` was repair and verification only, itemised in §5.
3. Two cross-file period divergences surfaced during verification and are
   recorded, not reconciled — §6.

---

## 1. The source situation, which is the whole story for China

**The governing instrument is a standard, and the state publishes its
existence and withholds its text.**

`GA 36-2018《中华人民共和国机动车号牌》` is the mandatory public-security
industry standard that fixes every Chinese plate. Its registry record on
全国标准信息公共服务平台 — run by the 国家标准技术审评中心 under 国家市场监督
管理总局 — is complete and was read in full. The same platform's full-text
endpoint for the same standard answers, verbatim:

> 您所查询的标准在本系统尚未公开，不公开理由如下：无

("the standard you have queried is not yet public in this system; reason for
non-disclosure: none".) Every other standard in the plate family behaves the
same way — GA 666-2018 (retroreflective film), GA/T 16.7-2012 (the plate-type
code list), GA/T 16.100-2015 (**the serial encoding rule, by title**),
GA/T 1287-2016, GA/T 804-2024 were each tested and each returned that sentence.
The one national standard that would give plate geometry, `GB 15741-1995
《汽车和挂车号牌板(架)及其位置》`, is refused for a different and stated reason
on openstd: 该标准采用了ISO、IEC等国际国外组织的标准，由于涉及版权保护问题，
本系统不提供文本阅读服务.

**The break in the wall.** The immediately preceding edition, GA 36-2007, is
republished **in full** by a Chinese municipal government — 巩义市人民政府,
www.hngy.gov.cn, dated 2012-11-15 — and that copy survives in the Internet
Archive. Clauses 3 to 7 and Annexes A and B of that text are the backbone of
`cn.yml` and of both decode files. Consequence, recorded on every affected
series: **claims taken from GA 36-2007 describe the system as it stood in
2007**, and the 2014 and 2018 change lists are not public.

This is the plates/gb.yml BS AU 145e finding in a harder form. There, one
paywalled British Standard held the plate's dimensions while a statutory
instrument held everything else. Here the format standard *and* the geometry
standard are both closed and there is no statutory instrument behind them that
spells the mark out — only a superseded edition someone re-hosted.

### 1.1 Pinned sources

All accessed **2026-08-02**.

| # | URL | What it proves |
|---|---|---|
| S1 | `https://hbba.sacinfo.org.cn/stdDetail/328b77ee80fdee1dee33d20e83d01d2ad128f380aa93c7dbe5c58c67d9d2075e` | GA 36-2018 registry record: 现行, 发布 2018-04-20, 实施 2018-05-01, 代替 GA 36-2014, CCS R82, ICS 43.040.60, 技术归口 公安部道路交通管理标准化技术委员会, 批准发布部门 公安部, 备案 66154-2019 / 2019-06-06, 起草单位 公安部交通管理科学研究所 etc. |
| S2 | `https://hbba.sacinfo.org.cn/portal/online/328b77ee…2075e` | The non-disclosure sentence quoted above. The negative finding, and it is load-bearing. |
| S3 | `https://hbba.sacinfo.org.cn/stdList` (POST `/stdQueryList`, `key=机动车号牌`) | The whole 机动车号牌 standard family — 15 records with 发布/实施/废止 dates and 代替标准 links, including all four GA 36 editions. |
| S4 | `https://web.archive.org/web/20150701102419/http://www.hngy.gov.cn/sitepublish/site1/wsbs/lyfwzl/jtfw/jdc/jdcfw/content_25106.html` | **GA 36-2007 FULL TEXT.** §3.1–3.2 definitions; §4 表1 classes/sizes/colours; §5.7 表2 province characters; §5.8 issuing-office rules; §5.9 表3 serial grammar; §5.10 classification characters; §5.11 separator; §6–7 materials and fixing; 附录A Table A.1 office codes; 前言 change list. |
| S5 | `https://hbba.sacinfo.org.cn/stdDetail/12b7710b682f0e13dfc423a325751920` | GA 36-2007 registry record — 发布 2007-09-28, 实施 2007-11-01, 代替 GA 36-1992, 废止. Provenance for S4 and the only evidence GA 36-1992 existed. |
| S6 | `https://www.gov.cn/zhengce/content/2018-12/11/content_5347765.htm` (also served at `/zhengce/zhengceku/2018-12/11/…`) | 国办发〔2018〕114号 — the emergency-rescue plate. The one Chinese plate instrument published openly and in full: encoding rule, X/S force codes, 480×140 and 220×140 mm, white/black/red, front-vs-rear force-code colour, priority passage, taxes. Nine specimen images attached. |
| S7 | `https://www.gov.cn/gongbao/content/2022/content_5682413.htm` | 《机动车登记规定》公安部令第164号 (施行 2022-05-01) in the State Council Gazette — the ministerial rule that delegates plate FORM to the MPS (第八十五条) and governs number selection and retention (第四十三条–第四十五条). |
| S8 | `https://web.archive.org/web/20161122160811/http://www.mps.gov.cn/n2254098/n4904352/c5550094/content.html` | 公安部交通管理局 2016-11-21: NEV pilot from **2016-12-01** in 上海/南京/无锡/济南/深圳; 渐变绿色 vs 黄绿双拼色; **5 positions → 6**; D = 纯电动, F = 非纯电动; the 145,400-vote design selection. |
| S9 | `https://web.archive.org/web/20181024152732/http://www.mps.gov.cn/n2253534/n2253535/n2253537/c5757013/content.html` | 公安部交通管理局 2017-08-13: the three-wave national rollout ladder verbatim; 76,000 pairs issued in the pilot; unique production serial identifier; 50选1 random draw. |
| S10 | `https://web.archive.org/web/20210527104341/https://www.fmprc.gov.cn/web/fw_673051/lbfw_673061/clgl1_673073/t1440531.shtml` | 外交部礼宾司（2017）礼字第1号 + 附件1《外交车辆管理办法》 (effective 2017-01-09; new-pattern diplomatic plates from **2017-02-06**; art. 7 = uniform pattern, issued by traffic police, **no characters stated**; consular vehicles expressly deferred). |
| S11 | `https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=A535F01DC2C23BEFBE80517AAF1AE5C5` | GB 15741-1995, 强制性, 现行, 发布 1995-11-16, 实施 1997-01-01, and the copyright-based text refusal. |
| S12 | `https://web.archive.org/web/20220222152934/http://www.npc.gov.cn/npc/c2376/200204/72c16fa92eba48ecae4a431f1d6be35a.shtml` | 中国人大网 on 非法生产、买卖军用标志罪: 军用车辆号牌 is a criminally protected 武装部队专用标志 — the boundary between military plates and the public-security system. |
| S13 | `https://web.archive.org/web/20240222001221/https://www.gov.cn/test/2005-06/15/content_18253.htm` | 中国政府网《中华人民共和国行政区划》: "在历史上和习惯上，各省级行政区都有简称" — the province abbreviations are **customary, not statutory**, which is why they live in a police standard. |
| S14 | `https://web.archive.org/web/20201104173257/http://www.zhengzhou.gov.cn/news1/3941801.jhtml` | 郑州市人民政府 2020-09-11: 豫V in use from 2020-09-16, approved by 公安部交通管理局 — the worked example of GA 36-2007 §5.8.3 adding an office code after 2007. |
| S15 | `https://www.gov.cn/zhengce/content/2018-12/11/W020230131856861149430.jpg` (+5 siblings) | The six official plate diagrams attached to S6. Reduced mechanically to five-colour palettes, they read white `#F8–#FD`, black `#0B–#18` and red `#CE3037–#E12D38` — an independent confirmation of S6's 白底黑字，配以红色汉字"应急" and the only Chinese plate colour in this dataset measured from an official specimen rather than observed. The images are **not** copied into the dataset; a colour measurement is a fact about a published specimen and PRD-PLATES §3's own-SVG rule is untouched. |
| S16 | `https://www.gov.cn/gongbao/2026/issue_12586/202602/content_7059934.html` | 《警车管理规定》 as amended by 公安部令第174号 — 2025年10月29日 approved, **2025-11-25 published, 2025-12-29 in force**, in Gazette 2026 No. 6. Confirms `cn.yml`'s police dates exactly. Its 附件2《警车号牌式样》 is referenced by article and **elided from the Gazette text** — which is precisely where the police serial grammar lives (§4 target 5). |
| S17 | `http://www.gov.cn/gongbao/content/2007/content_772748.htm` | 《临时入境机动车和驾驶人管理规定》公安部令第90号 (施行 2007-01-01) — the temporary-entry plate regime. |

**Wikipedia, per the §4 rule.** `en:Vehicle registration plates of China` and
`zh:中华人民共和国机动车号牌` / `zh:中华人民共和国民用机动车号牌` were mined as
finding aids: their citations were extracted mechanically and the instruments
they named were fetched. **S4 (the GA 36-2007 republication), S6, S8, S9, S10
and S12 all came out of that citation list.** No article text or table was
extracted into any deliverable in this directory, and no fact in the final
files carries a `secondary-wikipedia` tag — the interim draft that did was
discarded (§0). The mandatory-finding-aid rule earned its keep here more
clearly than anywhere else this pass has worked: without the zh-article's
reference list, GA 36-2007's full text would not have been found at all.

### 1.2 Method notes worth reusing on other CJK jurisdictions

- **`hbba.sacinfo.org.cn` has a usable JSON search.** `POST /stdQueryList` with
  `current`, `size`, `key` returns every 行业标准 record with epoch-millisecond
  `issueDate` / `actDate` / `fzDate`, `reviseStdCodes` and status. It is the
  fastest route to a Chinese industry standard's identity and lineage.
- **Beijing offset trap.** That JSON's epochs resolve to 2018-04-19 / 2018-04-30
  in UTC while the HTML detail page prints 2018-04-20 / 2018-05-01. The HTML
  dates are the Chinese calendar dates and are what the files record. A verifier
  reading the JSON will see the other pair; it is the same event.
- **`www.mps.gov.cn` returns HTTP 521** from this workstation (the ministry's
  origin, not a routable block). Every ministry page here is read through the
  Internet Archive.
- **`www.gov.cn` is directly reachable; its site search is not usable** — the
  `/search-gov/data` endpoint ignores `q` without an `athenaAppKey` signature
  and returns generic recent items. Content URLs work; search does not.
- **Encoding.** The 巩义市 GA 36-2007 page declares `charset=utf-8` and is
  **GB18030**. Decode it as GB18030 or you get mojibake and conclude the page is
  broken. This cost real time and is the single most useful line in this section.
- **DuckDuckGo, Bing, Baidu, Sogou, 360 and Mojeek were all unusable** from this
  workstation (CAPTCHA, JS shells, empty results). The Wayback CDX API plus
  `archive.org/wayback/available` substituted for search and is what found the
  gov.cn 省情 pages.

---

## 2. Modelling decisions a verifier should check first

### 2.1 The Han line (PRD-PLATES §2.6)

A Chinese registration number has **four** elements, and GA 36-2007 §3.2 says
so in terms: 省、自治区、直辖市的汉字简称 + 用英文字母表示发牌机关的代号 +
由阿拉伯数字和英文字母组成的序号 + 号牌分类用汉字简称. Two of the four are Han.

`_meta/separators.yml` fixes the dataset's serial alphabet as A–Z and 0–9, and
the lint enforces it, so no Han character may appear in `pattern`, `regex`,
`regex_strict` or `regex_statutory`. Unlike Greek — where Α U+0391 and A U+0041
are the same picture and the Latin form is lossless — **there is no Latin form
of 京**; "jing" is a reading, not a glyph, and no plate, registry or ANPR camera
emits it.

`cn.yml`'s answer: `format.pattern` / `format.regex` cover the Latin+digit
remainder (the substring an ALPR or a barrier actually matches), and
`format.han` carries the Han elements as structured data plus an **informational,
explicitly non-lint-validated** Han-aware regex for consumers holding a whole
plate string. The two decode files make the split mechanical.

**This is a schema amendment request, and it is the main ask of this dossier.**
PRD-PLATES §2.6 rule 3 anticipates it: a jurisdiction that prints a glyph
outside the serial alphabet "is a schema amendment, not a data entry". The
proposed shape: a `non_latin_elements` ruling in `_meta/separators.yml` naming
the scripts a mark may carry outside the serial alphabet, so that Japan, Korea,
Thailand, Greece's native rendering and China all resolve from one place rather
than each file inventing a convention. Until it lands, `cn.yml`'s convention is
stated once in its header rather than guessed per series.

### 2.2 The separator

GA 36-2007 §5.11, verbatim: 间隔符对机动车登记编号进行有效分割。间隔符可以和机动
车登记编号同样冲压并着色。 ("The separator effectively divides the registration
number. The separator may be embossed and coloured in the same way as the
registration number.") It is the raised mid-dot. **U+00B7 MIDDLE DOT is in
`_meta/separators.yml`'s FORGIVING set and not in its EMITTED set**, so no file
here spells it; every regex accepts an optional emitted separator `[- ]?` at
that position instead, exactly as plates/gb.yml does for the British
millimetre gap. Nothing is lost — the dot is forgiving-strippable by
construction.

The instrument-printed typography is in S6: 京·12345应急 and 京·X2345应急. Note
that on the emergency plate the dot follows the **province character**, not the
office letter — the only place in the Chinese record where the dot's position is
instrument-evidenced.

### 2.3 The serial grammar — the best-sourced thing in the file

GA 36-2007 §5.9.1, verbatim:

> a) 序号的每一位都使用阿拉伯数字；
> b) 序号的每一位可单独使用英文字母，26个英文字母中O和I不能使用；
> c) 序号中允许出现2位英文字母，26个英文字母中O和I不能使用。

and §5.9.2 a) fixes **which** positions may hold letters, in 表3 with two widths
(四位数 / 五位数) and eleven combinations, released in order:
序号用数字和字母组合方式的使用应按表3的规定依次有序使用。序号的使用率超过60％后，
应经省级公安机关交通管理部门批准并报公安部交通管理局备案后，依次启用下一种组合方式。

`cn-small-car-1992`'s `regex_strict` is that table, mechanically — all eleven
alternations, O and I excluded. It was re-derived independently in this pass
against the instrument text and **matches row for row**. It is the tightest
sourced serial grammar this programme has secured outside the UK's Schedule 3
Table A.

### 2.4 The I/O asymmetry — the thing almost every other dataset gets wrong

The O/I exclusion is a rule about the **serial**. The **issuing-office letter**
uses the full alphabet: GA 36-2007's 前言 lists 增加了发牌机关代号"I" among that
edition's changes, and Annex A gives **O** to the 省、自治区公安厅交通管理局、处
车辆管理所 in every province (the "O 牌"). So `[A-Z]` for the office letter and
`[0-9A-HJ-NP-Z]` for the serial in the same expression is not an inconsistency —
it is the sourced rule, and any validator that strips I and O everywhere is
wrong on the second character of every Chinese plate.

### 2.5 Period policy

The system in force is the 92-pattern created by GA 36-1992, whose existence and
designation year come from GA 36-2007's own 前言 (本标准代替GA36-1992) and the
registry's 代替标准 field. GA 36-1992 predates the filing database and no
发布/实施 date for it could be pinned, so series GA 36-2007 shows unchanged carry
`period: { start: 1992 }` with `period_evidence: enabling-instrument`. Where the
2007 前言 records that edition as having **added** a class or its character, the
series is dated 2007 with the foreword quoted on it.

---

## 3. Folklore — named, and deliberately not asserted

`cn.yml` cites these by number; this is the register.

**F-1 — "trialled 1992, nationwide 1 July 1994."** The universal account of the
92-pattern's rollout. No primary for either date in the accessible record.
GA 36-1992 is attested only as a title in a later foreword. *Not asserted; no
series starts in 1994.*

**F-2 — the embassy serial is a three-digit country code plus a three-digit
serial.** Repeated everywhere. GA 36-2007 sources the embassy plate's colours,
size, count, layout and 使 character and says **nothing** about its serial.
*Not asserted; `cn-embassy-*` carries a deliberately wide `\A\d{4,6}\z` and
`matching: recall-only`.*

**F-3 — "O" is a police plate.** What is sourced is narrower and duller: Annex A
gives O to the provincial public-security department's own vehicle office in
every province. Everything beyond that — that O marks police vehicles, that
provinces have "abolished" it — is unsourced. *The Annex A fact is in the decode
file; nothing else is.*

**F-4 — 粤Z港/粤Z澳 replaced the 86-pattern 广东02/广东03 plates in 2001.** No
primary. *Not asserted; `cn-hkmacau-crossborder-2007` is dated on the 2007
foreword addition of 港 and 澳 with `period_evidence: instrument-in-force`.*

**F-5 — the NEV plate went nationwide on 15 June 2018.** The Ministry's own
August 2017 announcement gives the national step as a **half-year**
(2018年上半年，全国所有城市全面启用新号牌), not a date, and no completion
announcement was located. *`period.rollout.national` records the half-year and
`national_note` names the folklore date.*

**F-6 — the NEV plate is 480 × 140 mm.** GA 36-2007 predates the class and
GA 36-2018 is withheld. *Not asserted. Note the tension worth keeping: the
emergency-rescue car plate created two years later **is** 480 × 140 mm and **is**
sourced (S6), which makes the NEV figure plausible and still unproven.*

**F-7 — the powertrain letter is the FIRST serial position on a small NEV plate
and the LAST on a large one.** Every popular account says so. The Ministry gives
the letters (D = 纯电动, F = 非纯电动) and never their position. *Not asserted —
and it is the highest-value verifier target in this jurisdiction (§4).*

**F-8 — "Chinese plates never use I or O."** Half true, and the half that is
false is the one a validator acts on. See §2.4. *Corrected in the data rather
than repeated.*

**F-9 — the province abbreviation is "the" abbreviation.** Six provincial-level
divisions have two customary abbreviations and Table 2 picks one: 四川 川 not 蜀,
贵州 贵 not 黔, 云南 云 not 滇, 陕西 陕 not 秦, 甘肃 甘 not 陇, 上海 沪 not 申.
A pipeline that maps 简称 → province by dictionary rather than by Table 2 will
disagree with the road. *Recorded per row as
`customary_alternate_not_on_plates`, so the wrong answer cannot be reached from
the file.*

**F-10 — China had personalised plates.** A 2002 experiment is widely described
and was withdrawn. No primary for either end was secured. *Absent from the data;
recorded here only as unverified history.*

---

## 4. Gaps and verifier targets, ranked

1. **GA 36-2018's text.** Everything else follows from it. Routes not yet tried:
   a provincial 公安厅 or 交警总队 republication of the 2018 edition (the 2007
   one surfaced exactly that way, from a county-level city); a 地方标准 or
   procurement annex quoting it; a CNKI/wanfang record.
2. **The NEV powertrain-letter position (F-7).** One sentence in GA 36-2018 or in
   `GA/T 16.100-2015《机动车序号编码规则》` turns `cn-nev-small-2016`'s regex from
   a shape into a diagnostic expression. Highest value per unit of effort.
3. **`GA/T 16.7-2012《道路交通管理信息代码 第7部分：机动车号牌种类代码》`.** The
   closed plate-type code list. It would settle every `class:` question in §5
   below at once.
4. **The embassy serial grammar (F-2).**
5. **《警车管理规定》公安部令第174号's 《警车号牌式样》 annex.** The Gazette prints
   （以上附件略，详情请登录公安部网站） and mps.gov.cn was unreachable. The police
   serial grammar is behind it.
6. **`NY 345.1-2005《拖拉机号牌》`.** GA 36-2007 表1 row 19 delegates tractor
   plates to it in terms. The register serves it as a scanned image with no text
   layer, so **no tractor series is modelled** — a known hole in an
   agricultural-heavy jurisdiction.
7. **The 2014 edition's change list.** The gap between the readable 2007 text and
   the current 2018 one runs through it.
8. **A corpus test.** The provincial 122.gov.cn platforms publish
   互联网预选号牌号池 (available-number pools) through the official
   交通安全综合服务管理平台. If that endpoint can be read, it is a government
   corpus of real, currently-issuable Chinese marks — the PRD §5.2 corpus test
   for China, and no competitor has one. This pass identified the platform
   (sh.122.gov.cn responds) but did not reach the endpoint.

---

## 5. Requests to the maintainers

### 5.1 `_meta/classes.yml` — four vocabulary additions

`cn.yml` records a `class_note` wherever it had to use an approximate value, so
a consumer reading `class:` alone is never silently misled. The four:

| needed | used instead | why |
|---|---|---|
| `low-speed` | `agricultural` | 低速车号牌 (GA 36-2007 表1 row 15): low-speed goods vehicles, three-wheelers, wheeled self-propelled machinery. 300×165 mm, unique in the range. |
| `driving-school` | `standard` | 教练汽车/摩托车号牌 (row 7) — a distinct legal issuance category with its own 学 character. |
| `cross-border` | `standard` | 港澳入出境车号牌 (row 6). `temporary` is wrong (multi-year permits); `export`/`transit` wrong in the other direction. |
| `emergency` | `government` | 应急救援专用号牌 (国办发〔2018〕114号). `government` is defensible — the national comprehensive fire-and-rescue force moved out of the armed forces into the civil Ministry of Emergency Management in 2018, and this plate exists to mark that transfer — but it is a fit, not a match. |

### 5.2 `_meta/separators.yml` — the non-Latin ruling

See §2.1. This is the schema amendment PRD-PLATES §2.6 rule 3 anticipates, and
China, Japan, Korea and Thailand all need it in the same wave.

---

## 6. Cross-file divergences — recorded, not averaged (PRD-PLATES §5.3)

Found while verifying this pass's rebuilt decode file against the earlier pass's
`cn.yml`. Both are left standing; a verifier resolves them.

1. **使 (embassy).** `cn-provinces.yml` dates the character **2007** on
   GA 36-2007's 前言, which lists 使 among the classification characters that
   edition added. `cn.yml` dates `cn-embassy-car-1992` and
   `cn-embassy-motorcycle-1992` to **1992** with `period_evidence:
   instrument-in-force`. Both can be true — an embassy plate very probably
   existed before 2007 in a construction the 2007 edition then standardised —
   but nothing secured proves it, and the foreword is the harder evidence.
2. **超 (over-dimension temporary plate).** Same foreword line dates the
   character to 2007; `cn.yml` carries it as one of two suffixes on
   `cn-temporary-travel-1992`, whose other suffix 试 is a 1992 character. Either
   split the series or move the start.

Both are written into `cn-provinces.yml` under `limits.cross_file_divergences`
so they cannot be lost if this dossier is read separately.

---

## 7. Repairs applied to `cn.yml` (earlier pass's file)

The file did not parse as YAML when this pass received it. Three defects, all
mechanical, all fixed; **no claim, citation, period, regex or note was
changed.**

1. **Line 207 — mapping key after a sequence at the same indent.** `instrument.lineage`
   was a four-item sequence followed by `    source:` at the sequence's own
   indent, which Psych rejects. Renamed to `instrument.lineage_source` at the
   parent level.
2. **Lines 1074, 1373, 1424 — unescaped `"` inside double-quoted scalars.** Three
   source lines quote Chinese instrument text containing ASCII double quotes
   (字母"D"代表纯电动汽车 …), which terminate the YAML scalar early. Converted to
   the Chinese quotation marks “ ” — which is what the instruments themselves
   print (the source HTML carries `&ldquo;`/`&rdquo;`), so the repair is more
   faithful to the original than the state it replaced, not less.
3. The same class of defect was found and fixed once in this pass's own
   `cn-provinces.yml` before delivery.

**Citation audit.** All **14 distinct URLs** pinned across the three files were
re-fetched in this pass and all 14 resolve. The only unreachable one is
`https://www.mps.gov.cn/` itself, carried as `authority.url` with its HTTP 521
recorded in an adjacent `url_status` — which is the correct value for the field
regardless of whether this workstation can reach it. Two citations the earlier
pass added without this pass having seen them were checked in full and are
sound: 公安部令第174号 (S16, dates confirmed against the Gazette text
character for character) and 公安部令第90号 (S17).

**Lesson for the wave, and it is a cheap one:** every draft should be run
through `YAML.safe_load_file` before it is written to the deliverable
directory. `lint_plates.rb` catches this — but only for files inside `plates/`,
and only once someone runs it.

---

## 8. Lint proof

Run in an **isolated** workspace (`scratchpad/cnws`) holding canonical
`plates/` minus `_art/`, plus `scripts/lint_plates.rb`, plus these three cn
files and nothing else. The isolation matters: the shared `scratchpad/work`
tree that several agents in this wave use had picked up sibling drafts
(`ar.yml`, `mx.yml`), so a proof run there would have counted other people's
work. The numbers below are cn's alone.

```
BASELINE (canonical only)
  plates lint: 91 files, 945 series
  plates lint: matching recall-only=200 strict=745 | twins regex_statutory=83 regex_strict=271
  plates lint: OK

WITH cn.yml + _decode/cn-provinces.yml + _decode/cn-issuing-offices.yml
  plates lint: 92 files, 967 series
  plates lint: matching recall-only=216 strict=751 | twins regex_statutory=83 regex_strict=277
  plates lint: OK
```

Delta: **+1 file, +22 series** (16 `recall-only`, 6 `strict`), **+6
`regex_strict` twins**, and two `_decode` sidecars which the lint parse-checks
but does not count. Exactly what `cn.yml` contains. `plates/_art` was excluded
from the workspace, so the art gate is skipped, as intended.

