### PR TITLE
plates L3: th-my — th my (S5W)

### DIFF
--- a/plates/_decode/my-index-marks.yml
+++ b/plates/_decode/my-index-marks.yml
@@ -1,0 +1,271 @@
+# plates/_decode/my-index-marks.yml — the decodable elements of a Malaysian
+# registration number. DRAFT for verification.
+#
+# ===========================================================================
+# THE SOURCE FINDING, AND IT IS THE GERMAN RESULT RATHER THAN THE IRISH ONE
+# ===========================================================================
+# The Road Transport Act 1987 (Act 333) s. 11(1)(a) requires the Director to
+# assign "THE PRESCRIBED INDEX MARK indicating the registration area in which
+# the vehicle is registered or the status of the owner of the motor vehicle and
+# a separate number". The Act therefore guarantees that this table EXISTS and
+# that it means what it means — area, or owner status — and says nothing about
+# its contents. "Prescribed" points at the Motor Vehicles (Registration and
+# Licensing) Rules 1959, and THAT INSTRUMENT IS NOT ONLINE: the Attorney
+# General's Chambers federal-legislation portal carries 727 subsidiary
+# instruments under Act 333, the oldest from 2000, and the Registration and
+# Licensing Rules appear only as amendments (P.U. (A) 79/2012, 94/2012,
+# 100/2018, 98/2019, 177/2019, 36/2023, 177/2024, 464/2025). No located
+# instrument prescribes an index mark.
+#
+# So every row in section 1 below is sourced to THE AUTHORITY'S OWN LIVE
+# SYSTEM, not to the instrument that legally prescribes it, and carries
+# `evidence: agency-api`. This is precisely the posture plates/_decode/ takes
+# for German district codes, and it is recorded rather than papered over.
+#
+# HOW SECTION 1 WAS OBTAINED — mechanically, from two JPJ endpoints:
+#   * GET  https://portal-api.jpj.gov.my/api/locations
+#       -> the closed list of registration areas and their codes (32 rows,
+#          2026-08-03). This is the list JPJ's own public enquiry form is
+#          built from.
+#   * POST https://portal-api.jpj.gov.my/api/semak-no-pendaftaran-terkini
+#       -> for a given area code, THE REGISTRATION NUMBER CURRENTLY BEING
+#          ISSUED in that area, with the authority's own server timestamp.
+#          Called once per code, 2026-08-03 00:47:43 to 00:49:21 (+08).
+#          28 of 32 returned a reading.
+# The second endpoint is the closest thing Malaysia has to the registry
+# corpora PRD-PLATES §5.2 uses elsewhere: it is the authority stating, on the
+# record and to the minute, what it is issuing. Those readings are the evidence
+# behind BOTH standard series in plates/my.yml and are reproduced per row as
+# `observed_2026_08_03`.
+#
+# ===========================================================================
+# THE DISAGREEMENT BETWEEN JPJ'S OWN TWO PUBLICATIONS — RECORDED, NOT AVERAGED
+# ===========================================================================
+# The JPJ portal page captured 2025-04-13 renders the SAME selector as a plain
+# HTML <select> with THIRTY-SIX options, four of which duplicate a code that is
+# already present with a different office name:
+#     QS = Sibu      AND  QS = Mukah
+#     QB = Sri Aman  AND  QB = Betong
+#     QL = Limbang   AND  QL = Lawas
+#     SS = Sandakan  AND  SM = Sandakan     (two codes, one town)
+# The 2026 JSON API returns THIRTY-TWO rows, keeping only the LATER member of
+# each colliding pair — so Sibu, Sri Aman and Limbang, which are real Sarawak
+# divisions with real plates on the road, have no row in the live list at all.
+# Both captures are recorded below and neither is silently preferred
+# (PRD-PLATES §5.3: record disagreements, never average them). The practical
+# reading is that the JPJ code is a QUERY KEY for a counter, not a bijection
+# with a place, and a decode consumer must treat the mapping as MANY-TO-ONE in
+# both directions.
+#
+# ===========================================================================
+# WHAT THE CODE IS *NOT* — the trap that would make a parse API lie
+# ===========================================================================
+# THE JPJ AREA CODE IS NOT ALWAYS THE PRINTED PREFIX. Three of the live
+# readings prove it outright: querying ST (Tawau) returns SWR 9584; querying SD
+# (Lahad Datu) returns SPA 3076; querying SA (Kota Kinabalu) returns SJT 4199.
+# The printed prefix in East Malaysia is S or Q plus a running letter pair that
+# has drifted well past the two-letter division code. A decoder must therefore
+# read only the FIRST letter as jurisdiction-bearing (S = Sabah, Q = Sarawak,
+# and the single peninsular letters), and must NOT assume the first two letters
+# name a division. In peninsular Malaysia the first letter alone is the mark and
+# the rest is sequence: APK is Perak's A, not a code "AP".
+#
+# Referenced by plates/my.yml from every series' `region_encoding`.
+jurisdiction: my
+topic: index-marks
+authority:
+  name: Jabatan Pengangkutan Jalan Malaysia (JPJ) — Road Transport Department Malaysia
+  url: "https://www.jpj.gov.my/"
+sources:
+  - "https://portal-api.jpj.gov.my/api/locations  # JPJ portal location API — the closed list of 32 registration areas and their codes, as served to the public 'Semakan Nombor Pendaftaran Terkini' form. Queried 2026-08-03"
+  - "https://portal-api.jpj.gov.my/api/semak-no-pendaftaran-terkini  # JPJ 'latest registration number' API — the number currently being issued per area, with the authority's own timestamp. Queried per code 2026-08-03 00:47:43-00:49:21 (+08); 28 of 32 codes returned a reading"
+  - "https://web.archive.org/web/20250413135106/https://www.jpj.gov.my/en/web/main-site/semakan-nombor-pendaftaran-terkini  # the same selector as a 36-option HTML <select>, capturing the four colliding codes the 2026 API drops. Accessed 2026-08-02"
+  - "https://lom.agc.gov.my/ilims/upload/portal/akta/outputaktap/1871744_BI/Act%20333_Final_15%20Oct%202023%20(25.3.24).pdf  # Road Transport Act 1987 s. 11(1)(a) — the statutory existence and meaning of the index mark, and the delegation that makes this table an agency artefact rather than a statutory one. Accessed 2026-08-02"
+  - "https://web.archive.org/web/20140714163606/http://www.kln.gov.my/web/guest/diplomat  # Ministry of Foreign Affairs Malaysia (Wisma Putra), Protocol > Foreign Missions > Diplomat, 'MOTOR VEHICLES' paras 6.4-6.11 — the complete DC, CC and UN allocation tables in sections 2-4 below. Accessed 2026-08-02"
+accessed: "2026-08-03"
+period: { start: 1987 }
+period_evidence: instrument-in-force
+period_note: >-
+  1987 is the Road Transport Act now in force, NOT the date these marks were
+  allotted. The peninsular single letters are conventionally traced to a 1948
+  rationalisation of the pre-war two-letter marks (PK -> A for Perak, JB -> J
+  for Johor and so on) and the Sabah/Sarawak Q and S systems to 1963-1991
+  reorganisations; none of those dates is sourced to an instrument here and
+  none is asserted. Rows added later carry their own `since:` where a date was
+  found; where none was, the row carries no date rather than a guessed one.
+
+# ---------------------------------------------------------------------------
+# 1. REGISTRATION AREAS AND THEIR INDEX MARKS
+#    `code` is JPJ's own key. `printed_prefix_first_letter` is the part a
+#    decoder may rely on. `observed_2026_08_03` is the authority's live counter
+#    at the moment of capture and is EVIDENCE, not a format claim.
+# ---------------------------------------------------------------------------
+areas:
+  peninsular:
+    note: >-
+      Peninsular states and the three federal territories. The INDEX MARK IS
+      THE FIRST LETTER ONLY; the second and third letters are sequence. Note
+      that E, G, H, U, X and Y open no peninsular registration (H is the hire
+      prefix, see plates/my.yml my-taxi), and that I, O and Z are never issued
+      at all.
+    codes:
+      - { code: A, area: Perak, printed_prefix_first_letter: A, observed_2026_08_03: "APK 4191", form: prefix, evidence: agency-api }
+      - { code: B, area: Selangor, printed_prefix_first_letter: B, observed_2026_08_03: "BSS 3435", form: prefix, evidence: agency-api }
+      - { code: C, area: Pahang, printed_prefix_first_letter: C, observed_2026_08_03: "CFH 3542", form: prefix, evidence: agency-api }
+      - { code: D, area: Kelantan, printed_prefix_first_letter: D, observed_2026_08_03: "DFQ 9814", form: prefix, evidence: agency-api }
+      - { code: F, area: "Wilayah Persekutuan Putrajaya", printed_prefix_first_letter: F, observed_2026_08_03: null, form: prefix, evidence: agency-api, note: "listed by the API; the live counter did not return a reading in this pass. Putrajaya's F series is issued in short lettered runs (FA, FB, FC …) rather than continuously, which is consistent with a null reading but does not explain it — recorded as observed, not interpreted." }
+      - { code: J, area: Johor, printed_prefix_first_letter: J, observed_2026_08_03: "JB 6419 J", form: suffix, evidence: agency-api, note: "Johor runs the SUFFIX form: the trailing J is a series letter, not part of the index mark" }
+      - { code: K, area: Kedah, printed_prefix_first_letter: K, observed_2026_08_03: "KGH 3943", form: prefix, evidence: agency-api }
+      - { code: KV, area: Langkawi, printed_prefix: KV, observed_2026_08_03: "KV 859 F", form: suffix, evidence: agency-api, note: "the one peninsular area whose printed prefix is genuinely two letters, and it sits INSIDE Kedah — Langkawi is a duty-free island district with its own mark and its own suffix arrangement" }
+      - { code: L, area: "Wilayah Persekutuan Labuan", printed_prefix_first_letter: L, observed_2026_08_03: "LH 6757", form: prefix, evidence: agency-api, note: "Labuan is geographically off Sabah but registers under a peninsular-style single letter, having been reinstated as a federal territory" }
+      - { code: M, area: Melaka, printed_prefix_first_letter: M, observed_2026_08_03: "MEG 6121", form: prefix, evidence: agency-api }
+      - { code: N, area: "Negeri Sembilan", printed_prefix_first_letter: N, observed_2026_08_03: "NEL 2986", form: prefix, evidence: agency-api }
+      - { code: P, area: "Pulau Pinang", printed_prefix_first_letter: P, observed_2026_08_03: "PSE 4213", form: prefix, evidence: agency-api }
+      - { code: R, area: Perlis, printed_prefix_first_letter: R, observed_2026_08_03: null, form: prefix, evidence: agency-api, note: "present in the API's location list; the counter returned no reading in this pass. Perlis is Malaysia's smallest state by registrations." }
+      - { code: T, area: Terengganu, printed_prefix_first_letter: T, observed_2026_08_03: "TDH 3264", form: prefix, evidence: agency-api }
+      - { code: W, area: "Wilayah Persekutuan Kuala Lumpur", printed_prefix_first_letter: "W or V", observed_2026_08_03: "VRJ 7380", form: prefix, evidence: agency-api, note: "THE MOST VALUABLE SINGLE DATUM IN THIS TABLE. JPJ keys Kuala Lumpur as area code W and its live counter returns a V number. That is the authority's own statement that V IS THE CONTINUATION OF THE W REGISTRATION AREA — one area, two index marks, W exhausted and V in issue. Every secondary account asserts this; this is the primary that carries it. A decoder must map BOTH W and V to Kuala Lumpur." }
+  sabah:
+    note: >-
+      Sabah registrations all begin S. The second letter historically named the
+      division, and the live readings show the running sequence has drifted past
+      it — querying the division code returns a number whose second letter is
+      something else entirely. Read only the leading S as jurisdiction-bearing.
+    codes:
+      - { code: SA, area: "Kota Kinabalu (West Coast)", observed_2026_08_03: "SJT 4199", form: prefix, evidence: agency-api, note: "queried as SA, issuing SJ-series — the drift is explicit here" }
+      - { code: SB, area: Beaufort, observed_2026_08_03: "SB 1644 L", form: suffix, evidence: agency-api }
+      - { code: SD, area: "Lahat Datu", observed_2026_08_03: "SPA 3076", form: prefix, evidence: agency-api, note: "JPJ spells it 'Lahat Datu'; the town is conventionally Lahad Datu. The authority's spelling is kept, per PRD-PLATES §5.3." }
+      - { code: SK, area: Kudat, observed_2026_08_03: "SK 4097 H", form: suffix, evidence: agency-api }
+      - { code: SM, area: Sandakan, observed_2026_08_03: null, form: unknown, evidence: agency-api, note: "one of TWO codes JPJ maps to Sandakan; see the disagreement note in the header" }
+      - { code: SS, area: Sandakan, observed_2026_08_03: "SMW 5063", form: prefix, evidence: agency-api, note: "queried as SS, issuing SM-series" }
+      - { code: ST, area: Tawau, observed_2026_08_03: "SWR 9584", form: prefix, evidence: agency-api, note: "queried as ST, issuing SW-series" }
+      - { code: SU, area: Keningau, observed_2026_08_03: "SU 7665 Q", form: suffix, evidence: agency-api, note: "a Q SUFFIX, which contradicts the secondary claim that Q and S are avoided as East Malaysian suffixes — recorded as counter-evidence in plates/my.yml my-standard-suffix" }
+  sarawak:
+    note: >-
+      Sarawak registrations all begin Q. Same drift and same reading rule as
+      Sabah. Sarawak moved to the Q system in the early 1990s; the date is not
+      sourced here.
+    codes:
+      - { code: QA, area: Kuching, observed_2026_08_03: "QAB 3426 P", form: suffix, evidence: agency-api, note: "three-letter prefix AND a suffix — the fullest Malaysian mark shape in the live sample" }
+      - { code: QB, area: Betong, observed_2026_08_03: "QBH 8695", form: prefix, evidence: agency-api, note: "the 2025 HTML selector maps QB to BOTH Sri Aman and Betong; the 2026 API keeps only Betong" }
+      - { code: QC, area: "Kota Samarahan", observed_2026_08_03: "QCW 4437", form: prefix, evidence: agency-api }
+      - { code: QL, area: Lawas, observed_2026_08_03: "QLG 4546", form: prefix, evidence: agency-api, note: "the 2025 selector maps QL to BOTH Limbang and Lawas; the 2026 API keeps only Lawas" }
+      - { code: QM, area: Miri, observed_2026_08_03: "QM 5771 U", form: suffix, evidence: agency-api }
+      - { code: QP, area: Kapit, observed_2026_08_03: "QPD 9177", form: prefix, evidence: agency-api }
+      - { code: QR, area: Sarikei, observed_2026_08_03: "QRY 2592", form: prefix, evidence: agency-api }
+      - { code: QS, area: Mukah, observed_2026_08_03: "QS 5608 Y", form: suffix, evidence: agency-api, note: "the 2025 selector maps QS to BOTH Sibu and Mukah; the 2026 API keeps only Mukah" }
+      - { code: QT, area: Bintulu, observed_2026_08_03: null, form: unknown, evidence: agency-api }
+  dropped_by_the_live_api:
+    note: >-
+      Present in JPJ's 2025 HTML selector, ABSENT from its 2026 JSON API because
+      each collides with a code the API resolves to another office. They are
+      real Sarawak divisions with plates on the road and are recorded here so
+      that a decoder does not conclude the codes are unallocated.
+    codes:
+      - { code: QS, area: Sibu, evidence: agency-page-2025, collides_with: "QS = Mukah in the 2026 API" }
+      - { code: QB, area: "Sri Aman", evidence: agency-page-2025, collides_with: "QB = Betong in the 2026 API" }
+      - { code: QL, area: Limbang, evidence: agency-page-2025, collides_with: "QL = Lawas in the 2026 API" }
+  never_issued:
+    letters: [I, O, Z]
+    note: >-
+      I and O are never issued anywhere in the system (confusable with 1 and 0);
+      Z is reserved for the Malaysian Armed Forces. Consistent with all 28 live
+      readings and with the absence of any I/O/Z code from JPJ's area list.
+      Sourced to the Malay and English Wikipedia articles — `secondary-wikipedia`
+      — and NOT to any instrument. THERE IS NO MALAYSIAN "NO VOWELS" RULE: A is
+      Perak's mark, and the live sample contains APK, SPA, QAB, SU…U and QM…U.
+
+# ---------------------------------------------------------------------------
+# 2. DIPLOMATIC CORPS ("DC") — allocation by rank.
+#    PRIMARY, from the Ministry of Foreign Affairs, and closed.
+# ---------------------------------------------------------------------------
+diplomatic_dc:
+  authority: "Ministry of Foreign Affairs, Malaysia (Wisma Putra), Protocol Department — 'MOTOR VEHICLES', paras 6.4-6.9"
+  marking: DC
+  colour_rule: >-
+    Para 6.9, verbatim: "All motor vehicles for diplomats and the Chief
+    Representative from the Regional Office of the United Nations will bear
+    white numbers on red field with the markings of 'DC' or 'UN' respectively."
+    / "All motor vehicles for the foreign mission including the consular corps
+    and Offices of the United Nations will bear white numbers on black field
+    with the markings of 'DC', 'CC' or 'UN' respectively." RED = an accredited
+    PERSON. BLACK = an INSTITUTION.
+  retention_rule: >-
+    Para 6.5: "A diplomat serving in Malaysia will be given one 'DC' number
+    according to his ranking. Hence he is required to retain the number plate
+    even when he disposes after 18 months or more as the same number will be
+    given to his new car upon approval from the Ministry of Foreign Affairs."
+  ranks:
+    - { number: "01", holder: "Head of Mission's official car" }
+    - { number: "02, 03", holder: "Head of Mission's personal car" }
+    - { number: "04", holder: "Deputy Chief of Mission / Deputy High Commissioner / Minister" }
+    - { number: "05", holder: "Minister Counsellor" }
+    - { number: "06-09", holder: "Counsellor" }
+    - { number: "10-19", holder: "First Secretary" }
+    - { number: "20-29", holder: "Second Secretary" }
+    - { number: "30-39", holder: "Third Secretary" }
+    - { number: "40-59", holder: "Attaché, including Military Advisers, Trade Representatives, Defence Advisers and other similar ranks" }
+    - { number: "60-99", holder: "the SECOND duty-free car of a diplomat entitled to two (para 6.6)" }
+    - { number: "101 and above", holder: "vehicles registered in the name of the foreign mission (para 6.8)" }
+  chargé_note: "Para 6.7: 'Personal cars of Charge d' Affaires will be numbered according to their respective ranks.'"
+  gap: >-
+    THE COUNTRY-CODE TABLE IS NOT ON THIS PAGE and was not located anywhere.
+    The number group above is the RANK group; the sending state's code is a
+    separate printed group whose allocation is unsourced. PRD-PLATES puts
+    diplomatic decode tables at L4 and this one is deliberately left there
+    rather than guessed.
+
+# ---------------------------------------------------------------------------
+# 3. CONSULAR CORPS ("CC") — allocation by CONSULAR DISTRICT, which makes this
+#    a genuine geographic decode dimension. PRIMARY and closed.
+# ---------------------------------------------------------------------------
+consular_cc:
+  authority: "Wisma Putra, 'MOTOR VEHICLES', para 6.10"
+  marking: CC
+  colour: "white numbers on black field (para 6.9)"
+  columns: ["head of consular mission", "heads of consular offices", "vehicles registered in the name of the consular mission"]
+  districts:
+    - { district: "Kuala Lumpur", head_of_mission: "01", office_heads: "10-19", mission_registered: "100-199" }
+    - { district: "Penang", head_of_mission: "02", office_heads: "20-29", mission_registered: "200-299" }
+    - { district: "Kota Bharu", head_of_mission: "03", office_heads: "30-39", mission_registered: "300-399" }
+    - { district: "Kota Kinabalu", head_of_mission: "04", office_heads: "40-49", mission_registered: "400-499" }
+    - { district: "Kuching", head_of_mission: "05", office_heads: "50-59", mission_registered: "500-599" }
+    - { district: "for other missions established hereafter", head_of_mission: "06, 07, 08, 09", office_heads: "60-69, 70-79, 80-89, 90-99", mission_registered: "600-699, 700-799, 800-899, 900-999" }
+  honorary_consuls: >-
+    Same page, verbatim: "Honorary Consuls are only issued with ID cards." There
+    is NO Malaysian honorary-consul plate — a clean negative fact, and the exact
+    opposite of Thailand, which gives honorary consuls their own grey plate.
+  decode_rule: >-
+    The LEADING DIGIT of a Malaysian CC number is the consular district
+    (1 = Kuala Lumpur, 2 = Penang, 3 = Kota Bharu, 4 = Kota Kinabalu,
+    5 = Kuching) and its MAGNITUDE is the holder class (one digit = head of
+    mission, two digits = head of a consular office, three digits = the mission
+    itself). That is a real, primary-sourced, two-dimensional decode.
+
+# ---------------------------------------------------------------------------
+# 4. UNITED NATIONS ("UN"). PRIMARY and closed as far as the page goes.
+# ---------------------------------------------------------------------------
+united_nations:
+  authority: "Wisma Putra, 'MOTOR VEHICLES', para 6.11"
+  marking: UN
+  allocation:
+    - { number: "01", holder: "official car of the Head of a United Nations Office or Specialised Agency" }
+    - { number: "02-05", holder: "personal car (if any) of that Head" }
+    - { number: "06-99", holder: "cars registered in the name of other UN officials" }
+    - { number: "101 and above", holder: "cars registered in the name of the UN Office or Specialised Agency" }
+  agency_numbers:
+    - { agency: UNDP, printed: "10 UN" }
+    - { agency: WHO, printed: "11 UN" }
+    - { agency: FAO, printed: "12 UN" }
+    - { agency: UNHCR, printed: "14 UN" }
+  agency_note: >-
+    Four agencies, and 13 IS SKIPPED. The page gives no reason and none is
+    invented here. The printed forms above are reproduced exactly as the
+    ministry writes them, which is why plates/my.yml my-un carries a
+    `recall-only` regex accepting both a one-group and a two-group arrangement:
+    "10 UN" and the two-group diplomatic-style form cannot both be described by
+    one strict grammar on this evidence.
+  colour: >-
+    RED field for the Chief Representative of the UN Regional Office; BLACK
+    field for UN Offices (para 6.9). JPJ's own specification page independently
+    lists "the UN" among those entitled to the red plate, alongside embassies
+    and the International Natural Rubber Association.

