### PR TITLE
plates L3: in — in (S5W)

### DIFF
--- a/plates/_decode/in-state-codes.yml
+++ b/plates/_decode/in-state-codes.yml
@@ -1,0 +1,169 @@
+# plates/_decode/in-state-codes.yml — the Indian State / Union Territory
+# registration codes. DRAFT for human verification, and READ THE NEXT
+# PARAGRAPH BEFORE USING ANY ROW.
+#
+# THE SOURCE FINDING, and it is the least comfortable one in this jurisdiction:
+# this table IS a closed statutory list, its instrument IS identified, and the
+# instrument's text was NOT reached.
+#
+#   * The enabling statute is MVA 1988 § 41(6): the registration mark consists
+#     of "one of the groups of such of those letters ... as are ALLOTTED TO THE
+#     STATE BY THE CENTRAL GOVERNMENT from time to time BY NOTIFICATION IN THE
+#     OFFICIAL GAZETTE". So the codes are neither in the Act nor in the Central
+#     Motor Vehicles Rules — they are a gazette allotment, exactly as the German
+#     district codes are a Bundesanzeiger publication and the British memory
+#     tags are a DVLA leaflet. Every chapter of MoRTH's own consolidated CMVR
+#     was fetched and searched: the word "Andhra" does not appear in any of
+#     them. The codes are not in the rules.
+#   * The notification is S.O. 444(E), dated the 12th June, 1989, Gazette of
+#     India, Extraordinary, Part II, Section 3, Sub-section (ii). That
+#     identification is not inferred: it is quoted, in terms, in two later
+#     notifications fetched verbatim for this pass, each of which amends "the
+#     TABLE" of that notification.
+#   * S.O. 444(E) itself predates e-Gazette's digital archive (which begins in
+#     the 2000s), and morth.nic.in was rebuilt as a single-page application
+#     whose legacy document paths now return the app shell rather than a file.
+#     The table was not reached. It is not on Wikipedia either — the
+#     en-wikipedia RTO-districts article carries no government citation for the
+#     state codes at all, which is why this file exists rather than a copy.
+#
+# CONSEQUENCE, STATED ONCE AND ENFORCED PER ROW: exactly TWO rows below are
+# instrument-evidenced (LA and TG, from the amendments in hand). Every other
+# row carries `evidence: corroboration-only` and `verify: true`. The codes are
+# universally used and are not in serious doubt as facts about the world; they
+# are simply not sourced to the standard this dataset holds itself to, and a
+# dataset that cites a source per claim must say so rather than quietly ship
+# thirty-eight unsourced rows. PINNING S.O. 444(E) IS THE SINGLE HIGHEST-VALUE
+# VERIFIER TASK FOR INDIA.
+#
+# A NOTE ON THE SERIAL NUMBERS, for whoever pins it. The two amendments in hand
+# reveal the table's shape: S.O. 4262(E) inserts Ladakh at "17A" (i.e. after
+# entry 17) and S.O. 1306(E) substitutes Telangana at "29A" (i.e. an entry
+# already inserted after entry 29). Both are consistent with a single list of
+# States AND Union Territories in one alphabetical sequence, in which new
+# entities are inserted with a letter suffix rather than renumbering — under
+# that reading entry 29 is Tamil Nadu, which places Telangana at 29A exactly.
+# That reading is written here as a NAVIGATION AID for the verifier and is
+# emphatically NOT data: no row below is justified by it.
+#
+# Referenced by: in-standard-1989, in-standard-hsrp-2004, in-transport-1989,
+# in-transport-hsrp-2004, in-electric-green-2018, in-temporary-2021,
+# in-dealer-1989, in-dealer-2022, in-vintage-2021 (plates/in.yml) via
+# region_encoding. NOT referenced by in-bh-2021 or by any diplomatic series:
+# those marks contain no state code (see their region_encoding_note).
+jurisdiction: in
+topic: state-codes
+authority:
+  name: "Central Government (Ministry of Road Transport and Highways), by notification under section 41(6) of the Motor Vehicles Act, 1988 — principal notification S.O. 444(E) dated 12 June 1989"
+  url: "https://morth.nic.in/"
+sources:
+  - "https://web.archive.org/web/20250804185944id_/https://www.indiacode.nic.in/bitstream/123456789/1798/1/aA1988-59.pdf  # MVA 1988 § 41(6) verbatim — the letters are 'allotted to the State by the Central Government from time to time by notification in the Official Gazette'; accessed 2026-08-02"
+  - "https://web.archive.org/web/20210514201915id_/https://morth.nic.in/sites/default/files/notifications_document/S.O.%204262%28E%29%20dated%2025%20th%20November%20Registration%20Mark%20for%20Ladakh%20LA.pdf  # S.O. 4262(E), 25 November 2019: 'In the Table to the said notification, after serial number 17 and the entries relating thereto, the following serial number and entities shall be inserted, namely:- “17A. Ladakh LA”.' Names the principal notification as S.O.444(E) dated 12 June 1989 and the then-last amendment as S.O.1486(E) dated 9 June 2014; accessed 2026-08-02"
+  - "https://web.archive.org/web/20240706034252id_/https://morth.nic.in/sites/default/files/notifications_document/8-SO%201306(E)%2012%20March%202024%20TG%20registration%20mark%20Telangana.pdf  # S.O. 1306(E), 12 March 2024: 'In the said notification, in the TABLE, for serial number 29A and the entries relating thereto, the following entries shall be substituted, namely:- “29A. Telangana TG”.' Names the then-last amendment as S.O. 2339(E) dated 14 July 2020; accessed 2026-08-02"
+  - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # CMVR rule 50(3) ('the State code and registering authority code forming the first line') and rule 35(1)/(3) ('AB—Represent State Code'), the rules that consume this table; accessed 2026-08-02"
+period: { start: 1989 }
+period_evidence: enabling-instrument
+period_note: >-
+  1989 is the date of the principal notification, S.O. 444(E) of 12 June 1989,
+  made three weeks before the Motor Vehicles Act 1988 came into force on
+  1 July 1989. It is NOT the date the two-letter codes came into use: codes of
+  this shape were carried on Indian plates under the Motor Vehicles Act 1939
+  regime as well, and the pre-1989 allotment instrument was not reached and is
+  not claimed here. A plate older than 1989 must be treated as unresolved
+  rather than decoded through this table.
+
+# ---------------------------------------------------------------------------
+# THE TRAPS a parse API must carry. Each is a real, dated change of meaning.
+# ---------------------------------------------------------------------------
+cautions:
+  dd_changed_meaning: >-
+    DD meant DAMAN AND DIU (a Union Territory) before 26 January 2020 and means
+    DADRA AND NAGAR HAVELI AND DAMAN AND DIU (the merged Union Territory) after
+    it. Same two letters, different territory, and plates issued under both
+    meanings are on the road. The merger notification is reported as S.O. 295(E)
+    of 25 January 2020 and was NOT reached; the DN row below (Dadra and Nagar
+    Haveli, the pre-merger UT) is what makes the change visible in the data.
+  ch_is_not_chhattisgarh: >-
+    CH is CHANDIGARH. Chhattisgarh is CG. The ISO 3166-2 code for Chhattisgarh
+    is IN-CT, which matches NEITHER — a consumer joining this table to ISO
+    3166-2 must map, not assume.
+  renamed_states_kept_issuing_the_old_code: >-
+    OR (Odisha, before the State's 2011 rename took effect on plates) and UA
+    (Uttaranchal, before the 2007 rename to Uttarakhand) are historic codes on
+    live plates, not errors. So is TS (Telangana, 2014 to 2024), which S.O.
+    1306(E) replaced with TG in March 2024 — the newest code change in India and
+    the one most likely to be wrong in every competing dataset.
+  the_district_is_not_here: >-
+    This table decodes the FIRST TWO LETTERS only. The two digits that follow
+    are the registering authority (RTO district) code, which no central
+    instrument enumerates and which each State creates, merges and renumbers on
+    its own. There are well over a thousand of them. They are deliberately not
+    tabled (PRD-PLATES § 2.4 mechanism-note rule) and a decode must not guess.
+
+# ---------------------------------------------------------------------------
+# CODES. `evidence: instrument` = the row is quoted verbatim in a gazette
+# notification held for this pass. `evidence: corroboration-only` = the code is
+# in universal use and is consistent with the amendment chain, but no primary
+# was reached for it; `verify: true` marks it for the human pass.
+# Ordered alphabetically by code.
+# ---------------------------------------------------------------------------
+codes:
+  - { code: "AN", name: "Andaman and Nicobar Islands", type: union-territory, evidence: corroboration-only, verify: true }
+  - { code: "AP", name: "Andhra Pradesh", type: state, evidence: corroboration-only, verify: true }
+  - { code: "AR", name: "Arunachal Pradesh", type: state, evidence: corroboration-only, verify: true }
+  - { code: "AS", name: "Assam", type: state, evidence: corroboration-only, verify: true }
+  - { code: "BR", name: "Bihar", type: state, evidence: corroboration-only, verify: true }
+  - { code: "CG", name: "Chhattisgarh", type: state, evidence: corroboration-only, verify: true, since: 2000, since_note: "State created 1 November 2000 by the Madhya Pradesh Reorganisation Act, 2000; the allotting amendment to S.O. 444(E) was not reached" }
+  - { code: "CH", name: "Chandigarh", type: union-territory, evidence: corroboration-only, verify: true }
+  - { code: "DD", name: "Dadra and Nagar Haveli and Daman and Diu", type: union-territory, evidence: corroboration-only, verify: true, meaning_changed: 2020, meaning_note: "before the 2020 merger these letters denoted Daman and Diu alone — see cautions.dd_changed_meaning" }
+  - { code: "DL", name: "Delhi (National Capital Territory)", type: union-territory, evidence: corroboration-only, verify: true }
+  - { code: "GA", name: "Goa", type: state, evidence: corroboration-only, verify: true }
+  - { code: "GJ", name: "Gujarat", type: state, evidence: corroboration-only, verify: true }
+  - { code: "HP", name: "Himachal Pradesh", type: state, evidence: corroboration-only, verify: true }
+  - { code: "HR", name: "Haryana", type: state, evidence: corroboration-only, verify: true }
+  - { code: "JH", name: "Jharkhand", type: state, evidence: corroboration-only, verify: true, since: 2000, since_note: "State created 15 November 2000; allotting amendment not reached" }
+  - { code: "JK", name: "Jammu and Kashmir", type: union-territory, evidence: corroboration-only, verify: true, note: "a State until 31 October 2019, a Union Territory since; the code did not change, and Ladakh was carved out with its own code (LA)" }
+  - { code: "KA", name: "Karnataka", type: state, evidence: corroboration-only, verify: true }
+  - { code: "KL", name: "Kerala", type: state, evidence: corroboration-only, verify: true }
+  - { code: "LA", name: "Ladakh", type: union-territory, evidence: instrument, verify: false, since: 2019, source: "S.O. 4262(E), 25 November 2019, inserting '17A. Ladakh LA' into the Table to S.O. 444(E); in force from the date of its publication in the Official Gazette" }
+  - { code: "LD", name: "Lakshadweep", type: union-territory, evidence: corroboration-only, verify: true }
+  - { code: "MH", name: "Maharashtra", type: state, evidence: corroboration-only, verify: true }
+  - { code: "ML", name: "Meghalaya", type: state, evidence: corroboration-only, verify: true }
+  - { code: "MN", name: "Manipur", type: state, evidence: corroboration-only, verify: true }
+  - { code: "MP", name: "Madhya Pradesh", type: state, evidence: corroboration-only, verify: true }
+  - { code: "MZ", name: "Mizoram", type: state, evidence: corroboration-only, verify: true }
+  - { code: "NL", name: "Nagaland", type: state, evidence: corroboration-only, verify: true }
+  - { code: "OD", name: "Odisha", type: state, evidence: corroboration-only, verify: true, replaced: "OR", replaced_note: "the OR code remained in issue until the change; see the withdrawn block" }
+  - { code: "PB", name: "Punjab", type: state, evidence: corroboration-only, verify: true }
+  - { code: "PY", name: "Puducherry", type: union-territory, evidence: corroboration-only, verify: true, note: "the territory was renamed from Pondicherry in 2006; the code did not change" }
+  - { code: "RJ", name: "Rajasthan", type: state, evidence: corroboration-only, verify: true }
+  - { code: "SK", name: "Sikkim", type: state, evidence: corroboration-only, verify: true }
+  - { code: "TG", name: "Telangana", type: state, evidence: instrument, verify: false, since: 2024, source: "S.O. 1306(E), 12 March 2024, substituting '29A. Telangana TG' for the previous entry 29A in the Table to S.O. 444(E), with effect from the date of publication in the Official Gazette" }
+  - { code: "TN", name: "Tamil Nadu", type: state, evidence: corroboration-only, verify: true }
+  - { code: "TR", name: "Tripura", type: state, evidence: corroboration-only, verify: true }
+  - { code: "UK", name: "Uttarakhand", type: state, evidence: corroboration-only, verify: true, replaced: "UA" }
+  - { code: "UP", name: "Uttar Pradesh", type: state, evidence: corroboration-only, verify: true }
+  - { code: "WB", name: "West Bengal", type: state, evidence: corroboration-only, verify: true }
+
+# ---------------------------------------------------------------------------
+# WITHDRAWN CODES. Rows are never deleted (PRD-PLATES § 2.4 period discipline):
+# every one of these is still on live, valid plates, because an Indian
+# registration mark is not reissued when a State is renamed or merged.
+# ---------------------------------------------------------------------------
+withdrawn_codes:
+  - { code: "OR", name: "Orissa / Odisha", type: state, until: 2012, evidence: corroboration-only, verify: true, note: "superseded by OD; the change is commonly dated to 2012 and no primary was reached for it" }
+  - { code: "TS", name: "Telangana", type: state, since: 2014, until: 2024, evidence: instrument-adjacent, verify: true, note: "entry 29A was inserted for Telangana on the State's creation (S.O. 1486(E), 9 June 2014, named as the then-last amendment by S.O. 4262(E)) and SUBSTITUTED with the TG code by S.O. 1306(E) on 12 March 2024. That the superseded code read TS is not quoted by the substituting notification — S.O. 1306(E) prints only the new entry — so the letters themselves are corroboration-only while the entry's existence, position and end date are instrument-evidenced." }
+  - { code: "UA", name: "Uttaranchal", type: state, since: 2000, until: 2007, evidence: corroboration-only, verify: true, note: "the State was renamed Uttarakhand on 1 January 2007; superseded by UK" }
+  - { code: "DN", name: "Dadra and Nagar Haveli", type: union-territory, until: 2020, evidence: corroboration-only, verify: true, note: "merged with Daman and Diu on 26 January 2020 into the UT that now carries DD; see cautions.dd_changed_meaning" }
+
+# ---------------------------------------------------------------------------
+# NOT A CODE. Recorded so that a decoder does not go looking.
+# ---------------------------------------------------------------------------
+not_state_codes:
+  - { token: "BH", meaning: "Bharat (India) — the national, geography-free series created by CMVR rule 50(8), G.S.R. 594(E) of 26 August 2021. Position two in the mark, not position one, and preceded by a two-digit YEAR rather than followed by a district.", evidence: instrument }
+  - { token: "VA", meaning: "Vintage — CMVR rule 81B, G.S.R. 492(E) of 15 July 2021. Position two, after the state code.", evidence: instrument }
+  - { token: "TC", meaning: "Trade certificate — CMVR rule 35(3) as substituted, G.S.R. 703(E) of 14 September 2022. Position five, near the end of the mark.", evidence: instrument }
+  - { token: "CD", meaning: "Corps diplomatique — CMVR rule 76(6). Preceded by a Ministry of External Affairs mission number, not a state code.", evidence: instrument }
+  - { token: "CC", meaning: "Consular corps — CMVR rule 76(7). Also, and this is the collision worth knowing about, CC is not a State: an Indian string beginning with two digits and then CC is consular, while a string beginning with two letters is an ordinary mark.", evidence: instrument }
+  - { token: "UN", meaning: "United Nations organisations — CMVR rule 76-A, G.S.R. 644 of 25 September 1995. Note NL is Nagaland but UN is not a State.", evidence: instrument }
+  - { token: "CDP / CCP", meaning: "home-based non-diplomatic officials of missions and consular posts — CMVR rule 76-B, G.S.R. 395(E) of 16 July 1997.", evidence: instrument }

--- a/plates/in.yml
+++ b/plates/in.yml
@@ -1,0 +1,1172 @@
+# plates/in.yml — India (PRD-PLATES gate L3). DRAFT for human verification.
+#
+# EVERY format, colour, dimension and class claim in this file comes from one
+# of five primaries, all fetched and quoted verbatim in the dossier:
+#
+#   * the Motor Vehicles Act, 1988 (59 of 1988) — the enabling STATUTE, in
+#     force 1 July 1989 (S.O. 368(E), 22 May 1989). India Code PDF.
+#   * the Central Motor Vehicles Rules, 1989 (G.S.R. 590(E), 2 June 1989) —
+#     rules 33-51 (registration + display), 76-80 (diplomatic), 81A-81C
+#     (vintage), read from MoRTH's own consolidated chapter PDF.
+#   * the Gazette of India (egazette.gov.in) for the instruments that create
+#     the newer series: G.S.R. 594(E) 26-8-2021 (BH), G.S.R. 492(E)
+#     15-7-2021 (vintage), G.S.R. 703(E) 14-9-2022 (trade), G.S.R. 240(E)
+#     31-3-2021 (temporary), G.S.R. 749(E) 7-8-2018 (EV green),
+#     G.S.R. 633(E) 23-6-2017 (consular colours), S.O. 6052(E) 6-12-2018
+#     (High Security Registration Plates Order, 2018).
+#   * S.O. 4262(E) 25-11-2019 and S.O. 1306(E) 12-3-2024 — two amendments to
+#     the state-code notification, which are how that notification's identity
+#     was recovered (see finding 2).
+#
+# FIVE STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. THE COMPOSITION OF AN ORDINARY INDIAN REGISTRATION MARK IS IN NO RULE.
+#    This is the German/British delegation pattern arriving in India by a
+#    third route. MVA 1988 § 41(6), verbatim: "The registering authority
+#    shall assign to the vehicle, for display thereon, a distinguishing mark
+#    (in this Act referred to as the registration mark) consisting of one of
+#    the groups of such of those letters and followed by such letters and
+#    figures as are allotted to the State by the Central Government from time
+#    to time BY NOTIFICATION IN THE OFFICIAL GAZETTE, and displayed and shown
+#    on the motor vehicle in such form and in such manner as may be prescribed
+#    by the Central Government." So: the LETTERS are a gazette allotment (the
+#    state-code notification, finding 2); the FORM AND MANNER are the rules
+#    (rule 50, rule 51). Nowhere does any instrument say "two letters, two
+#    digits, up to three letters, four numerals". That shape is reconstructed
+#    here from four rules that define OTHER marks BY REFERENCE to it, each
+#    quoted on its series below:
+#      rule 50(3)  "the State code and registering authority code forming the
+#                  first line and the rest forming the second line"
+#      rule 35(3)  "AB—Represents State Code, 12—Represents RTO Code"
+#      rule 53C    "AB- Represent State Code; 1234- Serial Number ..."
+#      rule 81B    "XX stands for State code, YY will be a two letter series"
+#    The 1-to-3-letter series group and the 4-digit 0001-9999 serial are
+#    therefore recorded as `format.composition_evidence: reconstructed` on the
+#    standard series, with the reconstruction spelled out. Do not upgrade that
+#    tag without the state-code notification in hand.
+#
+# 2. THE STATE-CODE LIST IS S.O. 444(E), 12 JUNE 1989 — AND IT IS NOT ONLINE.
+#    Two gazette notifications fetched for this pass name it in terms:
+#    S.O. 4262(E) (25-11-2019) inserts "17A. Ladakh LA" and S.O. 1306(E)
+#    (12-3-2024) substitutes "29A. Telangana TG", both "in the Table to the
+#    said notification ... number S.O.444(E), dated the 12th June, 1989".
+#    e-Gazette's archive does not reach 1989 and MoRTH's site was rebuilt as
+#    a single-page app whose document paths now return the app shell, so the
+#    TABLE ITSELF was not reached. Consequence, stated plainly: two rows of
+#    plates/_decode/in-state-codes.yml are instrument-evidenced and the rest
+#    are not. The decode file says so per row. This is the single highest-value
+#    verifier target for India.
+#
+# 3. HSRP IS A DESIGN REGIME LAID OVER AN UNCHANGED MARK, AND ITS DATE IS A
+#    TRAP. Rule 50(1) was substituted by G.S.R. 221(E) (28-3-2001) "as amended
+#    by S.O. 938(E), dated 24-9-2001, S.O. 499(E), dated 9-5-2002 and S.O.
+#    59(E), dated 21-1-2003 (w.e.f. 1-1-2004)" — so the security-licence-plate
+#    obligation bites from 1 January 2004, not 2001 and not 2005. The plates
+#    did not actually appear nationwide until the Motor Vehicles (High Security
+#    Registration Plates) Order, 2018 (S.O. 6052(E), 6-12-2018) forced OEM
+#    fitment "for a new vehicle to be sold on or after 1st April, 2019". Both
+#    dates are recorded; the ENFORCEMENT gap between them is in the notes and
+#    is not modelled as a period.
+#
+# 4. COLOUR IS PRESCRIBED BY CLASS OF USE, NOT BY VEHICLE KIND, AND EVERY
+#    COLOUR HERE IS NAMED-BUT-NOT-NUMBERED. Rule 50(2)(d) (substituted by
+#    G.S.R. 901(E), 13-12-2001): transport vehicles "in black colour on yellow
+#    background", "in other cases, in black colour on white background". Rule
+#    50(2A) (inserted by G.S.R. 749(E), 7-8-2018) adds battery-operated
+#    vehicles: yellow on green for transport, white on green otherwise. Rule
+#    39(2) (substituted 2022) makes the trade mark "white colour on red
+#    background". Rule 77(1) fixes the diplomatic/consular/CDP colours. NOT ONE
+#    of these instruments gives a chromaticity coordinate or a colour standard,
+#    so every hex in this file carries `hex_basis: observed` inside a
+#    statutorily NAMED colour — the plates/gb.yml and plates/de.yml posture.
+#
+# 5. THE ARMED FORCES ARE OUTSIDE THIS FILE, BY STATUTE. MVA § 60(1):
+#    "Such authority as the Central Government may, by notification in the
+#    Official Gazette, specify, may register any motor vehicle which is the
+#    property or for the time being under the exclusive control of the Central
+#    Government and is used for Government purposes relating to the defence of
+#    the country ... and any vehicle so registered shall not ... require to be
+#    registered otherwise under this Act." The broad-arrow Ministry of Defence
+#    mark is therefore issued under a different regime whose instrument was NOT
+#    reached in this pass. No military series is invented here; it is a
+#    recorded gap.
+#
+# REGEX POLICY (identical to plates/gb.yml, plates/nl.yml, plates/de.yml):
+# `format.regex` is the LINT-ROUND-TRIPPABLE regex — the lint generates
+# serials from `format.pattern` (L -> any A-Z, 9 -> any 0-9) and requires the
+# regex to accept all of them, so `regex` can never be narrower than the
+# pattern's own alphabet. `format.regex_strict` carries the tighter sourced
+# form: the closed state-code alternation, the 01-99 district range, the
+# 0001-9999 serial floor, and — where an instrument says so in terms — the
+# exclusion of I and O. `format.regex_statutory` appears only where an
+# instrument imposes NO digit count and our regex invents a practical bound
+# (the diplomatic series).
+#
+# SEPARATOR NOTE (PRD-PLATES § 2.6): an Indian plate prints NO separator
+# glyph. Rule 50(3) prescribes a two-LINE layout (state+district code above,
+# the rest below) and rule 51 prescribes inter-character spacing in
+# millimetres; the space in every `pattern` here is the conventional textual
+# rendering of that gap, and every regex accepts it as optional, exactly as
+# plates/gb.yml does for the British 33 mm gap. The hyphenated rendering
+# ("MH-12-AB-1234") is a data-entry convention, not a printed feature; a
+# separator-forgiving consumer collapses both to one serial by construction.
+jurisdiction: in
+authority:
+  name: Ministry of Road Transport and Highways (MoRTH), Government of India — registering authorities (RTOs) of the States and Union Territories
+  url: "https://morth.nic.in/"
+binding: vehicle
+binding_note: >-
+  MVA 1988 § 41(6): the registering authority "shall assign TO THE VEHICLE,
+  for display thereon, a distinguishing mark". § 47 provides for assignment of
+  a NEW registration mark on removal to another State, which is the one place
+  the vehicle-binding is broken — and the BH series (rule 50(8), 2021) exists
+  precisely to stop that happening to inter-State movers: rule 54(3), inserted
+  by the same instrument, disapplies re-registration for a BH vehicle.
+instrument:
+  statute:
+    citation: "The Motor Vehicles Act, 1988 (59 of 1988), § 41(6) (registration mark), § 39 (necessity for registration), § 43 (temporary registration), § 60 (Central Government / defence vehicles), § 64 (Central Government rule-making power)"
+    in_force: "1989-07-01"
+    in_force_source: "S.O. 368(E), dated 22 May 1989, Gazette of India, Extraordinary, Pt. II, sec. 3(ii) — the commencement notification, cited in the Act's own footnote 1 to § 1(3)"
+  rules:
+    citation: "The Central Motor Vehicles Rules, 1989, published vide G.S.R. 590(E), dated the 2nd June, 1989, Gazette of India, Extraordinary, Part II, Section 3, Sub-section (i)"
+    key_rules: "rule 33-43 (trade certificate and trade registration mark), rule 47-48 (application and issue of registration), rule 50 (form and manner of display of registration marks), rule 51 (size of letters and numerals), rule 53C (temporary registration marks), rule 76-80 (diplomatic and consular), rule 81A-81C (vintage motor vehicles)"
+  state_codes:
+    citation: "S.O. 444(E), dated the 12th June, 1989, Gazette of India, Extraordinary, Part II, Section 3, Sub-section (ii) — the TABLE of letters allotted to each State and Union Territory under MVA § 41(6)"
+    reached: false
+    amendment_chain_named_in_gazette:
+      - "S.O. 1486(E), dated 9 June 2014 — named as the then-last amendment by S.O. 4262(E)"
+      - "S.O. 4262(E), dated 25 November 2019 — inserts '17A. Ladakh LA' (fetched, verbatim)"
+      - "S.O. 2339(E), dated 14 July 2020 — named as the then-last amendment by S.O. 1306(E)"
+      - "S.O. 1306(E), dated 12 March 2024 — substitutes '29A. Telangana TG' (fetched, verbatim)"
+    source: "https://web.archive.org/web/20210514201915id_/https://morth.nic.in/sites/default/files/notifications_document/S.O.%204262%28E%29%20dated%2025%20th%20November%20Registration%20Mark%20for%20Ladakh%20LA.pdf  # 'In the Table to the said notification, after serial number 17 ... 17A. Ladakh LA'; identifies the principal notification as S.O.444(E) dated 12 June 1989; accessed 2026-08-02"
+  hsrp:
+    citation: "The Motor Vehicles (High Security Registration Plates) Order, 2018, S.O. 6052(E), dated 6 December 2018, made under MVA § 109(3), in supersession of the Motor Vehicles (New High Security Registration Plates) Order, 2001"
+    in_force: "2019-04-01"
+    companion: "G.S.R. 1162(E), dated 4 December 2018 — the matching amendment to CMVR rules 50 and 124"
+  licence: >-
+    Gazette of India material and Government of India departmental publications
+    are Government of India works. India has no OGL-equivalent blanket licence;
+    § 52(1)(q) of the Copyright Act, 1957 permits reproduction of any Act,
+    rule or order made thereunder, and of any report of a Government
+    Commission, subject to the conditions there stated. Facts are extracted and
+    cited here; no gazette text is redistributed beyond quotation.
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+common:
+  mark_composition:
+    reconstructed_shape: "SS RR X[X[X]] NNNN — two-letter State/UT code, two-digit registering-authority (RTO) district code, a series group of one to three letters, a four-digit serial 0001-9999"
+    evidence: >-
+      No instrument states this shape. It is reconstructed from the four rules
+      that define OTHER marks by reference to it, each of which is quoted on
+      the series that uses it: rule 50(3) (State code + registering authority
+      code on the first line, "the rest" on the second), rule 35(3) as
+      substituted in 2022 ("AB—Represents State Code, 12—Represents RTO
+      Code"), rule 53C as inserted in 2021 ("AB- Represent State Code",
+      "1234- Serial Number"), and rule 81B ("XX stands for State code, YY will
+      be a two letter series and '****' is a number from 0001 to 9999").
+    letter_exclusions: >-
+      I and O are excluded from the letter groups of the BH series (rule 50(8),
+      verbatim: "excluding 'I' & 'O'") and of the temporary series (rule 53C,
+      verbatim: "Alphabet of Temporary Registration (Except O and I)"). NO
+      instrument extends that exclusion to the ORDINARY series letters, and the
+      exclusion is not asserted for them here — it appears only in
+      `regex_strict` on the BH and temporary series, where it is sourced. That
+      the ordinary series also avoids I and O is widely repeated and is
+      recorded as folklore in the dossier.
+    serial_floor: >-
+      The 0001-9999 floor is instrument-evidenced for BH (rule 50(8): "4
+      numerals 0001 to 9999"), vintage (rule 81B: "a number from 0001 to 9999")
+      and trade (rule 35(3): "four digit numerals starting from 0001 to 9999").
+      It is applied to the ordinary series' `regex_strict` by the same
+      reconstruction, and flagged there.
+    state_code_alternations_are_period_scoped: >-
+      EVERY `regex_strict` IN THIS FILE CARRIES THE STATE CODES THAT WERE IN
+      ALLOTMENT DURING THAT SERIES' OWN PERIOD, and the two lists differ. The
+      series that run from 1989 (the ordinary and transport marks, the old
+      dealer mark) carry the withdrawn codes too — OR, UA, DN and TS — because
+      marks bearing them are on the road and inside those series' periods. The
+      series created in 2021 or later (temporary, vintage, the 2022 dealer
+      mark) carry neither OR (superseded 2012) nor UA (2007) nor DN (2020),
+      which could not be issued after those series began — but they DO carry
+      TS, because Telangana was TS until S.O. 1306(E) substituted TG on
+      12 March 2024, well inside every one of those periods. TS was missing
+      from all three of those alternations in the earlier draft and is
+      restored here; a vintage registration is valid ten years and a trade
+      certificate five, so TS marks of both kinds remain live into the 2030s.
+    source: "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # CMVR rules 33-51 and 76-80, MoRTH's own consolidated text (the live morth.nic.in path now returns the SPA shell; this is the fetched copy, captured 2021-11-30); accessed 2026-08-02"
+  colours:
+    rule_50_2_d: >-
+      Rule 50(2), proviso (d), as substituted by G.S.R. 901(E), dated
+      13-12-2001, verbatim: "the letters of the registration mark shall be in
+      English and the figures shall be in Arabic numerals and shall be
+      shown:— (A) in the case of transport vehicles in black colour on yellow
+      background; and (B) in other cases, in black colour on white background,
+      the registration mark on the trailer shall be exhibited on the left hand
+      side in black colour on yellow background. In addition, the registration
+      mark on the drawing vehicle shall be exhibited on the trailer also and
+      this shall be done on the right hand side at the rear of the trailer or
+      the last trailer as the case may be, in black colour on retro-reflective
+      type yellow background". Its own compliance proviso is the source of the
+      two dates the secondary web repeats: where the clause had not been
+      complied with before the Central Motor Vehicles (8th Amendment) Rules,
+      2001, it was to be complied with "(i) in respect of transport vehicle, on
+      or before 1st February, 2002; and (ii) in other cases, on or before 1st
+      July, 2002."
+    rule_50_2A: >-
+      Inserted by G.S.R. 749(E), dated 7 August 2018 (Central Motor Vehicles
+      (10th Amendment) Rules, 2018), verbatim: "2A. In case of Battery Operated
+      Vehicles, the registration mark shall be exhibited in Yellow colour on
+      Green background for transport vehicles and for all other cases, in White
+      colour on Green background."
+    hex_basis_note: >-
+      The instruments NAME the colours and never number them: no chromaticity
+      coordinates, no colour standard, no reference to AIS-159 or any BIS
+      specification for colour. Every hex in this file is therefore
+      `hex_basis: observed` inside a statutorily named colour. Do not upgrade
+      any of them without a numbered source.
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 50(2)(d) as substituted by G.S.R. 901(E) 13-12-2001, with its 1-2-2002 / 1-7-2002 compliance dates; accessed 2026-08-02"
+      - "https://web.archive.org/web/20210514202442id_/https://morth.nic.in/sites/default/files/notifications_document/Notification_no_G_S_R_749E_dated_07_08_2018_regarding_Background_colour_of_registration_plates_for_Electric_vehicles_0.pdf  # G.S.R. 749(E) 7-8-2018 inserting rule 50(2A) — the EV green plate; accessed 2026-08-02"
+  plate_sizes:
+    note: >-
+      Rule 50(1)(vi), verbatim heads: "For two and three-wheelers,
+      quadricycles, E-rickshaws and E-carts 200 x 100 mm / For Light Motor
+      Vehicles/Passenger cars 340x200mm/500x120 mm / For medium commercial
+      vehicles, heavy commercial vehicles and Trailer/combination 340 x 200
+      mm". Provisos add: agricultural tractors front 285x45 mm, rear
+      200x100 mm; combine harvester 340 x 200 mm; power tiller 285x45 mm front
+      and 200x100 mm on a coupled trailer; and "in case of a motor cycle, the
+      size of 285x45 mm for front registration plate shall also be permitted".
+      The two/three-wheeler head reached its present wording through
+      G.S.R. 99(E) (19-2-2014, w.e.f. 1-10-2014) and G.S.R. 709(E)
+      (8-10-2014).
+    source: "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 50(1)(vi) and its four provisos; accessed 2026-08-02"
+  characters:
+    note: >-
+      Rule 51 ("Size of letters and numerals of the registration mark"), as
+      substituted by G.S.R. 338(E) dated 26-3-1993, is a table of minima in
+      millimetres — height, thickness, and space between — by class of vehicle.
+      Rows, verbatim in the rule's own order: all motor cycles and three-wheeled
+      invalid carriages, rear letters 35/7/5 and rear numerals 40/7/5;
+      motorcycles under 70 cc, front letters and numerals 15/2.5/2.5; other
+      motor cycles, front 30/5/5; three-wheelers not exceeding 500 cc and
+      E-rickshaw/E-cart, front and rear 35/7/5; three-wheelers exceeding 500 cc,
+      front and rear 40/7/5; ALL OTHER MOTOR VEHICLES, front and rear 65/10/10;
+      power tillers front 15/2.5/2.5; trailers coupled to power tillers rear
+      30/5/5; combine harvester 65/10/10; trailer for header assembly 65/10/10.
+      The rule prescribes NO typeface and publishes NO drawing — unlike the UK,
+      German and Spanish Schriftmuster. The Indian plate font is fixed instead
+      by the HSRP type-approval chain (AIS/CMVR rule 126 test agencies), whose
+      standard was not reached in this pass and is a recorded gap.
+    source: "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 51 table, all ten rows; accessed 2026-08-02"
+  hsrp_specification:
+    note: >-
+      Rule 50(1)(i)-(v), as substituted by G.S.R. 221(E) (28-3-2001) and
+      amended to commence 1-1-2004, verbatim in outline: the plate is "a solid
+      unit made of 1.0 mm aluminium conforming to DIN 1745/DIN 1783 or ISO
+      7591", with rounded edges "to the extent of approx. 10 mm" and "an
+      embossed border"; it "should bear the letters 'IND' in blue colour on the
+      extreme left centre of the plate", one-fourth the rule-51 letter size,
+      hot-stamped and "an integral part of the plate"; it is "protected against
+      counterfeiting by applying chromium-based hologram, applied by hot
+      stamping. Stickers and adhesive labels are not permitted"; it bears "a
+      permanent consecutive identification number of minimum seven digits, to
+      be laser branded into the reflective sheeting"; a THIRD registration mark
+      "in the form of self-destructive type, chromium based hologram sticker"
+      goes on the left-hand top of the windshield; and the plate "shall be
+      fastened with non-removable/non-reusable snap lock fitting system".
+      The 2018 Order tightens two of those numbers: hologram 20 mm x 20 mm
+      carrying the CHAKRA in blue; permanent identification number "of minimum
+      10 digits ... with the letter size being 5 mm", preceded by two letters
+      identifying the vendor from a closed test-agency table; third
+      registration mark sticker 100 mm x 60 mm; and the fuel colour code —
+      orange for diesel, light blue for petrol and CNG, grey for all others.
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 50(1)(i)-(vi) and footnote 74 dating the substitution to G.S.R. 221(E) 28-3-2001 w.e.f. 1-1-2004; accessed 2026-08-02"
+      - "https://web.archive.org/web/20210514202317id_/https://morth.nic.in/sites/default/files/notifications_document/Notification_no_G_S_R_1162E_dated_04_12_2018_regarding_High_Security_Registration_Plate_0.pdf  # S.O. 6052(E) 6-12-2018, the Motor Vehicles (High Security Registration Plates) Order, 2018, in force 1-4-2019 — paras 4-6, the test-agency letter table, and the fuel-sticker colours; accessed 2026-08-02"
+      - "https://web.archive.org/web/20190919185053id_/http://morth.nic.in/sites/default/files/circulars_document/CMVR%20rules%201989%20for%20HSRP.pdf  # MoRTH circular RT-11028/01/2018-MVL to all States: the plates 'are to be affixed through the authorized dealers of OEM w.e.f. 01.04.2019', naming G.S.R. 1162(E) and S.O. 6052(E); accessed 2026-08-02"
+
+series:
+
+  # =========================================================================
+  # THE ORDINARY MARK. Same composition throughout; the series cut is by
+  # DESIGN ERA (pre-HSRP / HSRP) and by the rule-50(2)(d) colour class, which
+  # is a class of USE (transport vs other), not a vehicle kind.
+  # =========================================================================
+  - id: in-standard-1989
+    class: standard
+    categories: [car, van, motorcycle, tractor, machine]
+    period: { start: 1989, end: 2003 }
+    period_evidence: enabling-statute
+    matching: strict
+    format:
+      pattern: "LL 99 LL 9999"
+      regex: '\A[A-Z]{2} ?\d{1,2} ?[A-Z](?: ?[A-Z]){0,2} ?\d{4}\z'
+      regex_strict: '\A(?:AN|AP|AR|AS|BR|CG|CH|DD|DL|DN|GA|GJ|HP|HR|JH|JK|KA|KL|LA|LD|MH|ML|MN|MP|MZ|NL|OD|OR|PB|PY|RJ|SK|TG|TN|TR|TS|UA|UK|UP|WB) ?(?:0[1-9]|[1-9]\d?) ?[A-Z](?: ?[A-Z]){0,2} ?(?!0000)\d{4}\z'
+      composition_evidence: reconstructed
+      charset:
+        state_codes: "closed list — see plates/_decode/in-state-codes.yml"
+        district: "1-99, allotted by the State; NOT nationally closed (see region_encoding_mechanism)"
+        notes: >-
+          `regex_strict` narrows `regex` in exactly three sourced-by-analogy
+          ways and no more: the state code to the closed allotment list, the
+          district away from 0 (00 is not allotted anywhere observed), and the
+          serial away from 0000 (the 0001-9999 floor is verbatim in rules
+          35(3), 50(8) and 81B for the marks that reference this one). It does
+          NOT exclude I and O from the series letters, because no instrument
+          excludes them from the ORDINARY mark — only from BH and temporary.
+        district_width_note: >-
+          THE DISTRICT IS ONE OR TWO DIGITS, NOT TWO. Rule 50(3) says only
+          "registering authority code" and rule 35(3) only "RTO Code"; neither
+          fixes a width, and the zero-padded two-digit form that most States
+          print is a convention, not a rule. A regex fixed at `\d{2}` rejects
+          every Delhi mark of the "DL 3C AB 1234" shape, which is why both
+          `regex` and `regex_strict` here quantify `\d{1,2}`. This was found by
+          testing the first draft against real-world plate shapes, and it is
+          the single defect that pass caught.
+        series_group_note: >-
+          THE LETTER RUN IS SPELLED `[A-Z](?: ?[A-Z]){0,2}` — WITH AN INTERNAL
+          OPTIONAL GAP — AND THAT IS DELIBERATE. It looks like a candidate for
+          tightening to `[A-Z]{1,3}`; it is not, and this pass tried and
+          reverted the tightening after probing real shapes. Rule 50(3) puts
+          the State code and the REGISTERING-AUTHORITY code on the first line
+          and "the rest" on the second. Where a State prints a vehicle-class
+          letter immediately after the district digits — Delhi's "DL 3C" over
+          "AB 1234" is the standing case — the letter run is split ACROSS the
+          two lines, so its linear rendering carries a gap inside it
+          ("DL 3C AB 1234"). `[A-Z]{1,3}` rejects that string outright. The
+          repeated-optional-space form accepts it and still caps the run at
+          three letters. Cost of the choice, stated: the regex also accepts
+          "MH 12 A B 1234", which no plate prints. That is a recall-side
+          looseness inside a `strict` series, and it is preferred to silently
+          failing a whole State's plates.
+        recall_gap_blank_series: >-
+          RECORDED, NOT ASSERTED: the first block issued in a district is
+          commonly described as carrying NO series letters at all ("MH 01
+          1234"). The only support located is the en-Wikipedia article
+          ("one to three letters or blank"), which cites no instrument for it,
+          and no rule was reached that permits an empty series group. Both
+          regexes therefore REQUIRE at least one letter, and a blank-series
+          Indian mark will not match. Flagged for the verifier: if a State
+          registration manual or a rule proviso is pinned, widen to
+          `[A-Z]{0,3}` and say so in the PR.
+      progression: >-
+        The series group advances within a district as its four-digit block
+        exhausts (single letter, then two, then three); the allocation order is
+        an administrative matter for each State's registering authority and is
+        published by none of them uniformly. A series letter therefore gives a
+        LOWER bound on age within a district and nothing stronger.
+    design:
+      plate: { w: 340, h: 200, unit: mm }
+      plate_variants:
+        - { w: 500, h: 120, unit: mm, note: "light motor vehicles / passenger cars, the single-line alternative (rule 50(1)(vi))" }
+        - { w: 200, h: 100, unit: mm, note: "two- and three-wheelers, quadricycles, E-rickshaws, E-carts" }
+        - { w: 285, h: 45, unit: mm, note: "agricultural tractor front; power tiller front; also permitted as a motor cycle front plate" }
+      background: { color: "#FFFFFF", finish: painted, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      layout: >-
+        Rule 50(3): "The registration mark shall be exhibited in two lines, the
+        State code and registering authority code forming the first line and
+        the rest forming the second line, one below the other" — with a proviso
+        (substituted by G.S.R. 324(E), 7-5-2014) for the 200x100 mm plate that
+        splits the characters evenly, "and where the total number of alpha
+        numeric characters in the registration mark is odd, then any extra
+        alpha numeric character shall be exhibited on the second line".
+      characters: { min_height_mm: 65, min_thickness_mm: 10, min_space_mm: 10, note: "rule 51 row 'All other motor vehicles'; motorcycles and three-wheelers take the smaller rows — see common.characters" }
+    region_encoding: "plates/_decode/in-state-codes.yml"
+    region_encoding_mechanism: >-
+      TWO GEOGRAPHIC ELEMENTS, ONE CLOSED AND ONE OPEN, AND A PARSE API MUST
+      NOT TREAT THEM ALIKE. (1) The first two letters are the STATE/UT code, a
+      closed list allotted by the Central Government under MVA § 41(6) — the
+      decode table. (2) The two digits are the REGISTERING AUTHORITY (RTO
+      DISTRICT) code, which no central instrument enumerates: rule 50(3) simply
+      calls it "registering authority code" and rule 35(3) calls it "RTO Code".
+      Each State creates, merges and renumbers its own offices, and there are
+      well over a thousand of them, so this dimension is OPEN and is deliberately
+      NOT tabled here (PRD-PLATES § 2.4 mechanism-note rule). A decode may
+      return the State with confidence and the district only against a
+      State-published list of that State's own offices, dated. THIRD ELEMENT,
+      FLAGGED AS UNSOURCED: several States are widely reported to spend the
+      first letter of the series group on a VEHICLE-CLASS code rather than on
+      the series — Delhi's "C" for car in "DL 3C AB 1234" is the famous case.
+      No central instrument authorises that, no Delhi instrument was reached
+      for it, and this dataset therefore treats every letter after the district
+      as series alphabet. A parse API must not decode a class from it.
+    sources:
+      - "https://web.archive.org/web/20250804185944id_/https://www.indiacode.nic.in/bitstream/123456789/1798/1/aA1988-59.pdf  # MVA 1988 § 41(6) verbatim (the letters are allotted 'by notification in the Official Gazette'), § 1(3) footnote (in force 1 July 1989 vide S.O. 368(E) 22-5-1989); accessed 2026-08-02"
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 50(2)(d)(B) black on white for non-transport; rule 50(3) two-line layout and the state-code/registering-authority-code split; rule 50(1)(vi) sizes; rule 51 character minima; accessed 2026-08-02"
+      - "https://web.archive.org/web/20210514201915id_/https://morth.nic.in/sites/default/files/notifications_document/S.O.%204262%28E%29%20dated%2025%20th%20November%20Registration%20Mark%20for%20Ladakh%20LA.pdf  # identifies S.O. 444(E) dated 12 June 1989 as the state-code notification made under § 41(6); accessed 2026-08-02"
+    notes: >-
+      THE PRE-HSRP ORDINARY PLATE for non-transport vehicles — black on white,
+      painted or printed on a plain plate, no IND legend, no hologram, no laser
+      code. period.start 1989 is the enabling statute: the MV Act 1988 came
+      into force 1 July 1989 and the state-code notification S.O. 444(E) is
+      dated 12 June 1989, three weeks earlier, exactly as a commencement
+      package would be sequenced. period.end 2003 is the LEGAL end and nothing
+      more: rule 50(1), as substituted by G.S.R. 221(E) and amended, took
+      effect 1 January 2004 and made the security licence plate the only
+      lawful plate, with a proviso giving already-registered vehicles two more
+      years ("this sub-rule shall apply to already registered vehicles two
+      years from the date of commencement"). In fact non-HSRP plates went on
+      being made in most States for another fifteen years, until the HSRP Order
+      2018 put the obligation on vehicle manufacturers from 1 April 2019. That
+      enforcement gap is recorded here and is deliberately NOT modelled as a
+      period: the dataset states what the instruments say and lets the note
+      carry the messy truth.
+
+  - id: in-standard-hsrp-2004
+    class: standard
+    categories: [car, van, motorcycle, tractor, machine]
+    period: { start: 2004 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL 99 LL 9999"
+      regex: '\A[A-Z]{2} ?\d{1,2} ?[A-Z](?: ?[A-Z]){0,2} ?\d{4}\z'
+      regex_strict: '\A(?:AN|AP|AR|AS|BR|CG|CH|DD|DL|DN|GA|GJ|HP|HR|JH|JK|KA|KL|LA|LD|MH|ML|MN|MP|MZ|NL|OD|OR|PB|PY|RJ|SK|TG|TN|TR|TS|UA|UK|UP|WB) ?(?:0[1-9]|[1-9]\d?) ?[A-Z](?: ?[A-Z]){0,2} ?(?!0000)\d{4}\z'
+      composition_evidence: reconstructed
+      charset: { notes: "identical to in-standard-1989 — HSRP changed the PLATE, never the MARK" }
+    design:
+      plate: { w: 340, h: 200, unit: mm }
+      plate_variants:
+        - { w: 500, h: 120, unit: mm, note: "LMV / passenger car single-line" }
+        - { w: 200, h: 100, unit: mm, note: "two- and three-wheelers, quadricycles, E-rickshaws, E-carts" }
+        - { w: 285, h: 45, unit: mm, note: "tractor / power tiller / motor cycle front" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: false, note: "the CHAKRA appears inside the 20x20 mm chromium hologram, not as a plate emblem (HSRP Order 2018 para 6(v)(b) + Annexure)" }
+      material: "1.0 mm aluminium conforming to DIN 1745/DIN 1783 or ISO 7591, embossed border, corners rounded approx. 10 mm (rule 50(1)(i))"
+      security:
+        ind_legend: "'IND' in blue on the extreme left centre, one-fourth of the rule-51 letter size, hot-stamped, an integral part of the plate (rule 50(1)(ii))"
+        hologram: "chromium-based, hot-stamped, 20 mm x 20 mm at the top left of both plates, carrying the CHAKRA in blue (rule 50(1)(iii); HSRP Order 2018 para 6(v))"
+        laser_code: "permanent identification number, minimum seven digits in rule 50(1)(iii) and minimum TEN digits under HSRP Order 2018 para 6(vi), laser-branded into the reflective sheeting at the bottom left at 5 mm, preceded by two letters identifying the approved vendor"
+        third_mark: "self-destructive chromium-hologram sticker, 100 mm x 60 mm, inside the windscreen at the top left, carrying the registering authority, the registration number, the laser code and the date of first registration; background orange for diesel, light blue for petrol and CNG, grey otherwise (rule 50(1)(iv); HSRP Order 2018 para 6(viii)-(ix))"
+        fitment: "non-removable, non-reusable snap-lock fitting, fixed at the premises of the registering authority (rule 50(1)(v)); since G.S.R. 640(E) (18-8-2022) the plate may be issued by 'licence plate manufacturers or their dealers approved by the State Government or Union Territory Administration'"
+      rear_differs: false
+      characters: { min_height_mm: 65, min_thickness_mm: 10, min_space_mm: 10, note: "rule 51, 'All other motor vehicles' row" }
+    region_encoding: "plates/_decode/in-state-codes.yml"
+    region_encoding_mechanism: "identical to in-standard-1989 — closed State code, open RTO district code"
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 50(1)(i)-(vi) HSRP specification; footnote 74: sub-rule (1) 'substituted by G.S.R. 221(E), dated 28-3-2001 as amended by S.O. 938(E), dated 24-9-2001, S.O. 499(E), dated 9-5-2002 and S.O. 59(E), dated 21-1-2003 (w.e.f. 1-1-2004)'; accessed 2026-08-02"
+      - "https://web.archive.org/web/20210514202317id_/https://morth.nic.in/sites/default/files/notifications_document/Notification_no_G_S_R_1162E_dated_04_12_2018_regarding_High_Security_Registration_Plate_0.pdf  # HSRP Order 2018 (S.O. 6052(E), 6-12-2018), 'It shall come into force on the 1st day of April, 2019'; paras 4-6; accessed 2026-08-02"
+      - "https://web.archive.org/web/20230429221406id_/https://morth.nic.in/sites/default/files/notifications_document/8GSR%20640(E)%2018th%20August%202022%20HSRP%20rule%2050.pdf  # G.S.R. 640(E) 18-8-2022 (CMV Thirteenth Amendment Rules 2022) amending rule 50(1)(v) — who may supply the plate; accessed 2026-08-02"
+    notes: >-
+      THE CURRENT ORDINARY PLATE for non-transport vehicles. period.start 2004
+      is the commencement of the substituted rule 50(1), which is the
+      instrument that CREATED the security licence plate — not 2001 (the date
+      G.S.R. 221(E) was made, before three amendments deferred it) and not 2005
+      or 2019 (both of which the secondary web gives). The 1 April 2019 date is
+      real but is a DIFFERENT claim: it is when the HSRP Order 2018 moved the
+      duty onto vehicle manufacturers and their dealers for new vehicles, which
+      is when the plates finally appeared nationwide. Both are recorded; the
+      period claim is the rule's. Overlaps in-standard-1989 only at the design
+      boundary, and the notes on each state why.
+
+  - id: in-transport-1989
+    class: standard
+    categories: [truck, bus, van, car, trailer]
+    period: { start: 1989, end: 2003 }
+    period_evidence: enabling-statute
+    matching: strict
+    format:
+      pattern: "LL 99 LL 9999"
+      regex: '\A[A-Z]{2} ?\d{1,2} ?[A-Z](?: ?[A-Z]){0,2} ?\d{4}\z'
+      regex_strict: '\A(?:AN|AP|AR|AS|BR|CG|CH|DD|DL|DN|GA|GJ|HP|HR|JH|JK|KA|KL|LA|LD|MH|ML|MN|MP|MZ|NL|OD|OR|PB|PY|RJ|SK|TG|TN|TR|TS|UA|UK|UP|WB) ?(?:0[1-9]|[1-9]\d?) ?[A-Z](?: ?[A-Z]){0,2} ?(?!0000)\d{4}\z'
+      composition_evidence: reconstructed
+    design:
+      plate: { w: 340, h: 200, unit: mm }
+      background: { color: "#FFD200", finish: painted, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      rear_differs: false
+      display_extras: >-
+        Rule 50(2) provisos (a)-(c): the rear mark of a transport vehicle is
+        fixed on the right-hand side "at a distance not exceeding one metre
+        from the ground"; the mark "shall also be painted on the right and left
+        side on the body of the vehicle"; and on a stage or contract carriage
+        it is painted again on the driver/passenger partition, or on the
+        dash-board of a motor cab or taxi cab.
+      characters: { min_height_mm: 65, min_thickness_mm: 10, min_space_mm: 10 }
+    region_encoding: "plates/_decode/in-state-codes.yml"
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 50(2)(d)(A) 'in the case of transport vehicles in black colour on yellow background' (substituted by G.S.R. 901(E) 13-12-2001) and the compliance date 1 February 2002; rule 50(2) provisos (a)-(c) on where the mark is repeated; accessed 2026-08-02"
+    notes: >-
+      THE PRE-HSRP TRANSPORT PLATE — the yellow one. Identical mark, identical
+      composition, different colour, and the colour is a class of USE:
+      "transport vehicle" is an MVA § 2(47) category (goods carriage, stage
+      carriage, contract carriage, educational institution bus and so on), so a
+      privately-owned car used as a taxi carries yellow while the same model in
+      private hands carries white. THE COLOUR CLAIM'S DATE IS NOT THE SERIES'
+      DATE: rule 50(2)(d) in its present wording dates from G.S.R. 901(E)
+      (13-12-2001) with a compliance deadline of 1 February 2002 for transport
+      vehicles, and the pre-2001 text of clause (d) was not reached — so the
+      1989 start is the MARK's start, and whether yellow was prescribed for the
+      whole of 1989-2001 is a recorded gap, not an assertion. Overlaps
+      in-standard-1989 in kind, never in colour class.
+
+  - id: in-transport-hsrp-2004
+    class: standard
+    categories: [truck, bus, van, car, trailer]
+    period: { start: 2004 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL 99 LL 9999"
+      regex: '\A[A-Z]{2} ?\d{1,2} ?[A-Z](?: ?[A-Z]){0,2} ?\d{4}\z'
+      regex_strict: '\A(?:AN|AP|AR|AS|BR|CG|CH|DD|DL|DN|GA|GJ|HP|HR|JH|JK|KA|KL|LA|LD|MH|ML|MN|MP|MZ|NL|OD|OR|PB|PY|RJ|SK|TG|TN|TR|TS|UA|UK|UP|WB) ?(?:0[1-9]|[1-9]\d?) ?[A-Z](?: ?[A-Z]){0,2} ?(?!0000)\d{4}\z'
+      composition_evidence: reconstructed
+    design:
+      plate: { w: 340, h: 200, unit: mm }
+      background: { color: "#FFD200", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      material: "as in-standard-hsrp-2004 — rule 50(1) applies to every motor vehicle, whatever the colour of the plate"
+      rear_differs: false
+      characters: { min_height_mm: 65, min_thickness_mm: 10, min_space_mm: 10 }
+    variants:
+      - class: trailer
+        design: { background: { color: "#FFD200", finish: retroreflective, hex_basis: observed }, foreground: "#000000" }
+        note: >-
+          A trailer carries TWO marks under rule 50(2)(d): its own, "exhibited
+          on the left hand side in black colour on yellow background", and the
+          DRAWING VEHICLE's, repeated "on the right hand side at the rear of
+          the trailer or the last trailer as the case may be, in black colour
+          on retro-reflective type yellow background". A parse API reading a
+          photograph of an Indian truck-trailer combination will see the same
+          mark twice and a second, different mark once; it must not treat the
+          repetition as two vehicles. Colour-only variant of this series, hence
+          a sub-entry (PRD-PLATES § 2.3). Rule 50(6) exempts agricultural
+          tractors: "The registration mark of the drawing agricultural tractor
+          may not be exhibited on the agricultural trailer or trailers", and
+          rule 50(7) does the same for a modular hydraulic trailer behind a
+          puller tractor.
+        sources:
+          - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 50(2)(d) trailer sentence; rule 50(6); rule 50(7) (inserted by G.S.R. 212(E) 20-3-2015 w.e.f. 1-4-2015); accessed 2026-08-02"
+    region_encoding: "plates/_decode/in-state-codes.yml"
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 50(1) HSRP specification (w.e.f. 1-1-2004) read with rule 50(2)(d)(A) yellow-background rule; accessed 2026-08-02"
+      - "https://web.archive.org/web/20210514202317id_/https://morth.nic.in/sites/default/files/notifications_document/Notification_no_G_S_R_1162E_dated_04_12_2018_regarding_High_Security_Registration_Plate_0.pdf  # HSRP Order 2018 applies to 'motor vehicles as defined in clause (28) of section 2' — i.e. transport vehicles too; accessed 2026-08-02"
+    notes: >-
+      THE CURRENT TRANSPORT PLATE. The HSRP specification is colour-blind: rule
+      50(1) prescribes the plate, rule 50(2)(d) prescribes the colour, and a
+      yellow HSRP is the ordinary sight on an Indian goods carriage or taxi
+      today. Distinct from in-standard-hsrp-2004 only in background colour and
+      in the repetition rules that follow a transport vehicle around.
+
+  - id: in-electric-green-2018
+    class: electric
+    categories: [car, van, motorcycle, truck, bus]
+    period: { start: 2018 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL 99 LL 9999"
+      regex: '\A[A-Z]{2} ?\d{1,2} ?[A-Z](?: ?[A-Z]){0,2} ?\d{4}\z'
+      regex_strict: '\A(?:AN|AP|AR|AS|BR|CG|CH|DD|DL|DN|GA|GJ|HP|HR|JH|JK|KA|KL|LA|LD|MH|ML|MN|MP|MZ|NL|OD|OR|PB|PY|RJ|SK|TG|TN|TR|TS|UA|UK|UP|WB) ?(?:0[1-9]|[1-9]\d?) ?[A-Z](?: ?[A-Z]){0,2} ?(?!0000)\d{4}\z'
+      composition_evidence: reconstructed
+    design:
+      plate: { w: 340, h: 200, unit: mm }
+      plate_variants:
+        - { w: 200, h: 100, unit: mm, note: "E-rickshaws and E-carts take the two/three-wheeler size expressly (rule 50(1)(vi), as substituted by G.S.R. 709(E) 8-10-2014)" }
+      background: { color: "#00843D", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      rear_differs: false
+      characters: { min_height_mm: 65, min_thickness_mm: 10, min_space_mm: 10, note: "E-rickshaw and E-cart take rule 51's 35/7/5 row" }
+    variants:
+      - class: electric
+        design: { background: { color: "#00843D", finish: retroreflective, hex_basis: observed }, foreground: "#FFD200" }
+        note: >-
+          A battery-operated TRANSPORT vehicle carries the mark "in Yellow
+          colour on Green background" (rule 50(2A)) — the same green plate with
+          yellow characters instead of white. Colour-only variant of the same
+          format and period, hence a sub-entry rather than a series
+          (PRD-PLATES § 2.3). This is the one place in Indian plate law where
+          the transport/non-transport split changes the FOREGROUND rather than
+          the background.
+        sources:
+          - "https://web.archive.org/web/20210514202442id_/https://morth.nic.in/sites/default/files/notifications_document/Notification_no_G_S_R_749E_dated_07_08_2018_regarding_Background_colour_of_registration_plates_for_Electric_vehicles_0.pdf  # rule 50(2A), verbatim; accessed 2026-08-02"
+    region_encoding: "plates/_decode/in-state-codes.yml"
+    sources:
+      - "https://web.archive.org/web/20210514202442id_/https://morth.nic.in/sites/default/files/notifications_document/Notification_no_G_S_R_749E_dated_07_08_2018_regarding_Background_colour_of_registration_plates_for_Electric_vehicles_0.pdf  # G.S.R. 749(E), 7 August 2018, Central Motor Vehicles (10th Amendment) Rules 2018, inserting rule 50(2A) after rule 50(2); 'They shall come into force on the date of their publication in the Official Gazette'; accessed 2026-08-02"
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 50(1)(vi) sizes including E-rickshaw and E-cart; rule 51 row 5; accessed 2026-08-02"
+    notes: >-
+      THE GREEN PLATE. Its own series and not a colour variant of the standard
+      one, because its PERIOD differs: rule 50(2A) was inserted by G.S.R.
+      749(E) and came into force on publication, 7 August 2018 — before that
+      date a battery-operated vehicle took the ordinary white or yellow plate,
+      and green plates on the road are therefore a hard 2018-or-later signal.
+      The mark itself is unchanged: same state code, same district, same
+      series, same serial, so a green plate carries no serial-level tell at
+      all. Note the rule's own term is "Battery Operated Vehicles", which is
+      narrower than "electric": a hybrid does not qualify, and rule 50(2A)
+      offers no definition — a recorded gap.
+
+  - id: in-bh-2021
+    class: standard
+    categories: [car, van, motorcycle]
+    period: { start: 2021 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99 BH 9999 LL"
+      regex: '\A\d{2} ?BH ?\d{4} ?[A-Z]{1,2}\z'
+      regex_strict: '\A\d{2} ?BH ?(?!0000)\d{4} ?[A-HJ-NP-Z]{1,2}\z'
+      composition_evidence: instrument
+      charset:
+        excluded_letters: [I, O]
+        excluded_letters_note: "rule 50(8), verbatim: 'A, B, C …and then AA,AB…..AZ, BA, BB …..to ZZ excluding ‚I‘ & ‚O‘'"
+        notes: >-
+          Rule 50(8) is the ONLY Indian instrument that lays out a registration
+          mark as a labelled table, and it is worth quoting whole because it is
+          the model for how the ordinary mark ought to have been written:
+          "XX / Last two digits of year of registration | XX / Bharat Series
+          code (2) letters as 'BH' | #### XX / 4 numerals 0001 to 9999 followed
+          by letter(s) A, B, C …and then AA,AB…..AZ, BA, BB …..to ZZ excluding
+          'I' & 'O'".
+      progression: >-
+        The first two digits are the last two digits of the YEAR of
+        registration, which makes BH the only Indian series with an exact age
+        in the serial. The trailing letter group advances A..Z then AA..ZZ as
+        each year's four-digit block exhausts. The mark is not chosen: rule
+        48's new proviso requires it to be "generated randomly through the
+        portal after verification of working certificate in Form 60 or Official
+        identity card".
+    design:
+      plate: { w: 340, h: 200, unit: mm }
+      plate_variants:
+        - { w: 500, h: 120, unit: mm }
+        - { w: 200, h: 100, unit: mm, note: "two-wheelers" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      rear_differs: false
+      characters: { min_height_mm: 65, min_thickness_mm: 10, min_space_mm: 10 }
+    region_encoding: none
+    region_encoding_note: >-
+      THE ONE INDIAN MARK WITH NO GEOGRAPHY IN IT — that is the entire point of
+      the series. There is no state code and no district code; "BH" is Bharat,
+      the country. A parse API must not attempt a regional decode on a BH
+      string, and must not read the leading two digits as a district: they are
+      a year.
+    eligibility: >-
+      Rule 47(1)(ca)-(cb), inserted by the same instrument: a working
+      certificate in Form 60 for a private-sector applicant, whose employer
+      declares "we have offices in four States/UTs or more"; an official
+      identity card for a government employee. The series is voluntary
+      ("opted voluntarily by the vehicle owner", rule 48 proviso) and
+      non-transport only, since rule 51B's tax scheme is written for
+      "non-transport vehicles".
+    sources:
+      - "https://egazette.gov.in/WriteReadData/2021/229283.pdf  # G.S.R. 594(E), New Delhi, 26 August 2021 — Central Motor Vehicles (Twentieth Amendment) Rules, 2021, para 1(2) 'They shall come into force with effect from the 15th day of September, 2021'; para 4 inserting rule 50(8) with the mark table verbatim; para 2 inserting rule 47(1)(ca)-(cb); para 3 inserting the rule 48 proviso; para 6 inserting rule 54(3); Form 60; accessed 2026-08-02"
+    notes: >-
+      THE BHARAT (BH) SERIES — a genuinely new format, instrument-dated to the
+      day. G.S.R. 594(E) is dated 26 August 2021 and its own commencement
+      clause says 15 September 2021, so BOTH dates are real and they mean
+      different things; period.start records the year, and a verifier
+      re-deriving it should expect to find 2021 either way. What the series
+      solves is the § 47 re-registration burden on inter-State movers: rule
+      54(3), inserted by the same amendment, provides that the
+      re-registration rule "shall not apply to a vehicle having BH-Series
+      registration mark", the owner instead intimating the new State in
+      Form 33 within thirty days. The mark is black on white by rule 50(8) in
+      terms — the sub-rule prescribes the colour itself rather than leaning on
+      rule 50(2)(d) — and a transport BH plate does not exist.
+
+  - id: in-temporary-2021
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2021 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "T 9999 LL 9999 LL"
+      regex: '\AT ?\d{4} ?[A-Z]{2} ?\d{4} ?[A-Z]{2}\z'
+      regex_strict: '\AT ?(?:0[1-9]|1[0-2])\d{2} ?(?:AN|AP|AR|AS|BR|CG|CH|DD|DL|GA|GJ|HP|HR|JH|JK|KA|KL|LA|LD|MH|ML|MN|MP|MZ|NL|OD|PB|PY|RJ|SK|TG|TN|TR|TS|UK|UP|WB) ?(?!0000)\d{4} ?[A-HJ-NP-Z]{2}\z'
+      composition_evidence: instrument
+      charset:
+        excluded_letters: [I, O]
+        excluded_letters_note: "rule 53C(1), verbatim: 'AB- Alphabet of Temporary Registration (Except O and I)'"
+      progression: >-
+        The month and year of ISSUE are in the mark, which makes the Indian
+        temporary plate self-dating and its expiry mechanically checkable: rule
+        53B gives an initial validity extendable "one or more times by 30 days
+        each".
+    design:
+      band: { side: none }
+      note: >-
+        NO COLOUR AND NO DIMENSION IS PRESCRIBED FOR THE TEMPORARY MARK, and
+        this file does not invent one. Rule 53C(2) says only that "the owner
+        shall ensure that the said mark is affixed to the front and rear of the
+        motor vehicle". On its face rule 50(2)(d) applies to any registration
+        mark, which would make a temporary plate black on white (or yellow for
+        a transport vehicle); the red-on-yellow temporary plate that every
+        secondary source describes has NO primary and is logged as folklore in
+        the dossier. Recorded gap.
+    region_encoding: "plates/_decode/in-state-codes.yml"
+    region_encoding_mechanism: >-
+      State code only — rule 53C's legend has no RTO district element, which is
+      consistent with a temporary mark being valid for movement rather than
+      tied to an office. The decode returns a State and must not attempt a
+      district.
+    sources:
+      - "https://web.archive.org/web/20210421181546id_/https://morth.nic.in/sites/default/files/notifications_document/GSR%20240%28E%29%20dated%2031st%20March%202021%20Committee%20A%20Licensing%20of%20drivers%2C%20Fitness%20and%20Registration%20of%20motor%20vehicles%20%20.pdf  # G.S.R. 240(E), 31 March 2021 — Central Motor Vehicles (Sixth Amendment) Rules, 2021, 'They shall come into force with effect from 01st day of April, 2021'; the inserted rule 53C: 'T- Represent temporary certificate; 08- Month of issuance of temporary certificate of registration 20- Year of issuance ...; AB- Represent State Code; 1234- Serial Number of Temporary Registration; AB- Alphabet of Temporary Registration (Except O and I)'; accessed 2026-08-02"
+      - "https://web.archive.org/web/20250804185944id_/https://www.indiacode.nic.in/bitstream/123456789/1798/1/aA1988-59.pdf  # MVA § 43, the temporary-registration power the rule is made under; accessed 2026-08-02"
+    notes: >-
+      THE STANDARDISED TEMPORARY MARK, and the reason it is dated 2021 rather
+      than 1989: temporary registration has existed since the Act (§ 43), but
+      until rule 53C was inserted its mark had NO nationally prescribed shape
+      and every State invented one. G.S.R. 240(E) gave it a form for the first
+      time. Two consequences for a parse API: a temporary string of this shape
+      is a hard 2021-or-later signal, and any earlier Indian temporary mark is
+      out of scope of this dataset because no instrument describes it.
+      period.start 2021 is the amendment's own commencement, 1 April 2021.
+
+  - id: in-dealer-1989
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1989, end: 2022 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL 99 LL 999"
+      regex: '\A[A-Z]{2} ?\d{1,2} ?[A-Z]{2} ?\d{1,3}\z'
+      regex_strict: '\A(?:AN|AP|AR|AS|BR|CG|CH|DD|DL|DN|GA|GJ|HP|HR|JH|JK|KA|KL|LA|LD|MH|ML|MN|MP|MZ|NL|OD|OR|PB|PY|RJ|SK|TG|TN|TR|TS|UA|UK|UP|WB) ?(?:0[1-9]|[1-9]\d?) ?[A-Z]{2} ?[1-9]\d{0,2}\z'
+      composition_evidence: instrument
+      charset:
+        notes: >-
+          Rule 35(1) as originally made, verbatim: the registering authority
+          "shall assign in respect of each certificate a trade registration
+          mark consisting of the registration mark referred to in the
+          notification made under sub-section (6) of section 41 and followed by
+          two letters and a number containing not more than three digits for
+          each vehicle, for example:- AB—Represent State Code. 12—Registration
+          District Code. TC[1]—Trade certificate number for the vehicle." The
+          rule does NOT fix the two letters as "TC"; only the worked example
+          uses them, so `regex_strict` leaves the letter pair open. (The
+          example's third token is printed "TCI" in MoRTH's consolidated PDF,
+          which is an OCR artefact of "TC1" — flagged, not relied on.)
+    design:
+      band: { side: none }
+      note: >-
+        The pre-2022 rule prescribed no colour: rule 39(2) as originally made
+        said only that "the trade certificate shall be carried on a motor
+        vehicle in a weatherproof circular folder and the trade registration
+        mark shall be exhibited in a conspicuous place in the vehicle". No
+        colour is asserted for this series. Recorded gap.
+    region_encoding: "plates/_decode/in-state-codes.yml"
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 35(1) as originally made, with the AB / 12 / TC legend; rule 39(2) pre-2022; rule 34(2) classes (a)-(j); accessed 2026-08-02"
+      - "https://web.archive.org/web/20230429221141id_/https://morth.nic.in/sites/default/files/notifications_document/GSR%20703(E)%20dt%2014%20September%202022%20for%20Trade%20Certificate.pdf  # G.S.R. 703(E) substituting rule 35 entire, which is what ends this series, and its transitional para 1(3): certificates granted before commencement 'shall continue to remain in force till the date of their expiry'; accessed 2026-08-02"
+    notes: >-
+      THE OLD TRADE (DEALER) MARK. Its shape is instrument-evidenced and its
+      end is instrument-evidenced: G.S.R. 703(E) substituted rule 35 with
+      effect from 1 November 2022. The transitional clause means marks of this
+      shape stayed lawful past that date, on certificates already granted, until
+      those certificates expired — under the old rule 37 a trade certificate ran
+      for twelve months, so the tail is short. period.end 2022 records the
+      substitution; the tail is in this note, not in the period.
+
+  - id: in-dealer-2022
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2022 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL 99 L 9999 TC 9999"
+      regex: '\A[A-Z]{2} ?\d{1,2} ?[A-Z] ?\d{4} ?TC ?\d{4}\z'
+      regex_strict: '\A(?:AN|AP|AR|AS|BR|CG|CH|DD|DL|GA|GJ|HP|HR|JH|JK|KA|KL|LA|LD|MH|ML|MN|MP|MZ|NL|OD|PB|PY|RJ|SK|TG|TN|TR|TS|UK|UP|WB) ?(?:0[1-9]|[1-9]\d?) ?[A-J] ?\d{4} ?TC ?(?!0000)\d{4}\z'
+      composition_evidence: instrument
+      charset:
+        vehicle_class_letters:
+          A: "motor cycle"
+          B: "invalid carriage"
+          C: "light motor vehicle"
+          D: "medium passenger motor vehicle"
+          E: "medium goods vehicle"
+          F: "heavy passenger motor vehicle"
+          G: "heavy goods vehicle"
+          H: "E-rickshaw"
+          I: "E-cart"
+          J: "any other motor vehicle of a specified description"
+        vehicle_class_letters_note: >-
+          Rule 35(3) says the letter "Represents serial number of class of
+          vehicle as prescribed in Rule 34(2) i.e. from A to J"; rule 34(2)
+          lists those classes as clauses (a) to (j), which is the closed
+          primary list inlined above (PRD-PLATES § 2.4 small-inline-table
+          rule). NOTE THE TRAP: this is the one Indian series in which the
+          letter I IS issued — it is E-cart — while BH and temporary marks
+          expressly exclude I. A parse API must not apply a blanket I/O
+          exclusion across India.
+    design:
+      background: { color: "#D22630", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      rear_differs: false
+      characters: { note: "rule 39(2) as substituted: 'as per dimensions specified in rule 51'" }
+      note: "rule 39(2) as substituted: the mark 'shall be exhibited on front and rear of a motor vehicle'"
+    region_encoding: "plates/_decode/in-state-codes.yml"
+    sources:
+      - "https://web.archive.org/web/20230429221141id_/https://morth.nic.in/sites/default/files/notifications_document/GSR%20703(E)%20dt%2014%20September%202022%20for%20Trade%20Certificate.pdf  # G.S.R. 703(E), 14 September 2022 — Central Motor Vehicles (Fifteenth Amendment) Rules, 2022, 'They shall come into force with effect from the 1st day of November, 2022'; substituted rule 35(3) with the worked example 'AB 12 A 1234 TC 0001' and its five-line legend; substituted rule 39(2) 'in white colour on red background as per dimensions specified in rule 51'; rule 37(1) validity extended from twelve months to five years; accessed 2026-08-02"
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 34(2) clauses (a)-(j), the class list the letter A-J indexes; accessed 2026-08-02"
+    notes: >-
+      THE CURRENT TRADE MARK — and the most completely specified registration
+      mark in Indian law, which is the irony of this file: the dealer plate has
+      a worked example in the rule ("AB 12 A 1234 TC 0001") and the ordinary
+      plate every Indian sees does not. period.start 2022 is the amendment's
+      own commencement, 1 November 2022. The four-digit tail is the trade
+      registration mark number within the certificate, "starting from 0001 to
+      9999", and a dealer may hold many: rule 35A, inserted by the same
+      instrument, provides for additional marks in Form 17B.
+
+  - id: in-vintage-2021
+    class: historic
+    categories: [car, motorcycle]
+    period: { start: 2021 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL VA LL 9999"
+      regex: '\A[A-Z]{2} ?VA ?[A-Z]{2} ?\d{4}\z'
+      regex_strict: '\A(?:AN|AP|AR|AS|BR|CG|CH|DD|DL|GA|GJ|HP|HR|JH|JK|KA|KL|LA|LD|MH|ML|MN|MP|MZ|NL|OD|PB|PY|RJ|SK|TG|TN|TR|TS|UK|UP|WB) ?VA ?[A-Z]{2} ?(?!0000)\d{4}\z'
+      composition_evidence: instrument
+      charset:
+        fixed_letters: "VA"
+        notes: >-
+          Rule 81B(1), verbatim: "the Registering Authority shall assign to a
+          Vintage Motor Vehicle for display thereon, a registration mark
+          consisting of the letters 'XX VA YY ****', where VA stands for
+          Vintage, XX stands for State code, YY will be a two letter series and
+          '****' is a number from 0001 to 9999 allotted by State Registering
+          Authority." Note what is NOT said: nothing excludes I or O from the
+          two-letter series, so `regex_strict` does not exclude them.
+    design:
+      plate: { w: 340, h: 200, unit: mm }
+      plate_variants:
+        - { w: 200, h: 100, unit: mm, note: "L1/L2 two-wheelers" }
+      background: { color: "#FFFFFF", finish: painted, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      rear_differs: false
+      hsrp_exempt: true
+      note: >-
+        Rule 81B(2): the mark "shall conform to the specifications spelt out in
+        rules 50 and 51 of these rules" — but rule 81B(4) exempts vintage
+        vehicles from HSRP entirely: "All such Vintage Motor Vehicles shall be
+        exempted from the provisions of High Security Registration Plate as
+        mandated under rule 50." So the vintage plate takes rule 50's colours
+        and rule 51's character sizes and NONE of rule 50(1)'s security
+        features — the only Indian plate in current issue that lawfully has no
+        IND legend, no hologram and no laser code.
+    region_encoding: "plates/_decode/in-state-codes.yml"
+    region_encoding_mechanism: "State code only — rule 81B has no district element, and the mark is allotted by the State Registering Authority rather than by a district office"
+    eligibility: >-
+      Rule 81A explanation: a vehicle of category L1/L2 (two-wheeler) or M1
+      (four-wheeler) "which is more than fifty years old from the date of first
+      registration after first sale including any vehicle imported into India
+      subject to the condition that such vehicle should be maintained in its
+      original form and should not have undergone any substantial overhaul,
+      which includes any modification in chassis or body shell or engine".
+      Registration is valid ten years, renewable for five (rule 81C).
+    sources:
+      - "https://egazette.gov.in/WriteReadData/2021/228336.pdf  # G.S.R. 492(E), New Delhi, 15 July 2021 — Central Motor Vehicles (Fifteenth Amendment) Rules, 2021, in force 'on the date of their final publication in the Official Gazette'; inserted Chapter IIIA, rules 81A (procedure and the fifty-year definition), 81B(1) (the XX VA YY **** mark), 81B(3) (already-registered vintage vehicles keep their original number), 81B(4) (HSRP exemption) and 81C (validity); accessed 2026-08-02"
+    notes: >-
+      THE VINTAGE (VA) SERIES. Its own format, its own instrument and its own
+      date — and one modelling subtlety that matters to a decoder: rule 81B(3)
+      provides that "All those vehicles which are already registered as Vintage
+      Motor Vehicle shall continue to retain the original registration number
+      and registration plate intact without any change", so a fifty-year-old
+      Indian car may lawfully carry EITHER a VA mark or its original ordinary
+      mark, and the absence of a VA mark says nothing about the vehicle's
+      status. period.start 2021 is the notification's own date, 15 July 2021.
+
+  # =========================================================================
+  # DIPLOMATIC, CONSULAR AND UN. Rules 76-77 are the 1989 principal rules'
+  # own text (unfootnoted in MoRTH's consolidation = unamended since 1989)
+  # except where an amendment is named. The MARK here is not built from a
+  # state code at all: it is [mission number] + [letters] + [vehicle number],
+  # and the mission number is allotted by the MINISTRY OF EXTERNAL AFFAIRS,
+  # not by MoRTH — a second, entirely separate decode dimension, and one this
+  # dataset does NOT hold (recorded gap).
+  # =========================================================================
+  - id: in-diplomatic-cd-1989
+    class: diplomatic
+    categories: [car, van]
+    period: { start: 1989 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99 CD 999"
+      regex: '\A\d{1,3} ?CD ?\d{1,4} ?[A-Z]?\z'
+      regex_statutory: '\A\d+ ?CD ?\d+ ?[A-Z]?\z'
+      composition_evidence: instrument
+      charset:
+        fixed_letters: "CD"
+        notes: >-
+          Rule 76(6), as substituted by G.S.R. 221(E) (28-3-2001), verbatim: a
+          vehicle of a Delhi diplomatic mission or its diplomatic officer "shall
+          be assigned a registration mark consisting of the letters 'CD'
+          preceded by the number allotted to the mission by the Ministry of
+          External Affairs of the Government of India and followed by a number
+          allotted to the vehicle by the registering authority". NEITHER NUMBER
+          HAS A PRESCRIBED WIDTH. `regex` bounds them at three and four digits,
+          which is an OBSERVED practical bound and not a legal one;
+          `regex_statutory` is the unbounded form the rule actually authorises.
+          The optional trailing letter is rule 76(6)(ii): the head of mission's
+          PERSONAL vehicles take the number "1" "followed consecutively, in
+          alphabetical order, by a letter beginning with the letter 'A'".
+      progression: >-
+        Rule 76(6)(i)-(vi) is an allocation ladder, and it decodes: "1" is the
+        head of mission's official car; "1A", "1B" … are the head of mission's
+        personal cars; official vehicles other than the head's start at "2";
+        then other officers' vehicles; then vehicles acquired by the mission or
+        by non-head diplomatic officers, "irrespective of whether such vehicle
+        is for official or personal use". Numbers freed by sale or export may
+        be reissued within the same clause.
+    design:
+      plate: { w: 410, h: 140, unit: mm }
+      background: { color: "#00338D", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      rear_differs: false
+      characters:
+        letters: { min_height_mm: 60, min_thickness_mm: 20 }
+        numerals: { min_height_mm: 90, min_thickness_mm: 20 }
+        min_space_mm: 10
+        note: >-
+          Rule 77(2)(i): letters "not less than 6 centimetres high and 2
+          centimetres thick at any part", numerals "not less than 9 centimetres
+          high and 2 centimetres thick", spacing "not less than 1 centimetre";
+          rule 77(2)(ii): on a motor cycle or invalid carriage, two-thirds of
+          those. This is the one Indian plate whose NUMERALS are prescribed
+          taller than its LETTERS.
+      layout: >-
+        Rule 77(3): on a transport vehicle, two lines — "the number allotted to
+        the mission or post and the letters forming the first line followed by
+        the number allotted by the registering authority in the second line";
+        in all other cases one or two lines at choice. Rule 77(3) also caps the
+        tilt at thirty degrees from the vertical, against rule 50(5)'s
+        forty-five for tractors.
+    region_encoding: none
+    region_encoding_mechanism: >-
+      NO GEOGRAPHY AND NO STATE CODE. The leading number is the MISSION number
+      allotted by the Ministry of External Affairs, which is a country decode,
+      not a place decode — and the MEA list was NOT reached in this pass, so
+      this dataset cannot turn "13 CD 1" into a country. That table is the
+      single most requested Indian plate decode after the state codes and is a
+      recorded gap for gate L4 (PRD-PLATES § 7 lists diplomatic decode tables
+      there).
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 76(1)-(6) with footnote 96 dating the substitution of sub-rule (6) to G.S.R. 221(E) 28-3-2001; rule 77(1)(i) 'with deep blue background, the registration mark and the number being in white'; rule 77(1) plate size '41 centimetres by 14 centimetres'; rule 77(2)-(3); accessed 2026-08-02"
+    notes: >-
+      THE CD PLATE. period.start 1989 is the principal rules: rule 77(1)(i) and
+      its 41 x 14 cm plate carry no amendment footnote in MoRTH's consolidation,
+      so they are the text as made in G.S.R. 590(E) of 2 June 1989; only the
+      ALLOCATION ladder in sub-rule (6) was rewritten in 2001, which changes who
+      gets which number and not what the plate looks like. Rule 76(8) adds a
+      case this dataset does not model as a series: consular posts headed by
+      HONORARY consular officers "shall use standard size number plates bearing
+      ordinary registration number" and may add "name of the country followed by
+      CC (Honorary)" in white on black, smaller than the registration number, on
+      at most two vehicles — an ordinary mark with a legend beside it, not a
+      series of its own.
+
+  - id: in-consular-cc-1989
+    class: consular
+    categories: [car, van]
+    period: { start: 1989, end: 2017 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99 CC 999"
+      regex: '\A\d{1,3} ?CC ?\d{1,4} ?[A-Z]?\z'
+      regex_statutory: '\A\d+ ?CC ?\d+ ?[A-Z]?\z'
+      composition_evidence: instrument
+      charset:
+        fixed_letters: "CC"
+        notes: >-
+          Rule 76(7): a vehicle of a consular post "headed by a Carrier
+          Counsellor Officer" or of its officers takes "the letters 'CC'
+          preceded by the number of the post allotted to it by the Ministry of
+          External Affairs ... and followed by a number allotted to the vehicle
+          by the registering authority out of a block of numbers allotted for
+          that post". Same unbounded digit widths as the CD series, same
+          reason for `regex_statutory`.
+    design:
+      plate: { w: 410, h: 140, unit: mm }
+      background: { color: "#FFD200", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      rear_differs: false
+      characters:
+        letters: { min_height_mm: 60, min_thickness_mm: 20 }
+        numerals: { min_height_mm: 90, min_thickness_mm: 20 }
+        min_space_mm: 10
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 76(7); rule 77(1)(ii) in its pre-2017 form, 'with yellow background, the registration mark and the number being in black'; accessed 2026-08-02"
+      - "https://web.archive.org/web/20210514203127id_/https://morth.nic.in/sites/default/files/notifications_document/Notification_no_G_S_R_633E_dated_23_6_2017_regarding_registration_mark_under_rule_76_of_the_CMVR_0.pdf  # G.S.R. 633(E) 23-6-2017, which substitutes those exact words and so dates the end of this series; accessed 2026-08-02"
+    notes: >-
+      THE OLD CONSULAR PLATE — yellow with black characters, which is why an
+      Indian consular car of that era is easy to mistake for a taxi at a
+      distance. Ended by G.S.R. 633(E) on 23 June 2017; see in-consular-cc-2017.
+      Distinct from in-diplomatic-cd-1989 in letters and, until 2017, in colour.
+
+  - id: in-consular-cc-2017
+    class: consular
+    categories: [car, van]
+    period: { start: 2017 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99 CC 999"
+      regex: '\A\d{1,3} ?CC ?\d{1,4} ?[A-Z]?\z'
+      regex_statutory: '\A\d+ ?CC ?\d+ ?[A-Z]?\z'
+      composition_evidence: instrument
+      charset: { fixed_letters: "CC", notes: "unchanged by the 2017 amendment, which touched only rule 77(1)(ii)'s colours" }
+    design:
+      plate: { w: 410, h: 140, unit: mm }
+      background: { color: "#00338D", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFD200"
+      band: { side: none }
+      rear_differs: false
+      characters:
+        letters: { min_height_mm: 60, min_thickness_mm: 20 }
+        numerals: { min_height_mm: 90, min_thickness_mm: 20 }
+        min_space_mm: 10
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/20210514203127id_/https://morth.nic.in/sites/default/files/notifications_document/Notification_no_G_S_R_633E_dated_23_6_2017_regarding_registration_mark_under_rule_76_of_the_CMVR_0.pdf  # G.S.R. 633(E), 23 June 2017 — Central Motor Vehicles (Ninth Amendment) Rules, 2017, in force on publication: 'In the Central Motor Vehicles Rules, 1989, in rule 77, in sub-rule (1), in clause (ii), for the words “with yellow background, the registration mark and the number being in black”, the words “with deep blue background, the registration mark and the number being in yellow” shall be substituted'; its own draft was G.S.R. 40(E) of 17 January 2017; accessed 2026-08-02"
+    notes: >-
+      THE CURRENT CONSULAR PLATE — deep blue with YELLOW characters, against the
+      diplomatic plate's deep blue with WHITE. That one-word difference is the
+      whole distinction between a CD and a CC plate at a glance today, and it
+      is exactly six years old. period.start 2017 is the amendment's own
+      commencement (publication, 23 June 2017); its draft, G.S.R. 40(E) of
+      17 January 2017, is NOT the date — the draft invites objections and
+      creates nothing, which is the classic Indian instrument-date trap.
+
+  - id: in-un-1995
+    class: diplomatic
+    categories: [car, van]
+    period: { start: 1995 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99 UN 999"
+      regex: '\A\d{1,3} ?UN ?\d{1,4} ?[A-Z]?\z'
+      regex_statutory: '\A\d+ ?UN ?\d+ ?[A-Z]?\z'
+      composition_evidence: instrument
+      charset:
+        fixed_letters: "UN"
+        notes: >-
+          Rule 76-A, inserted by G.S.R. 644 dated 25-9-1995: rules 76 and 77 to
+          80 apply to vehicles of diplomatic officers of organisations notified
+          under the United Nations (Privileges and Immunities) Act, 1947
+          "with the modification that in rule 76,— (a) in sub-rule (6), for the
+          letters 'CD', the letters 'UN' shall be substituted; and (b) in
+          sub-rule (7), for the letters 'CC', the letters 'UN' shall be
+          substituted."
+    design:
+      plate: { w: 410, h: 140, unit: mm }
+      background: { color: "#00338D", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      rear_differs: false
+      note: >-
+        COLOUR CAVEAT, and it is a real ambiguity in the rule: rule 76-A
+        substitutes "UN" into BOTH sub-rule (6) (whose colour is rule 77(1)(i),
+        blue/white) and sub-rule (7) (whose colour is rule 77(1)(ii), now
+        blue/yellow). A UN plate therefore takes blue/white or blue/yellow
+        depending on which sub-rule the vehicle falls under, and the rule gives
+        no way to tell the two apart from the mark. Recorded as an ambiguity,
+        not resolved by invention; the blue/white recorded here is the
+        sub-rule (6) case.
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 76-A with footnote 1: 'Inserted by G.S.R. 644, dated 25-9-1995'; accessed 2026-08-02"
+    notes: >-
+      THE UN PLATE. period.start 1995 is the inserting instrument. The
+      footnote in MoRTH's consolidation gives "G.S.R. 644" without the (E)
+      suffix and without a separate commencement date, so the year is what is
+      claimed here and the day is a recorded gap.
+
+  - id: in-nondiplomatic-cdp-1997
+    class: diplomatic
+    categories: [car, van]
+    period: { start: 1997 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99 CDP 999"
+      regex: '\A\d{1,3} ?CDP ?\d{1,4}\z'
+      regex_statutory: '\A\d+ ?CDP ?\d+\z'
+      composition_evidence: instrument
+      charset:
+        fixed_letters: "CDP"
+        notes: >-
+          Rule 76-B(1), inserted by G.S.R. 395(E) dated 16-7-1997: a vehicle of
+          a NON-DIPLOMATIC official of a mission or post in Delhi "shall be
+          assigned a registration mark consisting of letters 'CDP' preceded by
+          the number allotted to the mission or post by the Ministry of
+          External Affairs ... and followed by a number allotted to the vehicle
+          by the registering authority."
+    design:
+      plate: { w: 410, h: 140, unit: mm }
+      background: { color: "#8DC63F", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 76-B(1) with footnote 2 ('Inserted by G.S.R. 395(E), dated 16-7-1997') and rule 77(1)(iii) with footnote 3 (same instrument): 'with light green background, the registration mark and the number being in white in case of motor vehicles referred to in rule 76-B'; accessed 2026-08-02"
+    notes: >-
+      THE LIGHT-GREEN CDP PLATE — home-based NON-diplomatic staff of a mission
+      in Delhi. Both the mark and its colour arrive in the same instrument,
+      G.S.R. 395(E) of 16 July 1997, so the period claim is unusually clean for
+      this jurisdiction. Do not confuse the light green of rule 77(1)(iii) with
+      the battery-vehicle green of rule 50(2A): different instruments,
+      different regimes, twenty-one years apart, and the CDP plate carries
+      white characters where a private EV plate also carries white — the mark
+      itself is the only reliable discriminator.
+
+  - id: in-nondiplomatic-ccp-1997
+    class: consular
+    categories: [car, van]
+    period: { start: 1997 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99 CCP 999"
+      regex: '\A\d{1,3} ?CCP ?\d{1,4}\z'
+      regex_statutory: '\A\d+ ?CCP ?\d+\z'
+      composition_evidence: instrument
+      charset:
+        fixed_letters: "CCP"
+        notes: >-
+          Rule 76-B(2): a vehicle of a home-based non-diplomatic official of a
+          consular post OUTSIDE Delhi "shall be assigned a registration mark
+          consisting of the letters 'CCP' preceded by the number of the post
+          allotted to it by the Ministry of External Affairs ... and followed
+          by the number allotted to the vehicle by the registering authority."
+    design:
+      plate: { w: 410, h: 140, unit: mm }
+      background: { color: "#8DC63F", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf  # rule 76-B(2) and rule 77(1)(iii), both inserted by G.S.R. 395(E) dated 16-7-1997; accessed 2026-08-02"
+    notes: >-
+      THE CCP PLATE — the outside-Delhi twin of CDP, same colour, same
+      instrument, same date. Two series rather than one because the letter
+      group differs and a parse API must be able to score each shape
+      independently (the plates/nl.yml GV-sidecode precedent).


### PR DESCRIPTION
**PRD-PLATES gate L3 (S5W; manifest branch s4w-plates/l3-manifest).** Researcher-drafted to the L1/L2 standard: primary instruments quoted verbatim (native-language gazettes read in the original), instrument-dated periods with honest period_evidence, folklore flagged not asserted, non-Latin scripts modelled as decode/field facts with the ASCII projection stated. Independent staged lint over origin/main with ALL 28 wave files: `plates lint: 123 files, 1360 series ... OK`.

**in**: 16 series, 13 pinned sources, lint green.

---

# Research dossier — INDIA (`in`), PRD-PLATES gate L3

**Researcher pass, 2026-08-02. DRAFT — not applied to any canonical repo.**
Deliverables: `in.yml` (16 series) + `in-state-codes.yml` (one decode table,
to land as `plates/_decode/in-state-codes.yml`). Lint green in a copied
workspace. A human session verifies, lints and applies.

Everything below is written so a verifier can re-derive each claim in one
step: instrument → clause → quoted words → the field in the YAML that carries
them. Where nothing was reached, the gap is named rather than filled.

---

## 1. What India is, structurally, and why it is ONE file and not per-state

India is **not** a federated plate jurisdiction in the sense that Australia,
Canada and the United States are. Every Indian registration mark is issued
under **one** central statute and **one** set of central rules; the State
appears *inside the serial* as a two-letter code, not as a separate issuing
system with its own format, colours and instrument. The decisive text is
**MVA 1988 § 41(6)**, fetched verbatim:

> "(6) The registering authority shall assign to the vehicle, for display
> thereon, a distinguishing mark (in this Act referred to as the registration
> mark) consisting of one of the groups of such of those letters and followed
> by such letters and figures as are allotted to the State by the Central
> Government from time to time by notification in the Official Gazette, and
> displayed and shown on the motor vehicle in such form and in such manner as
> may be prescribed by the Central Government."

So: the *letters* are a **Central Government gazette allotment**; the *form and
manner* are **Central** rules (CMVR rule 50, rule 51). Nothing is delegated to
the States except the running of the offices. India therefore gets **one
national file plus one decode table**, in the pattern of `de.yml` +
`_decode/de-*`, and not the `us-fl.yml` / `au-nsw` per-state shape.

**Consequence for the swarm's per-state instinct:** the *district* dimension
(the two digits after the state code) genuinely IS per-state and genuinely IS
open — see §6 GAP-3. It is modelled as a mechanism note, never as a table.

---

## 2. The script question, answered by the rule itself

The brief flags that L3 jurisdictions may carry non-Latin serial alphabets
(kanji office marks, Chinese province characters, Thai script) and asks where
the line was drawn. **For India the line is drawn by the instrument, not by
me.** CMVR **rule 50(2), proviso (d)**, as substituted by G.S.R. 901(E) of
13 December 2001, opens:

> "(d) the letters of the registration mark shall be in English and the figures
> shall be in Arabic numerals and shall be shown:— (A) in the case of transport
> vehicles in black colour on yellow background; and (B) in other cases, in
> black colour on white background…"

Rule 77(2) says the same for diplomatic marks: *"The registration mark shall be
in English letters and Arabic numerals."* **The entire Indian serial alphabet is
`A–Z` + `0–9`.** No Devanagari, no regional script, no state-language legend is
part of a registration mark. The one non-serial glyph on the plate is the
`IND` legend in blue (rule 50(1)(ii)) and the chromium hologram carrying the
Ashoka **Chakra** (HSRP Order 2018 para 6(v)) — both are recorded as `design`
facts (`security.ind_legend`, `security.hologram`, `emblem.note`), never as
serial characters. `_meta/separators.yml` needed no amendment for India.

---

## 3. Primary sources actually fetched (all live-checked 2026-08-02)

Every URL below returned HTTP 200 and a real PDF/HTML body on the day of the
pass. The live `morth.nic.in` / `morth.gov.in` site was rebuilt as an Angular
single-page app whose legacy document paths now return the **app shell**
(40,262 bytes of HTML) instead of the file — so the MoRTH documents are pinned
at **web.archive.org `id_` raw captures**, which do return the PDFs. That is a
sourcing weakness worth stating plainly, and it is stated per source line in
the YAML.

| # | Instrument | URL pinned | What it evidences |
|---|---|---|---|
| 1 | **Motor Vehicles Act, 1988 (59 of 1988)** | `https://web.archive.org/web/20250804185944id_/https://www.indiacode.nic.in/bitstream/123456789/1798/1/aA1988-59.pdf` | § 41(6) the mark and the gazette allotment; § 1(3) fn — in force 1 July 1989 vide S.O. 368(E) 22-5-1989; § 43 temporary registration; § 60 defence vehicles; § 64 rule-making power |
| 2 | **CMVR 1989, MoRTH consolidated Chapter III** (G.S.R. 590(E), 2-6-1989) | `https://web.archive.org/web/20211130113450id_/https://morth.nic.in/sites/default/files/CMVR-chapter3.pdf` | rules 34, 35, 37, 39 (trade); 47, 48; **50 (form/manner, HSRP spec, colours, two-line layout)**; **51 (character minima)**; 54; **76, 76-A, 76-B, 77 (diplomatic/consular)**; and every amendment footnote quoted below |
| 3 | **G.S.R. 594(E), 26-8-2021** — CMV (Twentieth Amendment) Rules 2021 | `https://egazette.gov.in/WriteReadData/2021/229283.pdf` | **BH series**: rule 50(8) mark table; rule 47(1)(ca)-(cb); rule 48 proviso; rule 51B tax; rule 54(3); Form 60 |
| 4 | **G.S.R. 492(E), 15-7-2021** — CMV (Fifteenth Amendment) Rules 2021 | `https://egazette.gov.in/WriteReadData/2021/228336.pdf` | **VA vintage series**: rules 81A–81D |
| 5 | **G.S.R. 703(E), 14-9-2022** — CMV (Fifteenth Amendment) Rules 2022 | `https://web.archive.org/web/20230429221141id_/https://morth.nic.in/…GSR%20703(E)…for%20Trade%20Certificate.pdf` | **new trade mark** rule 35(3) worked example; rule 39(2) white-on-red; rule 37 twelve months → five years; rule 35A |
| 6 | **G.S.R. 240(E), 31-3-2021** — CMV (Sixth Amendment) Rules 2021 | `https://web.archive.org/web/20210421181546id_/https://morth.nic.in/…GSR%20240(E)…pdf` | **rule 53C temporary mark** legend; rules 53A–53B validity |
| 7 | **G.S.R. 749(E), 7-8-2018** — CMV (10th Amendment) Rules 2018 | `https://web.archive.org/web/20210514202442id_/https://morth.nic.in/…749E…Electric_vehicles_0.pdf` | **rule 50(2A) green EV plate** |
| 8 | **G.S.R. 633(E), 23-6-2017** — CMV (Ninth Amendment) Rules 2017 | `https://web.archive.org/web/20210514203127id_/https://morth.nic.in/…633E…rule_76_of_the_CMVR_0.pdf` | consular colour change yellow/black → deep blue/yellow |
| 9 | **S.O. 6052(E), 6-12-2018** — MV (High Security Registration Plates) Order 2018, with G.S.R. 1162(E) 4-12-2018 | `https://web.archive.org/web/20210514202317id_/https://morth.nic.in/…1162E…High_Security_Registration_Plate_0.pdf` | HSRP fitment from **1 April 2019**; 10-digit laser code; 20×20 mm Chakra hologram; fuel-sticker colours |
| 10 | **G.S.R. 640(E), 18-8-2022** | `https://web.archive.org/web/20230429221406id_/https://morth.nic.in/…8GSR%20640(E)…HSRP%20rule%2050.pdf` | who may supply the plate (rule 50(1)(v)) |
| 11 | **S.O. 4262(E), 25-11-2019** | `https://web.archive.org/web/20210514201915id_/https://morth.nic.in/…S.O.%204262(E)…Ladakh%20LA.pdf` | inserts `17A. Ladakh  LA`; **names S.O. 444(E) 12-6-1989 as the state-code notification** |
| 12 | **S.O. 1306(E), 12-3-2024** | `https://web.archive.org/web/20240706034252id_/https://morth.nic.in/…8-SO%201306(E)…Telangana.pdf` | substitutes `29A. Telangana  TG`; names S.O. 2339(E) 14-7-2020 as the previous amendment |
| 13 | **MoRTH circular RT-11028/01/2018-MVL** | `https://web.archive.org/web/20190919185053id_/http://morth.nic.in/sites/default/files/circulars_document/CMVR%20rules%201989%20for%20HSRP.pdf` | HSRP "to be affixed through the authorized dealers of OEM w.e.f. 01.04.2019" |

Additional gazette PDFs were harvested and read but produced no claim that
isn't already covered (`egazette.gov.in/WriteReadData/2021/2283xx.pdf` sweep).

### 3.1 The verbatim quotes the file leans hardest on

**BH — the only Indian mark laid out as a labelled table** (G.S.R. 594(E) ¶ 4,
inserting rule 50(8); English column, verbatim including the rule's own smart
quotes):

> "(8) The registration mark for BH-series vehicle generated randomly through
> the portal shall be in black on white background and shall be exhibited in the
> following manner, namely:—
> | XX | XX | #### XX |
> | Last two digits of year of registration | Bharat Series code (2) letters as "BH" | 4 numerals 0001 to 9999 followed by letter(s) A, B, C …and then AA,AB…..AZ, BA, BB …..to ZZ excluding 'I' & 'O' |"

Commencement, same instrument ¶ 1: *"These rules may be called as the Central
Motor Vehicles (Twentieth Amendment) Rules, 2021. 2. They shall come into force
with effect from the 15th day of September, 2021."* Made **26 August 2021**,
published 27 August 2021.

**HSRP — the date trap** (CMVR consolidation, footnote 74 to rule 50):

> "74. Sub-R. (1) substituted by G.S.R. 221(E), dated 28-3-2001 as amended by
> S.O. 938(E), dated 24-9-2001, S.O. 499(E), dated 9-5-2002 and S.O. 59(E),
> dated 21-1-2003 (**w.e.f. 1-1-2004**)."

**Temporary** (G.S.R. 240(E), inserting rule 53C(1)):

> "T- Represent temporary certificate; 08- Month of issuance of temporary
> certificate of registration 20- Year of issuance of temporary certificate of
> registration; AB- Represent State Code; 1234- Serial Number of Temporary
> Registration; AB- Alphabet of Temporary Registration (Except O and I)."

**Trade, new** (G.S.R. 703(E), substituting rule 35(3)):

> "(3) A trade registration mark shall be the trade certificate number followed
> by four digit numerals starting from 0001 to 9999, for example: **AB 12 A 1234
> TC 0001**, in which, - (i) AB—Represents State Code, (ii) 12—Represents RTO
> Code, (iii) A - Represents serial number of class of vehicle as prescribed in
> Rule 34(2) i.e. from A to J, (iv) 1234- Represents four digit unique
> identification number…, (v) TC—Represent trade certificate."

and substituting rule 39(2): *"The trade registration mark shall be in white
colour on red background as per dimensions specified in rule 51 and shall be
exhibited on front and rear of a motor vehicle."*

**Vintage** (G.S.R. 492(E), inserting rule 81B(1)):

> "…a registration mark consisting of the letters 'XX VA YY ****', where VA
> stands for Vintage, XX stands for State code, YY will be a two letter series
> and '****' is a number from 0001 to 9999 allotted by State Registering
> Authority."

plus 81B(4): *"All such Vintage Motor Vehicles shall be exempted from the
provisions of High Security Registration Plate as mandated under rule 50."*

**EV** (G.S.R. 749(E), inserting rule 50(2A)):

> "2A. In case of Battery Operated Vehicles, the registration mark shall be
> exhibited in Yellow colour on Green background for transport vehicles and for
> all other cases, in White colour on Green background."

**Diplomatic** (rule 76(6), substituted by G.S.R. 221(E) 28-3-2001):

> "A motor vehicle belonging to a diplomatic mission in Delhi or to any of its
> diplomatic officer shall be assigned a registration mark consisting of the
> letters 'CD' preceded by the number allotted to the mission by the Ministry of
> External Affairs of the Government of India and followed by a number allotted
> to the vehicle by the registering authority…"

and rule 77(1): *"…the size of which shall be 41 centimetres by 14
centimetres— (i) with deep blue background, the registration mark and the
number being in white… (ii) with yellow background… in black… (iii) with light
green background… in white in case of motor vehicles referred to in rule 76-B."*
Clause (ii) is the one G.S.R. 633(E) rewrote to *"deep blue background, the
registration mark and the number being in yellow"*.

---

## 4. THE WIKIPEDIA RULE — how it was applied

Per the owner directive, `en:Vehicle registration plates of India` was used as a
**mandatory finding aid** and its citation list mined systematically. The
article's raw wikitext was fetched (`action=raw`, 54 KB) and every external URL
extracted (35 distinct). That extraction is **the entire reason this dossier has
primaries at all**: MoRTH's own site no longer serves its notification PDFs, and
the Wikipedia footnotes preserve the exact `notifications_document/…` paths that
Wayback has captures of.

**Instruments recovered from Wikipedia footnotes and then fetched directly**:
G.S.R. 512(E) (HSRP colours), G.S.R. 240(E), G.S.R. 703(E), G.S.R. 633(E),
S.O. 295(E), G.S.R. 492(E), the egazette BH PDF `2021/229283.pdf`, and
`egazette.nic.in/WriteReadData/2019/214357.pdf`. **Every one of those is cited
in the YAML as the instrument, never as the article.** No Wikipedia prose,
table arrangement or ordering is reproduced anywhere in `in.yml` or
`in-state-codes.yml`; the state-code table in the decode file is ordered
alphabetically by CODE (Wikipedia orders it in two interleaved columns by
territory name) and carries per-row evidence tags Wikipedia has no analogue of.

**Wikipedia-only claims that were NOT taken into the data** — this is the list a
reviewer should check, because it is where the temptation was:

- the "one to three letters **or blank**" series-group description → recorded
  as `charset.recall_gap_blank_series`, an explicit recall gap, NOT encoded;
- the colour-scheme matrix (rental yellow-on-black, military white-on-black
  with the broad-arrow, "199 CD 99" examples) → **not used**; the black-on-yellow
  *rental* plate and the armed-forces plate have no instrument in hand;
- the plate-dimension list (LMV 50×12 cm etc.) → **not used**; the YAML carries
  rule 50(1)(vi)'s own numbers (200×100 / 340×200 / 500×120 / 285×45), which
  differ in presentation and are instrument-sourced;
- the "HSRP mandated 1 June 2005" date → **contradicted by the footnote**, see
  §5 FOLKLORE-1;
- the "BH introduced 26 August 2021" framing → the instrument gives **two**
  dates and the YAML records both (§5 FOLKLORE-4).

No `period_evidence: secondary-*` tag was needed: every series in the file
resolved to an instrument.

---

## 5. Folklore flags — repeated claims this file refuses to assert

**FOLKLORE-1 — "HSRP has applied since 2005."** Repeated everywhere, including
the Wikipedia article. The consolidation's own footnote 74 says rule 50(1) was
substituted by G.S.R. 221(E) of 28-3-2001 **as amended three times** and takes
effect **w.e.f. 1-1-2004**. Neither 2001 nor 2005 is the legal start. The file
records **2004** with `period_evidence: enabling-instrument` and puts the
1 April 2019 OEM-fitment obligation (S.O. 6052(E)) in the notes as the separate
claim it is. *The 2005 figure appears to be an artefact of the two-year grace
proviso ("this sub-rule shall apply to already registered vehicles two years
from the date of commencement") counted off a 2003 base.* Recorded, not
asserted.

**FOLKLORE-2 — "Indian registration marks never use I and O."** The instruments
exclude those letters from **exactly two** series: BH (rule 50(8), *"excluding
'I' & 'O'"*) and temporary (rule 53C, *"Except O and I"*). Nothing excludes them
from the ordinary series letters, and the **new trade mark issues `I`
deliberately** — rule 35(3)(iii) maps the class letter to rule 34(2)'s clauses
(a)–(j), where **(i) is "E-cart"**. A blanket I/O exclusion applied across India
would reject a lawful trade mark. Flagged on `in-dealer-2022.charset`.

**FOLKLORE-3 — "the temporary plate is red on yellow."** Universal on the
secondary web. **No instrument prescribes any colour for the temporary mark.**
Rule 53C(2) says only that the owner *"shall ensure that the said mark is
affixed to the front and rear of the motor vehicle"*. `in-temporary-2021` ships
with **no `background`/`foreground` at all** and a note saying why. Recorded
gap.

**FOLKLORE-4 — "BH started 26 August 2021" vs "…15 September 2021" vs
"…21 September 2021."** All three circulate; the Wikipedia infobox says the
Twentieth Amendment is dated 21 September 2021. The instrument settles it:
G.S.R. 594(E) is **made 26 August 2021**, **published 27 August 2021**, and
**comes into force 15 September 2021**. All three real dates are in the notes;
`period.start` is 2021 either way, and 21 September 2021 is not one of them.

**FOLKLORE-5 — "the third character group is a vehicle-class code."** Delhi's
`DL 3C AB 1234` (`C` = car) is the famous case and it is real *as a Delhi
practice*. **No central instrument authorises it and no Delhi instrument was
reached.** The dataset treats every letter after the district as series
alphabet and says so in `region_encoding_mechanism`: *"A parse API must not
decode a class from it."*

**FOLKLORE-6 — the state-code table itself.** Thirty-eight rows that "everyone
knows" and that no fetched primary states. See GAP-1; the decode file tags each
row.

---

## 6. Gaps — named, ranked, not filled

**GAP-1 (HIGHEST VALUE) — S.O. 444(E) of 12 June 1989 was not reached.** This is
the notification that allots the two-letter codes under § 41(6). Its *identity*
is instrument-evidenced twice over (S.O. 4262(E) and S.O. 1306(E) each amend
"the Table to the said notification … number S.O.444(E), dated the 12th June,
1989"). Its *text* is not online: e-Gazette's digital archive does not reach
1989, and MoRTH's SPA rebuild broke its own legacy paths. **Consequence, honest
and per-row: of the 40 decode rows (36 current + 4 withdrawn), exactly 2 —
`LA` and `TG` — are `evidence: instrument`; 1 more (`TS`) is
`instrument-adjacent` (its entry's existence, position and end date are quoted
by S.O. 1306(E), but that notification prints only the NEW entry, so the
letters `TS` themselves are not quoted anywhere in hand); the remaining 37
carry `evidence: corroboration-only` and `verify: true`.** Every
chapter of MoRTH's consolidated CMVR was fetched and searched — the string
"Andhra" appears in none of them, confirming the codes are not in the rules.
Suggested verifier route: a physical/subscription gazette archive
(Manupatra/SCC/EBC reprints of CMVR frequently print the S.O. 444(E) table as an
appendix), or an RTI-published State transport-department reproduction.

**GAP-2 — the ordinary mark's composition is nowhere stated.** No instrument
says "two letters, two digits, one-to-three letters, four numerals". The shape
is **reconstructed** from four rules that define *other* marks by reference to
it (rule 50(3), rule 35(3), rule 53C, rule 81B), and every series carrying it is
tagged `format.composition_evidence: reconstructed`. This is the British/German
delegation pattern arriving by a third route, and it is the reason `regex` is
quantified rather than fixed. **Do not upgrade that tag without S.O. 444(E).**

**GAP-3 — the RTO district codes are open and are deliberately not tabled.** No
central instrument enumerates them (rule 50(3): *"registering authority code"*;
rule 35(3): *"RTO Code"*). Each State creates, merges and renumbers its own
offices; there are well over a thousand. Modelled as a mechanism note per
PRD-PLATES § 2.4. A decode returns the **State** with confidence and the
**district** only against a dated, State-published list.

**GAP-4 — the armed-forces (broad-arrow) series is not modelled.** MVA § 60(1)
takes defence vehicles out of the ordinary registration regime entirely
("*any vehicle so registered shall not … require to be registered otherwise
under this Act*"). The Ministry of Defence instrument was not reached. **No
military series is invented.**

**GAP-5 — the MEA mission-number table is not held.** A CD/CC/UN/CDP/CCP mark's
leading number is allotted by the **Ministry of External Affairs**, not MoRTH.
`idprotocolmea.gov.in` is named in the Wikipedia footnotes; its list was not
reached in this pass. This is the second-most-requested Indian decode and is L4
work per PRD-PLATES § 7.

**GAP-6 — no statutory font drawing exists.** Unlike the UK Schedule 4, the
German and Spanish *Schriftmuster*, **rule 51 is a table of millimetre minima
and nothing else** — no typeface named, no drawing published. The Indian plate
face is fixed downstream by the HSRP type-approval chain (AIS standards via
rule 126 test agencies), whose text was not reached. Render layer must use the
schematic fallback (PRD-PLATES § 6 binding default).

**GAP-7 — pre-2001 colour law.** Rule 50(2)(d) in its present wording dates from
G.S.R. 901(E) (13-12-2001); the clause's *original* 1989 text was not reached.
So `in-transport-1989`'s yellow is asserted for 2001→2003 and the 1989→2001
window is a recorded uncertainty in that series' notes, not an assertion.

**GAP-8 — no colour is numbered anywhere in Indian plate law.** Not one
instrument gives a chromaticity coordinate or names a BIS/AIS colour standard.
**Every hex in the file is `hex_basis: observed` inside a statutorily named
colour** — the `gb.yml`/`de.yml` posture. Do not upgrade any of them without a
numbered source.

**GAP-9 — "Battery Operated Vehicles" is undefined.** Rule 50(2A) uses the term
and offers no definition; whether a plug-in hybrid qualifies is unresolved on
the face of the rule. Recorded on `in-electric-green-2018`.

**GAP-10 — the blank-series ordinary mark.** See §5/§7; regexes require ≥1
series letter.

**GAP-11 — the UN plate's colour is genuinely ambiguous in the rule.** Rule 76-A
substitutes "UN" into *both* rule 76(6) (whose colour is blue/white) and rule
76(7) (now blue/yellow), and gives no way to tell which sub-rule a given UN
vehicle falls under from the mark. Recorded as an ambiguity, not resolved by
invention.

---

## 7. Two defects found and fixed in THIS pass

**DEFECT-A (fixed) — `TS` missing from three post-2021 alternations.** The
`regex_strict` state-code lists on `in-temporary-2021`, `in-dealer-2022` and
`in-vintage-2021` omitted **TS**, on the reasoning that those series post-date
the retired codes. But Telangana was **TS until S.O. 1306(E) substituted TG on
12 March 2024** — squarely inside all three periods, and a vintage registration
runs ten years (rule 81C) while a post-2022 trade certificate runs five (rule
37 as amended), so TS marks of both kinds are live into the 2030s. `TS` added;
`OR`/`UA`/`DN` correctly remain excluded from those three (retired 2012 / 2007 /
2020, before those series existed). The reasoning is now written into the file
as `common.mark_composition.state_code_alternations_are_period_scoped`.

**DEFECT-B (found by probing, then REVERTED — a near-miss worth recording).**
The ordinary-mark letter run is spelled `[A-Z](?: ?[A-Z]){0,2}` — with an
*internal optional space*. That looks like sloppiness and I tightened it to
`[A-Z]{1,3}`; lint stayed green, because lint generates from
`pattern: "LL 99 LL 9999"` and never produces a split letter run. A hand-written
probe of real shapes caught it immediately: **`DL 3C AB 1234` fails
`[A-Z]{1,3}`.** Rule 50(3) puts the state code and the registering-authority
code on line 1 and *"the rest"* on line 2, so where a State prints a letter
straight after the district digits (Delhi's `DL 3C` over `AB 1234`), the letter
run is split across lines and its linear rendering carries a gap inside it. The
original spelling was correct and is restored, with the reasoning now in
`charset.series_group_note` **including the cost**: the regex also accepts
`MH 12 A B 1234`, which no plate prints — a recall-side looseness inside a
`strict` series, preferred to silently failing a whole State's plates.

*Lesson for the programme, and it generalises past India:* `lint_plates.rb`
round-trips the regex against the **pattern**, and a pattern cannot express a
serial whose group boundaries move. Lint-green is necessary and not sufficient;
a hand-written probe corpus of real shapes is the only thing that catches this
class of defect.

---

## 8. The 16 series, and why each period is dated where it is

| id | class | period | `period_evidence` | dating instrument / clause |
|---|---|---|---|---|
| `in-standard-1989` | standard | 1989–2003 | enabling-statute | MVA in force 1-7-1989 (S.O. 368(E)); ends when rule 50(1) HSRP takes effect 1-1-2004 |
| `in-standard-hsrp-2004` | standard | 2004– | enabling-instrument | rule 50(1) subst. G.S.R. 221(E) **w.e.f. 1-1-2004** (fn 74) |
| `in-transport-1989` | standard | 1989–2003 | enabling-statute | as above; colour from rule 50(2)(d)(A) |
| `in-transport-hsrp-2004` | standard | 2004– | enabling-instrument | as above + rule 50(2)(d)(A) |
| `in-electric-green-2018` | electric | 2018– | enabling-instrument | G.S.R. 749(E) 7-8-2018, in force on publication |
| `in-bh-2021` | standard | 2021– | enabling-instrument | G.S.R. 594(E) 26-8-2021, in force **15-9-2021** |
| `in-temporary-2021` | temporary | 2021– | enabling-instrument | G.S.R. 240(E) 31-3-2021, in force **1-4-2021** |
| `in-dealer-1989` | dealer | 1989–2022 | enabling-instrument | rule 35(1) as made; ended by G.S.R. 703(E) w.e.f. 1-11-2022 |
| `in-dealer-2022` | dealer | 2022– | enabling-instrument | G.S.R. 703(E) 14-9-2022, in force **1-11-2022** |
| `in-vintage-2021` | historic | 2021– | enabling-instrument | G.S.R. 492(E) 15-7-2021, in force on publication |
| `in-diplomatic-cd-1989` | diplomatic | 1989– | enabling-instrument | rule 77(1)(i) unfootnoted ⇒ principal rules G.S.R. 590(E) 2-6-1989 |
| `in-consular-cc-1989` | consular | 1989–2017 | enabling-instrument | rule 77(1)(ii) as made; ended by G.S.R. 633(E) 23-6-2017 |
| `in-consular-cc-2017` | consular | 2017– | enabling-instrument | G.S.R. 633(E) 23-6-2017, in force on publication |
| `in-un-1995` | diplomatic | 1995– | enabling-instrument | rule 76-A ins. **G.S.R. 644, dated 25-9-1995** (fn 1; note: no "(E)" suffix and no separate commencement — day is a gap) |
| `in-nondiplomatic-cdp-1997` | diplomatic | 1997– | enabling-instrument | rule 76-B + rule 77(1)(iii), both ins. G.S.R. 395(E) 16-7-1997 |
| `in-nondiplomatic-ccp-1997` | consular | 1997– | enabling-instrument | as above |

**Why no `instrument-in-force` anywhere.** Every Indian series above resolved to
the instrument that *created* it, not merely to one that documents it — the
consolidation's amendment footnotes give the creating instrument and its
`w.e.f.` date for each. `in-diplomatic-cd-1989` and `in-consular-cc-1989` are
the closest calls: rule 77(1)(i)/(ii) carry **no** amendment footnote in MoRTH's
consolidation, which is that consolidation's convention for *text as originally
made*, so the principal rules (G.S.R. 590(E), 2-6-1989) are the enabling
instrument rather than a later witness. **A verifier who disagrees with that
reading should downgrade those two to `instrument-in-force` and say so.**

**Class-vocabulary notes.** `in-transport-*` is `class: standard`, not a new
class: the transport/non-transport split is a class of **use** (MVA § 2(47))
that changes only the colour, and `_meta/classes.yml` has no value for it — the
same posture `gb.yml` takes for the Q mark. Cut as separate series because the
DESIGN differs (PRD-PLATES § 2.3). The trailer case is a colour-only sub-entry
under `variants:` on `in-transport-hsrp-2004`, per the same rule.

---

## 9. Verification performed

**Lint.** `plates/` copied (excluding `_art/`) with `scripts/lint_plates.rb` into
`…/scratchpad/ws`; `in.yml` and `_decode/in-state-codes.yml` added.

```
plates lint: 92 files, 961 series
plates lint: matching recall-only=200 strict=761 | twins regex_statutory=89 regex_strict=281
             | separators emitted "-"," " forgiving 18
plates lint: OK
```

(Baseline before India: 91 files, 945 series, `strict=745`, `regex_strict=271`,
`regex_statutory=83`. India contributes **16 series, all `strict`, none
`recall-only`, 10 `regex_strict` and 6 `regex_statutory`** — the six statutory
twins are the diplomatic/consular/UN series, whose rules prescribe no digit
width at all, so `regex` carries an observed practical bound and
`regex_statutory` carries the unbounded form the rule actually authorises.)

**Probe corpus.** A hand-written 36-case probe (`/tmp/in_probe.rb`, reproducible
from this dossier) asserting, per series, that `regex` accepts real printed
shapes, that `regex_strict` rejects out-of-alphabet ones, and that neighbouring
series do not cross-match:

```
probe: all 36 cases OK
```

Cases include `MH 12 AB 1234`, `MH12AB1234`, `DL 3C AB 1234`, `KA 01 A 0001`,
`TN 07 ABC 9999`, `22 BH 1234 AB`, `21BH0001A`, `T 0820 MH 1234 AB`,
`T0124TS0001AB`, `MH 12 A 1234 TC 0001`, `TS01C9999TC9999`, `MH VA AB 1234`,
`TS VA ZZ 0001`, `13 CD 1`, `13 CD 1 A`, `199 CC 0123`, `13 CDP 45`; plus
negative cases `XX 12 AB 1234`, `MH 00 AB 1234`, `MH 12 AB 0000`,
`22 BH 1234 IO`, `22 BH 0000 AB`, `T 1320 MH 1234 AB`, `MH 12 Z 1234 TC 0001`,
`13 CC 1` against the CD regex, and `MH 12 AB 1234` against the BH regex.

**URL liveness.** Every pinned URL re-fetched 2026-08-02 and confirmed 200 with a
real body. `morth.nic.in`/`morth.gov.in` both return the 40,262-byte SPA shell
for document paths, which is exactly why the Wayback `id_` captures are pinned.

**Not done (out of a researcher's remit).** No corpus test — India publishes no
open registration dataset comparable to RDW's `kenteken`; VAHAN's public portal
is query-per-plate and its terms were not assessed. Recorded for L3 acceptance
("corpus tests where registries allow" — India does not).

---

## 10. Ranked verifier targets

1. **Pin S.O. 444(E) of 12 June 1989.** Unlocks 37 decode rows from
   `corroboration-only` to `instrument`, and upgrades `composition_evidence:
   reconstructed` on five series if the notification's Table carries a format
   note. Single highest-value task in this jurisdiction.
2. **Pin the MEA mission-number list** (`idprotocolmea.gov.in`) — turns
   `13 CD 1` into a country. L4 per the roadmap, but cheap if the page is live.
3. **Confirm the `in-diplomatic-cd-1989` / `in-consular-cc-1989` dating
   convention** (unfootnoted = as made). If rejected, downgrade both to
   `instrument-in-force`.
4. **Pin the pre-2001 text of rule 50(2)(d)** to close GAP-7 (was the transport
   plate yellow before 2001?).
5. **Pin the Ministry of Defence registration instrument** to open a military
   series (GAP-4).
6. **Decide the blank-series question** (GAP-10). If a State manual permits an
   empty series group, widen to `[A-Z]{0,3}` and note it.
7. **Pin S.O. 295(E) of 25 January 2020** (DD/DN merger) — currently reported,
   not fetched; it is the evidence for the `DD` meaning-change caution.
8. **Pin an AIS/HSRP type-approval standard** for the font and any numbered
   colour (GAP-6, GAP-8).