--- a/plates/_decode/th-registration-elements.yml
+++ b/plates/_decode/th-registration-elements.yml
@@ -1,0 +1,208 @@
+# plates/_decode/th-registration-elements.yml — the decodable elements of a
+# Thai registration mark. DRAFT for verification.
+#
+# WHY THIS FILE IS SHAPED LIKE THIS, stated up front because it is unusual:
+# Thailand has NO region letter-code table to decode. The Motor-Vehicle-Act
+# plate SPELLS THE PROVINCE OUT in Thai on its own line (กฎกระทรวง พ.ศ. ๒๕๕๔
+# ข้อ ๓ (๑) (ก) ๒)), so a parse API needs a NAME list, not a code table, and
+# that name list is ordinary Thai geography rather than plate law. What Thailand
+# does have that is closed, primary and genuinely decodable is smaller and it is
+# all here: the four diplomatic corps letters, the six commercial vehicle-type
+# code bands, and the one sub-provincial registration place named in the
+# regulation. Everything else is a MECHANISM, and each mechanism below says
+# plainly what is delegated and to whom.
+#
+# Referenced by plates/th.yml from every series' `region_encoding`.
+jurisdiction: th
+topic: registration-elements
+authority:
+  name: กรมการขนส่งทางบก (Department of Land Transport, DLT), Ministry of Transport
+  url: "https://www.dlt.go.th"
+sources:
+  - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # กฎกระทรวง กำหนดขนาด ลักษณะ และสีของแผ่นป้ายทะเบียนรถ ฯ พ.ศ. ๒๕๕๔, ราชกิจจานุเบกษา เล่ม ๑๒๘ ตอนที่ ๔๕ ก หน้า ๖, 8 June 2011 — ข้อ ๓ (๑) (ก) ๒) the province line and the Betong exception; ข้อ ๓ (๑) (ก) ๓) the leading numeral; ข้อ ๓ (๑) (ก) ๕) the delegation of the alphabet; ข้อ ๓ (๑) (ค) ๓) the four corps letters"
+  - "https://web.archive.org/web/20160304073451/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/E/044/52.PDF  # ประกาศกรมการขนส่งทางบก ฯ พ.ศ. ๒๕๕๔, ราชกิจจานุเบกษา เล่ม ๑๒๘ ตอนพิเศษ ๔๔ ง หน้า ๕๒, 19 April 2011 — ข้อ ๒ (๑) the numeric province code on line 1; ข้อ ๒ (๓) the six vehicle-type code bands and the 0001-9999 serial rule"
+accessed: "2026-08-02"
+period: { start: 2011 }
+period_evidence: instrument-in-force
+period_note: >-
+  2011 is the year of BOTH instruments (the ministerial regulation published
+  8 June 2011 and in force on the expiry of 180 days; the DLT announcement
+  published 19 April 2011). Neither created the elements below — the diplomatic
+  corps letters and the commercial type codes both carry over from revoked
+  predecessors (the B.E. 2547/2550 regulations and the B.E. 2549 announcement,
+  which itself replaced one of 14 April B.E. 2530). Their own start years are
+  recorded gaps and no year is invented for them.
+
+# ---------------------------------------------------------------------------
+# 1. THE PROVINCE LINE — a NAME, not a code. This is the decode dimension a
+#    consumer will reach for first, and it is the one Thailand does not encode.
+# ---------------------------------------------------------------------------
+province_line:
+  mechanism: spelled-out-name
+  rule: >-
+    กฎกระทรวง พ.ศ. ๒๕๕๔ ข้อ ๓ (๑) (ก) ๒), verbatim: "บรรทัดที่สองเป็นตัวอักษร
+    แสดงชื่อกรุงเทพมหานครหรือจังหวัดที่จดทะเบียน เว้นแต่กรณีจดทะเบียนที่อำเภอ
+    เบตง จังหวัดยะลา ให้ใช้คำว่า เบตง ทั้งนี้ ตัวอักษรให้ใช้ตัวอักษรไทย" — line
+    two carries the letters showing the name of Bangkok or of the province of
+    registration, except where the vehicle is registered at Betong District,
+    Yala Province, where the word เบตง is used; the letters shall be Thai
+    letters. The identical rule is repeated for motorcycles at ข้อ ๓ (๑) (ข) ๒),
+    where the province name is on line TWO of a three-line plate.
+  script: Thai
+  exceptions:
+    - name_on_plate: "เบตง"
+      romanised: Betong
+      covers: "อำเภอเบตง จังหวัดยะลา (Betong District, Yala Province)"
+      note: >-
+        The ONLY sub-provincial registration place in Thai plate law, and it is
+        in the regulation itself rather than in an administrative announcement.
+        A parse API that maps plate text to provinces must special-case it: a
+        Betong plate reads เบตง, never ยะลา.
+  gap: >-
+    A full Thai-name-to-province table (77 changwat plus Bangkok, with romanised
+    forms and ISO 3166-2:TH codes) is what a parse API actually needs and is NOT
+    supplied here: it was not secured from a primary in this pass and is
+    geography rather than plate law. It is the single highest-value follow-up
+    for Thailand and is deliberately left empty rather than filled from an
+    encyclopaedic source.
+
+# ---------------------------------------------------------------------------
+# 2. THE CATEGORY LETTERS — delegated, unpinned, and the reason Thai plates
+#    cannot yet be validated strictly by this dataset.
+# ---------------------------------------------------------------------------
+category_letters:
+  mechanism: delegated-to-director-general
+  rule: >-
+    กฎกระทรวง พ.ศ. ๒๕๕๔ ข้อ ๓ (๑) (ก) ๕), verbatim: "การใช้ตัวเลขนำหน้าตัวอักษร
+    ประจำหมวด ตัวอักษรประจำหมวด และหมายเลขทะเบียน ให้เป็นไปตามที่อธิบดีประกาศ
+    กำหนด" — the use of the numeral preceding the category letters, the category
+    letters themselves, and the registration number are as the Director-General
+    publicly prescribes. Repeated verbatim for motorcycles at ข้อ ๓ (๑) (ข) ๔).
+  count: 2
+  script: Thai
+  unicode_range: "U+0E01–U+0E2E (Thai consonants ก through ฮ)"
+  leading_numeral:
+    values: "1–9"
+    cars_rule: >-
+      ข้อ ๓ (๑) (ก) ๓): added in front of the first category letter ONLY once
+      every combination of the first and second category letters has been used.
+    motorcycles_rule: >-
+      ข้อ ๓ (๑) (ข) ๒) states the numeral as part of the base composition of
+      line 1, with no exhaustion condition — a real difference between the car
+      and motorcycle rules that a parse API must not smooth over.
+  partial_list_from_metrics:
+    values: ["ข", "ง", "ช", "ซ", "ฌ", "ญ", "ฎ", "ฏ", "ฐ", "ฒ", "ณ", "ป", "ฝ", "ฟ", "ศ", "ษ", "ส", "ฬ", "ฮ"]
+    rule: >-
+      ข้อ ๓ (๑) (ก) ๔) sets minimum letter heights and widths and then excepts
+      "ตัวอักษร ข ง ช ซ ฌ ญ ฎ ฏ ฐ ฒ ณ ป ฝ ฟ ศ ษ ส ฬ ฮ สระ วรรณยุกต์ และหมายเลข ๑",
+      whose dimensions the Director-General fixes instead. These nineteen
+      consonants therefore appear on Thai plates as a matter of primary law.
+    warning: >-
+      This is NOT the alphabet and must never be used as one. It is a side-door
+      list of the letters whose SHAPES need special metrics; the letters with
+      ordinary metrics (ก, ค, จ, ท, ม, ย, ร, ล, ว, อ and others) are absent from
+      it precisely because they are unexceptional.
+  gap: >-
+    No Director-General announcement fixing the category-letter alphabet, the
+    order in which letter pairs open, or the mapping of letter families to
+    vehicle classes was retrieved. Consequently plates/th.yml asserts no letter
+    set, offers no age inference from a letter pair, and marks every
+    Thai-script series `matching: recall-only`.
+
+# ---------------------------------------------------------------------------
+# 3. DIPLOMATIC CORPS LETTERS — closed, primary, four rows. The one Thai decode
+#    table that is complete on its face.
+# ---------------------------------------------------------------------------
+diplomatic_corps_letters:
+  mechanism: closed-list-in-instrument
+  rule: "กฎกระทรวง พ.ศ. ๒๕๕๔ ข้อ ๓ (๑) (ค) ๓) — 'การใช้ตัวอักษรในบรรทัดที่หนึ่งของตอนซ้ายของแผ่นป้ายให้เป็นดังต่อไปนี้' followed by exactly these four rows"
+  codes:
+    - letter: "ท"
+      thai: "รถยนต์ของบุคคลในคณะผู้แทนทางการทูต"
+      en: "vehicles of persons in the diplomatic corps"
+      ground_colour: "retroreflective white, black characters (ข้อ ๓ (๒) (ช))"
+    - letter: "พ"
+      thai: "รถยนต์ของบุคคลในหน่วยงานพิเศษของสถานทูต"
+      en: "vehicles of persons in a special agency of an embassy"
+      ground_colour: "retroreflective light blue, white characters (ข้อ ๓ (๒) (ซ))"
+    - letter: "ก"
+      thai: "รถยนต์ของบุคคลในคณะผู้แทนทางกงสุล"
+      en: "vehicles of persons in the consular corps"
+      ground_colour: "retroreflective light blue, white characters; retroreflective GREY with black characters for an honorary consul (เจ้าพนักงานกงสุลกิตติมศักดิ์), by the proviso to ข้อ ๓ (๒) (ซ)"
+    - letter: "อ"
+      thai: "รถยนต์ของบุคคลในองค์การระหว่างประเทศหรือทบวงการชำนัญพิเศษแห่งสหประชาชาติซึ่งประจำอยู่ในประเทศไทย"
+      en: "vehicles of persons in an international organisation or a UN specialised agency stationed in Thailand"
+      ground_colour: "retroreflective light blue, white characters"
+  collisions:
+    - "ก is BOTH the consular corps letter here and the first consonant of the Thai alphabet, which is also an ordinary category letter on civilian plates. The two are told apart by LAYOUT, not by the letter: a diplomatic plate is a single line of 11 x 38.7 cm with a two-line left block and a bar, while a civilian plate is two lines of 15 x 34 cm. A parser that looks only at the letter will get this wrong."
+    - "ท is the diplomatic letter here and is also reported as the first letter of Bangkok metered-taxi series. Same caution: the discriminator is the layout and the ground colour, not the consonant."
+  country_code:
+    mechanism: delegated
+    note: >-
+      ข้อ ๓ (๑) (ค) ๒) requires line 2 of the left block to be "ตัวเลขอารบิค
+      เป็นรหัสแทนชื่อประเทศหรือองค์การระหว่างประเทศหรือทบวงการชำนัญพิเศษแห่ง
+      สหประชาชาติซึ่งประจำอยู่ในประเทศไทย" — Arabic numerals coding the country
+      or the organisation. The regulation prescribes the FIELD and not the
+      CODES; no code list was secured. Recorded gap.
+
+# ---------------------------------------------------------------------------
+# 4. LAND TRANSPORT ACT VEHICLE-TYPE CODES — closed, primary, six rows, and the
+#    only Thai decode that a machine can apply to a purely numeric string.
+# ---------------------------------------------------------------------------
+lta_vehicle_type_codes:
+  mechanism: closed-list-in-instrument
+  rule: "ประกาศกรมการขนส่งทางบก พ.ศ. ๒๕๕๔ ข้อ ๒ (๓): 'เลขรหัสแสดงประเภทรถแบ่งตามประเภทการขนส่งดังนี้' followed by exactly these six rows"
+  ground_colour_rule: >-
+    ข้อ ๒ (๑) puts scheduled, non-scheduled and small-vehicle transport on a
+    retroreflective YELLOW ground; ข้อ ๒ (๒) puts private transport on a
+    retroreflective WHITE ground, otherwise identical. The type code therefore
+    PREDICTS the plate colour exactly, which is the useful inference.
+  codes:
+    - { code_range: "10-19", thai: "รถโดยสารประจำทาง", en: "scheduled passenger transport", ground: yellow }
+    - { code_range: "20-29", thai: "รถขนาดเล็ก", en: "small-vehicle transport", ground: yellow }
+    - { code_range: "30-39", thai: "รถโดยสารไม่ประจำทาง", en: "non-scheduled passenger transport", ground: yellow }
+    - { code_range: "40-49", thai: "รถโดยสารส่วนบุคคล", en: "private passenger transport", ground: white }
+    - { code_range: "60-69", thai: "รถบรรทุกไม่ประจำทาง", en: "non-scheduled goods transport", ground: yellow }
+    - { code_range: "70-79", thai: "รถบรรทุกไม่ประจำทาง", en: "non-scheduled goods transport — the band ADDED by the 2554 announcement because 60-69 was nearly exhausted, which the preamble states as the operative reason for the instrument", ground: yellow }
+    - { code_range: "50-59", thai: "รถบรรทุกส่วนบุคคล", en: "private goods transport", ground: white }
+    - { code_range: "80-99", thai: "รถบรรทุกส่วนบุคคล", en: "private goods transport, second band", ground: white }
+  serial_rule: >-
+    "หมายเลขทะเบียนรถใช้เลข ๔ หลัก ตั้งแต่ลำดับหมายเลข ๐๐๐๑ ถึงหมายเลข ๙๙๙๙
+    แล้วเริ่มต้นโดยใช้เลขรหัสแสดงประเภทรถเดิมลำดับถัดไป" — four digits, 0001 to
+    9999, then the next code within the same band. Leading zeros are REQUIRED,
+    which inverts the usual no-leading-zero convention and is why
+    plates/th.yml's `regex_strict` twins forbid only 0000.
+  unused_band:
+    note: >-
+      The six paragraphs of ข้อ ๒ (๓) leave 00-09 unallocated and the instrument
+      says nothing about it. Recorded as an observation about the instrument's
+      face, not as a claim that no such code exists.
+  province_code:
+    mechanism: delegated
+    note: >-
+      ข้อ ๒ (๑) puts "เลขรหัสจังหวัด" (a numeric province code) on line 1 beside
+      the word THAILAND, at a minimum height of 2.4 cm, and does not enumerate
+      the codes. No code list was secured. Recorded gap — and note that this is
+      the ONE place Thai plate law does encode the province numerically, so the
+      list is worth chasing.
+
+# ---------------------------------------------------------------------------
+# 5. WHAT A CONSUMER MUST NOT DO WITH THIS FILE.
+# ---------------------------------------------------------------------------
+decode_semantics: >-
+  The province on a Thai plate is the province of REGISTRATION, and Thai plates
+  are not re-issued on a change of the keeper's address, so a decoded province
+  is a fact about where the vehicle was first put on the register — not about
+  where it is, where its owner lives, or where it was built. The category
+  letters encode a VEHICLE CLASS FAMILY and a position in an issuing sequence,
+  not a place: there is no geographic information in a Thai category letter at
+  all, and any parser that treats the two consonants as a region code is wrong.
+maximal_munch: false
+maximal_munch_note: >-
+  Not applicable to the letters: the Motor-Vehicle-Act mark has exactly two
+  category letters (กฎกระทรวง ข้อ ๓ (๑) (ก) ๒) names ตัวอักษรประจำหมวดตัวที่หนึ่ง
+  and ตัวที่สอง and no more), so the letter/number boundary is fixed. It IS a
+  live hazard on the commercial plate, where a bare "701234" could be read as
+  type code 70 + serial 1234 or as 7 + 01234; the instrument settles it by
+  prescribing the printed bar between the two groups and a four-digit serial,
+  which is why plates/th.yml writes the separator into the pattern.

--- a/plates/my.yml
+++ b/plates/my.yml
@@ -1,0 +1,685 @@
+# plates/my.yml — Malaysia (PRD-PLATES gate L3). DRAFT for verification.
+#
+# ===========================================================================
+# THE CENTRAL SOURCING FACT, STATED FIRST BECAUSE IT SHAPES EVERY ENTRY
+# ===========================================================================
+# THE COMPOSITION OF A MALAYSIAN REGISTRATION NUMBER IS NOT IN ANY INSTRUMENT
+# THIS PASS COULD OBTAIN. The Road Transport Act 1987 (Act 333) creates the
+# object and then delegates every detail of it. Section 11(1)(a), verbatim
+# from the Attorney General's Chambers updated text as at 15 October 2023:
+#
+#   "Upon the registration of a motor vehicle, the Director shall—
+#    (a) assign to the motor vehicle THE PRESCRIBED INDEX MARK indicating the
+#        registration area in which the vehicle is registered or the status of
+#        the owner of the motor vehicle AND A SEPARATE NUMBER (in this Act such
+#        mark and number are referred to collectively as 'the registration
+#        number'), and such registration number shall continue to be the
+#        registration number of such motor vehicle until it is broken up,
+#        destroyed or sent permanently out of Malaysia, and such registration
+#        number shall not be assigned to any other motor vehicle"
+#
+# Read that clause closely: it fixes the STRUCTURE — an index mark plus a
+# separate number — and the SEMANTICS of the mark (registration area, or owner
+# status), and it fixes the binding (to the vehicle, for life). It does not
+# say A is Perak. "Prescribed" means prescribed by rules, and the rules are the
+# Motor Vehicles (Registration and Licensing) Rules 1959, which the AGC's own
+# federal-legislation portal DOES NOT CARRY: its subsidiary-legislation index
+# for Act 333 returns 727 records and the oldest is from 2000, with the
+# Registration and Licensing Rules present only as AMENDMENTS (P.U. (A) 79 and
+# 94 of 2012, 100/2018, 98 and 177/2019, 36/2023, 177/2024, 464/2025). The
+# PRINCIPAL 1959 rules are not digitised anywhere this pass could reach.
+#
+# CONSEQUENCE, AND IT IS THE GERMAN RESULT AGAIN: the index-mark table — the
+# single most valuable decode dimension in this jurisdiction — is sourced to
+# the AUTHORITY'S OWN PUBLISHED SYSTEM rather than to the instrument that
+# legally prescribes it. plates/_decode/my-index-marks.yml carries it, keyed to
+# the JPJ portal's own location API, with `evidence: agency-api` on every row
+# and the instrument gap stated at the top. Exactly as § 9 FZV delegates the
+# German district codes to the Bundesanzeiger and VERA 1994 leaves the British
+# memory tag to INF104, Act 333 leaves the Malaysian index mark to a 1959
+# statutory rule nobody has put online.
+#
+# Display is delegated the same way. Section 14(1), verbatim:
+#
+#   "The registration number assigned to a motor vehicle upon registration or a
+#    new registration number assigned under section 11 shall be displayed and
+#    illuminated on the number plate IN THE MANNER PRESCRIBED BY RULES MADE
+#    UNDER THIS ACT."
+#
+# and the rule-making power, section 66(1)(s), verbatim:
+#
+#   "to prescribe the size, shape and character of the registration number and
+#    signs to be displayed on any motor vehicle and the manner in which those
+#    registration numbers or signs are to be fixed, displayed, illuminated and
+#    rendered easily distinguishable, whether by night or day, and to provide
+#    for a distinctive registration number or other sign to be carried by
+#    public service vehicles or goods vehicles, or by public service vehicles
+#    or goods vehicles licensed for a particular purpose"
+#
+# So Malaysia's law fixes: that there is an index mark; that it means area or
+# owner status; that the number stays with the vehicle for life; that public
+# service and goods vehicles MAY be given a distinctive number or sign; and
+# that the Minister prescribes size, shape and character. Everything a plate
+# dataset actually wants is one layer below that, in an unreachable instrument.
+# Every series below therefore separates, in its own sources block, what comes
+# from THE ACT, what comes from THE AUTHORITY'S PAGES, and what comes from
+# secondary sources — and tags the last of those honestly.
+#
+# ===========================================================================
+# THE ONE PIECE OF LIVE PRIMARY EVIDENCE, AND IT IS UNUSUALLY GOOD
+# ===========================================================================
+# JPJ operates a public "Semakan Nombor Pendaftaran Terkini" (latest
+# registration number enquiry) service backed by a JSON API at
+# portal-api.jpj.gov.my. Two endpoints were called directly:
+#   * /api/locations            -> the CLOSED list of 32 registration
+#                                  offices/areas with their codes
+#   * /api/semak-no-pendaftaran-terkini  -> for each code, THE REGISTRATION
+#                                  NUMBER CURRENTLY BEING ISSUED there
+# The second call is a dated observation of the authority's own live counter,
+# captured 3 August 2026 00:47–00:49 (+08), and it is the evidence that pins
+# the CURRENT format of every Malaysian state in one pass. Its readings are
+# recorded per row in plates/_decode/my-index-marks.yml and drive the two
+# standard series below. This is as close to a registration-corpus test
+# (PRD-PLATES §5.2) as a jurisdiction without open registry data can get.
+#
+# WHAT THE SNAPSHOT PROVES, mechanically, from 28 successful readings:
+#   * TWO live arrangements coexist nationwide, not one.
+#       - PREFIX FORM, no suffix: KGH 3943 (Kedah), MEG 6121 (Melaka),
+#         NEL 2986 (Negeri Sembilan), CFH 3542 (Pahang), PSE 4213 (Penang),
+#         APK 4191 (Perak), BSS 3435 (Selangor), TDH 3264 (Terengganu),
+#         DFQ 9814 (Kelantan), SJT 4199 (Kota Kinabalu), SMW 5063 (Sandakan),
+#         SWR 9584 (Tawau), SPA 3076 (Lahad Datu), QAB 3426P is not this form,
+#         QBH 8695 (Betong), QRY 2592 (Sarikei), QLG 4546 (Lawas),
+#         QCW 4437 (Kota Samarahan), QPD 9177 (Kapit), VRJ 7380 (Kuala Lumpur),
+#         LH 6757 (Labuan).
+#       - SUFFIX FORM, a single trailing letter: JB 6419 J (Johor),
+#         KV 859 F (Langkawi), SK 4097 H (Kudat), SB 1644 L (Beaufort),
+#         SU 7665 Q (Keningau), QS 5608 Y (Mukah), QM 5771 U (Miri),
+#         QAB 3426 P (Kuching).
+#     Both are current. Neither is historic. A dataset that models only the
+#     three-letter prefix form is wrong for eight of the twenty-eight areas
+#     JPJ itself lists.
+#   * KUALA LUMPUR IS KEYED "W" AND ISSUES "V". Querying the area code W
+#     ("Wilayah Persekutuan Kuala Lumpur") returns VRJ7380. That is the
+#     authority's own confirmation, in one datum, that the V series is the
+#     continuation of the W registration area rather than a new area — the
+#     fact every secondary account states and none of them sources.
+#   * THE SUFFIX LETTER IS NOT A CHECK DIGIT and carries no visible arithmetic
+#     relation to the number (J on 6419, F on 859, H on 4097, L on 1644,
+#     Q on 7665, Y on 5608, U on 5771, P on 3426). It is a series counter.
+#
+# ===========================================================================
+# THE EXCLUDED LETTERS — AND A FOLKLORE CORRECTION THIS FILE MAKES EXPLICITLY
+# ===========================================================================
+# The rule Malaysia actually runs, per both the English and Malay Wikipedia
+# articles (the mandatory finding aid, PRD-PLATES §4) and CONSISTENT WITH every
+# one of the 28 live JPJ readings above: the letters I and O are never issued
+# (confusable with 1 and 0) and Z is reserved for military vehicles. The Malay
+# article states it directly — "Huruf I dan O ditiadakan daripada urutan abjad
+# kerana persamaannya dengan nombor 1 dan 0. Huruf Z ditinggalkan dan
+# dikhaskan untuk digunakan pada kenderaan tentera Malaysia."
+#
+# THERE IS NO "NO VOWELS" RULE IN MALAYSIA, and the claim that there is — which
+# circulates in plate-format lists and was carried into this programme's own
+# briefing — is FALSE ON THE AUTHORITY'S OWN DATA. A is a state mark (Perak);
+# the live snapshot contains SPA, QAB and APK; E and U appear freely in
+# suffixes (SU 7665 Q, QM 5771 U). Only I and O are dropped, and only Z is
+# reserved. Recorded here as a folklore correction, with the counter-evidence,
+# rather than silently omitted. See dossier-my.md §6.
+#
+# NOTE THE ONE PLACE THE EXCLUSION IS NOT VISIBLE: it is an ISSUING rule, not a
+# spelling rule, so `format.regex` cannot carry it (the lint generates "I" and
+# "O" from `pattern`). It lives in `format.regex_strict` on every series that
+# has one, which is exactly what PRD-PLATES §2.7 built the twin for.
+#
+# ===========================================================================
+# WHAT IS DELIBERATELY NOT MODELLED
+# ===========================================================================
+# THE SPECIAL-SERIES OCEAN. JPJ runs a continuous programme of bid-for special
+# registration series through JPJeBid, with statutory footing in Act 333
+# s. 66(1)(jj) ("to prescribe the procedures relating to tender of registration
+# numbers"). Well over a hundred series have been released — anniversary series
+# (FA, FB, FC, FD, FE, FF, FFF, FG, FH), university series, NGO series, event
+# series, the national "MALAYSIA 1-9999" series. Each is an ORDINARY
+# registration whose mark was auctioned; none has its own format, design or
+# period. PRD-PLATES §2.5 excludes exactly this, so the programme is recorded
+# once, as a class note on my-standard-prefix (see `special_series` in
+# `common`), and no series is authored for any individual release. The one
+# exception is `my-jpjeplate-ev-2024`, which is a genuinely different PLATE
+# rather than a different mark.
+#
+# PLATE DIMENSIONS ARE ABSENT FROM THIS FILE AND THEIR ABSENCE IS A FINDING.
+# Act 333 s. 66(1)(s) empowers the Minister to prescribe "the size, shape and
+# character" of the registration number, but the rules that do so were not
+# obtained; JPJ's own "Plate Number Specification" knowledge-base article
+# carries the measurements ONLY as an image ("Examples of Vehicle Plate
+# Measures") with no text equivalent. No `design.plate` block is written
+# anywhere below rather than invent millimetres, and the same posture applies
+# to the typeface: no instrument located names one. This is plates/gb.yml's
+# posture for the same reason (there, BS AU 145e is paywalled; here, the rules
+# are simply not online).
+jurisdiction: my
+authority:
+  name: Jabatan Pengangkutan Jalan Malaysia (JPJ) — Road Transport Department Malaysia, for the Minister of Transport
+  url: "https://www.jpj.gov.my/"
+binding: vehicle
+binding_note: >-
+  Act 333 s. 11(1)(a), verbatim: the registration number "shall continue to be
+  the registration number of such motor vehicle UNTIL IT IS BROKEN UP,
+  DESTROYED OR SENT PERMANENTLY OUT OF MALAYSIA, and such registration number
+  shall not be assigned to any other motor vehicle". The same subsection then
+  carries Malaysia's cherished-transfer proviso: a registered owner may,
+  "subject to any terms and conditions which may be prescribed, and on payment
+  of the prescribed fee, have the number assigned to such motor vehicle
+  assigned to another motor vehicle of which he applies to be registered as
+  owner and which has not previously been registered", whereupon the Director
+  assigns a new number to the first vehicle. Structurally identical to the UK
+  retention scheme, and in the ACT rather than in guidance.
+
+instrument:
+  citation: "Road Transport Act 1987 (Act 333), Laws of Malaysia"
+  royal_assent: "1987-08-30"
+  gazetted: "1987-09-24"
+  text_status: >-
+    The text used is the Attorney General's Chambers ONLINE VERSION OF UPDATED
+    TEXT OF REPRINT, "As at 15 October 2023", latest amendment Act A1684 in
+    operation 15 October 2023. AGC's own front matter warns: "This text is ONLY
+    AN UPDATED TEXT of the Road Transport Act 1987 by the Attorney General's
+    Chambers. Unless and until reprinted pursuant to the powers of the
+    Commissioner of Law Revision under subsection 14(1) of the Revision of Laws
+    Act 1968 [Act 1], this text is NOT AN AUTHENTIC TEXT." Recorded because
+    PRD-PLATES §5.3 says the authority is the authority: this is the authority's
+    own updated text, published by the authority, flagged by the authority as
+    non-authentic. Every quotation above and below is from it.
+  sections_used:
+    - "s. 11(1)(a) — assignment of the prescribed index mark and a separate number; lifetime binding to the vehicle; the cherished-transfer proviso"
+    - "s. 11(1A) — re-assignment of a number from a lost/stolen/destroyed/exported vehicle, on the Director General's prescribed terms"
+    - "s. 14(1) — display and illumination of the registration number on the number plate 'in the manner prescribed by rules made under this Act'"
+    - "s. 14(3) — a drawn trailer must display BOTH its own registration number and that of the drawing vehicle"
+    - "s. 14(4) — penalty for non-display: fine of not less than RM300 and not more than RM3,000"
+    - "s. 66(1)(s) — the rule-making power over size, shape and character of the registration number, and over distinctive numbers or signs for public service and goods vehicles"
+    - "s. 66(1)(jj) — 'to prescribe the procedures relating to tender of registration numbers', the statutory footing of JPJeBid"
+  subsidiary_gap: >-
+    THE MOTOR VEHICLES (REGISTRATION AND LICENSING) RULES 1959 — the instrument
+    that actually prescribes the index marks and the plate — WAS NOT OBTAINED.
+    AGC's json-subsid endpoint for Act 333 was called directly and enumerated:
+    it holds 727 subsidiary instruments, none earlier than 2000, and the
+    Registration and Licensing Rules appear only through their amendments
+    (P.U. (A) 79/2012, 94/2012, 100/2018, 98/2019, 177/2019, 36/2023, 177/2024,
+    464/2025). No instrument in the index prescribes plates, index marks,
+    registration numbers or tender procedure by title.
+  source: "https://lom.agc.gov.my/ilims/upload/portal/akta/outputaktap/1871744_BI/Act%20333_Final_15%20Oct%202023%20(25.3.24).pdf  # Road Transport Act 1987 (Act 333), AGC updated text as at 15 Oct 2023, 204 pp — ss. 11, 14, 66 quoted above. Accessed 2026-08-02"
+  source_subsidiary_index: "https://lom.agc.gov.my/json-subsid-2024.php?act=333  # AGC subsidiary-legislation index for Act 333, 727 records, enumerated 2026-08-02: earliest 2000, no principal 1959 Rules, no plate-specification instrument"
+
+charset_defaults:
+  letters: [A, B, C, D, E, F, G, H, J, K, L, M, N, P, Q, R, S, T, U, V, W, X, Y]
+  excluded_letters: [I, O, Z]
+  excluded_letters_note: >-
+    I and O are never issued (confusable with the numerals 1 and 0); Z is
+    reserved for the Malaysian Armed Forces and is issued only as
+    my-military-z. NO VOWEL IS EXCLUDED — see the folklore correction in the
+    file header. The rule is not in any instrument located; it is stated by
+    the Malay- and English-language Wikipedia articles and is CONSISTENT WITH
+    all 28 live JPJ readings of 3 August 2026, none of which contains I, O or
+    Z. Tagged `secondary-wikipedia` wherever it is load-bearing, per
+    PRD-PLATES §4.
+  digits_note: >-
+    "No leading zeroes permitted" is stated by the English Wikipedia article
+    and is corroborated by every one of the 28 live JPJ readings (859, 1644,
+    2592, 3076, 3426, 3435, 3542, 3943, 4097, 4199, 4213, 4437, 4546, 5063,
+    5608, 5771, 6121, 6419, 6757, 7380, 7665, 8695, 9177, 9584, 9814, 4191,
+    2986, 3264 — not one begins with 0). Carried in `regex_strict` as
+    `[1-9]\d{0,3}`, never in `regex`.
+  source: "https://ms.wikipedia.org/wiki/Plat_pendaftaran_kenderaan_Malaysia  # 'Huruf I dan O ditiadakan daripada urutan abjad kerana persamaannya dengan nombor 1 dan 0. Huruf Z ditinggalkan dan dikhaskan untuk digunakan pada kenderaan tentera Malaysia.' Accessed 2026-08-02. period_evidence: secondary-wikipedia wherever used"
+
+common:
+  colours:
+    jpj_statement: >-
+      JPJ's own "Vehicle Number Plate Specifications" page, verbatim as
+      published in English in 2013: "3 types of number plates that are allowed
+      for use — White alphabets and numbers, embossed or glued on a black
+      plate. White alphabets and numbers, embossed or glued on a red plate for
+      vehicles belonging to embassies, the UN and the International Natural
+      Rubber Association. Black alphabets and numbers, embossed or glued on a
+      white plate for taxicabs and hired cars."
+    current_wording: >-
+      The same article on the current JPJ portal (knowledge base, "Plate Number
+      Specification", captured 2023) says the same thing in a rougher machine
+      translation: "3 Form of Vehicle Registration Number: White letters and
+      numbers are affixed or bounced over a black frame. White letters and
+      numbers are affixed or embossed over red frames for embassy vehicles,
+      United Nations and the International Natural Rubber Association. Black
+      letters and numbers are bounced over white frame for taxi or rental car."
+      Both wordings are recorded because the 2013 English is the better text and
+      the 2023 page is the live one.
+    reading: >-
+      THREE plate forms, exhaustively, on the authority's own page: white on
+      black (everything ordinary), white on red (embassies, the UN, and — a
+      genuine curiosity worth keeping — the INTERNATIONAL NATURAL RUBBER
+      ORGANIZATION, which was headquartered in Kuala Lumpur), black on white
+      (taxis and hire cars). Note what is NOT there: no reflectivity
+      requirement, no colour coordinates, no dimensions in text, no front/rear
+      distinction. Every hex below is `hex_basis: observed` inside a named
+      colour, the same posture plates/gb.yml and plates/gr.yml take.
+    front_rear: >-
+      Malaysia is a WHITE-ON-BLACK jurisdiction front and rear — one of very
+      few left worldwide, and the single most recognisable thing about a
+      Malaysian plate. `rear_differs: false` throughout.
+    sources:
+      - "https://web.archive.org/web/20130516074518/http://www.jpj.gov.my/web/eng/specifications-of-vehicle-number-plates  # JPJ, 'Vehicle Number Plate Specifications', the three permitted plate forms, English. Accessed 2026-08-02"
+      - "https://web.archive.org/web/20230527152350/https://www.jpj.gov.my/en/web/main-site/kenderaan1-en/-/knowledge_base/vehicle/plate-number-registration  # JPJ knowledge base, 'Plate Number Specification' — same three forms; the dimensions appear only as an image ('Examples of Vehicle Plate Measures') with no text equivalent. Accessed 2026-08-02"
+  materials:
+    note: >-
+      Not prescribed by anything located. Malaysian plates are overwhelmingly
+      MOULDED PLASTIC with applied characters rather than pressed metal, which
+      is why kerning-tightening to defeat cameras is a live Malaysian
+      enforcement problem and why JPJ has repeatedly floated standardised
+      pressed plates. Recorded as context, not as a dataset claim.
+  special_series:
+    note: >-
+      JPJeBid: JPJ tenders "special" registration marks continuously, under
+      Act 333 s. 66(1)(jj). Each release (FA/FB/FC/FD/FE/FF/FFF/FG/FH
+      anniversary series, university and NGO series, the national
+      "MALAYSIA 1-9999" series, and well over a hundred others) is an ORDINARY
+      registration under my-standard-prefix or my-standard-suffix whose mark
+      was auctioned rather than allocated in sequence. No separate series is
+      authored for any of them (PRD-PLATES §2.5); a consumer wanting the
+      programme index should treat it as the Malaysian analogue of a US
+      specialty-plate index, which PRD-PLATES puts at L2/L4.
+    statutory_basis: "Act 333 s. 66(1)(jj), verbatim: 'to prescribe the procedures relating to tender of registration numbers'"
+    source: "https://lom.agc.gov.my/ilims/upload/portal/akta/outputaktap/1871744_BI/Act%20333_Final_15%20Oct%202023%20(25.3.24).pdf  # s. 66(1)(jj). Accessed 2026-08-02"
+
+series:
+
+  - id: my-standard-prefix
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1987 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL 9999"
+      regex: '\A[A-Z]{1,3}[- ]?\d{1,4}\z'
+      regex_strict: '\A[ABCDFJKLMNPQRSTVW][A-HJ-NP-Y]{0,2}[- ]?[1-9]\d{0,3}\z'
+      charset:
+        first_letter_note: >-
+          The first letter is the STATE OR TERRITORY INDEX MARK and comes from
+          the closed set JPJ's own location API publishes: A B C D F J K L M N P
+          R T W (peninsular states and federal territories), V (Kuala Lumpur's
+          second series), Q (Sarawak) and S (Sabah). E G H U X Y do not open an
+          ordinary registration — E was Sabah's pre-1963 mark, H is the hire
+          prefix (my-taxi), Z is military (my-military-z) — and I and O are
+          never issued at all.
+          See plates/_decode/my-index-marks.yml.
+        excluded: [I, O, Z]
+        no_leading_zero: true
+      progression: >-
+        The letters after the index mark advance alphabetically, skipping I, O
+        and Z, and the number runs 1-9999 within each letter combination:
+        A 1 … A 9999, AA 1 … AA 9999, AB 1 …, and so on to AY 9999, then AAA 1.
+        This is the mechanism every secondary account gives and the live JPJ
+        readings are consistent with it (Perak is at APK, Selangor at BSS,
+        Kelantan at DFQ — three letters deep in each case). The mechanism itself
+        is not in any instrument located: recorded as mechanism, not as law.
+      separator_note: >-
+        NO SEPARATOR GLYPH is prescribed by anything located, and Malaysian
+        plates print a GAP between the letter group and the number group. The
+        space in `pattern` is that gap; every regex accepts it as optional and
+        also accepts a hyphen, per PRD-PLATES §2.8 (a separator-only class).
+    design:
+      background: { color: "#000000", finish: non-reflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+      plate_note: >-
+        NO `design.plate` BLOCK: no located instrument or authority text gives
+        millimetres. See the file header — JPJ publishes the measurements only
+        as an image. Recorded gap, deliberately not estimated.
+      font_note: >-
+        NO TYPEFACE IS PRESCRIBED by anything located. JPJ's specification page
+        carries a diagram which secondary accounts read as naming a compact
+        Arial Bold with Calisto MT Italic and Franklin Gothic Bold as
+        alternates; the diagram is an image and was not read in this pass.
+        Charles Wright and FE-Schrift are both common in the wild and both are
+        aftermarket choices, not standards. PRD-PLATES §6's schematic-render
+        fallback applies.
+    region_encoding: "plates/_decode/my-index-marks.yml"
+    sources:
+      - "https://lom.agc.gov.my/ilims/upload/portal/akta/outputaktap/1871744_BI/Act%20333_Final_15%20Oct%202023%20(25.3.24).pdf  # Road Transport Act 1987 s. 11(1)(a) — 'the prescribed index mark indicating the registration area ... and a separate number', which is this format's structure and the whole of what statute gives; s. 14(1) display. Accessed 2026-08-02"
+      - "https://web.archive.org/web/20130516074518/http://www.jpj.gov.my/web/eng/specifications-of-vehicle-number-plates  # JPJ: 'White alphabets and numbers, embossed or glued on a black plate' — the ordinary plate's colours. Accessed 2026-08-02"
+      - "https://portal-api.jpj.gov.my/api/semak-no-pendaftaran-terkini  # JPJ live 'latest registration number' API, queried per area code 2026-08-03 00:47-00:49 (+08): KGH 3943 Kedah, MEG 6121 Melaka, NEL 2986 Negeri Sembilan, CFH 3542 Pahang, PSE 4213 Penang, APK 4191 Perak, BSS 3435 Selangor, TDH 3264 Terengganu, DFQ 9814 Kelantan, VRJ 7380 Kuala Lumpur, LH 6757 Labuan, SJT 4199 Kota Kinabalu, SMW 5063 Sandakan, SWR 9584 Tawau, SPA 3076 Lahad Datu, QBH 8695 Betong, QRY 2592 Sarikei, QLG 4546 Lawas, QCW 4437 Kota Samarahan, QPD 9177 Kapit — the prefix form, in issue now"
+      - "https://ms.wikipedia.org/wiki/Plat_pendaftaran_kenderaan_Malaysia  # the I/O/Z exclusion carried in regex_strict. period_evidence: secondary-wikipedia. Accessed 2026-08-02"
+    notes: >-
+      THE ORDINARY MALAYSIAN PLATE, prefix form: one to three letters, a gap,
+      one to four digits, white on black, front and rear. period.start 1987 is
+      the Road Transport Act 1987, which is the instrument currently in force
+      and NOT the date the format began — the index-mark system runs back
+      through the Road Traffic Ordinance 1958 to the 1948 rationalisation of
+      the state marks (PK->A, JB->J and the rest), and this file makes no claim
+      about those dates because no instrument for them was obtained.
+      `period_evidence: instrument-in-force` is therefore the honest tag and the
+      pre-1987 boundary is a recorded gap. Runs in PARALLEL with
+      my-standard-suffix, which is a different arrangement of the same
+      statutory mark-plus-number and is equally current — eight of JPJ's
+      twenty-eight live areas were issuing the suffix form on 3 August 2026.
+
+  - id: my-standard-suffix
+    class: standard
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1987 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL 9999 L"
+      regex: '\A[A-Z]{1,3}[- ]?\d{1,4}[- ]?[A-Z]\z'
+      regex_strict: '\A[ABCDFJKLMNPQRSTVW][A-HJ-NP-Y]{0,2}[- ]?[1-9]\d{0,3}[- ]?[A-HJ-NP-Y]\z'
+      charset:
+        excluded: [I, O, Z]
+        no_leading_zero: true
+        suffix_note: >-
+          The trailing letter is a SERIES COUNTER, not a check digit and not a
+          locality code: the live JPJ readings pair J with 6419, F with 859, H
+          with 4097, L with 1644, Q with 7665, Y with 5608, U with 5771 and P
+          with 3426, and no arithmetic relation survives that. Secondary
+          accounts add that Q and S are avoided as suffixes in Sabah and
+          Sarawak to prevent collision with the division prefixes; that
+          refinement is NOT carried in regex_strict because the live sample
+          contains a Q suffix (SU 7665 Q, Keningau) which contradicts it.
+          Recorded as a disagreement, not averaged (PRD-PLATES §5.3).
+      separator_note: "two printed gaps, both optional in the regexes and both spelled as separator-only classes"
+    design:
+      background: { color: "#000000", finish: non-reflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: "plates/_decode/my-index-marks.yml"
+    sources:
+      - "https://portal-api.jpj.gov.my/api/semak-no-pendaftaran-terkini  # JPJ live API, queried per area code 2026-08-03 00:47-00:49 (+08): JB 6419 J Johor, KV 859 F Langkawi, QAB 3426 P Kuching, QS 5608 Y Mukah, QM 5771 U Miri, SK 4097 H Kudat, SB 1644 L Beaufort, SU 7665 Q Keningau — eight of twenty-eight areas issuing the SUFFIX form on that date"
+      - "https://lom.agc.gov.my/ilims/upload/portal/akta/outputaktap/1871744_BI/Act%20333_Final_15%20Oct%202023%20(25.3.24).pdf  # Road Transport Act 1987 s. 11(1)(a), s. 14(1) — same statutory frame as my-standard-prefix. Accessed 2026-08-02"
+      - "https://web.archive.org/web/20130516074518/http://www.jpj.gov.my/web/eng/specifications-of-vehicle-number-plates  # colours. Accessed 2026-08-02"
+    notes: >-
+      THE ORDINARY MALAYSIAN PLATE, suffix form: index mark, number, then a
+      single trailing letter — SK 4097 H, QM 5771 U, JB 6419 J. Historically the
+      Sabah and Sarawak arrangement, it is now also Johor's (the J…J series),
+      Langkawi's (KV) and was Kuala Lumpur's during the W run-out before the V
+      series began. Separate series from my-standard-prefix because the FORMAT
+      differs (PRD-PLATES §2.3); same statutory frame, same colours, same
+      period, and both are live — which is why both carry distinct notes and
+      the lint's overlap rule is satisfied honestly rather than by accident.
+      period.start 1987 is the Act in force, not the arrangement's origin; the
+      suffix form is materially older in East Malaysia and its start is a
+      recorded gap.
+
+  - id: my-taxi
+    class: taxi
+    categories: [car]
+    period: { start: 1987 }
+    period_evidence: agency-page-in-force
+    matching: strict
+    format:
+      pattern: "LLL 9999"
+      regex: '\A[A-Z]{1,3}[- ]?\d{1,4}\z'
+      regex_strict: '\AH[A-HJ-NP-Y]{1,2}[- ]?[1-9]\d{0,3}\z'
+      charset:
+        first_letter: [H]
+        note: >-
+          H for HIRE, followed by the state letter — HW for Kuala Lumpur, HP for
+          Penang, and so on. THE H PREFIX IS NOT SOURCED TO ANY INSTRUMENT OR
+          AUTHORITY PAGE: it is stated by the English Wikipedia article and
+          corroborated by photographs. It is carried in `regex_strict` and
+          flagged here; the COLOURS, which are the sourced part, are in
+          `design`. period_evidence records the sourcing of the SERIES (JPJ's
+          own page), not of the prefix.
+        excluded: [I, O, Z]
+    design:
+      background: { color: "#FFFFFF", finish: non-reflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: "plates/_decode/my-index-marks.yml"
+    sources:
+      - "https://web.archive.org/web/20130516074518/http://www.jpj.gov.my/web/eng/specifications-of-vehicle-number-plates  # JPJ, verbatim: 'Black alphabets and numbers, embossed or glued on a white plate for taxicabs and hired cars.' — the inverted colours, one of only three plate forms JPJ recognises. Accessed 2026-08-02"
+      - "https://lom.agc.gov.my/ilims/upload/portal/akta/outputaktap/1871744_BI/Act%20333_Final_15%20Oct%202023%20(25.3.24).pdf  # Road Transport Act 1987 s. 66(1)(s), which expressly empowers rules 'to provide for a distinctive registration number or other sign to be carried by public service vehicles or goods vehicles' — the statutory hook for a distinct taxi plate. Accessed 2026-08-02"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Malaysia  # the H (hire) prefix and its state second letters. period_evidence: secondary-wikipedia. Accessed 2026-08-02"
+    notes: >-
+      TAXIS AND HIRE CARS: black on white, the exact inverse of the ordinary
+      plate, and one of the three plate forms JPJ's own specification page
+      recognises. The colour inversion is sourced to the authority; the H
+      prefix is secondary and is tagged as such inside `format.charset`. Note
+      the statutory hook in s. 66(1)(s) — Malaysian law expressly contemplates
+      a distinctive number or sign for public service vehicles, which is
+      unusually explicit for a common-law road traffic act.
+
+  - id: my-diplomatic-dc
+    class: diplomatic
+    categories: [car]
+    period: { start: 1987 }
+    period_evidence: agency-page-in-force
+    matching: strict
+    format:
+      pattern: "99-99-DC"
+      regex: '\A\d{1,3}[- ]\d{1,4}[- ]DC\z'
+      pattern_note: >-
+        Country code, rank/serial number, and the literal DC. The two numeric
+        groups and the DC marking are printed as three groups; the country-code
+        group's own table is a RECORDED GAP (PRD-PLATES puts diplomatic decode
+        tables at L4) and \d{1,3} is a practical bound, not a sourced one. The
+        RANK BLOCK of the second group IS sourced, in detail, and is carried in
+        plates/_decode/my-index-marks.yml.
+      fields:
+        - { name: country_code, note: "the sending state's code — table not located, recorded gap" }
+        - { name: rank_number, note: "allocated by diplomatic rank: 01 head of mission's official car, 02/03 head of mission's personal car, 04 deputy chief of mission / deputy high commissioner / minister, 05 minister counsellor, 06-09 counsellor, 10-19 first secretary, 20-29 second secretary, 30-39 third secretary, 40-59 attaché (including military advisers, trade representatives and defence advisers), 60-99 a diplomat's SECOND duty-free car, 101 and above vehicles registered in the name of the mission — Wisma Putra, Protocol Department, paras 6.4, 6.6, 6.8" }
+        - { name: marking, value: "DC", note: "Diplomatic Corps" }
+      separator_note: "printed as three groups; the regexes spell the gap as an emitted separator class per PRD-PLATES §2.8"
+    design:
+      background: { color: "#CC0000", finish: non-reflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+    variants:
+      - class: diplomatic
+        design: { background: { color: "#000000", finish: non-reflective, hex_basis: observed }, foreground: "#FFFFFF" }
+        note: >-
+          MISSION-REGISTERED VEHICLES GET THE BLACK PLATE, NOT THE RED ONE, and
+          this is the distinction most accounts of Malaysian diplomatic plates
+          miss. Wisma Putra para 6.9, verbatim: "All motor vehicles for
+          diplomats and the Chief Representative from the Regional Office of the
+          United Nations will bear WHITE NUMBERS ON RED FIELD with the markings
+          of 'DC' or 'UN' respectively." / "All motor vehicles for the foreign
+          mission including the consular corps and Offices of the United Nations
+          will bear WHITE NUMBERS ON BLACK FIELD with the markings of 'DC', 'CC'
+          or 'UN' respectively." So RED means a PERSON (an accredited diplomat);
+          BLACK means an INSTITUTION (the mission, the consular corps, a UN
+          office). Colour-only variant of the same format and period, hence a
+          sub-entry per PRD-PLATES §2.3.
+        sources:
+          - "https://web.archive.org/web/20140714163606/http://www.kln.gov.my/web/guest/diplomat  # Ministry of Foreign Affairs Malaysia, Protocol > Foreign Missions > Diplomat, 'MOTOR VEHICLES' para 6.9 'Colour Identification Of Registration Plate'. Accessed 2026-08-02"
+    region_encoding: "plates/_decode/my-index-marks.yml"
+    sources:
+      - "https://web.archive.org/web/20140714163606/http://www.kln.gov.my/web/guest/diplomat  # Ministry of Foreign Affairs Malaysia (Wisma Putra), 'MOTOR VEHICLES' paras 6.4 (the full DC rank allocation table), 6.5 (a diplomat keeps his DC number across vehicles), 6.6 (second car 60-99), 6.7 (chargés d'affaires numbered by rank), 6.8 (mission-registered vehicles from 101), 6.9 (red vs black fields). Accessed 2026-08-02"
+      - "https://web.archive.org/web/20130516074518/http://www.jpj.gov.my/web/eng/specifications-of-vehicle-number-plates  # JPJ, verbatim: 'White alphabets and numbers, embossed or glued on a red plate for vehicles belonging to embassies, the UN and the International Natural Rubber Association.' — the ROAD AUTHORITY's own statement of the red plate, independent of the foreign ministry's. Accessed 2026-08-02"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Malaysia  # the printed group arrangement 'NN-NN-DC'. period_evidence: secondary-wikipedia. Accessed 2026-08-02"
+    notes: >-
+      DIPLOMATIC CORPS. TWO INDEPENDENT AUTHORITIES SOURCE THIS PLATE and they
+      agree, which is rare: JPJ (the road authority) publishes the red plate as
+      one of the three permitted plate forms, and Wisma Putra (the foreign
+      ministry) publishes the allocation rules and the red/black split. What is
+      sourced: the colours, the red-for-person / black-for-institution rule, and
+      the complete RANK-TO-NUMBER table. What is NOT sourced: the country-code
+      table and the exact printed group order, which come from secondary
+      accounts. Wisma Putra para 6.5 also gives Malaysia a small cherished-number
+      rule of its own — a diplomat "is required to retain the number plate even
+      when he disposes [of the car] after 18 months or more as the same number
+      will be given to his new car".
+
+  - id: my-consular-cc
+    class: consular
+    categories: [car]
+    period: { start: 1987 }
+    period_evidence: agency-page-in-force
+    matching: strict
+    format:
+      pattern: "99-99-CC"
+      regex: '\A\d{1,3}[- ]\d{1,4}[- ]CC\z'
+      fields:
+        - { name: country_code, note: "table not located, recorded gap" }
+        - { name: allocation_number, note: "allocated BY CONSULAR DISTRICT, not by rank alone — Kuala Lumpur 01 / 10-19 / 100-199, Penang 02 / 20-29 / 200-299, Kota Bharu 03 / 30-39 / 300-399, Kota Kinabalu 04 / 40-49 / 400-499, Kuching 05 / 50-59 / 500-599, further missions 06-09 / 60-99 / 600-999; the three columns are respectively the head of consular mission, the heads of consular offices, and vehicles registered in the mission's name. Full table in plates/_decode/my-index-marks.yml" }
+        - { name: marking, value: "CC", note: "Consular Corps" }
+    design:
+      background: { color: "#000000", finish: non-reflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: "plates/_decode/my-index-marks.yml"
+    sources:
+      - "https://web.archive.org/web/20140714163606/http://www.kln.gov.my/web/guest/diplomat  # Wisma Putra 'MOTOR VEHICLES' para 6.10, the full CC allocation table by consular district; para 6.9, consular corps vehicles bear white numbers on a BLACK field. Also: 'Honorary Consuls are only issued with ID cards' — Malaysia gives honorary consuls NO plate at all, in pointed contrast to Thailand's grey honorary-consul plate. Accessed 2026-08-02"
+    notes: >-
+      CONSULAR CORPS: white on black, marked CC. THE ALLOCATION IS GEOGRAPHIC,
+      which makes it a genuine decode dimension rather than a rank code — the
+      leading digit of a Malaysian CC number tells you the consular district
+      (1 Kuala Lumpur, 2 Penang, 3 Kota Bharu, 4 Kota Kinabalu, 5 Kuching), and
+      the magnitude tells you whether the car belongs to the head of mission,
+      an office head, or the mission itself. One sentence on the same page is
+      worth recording for what it rules OUT: "Honorary Consuls are only issued
+      with ID cards" — there is no Malaysian honorary-consul plate.
+
+  - id: my-un
+    class: diplomatic
+    categories: [car]
+    period: { start: 1987 }
+    period_evidence: agency-page-in-force
+    # RECALL-ONLY: the printed arrangement of the UN plate is only partly
+    # evidenced. Wisma Putra prints its agency allocations as "10 UN", "11 UN",
+    # "12 UN", "14 UN" — a single number and the marking — while the personal
+    # and office allocations run 01-99 and "101 and above", which implies at
+    # least one further group. The regex therefore accepts both a one-group and
+    # a two-group form, which makes it wider than any single issuing grammar.
+    matching: recall-only
+    format:
+      pattern: "99 UN"
+      regex: '\A\d{1,3}[- ]?\d{0,4}[- ]?UN\z'
+      fields:
+        - { name: agency_or_country_code, note: "Wisma Putra: UNDP = 10 UN, WHO = 11 UN, FAO = 12 UN, UNHCR = 14 UN — a closed, primary, four-row allocation, carried in plates/_decode/my-index-marks.yml. 13 is skipped and the page does not say why." }
+        - { name: allocation_number, note: "01 official car of the head of a UN office or specialised agency; 02-05 that head's personal car; 06-99 cars registered to other UN officials; 101 and above cars registered in the name of the office or agency (Wisma Putra para 6.11)" }
+        - { name: marking, value: "UN" }
+    design:
+      background: { color: "#CC0000", finish: non-reflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+    variants:
+      - class: diplomatic
+        design: { background: { color: "#000000", finish: non-reflective, hex_basis: observed }, foreground: "#FFFFFF" }
+        note: >-
+          Offices of the United Nations take the BLACK field; only the Chief
+          Representative of the UN Regional Office takes the RED one
+          (Wisma Putra para 6.9) — the same person/institution split as DC.
+        sources:
+          - "https://web.archive.org/web/20140714163606/http://www.kln.gov.my/web/guest/diplomat  # para 6.9. Accessed 2026-08-02"
+    region_encoding: "plates/_decode/my-index-marks.yml"
+    sources:
+      - "https://web.archive.org/web/20140714163606/http://www.kln.gov.my/web/guest/diplomat  # Wisma Putra 'MOTOR VEHICLES' para 6.11, the UN allocation table and the four named agency numbers (UNDP 10, WHO 11, FAO 12, UNHCR 14); para 6.9 the red/black split. Accessed 2026-08-02"
+      - "https://web.archive.org/web/20130516074518/http://www.jpj.gov.my/web/eng/specifications-of-vehicle-number-plates  # JPJ lists 'the UN' alongside embassies as entitled to the red plate. Accessed 2026-08-02"
+    notes: >-
+      UNITED NATIONS OFFICES AND SPECIALISED AGENCIES, marked UN. Malaysia is
+      one of few jurisdictions with a distinct UN marking beside DC and CC, and
+      the reason is historical: Kuala Lumpur hosted UN regional offices and, on
+      JPJ's own account, the INTERNATIONAL NATURAL RUBBER ORGANIZATION, which
+      JPJ names in the same breath as the UN when listing who may carry the red
+      plate. `matching: recall-only` because the printed group count is not
+      fully evidenced — see the comment above the key.
+
+  - id: my-military-z
+    class: military
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1987 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LL 9999"
+      regex: '\A[A-Z]{2}[- ]?\d{1,4}\z'
+      regex_strict: '\AZ[A-HJ-NP-Y][- ]?[1-9]\d{0,3}\z'
+      charset:
+        first_letter: [Z]
+        note: >-
+          Z is reserved to the Malaysian Armed Forces and is issued as no
+          state's mark, which is why Z is missing from the ordinary alphabet.
+          The second letter advances (ZA, ZB, ZC …). NOT SOURCED TO ANY
+          INSTRUMENT OR AUTHORITY PAGE — the reservation is stated by both the
+          English and Malay Wikipedia articles ("Huruf Z ditinggalkan dan
+          dikhaskan untuk digunakan pada kenderaan tentera Malaysia") and is
+          consistent with Z's absence from JPJ's own live area/prefix data.
+      separator_note: "a printed gap, optional in the regexes"
+    design:
+      background: { color: "#000000", finish: non-reflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      emblem: { present: false }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://ms.wikipedia.org/wiki/Plat_pendaftaran_kenderaan_Malaysia  # 'Huruf Z ditinggalkan dan dikhaskan untuk digunakan pada kenderaan tentera Malaysia' — Z reserved for Malaysian military vehicles. period_evidence: secondary-wikipedia. Accessed 2026-08-02"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Malaysia  # the ZA-prefixed arrangement and the white-on-black plate. period_evidence: secondary-wikipedia. Accessed 2026-08-02"
+      - "https://portal-api.jpj.gov.my/api/locations  # NEGATIVE evidence, and the honest kind: JPJ's closed list of 32 registration areas contains no Z code, which is consistent with Z being outside the civil registration system entirely. Queried 2026-08-03"
+    notes: >-
+      MALAYSIAN ARMED FORCES (Angkatan Tentera Malaysia). THE WEAKEST-SOURCED
+      SERIES IN THIS FILE and labelled as such: no instrument and no authority
+      page located says anything about Z. It is carried because the RESERVATION
+      of Z is load-bearing elsewhere — it is why `regex_strict` on every
+      civilian series excludes Z — and because omitting it would leave that
+      exclusion unexplained. period.start 1987 is the Act in force, carrying no
+      claim about when the Z reservation began. A verifier with access to the
+      Malaysian Armed Forces' own regulations should expect to replace this
+      entry wholesale.
+
+  - id: my-jpjeplate-ev-2024
+    class: electric
+    categories: [car]
+    period: { start: 2024 }
+    period_evidence: secondary-first-issue
+    matching: strict
+    format:
+      pattern: "LLL 9999"
+      regex: '\A[A-Z]{1,3}[- ]?\d{1,4}\z'
+      regex_strict: '\A[ABCDFJKLMNPQRSTVW][A-HJ-NP-Y]{0,2}[- ]?[1-9]\d{0,3}\z'
+      note: >-
+        The MARK is an ordinary Malaysian registration — this is a different
+        PLATE, not a different numbering system, which is exactly the
+        PRD-PLATES §2.3 test for a series of its own (design differs, format
+        and period do not).
+    design:
+      plate_note: >-
+        "European-style" proportions are reported by every account and no
+        millimetres are sourced; none are recorded here.
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: left, color: "#009000", content: "green stripe + Jalur Gemilang (national flag) + the international distinguishing code MAL", hex_basis: observed }
+      emblem: { present: true, rendered: placeholder, note: "the national flag is a state emblem — PRD-PLATES §3 placeholder rule applies, artwork not reproduced" }
+      rear_differs: false
+      features: >-
+        Embossed characters in FE-Schrift on a white retroreflective ground with
+        an embedded RFID tag — the first Malaysian plate to prescribe a
+        typeface at all, and the first to leave white-on-black.
+    region_encoding: "plates/_decode/my-index-marks.yml"
+    sources:
+      - "https://soyacincau.com/2024/09/09/jpjeplate-ev-number-plate-malaysia-official-price/  # JPJePlate launch, September 2024: mandatory for newly registered electric cars, European-style plate, black FE-Schrift on white reflective ground, green stripe, Jalur Gemilang, MAL code, embedded RFID. period_evidence: secondary-first-issue. Accessed 2026-08-02"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Malaysia  # 'The JPJePlate number plate was introduced in September 2024 ... compulsory for newly registered EVs from September 2024 onwards. Currently available for Electric powered cars only.' period_evidence: secondary-wikipedia. Accessed 2026-08-02"
+    notes: >-
+      JPJePLATE, the electric-vehicle plate, mandatory for EVs newly registered
+      from September 2024. THE FIRST BREAK IN MALAYSIA'S WHITE-ON-BLACK
+      CONVENTION IN THE MODERN ERA, and the first Malaysian plate with a named
+      typeface, an international distinguishing code and an RFID tag. ENTIRELY
+      SECONDARY-SOURCED: no instrument and no JPJ page carrying its
+      specification was located in this pass, and JPJ's own knowledge-base
+      article still describes only the three older plate forms. Recorded because
+      a current-standard file that omits the current EV plate is incomplete, and
+      tagged so a verifier knows precisely how much to re-check. A related 2026
+      development — the "Teksi Madani" scheme's red-on-white JPJePlate for taxis
+      from 3 July 2026 — is NOT authored here: it rests on a single secondary
+      mention and has no located specification.

--- a/plates/th.yml
+++ b/plates/th.yml
@@ -1,0 +1,1130 @@
+# plates/th.yml — Thailand (PRD-PLATES gate L3). DRAFT for verification.
+#
+# EVERY size, layout, colour and class claim about the MOTOR-VEHICLE-ACT plates
+# in this file comes from one instrument, read verbatim from the Royal Gazette
+# PDF: กฎกระทรวง กำหนดขนาด ลักษณะ และสีของแผ่นป้ายทะเบียนรถ และการแสดงแผ่นป้าย
+# ทะเบียนรถและเครื่องหมายแสดงการเสียภาษีประจำปี พ.ศ. ๒๕๕๔ ("Ministerial
+# Regulation prescribing the size, characteristics and colour of vehicle
+# registration plates and the display of registration plates and the annual tax
+# mark, B.E. 2554"), ราชกิจจานุเบกษา เล่ม ๑๒๘ ตอนที่ ๔๕ ก หน้า ๖ (Royal Gazette
+# vol. 128, part 45 Kor, p. 6), 8 June 2011, given 30 May 2011 by the Deputy
+# Minister of Transport acting for the Minister.
+#
+# EVERY claim about the COMMERCIAL (Land Transport Act) plates comes from
+# ประกาศกรมการขนส่งทางบก เรื่อง กำหนดลักษณะ ขนาด สีของแผ่นป้ายเลขทะเบียนรถ
+# และการแสดงแผ่นป้ายและเครื่องหมายแสดงการเสียภาษี พ.ศ. ๒๕๕๔ (DLT Announcement,
+# made 10 March 2011), ราชกิจจานุเบกษา เล่ม ๑๒๘ ตอนพิเศษ ๔๔ ง หน้า ๕๒,
+# 19 April 2011, made under s. 90 of the Land Transport Act B.E. 2522.
+#
+# ---------------------------------------------------------------------------
+# SIX STRUCTURAL FACTS THAT SHAPE THIS FILE
+# ---------------------------------------------------------------------------
+#
+# 1. THAILAND RUNS TWO PARALLEL REGISTRATION SYSTEMS UNDER TWO ACTS, AND THEY
+#    HAVE DIFFERENT PLATES. พระราชบัญญัติรถยนต์ พ.ศ. ๒๕๒๒ (Motor Vehicle Act
+#    B.E. 2522, given 8 May 1979) governs private cars, pickups, motorcycles,
+#    taxis, tuk-tuks and tractors; พระราชบัญญัติการขนส่งทางบก พ.ศ. ๒๕๒๒ (Land
+#    Transport Act B.E. 2522) governs licensed public and private TRANSPORT
+#    operators — buses and heavy trucks. The Motor-Vehicle-Act plate is a
+#    Thai-script plate (two category letters + up to four Arabic digits +
+#    the province name spelled out). The Land-Transport-Act plate is an
+#    ALL-NUMERIC plate reading "THAILAND" + a province code over a two-digit
+#    vehicle-type code, a dash and a four-digit serial. The two systems do not
+#    share a serial space, a colour scheme, a size or an authority page, and
+#    this file models them as two blocks of series.
+#
+# 2. THE SERIAL IS PARTLY IN THAI SCRIPT, WHICH IS A GENUINE COLLISION WITH
+#    PRD-PLATES §2.6. The separator contract fixes the dataset-wide serial
+#    alphabet at A-Z0-9 "and nothing else", and says in terms that a
+#    jurisdiction printing a glyph inside the serial "is a schema amendment,
+#    not a data entry". Thailand is that jurisdiction. The line taken here,
+#    and it is taken deliberately and identically on every affected series:
+#
+#      * `format.pattern` and `format.regex` describe ONLY the Arabic-numeral
+#        block the plate prints — which is what §2.6 permits us to spell — and
+#        every such series therefore carries `matching: recall-only`, because a
+#        bare digit regex is deliberately wider than the mark it belongs to.
+#      * `format.fields` (the PRD §2.2 Japan extension point) carries the WHOLE
+#        composition, field by field, each with its script and its source.
+#      * `format.regex_native` carries the full Unicode-aware regex. It is NOT
+#        one of the three lint-checked regex keys (`regex`, `regex_strict`,
+#        `regex_statutory`), so the lint ignores it and nothing is lost while
+#        the schema amendment is pending. See the dossier §7 for the proposed
+#        amendment (a `scripts:` block in _meta/separators.yml).
+#      * The Land-Transport-Act series are UNAFFECTED — their serial really is
+#        all-Arabic — so they carry ordinary `matching: strict` regexes with
+#        sourced `regex_strict` twins. They are the two best-evidenced regexes
+#        in this file and the reason it is worth having at all.
+#
+# 3. THE CATEGORY-LETTER ALPHABET IS DELEGATED AND UNPINNED — the German
+#    Bundesanzeiger pattern, arriving in Thailand by a different route.
+#    ข้อ ๓ (๑) (ก) ๕) of the 2554 regulation, verbatim: "การใช้ตัวเลขนำหน้า
+#    ตัวอักษรประจำหมวด ตัวอักษรประจำหมวด และหมายเลขทะเบียน ให้เป็นไปตามที่
+#    อธิบดีประกาศกำหนด" — "the use of the numeral preceding the category
+#    letters, the category letters, and the registration number shall be as the
+#    Director-General publicly prescribes". WHICH Thai consonants may be a
+#    category letter is therefore an administrative allocation by the DLT
+#    Director-General and is in NO ministerial regulation. No such announcement
+#    was secured in this pass; the alphabet is a recorded GAP and no letter list
+#    is asserted anywhere in this file.
+#    What the regulation DOES give is a partial, primary letter list by a side
+#    door: ข้อ ๓ (๑) (ก) ๔) fixes minimum character heights and widths "เว้นแต่
+#    กรณีตัวอักษร ข ง ช ซ ฌ ญ ฎ ฏ ฐ ฒ ณ ป ฝ ฟ ศ ษ ส ฬ ฮ สระ วรรณยุกต์ และ
+#    หมายเลข ๑" — nineteen named consonants, plus vowels and tone marks, whose
+#    metrics the Director-General sets instead. Those nineteen letters
+#    demonstrably appear on plates; that is a fact of primary law and it is
+#    recorded in `charset_defaults`, but it is NOT the alphabet.
+#
+# 4. THE LEADING DIGIT IS A SOURCED EXHAUSTION RULE, NOT A SEPARATE FORMAT.
+#    ข้อ ๓ (๑) (ก) ๓), verbatim: "ในกรณีที่ใช้ตัวอักษรประจำหมวดตัวที่หนึ่งและ
+#    ตัวที่สองจนครบทุกตัวอักษรแล้ว ในบรรทัดที่หนึ่งให้เพิ่มตัวเลขอารบิคตั้งแต่
+#    ๑ ถึง ๙ ตามลำดับ ไว้ด้านหน้าของตัวอักษรประจำหมวดตัวที่หนึ่ง" — "where the
+#    first and second category letters have been used through every letter, an
+#    Arabic numeral from 1 to 9 shall be added in order, in the first line, in
+#    front of the first category letter." It is the same series continuing, so
+#    it is modelled as `format.fields` + `progression`, not as a second series.
+#    (For MOTORCYCLES the leading numeral is part of the base composition:
+#    ข้อ ๓ (๑) (ข) ๒) puts it in line 1 without an exhaustion condition.)
+#
+# 5. THE PROVINCE IS SPELLED OUT, NOT CODED — so Thailand has no province
+#    letter-code table to decode. ข้อ ๓ (๑) (ก) ๒): line two is "ตัวอักษรแสดง
+#    ชื่อกรุงเทพมหานครหรือจังหวัดที่จดทะเบียน เว้นแต่กรณีจดทะเบียนที่อำเภอเบตง
+#    จังหวัดยะลา ให้ใช้คำว่า เบตง" — the letters showing the name of Bangkok or
+#    of the province of registration, EXCEPT for registration at Betong
+#    District, Yala Province, where the word "เบตง" (Betong) is used. Betong is
+#    the only sub-provincial registration place in Thai plate law and it is in
+#    the regulation itself. The COMMERCIAL plate is the one that carries a
+#    numeric province code, and that code list is delegated (see
+#    plates/_decode/th-registration-elements.yml).
+#
+# 6. NO COLOUR IN THIS FILE IS NUMBERED BY THE AUTHORITY. The regulation names
+#    colours — สีขาวสะท้อนแสง (retroreflective white), สีเหลืองสะท้อนแสง
+#    (yellow), สีเขียวสะท้อนแสง (green), สีส้มสะท้อนแสง (orange),
+#    สีฟ้าสะท้อนแสง (light blue), สีเทาสะท้อนแสง (grey), and the character
+#    colours ดำ / แดง / เขียว / น้ำเงิน / ขาว — and never gives a chromaticity,
+#    a Pantone or a hex. Every hex here is therefore `hex_basis: observed`
+#    inside a statutorily NAMED colour, the same posture plates/gb.yml takes.
+#
+# TRANSLATION NOTE: Thai quotations are given in the original throughout;
+# English renderings in comments and notes are this researcher's working
+# translations and are not official.
+jurisdiction: th
+authority:
+  name: กรมการขนส่งทางบก (Department of Land Transport, DLT), Ministry of Transport
+  url: "https://www.dlt.go.th"
+binding: vehicle
+binding_note: >-
+  ข้อ ๓ of the 2554 regulation opens "แผ่นป้ายทะเบียนรถที่นายทะเบียนออกให้ซึ่งมี
+  หมายเลขตรงกับใบคู่มือจดทะเบียนรถ" — the plate the registrar issues bears the
+  number that MATCHES THE VEHICLE'S REGISTRATION HANDBOOK (ใบคู่มือจดทะเบียนรถ).
+  The mark is a property of the registered vehicle, not of the keeper. The one
+  qualification is the auction regime: a number bought at auction under
+  s. 10/1 is bought FOR a vehicle the successful bidder registers.
+
+instrument:
+  motor_vehicle_act:
+    citation: "พระราชบัญญัติรถยนต์ พ.ศ. ๒๕๒๒ (Motor Vehicle Act B.E. 2522), given 8 May B.E. 2522 (1979), consolidated by the Office of the Council of State"
+    key_sections:
+      - "มาตรา ๕ (๔) — the rule-making power under which the plate regulation is made (as amended by the Motor Vehicle Act (No. 10) B.E. 2542)"
+      - "มาตรา ๑๑, verbatim: 'รถที่จดทะเบียนแล้ว ต้องมีและแสดงแผ่นป้ายและเครื่องหมายครบถ้วนถูกต้องตามที่กำหนดในกฎกระทรวง' — a registered vehicle must carry and display the plate and the mark completely and correctly as prescribed in the ministerial regulation"
+      - "มาตรา ๑๐/๑ — the Director-General must put desirable/popular registration numbers to general auction (inserted by the Motor Vehicle Act (No. 12) B.E. 2546)"
+      - "มาตรา ๒๗ — the dealer/repairer licence, and with it 'ให้นายทะเบียนออกเครื่องหมายพิเศษและสมุดคู่มือประจำรถให้ด้วย' (the registrar shall also issue a SPECIAL MARK and a vehicle handbook), driveable 'ระหว่างพระอาทิตย์ขึ้นถึงพระอาทิตย์ตก' (between sunrise and sunset) unless the registrar permits otherwise; the form of the special mark is left to a ministerial regulation"
+      - "มาตรา ๖/๑ วรรคสาม — test-vehicle permission and its mark (inserted by the Motor Vehicle Act (No. 17) B.E. 2557)"
+      - "มาตรา ๖๐ — the general penalty for the plate offences: a fine not exceeding two thousand baht"
+    source: "https://web.archive.org/web/20110203044221/http://web.krisdika.go.th/data/law/law2/%C301/%C301-20-9999-update.pdf  # Office of the Council of State consolidation of the Motor Vehicle Act B.E. 2522; ss. 5, 6/1, 10/1, 11, 27, 60 read from the PDF text layer (the live krisdika host refused the connection on 2026-08-02; the Internet Archive copy was used)"
+  plate_regulation_2554:
+    citation: "กฎกระทรวง กำหนดขนาด ลักษณะ และสีของแผ่นป้ายทะเบียนรถ และการแสดงแผ่นป้ายทะเบียนรถและเครื่องหมายแสดงการเสียภาษีประจำปี พ.ศ. ๒๕๕๔"
+    given: "2011-05-30"
+    published: "2011-06-08"          # ราชกิจจานุเบกษา เล่ม ๑๒๘ ตอนที่ ๔๕ ก หน้า ๖
+    entry_into_force: >-
+      ข้อ ๑, verbatim: "กฎกระทรวงนี้ให้ใช้บังคับเมื่อพ้นกำหนดหนึ่งร้อยแปดสิบวัน
+      นับแต่วันประกาศในราชกิจจานุเบกษาเป็นต้นไป" — in force on the expiry of
+      180 days from publication in the Royal Gazette. Counted from 8 June 2011
+      that falls in the first week of DECEMBER 2011. The regulation states no
+      calendar date; the arithmetic is recorded, the day is not asserted.
+    revokes:
+      - "กฎกระทรวงกำหนดลักษณะ ขนาด และสีของแผ่นป้ายทะเบียนรถ พ.ศ. ๒๕๔๗"
+      - "กฎกระทรวงกำหนดลักษณะ ขนาด และสีของแผ่นป้ายทะเบียนรถ (ฉบับที่ ๒) พ.ศ. ๒๕๕๐"
+    reason: >-
+      หมายเหตุ, verbatim: "โดยที่แผ่นป้ายทะเบียนรถตามขนาด ลักษณะ และสีที่กำหนด
+      ในปัจจุบันไม่สามารถรองรับการจดทะเบียนรถยนต์ที่เพิ่มจำนวนมากขึ้นได้ และมี
+      ลักษณะที่ยากต่อการตรวจสอบ" — the existing size, characteristics and colour
+      cannot absorb the growing number of registrations and are hard to inspect.
+      This is the reason the leading numeral of ข้อ ๓ (๑) (ก) ๓) exists.
+    signed_by: "สุชาติ โชคชัยรัตนากร, รัฐมนตรีช่วยว่าการกระทรวงคมนาคม ปฏิบัติราชการแทนรัฐมนตรีว่าการกระทรวงคมนาคม"
+    source: "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # the whole instrument: ข้อ ๑ entry into force, ข้อ ๒ revocations, ข้อ ๓ (๑) sizes and layouts (ก)-(ง), ข้อ ๓ (๒) colours (ก)-(ซ), ข้อ ๔ picture backgrounds, ข้อ ๕ front/rear display, ข้อ ๖-๑๑ transitionals, หมายเหตุ. The live ratchakitcha host returned HTTP 403 on 2026-08-02; the Internet Archive copy was used"
+  commercial_announcement_2554:
+    citation: "ประกาศกรมการขนส่งทางบก เรื่อง กำหนดลักษณะ ขนาด สีของแผ่นป้ายเลขทะเบียนรถ และการแสดงแผ่นป้ายและเครื่องหมายแสดงการเสียภาษี พ.ศ. ๒๕๕๔"
+    made: "2011-03-10"
+    published: "2011-04-19"          # ราชกิจจานุเบกษา เล่ม ๑๒๘ ตอนพิเศษ ๔๔ ง หน้า ๕๒
+    enabling: "มาตรา ๙๐ แห่งพระราชบัญญัติการขนส่งทางบก พ.ศ. ๒๕๒๒ (s. 90 Land Transport Act B.E. 2522), and giving effect to the Greater Mekong Subregion Cross-Border Transport Agreement"
+    entry_into_force: 'ข้อ ๕: "ประกาศนี้ให้ใช้บังคับตั้งแต่บัดนี้เป็นต้นไป" — in force from now on'
+    revokes: "ประกาศกรมการขนส่งทางบก เรื่อง กำหนดลักษณะ ขนาด สีของแผ่นป้ายเลขทะเบียนสำหรับรถ และการแสดงแผ่นป้ายและเครื่องหมายแสดงการเสียภาษี ลงวันที่ ๑๓ กันยายน ๒๕๔๙ (13 September 2006)"
+    reason: >-
+      The preamble states the operative cause in one sentence: the vehicle-type
+      codes for NON-SCHEDULED TRUCK transport prescribed by the 2549 (2006)
+      announcement "ได้ใช้สำหรับจดทะเบียนรถใกล้จะหมดลง" — were nearly used up —
+      so a further code band had to be prescribed. That is why the
+      non-scheduled-truck band in ข้อ ๒ (๓) (จ) reads "๖๐ ถึง ๖๙ และ ๗๐ ถึง ๗๙".
+    signed_by: "เทียนโชติ จงพีร์เพียร, อธิบดีกรมการขนส่งทางบก (Director-General, DLT)"
+    source: "https://web.archive.org/web/20160304073451/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/E/044/52.PDF  # ข้อ ๑ revocation, ข้อ ๒ (๑)-(๓) size/colour/lines/metrics and the six vehicle-type code bands, ข้อ ๓ display, ข้อ ๔ transitional from the 14 April B.E. 2530 announcement, ข้อ ๕ entry into force"
+  auction_regulation_2546:
+    citation: "กฎกระทรวง กำหนดหมายเลขทะเบียนซึ่งเป็นที่ต้องการหรือเป็นที่นิยม เพื่อนำออกเปิดประมูลเป็นการทั่วไป พ.ศ. ๒๕๔๖"
+    given: "2003-08-07"
+    published: "2003-08-08"          # ราชกิจจานุเบกษา เล่ม ๑๒๐ ตอนที่ ๗๕ ก
+    enabling: "มาตรา ๕ (๑๘) และมาตรา ๑๐/๑ วรรคหนึ่ง แห่งพระราชบัญญัติรถยนต์ พ.ศ. ๒๕๒๒ (s. 10/1 inserted by the Motor Vehicle Act (No. 12) B.E. 2546)"
+    scope: >-
+      ข้อ ๑ applies the auction regime to the registration numbers of the
+      category letters issued to รถยนต์นั่งส่วนบุคคลไม่เกินเจ็ดคน (private cars
+      of not more than seven persons), รถยนต์นั่งส่วนบุคคลเกินเจ็ดคนแต่ไม่เกิน
+      สิบสองคน (more than seven but not more than twelve) and
+      รถยนต์บรรทุกส่วนบุคคล (private goods vehicles), and defines TEN closed
+      classes of "desirable or popular" number: single digits; two, three and
+      four identical digits; thousands; three and four ascending digits;
+      เลขคู่เหมือน, เลขคู่หาม and เลขคู่สลับ (mirrored, bracketed and
+      alternating pairs). ข้อ ๓: an unsold number is issued normally.
+    signed_by: "นิกร จำนง, รัฐมนตรีช่วยว่าการกระทรวงคมนาคม ปฏิบัติราชการแทนรัฐมนตรีว่าการกระทรวงคมนาคม"
+    source: "https://web.archive.org/web/20141019064112/http://www.ratchakitcha.soc.go.th/DATA/PDF/00126585.PDF  # the whole instrument. NOTE: this Gazette PDF's text layer is in a legacy Thai font encoding and renders as mojibake under pdftotext; the structure, the ten number classes and the dates were read from it, the Thai wording was NOT quotable and is therefore not quoted anywhere in this file"
+  test_vehicle_announcement_2560:
+    citation: "ประกาศกรมการขนส่งทางบก เรื่อง กำหนดหลักเกณฑ์ วิธีการ และเงื่อนไขในการขออนุญาต การอนุญาต และระยะเวลาในการใช้รถ และเครื่องหมายแสดงการใช้รถที่ใช้เพื่อการทดสอบ พ.ศ. ๒๕๖๐"
+    made: "2017-02-03"
+    published: "2017-03-30"          # ราชกิจจานุเบกษา เล่ม ๑๓๔ ตอนพิเศษ ๙๒ ง หน้า ๖
+    entry_into_force: 'ข้อ ๑: "ประกาศนี้ให้ใช้บังคับตั้งแต่วันที่ ๑ เมษายน พ.ศ. ๒๕๖๐ เป็นต้นไป" — 1 April 2017'
+    enabling: "มาตรา ๖/๑ วรรคสาม แห่งพระราชบัญญัติรถยนต์ พ.ศ. ๒๕๒๒ ซึ่งแก้ไขเพิ่มเติมโดยพระราชบัญญัติรถยนต์ (ฉบับที่ ๑๗) พ.ศ. ๒๕๕๗"
+    signed_by: "สนิท พรหมวงษ์, อธิบดีกรมการขนส่งทางบก"
+    source: "https://web.archive.org/web/2020id_/https://www.ratchakitcha.soc.go.th/DATA/PDF/2560/E/092/6.PDF  # definitions of รถทดสอบก่อนผลิต (pre-production test vehicle) and รถทดสอบคุณภาพ (quality test vehicle), ข้อ ๗ 'เครื่องหมายแสดงการใช้รถ ... ให้เป็นไปตามแบบแนบท้ายประกาศนี้', ข้อ ๘ permit lives of 180 and 90 days, ข้อ ๙ (๑) (ข) front-and-rear display (rear only for motorcycles). The annexed FORMS are the permit documents; the mark itself is an image and its letters are not in the text layer"
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide charset facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+charset_defaults:
+  serial_scripts:
+    letters: "Thai consonants (Unicode Thai block U+0E01–U+0E2E) on every Motor-Vehicle-Act plate; Latin only on the Land-Transport-Act plates (the fixed word THAILAND) and on the international-use and test-vehicle marks"
+    digits: "Arabic (Western) numerals — ข้อ ๓ (๑) (ก) ๒): 'หมายเลขทะเบียนให้ใช้ตัวเลขอารบิค'. Thai numerals are NOT used for the registration number"
+  letters_with_delegated_metrics:
+    values: ["ข", "ง", "ช", "ซ", "ฌ", "ญ", "ฎ", "ฏ", "ฐ", "ฒ", "ณ", "ป", "ฝ", "ฟ", "ศ", "ษ", "ส", "ฬ", "ฮ"]
+    note: >-
+      ข้อ ๓ (๑) (ก) ๔) and ข้อ ๓ (๑) (ข) ๓) both set minimum letter heights and
+      widths and then except these nineteen consonants (plus สระ vowels,
+      วรรณยุกต์ tone marks and the numeral ๑), whose height and width the
+      Director-General fixes instead. These letters therefore demonstrably occur
+      on Thai plates as a matter of primary law. This is a PARTIAL list arrived
+      at by a side door: it is NOT the category-letter alphabet, which is
+      delegated (see the header, fact 3) and is a recorded gap.
+    source: "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๑) (ก) ๔) and (ข) ๓)"
+  alphabet_delegation:
+    note: >-
+      "การใช้ตัวเลขนำหน้าตัวอักษรประจำหมวด ตัวอักษรประจำหมวด และหมายเลขทะเบียน
+      ให้เป็นไปตามที่อธิบดีประกาศกำหนด" (ข้อ ๓ (๑) (ก) ๕), repeated verbatim at
+      (ข) ๔) for motorcycles). The alphabet, the order in which letter pairs are
+      opened, and the numbering are all Director-General announcements. NO such
+      announcement was retrieved in this pass. Consequently no series in this
+      file asserts a letter set, and every `regex_native` writes the letter
+      positions as the whole Thai consonant range with an explicit note.
+    source: "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๑) (ก) ๕) and (ข) ๔) — the delegation"
+
+# The pattern/regex policy, stated once and referenced by every Thai-script
+# series (PRD-PLATES §2.6 collision — see header fact 2).
+regex_policy:
+  thai_script_series: >-
+    `format.pattern` is the ARABIC-NUMERAL BLOCK ONLY ("9999" = the registration
+    number of not more than four digits). `format.regex` is its round-trippable
+    twin. `matching: recall-only` on every such series: a match says the string
+    is a shape the Thai numbering issues, never that it is a valid Thai
+    registration, because the Thai category letters and the province name — the
+    parts that actually identify the plate — cannot be spelled in the dataset's
+    serial alphabet. The full mark is in `format.fields`; the full regex is in
+    the non-lint-checked `format.regex_native`.
+regex_native_correction: >-
+  CORRECTION APPLIED 2026-08-03 by the assigned th researcher before hand-off,
+  and called out here rather than made silently. Every `regex_native` in this
+  file originally spelled the leading numeral as a class accepting THAI DIGITS
+  as well as Arabic ones. That is wrong on the instrument's own words: the
+  regulation requires the leading numeral to be an ARABIC numeral
+  ("ในบรรทัดที่หนึ่งให้เพิ่มตัวเลขอารบิคตั้งแต่ ๑ ถึง ๙ ตามลำดับ",
+  ข้อ ๓ (๑) (ก) ๓)), exactly as ข้อ ๓ (๑) (ก) ๒) requires the registration number
+  to be one ("หมายเลขทะเบียนให้ใช้ตัวเลขอารบิค"). The Thai digits ๑-๙ that appear
+  in that sentence are the GAZETTE'S typesetting of the numerals one to nine,
+  not a description of what the plate prints — Thai plates print Arabic
+  numerals and nothing else, and a consumer normalising Thai digits into a Thai
+  plate serial would be normalising a character that never occurs there. Every
+  `regex_native` now spells [1-9], consistently with each series' own `fields`
+  block, which already recorded the leading numeral as "Arabic numerals".
+  OCCURRENCES CHANGED: 14.
+  numeric_series: >-
+    The Land-Transport-Act series, the international-use mark and the
+    test-vehicle mark have all-Latin/Arabic serials and are modelled normally,
+    with `matching: strict` and sourced `regex_strict` twins.
+
+series:
+
+  # =========================================================================
+  # BLOCK A — MOTOR VEHICLE ACT B.E. 2522 PLATES (กฎกระทรวง พ.ศ. ๒๕๕๔).
+  # All of these share ONE layout and ONE size and differ only in colour and
+  # in the legal vehicle class, which is exactly why the regulation writes the
+  # sizes once in ข้อ ๓ (๑) (ก) and the colours eight times in ข้อ ๓ (๒).
+  # Because DESIGN differs (background and character colour), each is its own
+  # SERIES under PRD-PLATES §2.3 and not a colour sub-entry.
+  # =========================================================================
+
+  - id: th-private-car-2011
+    class: standard
+    categories: [car]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: >-
+        The pattern is the REGISTRATION NUMBER ONLY. The printed mark is two
+        lines: line 1 = [optional leading numeral 1-9] + category letter 1 +
+        category letter 2 + the registration number of not more than four
+        digits; line 2 = the province name in Thai. See `fields` and
+        `regex_native`, and the file header, fact 2.
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+      regex_native_note: >-
+        Not lint-checked (PRD-PLATES §2.6 admits only A-Z0-9 in a serial). It
+        covers ONE LINE — the province name of line 2 is a separate field. The
+        letter positions are written as the whole Thai consonant range
+        U+0E01-U+0E2E because the category-letter alphabet is delegated and
+        unpinned; the true set is a strict subset of that range.
+      fields:
+        - name: leading_numeral
+          line: 1
+          script: "Arabic numerals"
+          values: "1-9"
+          presence: conditional
+          rule: >-
+            ข้อ ๓ (๑) (ก) ๓): added in front of the first category letter only
+            once every first/second category-letter combination has been used.
+        - name: category_letter_1
+          line: 1
+          script: Thai
+          values: delegated
+          rule: "ตัวอักษรประจำหมวดตัวที่หนึ่ง — set by Director-General announcement (ข้อ ๓ (๑) (ก) ๕))"
+        - name: category_letter_2
+          line: 1
+          script: Thai
+          values: delegated
+          rule: "ตัวอักษรประจำหมวดตัวที่สอง"
+        - name: registration_number
+          line: 1
+          script: "Arabic numerals"
+          values: "not more than four digits (หมายเลขทะเบียนไม่เกินสี่หลัก)"
+        - name: province
+          line: 2
+          script: Thai
+          values: "the name of Bangkok or of the province of registration, spelled out; the word เบตง where the vehicle is registered at Betong District, Yala Province"
+          rule: "ข้อ ๓ (๑) (ก) ๒)"
+      progression: >-
+        A letter pair runs 1..9999 and the registrar then moves to the next pair
+        the Director-General has opened; when the pairs are exhausted the
+        leading numeral 1-9 is prefixed and the pairs restart. The pair-opening
+        ORDER is not published in any instrument secured here, so no age
+        inference is offered — this is the single biggest gap for a parse API.
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem:
+        present: true
+        rendered: placeholder
+        note: >-
+          "ในแผ่นป้ายมีเครื่องหมายเป็นตัวอักษร ขส อยู่ภายในวงกลมอัดเป็นรอยดุนที่
+          มุมล่างด้านขวาของแผ่นป้าย" — the letters ขส (the DLT's abbreviation)
+          inside an embossed circle at the LOWER RIGHT corner, at a size the
+          Director-General fixes. PRD-PLATES §3 placeholder rule applies.
+      border: { note: "ขอบแผ่นป้ายอัดเป็นรอยดุน — the plate edge is embossed; the border takes the character colour (ข้อ ๓ (๒) (ค))" }
+      characters:
+        line1_digit_min_h_mm: 58
+        line1_digit_min_w_mm: 31
+        line1_letter_min_h_mm: 58
+        line1_letter_min_w_mm: 38
+        line2_min_h_mm: 21
+        line2_min_w_mm: 18
+        note: "minima only; the nineteen named consonants, vowels, tone marks and the numeral ๑ are excepted and sized by the Director-General"
+      embossed: true
+      rear_differs: false
+      display: "ข้อ ๕: one plate at the front and one at the rear"
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๑) (ก) ๑)-๕) size 15 x 34 cm, ขส roundel lower right, two-line layout, leading numeral, character minima; ข้อ ๓ (๒) (ค) ๑) 'รถยนต์นั่งส่วนบุคคลไม่เกินเจ็ดคนใช้สีดำ' on a retroreflective white ground; ข้อ ๕ front and rear"
+    notes: >-
+      PRIVATE PASSENGER CAR of not more than seven persons (รถยนต์นั่งส่วนบุคคล
+      ไม่เกินเจ็ดคน) — the ordinary Thai car plate: black Thai characters on a
+      retroreflective white ground. period.start 2011 is the ministerial
+      regulation's own year and carries `instrument-in-force`, NOT a claim that
+      the two-letter composition began then: the 2554 regulation revokes and
+      replaces the B.E. 2547 (2004) regulation and its 2550 (2007) amendment, so
+      the composition is demonstrably older. What IS new in 2011 is the size
+      (the 2547 sizes are in the revoked instrument, not secured here) and the
+      leading-numeral exhaustion rule the หมายเหตุ explains. Thai press dates
+      the modern arrangement to 1997 and Bangkok's first leading-numeral series
+      to 2012; neither was pinned to an instrument and neither is asserted.
+
+  - id: th-private-car-over7-2011
+    class: standard
+    categories: [van, bus]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only — see th-private-car-2011 and the header, fact 2"
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#002F87"
+      foreground_note: "สีน้ำเงิน — the regulation names the colour 'navy/dark blue' and does not number it"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder, note: "ขส roundel, lower right" }
+      embossed: true
+      rear_differs: false
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ค) ๒) 'รถยนต์นั่งส่วนบุคคลเกินเจ็ดคนใช้สีน้ำเงิน' on retroreflective white; size and layout per ข้อ ๓ (๑) (ก)"
+    notes: >-
+      PRIVATE PASSENGER VEHICLE of MORE than seven persons (รถยนต์นั่งส่วนบุคคล
+      เกินเจ็ดคน) — vans and minibuses in private ownership. Identical format and
+      size to the ordinary car plate; only the character colour differs, which
+      under PRD-PLATES §2.3 would make it a sub-entry — except that the
+      regulation treats it as a distinct legal vehicle class with its own
+      colour rule, and the auction regulation of B.E. 2546 draws its own line at
+      "more than seven but not more than twelve", so it is carried as a series.
+
+  - id: th-private-pickup-2011
+    class: standard
+    categories: [truck]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only"
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#009A44"
+      foreground_note: "สีเขียว — named, not numbered"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ค) ๓) 'รถยนต์บรรทุกส่วนบุคคลใช้สีเขียว' on retroreflective white"
+    notes: >-
+      PRIVATE GOODS VEHICLE (รถยนต์บรรทุกส่วนบุคคล) — the pickup truck, the most
+      numerous body style in Thailand, on green characters over retroreflective
+      white. Distinguishing this from the black-charactered car plate is the
+      single most useful colour fact in Thai plate reading, and it is primary.
+
+  - id: th-private-threewheeler-2011
+    class: standard
+    categories: [tricycle]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only"
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#D0021B"
+      foreground_note: "สีแดง — named, not numbered"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ค) ๔) 'รถยนต์สามล้อส่วนบุคคลใช้สีแดง' on retroreflective white"
+    notes: >-
+      PRIVATE THREE-WHEELED CAR (รถยนต์สามล้อส่วนบุคคล) — red characters on
+      retroreflective white. Not to be confused with the FOR-HIRE three-wheeler
+      (th-tuktuk-2011), which is green on YELLOW. `categories: [tricycle]` uses
+      the kinds vocabulary already present in the dataset.
+
+  - id: th-taxi-2011
+    class: taxi
+    categories: [car]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only"
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#FFD400", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ก) retroreflective yellow ground for the four hire classes; ๒) 'รถยนต์รับจ้างบรรทุกคนโดยสารไม่เกินเจ็ดคนใช้สีดำ'"
+    notes: >-
+      METERED TAXI (รถยนต์รับจ้างบรรทุกคนโดยสารไม่เกินเจ็ดคน — a car for hire
+      carrying not more than seven passengers): black characters on a
+      retroreflective YELLOW ground. Yellow is the statutory ground for all four
+      hire classes of ข้อ ๓ (๒) (ก); the CHARACTER colour is what separates them,
+      and that is the whole design logic of the Thai hire fleet.
+
+  - id: th-interprovincial-taxi-2011
+    class: taxi
+    categories: [car]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only"
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#FFD400", finish: retroreflective, hex_basis: observed }
+      foreground: "#D0021B"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ก) ๑) 'รถยนต์รับจ้างระหว่างจังหวัดใช้สีแดง' on retroreflective yellow"
+    notes: >-
+      INTER-PROVINCIAL HIRE CAR (รถยนต์รับจ้างระหว่างจังหวัด) — red characters on
+      retroreflective yellow. First-named of the four yellow-ground hire classes.
+
+  - id: th-tuktuk-2011
+    class: taxi
+    categories: [tricycle]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only"
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#FFD400", finish: retroreflective, hex_basis: observed }
+      foreground: "#009A44"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ก) ๓) 'รถยนต์รับจ้างสามล้อใช้สีเขียว' on retroreflective yellow"
+    notes: >-
+      THREE-WHEELED HIRE CAR (รถยนต์รับจ้างสามล้อ) — the tuk-tuk: green
+      characters on retroreflective yellow.
+
+  - id: th-smallfourwheel-hire-2011
+    class: taxi
+    categories: [car]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only"
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#FFD400", finish: retroreflective, hex_basis: observed }
+      foreground: "#002F87"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ก) ๔) 'รถยนต์สี่ล้อเล็กรับจ้างใช้สีน้ำเงิน' on retroreflective yellow"
+    notes: >-
+      SMALL FOUR-WHEELED HIRE CAR (รถยนต์สี่ล้อเล็กรับจ้าง) — the small shared
+      pickup/songthaew class: navy characters on retroreflective yellow. Fourth
+      and last of the yellow-ground hire classes of ข้อ ๓ (๒) (ก).
+
+  - id: th-service-green-2011
+    class: taxi
+    categories: [car, van, bus]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only"
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#009A44", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ข) 'รถยนต์บริการธุรกิจ รถยนต์บริการทัศนาจร และรถยนต์บริการให้เช่า ให้พื้นแผ่นป้ายใช้สีเขียวสะท้อนแสง ... และขอบแผ่นป้ายใช้สีขาว'"
+    notes: >-
+      SERVICE VEHICLES — the three classes of ข้อ ๓ (๒) (ข): รถยนต์บริการธุรกิจ
+      (business service), รถยนต์บริการทัศนาจร (tour service) and
+      รถยนต์บริการให้เช่า (rental service). White characters and white border on
+      a retroreflective GREEN ground. The green plate is the one a visitor sees
+      on hotel shuttles and rental cars. `class: taxi` is used because the
+      controlled vocabulary's taxi entry covers "for-hire vehicles where
+      separately serialized or colored" and these are hire-and-reward classes;
+      they are NOT metered taxis and the note says so.
+
+  - id: th-trailer-orange-2011
+    class: trailer
+    categories: [trailer]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only"
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#F58220", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+      display: "ข้อ ๕: a trailer carries ONE plate, at the rear"
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ง) retroreflective orange ground with black characters and border for รถพ่วง รถบดถนน รถแทรกเตอร์ และรถใช้งานเกษตรกรรม; ข้อ ๕ rear-only display for รถพ่วง"
+    notes: >-
+      TRAILER (รถพ่วง) on the orange ground of ข้อ ๓ (๒) (ง). The regulation puts
+      trailers, road rollers, tractors and agricultural vehicles in ONE colour
+      rule; they are split here into two series because the CLASS differs and a
+      consumer asking for Thailand's trailer class must not get an agricultural
+      answer. Format, size, colour and period are identical — this split is a
+      classification decision and is flagged for the verifier.
+
+  - id: th-agricultural-orange-2011
+    class: agricultural
+    categories: [tractor, machine]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only"
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#F58220", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ง), and ข้อ ๓ (๑) (ก) which lists รถบดถนน รถแทรกเตอร์ และรถใช้งานเกษตรกรรม among the 15 x 34 cm classes"
+    notes: >-
+      ROAD ROLLER (รถบดถนน), TRACTOR (รถแทรกเตอร์) and AGRICULTURAL WORK VEHICLE
+      (รถใช้งานเกษตรกรรม) — black characters on retroreflective orange. Note that
+      the ANNUAL TAX MARK rule of ข้อ ๖ excepts this class along with
+      motorcycles and trailers: the sticker need not go on the windscreen.
+
+  - id: th-motorcycle-private-2011
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: >-
+        The motorcycle plate is THREE lines, not two: line 1 = numeral 1-9 +
+        category letter 1 + category letter 2; line 2 = the province name;
+        line 3 = the registration number of not more than four digits. The
+        pattern is line 3.
+      regex_native: '\A[1-9][ก-ฮ]{2}\s?\d{1,4}\z'
+      fields:
+        - { name: leading_numeral, line: 1, script: "Arabic numerals", values: "1-9", presence: "part of the base composition for motorcycles — ข้อ ๓ (๑) (ข) ๒) states it without an exhaustion condition, unlike the car rule" }
+        - { name: category_letter_1, line: 1, script: Thai, values: delegated }
+        - { name: category_letter_2, line: 1, script: Thai, values: delegated }
+        - { name: province, line: 2, script: Thai, values: "Bangkok or the province of registration; เบตง for Betong District, Yala" }
+        - { name: registration_number, line: 3, script: "Arabic numerals", values: "not more than four digits" }
+    design:
+      plate: { w: 220, h: 172, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem:
+        present: true
+        rendered: placeholder
+        note: "ขส roundel embossed at the UPPER RIGHT on motorcycle plates (ข้อ ๓ (๑) (ข) ๑)) — the opposite corner from the car plate"
+      characters:
+        line1_and_line3_min_h_mm: 40
+        line1_and_line3_min_w_mm: 30
+        line2_min_h_mm: 20
+        line2_min_w_mm: 13
+      embossed: true
+      display: "ข้อ ๕: motorcycles carry ONE plate, at the rear"
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๑) (ข) ๑)-๔) 17.20 x 22 cm, ขส roundel upper right, three-line layout, character minima; ข้อ ๓ (๒) (จ) 'รถจักรยานยนต์ส่วนบุคคล ให้พื้นแผ่นป้ายใช้สีขาวสะท้อนแสง ... และขอบแผ่นป้ายใช้สีดำ'; ข้อ ๕ rear only"
+    notes: >-
+      PRIVATE MOTORCYCLE (รถจักรยานยนต์ส่วนบุคคล) — black on retroreflective
+      white, one plate at the rear. TRANSITIONAL TRAP the verifier should read:
+      ข้อ ๑๐ says that where a plate issued BEFORE this regulation is lost or
+      damaged, the replacement is issued under this regulation "เว้นแต่กรณี
+      แผ่นป้ายทะเบียนรถจักรยานยนต์" — EXCEPT for motorcycle plates, whose
+      replacements are still made under the revoked B.E. 2547 regulation and its
+      amendments. Thailand therefore still issues an older motorcycle plate
+      design today, by law, and its specification is in an instrument this pass
+      did not secure. That is a recorded gap and a real "one series back".
+
+  - id: th-motorcycle-public-2011
+    class: taxi
+    categories: [motorcycle]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "registration-number block only; three-line motorcycle layout as th-motorcycle-private-2011"
+      regex_native: '\A[1-9][ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 220, h: 172, unit: mm }
+      background: { color: "#FFD400", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder, note: "ขส roundel upper right" }
+      embossed: true
+      display: "rear only"
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ฉ) 'รถจักรยานยนต์สาธารณะ ให้พื้นแผ่นป้ายใช้สีเหลืองสะท้อนแสง ... และขอบแผ่นป้ายใช้สีดำ'; size and layout per ข้อ ๓ (๑) (ข)"
+    notes: >-
+      PUBLIC MOTORCYCLE (รถจักรยานยนต์สาธารณะ) — the motorcycle taxi: black on
+      retroreflective YELLOW. Classed `taxi` rather than `motorcycle` because
+      the distinguishing legal fact is that it is for hire; the category array
+      keeps the vehicle kind.
+
+  - id: th-diplomatic-2011
+    class: diplomatic
+    categories: [car, motorcycle]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: >-
+        Three sections. LEFT, two lines: line 1 the Thai letter ท; line 2 the
+        Arabic country/organisation code. MIDDLE: a longitudinal dash 1.1 cm x
+        4 cm with the ขส roundel above it. RIGHT: the registration number in
+        Arabic numerals, 7.2 cm high, running 1 to 9999. The pattern is the
+        registration number.
+      regex_native: '\Aท\s?\d{1,3}\s?-\s?\d{1,4}\z'
+      regex_native_note: "country-code digit count is not fixed by the regulation; 1-3 is an observation-shaped bound, not a sourced one"
+      fields:
+        - { name: corps_letter, section: left, line: 1, script: Thai, values: ["ท"], rule: "ข้อ ๓ (๑) (ค) ๓) ก): 'รถยนต์ของบุคคลในคณะผู้แทนทางการทูต ให้ใช้อักษร ท'" }
+        - { name: country_code, section: left, line: 2, script: "Arabic numerals", values: "a code standing for the country or the international organisation or UN specialised agency stationed in Thailand — the code list is not in the regulation" }
+        - { name: separator_bar, section: middle, note: "ขีดตามทางยาว, 1.1 cm wide x 4 cm long, embossed; a printed SEPARATOR, spelled '-' under PRD-PLATES §2.6" }
+        - { name: registration_number, section: right, script: "Arabic numerals", values: "1 to 9999 (หมายเลขทะเบียนให้เริ่มตั้งแต่ ๑ ถึง ๙๙๙๙)" }
+    design:
+      plate: { w: 387, h: 110, unit: mm }
+      plate_variants:
+        - { w: 270, h: 90, unit: mm, note: "motorcycles of the same persons — ข้อ ๓ (๑) (ง) ๑)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder, note: "ขส roundel above the middle bar" }
+      characters:
+        left_section_h_mm: 40
+        right_number_h_mm: 72
+        motorcycle_left_h_mm: 35
+        motorcycle_number_h_mm: 50
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๑) (ค) ๑)-๓) 11 x 38.7 cm, three sections, the bar, numbers 1-9999, and the four corps letters; ข้อ ๓ (๑) (ง) the 9 x 27 cm motorcycle variant; ข้อ ๓ (๒) (ช) 'รถยนต์และรถจักรยานยนต์ส่วนบุคคลของบุคคลในคณะผู้แทนทางการทูต ให้พื้นแผ่นป้ายใช้สีขาวสะท้อนแสง โดยให้ตัวอักษร ตัวเลข และขีดใช้สีดำ'"
+    notes: >-
+      DIPLOMATIC CORPS (คณะผู้แทนทางการทูต) — letter ท, black on retroreflective
+      WHITE. Thailand splits the privileged fleet by GROUND COLOUR, not by
+      letter: ท alone gets white (ข้อ ๓ (๒) (ช)); the other three letters get
+      light blue (see th-consular-2011). The corps letter is a Thai consonant,
+      so this series is Thai-script and recall-only like the rest of Block A,
+      even though its number block is otherwise clean.
+
+  - id: th-consular-2011
+    class: consular
+    categories: [car, motorcycle]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: "as th-diplomatic-2011, with the corps letter พ, ก or อ"
+      regex_native: '\A[พกอ]\s?\d{1,3}\s?-\s?\d{1,4}\z'
+      fields:
+        - name: corps_letter
+          section: left
+          line: 1
+          script: Thai
+          values: ["พ", "ก", "อ"]
+          rule: >-
+            ข้อ ๓ (๑) (ค) ๓): ข) 'รถยนต์ของบุคคลในหน่วยงานพิเศษของสถานทูต ให้ใช้
+            อักษร พ' (special agency of an embassy); ค) 'รถยนต์ของบุคคลในคณะ
+            ผู้แทนทางกงสุล ให้ใช้อักษร ก' (consular corps); ง) 'รถยนต์ของบุคคลใน
+            องค์การระหว่างประเทศหรือทบวงการชำนัญพิเศษแห่งสหประชาชาติ ... ให้ใช้
+            อักษร อ' (international organisation / UN specialised agency).
+        - { name: country_code, section: left, line: 2, script: "Arabic numerals" }
+        - { name: registration_number, section: right, script: "Arabic numerals", values: "1 to 9999" }
+    design:
+      plate: { w: 387, h: 110, unit: mm }
+      plate_variants:
+        - { w: 270, h: 90, unit: mm, note: "motorcycles" }
+      background: { color: "#4FA8DC", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+    variants:
+      - class: consular
+        design:
+          background: { color: "#9E9E9E", finish: retroreflective, hex_basis: observed }
+          foreground: "#000000"
+        note: >-
+          HONORARY CONSUL (เจ้าพนักงานกงสุลกิตติมศักดิ์) — ข้อ ๓ (๒) (ซ) carves
+          this one case out of the light-blue rule: "เว้นแต่แผ่นป้ายทะเบียนรถ
+          สำหรับรถยนต์ของเจ้าพนักงานกงสุลกิตติมศักดิ์ ให้พื้นแผ่นป้ายใช้สีเทา
+          สะท้อนแสง โดยให้ตัวอักษร ตัวเลข และขีดใช้สีดำ" — a retroreflective GREY
+          ground with black characters, digits and bar. Colour-only variant of
+          the same format and period, so a sub-entry per PRD-PLATES §2.3.
+        sources:
+          - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๒) (ซ) proviso"
+    sources:
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ (๑) (ค) ๓) ข)-ง) the letters พ ก อ; ข้อ ๓ (๒) (ซ) 'ให้พื้นแผ่นป้ายใช้สีฟ้าสะท้อนแสง โดยให้ตัวอักษร ตัวเลข และขีดใช้สีขาว' with the honorary-consul grey proviso"
+    notes: >-
+      EMBASSY SPECIAL AGENCIES (พ), CONSULAR CORPS (ก) and INTERNATIONAL
+      ORGANISATIONS / UN SPECIALISED AGENCIES (อ) — white characters on a
+      retroreflective LIGHT BLUE ground, with a grey sub-variant for honorary
+      consuls. Three corps letters share one design and one series because the
+      regulation gives them one colour rule; the letter is carried in `fields`
+      so a parse API can still separate them. `class: consular` is the closest
+      vocabulary fit for a series that also covers embassy special agencies and
+      international organisations; the note records the imprecision rather than
+      inventing a class.
+
+  - id: th-auction-graphic-2003
+    class: personalized
+    categories: [car, truck, van]
+    period: { start: 2003 }
+    period_evidence: enabling-statute
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: >-
+        An auctioned plate carries an ORDINARY registration: the same two
+        category letters, the same up-to-four-digit number and the same province
+        line. What is bought is WHICH number, and what changes is the plate's
+        ground, which may carry a picture. The pattern is the number block.
+      regex_native: '\A[1-9]?[ก-ฮ]{2}\s?\d{1,4}\z'
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background:
+        color: "#FFFFFF"
+        finish: retroreflective
+        hex_basis: observed
+        note: >-
+          The colours are NOT fixed for this class. ข้อ ๓ closing paragraph: "ใน
+          กรณีแผ่นป้ายทะเบียนรถที่มีกฎกระทรวงกำหนดหมายเลขทะเบียนซึ่งเป็นที่
+          ต้องการหรือเป็นที่นิยม อธิบดีอาจประกาศกำหนดให้ใช้สีพื้นแผ่นป้าย ...
+          เป็นประการอื่นก็ได้" — for plates whose numbers a ministerial
+          regulation has declared desirable or popular, the Director-General MAY
+          announce a different ground colour, numeral colour, letter colour,
+          province-letter colour and border. The hex here is the ordinary
+          private-car ground and is a placeholder, not a claim.
+      graphic:
+        permitted: true
+        rule: >-
+          ข้อ ๔, verbatim: "พื้นแผ่นป้ายทะเบียนรถประเภทใดจะมีรูปภาพที่สามารถอธิบาย
+          หรือมองเห็นความหมายในภาพที่ปรากฏเสมือนจริงนั้นได้ ให้เป็นไปตามที่อธิบดี
+          ประกาศกำหนด" — whether a plate class's ground may bear a realistic
+          PICTURE is for the Director-General to announce. This is the primary
+          hook for Thailand's famous pictorial auction plates.
+      foreground: "#000000"
+      emblem: { present: true, rendered: placeholder }
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20141019064112/http://www.ratchakitcha.soc.go.th/DATA/PDF/00126585.PDF  # กฎกระทรวง กำหนดหมายเลขทะเบียนซึ่งเป็นที่ต้องการหรือเป็นที่นิยม เพื่อนำออกเปิดประมูลเป็นการทั่วไป พ.ศ. ๒๕๔๖ — ข้อ ๑ the ten closed classes of auctionable number and the three vehicle classes they apply to; ข้อ ๒ auctions follow the DLT's published order of category letters; ข้อ ๓ unsold numbers are issued normally; ข้อ ๔ the first auction starts at the letter pair after the one then in issue"
+      - "https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF  # ข้อ ๓ closing paragraph (the Director-General may vary every colour on an auctioned plate) and ข้อ ๔ (pictorial grounds)"
+    notes: >-
+      AUCTIONED "DESIRABLE OR POPULAR" NUMBERS (หมายเลขทะเบียนซึ่งเป็นที่ต้องการ
+      หรือเป็นที่นิยม) — the Thai fancy-plate regime, and it is statutory, not a
+      programme. period.start 2003 carries `enabling-statute`: s. 10/1 of the
+      Motor Vehicle Act B.E. 2522, inserted by the Motor Vehicle Act (No. 12)
+      B.E. 2546, obliges the Director-General to put such numbers to general
+      auction, and the B.E. 2546 ministerial regulation given 7 August 2003
+      defines them. The ten classes are closed and primary (single digits; two,
+      three and four repeated digits; round thousands; three- and four-digit
+      ascending runs; and the mirrored, bracketed and alternating pair families)
+      — but the Gazette PDF's text layer is legacy-encoded, so they are
+      described here and not quoted. This is Thailand's `personalized` class in
+      the controlled vocabulary: the serial stays inside the official frame and
+      only its SELECTION is the owner's.
+
+  - id: th-trade-red
+    class: dealer
+    categories: [car, truck, van, motorcycle]
+    period: { start: 1979 }
+    period_evidence: enabling-statute
+    matching: recall-only
+    format:
+      pattern: "9999"
+      regex: '\A\d{1,4}\z'
+      pattern_note: >-
+        The registration-number block. The mark ("เครื่องหมายพิเศษ") is reported
+        to carry one or two Thai consonants and four digits on a red ground —
+        that grammar is CORROBORATION ONLY (see notes); the number block is the
+        only element modelled.
+      regex_native: '\A[ก-ฮ]{1,2}\s?\d{1,4}\z'
+      regex_native_note: "shape reported by secondary sources; no instrument secured"
+    design:
+      background: { color: "#D0021B", finish: painted, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      design_basis: corroboration-only
+    region_encoding: none
+    validity:
+      note: >-
+        มาตรา ๒๗ of the Motor Vehicle Act, verbatim: "ผู้ใดมีรถยนต์ไว้เพื่อขาย
+        หรือเพื่อซ่อม ถ้าจะขับเองหรือให้ผู้อื่นขับเพื่อการนั้น ต้องได้รับใบอนุญาต
+        จากนายทะเบียน และให้ขับได้ระหว่างพระอาทิตย์ขึ้นถึงพระอาทิตย์ตก เว้นแต่มี
+        ความจำเป็นและได้รับอนุญาตจากนายทะเบียน" — a person holding a car for sale
+        or repair needs a registrar's licence to drive it or have it driven, and
+        it may be driven only BETWEEN SUNRISE AND SUNSET unless the registrar
+        permits otherwise. The famous Thai "red plate" night-driving rule is in
+        the Act itself.
+    sources:
+      - "https://web.archive.org/web/20110203044221/http://web.krisdika.go.th/data/law/law2/%C301/%C301-20-9999-update.pdf  # มาตรา ๒๗ — the dealer/repairer licence, the sunrise-to-sunset limit, and 'ในการออกใบอนุญาต ให้นายทะเบียนออกเครื่องหมายพิเศษและสมุดคู่มือประจำรถให้ด้วย' with 'เครื่องหมายพิเศษ ... ให้เป็นไปตามแบบที่กำหนดในกฎกระทรวง'; the fee schedule prices เครื่องหมายพิเศษตามมาตรา ๒๗ at 100 baht each"
+      - "https://www.bangkokpost.com/opinion/opinion/1336019/red-licence-plates-drive-us-to-distraction  # Bangkok Post editorial, 4 October 2017 — the red ground, the province-of-purchase restriction, the expressway ban and the permission-to-travel paperwork. SECONDARY, used only for the colour and the practical restrictions"
+    notes: >-
+      TRADE / DEALER MARK (เครื่องหมายพิเศษ, universally "ป้ายแดง", the red
+      plate). period.start 1979 is `enabling-statute`: the mark is created by
+      มาตรา ๒๗ of the Motor Vehicle Act B.E. 2522, given 8 May B.E. 2522. THE
+      FORM IS NOT: มาตรา ๒๗ leaves it to a ministerial regulation
+      ("ให้เป็นไปตามแบบที่กำหนดในกฎกระทรวง"), and that regulation was NOT secured
+      in this pass. The red ground and the reported "one or two Thai consonants
+      plus four digits" grammar are therefore corroboration-only and are marked
+      as such on the design block and the pattern note. A verifier should either
+      pin the ministerial regulation or cut this series' design claims.
+      Live-issue caveat: DLT announced in 2015 an intention to abolish red
+      plates in B.E. 2560 (2017); Thai press since reports them still in use.
+      No instrument either way was secured, so the series is left OPEN.
+
+  - id: th-test-tcqc-2017
+    class: temporary
+    categories: [car, motorcycle]
+    period: { start: 2017 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL-9999"
+      regex: '\A[A-Z]{2}-\d{1,4}\z'
+      regex_strict: '\A(?:TC|QC)-\d{1,4}\z'
+      charset:
+        prefixes: ["TC", "QC"]
+        prefix_basis: corroboration-only
+        note: >-
+          The 2560 announcement prescribes the mark by an ANNEXED FORM
+          ("เครื่องหมายแสดงการใช้รถ ... ให้เป็นไปตามแบบแนบท้ายประกาศนี้", ข้อ ๗)
+          and the annex is an image: the letters are not in the Gazette PDF's
+          text layer. TC (รถทดสอบก่อนผลิต, pre-production test) and QC
+          (รถทดสอบคุณภาพ, quality test) are reported by the DLT Chanthaburi
+          provincial office and by encyclopaedic sources; the DLT page did not
+          respond on 2026-08-02. Treat the LETTERS as unverified and the
+          INSTRUMENT, the dates and the two vehicle definitions as primary.
+    design:
+      plate: { w: 340, h: 150, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder }
+      design_basis: corroboration-only
+      display: "ข้อ ๙ (๑) (ข): one at the front and one at the rear, 'เว้นแต่รถจักรยานยนต์ให้ติดที่ด้านท้ายรถเพียงด้านเดียว'"
+    validity:
+      pre_production_days: 180
+      quality_test_days: 90
+      note: "ข้อ ๘: the permit runs 180 days for a pre-production test vehicle and 90 days for a quality-test vehicle, from the day of permission"
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/2020id_/https://www.ratchakitcha.soc.go.th/DATA/PDF/2560/E/092/6.PDF  # ประกาศกรมการขนส่งทางบก ... รถที่ใช้เพื่อการทดสอบ พ.ศ. ๒๕๖๐ — ข้อ ๑ in force 1 April 2017; ข้อ ๒ the definitions of รถทดสอบก่อนผลิต and รถทดสอบคุณภาพ; ข้อ ๗ the annexed form and the rule that quality-test marks are interchangeable between vehicles; ข้อ ๘ permit lives; ข้อ ๙ display and conditions; made under มาตรา ๖/๑ วรรคสาม"
+    notes: >-
+      TEST-VEHICLE MARK (เครื่องหมายแสดงการใช้รถที่ใช้เพื่อการทดสอบ), in force
+      1 April 2017. The instrument is fully primary and unusually informative —
+      it even provides that a QUALITY-TEST mark "ให้ใช้สับเปลี่ยนกันได้ไม่เฉพาะ
+      คันรถ" (may be swapped between vehicles, unlike the pre-production mark,
+      which is issued per vehicle). Only the two-letter prefixes are unverified.
+      DATE DISAGREEMENT, recorded not averaged: the instrument says 1 April 2017;
+      encyclopaedic sources say 3 April 2017. The instrument governs.
+      `class: temporary` is used because the controlled vocabulary's temporary
+      entry expressly covers transit and short-validity plates and this mark has
+      a statutory 90/180-day life; it is NOT a dealer plate (that is
+      th-trade-red, under a different section of the Act).
+
+  - id: th-international-english
+    class: temporary
+    categories: [car, truck, van, bus]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: recall-only
+    format:
+      pattern: "LL-999"
+      regex: '\A[A-Z0-9]{2,3}\s?-\s?\d{1,4}\z'
+      pattern_note: >-
+        The DLT press release gives exactly two specimens and no grammar:
+        "HA - 753 THAILAND" and "3K-201 THAILAND". The regex is the union of
+        those two shapes generalised — two or three Latin/Arabic characters,
+        a dash, and up to four digits — and it is deliberately wider than
+        anything sourced, hence `matching: recall-only`.
+      fields:
+        - { name: transliterated_prefix, script: Latin, values: "a Latin transliteration of the Thai category letters; the code table is in ระเบียบกรมการขนส่งทางบกว่าด้วยการออกเอกสารและเครื่องหมายกำกับรถเพื่อนำรถไปใช้ระหว่างประเทศ พ.ศ. ๒๕๕๔, which was NOT secured — recorded gap" }
+        - { name: number, script: "Arabic numerals" }
+        - { name: country_word, script: Latin, values: ["THAILAND"], note: "printed below the mark" }
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      design_basis: corroboration-only
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/20141016101731/http://www.dlt.go.th/th/attachments/plan48-51/2532_75-03-54.pdf  # DLT press release no. 75 of 18 March 2011, over the name of the Director-General นายเฉลิมไท ญาณภิรัต: the English-language plate is issued for vehicles permitted to be used temporarily in Laos, Myanmar, Cambodia, Vietnam and southern China (Yunnan and Guangxi); the specimens 'HA - 753 THAILAND' and '3K-201 THAILAND'; the duty to refit the Thai plate on return; the fine of not more than 2,000 baht for using it in Thailand; and the making of ระเบียบกรมการขนส่งทางบกว่าด้วยการออกเอกสารและเครื่องหมายกำกับรถเพื่อนำรถไปใช้ระหว่างประเทศ พ.ศ. ๒๕๕๔"
+    notes: >-
+      INTERNATIONAL-USE PLATE (แผ่นป้ายทะเบียนรถที่เป็นภาษาอังกฤษ) — the only
+      routinely-issued Thai plate written in the Latin alphabet, and the only
+      one that is ILLEGAL AT HOME: the DLT release states that keeping it fitted
+      inside Thailand is an offence carrying a fine of up to 2,000 baht under
+      the Motor Vehicle Act. period.start 2011 carries `instrument-in-force`
+      because the 2011 DLT regulation named in the release IMPROVES an existing
+      practice rather than creating it ("เพื่อเป็นการปรับปรุงระเบียบ..."), and
+      the regulation itself was not retrieved. DISAGREEMENT RECORDED, NOT
+      AVERAGED: an encyclopaedic secondary dates availability to 2008. The
+      transliteration table that maps Thai consonants to Latin codes is the key
+      missing artefact for a parse API and is the top follow-up for this
+      jurisdiction.
+
+  # =========================================================================
+  # BLOCK B — LAND TRANSPORT ACT B.E. 2522 PLATES (ประกาศกรมการขนส่งทางบก
+  # พ.ศ. ๒๕๕๔). These are the ALL-NUMERIC commercial plates, and they are the
+  # only Thai series whose serial fits the dataset's serial alphabet without
+  # loss. Both carry sourced `regex_strict` twins built from the six
+  # vehicle-type code bands of ข้อ ๒ (๓).
+  # =========================================================================
+
+  - id: th-lta-public-yellow-2011
+    class: standard
+    categories: [bus, truck]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "99-9999"
+      regex: '\A\d{2}-\d{4}\z'
+      regex_strict: '\A(?:1\d|2\d|3\d|6\d|7\d)-(?!0000)\d{4}\z'
+      charset:
+        type_code_bands:
+          - { code_range: "10-19", thai: "รถโดยสารประจำทาง", en: "scheduled passenger transport" }
+          - { code_range: "20-29", thai: "รถขนาดเล็ก", en: "small-vehicle transport" }
+          - { code_range: "30-39", thai: "รถโดยสารไม่ประจำทาง", en: "non-scheduled passenger transport" }
+          - { code_range: "60-69", thai: "รถบรรทุกไม่ประจำทาง", en: "non-scheduled goods transport" }
+          - { code_range: "70-79", thai: "รถบรรทุกไม่ประจำทาง", en: "non-scheduled goods transport (the band added by this instrument because 60-69 was nearly exhausted)" }
+        serial_rule: >-
+          ข้อ ๒ (๓), verbatim: "หมายเลขทะเบียนรถใช้เลข ๔ หลัก ตั้งแต่ลำดับหมายเลข
+          ๐๐๐๑ ถึงหมายเลข ๙๙๙๙ แล้วเริ่มต้นโดยใช้เลขรหัสแสดงประเภทรถเดิมลำดับ
+          ถัดไป" — the registration number uses FOUR digits, 0001 to 9999, and
+          then restarts on the next code in the same vehicle-type band. This is
+          why `regex_strict` forbids 0000 and why leading zeros are REQUIRED
+          rather than forbidden — the opposite of most jurisdictions.
+      fields:
+        - { name: country_word, line: 1, script: Latin, values: ["THAILAND"], min_h_mm: 24 }
+        - { name: province_code, line: 1, script: "Arabic numerals", min_h_mm: 24, note: "เลขรหัสจังหวัด — a NUMERIC province code, unlike the Motor-Vehicle-Act plate which spells the province out. The code list is not in the instrument" }
+        - { name: vehicle_type_code, line: 2, script: "Arabic numerals", values: "two digits from the bands above", min_h_mm: 100, min_w_mm: 50 }
+        - { name: separator_bar, line: 2, note: "ขีดตามทางยาวคั่นกลาง between the type code and the serial, at least 1.5 cm wide x 2.5 cm long — a printed separator, spelled '-'" }
+        - { name: registration_number, line: 2, script: "Arabic numerals", values: "0001-9999", min_h_mm: 100, min_w_mm: 50 }
+        - { name: province_name, line: 3, script: Thai, min_h_mm: 25 }
+    design:
+      plate: { w: 440, h: 220, unit: mm }
+      background: { color: "#FFD400", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder, note: "ขส roundel at the LOWER LEFT corner — the opposite corner from the Motor-Vehicle-Act car plate" }
+      embossed: true
+      display: "ข้อ ๓ (๑): one at the front and one at the rear"
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20160304073451/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/E/044/52.PDF  # ข้อ ๒ (๑) 22 x 44 cm, retroreflective YELLOW ground, three lines (THAILAND + province code / type code - number / province name in Thai), ขส roundel lower left, all embossed in black, and the five character-metric minima (ก)-(จ); ข้อ ๒ (๓) the four-digit 0001-9999 rule and the six type-code bands; ข้อ ๓ (๑) display"
+    notes: >-
+      PUBLIC-TRANSPORT PLATE under the Land Transport Act — retroreflective
+      YELLOW. This is the plate on every intercity bus and hired truck in
+      Thailand, and it is the best-evidenced Thai series in this file: the
+      layout, the size, the colour, the character metrics, the separator, the
+      serial range and the type-code bands are all in one primary instrument.
+      period.start 2011 carries `instrument-in-force`, not `enabling-instrument`:
+      ข้อ ๑ revokes a 13 September B.E. 2549 (2006) announcement and ข้อ ๔ saves
+      plates made under an announcement of 14 April B.E. 2530 (1987), so the
+      format is at least 24 years older than this instrument. Those two earlier
+      announcements are the true "one series back" and neither was secured — a
+      recorded gap and the cleanest available follow-up target for Thailand.
+
+  - id: th-lta-private-white-2011
+    class: standard
+    categories: [bus, truck]
+    period: { start: 2011 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "99-9999"
+      regex: '\A\d{2}-\d{4}\z'
+      regex_strict: '\A(?:4\d|5\d|8\d|9\d)-(?!0000)\d{4}\z'
+      charset:
+        type_code_bands:
+          - { code_range: "40-49", thai: "รถโดยสารส่วนบุคคล", en: "private passenger transport" }
+          - { code_range: "50-59", thai: "รถบรรทุกส่วนบุคคล", en: "private goods transport" }
+          - { code_range: "80-99", thai: "รถบรรทุกส่วนบุคคล", en: "private goods transport (second band)" }
+        serial_rule: "as th-lta-public-yellow-2011: four digits, 0001 to 9999, then the next code in the band"
+    design:
+      plate: { w: 440, h: 220, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: none }
+      emblem: { present: true, rendered: placeholder, note: "ขส roundel lower left" }
+      embossed: true
+    region_encoding: "plates/_decode/th-registration-elements.yml"
+    sources:
+      - "https://web.archive.org/web/20160304073451/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/E/044/52.PDF  # ข้อ ๒ (๒), verbatim: 'แผ่นป้ายเลขทะเบียนรถที่ใช้ในการขนส่งส่วนบุคคล มีลักษณะและขนาดเป็นไปตาม (๑) แต่มีพื้นเป็นวัสดุสะท้อนแสงสีขาว'; ข้อ ๒ (๓) (ง) (ฉ) the private bands 40-49, 50-59 and 80-99"
+    notes: >-
+      PRIVATE-TRANSPORT PLATE under the Land Transport Act — identical in every
+      dimension and metric to the yellow public plate, on a retroreflective
+      WHITE ground. The instrument says so in one sentence, which is why the
+      design block here is short and the sources line quotes it. The
+      colour/type-code correspondence is exact and is the useful decode fact:
+      a Thai commercial plate whose type code begins 4, 5, 8 or 9 is white and
+      privately operated; 1, 2, 3, 6 or 7 is yellow and for hire.


### PR DESCRIPTION
**PRD-PLATES gate L3 (S5W; manifest branch s4w-plates/l3-manifest).** Researcher-drafted to the L1/L2 standard: primary instruments quoted verbatim (native-language gazettes read in the original), instrument-dated periods with honest period_evidence, folklore flagged not asserted, non-Latin scripts modelled as decode/field facts with the ASCII projection stated. Independent staged lint over origin/main with ALL 28 wave files: `plates lint: 123 files, 1360 series ... OK`.

**th**: 21 series, 8 pinned sources, lint green.

---

# Research dossier — THAILAND (`th`), PRD-PLATES gate L3

**Researcher:** Opus L3 wave agent (assignment: `th`, `my`).
**Date of research:** 2026-08-02 / 2026-08-03.
**Deliverables:** `th.yml` (21 series), `th-registration-elements.yml`
(→ `plates/_decode/th-registration-elements.yml`).
**Lint:** GREEN in a clean-room copy of `plates/` (excluding `_art`) +
`scripts/lint_plates.rb` — `93 files, 974 series … plates lint: OK`
(baseline before adding `th` + `my`: `91 files, 945 series`).
**Status:** DRAFT for the human verification pass (PRD-PLATES §5.3). Not applied
to any canonical repo.

**Provenance note, stated because it matters for review.** `th.yml` and
`th-registration-elements.yml` were drafted earlier in this same assignment
slot (files timestamped 2026-08-02 18:08–18:10) and were left without a dossier.
This pass **re-derived the primary sources independently** — the same two Royal
Gazette PDFs were fetched again from the Internet Archive, re-extracted with
`pdftotext -enc UTF-8 -layout`, and the operative clauses re-read from the Thai
— **confirmed the file's substantive claims**, applied **one correction**
(§9 below), and wrote this dossier. The file was otherwise preserved rather than
rewritten; its id contract (PRD-QUALITY I-5/I-6) is intact.

---

## 1. The two instruments, both obtained in full and both quoted verbatim

| key | instrument | gazette | commencement |
|---|---|---|---|
| **MR2554** | กฎกระทรวง กำหนดขนาด ลักษณะ และสีของแผ่นป้ายทะเบียนรถ และการแสดงแผ่นป้ายทะเบียนรถและเครื่องหมายแสดงการเสียภาษีประจำปี พ.ศ. ๒๕๕๔ (Ministerial Regulation on plate size, characteristics and colour, and on display) | ราชกิจจานุเบกษา **เล่ม ๑๒๘ ตอนที่ ๔๕ ก หน้า ๖, ๘ มิถุนายน ๒๕๕๔** (vol. 128 pt 45 ก p. 6, 8 June 2011); given 30 May 2011 | ข้อ ๑: **on the expiry of 180 days** from publication → first week of **December 2011** |
| **DLT2554** | ประกาศกรมการขนส่งทางบก เรื่อง กำหนดลักษณะ ขนาด สีของแผ่นป้ายเลขทะเบียนรถ และการแสดงแผ่นป้ายและเครื่องหมายแสดงการเสียภาษี พ.ศ. ๒๕๕๔ (DLT Notification) | ราชกิจจานุเบกษา **เล่ม ๑๒๘ ตอนพิเศษ ๔๔ ง หน้า ๕๒, ๑๙ เมษายน ๒๕๕๔**; announced 10 March 2011 | ข้อ ๕: **"ตั้งแต่บัดนี้เป็นต้นไป"** — from now on, i.e. on publication |

MR2554 is made under **มาตรา ๕ (๔)** (as amended by the Motor Vehicle Act
(No. 10) B.E. 2542) and **มาตรา ๑๑** of the **Motor Vehicle Act B.E. 2522**;
DLT2554 under **มาตรา ๙๐** of the **Land Transport Act B.E. 2522**, expressly
"อนุวัตรการความตกลงว่าด้วยการขนส่งข้ามพรมแดนในอนุภูมิภาคลุ่มแม่น้ำโขง" — in
implementation of the **Greater Mekong Subregion Cross-Border Transport
Agreement**, which is why that plate says THAILAND in Latin letters.

**Both PDFs carry real Thai text layers and extracted cleanly.** Two mechanical
artefacts were normalised before quoting, losslessly and reproducibly:
(1) SARA AM is emitted decomposed as NIKHAHIT U+0E4D + SARA AA U+0E32 and is
recomposed to U+0E33; (2) justification inserts spaces *inside* Thai runs (Thai
does not space between words) and a space with a Thai character on both sides is
deleted. Nothing else was altered.

---

## 2. Thailand is the programme's first non-Latin serial — where the line was drawn

MR2554 ข้อ ๓ (๑) (ก) ๒) partitions the plate itself, and the file is built on
that sentence:

> "…ทั้งนี้ **ตัวอักษรให้ใช้ตัวอักษรไทย และหมายเลขทะเบียนให้ใช้ตัวเลขอารบิค**
> และทั้งตัวเลขและตัวอักษรให้อัดเป็นรอยดุน"
> — "the letters shall use **Thai letters** and the registration number shall
> use **Arabic numerals**, and both the numerals and the letters shall be
> embossed."

`plates/_meta/separators.yml` fixes the dataset's serial alphabet at `A–Z0–9`
"and nothing else", and `lint_plates.rb` enforces it, so emitting U+0E01 in a
regex is a lint failure by construction. The rule applied throughout `th.yml`:

* **`format.pattern` / `format.regex` describe only the Arabic-numeral block**,
  in printed order, with the statutory dash where one is prescribed.
* **`format.fields`** (the PRD §2.2 Japan extension point) carries the whole
  composition — leading numeral, category letter 1, category letter 2,
  registration number, province line — each with its script and its clause.
* **`format.regex_native`** carries the full Unicode-aware regex. It is *not*
  one of the three lint-checked keys, so nothing is lost while the schema
  amendment is pending.
* Every Thai-script series is **`matching: recall-only`**: a match of `1234`
  against `\A\d{1,4}\z` is a shape hit on the numeral group, never the claim
  that the string is a valid Thai registration.
* The **Land Transport Act series are `matching: strict`** with sourced
  `regex_strict` twins — those plates are numeric end to end. **Thailand ships
  both answers in one file**, which is the most interesting thing about it
  schema-wise.

**Why not transliterate.** `plates/gr.yml` sets the precedent: Greece issues
only the fourteen capitals whose *glyph* is shared with Latin, so the Latin form
is lossless there. Thai has no such intersection. Rendering กข as "KKh" or "GK"
would be a *choice*, not a glyph identity — no Thai plate has ever shown K or H
— and a regex spelling it would be a fabricated string presented as a format.
Per PRD-PLATES §2.6 the Thai letter positions are reported as data and the
schema amendment that would admit them is **reported, not performed**.

**Proposed amendment (for the maintainer):** a `scripts:` block in
`_meta/separators.yml` declaring, per script, the permitted codepoint ranges and
the `regex_native` key, so that `regex_native` becomes lint-checked rather than
merely tolerated. Thailand, Greece's ΔΣ/ΞΑ/ΔΟΚ series, Japan, China and India
all queue behind that one decision.

---

## 3. The delegation — the German/British pattern by a third route

MR2554 ข้อ ๓ (๑) (ก) ๕), verbatim:

> "การใช้ตัวเลขนำหน้าตัวอักษรประจำหมวด ตัวอักษรประจำหมวด และหมายเลขทะเบียน
> **ให้เป็นไปตามที่อธิบดีประกาศกำหนด**"
> — the use of the leading numeral, of the category letters and of the
> registration numbers shall be **as the Director-General announces**
> (repeated verbatim for motorcycles at (ข) ๔)).

So *which* Thai consonants may be a category letter, in what order pairs open,
and how numbers are allotted are **not in any ministerial regulation**. No such
announcement was obtained (ratchakitcha.soc.go.th is behind Cloudflare from this
host and dlt.go.th did not resolve). **No letter list is asserted anywhere in
`th.yml`**; every `regex_native` writes the letter positions as the whole Thai
consonant range U+0E01–U+0E2E with an explicit note that the true set is a
strict subset.

**One partial letter list survives, by a side door, and it is primary.**
ข้อ ๓ (๑) (ก) ๔) (and (ข) ๓) for motorcycles) sets minimum character heights and
widths and then excepts nineteen named consonants — those with loops, ascenders
or descenders — plus vowels, tone marks and the numeral ๑, whose metrics the
Director-General sets instead:

> ข ง ช ซ ฌ ญ ฎ ฏ ฐ ฒ ณ ป ฝ ฟ ศ ษ ส ฬ ฮ

Codepoints, extracted **mechanically from the fetched PDF's bytes** (all
nineteen in U+0E02–U+0E2E, all Thai script, none Latin — the same provenance
discipline `gr.yml` applies to the Greek fourteen):

`U+0E02 U+0E07 U+0E0A U+0E0B U+0E0C U+0E0D U+0E0E U+0E0F U+0E10 U+0E12 U+0E13
U+0E1B U+0E1D U+0E1F U+0E28 U+0E29 U+0E2A U+0E2C U+0E2E`

These letters **demonstrably appear on Thai plates as a matter of primary law**.
They are **not** the category-letter alphabet, which is a superset, and the file
says so at the point of use.

---

## 4. The 21 series, and what carries each

**Block A — Motor Vehicle Act plates (MR2554), 15 cm × 34 cm, two lines.**
One layout, one size, **nine statutory colour pairs**, and each colour pair is
its own series under §2.3 (design differs):

* `th-private-car-2011` (white/black), `th-private-car-over7-2011` (white/blue),
  `th-private-pickup-2011` (white/green), `th-private-threewheeler-2011`
  (white/red) — ข้อ ๓ (๒) (ค) ๑)–๔).
* `th-taxi-2011` (yellow/black), `th-interprovincial-taxi-2011` (yellow/red),
  `th-tuktuk-2011` (yellow/green), `th-smallfourwheel-hire-2011` (yellow/blue)
  — ข้อ ๓ (๒) (ก) ๑)–๔). **Four for-hire classes, one ground, four character
  colours** — the sharpest colour-as-class system in the dataset.
* `th-service-green-2011` (green/white) — business, touring and rental service
  cars, ข้อ ๓ (๒) (ข).
* `th-trailer-orange-2011`, `th-agricultural-orange-2011` (orange/black) —
  ข้อ ๓ (๒) (ง); split only because `class` takes one value.
* `th-motorcycle-private-2011` (white/black), `th-motorcycle-public-2011`
  (yellow/black) — 17.20 cm × 22 cm, **three lines**, ขส roundel upper right,
  ข้อ ๓ (๑) (ข) and ข้อ ๓ (๒) (จ)/(ฉ).
* `th-diplomatic-2011` (white/black, letter **ท**) and `th-consular-2011`
  (light blue/white, letters **พ ก อ**, with the **grey honorary-consul**
  sub-entry) — 11 cm × 38.7 cm, three sections with a **dimensioned statutory
  dash**, serial expressly **1–9999**, ข้อ ๓ (๑) (ค)/(ง) and ข้อ ๓ (๒) (ช)/(ซ).
* `th-auction-graphic-2003` (`personalized`) — see §5.
* `th-trade-red` (`dealer`) — the ป้ายแดง, created by **มาตรา ๒๗** of the Act;
  its FORM is left to a ministerial regulation that was not secured, so the red
  ground and the reported letter grammar are `corroboration-only`. The famous
  sunrise-to-sunset rule is quoted from the Act itself.
* `th-test-tcqc-2017` (`temporary`) — ประกาศกรมการขนส่งทางบก … รถที่ใช้เพื่อการ
  ทดสอบ พ.ศ. ๒๕๖๐, in force **1 April 2017**, made under มาตรา ๖/๑ วรรคสาม.
  Instrument fully primary; only the TC/QC letters are unverified (the mark is
  prescribed by an **annexed image**, ข้อ ๗).
* `th-international-english` (`temporary`) — the English-language GMS plate, the
  only routinely-issued Thai plate in Latin script **and the only one that is
  illegal at home**.

**Block B — Land Transport Act plates (DLT2554), 22 cm × 44 cm, three lines,
"THAILAND" in Latin + numeric province code, all-numeric serial.**

* `th-lta-public-yellow-2011` — bands **10–19** scheduled passenger,
  **20–29** small-vehicle, **30–39** non-scheduled passenger, **60–69** and
  **70–79** non-scheduled goods, on a yellow retroreflective ground.
* `th-lta-private-white-2011` — bands **40–49** private passenger, **50–59** and
  **80–99** private goods, on white (ข้อ ๒ (๒), one sentence).

These two are the **only Thai regexes this dataset can validate strictly**, and
the colour/band correspondence is an exact decode: a leading type-code digit of
1, 2, 3, 6 or 7 means a yellow for-hire plate; 4, 5, 8 or 9 means a white
private one. ข้อ ๒ (๓) also gives the rule that makes Thailand unusual —
**leading zeros are REQUIRED** ("ใช้เลข ๔ หลัก ตั้งแต่ลำดับหมายเลข ๐๐๐๑ ถึง
หมายเลข ๙๙๙๙"), the opposite of most jurisdictions — which is why `regex_strict`
forbids `0000` and permits `0001`.

---

## 5. The auction regime — statutory, not a programme

`th-auction-graphic-2003`, `period_evidence: enabling-statute`:

* **มาตรา ๑๐/๑**, inserted by the **Motor Vehicle Act (No. 12) B.E. 2546
  (2003)**, obliges the Director-General to put registration numbers "ซึ่งเป็น
  ที่ต้องการหรือเป็นที่นิยม" (desirable or popular), as prescribed by
  ministerial regulation, to **general public auction**, the highest bid being
  deemed the special fee for that number.
* **มาตรา ๑๐/๒**, inserted by the same amending Act, establishes the
  **กองทุนเพื่อความปลอดภัยในการใช้รถใช้ถนน** (Road Safety Fund) inside the DLT
  and directs the proceeds into it. *The money is hypothecated by statute* —
  a materially different arrangement from a Western vanity plate.
* **กฎกระทรวง … เพื่อนำออกเปิดประมูลเป็นการทั่วไป พ.ศ. ๒๕๔๖** (Royal Gazette,
  8 August 2003) defines the ten closed classes of auctionable number.
* The **pictorial** plate designs are authorised, not specified: MR2554 ข้อ ๓'s
  closing paragraph lets the Director-General vary every colour on such a plate,
  and **ข้อ ๔** asks whether a plate ground "จะมีรูปภาพที่สามารถอธิบายหรือมองเห็น
  ความหมายในภาพที่ปรากฏเสมือนจริงนั้นได้ ให้เป็นไปตามที่อธิบดีประกาศกำหนด" —
  whether it may bear a realistic picture is as the Director-General announces.
  **The designs themselves are a recorded gap and are not modelled.**

**Press prices are not dataset facts.** The widely-reported records (25 m baht
2014, 28.1 m 2020, 45.09 m for a Bangkok plate in 2022) are journalism and are
cited nowhere in the data.

---

## 6. Sources actually used

**PRIMARY (fetched, extracted, quoted):**
* MR2554 — `https://web.archive.org/web/20171113165614/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/A/045/6.PDF` (7 pp).
* DLT2554 — `https://web.archive.org/web/20160304073451/http://www.ratchakitcha.soc.go.th/DATA/PDF/2554/E/044/52.PDF` (2 pp).
* ประกาศกรมการขนส่งทางบก … รถที่ใช้เพื่อการทดสอบ พ.ศ. ๒๕๖๐ —
  `https://www.ratchakitcha.soc.go.th/DATA/PDF/2560/E/092/6.PDF` (403 live from
  this host on the re-derivation pass; the earlier capture is in `captures/`).
* Motor Vehicle Act B.E. 2522, Council of State consolidation —
  `https://web.archive.org/web/20110203044221/http://web.krisdika.go.th/data/law/law2/%C301/%C301-20-9999-update.pdf`
  (ss. 5, 6/1, 10/1, 10/2, 11, 27, 60 located).
* Land Transport Act B.E. 2522 consolidation — the `%C302` companion PDF.
* DLT press release no. 75 of 18 March 2011 (the English-language GMS plate) —
  `http://www.dlt.go.th/th/attachments/plan48-51/2532_75-03-54.pdf` via the
  Internet Archive.
* กฎกระทรวง … ประมูล พ.ศ. ๒๕๔๖ —
  `https://web.archive.org/web/20141019064112/http://www.ratchakitcha.soc.go.th/DATA/PDF/00126585.PDF`.

**QUOTATION CAUTIONS, both recorded in the data files:**
1. The **B.E. 2546 auction regulation PDF uses a legacy non-Unicode Thai font
   encoding**. Its text layer extracts as mojibake, so its title, date and
   enabling recital were read by **glyph mapping** and **nothing is quoted from
   it**; its ten number classes are *described*, not reproduced.
2. The **krisdika consolidation of the Motor Vehicle Act drops tone marks and
   some vowel signs** ("แผ่นป้าย" extracts as "แผนปาย"). Sections from it are
   **paraphrased**, and where `th.yml` quotes มาตรา ๒๗ the quotation should be
   re-checked against a clean text before publication. **Flagged as a verifier
   action.**

**SECONDARY (the Wikipedia rule, PRD-PLATES §4):** the English and Thai
`Vehicle registration plates of Thailand` articles were mined as finding aids —
they are where the two Royal Gazette PDF URLs and the DLT press-release URL came
from. Every fact taken from them is tagged at the point of use. No prose or
table arrangement was copied. One press source (Bangkok Post editorial,
4 Oct 2017) is cited for the red-plate practical restrictions only.

**FETCHED AND FAILED:** `ratchakitcha.soc.go.th` (Cloudflare interstitial on
every direct request), `www.dlt.go.th` (no route from this host),
`tabien.dlt.go.th` (does not resolve). **The session's WebSearch budget was
exhausted during the Thailand pass**, so all later sources were located by URL
construction and Wayback CDX enumeration.

---

## 7. FOLKLORE FLAGS

1. **"Thai plates use Thai numerals."** They do not. MR2554 requires **ตัวเลข
   อารบิค** (Arabic numerals) in three separate clauses and DLT2554 in a fourth.
   The Thai digits ๐–๙ (U+0E50–U+0E59) appear in the *gazette's typesetting* and
   never on the plate. **This is the single most likely error for a
   well-meaning consumer to introduce**, and it is exactly the error corrected
   in §9 below.
2. **"The letters run กก, กข, กค …" / "ฃ and ฅ are never used."** Both are
   universally repeated and **neither is sourced**. The alphabet is delegated to
   Director-General announcements that were not obtained (§3). No letter list is
   asserted.
3. **Test-plate date.** Encyclopaedic sources say the TC/QC scheme began
   **3 April 2017**; the instrument says **1 April 2017** (ข้อ ๑). *Recorded, not
   averaged* — the instrument governs.
4. **English-plate date.** A secondary dates the international plate to **2008**;
   the DLT release of 18 March 2011 describes the 2011 regulation as
   *improving* an existing arrangement. Recorded as a disagreement;
   `period_evidence: instrument-in-force` reflects exactly that.
5. **"Red plates were abolished in 2017."** DLT announced an intention in 2015;
   Thai press since reports them still in use; **no instrument either way was
   secured**, so `th-trade-red` is left open with the disagreement stated.
6. **The 1967/1975/1997 format-history dates** that circulate for Thai plates
   are carried by no instrument obtained here and are **not** in the data.

---

## 8. GAPS — ranked for the verifier

1. **The Director-General's announcements on category letters and numbering**
   (MR2554 ข้อ ๓ (๑) (ก) ๕) / (ข) ๔)). Unlocks the real alphabet and would turn
   every `regex_native` from a range into a set. **Top target.**
2. **The Latin transliteration table** for the international plate
   (ระเบียบกรมการขนส่งทางบก … เพื่อนำรถไปใช้ระหว่างประเทศ พ.ศ. ๒๕๕๔). The key
   missing artefact for a parse API: it is the only published Thai→Latin plate
   mapping that exists.
3. **The numeric province-code table** for Land-Transport-Act plates
   (DLT2554 ข้อ ๒ (๑) prescribes เลขรหัสจังหวัด and does not enumerate it).
   Deliberately **not guessed**, and the reason `th-registration-elements.yml`
   ships a *mechanism* rather than a province table.
4. **The B.E. 2547 / B.E. 2550 predecessor regulations** (repealed by MR2554
   ข้อ ๒). Needed for a proper "one series back" on the Motor Vehicle Act side.
5. **The ministerial regulation prescribing the form of the เครื่องหมายพิเศษ**
   (red trade plate) under มาตรา ๒๗.
6. **The DLT notification of 14 April B.E. 2530 (1987)** preserved by DLT2554
   ข้อ ๔ — the previous Land-Transport-Act plate.
7. **The TC/QC annex image** (ข้อ ๗ of the 2560 announcement) — would confirm or
   refute the two letter pairs.
8. **The diplomatic country-code table** (MR2554 ข้อ ๓ (๑) (ค) ๒) prescribes a
   "รหัสแทนชื่อประเทศ" and does not enumerate it). L4 per PRD-PLATES.
9. **A clean text of the Motor Vehicle Act** to replace the diacritic-lossy
   krisdika extraction.

---

## 9. CORRECTION APPLIED IN THIS PASS

**Every `regex_native` in `th.yml` accepted Thai digits in the leading-numeral
position.** Fourteen occurrences spelled that position as a class admitting
๑–๙ as well as 1–9.

That is wrong on the instrument's own words. MR2554 ข้อ ๓ (๑) (ก) ๓) requires the
leading numeral to be an **Arabic** numeral — "ในบรรทัดที่หนึ่งให้เพิ่ม**ตัวเลข
อารบิค**ตั้งแต่ ๑ ถึง ๙ ตามลำดับ" — exactly as ข้อ ๓ (๑) (ก) ๒) requires the
registration number to be one. The Thai digits in that sentence are the
**gazette's typesetting of the numerals one to nine**, not a description of what
the plate prints. The file's own `fields` blocks already recorded the leading
numeral as `script: "Arabic numerals"`, so the regex contradicted the file.

All fourteen now spell `[1-9]`, and the correction is recorded **in the file
itself** under `regex_policy.regex_native_correction` with its reasoning, per
the house rule that corrections are called out rather than made silently. Lint
re-run green after the change.

This is precisely folklore flag #1 caught in our own artefact, which is worth
saying plainly: the Thai-digit trap is attractive enough that it got into a
carefully-sourced file on the first pass.

---

## 10. What a verifier should re-derive first

* Re-fetch MR2554 and confirm ข้อ ๓ (๑) (ก) ๒), ๓), ๔), ๕) and ข้อ ๓ (๒) (ก)–(ซ)
  against the nine colour pairs and the two plate sizes. Everything in Block A
  stands or falls on those clauses.
* Re-fetch DLT2554 and confirm the six type-code bands against the two Block B
  `regex_strict` twins, and the 0001–9999 leading-zero rule.
* Re-check the **มาตรา ๒๗ quotation** in `th-trade-red` against a clean text of
  the Act (see §6 caution 2) — it is the one verbatim quote in the file taken
  from a diacritic-lossy extraction.
* Confirm the 180-day commencement arithmetic for MR2554 if a day-precise date
  is ever needed; the file deliberately asserts only the year.

**my**: 8 series, 12 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 16730B)
