### PR TITLE
plates L3: mx-ar — mx mx-entity-series ar (S5W)

### DIFF
--- a/plates/_decode/mx-entity-series.yml
+++ b/plates/_decode/mx-entity-series.yml
@@ -1,0 +1,380 @@
+# plates/_decode/mx-entity-series.yml — Mexico's ENTIDAD FEDERATIVA serial
+# ranges: the table that turns a Mexican private plate into a state.
+#
+# WHAT THIS IS, AND WHY IT IS NOT A PREFIX TABLE. Mexico does not encode its
+# states the way Germany encodes its districts. There is no district letter and
+# no province suffix: the 32 entidades federativas issue out of ONE national
+# serial space, and the state is recoverable only by asking WHICH RANGE the
+# serial falls in. Those ranges are enacted, closed and primary — Apéndice "C"
+# Normativo of NOM-001-SCT-2-2016 ("ESTABLECE LA ASIGNACIÓN DE SERIES POR
+# ENTIDAD FEDERATIVA, LA CIUDAD DE MÉXICO Y LA SECRETARÍA, POR TIPO DE SERVICIO
+# Y VEHÍCULO, MATRICULADOS EN LA REPÚBLICA MEXICANA"), read off the Diario
+# Oficial de la Federación text of 24 June 2016. Every row below is that
+# appendix.
+#
+# THE DECODE IS A RANGE COMPARISON, NOT A LOOKUP. `AAA-001-A` to `AFZ-999-Z`
+# is Aguascalientes; `AGA-001-A` to `CYZ-999-Z` is Baja California. A consumer
+# decodes by comparing the LETTER GROUP against the interval endpoints in the
+# NOM's own collating order — and that order is NOT plain A-Z, because the same
+# appendix forbids four letters outright:
+#
+#   "NOTA: EN LOS CARACTERES ALFABÉTICOS NO DEBERÁN UTILIZARSE LAS LETRAS
+#    I, Ñ, O, Q."
+#
+# so the alphabet actually walked is A B C D E F G H J K L M N P R S T U V W X
+# Y Z (23 letters). `alphabet:` below is that sequence, machine-readable, and a
+# decoder that compares with a 26-letter alphabet will mis-assign every range
+# that straddles a forbidden letter.
+#
+# FOUR CAUTIONS, all of them load-bearing:
+#
+# 1. RANGES ARE ALLOCATIONS, NOT OCCUPANCY. The NOM allocates Baja California
+#    32,765,202 private-car combinations. Nobody has issued them. A range hit
+#    says "if this plate exists, it was issued by that state", never "this
+#    plate exists".
+# 2. THE RANGES ARE PER SERVICE TYPE AND PER VEHICLE TYPE. The private-car
+#    table and the private-truck table are different serial spaces in different
+#    formats (AAA-000-A vs AA-0000-A); the border (fronterizo) tables are a
+#    third; the public-local tables a fourth. They are kept apart here for the
+#    same reason plates/_decode/it-provinces.yml keeps its two tables apart.
+# 3. THE 2016 ALLOCATION REPLACED THE 2000 ONE. The Acuerdo of 25 September
+#    2000 (DOF) carried its own per-entity assignment for the AAA-00-00 era;
+#    those ranges are NOT these ranges, and this file does not carry them.
+#    A pre-2016 Mexican plate does not decode through this table.
+# 4. CIUDAD DE MÉXICO IS NOT IN THE STATE TABLE. It gets its own format
+#    (A00-AAA for private cars) and its own single range, listed separately
+#    below — which is why a CDMX plate can never collide with a state plate.
+jurisdiction: mx
+topic: entity-series
+authority:
+  name: "Secretaría de Comunicaciones y Transportes — NOM-001-SCT-2-2016, Apéndice C Normativo"
+  url: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016"
+sources:
+  - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # NOM-001-SCT-2-2016, Apéndice C Normativo — every range row below, verbatim, plus the note excluding I, Ñ, O and Q; accessed 2026-08-02"
+  - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice B Normativo, Tabla C — the character ORDER each range is expressed in (AAA-000-A private car, AA-0000-A private truck, A-000-AAA public-local car, A00-AAA-0 border private car)"
+period: { start: 2016 }
+period_evidence: enabling-instrument
+period_note: >-
+  The allocation below is created by NOM-001-SCT-2-2016 itself, published in the
+  DOF on 24 June 2016 and in force sixty calendar days later (numeral 13:
+  "la presente Norma Oficial Mexicana entrará en vigor sesenta días naturales
+  contados a partir de la fecha de su publicación en el Diario Oficial de la
+  Federación") — 23 August 2016. The NOM's own recital says WHY it was needed:
+  the series assigned by the 2000 Acuerdo "se han agotado para algunos tipos de
+  servicio en diversas Entidades Federativas, la Ciudad de México y el
+  Autotransporte Federal, se hace necesario realizar una nueva asignación y
+  distribución de series, que evite la duplicidad de las mismas".
+
+alphabet:
+  order: [A, B, C, D, E, F, G, H, J, K, L, M, N, P, R, S, T, U, V, W, X, Y, Z]
+  excluded: [I, "Ñ", O, Q]
+  source: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # 'NOTA: EN LOS CARACTERES ALFABÉTICOS NO DEBERÁN UTILIZARSE LAS LETRAS I, Ñ, O, Q.' — repeated under every per-entity table in Apéndice C"
+  note: >-
+    Ñ is excluded by the NOM but is not in this dataset's serial alphabet
+    (plates/_meta/separators.yml) in the first place, so it never reaches a
+    regex; it is recorded because the NOM records it.
+
+# ---------------------------------------------------------------------------
+# 1. TRANSPORTE PRIVADO, ENTIDADES FEDERATIVAS (non-border). Referenced by
+#    series mx-private-car-2016 (AAA-000-A) and mx-private-truck-2016
+#    (AA-0000-A).
+# ---------------------------------------------------------------------------
+private_entity:
+  - { code: MX-AGU, name: "Aguascalientes", car_from: "AAA-001-A", car_to: "AFZ-999-Z", car_allocated: 3170826, truck_from: "AA-0001-A", truck_to: "AF-9999-Z", truck_allocated: 1379862 }
+  - { code: MX-BCN, name: "Baja California", car_from: "AGA-001-A", car_to: "CYZ-999-Z", car_allocated: 32765202, truck_from: "AG-0001-A", truck_to: "CD-9999-Z", truck_allocated: 10118988 }
+  - { code: MX-BCS, name: "Baja California Sur", car_from: "CZA-001-A", car_to: "DEZ-999-Z", car_allocated: 3170826, truck_from: "CE-0001-A", truck_to: "CL-9999-Z", truck_allocated: 1609839 }
+  - { code: MX-CAM, name: "Campeche", car_from: "DFA-001-A", car_to: "DKZ-999-Z", car_allocated: 2642355, truck_from: "CM-0001-A", truck_to: "CU-9999-Z", truck_allocated: 1609839 }
+  - { code: MX-CHP, name: "Chiapas", car_from: "DLA-001-A", car_to: "DSZ-999-Z", car_allocated: 3170826, truck_from: "CV-0001-A", truck_to: "DC-9999-Z", truck_allocated: 1839816 }
+  - { code: MX-CHH, name: "Chihuahua", car_from: "DTA-001-A", car_to: "ETZ-999-Z", car_allocated: 12683304, truck_from: "DD-0001-A", truck_to: "EG-9999-Z", truck_allocated: 6209379 }
+  - { code: MX-COA, name: "Coahuila de Zaragoza", car_from: "EUA-001-A", car_to: "FPZ-999-Z", car_allocated: 10569420, truck_from: "EH-0001-A", truck_to: "FB-9999-Z", truck_allocated: 4139586 }
+  - { code: MX-COL, name: "Colima", car_from: "FRA-001-A", car_to: "FWZ-999-Z", car_allocated: 3170826, truck_from: "FC-0001-A", truck_to: "FJ-9999-Z", truck_allocated: 1609839 }
+  - { code: MX-DUR, name: "Durango", car_from: "FXA-001-A", car_to: "GFZ-999-Z", car_allocated: 4756239, truck_from: "FK-0001-A", truck_to: "FZ-9999-Z", truck_allocated: 3219678 }
+  - { code: MX-MEX, name: "México (Estado de)", car_from: "LGA-001-A", car_to: "PEZ-999-Z", car_allocated: 35936028, truck_from: "KL-0001-A", truck_to: "MS-9999-Z", truck_allocated: 11958804 }
+  - { code: MX-GUA, name: "Guanajuato", car_from: "GGA-001-A", car_to: "GYZ-999-Z", car_allocated: 8455536, truck_from: "FY-0001-A", truck_to: "GW-9999-Z", truck_allocated: 5059540 }
+  - { code: MX-GRO, name: "Guerrero", car_from: "GZA-001-A", car_to: "HFZ-999-Z", car_allocated: 3699297, truck_from: "GX-0001-A", truck_to: "HG-9999-Z", truck_allocated: 2299770 }
+  - { code: MX-HID, name: "Hidalgo", car_from: "HGA-001-A", car_to: "HRZ-999-Z", car_allocated: 4756239, truck_from: "HH-0001-A", truck_to: "HT-9999-Z", truck_allocated: 2299770 }
+  - { code: MX-JAL, name: "Jalisco", car_from: "HSA-001-A", car_to: "LFZ-999-Z", car_allocated: 31708260, truck_from: "HU-0001-A", truck_to: "KK-9999-Z", truck_allocated: 8969103 }
+  - { code: MX-MIC, name: "Michoacán de Ocampo", car_from: "PFA-001-A", car_to: "PUZ-999-Z", car_allocated: 6870123, truck_from: "MT-0001-A", truck_to: "NT-9999-Z", truck_allocated: 5519448 }
+  - { code: MX-MOR, name: "Morelos", car_from: "PVA-001-A", car_to: "RDZ-999-Z", car_allocated: 4756239, truck_from: "UN-0001-A", truck_to: "NZ-9999-Z", truck_allocated: 1379862 }
+  - { code: MX-NAY, name: "Nayarit", car_from: "REA-001-A", car_to: "RJZ-999-Z", car_allocated: 2642355, truck_from: "PA-0001-A", truck_to: "PG-9999-Z", truck_allocated: 1609839 }
+  - { code: MX-NLE, name: "Nuevo León", car_from: "RKA-001-A", car_to: "TGZ-999-Z", car_allocated: 23252724, truck_from: "PH-0001-A", truck_to: "RP-9999-Z", truck_allocated: 6899310 }
+  - { code: MX-OAX, name: "Oaxaca", car_from: "THA-001-A", car_to: "TMZ-999-Z", car_allocated: 2642355, truck_from: "RR-0001-A", truck_to: "RY-9999-Z", truck_allocated: 3679632 }
+  - { code: MX-PUE, name: "Puebla", car_from: "TNA-001-A", car_to: "UJZ-999-Z", car_allocated: 10569420, truck_from: "RZ-0001-A", truck_to: "SR-9999-Z", truck_allocated: 3679632 }
+  - { code: MX-QUE, name: "Querétaro", car_from: "UKA-001-A", car_to: "UPZ-999-Z", car_allocated: 2642355, truck_from: "SS-0001-A", truck_to: "SY-9999-Z", truck_allocated: 1609839 }
+  - { code: MX-ROO, name: "Quintana Roo", car_from: "URA-001-A", car_to: "UVZ-999-Z", car_allocated: 2642355, truck_from: "SZ-0001-A", truck_to: "TB-9999-Z", truck_allocated: 689931 }
+  - { code: MX-SLP, name: "San Luis Potosí", car_from: "UWA-001-A", car_to: "VEZ-999-Z", car_allocated: 4756239, truck_from: "TC-0001-A", truck_to: "TP-9999-Z", truck_allocated: 2759724 }
+  - { code: MX-SIN, name: "Sinaloa", car_from: "VFA-001-A", car_to: "VSZ-999-Z", car_allocated: 5813181, truck_from: "TR-0001-A", truck_to: "UL-9999-Z", truck_allocated: 4599540 }
+  - { code: MX-SON, name: "Sonora", car_from: "VTA-001-A", car_to: "WKZ-999-Z", car_allocated: 8984007, truck_from: "UM-0001-A", truck_to: "VK-9999-Z", truck_allocated: 5059494 }
+  - { code: MX-TAB, name: "Tabasco", car_from: "WLA-001-A", car_to: "WWZ-999-Z", car_allocated: 5284710, truck_from: "VL-0001-A", truck_to: "VT-9999-Z", truck_allocated: 1609839 }
+  - { code: MX-TAM, name: "Tamaulipas", car_from: "WXA-001-A", car_to: "XSZ-999-Z", car_allocated: 10040949, truck_from: "VU-0001-A", truck_to: "WX-9999-Z", truck_allocated: 6209379 }
+  - { code: MX-TLA, name: "Tlaxcala", car_from: "XTA-001-A", car_to: "XXZ-999-Z", car_allocated: 2642355, truck_from: "WY-0001-A", truck_to: "XE-9999-Z", truck_allocated: 1609839 }
+  - { code: MX-VER, name: "Veracruz de Ignacio de la Llave", car_from: "XYA-001-A", car_to: "YVZ-999-Z", car_allocated: 11097891, truck_from: "XF-0001-A", truck_to: "YM-9999-Z", truck_allocated: 6899310 }
+  - { code: MX-YUC, name: "Yucatán", car_from: "YWA-001-A", car_to: "ZCZ-999-Z", car_allocated: 3699297, truck_from: "YN-0001-A", truck_to: "YU-9999-Z", truck_allocated: 1379862 }
+  - { code: MX-ZAC, name: "Zacatecas", car_from: "ZDA-001-A", car_to: "ZHZ-999-Z", car_allocated: 2642355, truck_from: "YV-0001-A", truck_to: "ZJ-9999-Z", truck_allocated: 3219678 }
+
+# ---------------------------------------------------------------------------
+# 2. CIUDAD DE MÉXICO. Its own formats, its own single ranges — no overlap with
+#    the state table above is possible because the FORMATS differ.
+# ---------------------------------------------------------------------------
+private_cdmx:
+  - { code: MX-CMX, name: "Ciudad de México", vehicle: car,   format: "A00-AAA",   from: "A01-AAA", to: "Z99-ZZZ", allocated: 27704259 }
+  - { code: MX-CMX, name: "Ciudad de México", vehicle: truck, format: "A-000-AA",  from: "A-001-AA", to: "Z-999-ZZ", allocated: 12154833 }
+  - { code: MX-CMX, name: "Ciudad de México", vehicle: bus,   format: "00-AA-0",   from: "01-AA-1",  to: "99-ZZ-9",  allocated: 471339 }
+  - { code: MX-CMX, name: "Ciudad de México", vehicle: trailer, format: "A-0A-00", from: "A-1A-01",  to: "Z-9Z-99",  allocated: 471339 }
+
+# ---------------------------------------------------------------------------
+# 3. TRANSPORTE PRIVADO FRONTERIZO — the BORDER-ZONE private series, a
+#    separate format (A00-AAA-0 for cars) issued only by the seven entities
+#    the NOM lists. Referenced by series mx-private-border-car-2016.
+# ---------------------------------------------------------------------------
+private_border:
+  - { code: MX-BCN, name: "Baja California", car_from: "A01-NRA-1", car_to: "Z99-NZZ-9", car_allocated: 4242051, truck_from: "ZJA-001-A", truck_to: "ZLC-999-Z", truck_allocated: 1125873, bus_from: "ZLD-001-A", bus_to: "ZLN-999-Z", trailer_from: "ZLP-001-A", trailer_to: "ZLZ-999-Z" }
+  - { code: MX-BCS, name: "Baja California Sur", car_from: "A01-PLA-1", car_to: "Z99-PRZ-9", car_allocated: 2356695, truck_from: "ZMA-001-A", truck_to: "ZNC-999-Z", truck_allocated: 597402, bus_from: "ZND-001-A", bus_to: "ZNN-999-Z", trailer_from: "ZNP-001-A", trailer_to: "ZNZ-999-Z" }
+  - { code: MX-COA, name: "Coahuila de Zaragoza", car_from: "A01-RAA-1", car_to: "Z99-REZ-9", car_allocated: 2356695, truck_from: "ZPA-001-A", truck_to: "ZRC-999-Z", truck_allocated: 597402, bus_from: "ZRD-001-A", bus_to: "ZRN-999-Z", trailer_from: "ZRP-001-A", trailer_to: "ZRZ-999-Z" }
+  - { code: MX-CHP, name: "Chiapas", car_from: "A01-RPA-1", car_to: "Z99-RTZ-9", car_allocated: 1885356, truck_from: "ZSA-001-A", truck_to: "ZST-999-Z", truck_allocated: 390609, bus_from: "ZSU-001-A", bus_to: "ZTD-999-Z", trailer_from: "ZTE-001-A", trailer_to: "ZTP-999-Z" }
+  - { code: MX-CHH, name: "Chihuahua", car_from: "A01-SAA-1", car_to: "Z99-SKZ-9", car_allocated: 4713390, truck_from: "ZTR-001-A", truck_to: "ZUY-999-Z", truck_allocated: 712287, bus_from: "ZUZ-001-A", bus_to: "ZVJ-999-Z", trailer_from: "ZVK-001-A", trailer_to: "ZVV-999-Z" }
+  - { code: MX-SON, name: "Sonora", car_from: "A01-SWA-1", car_to: "Z99-TAZ-9", car_allocated: 2356695, truck_from: "ZVW-001-A", truck_to: "ZXB-999-Z", truck_allocated: 666333, bus_from: "ZXC-001-A", bus_to: "ZXM-999-Z", trailer_from: "ZXN-001-A", trailer_to: "ZXY-999-Z" }
+  - { code: MX-TAM, name: "Tamaulipas", car_from: "A01-THA-1", car_to: "Z99-TTZ-9", car_allocated: 4713390, truck_from: "ZXZ-001-A", truck_to: "ZZC-999-Z", truck_allocated: 620379, bus_from: "ZZD-001-A", bus_to: "ZZN-999-Z", trailer_from: "ZZP-001-A", trailer_to: "ZZZ-999-Z" }
+
+# ---------------------------------------------------------------------------
+# 4. PÚBLICO LOCAL FRONTERIZO — the border public-transport series
+#    (A-000-AAA). Kept separate: same shape as the ordinary public-local
+#    car format, different range block (all in the Z-tail).
+# ---------------------------------------------------------------------------
+public_border:
+  - { code: MX-BCN, car_from: "A-001-ZLA", car_to: "Z-999-ZMN", car_allocated: 827172, truck_from: "A-001-ZMP", truck_to: "Z-999-ZNB", truck_allocated: 275724 }
+  - { code: MX-BCS, car_from: "A-001-ZNR", car_to: "Z-999-ZPJ", car_allocated: 413586, truck_from: "A-001-ZPK", truck_to: "Z-999-ZPR", truck_allocated: 137862 }
+  - { code: MX-COA, car_from: "A-001-ZPY", car_to: "Z-999-ZRS", car_allocated: 413586, truck_from: "A-001-ZRT", truck_to: "Z-999-ZRY", truck_allocated: 137862 }
+  - { code: MX-CHP, car_from: "A-001-ZSF", car_to: "Z-999-ZSZ", car_allocated: 413586, truck_from: "A-001-ZTA", truck_to: "Z-999-ZTF", truck_allocated: 137862 }
+  - { code: MX-CHH, car_from: "A-001-ZTN", car_to: "Z-999-ZVA", car_allocated: 804195, truck_from: "A-001-ZVB", truck_to: "Z-999-ZVN", truck_allocated: 275724 }
+  - { code: MX-SON, car_from: "A-001-ZWC", car_to: "Z-999-ZWW", car_allocated: 413586, truck_from: "A-001-ZWX", truck_to: "Z-999-ZXC", truck_allocated: 137862 }
+  - { code: MX-TAM, car_from: "A-001-ZXK", car_to: "Z-999-ZYY", car_allocated: 827172, truck_from: "A-001-ZYZ", truck_to: "Z-999-ZZL", truck_allocated: 275724 }
+
+# ---------------------------------------------------------------------------
+# 5. PÚBLICO LOCAL, ENTIDADES FEDERATIVAS (non-border) — added by the
+#    verification pass, 2026-08-02. Referenced by mx-public-car-2016
+#    (A-000-AAA).
+#
+#    THE DECODE KEY INVERTS, AND THIS IS THE MOST IMPORTANT SINGLE FACT IN
+#    THIS FILE. The private-car series carries the entity in its LEADING
+#    letter triple; the public-local car series carries it in the TRAILING
+#    triple. Two seven-character shapes, opposite decode keys. A parse API
+#    that reuses the private decoder on a public plate will confidently name
+#    the wrong state, every time.
+# ---------------------------------------------------------------------------
+public_entity:
+  - { code: MX-AGU, name: "Aguascalientes", car_from: "A-001-AAA", car_to: "Z-999-ACZ", car_allocated: 1585413 }
+  - { code: MX-BCN, name: "Baja California", car_from: "A-001-ADA", car_to: "Z-999-AUZ", car_allocated: 7927065 }
+  - { code: MX-BCS, name: "Baja California Sur", car_from: "A-001-AVA", car_to: "Z-999-BDZ", car_allocated: 4756239 }
+  - { code: MX-CAM, name: "Campeche", car_from: "A-001-BEA", car_to: "Z-999-BGZ", car_allocated: 1585413 }
+  - { code: MX-CHP, name: "Chiapas", car_from: "A-001-BHA", car_to: "Z-999-BVZ", car_allocated: 6341652 }
+  - { code: MX-CHH, name: "Chihuahua", car_from: "A-001-BWA", car_to: "Z-999-CSZ", car_allocated: 10569420 }
+  - { code: MX-COA, name: "Coahuila de Zaragoza", car_from: "A-001-CTA", car_to: "Z-999-DUZ", car_allocated: 13211775 }
+  - { code: MX-COL, name: "Colima", car_from: "A-001-DVA", car_to: "Z-999-DXZ", car_allocated: 1585413 }
+  - { code: MX-DUR, name: "Durango", car_from: "A-001-DYA", car_to: "Z-999-EFZ", car_allocated: 4227768 }
+  - { code: MX-GUA, name: "Guanajuato", car_from: "A-001-EGA", car_to: "Z-999-FEZ", car_allocated: 11626362 }
+  - { code: MX-GRO, name: "Guerrero", car_from: "A-001-FFA", car_to: "Z-999-FTZ", car_allocated: 6341652 }
+  - { code: MX-HID, name: "Hidalgo", car_from: "A-001-FUA", car_to: "Z-999-GLZ", car_allocated: 8984007 }
+  - { code: MX-JAL, name: "Jalisco", car_from: "A-001-GMA", car_to: "Z-999-JDZ", car_allocated: 20610369 }
+  - { code: MX-MEX, name: "México (Estado de)", car_from: "A-001-JEA", car_to: "Z-999-LAZ", car_allocated: 22724253 }
+  - { code: MX-MIC, name: "Michoacán de Ocampo", car_from: "A-001-LBA", car_to: "Z-999-LSZ", car_allocated: 7927065 }
+  - { code: MX-MOR, name: "Morelos", car_from: "A-001-LTA", car_to: "Z-999-MCZ", car_allocated: 5284710 }
+  - { code: MX-NAY, name: "Nayarit", car_from: "A-001-MDA", car_to: "Z-999-MJZ", car_allocated: 3170826 }
+  - { code: MX-NLE, name: "Nuevo León", car_from: "A-001-MKA", car_to: "Z-999-SHZ", car_allocated: 48090861 }
+  - { code: MX-OAX, name: "Oaxaca", car_from: "A-001-SJA", car_to: "Z-999-SRZ", car_allocated: 3699297 }
+  - { code: MX-PUE, name: "Puebla", car_from: "A-001-SSA", car_to: "Z-999-TFZ", car_allocated: 7398594 }
+  - { code: MX-QUE, name: "Querétaro", car_from: "A-001-TGA", car_to: "Z-999-TLZ", car_allocated: 2642355 }
+  - { code: MX-ROO, name: "Quintana Roo", car_from: "A-001-TMA", car_to: "Z-999-TRZ", car_allocated: 2113884 }
+  - { code: MX-SLP, name: "San Luis Potosí", car_from: "A-001-TSA", car_to: "Z-999-TUZ", car_allocated: 1585413 }
+  - { code: MX-SIN, name: "Sinaloa", car_from: "A-001-TVA", car_to: "Z-999-UNZ", car_allocated: 9512478 }
+  - { code: MX-SON, name: "Sonora", car_from: "A-001-UPA", car_to: "Z-999-VLZ", car_allocated: 11097891 }
+  - { code: MX-TAB, name: "Tabasco", car_from: "A-001-VMA", car_to: "Z-999-VRZ", car_allocated: 2113884 }
+  - { code: MX-TAM, name: "Tamaulipas", car_from: "A-001-VSA", car_to: "Z-999-WVZ", car_allocated: 14268717 }
+  - { code: MX-TLA, name: "Tlaxcala", car_from: "A-001-WWA", car_to: "Z-999-XBZ", car_allocated: 3170826 }
+  - { code: MX-VER, name: "Veracruz de Ignacio de la Llave", car_from: "A-001-XCA", car_to: "Z-999-YRZ", car_allocated: 19024956 }
+  - { code: MX-YUC, name: "Yucatán", car_from: "A-001-YSA", car_to: "Z-999-ZEZ", car_allocated: 6870123 }
+  - { code: MX-ZAC, name: "Zacatecas", car_from: "A-001-ZFA", car_to: "Z-999-ZKZ", car_allocated: 2642355 }
+public_entity_note: >-
+  The trailing triples skip I, O and Q exactly as the Apéndice C NOTA requires
+  — Oaxaca runs SJA..SRZ and not SIA.., Sonora runs UPA..VLZ and not UOA.. That
+  the allocation is internally consistent with its own charset rule is the best
+  available corroboration that this transcription is faithful, and it is the
+  check a verifier should re-run before trusting any row.
+public_entity_source: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C, 'NUMERACIÓN DE LAS PLACAS ASIGNADAS A CADA ENTIDAD FEDERATIVA PÚBLICO LOCAL', AUTOMÓVILES column; accessed 2026-08-02"
+
+# ---------------------------------------------------------------------------
+# 6. POLICE ENTITY CODES — added by the verification pass, 2026-08-02.
+#
+#    THE ONE MEXICAN SERIES THAT PRINTS A LITERAL ENTITY CODE. Everywhere else
+#    in this file the state is recoverable only by range comparison; on a
+#    police plate it is the first two characters, and a human can read it off.
+#    Grammar AA-000A-0 for vehicles, AA00A for motorcycles (NOM Apéndice B
+#    Tabla C row 4). Each entity gets the whole space under its own pair —
+#    206,793 vehicle and 2,277 motorcycle combinations — so the code IS the
+#    decode and per-entity ranges add nothing.
+#
+#    THESE ARE NOT THE §5.1.4.2 LEGEND ABBREVIATIONS AND MUST NOT BE MERGED
+#    WITH THEM: Oaxaca is AX here and OAX/OC there; Querétaro is ER here and
+#    QRO/QT there; Quintana Roo is TR here and QR there. Mexico City's code is
+#    DF — a name abolished in 2016, surviving inside a 2016 instrument.
+# ---------------------------------------------------------------------------
+police_entity_codes:
+  - { code: MX-AGU, name: "Aguascalientes", plate_code: "AG" }
+  - { code: MX-BCN, name: "Baja California", plate_code: "BC" }
+  - { code: MX-BCS, name: "Baja California Sur", plate_code: "BS" }
+  - { code: MX-CAM, name: "Campeche", plate_code: "CM" }
+  - { code: MX-COA, name: "Coahuila de Zaragoza", plate_code: "CA" }
+  - { code: MX-COL, name: "Colima", plate_code: "CL" }
+  - { code: MX-CHP, name: "Chiapas", plate_code: "CS" }
+  - { code: MX-CHH, name: "Chihuahua", plate_code: "CH" }
+  - { code: MX-CMX, name: "Ciudad de México", plate_code: "DF" }
+  - { code: MX-DUR, name: "Durango", plate_code: "DG" }
+  - { code: MX-MEX, name: "México (Estado de)", plate_code: "ME" }
+  - { code: MX-GUA, name: "Guanajuato", plate_code: "GT" }
+  - { code: MX-GRO, name: "Guerrero", plate_code: "GR" }
+  - { code: MX-HID, name: "Hidalgo", plate_code: "HG" }
+  - { code: MX-JAL, name: "Jalisco", plate_code: "JA" }
+  - { code: MX-MIC, name: "Michoacán de Ocampo", plate_code: "MC" }
+  - { code: MX-MOR, name: "Morelos", plate_code: "MR" }
+  - { code: MX-NAY, name: "Nayarit", plate_code: "NA" }
+  - { code: MX-NLE, name: "Nuevo León", plate_code: "NL" }
+  - { code: MX-OAX, name: "Oaxaca", plate_code: "AX" }
+  - { code: MX-PUE, name: "Puebla", plate_code: "PB" }
+  - { code: MX-QUE, name: "Querétaro", plate_code: "ER" }
+  - { code: MX-ROO, name: "Quintana Roo", plate_code: "TR" }
+  - { code: MX-SLP, name: "San Luis Potosí", plate_code: "SL" }
+  - { code: MX-SIN, name: "Sinaloa", plate_code: "SA" }
+  - { code: MX-SON, name: "Sonora", plate_code: "SN" }
+  - { code: MX-TAB, name: "Tabasco", plate_code: "TB" }
+  - { code: MX-TAM, name: "Tamaulipas", plate_code: "TM" }
+  - { code: MX-TLA, name: "Tlaxcala", plate_code: "TL" }
+  - { code: MX-VER, name: "Veracruz de Ignacio de la Llave", plate_code: "VE" }
+  - { code: MX-YUC, name: "Yucatán", plate_code: "YU" }
+  - { code: MX-ZAC, name: "Zacatecas", plate_code: "ZA" }
+police_entity_codes_collision_warning: >-
+  VE is Veracruz's police code AND the fixed pair on manufacturer diagnostic
+  plates ("En la numeración de placas para vehículos de diagnóstico no se
+  modifican las letras 'VE'"). The two are separated by GRAMMAR, not by the
+  pair: police is AA-000A-0, diagnostic is AA-A000. A consumer that strips
+  separators before decoding must keep the shapes apart first.
+police_entity_codes_source: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C, 'SERIES ASIGNADAS PARA LA POLICÍA DE LAS DIFERENTES ENTIDADES FEDERATIVAS Y LA CIUDAD DE MÉXICO', AUTOMÓVILES and MOTOCICLETAS columns (AG-001A-1..AG-999Z-9 and AG01A..AG99Z per entity); accessed 2026-08-02"
+
+# ---------------------------------------------------------------------------
+# 7. LEGEND ABBREVIATIONS — NOM §5.1.4.2, columns (A), (B) and (C). Added by
+#    the verification pass, 2026-08-02.
+#
+#    These are WORDS PRINTED ON THE PLATE, not part of any serial, and they are
+#    in this file only so nobody mistakes them for the police codes above.
+#    Column B is the traditional abbreviation; column C is the RENAPO-aligned
+#    catalogue code. The NOM permits either ("las posibles abreviaturas"), so a
+#    renderer must be able to set both.
+#
+#    COLLISION IN THE PRIMARY, recorded not repaired: COLIMA and CIUDAD DE
+#    MÉXICO both carry the column-C code CM.
+# ---------------------------------------------------------------------------
+legend_abbreviations:
+  - { code: MX-AGU, option1: "AGS",  renapo: "AS" }
+  - { code: MX-BCN, option1: "BC",   renapo: "BC" }
+  - { code: MX-BCS, option1: "BCS",  renapo: "BS" }
+  - { code: MX-CAM, option1: "CAMP", renapo: "CC" }
+  - { code: MX-COA, option1: "COAH", renapo: "CL" }
+  - { code: MX-COL, option1: "COL",  renapo: "CM" }
+  - { code: MX-CHP, option1: "CHIS", renapo: "CS" }
+  - { code: MX-CHH, option1: "CHIH", renapo: "CH" }
+  - { code: MX-CMX, option1: "CDMX", renapo: "CM" }
+  - { code: MX-DUR, option1: "DGO",  renapo: "DG" }
+  - { code: MX-GUA, option1: "GTO",  renapo: "GT" }
+  - { code: MX-GRO, option1: "GRO",  renapo: "GR" }
+  - { code: MX-HID, option1: "HGO",  renapo: "HG" }
+  - { code: MX-JAL, option1: "JAL",  renapo: "JC" }
+  - { code: MX-MEX, option1: "MEX",  renapo: "MC" }
+  - { code: MX-MIC, option1: "MICH", renapo: "MN" }
+  - { code: MX-MOR, option1: "MOR",  renapo: "MS" }
+  - { code: MX-NAY, option1: "NAY",  renapo: "NT" }
+  - { code: MX-NLE, option1: "NL",   renapo: "NL" }
+  - { code: MX-OAX, option1: "OAX",  renapo: "OC" }
+  - { code: MX-PUE, option1: "PUE",  renapo: "PL" }
+  - { code: MX-QUE, option1: "QRO",  renapo: "QT" }
+  - { code: MX-ROO, option1: "QR",   renapo: "QR" }
+  - { code: MX-SLP, option1: "SLP",  renapo: "SP" }
+  - { code: MX-SIN, option1: "SIN",  renapo: "SL" }
+  - { code: MX-SON, option1: "SON",  renapo: "SR" }
+  - { code: MX-TAB, option1: "TAB",  renapo: "TC" }
+  - { code: MX-TAM, option1: "TAMP", renapo: "TS" }
+  - { code: MX-TLA, option1: "TLAX", renapo: "TL" }
+  - { code: MX-VER, option1: "VER",  renapo: "VZ" }
+  - { code: MX-YUC, option1: "YUC",  renapo: "YN" }
+  - { code: MX-ZAC, option1: "ZAC",  renapo: "ZS" }
+legend_abbreviations_source: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # §5.1.4.2: 'El nombre y las posibles abreviaturas que deben emplear las Entidades Federativas se indica en las columnas A, B y C de la siguiente Tabla.'; accessed 2026-08-02"
+
+# ---------------------------------------------------------------------------
+# 8. RESERVED LETTER TOKENS — added by the verification pass, 2026-08-02.
+#    Small, closed, and each one is a ONE-SHOT identification for a parse API,
+#    which is why they belong beside the ranges rather than buried in a series
+#    note. Every one is fixed by an express NOTA in Apéndice C or spelled
+#    literally in Tabla C.
+# ---------------------------------------------------------------------------
+reserved_letter_tokens:
+  - token: "D"
+    applies_to: "Convertidor (Dolly), federal, grammar A-00-000"
+    quote: "NOTA: En la numeración de placas para convertidor (Dolly) no se modifica la letra “D”."
+  - token: "VE"
+    applies_to: "Vehículos de diagnóstico (manufacturer road-test), grammar AA-A000"
+    quote: "NOTA: En la numeración de placas para vehículos de diagnóstico no se modifican las letras “VE”."
+  - token: "MT"
+    applies_to: "Traslado Nacional motocicletas, grammar AA000A, whole national range MT001A-MT999Z (22,977)"
+    quote: "NOTA: En la numeración de placas para traslado de motocicleta no se modifican las letras “MT”."
+  - token: "DM"
+    applies_to: "Demostración, Ciudad de México, grammar DM-AA-0 — spelled literally in Tabla C itself"
+    quote: "Tabla C, Apéndice B: 6.- Transporte Privado — Demostración, Ciudad de México (Todo tipo de vehículos) — DM-AA-0"
+  - token: "AM"
+    applies_to: "Ambulancias, grammar AA-000-AA; the pair is fixed by the ALLOCATION, not by Tabla C, which writes it generically"
+    quote: "Apéndice C, AMBULANCIA: AGUASCALIENTES AM-001-AA - AM-879-AS ... ZACATECAS AM-600-ZP - AM-999-ZZ"
+  - token: "BM"
+    applies_to: "Bomberos, grammar AA-000-AA; same basis as AM"
+    quote: "Apéndice C, BOMBEROS: AGUASCALIENTES BM-001-AA - BM-879-AS ... ZACATECAS BM-600-ZP - BM-999-ZZ"
+  - token: "PC"
+    applies_to: "Protección Civil, grammar 00-AA-000; and the LEADING DIGIT PAIR is the entity's fiscal number 01-32, which makes this the only Mexican series with a NUMERIC geographic decode"
+    quote: "Apéndice C, PROTECCIÓN CIVIL: AGUASCALIENTES 01-PC-001 - 01-PC-999 ... ZACATECAS 32-PC-001 - 32-PC-999"
+reserved_letter_tokens_source: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # the NOTA lines and the AM/BM/PC allocation tables in Apéndice C; Tabla C in Apéndice B for the DM token; accessed 2026-08-02"
+
+# ---------------------------------------------------------------------------
+# 9. VERIFICATION RECORD — independent second transcription, 2026-08-02.
+# ---------------------------------------------------------------------------
+verification:
+  method: >-
+    The whole of Apéndice C was re-extracted independently from a SECOND
+    federal copy of the instrument — the Secretaría de Economía NOM repository
+    PDF at http://www.economia-noms.gob.mx/normas/noms/2010/001sct22016.pdf,
+    86 pages, text-extracted with `pdftotext -layout` and parsed by script —
+    and the resulting rows were compared against sections 1 to 4 of this file
+    row by row.
+  result: >-
+    AGREEMENT on every private-car range, every Ciudad de México range, and
+    every border range checked. Two independent transcriptions of a scanned
+    federal instrument agreeing is the strongest evidence available short of
+    the DOF facsimile itself.
+  anomalies_found:
+    - >-
+      MORELOS private-TRUCK row (section 1): the instrument prints
+      "UN-0001-A - NZ-9999-Z", whose end sorts BEFORE its start in the NOM's
+      own 23-letter alphabet. Both transcriptions read it identically, so the
+      defect is in the instrument or in its DOF type-setting, not in the
+      extraction. It is recorded, not repaired. A verifier with the DOF
+      facsimile should settle it; until then no consumer should range-decode a
+      Mexican private truck through that row.
+    - >-
+      PRINTED ORDER IS NOT MONOTONIC IN `from`. Apéndice C prints entities in
+      SPANISH alphabetical order, in which CH sorts as its own letter, so
+      Chiapas and Chihuahua precede Coahuila; and the Estado de México and
+      Michoacán blocks (LGA.. and PFA..) sit between Jalisco and Morelos in
+      letter space while being printed at their alphabetical positions. A
+      consumer MUST sort by `from` and must not assume row order. Sorted, the
+      blocks are contiguous and non-overlapping — which is the first check a
+      verifier should run.
+  not_transcribed: >-
+    Apéndice C also carries per-entity allocations for autobuses, remolques,
+    convertidores, motocicletas (three grammars), demostración, ecológicos,
+    ambulancias, bomberos, protección civil and escoltas. They are sourced at
+    exactly the same quality and are omitted for scope (PRD-PLATES §2.5).
+    Extending this file needs no new sourcing, only transcription.

--- a/plates/ar.yml
+++ b/plates/ar.yml
@@ -1,0 +1,762 @@
+# plates/ar.yml — Argentina (PRD-PLATES gate L3).
+#
+# EVERY format, period, dimension, colour and font claim in this file comes
+# from an Argentine or MERCOSUR instrument read in full. The chain, in the
+# order the instruments themselves cite each other:
+#
+#   * Decreto-Ley N° 6582/58 (Régimen Jurídico del Automotor), ratified by Ley
+#     N° 14.467, t.o. Decreto N° 1114/97 — arts. 24 and 25. Art. 24 is the
+#     ENABLING RULE and Disposición 411/2015's own VISTO quotes its effect:
+#     "cada automotor se identificará en todo el país por una codificación de
+#     dominio formada por letras y números, la que debe ser reproducida en
+#     placas de identificación visibles exteriormente, colocadas en las partes
+#     delantera y trasera del automotor". Art. 25, as SUBSTITUTED by Ley
+#     N° 27.187 art. 3, now reads verbatim: "Las características de la placa de
+#     identificación prevista en el artículo anterior se establecerán por la
+#     reglamentación, en los términos de las normas nacionales y los acuerdos
+#     internacionales en la materia." That clause is what lets a MERCOSUR
+#     resolution reach an Argentine plate.
+#   * MERCOSUR/CMC/DEC. N° 53/10 (XL CMC, Foz de Iguazú, 16/XII/10) created the
+#     Patente MERCOSUR; DEC. N° 52/12 (XLIV CMC, Brasilia, 6/XII/12) replaced
+#     its art. 7 with the 1 January 2016 obligation; MERCOSUR/GMC/RES.
+#     N° 33/14 (XCV GMC, Buenos Aires, 08/X/14) approved the DESIGN and its
+#     technical Annex.
+#   * Ley N° 27.187 (sanctioned 23 September 2015, promulgated 14 October 2015)
+#     incorporated all three into Argentine law under art. 40 of the Protocolo
+#     de Ouro Preto, "cuyas fotocopias autenticadas en idioma español se agregan
+#     como Anexo a la presente ley". THE ANNEX IS THE SOURCE OF THE MERCOSUR
+#     SPECIFICATION QUOTED THROUGHOUT THIS FILE — it is a scanned annex to an
+#     Argentine statute, fetched from InfoLeg and read by OCR; where OCR is
+#     unreliable the fact is flagged rather than asserted (see the Pantone note
+#     on ar-mercosur-2016).
+#   * Disposición D.N. N° 411/2015 (DNRPA, Bs. As. 15/09/2015, B.O. 17/09/2015
+#     N° 33216 p. 13) — art. 1, verbatim: "A partir del 1° de enero de 2016 la
+#     identificación dominial de los automotores y motovehículos estará
+#     compuesta por CUATRO (4) letras y TRES (3) números." It also approved the
+#     plate models and the technical Anexo A.
+#   * Disposición D.N. N° 659/2015 (Bs. As. 18/12/2015, B.O. 24/12/2015)
+#     postponed that entry into force to 1 APRIL 2016 — because Casa de Moneda
+#     SE could not deliver ("debido a serios inconvenientes de índole
+#     operativa … la imposibilidad de obtener rápidamente otro proveedor por
+#     haber quedado desierto el proceso licitatorio").
+#   * Disposición D.N. N° 40/2016 (Bs. As. 16/02/2016, B.O. 19/02/2016) — art.
+#     1, THE ARRANGEMENT, verbatim: "A partir del dominio 'AA 000 AA' en el caso
+#     de los automotores y 'A 000 AAA' en el caso de los motovehículos, la
+#     codificación variará de derecha a izquierda. Las posiciones alfabéticas
+#     seguirán el orden A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S,
+#     T, U, V, W, X, Y y Z; y las posiciones numéricas seguirán la progresión
+#     ordinal desde el 0 hasta el 9."
+#   * Digesto de Normas Técnico-Registrales del Registro Nacional de la
+#     Propiedad del Automotor, Título I Capítulo IX (consolidated text as
+#     published by the DNRPA, last updated 25 February 2026) and its
+#     CORRELATIVIDADES, which name the instrument behind every article.
+#
+# FIVE STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. THE ARRANGEMENT IS IN A DIFFERENT INSTRUMENT FROM THE COMPOSITION, AND
+#    ONLY THE SECOND ONE IS USUALLY QUOTED. Disposición 411/2015 says only
+#    "CUATRO (4) letras y TRES (3) números" — it never says WHERE the letters
+#    go. The famous AA 123 BB shape is fixed three months later by Disposición
+#    40/2016 art. 1, together with the motorcycle shape A 000 AAA, the
+#    right-to-left progression and the full 26-letter alphabet. A dataset that
+#    cites only 411/2015 for the format is citing the wrong instrument, and one
+#    that assumes cars and motorcycles share a shape is simply wrong: they do
+#    not, and never have (see 2).
+#
+# 2. ARGENTINE MOTORCYCLES HAVE ALWAYS BEEN THE MIRROR OF ARGENTINE CARS.
+#    Disposición 411/2015's own recital, verbatim: "Que la configuración
+#    actualmente en uso —tres letras y tres números en el caso de los
+#    automotores, y a la inversa en el caso de los Motovehículos— fue puesta en
+#    vigencia a partir del año 1995." So 1995-2016 was AAA 999 for cars and
+#    999 AAA for motorcycles; 2016 onward is AA 999 LL for cars and A 999 AAA
+#    for motorcycles. Four series, not two.
+#
+# 3. NO LETTER IS EXCLUDED. Disposición 40/2016 spells the alphabet out in
+#    full and it contains I, O and Q. Argentina is therefore one of the few
+#    jurisdictions in this dataset where `format.regex` IS the authority's own
+#    grammar and no `regex_strict` twin is needed or honest.
+#
+# 4. THE MERCOSUR COLOUR TABLE IS ARGENTINE LAW. Res. GMC 33/14's Annex fixes
+#    the CHARACTER colour by vehicle use on a white ground — particular negra,
+#    comercial roja, oficial azul, diplomático/consular dorada, especiales
+#    verde, de colección gris plata — and Ley 27.187 made that annex part of the
+#    Argentine legal order. Those are colour-only variants of one format and one
+#    period, so under PRD-PLATES §2.3 they are SUB-ENTRIES on the standard
+#    series, not series of their own.
+#
+# 5. THE SEPARATOR IS A GAP, NOT A GLYPH — AND THE AUTHORITY WRITES IT AS A
+#    SPACE. Res. GMC 33/14's Annex describes "un arreglo de siete caracteres";
+#    no instrument prescribes a separator character. Disposición 40/2016 writes
+#    the shapes as "AA 000 AA" and "A 000 AAA", so this file spells that gap as
+#    the emitted SPACE of PRD-PLATES §2.6 and makes it optional in every regex,
+#    exactly as plates/gb.yml does for the British 33 mm gap.
+jurisdiction: ar
+authority:
+  name: Dirección Nacional de los Registros Nacionales de la Propiedad del Automotor y de Créditos Prendarios (DNRPA), Ministerio de Justicia
+  url: "https://www.dnrpa.gov.ar/portal_dnrpa/index.php"
+binding: vehicle
+binding_note: >-
+  Argentine plates bind to the VEHICLE and are issued at INSCRIPCIÓN INICIAL by
+  the Registro Seccional. Digesto Título I, Capítulo IX, Sección 1ª, art. 1,
+  verbatim: "Los automotores se identificarán a partir de su inscripción inicial
+  con las 'placas de identificación metálica' que los Registros Seccionales
+  suministrarán al titular. Una placa se colocará en la parte delantera y otra
+  en la parte trasera del automotor, siendo requisito ineludible para su
+  circulación. En los motovehículos, la placa de identificación metálica deberá
+  ser colocada en la parte trasera, sirviendo ésta de única y excluyente
+  identificación exterior del motovehículo." The dominio stays with the vehicle
+  for life except through the Convocatoria re-registration (see
+  ar-convocatoria-reempadronamiento).
+
+instrument:
+  citation: "Disposición D.N. N° 411 del 15 de septiembre de 2015 (DNRPA), dictada bajo los artículos 24 y 25 del Régimen Jurídico del Automotor (Decreto-Ley N° 6582/58, ratificado por Ley N° 14.467, t.o. Decreto N° 1114/97) y el artículo 2° inciso c) del Decreto N° 335/88"
+  signed: "2015-09-15"
+  published: "2015-09-17"          # B.O. N° 33216, p. 13
+  in_force_original: "2016-01-01"  # Disp. 411/2015 art. 1
+  in_force_actual: "2016-04-01"    # Disp. 659/2015 art. 1 (prórroga)
+  supranational:
+    - "MERCOSUR/CMC/DEC. N° 53/10 — XL CMC, Foz de Iguazú, 16/XII/10: 'Crear la Patente MERCOSUR, válida para la circulación, identificación y fiscalización de vehículos'; art. 4: 'La Patente MERCOSUR deberá presentar el Emblema Representativo del MERCOSUR y poseer el mismo color de fuente y fondo en todos los Estados Partes'; art. 5: 'La combinación alfanumérica de la Patente MERCOSUR será concedida por el Estado Parte de registro del vehículo'"
+    - "MERCOSUR/CMC/DEC. N° 52/12 — XLIV CMC, Brasilia, 6/XII/12: substitutes art. 7 of Dec. 53/10 with 'A partir del 1° de enero de 2016, la Patente MERCOSUR será de uso obligatorio en todos los Estados Partes para todos los vehículos que sean registrados por primera vez'"
+    - "MERCOSUR/GMC/RES. N° 33/14 — XCV GMC, Buenos Aires, 08/X/14, art. 2: 'Aprobar el diseño de la Patente MERCOSUR que consta como Anexo … Corresponde a cada Estado Parte la distribución de los caracteres alfanuméricos de la Patente MERCOSUR. La distribución seleccionada no debe ser coincidente con la de ningún otro Estado Parte a fin de impedir la obstrucción y confusión en su lectura' — the clause that makes Argentina's AA 000 AA and Brazil's AAA 0A00 deliberately different"
+  national_incorporation: "Ley N° 27.187 (sanc. 23-09-2015, prom. 14-10-2015) arts. 1 and 3"
+  source: "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/252063/norma.htm  # Disposición 411/2015, full text with VISTO, CONSIDERANDO, arts. 1-7 and Anexos I-III; accessed 2026-08-02"
+  licence: >-
+    InfoLeg (Ministerio de Justicia) publishes the consolidated national
+    normative corpus; DNRPA site content is licensed CC BY 4.0 ("Los contenidos
+    de Argentina.gob.ar están licenciados bajo Creative Commons Atribución 4.0
+    Internacional"). Argentine statutes and administrative acts are edicts of
+    government. Facts extracted; quoted fragments cited.
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+charset_defaults:
+  letters: [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z]
+  excluded_letters: []
+  excluded_letters_note: >-
+    NONE. Disposición D.N. N° 40/2016 art. 1 enumerates the alphabet in full —
+    "Las posiciones alfabéticas seguirán el orden A, B, C, D, E, F, G, H, I, J,
+    K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y y Z" — and I, O and Q are in it.
+    Argentina does not do the lookalike exclusions the Netherlands, Mexico and
+    most US states do, so no series in this file carries a `regex_strict`: the
+    round-trippable `regex` already IS the issuing grammar.
+  progression: >-
+    Disposición 40/2016 art. 1, verbatim: "la codificación variará de derecha a
+    izquierda … Al agotarse los signos de una posición, el inmediato a su
+    izquierda progresará una letra o dígito, al tiempo que la posición agotada
+    volverá a 'A' o '0', según corresponda, hasta volver a agotarse."
+  source: "https://servicios.infoleg.gob.ar/infolegInternet/anexos/255000-259999/258787/norma.htm  # Disposición D.N. N° 40/2016 art. 1 — the arrangement, the alphabet and the progression rule; accessed 2026-08-02"
+
+common:
+  mercosur_spec:
+    plate: { w: 400, h: 130, unit: mm, tolerance_mm: 2, thickness_mm: 1, thickness_tolerance_mm: 0.2 }
+    motorcycle_plate: { w: 200, h: 170, unit: mm, tolerance_mm: 2 }
+    font: { name: "FE-Engschrift", cap_height_mm: 65, motorcycle_cap_height_mm: 53, license: "statutory reference by NAME, not by file — the instruments name the typeface and prescribe its cap height; no font is embedded (PRD-PLATES §6)" }
+    band: { side: top, pantone: "286 C", w: 390, h: 30, unit: mm, motorcycle_w: 196 }
+    emblem_mercosur: { w: 32, h: 22, unit: mm, motorcycle_w: 25, motorcycle_h: 20, pantone: ["286 (azul)", "347 (verde)"], placement: "left edge of the logo begins 15 mm from the left border of the plate" }
+    flag: { w: 28, h: 20, unit: mm, motorcycle_w: 23, motorcycle_h: 16, placement: "upper-right quadrant, 4 mm from the top and 4 mm from the right border, with a 1 mm white frame" }
+    substrate: "aluminium, 1 mm ± 0,2 mm"
+    sheeting: "flexible retroreflective sheeting, enclosed-lens elements in transparent resin, minimum 50 candelas"
+    security: >-
+      Res. GMC 33/14 Anexo §§ 1, 11, 12, 13: country flag, MERCOSUR emblem,
+      watermark ("Se puede utilizar como marca de agua el Emblema del MERCOSUR/
+      MERCOSUL"), hot stamping with a diffractive foil whose design is an endless
+      band reading "MERCOSUR 'Nombre del país' MERCOSUL" in Gill Sans at 5 mm,
+      and a sinusoidal wave "utilizada de manera horizontal o vertical a
+      discrecionalidad de cada Estado Parte".
+    colours_by_use:
+      particular: "Negra"
+      comercial: "Roja"
+      oficial: "Azul (Pantone 286 C)"
+      diplomatico_consular: "Dorada (Pantone 130 C)"
+      especiales: "Verde (Pantone 341 C)"
+      de_coleccion: "Gris Plata (Swop Pantone Grey)"
+      ground: "Blanco"
+      note: >-
+        Res. GMC 33/14 Anexo § 2 "Tipo de Color según el uso del Vehículo", on a
+        white ground ("Color de fondo: Blanco"). OCR CAUTION: the Ley 27.187
+        annex is a SCANNED photocopy and its Pantone digits are the least
+        reliable characters on the page. 286 C (azul) is corroborated three
+        times across the annex and by the Argentine Anexo A independently, and
+        130 C / 341 C read cleanly; the COMERCIAL red reads as "106C", which is
+        a yellow in the Pantone solid-coated system and is therefore recorded
+        here by NAME ONLY, with the number withheld pending a clean copy. No hex
+        is asserted for any of these variants.
+    source_law: "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/253150/ley27187.pdf  # Ley N° 27.187, Anexo — authenticated Spanish text of CMC Dec. 53/10, CMC Dec. 52/12 and GMC Res. 33/14 including the full 14-point ESPECIFICACIONES DE LA PATENTE MERCOSUR; scanned, read by OCR; accessed 2026-08-02"
+    source_national: "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1.pdf  # Digesto Título I, Capítulo IX, Sección 1ª, ANEXO A — the same specification restated as Argentine registral law; accessed 2026-08-02"
+
+series:
+
+  # =========================================================================
+  # PATENTE MERCOSUR — the current issue. Disposición 411/2015 + 40/2016.
+  # =========================================================================
+  - id: ar-mercosur-2016
+    class: standard
+    categories: [car, van, truck, bus, semitrailer]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL 999 LL"
+      regex: '\A[A-Z]{2} ?\d{3} ?[A-Z]{2}\z'
+      charset:
+        letters: [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z]
+        notes: "no letter is excluded — see charset_defaults"
+      progression: >-
+        From AA 000 AA, right to left, letters A→Z and digits 0→9, each position
+        rolling its left neighbour on exhaustion (Disposición 40/2016 art. 1).
+        Because the progression is a pure odometer over a fully-populated
+        alphabet, an Argentine Mercosur dominio is a usable AGE PROXY: the
+        left-most letters advance monotonically with issue date, nationally,
+        with no regional reset.
+    design:
+      plate: { w: 400, h: 130, unit: mm }
+      plate_note: "±2 mm on both axes; 1 mm ± 0,2 mm thick; rounded corners (Digesto Anexo A § 2 e))"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: top, color: "#0033A0", content: "mercosur-emblem+ARGENTINA+flag", hex_basis: observed }
+      band_note: >-
+        Digesto Anexo A § 2 g), verbatim: "La Impresión sobre la lámina
+        retrorreflectiva, presenta una franja azul que se desplegará en forma
+        horizontal en su parte superior, cuyo color es el Pantone Nº 286 C. La
+        misma contiene el emblema oficial del Mercosur - República Argentina -
+        Bandera Argentina." The hex is an OBSERVED rendering of the named
+        Pantone; Pantone coordinates are a licensed dataset (PRD-PLATES §6), so
+        the standard is cited and the hex is marked observed.
+      font: { name: "FE-Engschrift", cap_height_mm: 65 }
+      emblem: { present: true, rendered: placeholder, note: "MERCOSUR emblem 32 × 22 mm at Pantone 286/347, left edge 15 mm from the plate's left border; Argentine flag 28 × 20 mm in the upper-right quadrant with a 1 mm white frame" }
+      security: >-
+        Digesto Anexo A § 2 d), verbatim: "La lámina retrorreflectiva deberá
+        contener imágenes direccionales, compuestas por imágenes del Emblema del
+        Mercosur, Escudo Nacional e Islas Malvinas, ubicados alternadamente.
+        Asimismo dicha lámina contiene una onda sinusoidal ubicada en forma
+        horizontal." The Islas Malvinas outline is a SECURITY FEATURE written
+        into Argentine registral law, and it is recorded here as the instrument
+        states it; it carries obvious political sensitivity and PRD-PLATES §3's
+        neutral-placeholder rule for emblems applies to it in the render layer
+        exactly as it does to every other emblem.
+      construction: >-
+        Anexo A § 1: aluminium sheet, white retroreflective film over the whole
+        plate, black hot-stamped continuous-design foil, and the alphanumerics
+        "embozados hacia delante respecto al plano principal de la chapa
+        metálica" — embossed FORWARD, the opposite of the pre-2016 plate, which
+        embossed them backward. That single word is the fastest physical test of
+        which era an Argentine plate belongs to.
+      rear_differs: false
+    region_encoding: none
+    region_encoding_note: >-
+      Argentine dominios encode NO geography and never have. The Registro
+      Seccional that issues a plate draws from a nationally-adjudicated stock
+      (Digesto Título I Cap. IX Sec. 1ª art. 2: "El Sistema Informático
+      adjudicará a los Registros Seccionales (en función de las placas metálicas
+      obrantes en su stock) los números de dominio"), so a serial says WHEN, not
+      WHERE.
+    variants:
+      - class: taxi
+        design: { foreground_name: "Roja", background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed } }
+        note: >-
+          COMERCIAL use — red characters on the same white ground and the same
+          dominio. Colour-only variant of this series, hence a sub-entry per
+          PRD-PLATES §2.3. No hex: see common.mercosur_spec.colours_by_use for
+          the OCR caution on the Pantone number.
+        sources:
+          - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/253150/ley27187.pdf  # Res. GMC 33/14 Anexo § 2, 'Comercial — Roja'"
+      - class: government
+        design: { foreground_name: "Azul (Pantone 286 C)", background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed } }
+        note: "OFICIAL use — blue characters, Pantone 286 C, the same blue as the band. Colour-only variant."
+        sources:
+          - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/253150/ley27187.pdf  # Res. GMC 33/14 Anexo § 2, 'Oficial — Azul (Pantone Fórmula Sólido Brillante 286C)'"
+      - class: diplomatic
+        design: { foreground_name: "Dorada (Pantone 130 C)", background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed } }
+        note: >-
+          DIPLOMÁTICO/CONSULAR use — gold characters. Recorded as a colour
+          variant ONLY: the SERIAL COMPOSITION of Argentine diplomatic plates is
+          set by the Ministerio de Relaciones Exteriores, not by the DNRPA, and
+          no MRECIC instrument was pinned in this pass, so no diplomatic format
+          is asserted here (recorded gap).
+        sources:
+          - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/253150/ley27187.pdf  # Res. GMC 33/14 Anexo § 2, 'Diplomático/Consular — Dorada (Pantone Fórmula Sólido Brillante 130C)'"
+      - class: historic
+        design: { foreground_name: "Gris Plata (Swop Pantone Grey)", background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed } }
+        note: >-
+          DE COLECCIÓN use — silver-grey characters. The eligibility rule is
+          Argentine: Digesto Título II, Capítulo XXI, art. 1 a) requires that the
+          vehicle "por sus características y/o antecedentes históricos
+          constituyan una reserva para la defensa y el mantenimiento del
+          patrimonio cultural de la Nación y tengan como mínimo TREINTA (30)
+          años de antigüedad".
+        sources:
+          - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/253150/ley27187.pdf  # Res. GMC 33/14 Anexo § 2, 'De Colección — Gris Plata (Swop Pantone Grey)'"
+          - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo2.pdf  # Título II Cap. XXI art. 1 a), the 30-year threshold for the Registro de Automotores Clásicos"
+      - class: specialty
+        design: { foreground_name: "Verde (Pantone 341 C)", background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed } }
+        note: "ESPECIALES use — green characters. The MERCOSUR annex does not define which vehicles fall in this class and no Argentine instrument pinning it was secured (recorded gap)."
+        sources:
+          - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/253150/ley27187.pdf  # Res. GMC 33/14 Anexo § 2, 'Especiales — Verde (Pantone Fórmula Sólido Brillante 341C)'"
+    sources:
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/255000-259999/258787/norma.htm  # Disposición D.N. N° 40/2016 art. 1 — 'A partir del dominio AA 000 AA en el caso de los automotores … la codificación variará de derecha a izquierda', the 26-letter alphabet, the roll-over rule"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/252063/norma.htm  # Disposición D.N. N° 411/2015 arts. 1-6 and Anexo II (ESPECIFICACIONES TECNICAS): seven characters, 400 × 130 mm, FE Engschrift 65 mm, Pantone 286 C band, directional images"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/255000-259999/257320/norma.htm  # Disposición D.N. N° 659/2015 — the prórroga of the entry into force to 1 April 2016"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1.pdf  # Digesto Título I Cap. IX Sec. 1ª arts. 1-2 and Anexo A, the consolidated text in force"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/253150/ley27187.pdf  # Ley N° 27.187 Anexo — GMC Res. 33/14 and the MERCOSUR technical specification"
+    notes: >-
+      THE CURRENT ARGENTINE PLATE — the Patente MERCOSUR, two letters, three
+      digits, two letters. period.start 2016 is evidenced twice over and the two
+      dates disagree by three months, which is itself the record: Disposición
+      411/2015 art. 1 set 1 January 2016, Disposición 659/2015 postponed it to
+      1 April 2016 because the mint could not deliver, and Disposición 232/2016
+      then states the outcome in the past tense — "con fecha 1° de abril de 2016
+      entró en vigencia una nueva identificación dominial para los automotores,
+      compuesta por CUATRO (4) letras y TRES (3) números". OLD STOCK ISSUED ON
+      after the switch: Circulares D.N. Nros. 3/16 and 4/16 authorised Registros
+      Seccionales to keep using pre-Mercosur plates "aun después del 1° de abril
+      de 2016" until stocks ran out, which is why this series and
+      ar-1995-car overlap at 2016 rather than meeting cleanly.
+
+  - id: ar-mercosur-motorcycle-2016
+    class: motorcycle
+    categories: [motorcycle, moped]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L 999 LLL"
+      regex: '\A[A-Z] ?\d{3} ?[A-Z]{3}\z'
+      charset: { notes: "full 26-letter alphabet — see charset_defaults" }
+      progression: "from A 000 AAA, right to left, same odometer rule as the car series"
+    design:
+      plate: { w: 200, h: 170, unit: mm }
+      plate_note: "±2 mm on both axes; 1 mm ± 0,2 mm thick — a PORTRAIT-ish plate, taller relative to width than any other Mercosur format"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: top, color: "#0033A0", content: "mercosur-emblem+ARGENTINA+flag", hex_basis: observed }
+      band_note: "30 × 196 mm on the motorcycle plate (Res. GMC 33/14 Anexo § 8)"
+      font: { name: "FE-Engschrift", cap_height_mm: 53 }
+      emblem: { present: true, rendered: placeholder, note: "MERCOSUR emblem 25 × 20 mm, positioned so that the bisector of the plate's corner angle coincides with the bisector of the emblem's; flag 23 × 16 mm" }
+      rear_differs: false
+      note: "one plate, rear only — Digesto Título I Cap. IX Sec. 1ª art. 1: the motorcycle plate is the 'única y excluyente identificación exterior del motovehículo'"
+    region_encoding: none
+    sources:
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/255000-259999/258787/norma.htm  # Disposición D.N. N° 40/2016 art. 1 — 'A 000 AAA en el caso de los motovehículos'"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/252063/norma.htm  # Disposición D.N. N° 411/2015 art. 5 and Anexo III (modelo de placa del motovehículo); Anexo II § 2 E) and F) for the 200 × 170 mm size and the 53 mm cap height"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/253150/ley27187.pdf  # Res. GMC 33/14 Anexo §§ 4, 5, 6, 7, 8 — motorcycle dimensions, font, emblem, flag and band"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/260000-264999/260175/norma.htm  # Disposición D.N. N° 118/2016 — the motorcycle plate's own rollout, see notes"
+    notes: >-
+      The Argentine Mercosur MOTORCYCLE plate — ONE letter, three digits, THREE
+      letters, the mirror of the car shape, and a fact almost every secondary
+      source omits. Its rollout has a documented wrinkle of its own: Disposición
+      D.N. N° 118/2016 (29 March 2016) had to authorise a NAMED SUBSET of
+      motorcycle-only Registros Seccionales to start issuing the new plate
+      immediately, because those offices had exhausted their old-model stock
+      while the general date was still being deferred — so a handful of
+      Argentine motorcycles carry Mercosur plates issued days before the
+      national start.
+
+  # =========================================================================
+  # ONE SERIES BACK — the 1995 codification. Three letters and three numbers
+  # for cars, and the inverse for motorcycles.
+  # =========================================================================
+  - id: ar-1995-car
+    class: standard
+    categories: [car, van, truck, bus, semitrailer]
+    period: { start: 1995, end: 2016 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset: { notes: "no exclusion rule was found in any instrument secured for this pass; Disposición 40/2016's full alphabet post-dates this series and is not evidence for it" }
+      progression: >-
+        Letter group ascending. Two dated waypoints are primary and both are
+        useful for era inference: (a) Circular D.N. N° 23/11 — "A partir del
+        dominio KQG-000 las placas contienen adherido al film retroreflectivo
+        que recubre la placa el holograma tridimensional ubicado en el extremo
+        superior derecho, que contiene imágenes y nanotexto", so a plate at or
+        after KQG-000 is 2011 or later; (b) Disposición D.N. N° 232/2016 records
+        that the last new-registration stock left over in 2016 began with the
+        letter "P".
+    design:
+      plate: { w: 294, h: 129, unit: mm }
+      plate_note: >-
+        Disposición D.N. N° 471/2011 Anexo II § 2 f), verbatim: "Las medidas de
+        las placas son: 29,4 cm. por 12,9 cm. la placa completa con bordes
+        redondeados. En la parte central, pintado de color negro mate y en
+        sobrerrelieve un rectángulo de 28,3 cm. por 7,8 cm. Las letras y los
+        números de placa miden 3,2 cm. de ancho por 6,7 cm. de altura, con una
+        separación entre letras y números central de 9 cm."
+      background: { color: "#000000", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      background_note: >-
+        The plate is a WHITE retroreflective sheet with a MATT BLACK painted,
+        embossed central rectangle; the characters are the white sheet showing
+        through. So `background` here describes the character field, and the
+        plate's outer border is white retroreflective. The word "ARGENTINA" runs
+        along the top edge (Anexo II § 2 e) refers to "el borde de la placa que
+        posee la leyenda ARGENTINA").
+      characters: { w: 32, h: 67, unit: mm, group_gap_mm: 90 }
+      emboss: "backward — 'Los caracteres alfanuméricos que identifican al dominio del automotor deberán ser embozados hacia atrás respecto al plano principal de la chapa metálica' (Anexo II § 1 c)), the exact inverse of the Mercosur plate"
+      security: >-
+        Directional images of the letters RNPA inside a circle, alternately
+        distributed and visible only at an angle (Anexo II § 2 e), which even
+        prescribes the viewing geometry: illumination at 45°, observer offset
+        with a tangent of about 0,40, 60 W lamp). From 12 July 2011 a
+        three-dimensional hologram at the upper right, hot-stamped onto the
+        retroreflective film, containing images and nanotext (Anexo II § 2 b)).
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/252063/norma.htm  # Disposición D.N. N° 411/2015, CONSIDERANDO: 'Que la configuración actualmente en uso —tres letras y tres números en el caso de los automotores, y a la inversa en el caso de los Motovehículos— fue puesta en vigencia a partir del año 1995' — the format AND the year"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/180000-184999/184562/norma.htm  # Disposición D.N. N° 471/2011 (Bs. As. 12/7/2011) Anexo II — the complete technical specification quoted above; art. 3: 'Las Placas de Identificación Metálicas del viejo modelo conservarán su vigencia y serán utilizadas hasta agotar el stock existente'"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/260000-264999/263260/norma.htm  # Disposición D.N. N° 232/2016 — 'con fecha 1° de abril de 2016 entró en vigencia una nueva identificación dominial', and the leftover 'P' stock"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1_correlatividades.pdf  # CORRELATIVIDAD, Título I Cap. IX Sec. 1ª — names Disposición D.N. Nº 711/94 (t.o. Orden 'N' Nº 1/94) as the instrument behind arts. 1-3, and Circular D.N. N° 23/11 for the KQG-000 hologram waypoint"
+    notes: >-
+      THE ONE-BACK ARGENTINE PLATE — three letters, three digits, white on matt
+      black, "ARGENTINA" along the top. PERIOD DISCIPLINE, stated plainly: 1995
+      is `corroboration-only` and the corroboration is the AUTHORITY'S OWN
+      RECITAL in Disposición 411/2015, which is stronger than the label sounds
+      but is still not the creating instrument. The Digesto's correlatividad
+      names that instrument — Disposición D.N. Nº 711/94, texto ordenado Orden
+      "N" Nº 1/94 — and it is NOT in InfoLeg and was not retrieved in this pass;
+      until it is, the 1995 start rests on a 2015 recital and nothing else. The
+      end is far better evidenced: 1 April 2016 by Disposición 411/2015 as
+      deferred by 659/2015 and confirmed in the past tense by 232/2016, with
+      old-stock issuance continuing after that date under Circulares D.N. Nros.
+      3/16 and 4/16.
+
+  - id: ar-1995-motorcycle
+    class: motorcycle
+    categories: [motorcycle, moped]
+    period: { start: 1995, end: 2016 }
+    period_evidence: corroboration-only
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+    design:
+      background: { color: "#000000", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      rear_differs: false
+      note: >-
+        One plate, rear only. The 2011 Anexo A specification is written for the
+        AUTOMOTOR plate; the motovehículo model was a separate annex (Anexo II
+        of the Digesto section, substituted by Disposición D.N. Nº 745/10) whose
+        dimensions were not retrieved in this pass — recorded gap, so no
+        `plate` block is asserted here rather than borrowing the car's.
+    region_encoding: none
+    sources:
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/250000-254999/252063/norma.htm  # Disposición D.N. N° 411/2015 CONSIDERANDO — 'a la inversa en el caso de los Motovehículos', from 1995"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1_correlatividades.pdf  # CORRELATIVIDAD Título I Cap. IX Sec. 1ª — Disposición D.N. Nº 581/91 arts. 14-16 (motovehículos) and Disposición D.N. Nº 745/10 (sustituye el Anexo II, the motorcycle plate model)"
+    notes: >-
+      THE INVERTED MOTORCYCLE SHAPE — three digits then three letters, the exact
+      mirror of the contemporaneous car plate, in force over the same window.
+      This is the single most under-recorded Argentine plate fact and the reason
+      a naive AAA-999 regex mis-classifies every pre-2016 Argentine motorcycle.
+      Same period caveat as ar-1995-car: the 1995 start is the authority's own
+      later recital, not the creating instrument.
+
+  # =========================================================================
+  # CONVOCATORIA AL PARQUE AUTOMOTOR — still-current re-registration of
+  # vehicles that never received a 1995-model dominio.
+  # =========================================================================
+  - id: ar-convocatoria-reempadronamiento
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1995 }
+    period_evidence: earliest-underlying-series
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      progression: >-
+        Deliberately kept OUT of the new-registration run so the two cannot
+        collide: Disposición D.N. N° 232/2016 records that convocatoria
+        combinations ran "a partir de la letra 'R'", then from a stock beginning
+        with "X", and that "A continuación de la combinación alfanumérica
+        'XOU-999' … los Registros Seccionales de la Propiedad del Automotor
+        otorgarán placas metálicas correspondientes a los lotes disponibles que
+        comiencen con la letra 'P'".
+    design:
+      plate: { w: 294, h: 129, unit: mm }
+      background: { color: "#000000", finish: painted, hex_basis: observed }
+      foreground: "#FFFFFF"
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo2.pdf  # Digesto Título II Cap. XXV (Convocatoria al Parque Automotor) art. 2 a): 'El cambio de la Identificación del dominio del automotor por otra, compuesta por TRES (3) letras y TRES (3) números'; art. 2 b): a set of TWO plates"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/anexos/260000-264999/263260/norma.htm  # Disposición D.N. N° 232/2016 arts. 1 and CONSIDERANDO — the R / X / XOU-999 / P lot sequence and the reason for it"
+    notes: >-
+      THE SERIES THAT SURVIVED THE MERCOSUR SWITCH. Argentine vehicles
+      registered before the 1995 codification keep their old dominio until a
+      registral act forces a Convocatoria, and a Convocatoria still issues a
+      THREE-LETTER, THREE-DIGIT dominio — not a Mercosur one — out of reserved
+      letter lots. So a freshly-made AAA 999 plate in Argentina today is not an
+      anachronism and not a fake: it is a re-registration. period.start records
+      the earliest date the underlying three-plus-three codification existed
+      (1995); the Convocatoria regime's own start date is on no instrument
+      secured in this pass and is a recorded gap. The series is OPEN because
+      Disposición 232/2016 provides for its continuation.
+
+  # =========================================================================
+  # MAQUINARIA AGRÍCOLA, VIAL E INDUSTRIAL (M.A.V.I.).
+  # =========================================================================
+  - id: ar-mavi-2019
+    class: agricultural
+    categories: [tractor, machine]
+    period: { start: 2019 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LLL 99"
+      regex: '\A[A-Z]{3} ?\d{2}\z'
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+      note: >-
+        Two plates, front and rear — Digesto Título I Cap. IX Sec. 1ª art. 2 e):
+        the M.A.V.I. plates "deberán colocarse una en la parte delantera y otra
+        en la parte trasera de la maquinaria". Model at Anexo VI of that Section;
+        its dimensions are not in the consolidated text and are a recorded gap.
+    region_encoding: none
+    sources:
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1.pdf  # Digesto Título I Cap. IX Sec. 1ª art. 2 e): 'Las Placas de Identificación Metálica para Maquinaria Agrícola, Vial e Industrial contendrán el dominio otorgado -compuesto por TRES (3) letras y DOS (2) números-'"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1_correlatividades.pdf  # CORRELATIVIDAD: 'Artículo 2°.- … inciso e).- Incorporado conforme Disposición D.N. N° 480/18 (puesto en vigencia por Disposición D. N. N° 194/2019)'"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/buscarNormas.do?tipoNorma=4&numero=480&anioSancion=2018&dependencia=258  # Disposición D.N. N° 480/2018, B.O. 10-dic-2018, 'MODELO DE PLACA DE IDENTIFICACION METALICA PARA MAQUINARIA AGRICOLA, VIAL E INDUSTRIAL'"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/buscarNormas.do?tipoNorma=4&numero=194&anioSancion=2019&dependencia=258  # Disposición D.N. N° 194/2019, B.O. 13-jun-2019, 'ESTABLECESE EL 1° DE JULIO DE 2019 COMO' fecha de entrada en vigencia"
+    notes: >-
+      M.A.V.I. — agricultural, road-building and industrial machinery, the
+      shortest Argentine dominio at five characters. period.start 2019 is the
+      IN-FORCE date, not the approval date: Disposición D.N. N° 480/2018
+      approved the model in December 2018 and Disposición D.N. N° 194/2019 set
+      1 July 2019 as the day the package took effect. The five-character shape
+      cannot collide with any other Argentine series.
+
+  # =========================================================================
+  # TRAILERS (O1) — the plate that repeats the towing vehicle's dominio.
+  # =========================================================================
+  - id: ar-trailer-2019
+    class: trailer
+    categories: [trailer]
+    period: { start: 2019 }
+    period_evidence: enabling-instrument
+    # RECALL-ONLY (PRD-PLATES §2.7): this plate carries the TOWING VEHICLE's
+    # existing dominio, so its regex is the union of the Argentine shapes in
+    # circulation. A match is a SHAPE hit — it says the string has a shape
+    # Argentina has issued, never that it is a valid trailer registration.
+    matching: recall-only
+    format:
+      pattern: "LL 999 LL"
+      regex: '\A(?:[A-Z]{2} ?\d{3} ?[A-Z]{2}|[A-Z]{3} ?\d{3})\z'
+      pattern_note: >-
+        The pattern shown is ONE representative shape (the Mercosur car
+        dominio). This series has no format of its own: Digesto Título I Cap. IX
+        Sec. 1ª art. 3 gives the trailer plate "el dominio del vehículo que lo
+        remolque", so any dominio a towing car may carry can appear on it — the
+        Mercosur AA 000 AA and the pre-2016 AAA 000 alike.
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+      note: "model at Anexo V of the Section, incorporated by art. 5 of Disposición D.N. N° 125/2018; its dimensions are not in the consolidated text (recorded gap)"
+    region_encoding: none
+    sources:
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1.pdf  # Digesto Título I Cap. IX Sec. 1ª art. 3, verbatim: 'La \"Placa de Identificación Metálica para Trailers\" destinados al traslado de equipaje, pequeñas embarcaciones deportivas o elementos de recreación familiar, comprendidos en la categoría O1, remolcados por vehículos automotores de uso particular, contendrá el dominio del vehículo que lo remolque'"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1_correlatividades.pdf  # CORRELATIVIDAD: 'Artículo 3°.- Sustituido por artículo 7° de la Disposición D.N. N° 125/2018'; 'Anexo V.- Incorporado por artículo 5° de la Disposición D.N. N° 125/18'"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/buscarNormas.do?tipoNorma=4&numero=194&anioSancion=2019&dependencia=258  # Disposición D.N. N° 194/2019 — 1 July 2019 in-force date for the Disposición 125/2018 package"
+    notes: >-
+      LIGHT TRAILER plates (UNECE category O1 — luggage trailers, small boat
+      trailers, family recreation equipment) towed by a private car. Argentina
+      does NOT give these a registration of their own; the plate repeats the
+      tow vehicle's dominio, which is precisely the nl-export situation and gets
+      the same `recall-only` treatment. period.start 2019 is the in-force date of
+      the Disposición 125/2018 package set by Disposición 194/2019.
+
+  # =========================================================================
+  # PLACAS PROVISORIAS (paper).
+  # =========================================================================
+  - id: ar-provisoria
+    class: temporary
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 1993 }
+    period_evidence: enabling-instrument
+    # RECALL-ONLY: the paper plate reproduces the vehicle's OWN dominio, so the
+    # regex is the union of Argentine shapes, exactly like ar-trailer-2019.
+    matching: recall-only
+    format:
+      pattern: "LL 999 LL"
+      regex: '\A(?:[A-Z]{2} ?\d{3} ?[A-Z]{2}|[A-Z]{3} ?\d{3}|\d{3} ?[A-Z]{3}|[A-Z] ?\d{3} ?[A-Z]{3})\z'
+      pattern_note: "representative shape only; the regex is the union of the four Argentine road shapes (Mercosur car and motorcycle, 1995 car and motorcycle) because the provisional plate carries the vehicle's existing dominio"
+    design:
+      background: { color: "#FFFFFF", finish: painted, hex_basis: observed }
+      foreground: "#CC0000"
+      background_note: >-
+        Digesto Título II Cap. XVI, ANEXO I, "ESPECIFICACIONES DE LA PLACA
+        PROVISORIA (DE PAPEL)", in its entirety: "Papel blanco. Letras, números
+        y texto en tinta roja." That is the whole specification — no dimensions,
+        no font, no security features. The red hex is `observed`; the instrument
+        names the colour and numbers nothing.
+      rear_differs: false
+    validity: { days: 30, note: "'con vencimiento de TREINTA (30) días corridos desde su expedición' (Título II Cap. XVI art. 2 b))" }
+    region_encoding: none
+    sources:
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo2.pdf  # Título II Cap. XVI, arts. 1-3 and Anexo I — the 200 km rule, the 30-day validity and the paper specification"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1.pdf  # Título I Cap. IX Sec. 2ª — the eight cases in which a vehicle may circulate on provisional plates, and the referral to Título II Cap. XVI for their characteristics"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1_correlatividades.pdf  # CORRELATIVIDAD Sección 2ª: 'Artículo 1º.- Incorporado según texto aprobado por Disposición D.N. Nº 119/93'"
+    notes: >-
+      PLACAS PROVISORIAS — white paper, red ink, thirty days. The case the
+      Digesto specifies in detail is the one that most needs a machine-readable
+      rule: a registrant more than 200 km in a straight line from the Registro
+      where the vehicle is domiciled may obtain a provisional plate on the spot
+      after the home Registro confirms by e-mail (and must answer "dentro de las
+      DOS (2) horas contadas desde su recepción"). Title I Cap. IX Sec. 2ª lists
+      eight further cases — factories, importers, official dealers,
+      out-of-factory builds, auctioned vehicles, imports pending clearance,
+      cross-jurisdiction purchases and lost-plate replacement — but the SERIAL
+      GRAMMAR of the pre-registration provisional plates (which have no dominio
+      yet) is not published in the consolidated Digesto and is NOT modelled
+      here: recorded gap, and the reason this series is recall-only rather than a
+      claim.
+
+  # =========================================================================
+  # PLACAS ALTERNATIVAS — added by the verification pass, 2026-08-02.
+  #
+  # Argentina issues a SECOND, VISUALLY DISTINCT plate to vehicles that are
+  # lawfully registered but NOT lawfully in general circulation: units whose
+  # Certificación de Seguridad Vehicular discloses a restriction, or which
+  # lack a Licencia de Configuración de Modelo / Ambiental. The vehicle still
+  # gets a dominio and still gets registral documents — Digesto Título II is
+  # explicit that "En ningún caso se restringirá la entrega de la
+  # documentación registral" — but the metal it carries is the "Placa de
+  # Identificación Metálica Alternativa" of Anexos III (automotores) and IV
+  # (motovehículos), incorporated by arts. 3 and 4 of Disposición D.N.
+  # N° 125/2018.
+  #
+  # THESE ARE THEIR OWN SERIES, NOT A DESIGN VARIANT, and the reason is the
+  # ALLOCATION: alternative dominios are drawn from the OPPOSITE END of the
+  # national space and run the odometer BACKWARDS. Digesto Título II,
+  # Capítulo I, Sección 3ª, artículo 6°, verbatim:
+  #
+  #   "La asignación de dominio en el supuesto contemplado en el artículo 3°
+  #    de esta Sección, seguirá el siguiente orden: a partir del dominio
+  #    'ZZ 000 AA' en el caso de los automotores y 'Z 000 AAA' en el caso de
+  #    los motovehículos, la codificación variará de derecha a izquierda. Las
+  #    posiciones alfabéticas seguirán el orden A, B, C, D, E, F, G, H, I, J,
+  #    K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y y Z; y las posiciones
+  #    numéricas seguirán la progresión ordinal desde el 0 hasta el 9. …
+  #    Cuando corresponda modificar la segunda posición en el caso de
+  #    automotores o la primera posición en el caso de motovehículos, la
+  #    sucesión alfabética anteriormente indicada seguirá el sentido inverso."
+  #
+  # Two things fall out of that paragraph and both matter:
+  #   1. INDEPENDENT CORROBORATION OF THE WHOLE ARGENTINE GRAMMAR. This is a
+  #      DIFFERENT instrument, in a DIFFERENT Title of the Digesto, from
+  #      Disposición 40/2016 — and it states the same two shapes (2+3+2 for
+  #      cars, 1+3+3 for motorcycles), the same right-to-left odometer and the
+  #      same full 26-letter alphabet including I, O and Q. The AA 000 AA
+  #      grammar in this file therefore rests on two independent primaries,
+  #      not one.
+  #   2. THE TWO SERIES CANNOT COLLIDE — YET. The ordinary series climbs from
+  #      AA 000 AA and the alternative series descends from ZZ 000 AA, with
+  #      the second letter running in REVERSE. They will meet only when the
+  #      national space is exhausted from both ends, which is decades away;
+  #      until then the leading pair is a reliable discriminator and a parse
+  #      API should rank an alternative interpretation for high Z-block
+  #      serials.
+  # =========================================================================
+  - id: ar-alternative-2018
+    class: standard
+    categories: [car, van, truck, bus, semitrailer]
+    period: { start: 2019 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL 999 LL"
+      regex: '\A[A-Z]{2} ?\d{3} ?[A-Z]{2}\z'
+      charset: { notes: "full 26-letter alphabet, expressly enumerated in Título II Cap. I Sec. 3ª art. 6° — see charset_defaults" }
+      progression: >-
+        DESCENDING from ZZ 000 AA, right to left, with the SECOND position
+        running in reverse alphabetical order (Z, Y, X, ...) while every other
+        alphabetic position runs forward. This is the mirror image of the
+        ordinary Mercosur series and is the only Argentine series whose
+        odometer runs backwards in any position.
+    design:
+      plate: { w: 400, h: 130, unit: mm }
+      plate_note: "the Anexo III model; the Section prescribes no separate dimensions, so the Anexo A specification for the ordinary automotor plate governs"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: top, color: "#0033A0", content: "mercosur-emblem+ARGENTINA+flag", hex_basis: observed }
+      font: { name: "FE-Engschrift", cap_height_mm: 65 }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+      distinguishing_note: >-
+        WHAT MAKES IT "ALTERNATIVA" IS NOT RECORDED IN THE CONSOLIDATED TEXT.
+        Anexo III is a MODEL IMAGE in the Digesto PDF and the surrounding
+        articles never describe how the alternative plate differs visually from
+        the ordinary one. The difference is therefore a recorded gap, not a
+        guess: no colour, marking or legend claim is made here beyond what the
+        governing Anexo A specification gives.
+    region_encoding: none
+    region_encoding_note: "none — Argentine dominios encode no geography, and the alternative series is allocated from one national pool exactly as the ordinary one is"
+    validity:
+      note: >-
+        The vehicle is registered but restricted: the Registro Seccional
+        inserts the legend "Vehículo con circulación restringida" and, pending
+        the metal plates, issues provisional plates (automotores) or a
+        thirty-day permiso de circulación (motovehículos).
+    sources:
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1.pdf  # Digesto Título I Cap. IX Sec. 1ª art. 2 c), verbatim: 'La \"Placa de Identificación Metálica Alternativa\" del automotor, que contendrá el dominio otorgado a este, compuesto por CUATRO (4) letras y TRES (3) números, cuyo modelo obra como Anexo III de esta Sección y en el que se establece su diseño, contenido y demás características.'"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo2.pdf  # Digesto Título II Cap. I Sec. 3ª arts. 3, 5 and 6 — WHEN the alternative plate is issued (a restriction disclosed by the Certificación de Seguridad Vehicular), the 'Vehículo con circulación restringida' legend, and the ZZ 000 AA descending allocation quoted in full above"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1_correlatividades.pdf  # CORRELATIVIDAD Cap. IX Sec. 1ª: 'Anexo III.- Incorporado por artículo 3° de la Disposición D.N. N° 125/18'; and 'Artículo 2°.- … Incorporado conforme Disposición D.N. N° 480/18 (puesto en vigencia por Disposición D. N. N° 194/2019)'"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/buscarNormas.do?tipoNorma=4&numero=194&anioSancion=2019&dependencia=258  # Disposición D.N. N° 194/2019 — the 1 July 2019 in-force date for the Disposición 125/2018 package, which is this series' period.start"
+    notes: >-
+      The ALTERNATIVE plate for automotores whose circulation is restricted.
+      Same seven-character Mercosur grammar as ar-mercosur-2016 and the same
+      400 x 130 mm plate — the two are separated by ALLOCATION, not by shape:
+      this series descends from ZZ 000 AA while the ordinary one climbs from
+      AA 000 AA. period.start 2019 is the in-force date set by Disposición
+      194/2019 for the Disposición 125/2018 package, not the 2018 approval
+      date, which is the same treatment ar-mavi-2019 and ar-trailer-2019 get.
+
+  - id: ar-alternative-motorcycle-2018
+    class: motorcycle
+    categories: [motorcycle, moped]
+    period: { start: 2019 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L 999 LLL"
+      regex: '\A[A-Z] ?\d{3} ?[A-Z]{3}\z'
+      charset: { notes: "full 26-letter alphabet — see charset_defaults" }
+      progression: >-
+        DESCENDING from Z 000 AAA, right to left, with the FIRST position
+        running in reverse alphabetical order — the motorcycle counterpart of
+        the car rule, and note that the reversed position is the first here and
+        the second there, exactly as the article distinguishes them.
+    design:
+      plate: { w: 200, h: 170, unit: mm }
+      plate_note: "the Anexo IV model; the Anexo A motovehículo specification governs its dimensions"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      band: { side: top, color: "#0033A0", content: "mercosur-emblem+ARGENTINA+flag", hex_basis: observed }
+      font: { name: "FE-Engschrift", cap_height_mm: 53 }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: false
+      distinguishing_note: "as for ar-alternative-2018: Anexo IV is a model image and the consolidated text describes no visual difference — recorded gap"
+    region_encoding: none
+    validity:
+      note: >-
+        Pending the metal plate the Registro issues a permiso de circulación
+        valid THIRTY (30) days (Título II Cap. I Sec. 3ª art. 5 b), referring to
+        Título II Cap. XVI Sec. 10ª art. 4°).
+    sources:
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1.pdf  # Digesto Título I Cap. IX Sec. 1ª art. 2 d), verbatim: 'La \"Placa de Identificación Metálica Alternativa\" para motovehículos, que contendrá el dominio otorgado a este, compuesto por CUATRO (4) letras y TRES (3) números, cuyo modelo obra como Anexo IV de esta Sección.'"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo2.pdf  # Digesto Título II Cap. I Sec. 3ª art. 6°: 'Z 000 AAA en el caso de los motovehículos … Cuando corresponda modificar … la primera posición en el caso de motovehículos, la sucesión alfabética anteriormente indicada seguirá el sentido inverso.'"
+      - "https://www.dnrpa.gov.ar/nuevodigesto/digesto/Titulo1_correlatividades.pdf  # CORRELATIVIDAD: 'Anexo IV.- Incorporado por artículo 4° de la Disposición D.N. N° 125/18'"
+      - "https://servicios.infoleg.gob.ar/infolegInternet/buscarNormas.do?tipoNorma=4&numero=194&anioSancion=2019&dependencia=258  # Disposición D.N. N° 194/2019 — the in-force date"
+    notes: >-
+      The ALTERNATIVE plate for motovehículos with restricted circulation.
+      Shares the 1+3+3 grammar and the 200 x 170 mm plate with
+      ar-mercosur-motorcycle-2016 and is separated from it only by descending
+      allocation from Z 000 AAA. Note the asymmetry the instrument is careful
+      about: the reversed alphabetic position is the FIRST for motorcycles and
+      the SECOND for cars.

--- a/plates/mx.yml
+++ b/plates/mx.yml
@@ -1,0 +1,1372 @@
+# plates/mx.yml — Mexico (PRD-PLATES gate L3).
+#
+# EVERY format, dimension, character-metric, alphabet and series-allocation
+# claim in this file comes from ONE primary instrument and its predecessor,
+# both read off the Diario Oficial de la Federación:
+#
+#   * NOM-001-SCT-2-2016 — "Placas metálicas, calcomanías de identificación y
+#     tarjetas de circulación empleadas en automóviles, tractocamiones,
+#     autobuses, camiones, motocicletas, remolques, semirremolques,
+#     convertidores y grúas, matriculados en la República Mexicana, licencia
+#     federal de conductor, calcomanía de verificación físico-mecánica, listado
+#     de series asignadas por tipo de vehículo, servicio y entidad federativa o
+#     dependencia de gobierno, especificaciones y método de prueba",
+#     DOF 24 June 2016. In force sixty calendar days after publication
+#     (numeral 13, verbatim: "Para los efectos correspondientes, la presente
+#     Norma Oficial Mexicana entrará en vigor sesenta días naturales contados a
+#     partir de la fecha de su publicación en el Diario Oficial de la
+#     Federación") — 23 August 2016.
+#   * NOM-001-SCT-2-2000, DOF 26 January 2001, in force sixty calendar days
+#     later (27 March 2001) and CANCELLED by the 2016 NOM (Transitorio SEGUNDO,
+#     verbatim: "Una vez que entre en vigor la presente Norma Oficial Mexicana
+#     definitiva, se cancela la Norma Oficial Mexicana NOM-001-SCT-2-2000 …
+#     publicada en el Diario Oficial de la Federación el 26 de enero de 2001, y
+#     sus modificaciones publicadas con fecha 1 de julio de 2002 y 3 de marzo de
+#     2003"). This is the ONE-SERIES-BACK layer.
+#   * The ACUERDO of 25 September 2000 (DOF) — the Secretarial agreement the
+#     NOM is issued under, which is where the PLATE VALIDITY rule lives and,
+#     decisively for this file, where the COLOURS are made optional.
+#
+# SIX STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. MEXICO IS FEDERATED IN ISSUANCE AND UNITARY IN FORMAT — SO IT GETS ONE
+#    FILE, NOT THIRTY-TWO. The 31 states and Ciudad de México each register
+#    their own vehicles and each design their own plate artwork, but the
+#    CHARACTER ORDER of every Mexican serial is fixed nationally by the SCT in
+#    Tabla C del Apéndice "B" Normativo, and the SERIAL RANGES are allocated
+#    nationally in Apéndice "C" Normativo so that no two states can collide.
+#    NOM 5.1.4.4, verbatim: "La conformación de los caracteres de
+#    identificación (letras y dígitos) que integran los números de serie para
+#    los diferentes tipos de placas, deben sujetarse a lo establecido en la
+#    Tabla C del Apéndice 'B' Normativo." Every `format.pattern` below is a row
+#    of that table. Contrast us-*.yml and (in this same wave) au-*/ca-*: those
+#    federations set their formats per state, Mexico does not.
+#
+# 2. THE COLOURS ARE OPTIONAL AND STATE-CHOSEN — SO NO STANDARD SERIES HERE
+#    CARRIES A BACKGROUND HEX. The 2000 Acuerdo, ARTICULO TERCERO, verbatim:
+#    "la combinación de colores a utilizar en los caracteres de identificación,
+#    fondo y leyendas, serán optativos, para lo cual deben utilizarse colores
+#    contrastantes, fondo oscuro con caracteres claros o fondo claro con
+#    caracteres oscuros, debiendo remitir a la Secretaría, por conducto de la
+#    Dirección General de Autotransporte Federal para su autorización, los
+#    modelos de placas que determinen." A Mexican plate's colours are therefore
+#    a per-state, per-canje FACT that changes every three years (see 3), not a
+#    national one — so `design.background.color` is ABSENT from every ordinary
+#    series in this file and its absence is a sourced finding, exactly as
+#    plates/gb.yml omits `design.plate` because no British regulation fixes it.
+#    The NOM prescribes colours in exactly one place — Sistema Nacional de
+#    Protección Civil (5.1.6.5.1: "Placa metálica de color rojo pantone 200C al
+#    100%") — and that is the only series here that carries one.
+#
+# 3. THE THREE-YEAR CYCLE IS REAL, IT IS PRIMARY, AND IT IS NOT A REDESIGN
+#    MANDATE. Acuerdo ARTICULO SEPTIMO, verbatim: "La vigencia de las placas
+#    será de tres años, contados a partir de que las entidades federativas, el
+#    Distrito Federal o la Secretaría hayan realizado sus canjes totales de
+#    placas, ya sea en los años 1998, 1999 o 2000, de tal forma que los
+#    siguientes canjes totales deberán efectuarse en los años 2001, 2002 o 2003,
+#    según corresponda y así sucesivamente en los trienios posteriores." NOM
+#    2016 numeral 9.4 keeps that rule alive by reference. What the instruments
+#    fix is a REPLACEMENT cycle (canje) whose phase differs per state; the
+#    widely repeated "Mexican states redesign their plates every three years"
+#    is the consequence, not the rule, and the artwork of a given state in a
+#    given trienio is NOT modelled here (PRD-PLATES §2.5).
+#
+# 4. THE HYPHENS ARE PHYSICAL. NOM Apéndice A, under every figure, verbatim:
+#    "Las dimensiones de los guiones serán de 16 x 5.6." — the group separator
+#    is a stamped 16 × 5.6 mm bar, not typography, and 5.1.4.3 says the figures
+#    "contienen un guión o dos guiones de separación entre letras y dígitos".
+#    Every regex here therefore spells the hyphen as a MANDATORY literal
+#    (PRD-PLATES §2.6 rule 2: regexes are written in printed form). The
+#    five-character motorcycle formats print NO separator and carry none.
+#
+# 5. FRONT AND REAR DIFFER — BY A LETTER, NOT A COLOUR. NOM 5.3.5, verbatim:
+#    "Asimismo, se colocarán en la esquina superior izquierda y en diferente
+#    color cada una, la letra 'F' para la placa frontal y la letra 'T' para la
+#    placa trasera del vehículo." Both plates carry the same serial; the F/T
+#    marker is what differs. `rear_differs: true` on the road series records it.
+#    5.3.4: "Las placas deberán tener impreso el Escudo Nacional en la parte
+#    inferior izquierda."
+#
+# 6. FOUR LETTERS ARE FORBIDDEN, AND ONLY SINCE 2016. Apéndice C repeats under
+#    every per-entity table: "NOTA: EN LOS CARACTERES ALFABÉTICOS NO DEBERÁN
+#    UTILIZARSE LAS LETRAS I, Ñ, O, Q." No equivalent note appears anywhere in
+#    NOM-001-SCT-2-2000, so the 2001-era series in this file carry NO
+#    `regex_strict` — their alphabet is unrestricted so far as any primary
+#    secured for this pass says. Ñ is outside this dataset's serial alphabet
+#    (plates/_meta/separators.yml) and so never reaches a regex.
+#
+# REGEX POLICY (identical to plates/nl.yml, de.yml and gb.yml): `format.regex`
+# is the LINT-ROUND-TRIPPABLE regex — the lint generates serials from
+# `format.pattern` (L -> any A-Z, 9 -> any 0-9) and requires the regex to accept
+# every one, so `regex` can never be narrower than the pattern's own alphabet.
+# `format.regex_strict` carries the sourced 23-letter NOM alphabet, which
+# `regex` cannot carry because the lint generates "I", "O" and "Q".
+jurisdiction: mx
+authority:
+  name: Secretaría de Comunicaciones y Transportes (SCT) — Dirección General de Autotransporte Federal
+  url: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016"
+binding: vehicle
+binding_note: >-
+  Mexican plates bind to the VEHICLE: the NOM's stated purpose (Considerando)
+  is "que los vehículos automotores nacionales que circulan dentro del
+  territorio nacional, se encuentren debidamente identificados y se compruebe
+  la posesión legal de los mismos". Registration is state-level (the entidad
+  federativa or the Secretaría for federal carriers), and a change of state
+  means a new plate out of the receiving state's allocated range.
+
+instrument:
+  citation: "NOM-001-SCT-2-2016, Norma Oficial Mexicana, expedida por el Comité Consultivo Nacional de Normalización de Transporte Terrestre (Subsecretaría de Transporte, SCT)"
+  published: "2016-06-24"
+  in_force: "2016-08-23"          # publication + 60 días naturales (numeral 13)
+  in_force_rule: >-
+    Numeral 13 (Vigencia), verbatim: "Para los efectos correspondientes, la
+    presente Norma Oficial Mexicana entrará en vigor sesenta días naturales
+    contados a partir de la fecha de su publicación en el Diario Oficial de la
+    Federación."
+  cancels: "NOM-001-SCT-2-2000 (DOF 26-01-2001, y sus modificaciones DOF 01-07-2002 y 03-03-2003) — Transitorio SEGUNDO"
+  enabling: >-
+    Ley Orgánica de la Administración Pública Federal art. 36 fracc. I, XII y
+    XXVII; Ley Federal sobre Metrología y Normalización arts. 1, 38 fracc. II,
+    40 fracc. XVI, 41, 43, 47, 51 y 64; Ley de Caminos, Puentes y Autotransporte
+    Federal art. 5 fracc. VI; Reglamento de Tránsito en Carreteras y Puentes de
+    Jurisdicción Federal art. 85; and the Acuerdo Secretarial published in the
+    DOF on 25 September 2000, Décimo Sexto.
+  draft_history: "PROY-NOM-001-SCT2-2012 was ordered published on 21 March 2013 (Considerando) — the definitive NOM arrived three years later."
+  source: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # front matter, Considerandos, numerales 1-15, Apéndices A/B/C; accessed 2026-08-02"
+  licence: >-
+    DOF texts are edicts of the Mexican federal government. Ley Federal del
+    Derecho de Autor art. 14 fracc. VIII excludes from copyright protection
+    "los textos legislativos, reglamentarios, administrativos o judiciales, así
+    como sus traducciones oficiales" (publication of them as a compilation is
+    reserved to the State). Facts are extracted; no DOF text is redistributed
+    beyond the quoted fragments this file cites.
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+charset_defaults:
+  letters: [A, B, C, D, E, F, G, H, J, K, L, M, N, P, R, S, T, U, V, W, X, Y, Z]
+  excluded_letters: [I, O, Q]
+  excluded_letters_also: ["Ñ"]
+  excluded_letters_note: >-
+    "NOTA: EN LOS CARACTERES ALFABÉTICOS NO DEBERÁN UTILIZARSE LAS LETRAS
+    I, Ñ, O, Q." — repeated verbatim under every per-entity allocation table in
+    Apéndice C Normativo of the 2016 NOM. The rule is NEW in 2016: no such note
+    appears in NOM-001-SCT-2-2000, whose own Apéndice C tables carry none.
+  source: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C Normativo, per-entity tables, closing NOTA"
+
+common:
+  dimensions:
+    road: { w: 300, h: 150, unit: mm }
+    motorcycle_2016: { w: 215, h: 134, unit: mm }
+    motorcycle_2001: { w: 150, h: 100, unit: mm }
+    note: >-
+      NOM 5.1.1, verbatim: "Las placas metálicas para automóviles,
+      tractocamiones, autobuses, camiones, remolques, semirremolques y
+      convertidores (dolly), grúas deben ser rectangulares con las siguientes
+      dimensiones: Largo 300 mm / Ancho 150 mm." 5.1.2: "Placas metálicas para
+      motocicleta deben ser rectangulares con las siguientes dimensiones:
+      Largo 215 mm / Ancho 134 mm." The MOTORCYCLE plate GREW in 2016: the 2000
+      NOM's 5.1.1.2 gave 150 × 100 mm. The road plate is unchanged at 300 × 150
+      (the North American 12 × 6 inch convention).
+    corners: "radius 14,0 mm; a 3,0 mm hole 13,0 mm from the periphery in the upper-right corner for the SCT aluminium seal; four 20,0 × 6,0 mm mounting slots (two on motorcycle plates); 3,0 mm perimeter ceja (5.1.1.1, 5.1.2.1)"
+    source: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # 5.1.1, 5.1.1.1, 5.1.2, 5.1.2.1"
+  characters:
+    emboss_height_mm: 2.0
+    stroke_width_road_mm: 5.6
+    stroke_width_motorcycle_mm: 5.0
+    hyphen_mm: { w: 16, h: 5.6 }
+    note: >-
+      5.1.3.1, verbatim: "los caracteres de las placas metálicas para
+      automóviles, tractocamiones, autobuses, camiones, remolques,
+      semirremolques y convertidores (dolly), grúas, deben ser troquelados en
+      alto relieve con una altura de 2,0 mm y un ancho de rasgo de 5,6 mm …
+      utilizando los patrones de letras y dígitos establecidos en las figuras de
+      la 36 a la 39 del Apéndice A Normativo. Para el caso de motocicletas los
+      caracteres deberán ser troquelados en alto relieve con una altura de
+      2,0 mm y un ancho de rasgo de 5,0 mm." 5.1.3.2: "El área de caracteres
+      alfanuméricos de la serie de placa deberá ser exclusiva y estar libre de
+      figuras, distintivos o leyendas que dificulten su lectura."
+    font_posture: >-
+      The glyph shapes are STATUTORY DRAWINGS (figuras 36-39 of Apéndice A
+      Normativo), not a named typeface — the same posture PRD-PLATES §6 records
+      for the UK, Germany and Spain. No licensable font is mandated and none is
+      recorded here.
+    source: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # 5.1.3.1, 5.1.3.2, 5.1.4.3 (guiones 16 x 5.6)"
+  security:
+    two_d_code: "20 × 20 mm two-dimensional error-correcting code printed directly on the reflective sheeting, controlled by the SCT (5.3.11.1)"
+    seal: "aluminium rivet 6,5-7,5 mm bearing 'SCT' on the face and the manufacturer's registration number on the back (5.3.1), plus two engraved seals in the sheeting itself (5.3.2)"
+    escudo: "Escudo Nacional printed at the lower left of every plate (5.3.4)"
+    front_rear: "letter 'F' (frontal) or 'T' (trasera) in the upper-left corner, each in a different colour (5.3.5)"
+    source: "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # 5.3.1, 5.3.2, 5.3.4, 5.3.5, 5.3.11.1"
+  validity:
+    years: 3
+    note: >-
+      Acuerdo (DOF 25-09-2000) ARTICULO SEPTIMO, verbatim: "La vigencia de las
+      placas será de tres años, contados a partir de que las entidades
+      federativas, el Distrito Federal o la Secretaría hayan realizado sus
+      canjes totales de placas, ya sea en los años 1998, 1999 o 2000, de tal
+      forma que los siguientes canjes totales deberán efectuarse en los años
+      2001, 2002 o 2003, según corresponda y así sucesivamente en los trienios
+      posteriores." NOM 2016 numeral 9.4 keeps it in force by reference: "La
+      vigencia de las placas y calcomanías se sujetará a lo dispuesto en el
+      artículo séptimo del Acuerdo Secretarial … publicado en el Diario Oficial
+      de la Federación el 25 de Septiembre de 2000." In practice states run
+      their canje on their own phase, so the trienio boundary is per-state and
+      is NOT modelled as a series period.
+    source: "https://www.dof.gob.mx/nota_detalle.php?codigo=2060390&fecha=25/09/2000  # ARTICULO SEPTIMO"
+  colours:
+    posture: state-optional
+    note: >-
+      See file header §2. Acuerdo ARTICULO TERCERO makes the colour combination
+      optativa for every canje from 2000 onward, subject only to contrast and to
+      SCT authorization of the model. Consequently `design.background.color` is
+      absent from the ordinary series in this file. Where a colour IS
+      prescribed — Protección Civil — it is carried on that series and cited.
+    source: "https://www.dof.gob.mx/nota_detalle.php?codigo=2060390&fecha=25/09/2000  # ARTICULO TERCERO, penultimate paragraph"
+
+region_encoding_note: >-
+  Mexican plates encode the issuing entidad federativa NOT by a prefix but by
+  the RANGE the serial falls in — a national allocation in Apéndice C Normativo.
+  The table is large, closed and primary, so it lives in
+  plates/_decode/mx-entity-series.yml and is referenced from the series below.
+
+series:
+
+  # =========================================================================
+  # TRANSPORTE PRIVADO — ENTIDADES FEDERATIVAS. Tabla C row 9. This is the
+  # national private format and the single most important record in this file.
+  # =========================================================================
+  - id: mx-private-car-2016
+    class: standard
+    categories: [car]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LLL-999-L"
+      regex: '\A[A-Z]{3}-\d{3}-[A-Z]\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]{3}-\d{3}-[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+      charset:
+        letters: [A, B, C, D, E, F, G, H, J, K, L, M, N, P, R, S, T, U, V, W, X, Y, Z]
+        notes: "I, Ñ, O and Q are excluded by the Apéndice C nota — see charset_defaults"
+      progression: >-
+        Allocated as a contiguous interval per entidad federativa
+        (AAA-001-A … AFZ-999-Z is Aguascalientes, AGA-001-A … CYZ-999-Z is Baja
+        California, and so on to ZDA-001-A … ZHZ-999-Z for Zacatecas). Within a
+        state the NOM publishes only the interval, not the issue order.
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder, note: "Escudo Nacional at the lower left (5.3.4), plus whatever gráficos, emblemas, logotipos or escudos the state elects under 5.3.3" }
+      rear_differs: true
+      rear_differs_note: "same serial front and rear; the front plate carries 'F' and the rear 'T' in the upper-left corner, each in a different colour (5.3.5)"
+      colour_note: "state-optional, contrasting, SCT-authorized — see common.colours"
+    region_encoding: "plates/_decode/mx-entity-series.yml  # private_entity, car_from/car_to"
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice B Normativo Tabla C, row 9 'Transporte Privado (Entidades Federativas) — Automóviles — AAA-000-A'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A, Figura 18 'Transporte Privado Automóvil Entidades Federativas' (siete caracteres); guiones 16 x 5.6"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C Normativo, 'NUMERACIÓN DE LAS PLACAS TRANSPORTES PRIVADOS ASIGNADAS A CADA ENTIDAD FEDERATIVA' — the 31 per-state ranges carried in the decode file"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=2060390&fecha=25/09/2000  # Acuerdo ARTICULO TERCERO (colours optional) and SEPTIMO (three-year vigencia)"
+    notes: >-
+      THE current private-car plate of the 31 Mexican states, three letters,
+      three digits, one letter, created by NOM-001-SCT-2-2016. period.start 2016
+      is the INSTRUMENT date: the NOM was published on 24 June 2016 and came into
+      force on 23 August 2016, and each state then reaches the new format on its
+      own canje date, so a 2016 start is the earliest any AAA-000-A plate can
+      exist, not the date every state began issuing them. Ciudad de México is NOT
+      in this series — it issues A00-AAA (see mx-cdmx-private-car-2016), which is
+      why a CDMX plate can never collide with a state plate.
+
+  - id: mx-private-truck-2016
+    class: standard
+    categories: [truck]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL-9999-L"
+      regex: '\A[A-Z]{2}-\d{4}-[A-Z]\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]{2}-\d{4}-[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+      charset: { notes: "no I/Ñ/O/Q — see charset_defaults" }
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: true
+      colour_note: "state-optional — see common.colours"
+    region_encoding: "plates/_decode/mx-entity-series.yml  # private_entity, truck_from/truck_to"
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 9 'Camiones — AA-0000-A'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 19 'Transporte Privado Camión, Tractocamión y Grúas Entidades Federativas' (siete caracteres)"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C per-entity truck ranges (AA-0001-A … AF-9999-Z Aguascalientes, etc.)"
+    notes: >-
+      Private TRUCK, TRACTOCAMIÓN and GRÚA registrations of the 31 states — a
+      different serial space from the private car series and a different shape,
+      which is what lets a Mexican decoder tell a camión from an automóvil
+      without any other signal.
+
+  - id: mx-private-bus-2016
+    class: standard
+    categories: [bus]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99-LLL-99"
+      regex: '\A\d{2}-[A-Z]{3}-\d{2}\z'
+      regex_strict: '\A\d{2}-[ABCDEFGHJKLMNPRSTUVWXYZ]{3}-\d{2}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+      colour_note: "state-optional — see common.colours"
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 9 'Autobuses — 00-AAA-00'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 20 'Transporte Privado Autobús Entidades Federativas'"
+    notes: >-
+      Private BUS registrations of the 31 states. The NOM allocates the
+      per-entity bus ranges in a separate Apéndice C table which was NOT carried
+      into plates/_decode/mx-entity-series.yml in this pass (recorded gap); a
+      decoder can still identify the SHAPE as a state private bus.
+
+  - id: mx-private-trailer-2016
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "9LL-999-L"
+      regex: '\A\d[A-Z]{2}-\d{3}-[A-Z]\z'
+      regex_strict: '\A\d[ABCDEFGHJKLMNPRSTUVWXYZ]{2}-\d{3}-[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+      colour_note: "state-optional — see common.colours"
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 9 'Remolques — 0AA-000-A'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 21 'Transporte Privado Remolque Entidades Federativas'"
+    notes: >-
+      Private TRAILER and SEMITRAILER registrations of the 31 states. A trailer
+      carries ONE plate, so `rear_differs` is false and the F/T rule of 5.3.5
+      does not bite here.
+
+  - id: mx-private-dolly-2016
+    class: trailer
+    categories: [dolly]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L-99999"
+      regex: '\A[A-Z]-\d{5}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]-\d{5}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C rows 8 and 9, 'Convertidor (Dolly) — A-00000'"
+    notes: >-
+      CONVERTIDOR (dolly) — the converter axle that turns a semitrailer into a
+      full trailer. Tabla C gives the SAME order (A-00000) for the Ciudad de
+      México and the Entidades Federativas rows, which is the one place the NOM
+      hands two issuers one shape; they are separated only by their allocated
+      ranges, so a dolly serial does not by itself say which issuer made it.
+
+  # =========================================================================
+  # TRANSPORTE PRIVADO — CIUDAD DE MÉXICO. Tabla C row 8. CDMX is a separate
+  # issuer with separate FORMATS, which is why it needs no separate file.
+  # =========================================================================
+  - id: mx-cdmx-private-car-2016
+    class: standard
+    categories: [car]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L99-LLL"
+      regex: '\A[A-Z]\d{2}-[A-Z]{3}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]\d{2}-[ABCDEFGHJKLMNPRSTUVWXYZ]{3}\z'
+      charset: { notes: "no I/Ñ/O/Q — see charset_defaults" }
+      progression: "one allocated interval, A01-AAA … Z99-ZZZ, 27'704,259 combinations"
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: true
+      colour_note: "CDMX chooses its own colours under the Acuerdo — see common.colours"
+    region_encoding: "plates/_decode/mx-entity-series.yml  # private_cdmx, vehicle: car"
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 8 'Transporte Privado (Ciudad de México) — Automóviles — A00-AAA'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 14 'Transporte Privado Automóvil Ciudad de México' (seis caracteres)"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C 'NUMERACIÓN DE LAS PLACAS ASIGNADAS A LA CIUDAD DE MÉXICO — TRANSPORTES PRIVADOS — A01-AAA - Z99-ZZZ'"
+    notes: >-
+      Private cars of the Ciudad de México — SIX characters where the states use
+      seven, and one single national range rather than 31 intervals. The pattern
+      is what identifies the issuer: no state plate has this shape.
+
+  - id: mx-cdmx-private-truck-2016
+    class: standard
+    categories: [truck]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L-999-LL"
+      regex: '\A[A-Z]-\d{3}-[A-Z]{2}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]-\d{3}-[ABCDEFGHJKLMNPRSTUVWXYZ]{2}\z'
+      progression: "A-001-AA … Z-999-ZZ, 12'154,833 combinations"
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: "plates/_decode/mx-entity-series.yml  # private_cdmx, vehicle: truck"
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 8 'Camiones — A-000-AA'; Apéndice A Figura 15"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C CDMX transportes privados camiones range"
+    notes: >-
+      Private trucks, tractocamiones and grúas of the Ciudad de México. NOTE the
+      collision hazard this file cannot remove: the SAME shape A-000-AA is what
+      the FEDERAL autotransporte transfronterizo de pasaje row of Tabla C also
+      prescribes, so a bare A-000-AA string is ambiguous between CDMX private
+      truck and federal cross-border passenger service, and only the plate's
+      leyendas and colours (which the NOM leaves to the issuer) resolve it.
+
+  - id: mx-cdmx-private-trailer-2016
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L-9L-99"
+      regex: '\A[A-Z]-\d[A-Z]-\d{2}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]-\d[ABCDEFGHJKLMNPRSTUVWXYZ]-\d{2}\z'
+      progression: "A-1A-01 … Z-9Z-99, 471,339 combinations"
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: "plates/_decode/mx-entity-series.yml  # private_cdmx, vehicle: trailer"
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 8 'Remolques — A-0A-00'; Apéndice A Figura 17 (cinco caracteres)"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C CDMX remolques range A-1A-01 - Z-9Z-99"
+    notes: >-
+      Private trailers and semitrailers of the Ciudad de México. Five characters
+      in three groups — the most distinctive shape in the whole Mexican set and
+      therefore a near-free identification for a parse API.
+
+  # =========================================================================
+  # TRANSPORTE PRIVADO FRONTERIZO — the BORDER-ZONE private series. Tabla C
+  # row 2. Seven entities only, all of them on a land border.
+  # =========================================================================
+  - id: mx-private-border-car-2016
+    class: standard
+    categories: [car]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L99-LLL-9"
+      regex: '\A[A-Z]\d{2}-[A-Z]{3}-\d\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]\d{2}-[ABCDEFGHJKLMNPRSTUVWXYZ]{3}-\d\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+      colour_note: "state-optional — see common.colours"
+    region_encoding: "plates/_decode/mx-entity-series.yml  # private_border, car_from/car_to"
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 2 'Transporte Privado Fronterizo — Automóviles — A00-AAA-0'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 8 'Para vehículos del Transporte Privado Local Fronterizo' (siete caracteres)"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C 'FRONTERIZOS — NUMERACIÓN DE LAS PLACAS ASIGNADAS A CADA ENTIDAD FEDERATIVA TRANSPORTES PRIVADOS' — seven entities: BC, BCS, Coahuila, Chiapas, Chihuahua, Sonora, Tamaulipas"
+    notes: >-
+      The FRONTERIZO private-car plate, issued in the border zone only, by the
+      seven entities Apéndice C lists (Baja California, Baja California Sur,
+      Coahuila, Chiapas, Chihuahua, Sonora, Tamaulipas). Its ranges live in the
+      Z-tail of the national space, deliberately far from the ordinary private
+      allocation. Border trucks, buses and trailers take AAA-000-A — the SAME
+      shape as the ordinary private CAR series — and are told apart only by
+      range, which is the sharpest reason this jurisdiction needs a decode file
+      rather than a prefix rule.
+
+  # =========================================================================
+  # MOTOCICLETAS — PRIVADAS. Tabla C row 16 gives THREE orders for one
+  # modality, so this is three series (one series = one PATTERN, the same rule
+  # plates/nl.yml applies to the GV sidecodes).
+  # =========================================================================
+  - id: mx-private-motorcycle-2016-a
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L99LL"
+      regex: '\A[A-Z]\d{2}[A-Z]{2}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]\d{2}[ABCDEFGHJKLMNPRSTUVWXYZ]{2}\z'
+    design:
+      plate: { w: 215, h: 134, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+      note: "one plate, rear only; characters troquelados at 2,0 mm height and 5,0 mm stroke (5.1.3.1)"
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 16 'Transporte Privado — Ciudad de México y Entidades Federativas Motocicleta — A00AA / 0A0AA / A0AA0'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 29 'Transporte Privado Motocicleta Ciudad de México y Entidades Federativas' (cinco caracteres); 5.1.2 dimensions 215 x 134 mm"
+    notes: >-
+      Private MOTORCYCLE order A00AA — the first of the three arrangements Tabla
+      C sanctions for one and the same modality. Five characters and NO printed
+      hyphen (Figura 29 is a five-character figure). Both the Ciudad de México
+      and the Entidades Federativas issue from this row, so the shape does not
+      identify the issuer.
+
+  - id: mx-private-motorcycle-2016-b
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "9L9LL"
+      regex: '\A\d[A-Z]\d[A-Z]{2}\z'
+      regex_strict: '\A\d[ABCDEFGHJKLMNPRSTUVWXYZ]\d[ABCDEFGHJKLMNPRSTUVWXYZ]{2}\z'
+    design:
+      plate: { w: 215, h: 134, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 16, second order '0A0AA'"
+    notes: >-
+      Private MOTORCYCLE order 0A0AA — the second of the three Tabla C
+      arrangements. Kept as its own entry because a series is one PATTERN and a
+      parse API must be able to score each shape independently.
+
+  - id: mx-private-motorcycle-2016-c
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L9LL9"
+      regex: '\A[A-Z]\d[A-Z]{2}\d\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]\d[ABCDEFGHJKLMNPRSTUVWXYZ]{2}\d\z'
+    design:
+      plate: { w: 215, h: 134, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 16, third order 'A0AA0'"
+    notes: >-
+      Private MOTORCYCLE order A0AA0 — the third of the three Tabla C
+      arrangements, and the only Mexican shape that both begins with a letter
+      and ends with a digit at five characters.
+
+  # =========================================================================
+  # SERVICIO PÚBLICO LOCAL — the state and CDMX for-hire series. Tabla C
+  # rows 10, 11 and 14.
+  # =========================================================================
+  - id: mx-public-car-2016
+    class: taxi
+    categories: [car]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L-999-LLL"
+      regex: '\A[A-Z]-\d{3}-[A-Z]{3}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]-\d{3}-[ABCDEFGHJKLMNPRSTUVWXYZ]{3}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+      colour_note: "state-optional — see common.colours"
+    region_encoding: "plates/_decode/mx-entity-series.yml  # public_border for the seven border entities; the non-border public-local ranges were not carried in this pass"
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 11 'Público Local (Entidades Federativas) — Automóviles — A-000-AAA'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 25 'Automóvil público local para Entidades Federativas' (siete caracteres)"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 3 'Público Local (Fronterizos) — Automóviles, Camiones, Autobuses y Remolques — A-000-AAA' (same order, Z-tail ranges)"
+    notes: >-
+      SERVICIO PÚBLICO LOCAL cars — taxis and for-hire cars licensed by an
+      entidad federativa. `class: taxi` is used for the whole público-local
+      family because _meta/classes.yml has no for-hire-carrier value and taxi is
+      defined as "for-hire vehicles where separately serialized or colored",
+      which is exactly what this is. The BORDER público-local series shares the
+      identical order A-000-AAA and is separated only by range (Apéndice C
+      allocates it entirely inside the Z tail), so this series' regex is the
+      right shape claim for both and the decode file carries the border ranges.
+
+  - id: mx-public-truck-2016
+    class: taxi
+    categories: [truck]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "9-LLL-99L"
+      regex: '\A\d-[A-Z]{3}-\d{2}[A-Z]\z'
+      regex_strict: '\A\d-[ABCDEFGHJKLMNPRSTUVWXYZ]{3}-\d{2}[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 11 'Camiones — 0-AAA-00A'; Apéndice A Figura 26"
+    notes: >-
+      Público-local FREIGHT vehicles of the entidades federativas — carriers
+      operating under a state concession rather than a federal permit, which is
+      the line the NOM draws between this series and the Autotransporte Federal
+      family below.
+
+  - id: mx-public-bus-2016
+    class: taxi
+    categories: [bus]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L-99999-L"
+      regex: '\A[A-Z]-\d{5}-[A-Z]\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]-\d{5}-[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 11 'Autobuses — A-00000-A'; Apéndice A Figura 27"
+    notes: >-
+      Público-local BUSES of the entidades federativas — the state-concession
+      urban and intercity bus fleets. Seven characters with a five-digit middle
+      group, a shape no other Mexican series uses.
+
+  - id: mx-cdmx-public-car-2016
+    class: taxi
+    categories: [car]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L-9999-L"
+      regex: '\A[A-Z]-\d{4}-[A-Z]\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]-\d{4}-[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 10 'Público Local (Ciudad de México) — Libre y Sitio — A-0000-A'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 22 'Público local para la Ciudad de México, Libre y Sitio' (seis caracteres)"
+    notes: >-
+      The Mexico City TAXI plate — "libre" (cruising) and "sitio" (rank) taxis
+      share one order. Note the NOM shape A-0000-A is also the order Tabla C
+      row 1 gives to federal "Pasaje Económico y Mixto", so this string is
+      ambiguous on shape alone between a CDMX taxi and a federal economy
+      passenger vehicle; the leyendas resolve it.
+
+  - id: mx-cdmx-public-fixedroute-2016
+    class: taxi
+    categories: [bus, van]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "999-L-999"
+      regex: '\A\d{3}-[A-Z]-\d{3}\z'
+      regex_strict: '\A\d{3}-[ABCDEFGHJKLMNPRSTUVWXYZ]-\d{3}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 10 'Con itinerario fijo — 000-A-000'; Apéndice A Figura 23"
+    notes: >-
+      Mexico City FIXED-ROUTE public transport (microbuses, combis, the
+      "itinerario fijo" concessions) — a single letter between two three-digit
+      groups. The distinctive symmetry makes this the easiest CDMX shape to
+      recognise.
+
+  # =========================================================================
+  # DEMOSTRACIÓN (dealer/trade plates). Tabla C rows 6, 7 and 15. The CDMX row
+  # is the only Mexican series with LITERAL fixed letters.
+  # =========================================================================
+  - id: mx-cdmx-dealer-2016
+    class: dealer
+    categories: [car, truck, bus, trailer, motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "DM-LL-9"
+      regex: '\ADM-[A-Z]{2}-\d\z'
+      regex_strict: '\ADM-[ABCDEFGHJKLMNPRSTUVWXYZ]{2}-\d\z'
+      charset: { fixed_letters: "DM", notes: "the first group is literally DM (demostración); allocated range DM-AA-1 … DM-ZZ-9" }
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 6 'Transporte Privado — Demostración, Ciudad de México (Todo tipo de vehículos) — DM-AA-0'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C 'DM-AA-1 - DM-ZZ-9'; Apéndice A Figura 12 (cinco caracteres)"
+    notes: >-
+      Ciudad de México DEMOSTRACIÓN (dealer/demonstration) plates. The only
+      Mexican series whose leading group is a fixed literal — DM — which makes
+      it the one Mexican plate a machine can classify with certainty from the
+      first two characters.
+
+  - id: mx-dealer-2016
+    class: dealer
+    categories: [car, truck, bus, trailer]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "9-LL-99L"
+      regex: '\A\d-[A-Z]{2}-\d{2}[A-Z]\z'
+      regex_strict: '\A\d-[ABCDEFGHJKLMNPRSTUVWXYZ]{2}-\d{2}[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 7 'Demostración Entidades Federativas (Todo tipo de vehículos) — 0-AA-00A'; Apéndice A Figura 13 (seis caracteres)"
+    notes: >-
+      DEMOSTRACIÓN plates of the entidades federativas — the state equivalent of
+      the CDMX DM series, but with no literal marker, so it is identifiable only
+      by shape.
+
+  - id: mx-dealer-motorcycle-2016
+    class: dealer
+    categories: [motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "L999L"
+      regex: '\A[A-Z]\d{3}[A-Z]\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]\d{3}[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+    design:
+      plate: { w: 215, h: 134, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 15 'Demostración — Ciudad de México y Entidades Federativas Motocicleta — A000A'"
+    notes: >-
+      MOTORCYCLE demonstration plates, one order for both the Ciudad de México
+      and the states — five characters, letter-digits-letter, no separator.
+
+  # =========================================================================
+  # AUTO ANTIGUO (historic). Tabla C row 12 — the shortest Mexican serials.
+  # =========================================================================
+  - id: mx-cdmx-historic-2016
+    class: historic
+    categories: [car, truck, motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "9LL-99"
+      regex: '\A\d[A-Z]{2}-\d{2}\z'
+      regex_strict: '\A\d[ABCDEFGHJKLMNPRSTUVWXYZ]{2}-\d{2}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder, note: "5.1.6.3 requires a distintivo identifying the Auto Antiguo service plus the leyenda and pictograma of that service (figuras 31 y 32)" }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 12 'Transporte Privado (Autos Antiguos) — Ciudad de México — 0AA-00'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # 5.1.6.3 Auto Antiguo distintivo; Apéndice A Figura 31 (cinco caracteres)"
+    notes: >-
+      Ciudad de México AUTO ANTIGUO (historic vehicle) plates. The NOM prescribes
+      a distintivo, leyenda and pictograma for the class but — unlike Germany's H
+      suffix or Spain's histórico regime — sets NO age threshold: the eligibility
+      rule is state law and is not modelled here (recorded gap).
+
+  - id: mx-historic-2016
+    class: historic
+    categories: [car, truck, motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL-9-L"
+      regex: '\A[A-Z]{2}-\d-[A-Z]\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]{2}-\d-[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 12 'Entidades Federativas — AA-0-A'; Apéndice A Figura 32 (cuatro caracteres)"
+    notes: >-
+      AUTO ANTIGUO plates of the entidades federativas — FOUR characters, the
+      shortest serial the 2016 NOM issues anywhere, and the only Mexican format
+      with a single-digit middle group.
+
+  # =========================================================================
+  # VEHÍCULO ECOLÓGICO. Tabla C row 17 — Mexico's EV/alternative-fuel series.
+  # =========================================================================
+  - id: mx-eco-2016
+    class: electric
+    categories: [car, truck, bus, motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99L-999"
+      regex: '\A\d{2}[A-Z]-\d{3}\z'
+      regex_strict: '\A\d{2}[ABCDEFGHJKLMNPRSTUVWXYZ]-\d{3}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder, note: "distintivo per figura 33 plus the leyenda VEHÍCULO ECOLÓGICO" }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 17 'Vehículo Ecológico — Ciudad de México y Entidades Federativas — 00A-000'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # 5.1.6.4, verbatim: placas 'para los vehículos que utilicen combustibles y/o energías alternas con motores denominados ecológicos para protección del medio ambiente, deben contar en su diseño con distintivo que los identifique, como el que se muestra en la figura 33 … Así como la leyenda VEHÍCULO ECOLÓGICO'"
+    notes: >-
+      VEHÍCULO ECOLÓGICO — the Mexican alternative-fuel/EV series, one order for
+      both the Ciudad de México and the states. Note the class is broader than
+      `electric` suggests: 5.1.6.4 covers any vehicle using "combustibles y/o
+      energías alternas", so hybrids and gas conversions qualify where the issuer
+      says they do.
+
+  # =========================================================================
+  # CAPACIDADES DIFERENTES (disability). Tabla C row 22 and row 1's federal
+  # equivalent.
+  # =========================================================================
+  - id: mx-cdmx-disability-2016
+    class: specialty
+    categories: [car, truck, bus, motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99-L-99"
+      regex: '\A\d{2}-[A-Z]-\d{2}\z'
+      regex_strict: '\A\d{2}-[ABCDEFGHJKLMNPRSTUVWXYZ]-\d{2}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder, note: "5.1.6.2: distintivo per figura 30 plus the leyenda y pictograma del servicio Capacidades Diferentes" }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 22 'Capacidades Diferentes — Ciudad de México todos los vehículos — 00-A-00'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # 5.1.6.2 Capacidades Diferentes distintivo; Apéndice A Figura 30 (cinco caracteres)"
+    notes: >-
+      CAPACIDADES DIFERENTES (disability) plates of the Ciudad de México.
+      `class: specialty` is the least-bad fit from _meta/classes.yml, which has
+      no disability value; the vocabulary gap is flagged in the jurisdiction
+      dossier rather than papered over with an invented class.
+
+  - id: mx-disability-2016
+    class: specialty
+    categories: [car, truck, bus, motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99-LLL"
+      regex: '\A\d{2}-[A-Z]{3}\z'
+      regex_strict: '\A\d{2}-[ABCDEFGHJKLMNPRSTUVWXYZ]{3}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 22 'Entidades Federativas todos los vehículos — 00-AAA'"
+    notes: >-
+      CAPACIDADES DIFERENTES plates of the entidades federativas — five
+      characters in two groups, distinct from the CDMX three-group form, and one
+      of only two 2016 series that carry no letter after the digits.
+
+  # =========================================================================
+  # POLICE AND CIVIL PROTECTION. Tabla C rows 4, 5, 18, 19, 20.
+  # =========================================================================
+  - id: mx-police-2016
+    class: police
+    categories: [car, truck, van]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL-999L-9"
+      regex: '\A[A-Z]{2}-\d{3}[A-Z]-\d\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]{2}-\d{3}[ABCDEFGHJKLMNPRSTUVWXYZ]-\d\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 4 'Corporaciones Policiacas y de Vigilancia — Patrullas de todo tipo de vehículos — AA-000A-0'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 10 'Corporaciones policiacas y de vigilancia vehículo' (siete caracteres)"
+    notes: >-
+      PATRULLAS — police and public-security fleets of every level below the
+      federal police. A 2000-Acuerdo rule that the 2016 NOM does not repeat is
+      worth recording here: ARTICULO NOVENO of the Acuerdo required that "los
+      caracteres de identificación de las placas para las unidades de las
+      diferentes corporaciones policiacas y de vigilancia deben corresponder al
+      número económico que porte la unidad" — the plate had to match the fleet
+      number painted on the car.
+
+  - id: mx-police-motorcycle-2016
+    class: police
+    categories: [motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL99L"
+      regex: '\A[A-Z]{2}\d{2}[A-Z]\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]{2}\d{2}[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+    design:
+      plate: { w: 215, h: 134, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 4 (second entry) 'Patrullas de tipo motocicletas — AA00A'; Apéndice A Figura 11 (cinco caracteres)"
+    notes: >-
+      POLICE MOTORCYCLE plates — five characters, no separator, distinct from
+      every private motorcycle order by having TWO leading letters.
+
+  - id: mx-federal-police-2016
+    class: police
+    categories: [car, truck, van]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL-9999-L"
+      regex: '\A[A-Z]{2}-\d{4}-[A-Z]\z'
+      regex_strict: '\APF-\d{4}-[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+      charset: { fixed_letters: "PF", notes: "Apéndice C allocates the whole federal-police block as PF-0001-A … PF-9999-Z, so the leading pair is in practice the literal PF even though Tabla C spells the order generically as AA-0000-A" }
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: none
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 5 'Policía Federal — Patrullas de todo tipo de vehículos — AA-0000-A'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C 'SERIES ASIGNADAS PF-0001-A - PF-9999-Z'"
+    notes: >-
+      POLICÍA FEDERAL fleet plates. This is the one series in the file whose
+      ISSUING BODY no longer exists: the Policía Federal was wound up in 2019 and
+      its functions passed to the Guardia Nacional. The series is left OPEN
+      because no instrument secured for this pass closes it, and PF plates
+      remained in circulation; whether the Guardia Nacional issues from the same
+      block is a recorded gap. This is also the reason `regex_strict` is pinned
+      to the literal PF while `regex` keeps Tabla C's generic AA order — the tier
+      order (strict inside loose) holds and the honest wide claim survives.
+
+  - id: mx-emergency-2016
+    class: government
+    categories: [car, truck, van, bus]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL-999-LL"
+      regex: '\A[A-Z]{2}-\d{3}-[A-Z]{2}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]{2}-\d{3}-[ABCDEFGHJKLMNPRSTUVWXYZ]{2}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      emblem: { present: true, rendered: placeholder }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C rows 18 and 19 'Ambulancias' and 'Bomberos — Ciudad de México y Entidades Federativas — AA-000-AA' (identical order)"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 34 'Heroico Cuerpo de Bomberos y Ambulancias de Ciudad de México y Entidades Federativas' (siete caracteres)"
+    notes: >-
+      AMBULANCIAS and BOMBEROS. Tabla C gives them two rows and ONE order
+      (AA-000-AA), and Apéndice A gives them ONE figure (34), so under
+      PRD-PLATES §2.3 they are one series with a shared format and design rather
+      than two — the color-only-variant rule applied to a leyenda-only variant.
+
+  - id: mx-civil-protection-2016
+    class: government
+    categories: [car, truck, van, bus, motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99-LL-999"
+      regex: '\A\d{2}-[A-Z]{2}-\d{3}\z'
+      regex_strict: '\A\d{2}-[ABCDEFGHJKLMNPRSTUVWXYZ]{2}-\d{3}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { color: "#BA0C2F", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      band: { side: top, color: "#63666A", content: "grey bar 300 × 25 mm, Pantone Cool Gray 10 at 60%, carrying four Sistema Nacional de Protección Civil symbols at Cool Gray 10 100%", hex_basis: observed }
+      band_hex_note: >-
+        The hex is an observed rendering of Cool Gray 10 at FULL strength (the
+        symbols); the BAR itself is that colour at 60%, which the NOM states as a
+        tint and which no hex in this file attempts to compute.
+      emblem: { present: true, rendered: placeholder, note: "SNPC symbol at 3/4 as a background wash; SNPC symbol grey/red at mid-left; universal civil-protection symbol orange/blue at mid-right" }
+      rear_differs: true
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 20 'Protección Civil — Coordinación Nacional de Protección Civil / Ciudad de México y Entidades Federativas todos los vehículos — 00-AA-000'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # 5.1.6.5.1-5.1.6.5.3, verbatim: 'Placa metálica de color rojo pantone 200C al 100%'; the 300 x 25 mm grey bars top and bottom at Cool gray 10 al 60%; 'la palabra PROTECCIÓN CIVIL y debajo de ésta la palabra MÉXICO, ambas escritas en mayúsculas y color rojo pantone 200C al 100%'; the entity name and Código Fiscal on the lower bar"
+    notes: >-
+      SISTEMA NACIONAL DE PROTECCIÓN CIVIL — the ONLY series in this file whose
+      colours the NOM prescribes, which is why it is the only one carrying a
+      background hex. The hexes are `observed` renderings of the NAMED Pantone
+      references (200 C red, Cool Gray 10 grey): PRD-PLATES §6 lets us build to a
+      colour standard and forbids reproducing it, and Pantone's own coordinates
+      are a licensed dataset, so the numbered colour is cited and the hex is
+      marked observed — the same posture plates/gb.yml takes for BS AU 145e.
+
+  # =========================================================================
+  # AUTOTRANSPORTE FEDERAL — the SCT's own series (Tabla C row 1), issued by
+  # the Secretaría rather than by any state, for federally permitted carriers.
+  # =========================================================================
+  - id: mx-federal-freight-2016
+    class: standard
+    categories: [truck, bus, trailer]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99-LL-9L"
+      regex: '\A\d{2}-[A-Z]{2}-\d[A-Z]\z'
+      regex_strict: '\A\d{2}-[ABCDEFGHJKLMNPRSTUVWXYZ]{2}-\d[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+      progression: >-
+        Apéndice C allocates the federal space by traffic: carga 01-AA-1A …
+        99-CZ-9Z (motrices) and 01-TX-1A … 99-VZ-9Z (remolques); pasaje
+        01-HA-1A … 99-JZ-9Z; turismo 01-RA-1A … 99-RZ-9Z; con inversión
+        extranjera, arrendamiento, transfronterizo and internacional each get
+        their own blocks. The SECOND GROUP is the discriminator.
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: none
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 1 'Autotransporte Federal — Carga, Pasaje y Turismo, con inversión extranjera, arrendamiento … — 00-AA-0A' (also Transfronterizo de carga, Transporte Internacional Largo Recorrido, and Grúas de Arrastre)"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice A Figura 1 'Para vehículos Motrices y Remolques del Servicio de Autotransporte Federal (Carga, Pasaje, Turismo y Arrendamiento)' (seis caracteres)"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C 'SERVICIO DE AUTOTRANSPORTE FEDERAL (CARGA, PASAJE Y TURISMO)' range blocks"
+    notes: >-
+      AUTOTRANSPORTE FEDERAL — the federally permitted road-haulage and
+      intercity-passenger fleet, plated by the SCT rather than by a state and
+      recognisable anywhere in Mexico. `class: standard` is used because
+      _meta/classes.yml has no commercial-carrier value and this is the ordinary
+      registration of those vehicles; the same choice plates/us-fl.yml makes for
+      its Apportioned series. FOUR distinct Tabla C modalities share this one
+      order — carga/pasaje/turismo, transfronterizo de carga, transporte
+      internacional de largo recorrido, and grúas de arrastre — separated only by
+      their Apéndice C range blocks.
+
+  - id: mx-federal-transfer-2016
+    class: temporary
+    categories: [car, truck, bus, trailer]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "99-L9-LL"
+      regex: '\A\d{2}-[A-Z]\d-[A-Z]{2}\z'
+      regex_strict: '\A\d{2}-[ABCDEFGHJKLMNPRSTUVWXYZ]\d-[ABCDEFGHJKLMNPRSTUVWXYZ]{2}\z'
+      progression: "01-A1-AA … 99-C9-ZZ"
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: none
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 1 'Traslado Nacional (Para todo tipo de vehículos) — 00-A0-AA'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C 'TRASLADO NACIONAL — SERIES ASIGNADAS 01-A1-AA - 99-C9-ZZ'; Apéndice A Figura 5"
+    notes: >-
+      TRASLADO NACIONAL — the federal transfer/ferry plate for moving an
+      unregistered vehicle across the country, which is Mexico's `temporary`
+      class in the PRD vocabulary sense (short-validity, movement-only). Distinct
+      from the state DEMOSTRACIÓN plates above, which are bound to a dealer
+      rather than to a journey.
+
+  - id: mx-federal-transfer-motorcycle-2016
+    class: temporary
+    categories: [motorcycle]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "MT999L"
+      regex: '\AMT\d{3}[A-Z]\z'
+      regex_strict: '\AMT\d{3}[ABCDEFGHJKLMNPRSTUVWXYZ]\z'
+      charset:
+        fixed_letters: "MT"
+        notes: >-
+          Apéndice C, verbatim: "NOTA: En la numeración de placas para traslado
+          de motocicleta no se modifican las letras 'MT'." Range MT001A …
+          MT999Z. Tabla C spells the order generically as AA000A; the NOTA is
+          what fixes the pair, so the literal is written into the pattern.
+    design:
+      plate: { w: 215, h: 134, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 1 'Traslado Nacional (Para Motocicletas) — AA000A'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C 'TRASLADO NACIONAL MOTOCICLETAS — MT001A - MT999Z' + the NOTA fixing 'MT'"
+    notes: >-
+      MOTORCYCLE TRASLADO NACIONAL. One of only two Mexican series with a fixed
+      literal prefix (the other is CDMX DM), and the cleanest example in this
+      file of Apéndice C constraining what Tabla C leaves generic.
+
+  - id: mx-federal-inspection-2016
+    class: government
+    categories: [car, truck, van]
+    period: { start: 2016 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LL-99"
+      regex: '\A[A-Z]{2}-\d{2}\z'
+      regex_strict: '\AA[DEFGHJKLMNPRSTUVWXYZ]-\d{2}\z'
+      charset: { notes: "Apéndice C allocates AD-01 … AZ-99, so the first letter is A and the second runs D-Z inside the NOM alphabet" }
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: true
+    region_encoding: none
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Tabla C row 1 'Inspección de Vías Generales de Comunicación Federal — AA-00'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # Apéndice C 'SERIES ASIGNADAS AD-01 - AZ-99'; Apéndice A Figura 7 (cuatro caracteres)"
+    notes: >-
+      SCT road-inspection vehicles (Inspección de Vías Generales de
+      Comunicación) — four characters, joint-shortest in the file with the state
+      Auto Antiguo series, and the only Mexican format with two letters followed
+      by exactly two digits.
+
+  # =========================================================================
+  # ONE SERIES BACK — NOM-001-SCT-2-2000 (DOF 26-01-2001, in force
+  # 27-03-2001, cancelled when the 2016 NOM took effect on 23-08-2016).
+  # Apéndice C Normativo of that NOM is the source of every order below.
+  # =========================================================================
+  - id: mx-private-car-2001
+    class: standard
+    categories: [car]
+    period: { start: 2001, end: 2016 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL-99-99"
+      regex: '\A[A-Z]{3}-\d{2}-\d{2}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+      note: "the 2000 NOM has no F/T rule; 5.3.5's front/rear letters are a 2016 addition"
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=774741&fecha=26/01/2001  # NOM-001-SCT-2-2000, Apéndice C Normativo, row 8 'Transportes Privados (Entidades Federativas) — Automóviles — AAA-00-00'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=774737&fecha=26/01/2001  # NOM-001-SCT-2-2000 numeral 5.1.1 (300 x 150 mm) and the 'entrará en vigor sesenta días naturales después de su publicación' clause"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016  # 2016 NOM Transitorio SEGUNDO — the cancellation that ends this period"
+    notes: >-
+      THE ONE-BACK national private car format — three letters and two
+      two-digit groups, the shape most Mexicans still picture when they picture a
+      plate. PERIOD DISCIPLINE, and it matters here: 2001 is an INSTRUMENT date,
+      not a first-issue date. NOM-001-SCT-2-2000 was published on 26 January 2001
+      and took effect sixty calendar days later, but its own numeral 5.1.4
+      addresses states that "ya hayan efectuado su canje total de placas" in 1998
+      or 1999 — so AAA-00-00 plates were already on the road when the instrument
+      that documents them appeared, and the true creation date of the format is
+      NOT pinned by any primary secured in this pass. period.end 2016 is the
+      cancellation of the 2000 NOM by the 2016 NOM's Transitorio SEGUNDO; plates
+      already issued stayed valid to the end of their trienio and beyond.
+
+  - id: mx-private-truck-2001
+    class: standard
+    categories: [truck]
+    period: { start: 2001, end: 2016 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL-99-999"
+      regex: '\A[A-Z]{2}-\d{2}-\d{3}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=774741&fecha=26/01/2001  # Apéndice C row 8 'Camiones — AA-00-000'"
+    notes: >-
+      One-back private TRUCK format of the entidades federativas. Two letters and
+      a 2+3 digit split — replaced in 2016 by AA-0000-A, which keeps the two
+      leading letters and moves to a single four-digit block plus a check letter.
+
+  - id: mx-private-bus-2001
+    class: standard
+    categories: [bus]
+    period: { start: 2001, end: 2016 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "9-LLL-99"
+      regex: '\A\d-[A-Z]{3}-\d{2}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=774741&fecha=26/01/2001  # Apéndice C row 8 'Autobuses — 0-AAA-00'"
+    notes: >-
+      One-back private BUS format of the entidades federativas — the closest
+      shape in the whole Mexican corpus to the 2016 private bus order
+      (00-AAA-00), differing only in the leading group's width, which is exactly
+      the kind of near-collision an era-inference engine has to handle.
+
+  - id: mx-private-trailer-2001
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 2001, end: 2016 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "9-LL-9999"
+      regex: '\A\d-[A-Z]{2}-\d{4}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=774741&fecha=26/01/2001  # Apéndice C row 8 'Remolques — 0-AA-0000'"
+    notes: >-
+      One-back private TRAILER format of the entidades federativas, replaced in
+      2016 by 0AA-000-A.
+
+  - id: mx-cdmx-private-car-2001
+    class: standard
+    categories: [car]
+    period: { start: 2001, end: 2016 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "999-LLL"
+      regex: '\A\d{3}-[A-Z]{3}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=774741&fecha=26/01/2001  # Apéndice C row 7 'Transportes Privados (Distrito Federal) — Automóviles — 000-AAA'"
+    notes: >-
+      One-back DISTRITO FEDERAL private car format. Note the name change the
+      instruments record: the 2000 NOM says Distrito Federal throughout, the 2016
+      NOM says Ciudad de México throughout — the 2016 constitutional reform is
+      visible in the plate law. The format also inverts: 000-AAA became A00-AAA.
+
+  - id: mx-cdmx-private-truck-2001
+    class: standard
+    categories: [truck]
+    period: { start: 2001, end: 2016 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "99-99-LL"
+      regex: '\A\d{2}-\d{2}-[A-Z]{2}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=774741&fecha=26/01/2001  # Apéndice C row 7 'Camiones — 00-00-AA'"
+    notes: >-
+      One-back DISTRITO FEDERAL private truck format — two digit pairs then two
+      letters, a shape the 2016 NOM abandons entirely.
+
+  - id: mx-public-car-2001
+    class: taxi
+    categories: [car]
+    period: { start: 2001, end: 2016 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "99-99-LLL"
+      regex: '\A\d{2}-\d{2}-[A-Z]{3}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=774741&fecha=26/01/2001  # Apéndice C row 10 'Público Local (Entidades Federativas) — Automóviles — 00-00-AAA' (and row 3, the fronterizo equivalent, same order)"
+    notes: >-
+      One-back PÚBLICO LOCAL car format of the entidades federativas. The 2000
+      NOM gives the SAME order to the border público-local row, so this shape
+      covered both, exactly as A-000-AAA does in the 2016 NOM.
+
+  - id: mx-historic-2001
+    class: historic
+    categories: [car, truck, motorcycle]
+    period: { start: 2001, end: 2016 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LL-99"
+      regex: '\A[A-Z]{2}-\d{2}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: mechanism
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=774741&fecha=26/01/2001  # Apéndice C row 11 'Transportes Privados (Autos Antiguos) — Entidades Federativas — AA-00'"
+    notes: >-
+      One-back AUTO ANTIGUO format of the entidades federativas — four
+      characters, and the same shape the 2000 NOM gives to SCT road-inspection
+      vehicles (row 13, AA-00), which the 2016 NOM keeps for inspection while
+      moving historics to AA-0-A. A four-character Mexican string is therefore
+      genuinely ambiguous across eras and classes and a parse API must say so.
+
+  - id: mx-police-2001
+    class: police
+    categories: [car, truck, van, motorcycle]
+    period: { start: 2001, end: 2016 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "99-999"
+      regex: '\A\d{2}-\d{3}\z'
+    design:
+      plate: { w: 300, h: 150, unit: mm }
+      background: { finish: retroreflective }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=774741&fecha=26/01/2001  # Apéndice C row 4 'Corporaciones Policiacas y de Vigilancia — Todo tipo de vehículos — 00-000'"
+      - "https://www.dof.gob.mx/nota_detalle.php?codigo=2060390&fecha=25/09/2000  # Acuerdo ARTICULO NOVENO — the plate characters had to correspond to the unit's número económico"
+    notes: >-
+      One-back POLICE format — five DIGITS and nothing else, the only
+      all-numeric series either NOM ever prescribed, and the direct consequence
+      of the Acuerdo's rule that a patrol plate had to reproduce the vehicle's
+      fleet number. The 2016 NOM abandons it for AA-000A-0.


### PR DESCRIPTION
**PRD-PLATES gate L3 (S5W; manifest branch s4w-plates/l3-manifest).** Researcher-drafted to the L1/L2 standard: primary instruments quoted verbatim (native-language gazettes read in the original), instrument-dated periods with honest period_evidence, folklore flagged not asserted, non-Latin scripts modelled as decode/field facts with the ASCII projection stated. Independent staged lint over origin/main with ALL 28 wave files: `plates lint: 123 files, 1360 series ... OK`.

**mx**: 43 series, 6 pinned sources, lint green.

---

# Jurisdiction dossier — MEXICO (`mx`)

PRD-PLATES gate L3, researcher pass. **DRAFT for human verification.** Nothing
in this dossier or the accompanying YAML has been applied to any canonical
repo. Access date for every URL below: **2026-08-02**.

Deliverables:

- `mx.yml` — 43 series
- `mx-entity-series.yml` → applies as `plates/_decode/mx-entity-series.yml`
- this dossier

---

## 1. The one-line finding

**Mexico is federated in ISSUANCE and unitary in FORMAT.** Thirty-one states
and the Ciudad de México each register their own vehicles, design their own
artwork and choose their own colours — but the CHARACTER ORDER of every Mexican
serial and the SERIAL RANGE every issuer may draw from are both fixed
nationally by the SCT in one instrument. That is why this jurisdiction gets ONE
file plus ONE decode table, and not thirty-two files the way `us-*` does.

## 2. Instruments secured (all PRIMARY, all fetched in full)

| instrument | what it fixes | URL | fetch |
|---|---|---|---|
| **NOM-001-SCT-2-2016** (DOF 24-06-2016) | the whole current system: Tabla C character orders, Apéndice C per-entity ranges, dimensions, character metrics, security elements, alphabet exclusions, entry into force | `https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016` | 200, 2,236,982 B, 186 KB of text extracted |
| **NOM-001-SCT-2-2000** (DOF 26-01-2001, two notes) | the ONE-BACK layer: Apéndice C character orders, 300×150 mm road / 150×100 mm motorcycle dimensions, its own 60-day in-force clause | `…?codigo=774737&fecha=26/01/2001` and `…?codigo=774741&fecha=26/01/2001` | 200 / 200 |
| **ACUERDO** (DOF 25-09-2000) | the three-year plate validity (art. SÉPTIMO); the **colours are optional** rule (art. TERCERO); the police-plate = fleet-number rule (art. NOVENO) | `https://www.dof.gob.mx/nota_detalle.php?codigo=2060390&fecha=25/09/2000` | 200, 338,566 B |

The DOF day-index endpoint `https://www.dof.gob.mx/index_111.php?year=…&month=…&day=…`
resolves each note code and is the reproducible route to all three.

### 2.1 Verbatim quotes the file leans on

- **Format authority.** NOM 5.1.4.4: *"La conformación de los caracteres de
  identificación (letras y dígitos) que integran los números de serie para los
  diferentes tipos de placas, deben sujetarse a lo establecido en la Tabla C del
  Apéndice 'B' Normativo."*
- **Entry into force.** NOM numeral 13: *"Para los efectos correspondientes, la
  presente Norma Oficial Mexicana entrará en vigor sesenta días naturales
  contados a partir de la fecha de su publicación en el Diario Oficial de la
  Federación."* → 24 June 2016 + 60 días naturales = **23 August 2016**.
- **Cancellation of the predecessor.** NOM Transitorio SEGUNDO: *"Una vez que
  entre en vigor la presente Norma Oficial Mexicana definitiva, se cancela la
  Norma Oficial Mexicana NOM-001-SCT-2-2000 … publicada en el Diario Oficial de
  la Federación el 26 de enero de 2001, y sus modificaciones publicadas con
  fecha 1 de julio de 2002 y 3 de marzo de 2003."*
- **Why a new allocation was needed.** NOM Considerando: *"…las series
  asignadas en el 'ACUERDO…' publicado en el Diario Oficial de la Federación el
  25 de septiembre de 2000, se han agotado para algunos tipos de servicio en
  diversas Entidades Federativas, la Ciudad de México y el Autotransporte
  Federal, se hace necesario realizar una nueva asignación y distribución de
  series, que evite la duplicidad de las mismas."*
- **Alphabet.** Apéndice C, repeated under every per-entity table: *"NOTA: EN
  LOS CARACTERES ALFABÉTICOS NO DEBERÁN UTILIZARSE LAS LETRAS I, Ñ, O, Q."*
- **Colours are optional.** Acuerdo ART. TERCERO: *"…la combinación de colores
  a utilizar en los caracteres de identificación, fondo y leyendas, serán
  optativos, para lo cual deben utilizarse colores contrastantes, fondo oscuro
  con caracteres claros o fondo claro con caracteres oscuros, debiendo remitir a
  la Secretaría, por conducto de la Dirección General de Autotransporte Federal
  para su autorización, los modelos de placas que determinen."*
- **Three-year validity.** Acuerdo ART. SÉPTIMO: *"La vigencia de las placas
  será de tres años, contados a partir de que las entidades federativas, el
  Distrito Federal o la Secretaría hayan realizado sus canjes totales de placas,
  ya sea en los años 1998, 1999 o 2000, de tal forma que los siguientes canjes
  totales deberán efectuarse en los años 2001, 2002 o 2003, según corresponda y
  así sucesivamente en los trienios posteriores."* Kept alive by NOM 9.4.
- **Hyphens are physical.** NOM Apéndice A, under every figure: *"Las
  dimensiones de los guiones serán de 16 x 5.6."*; NOM 5.1.4.3: the figures
  *"contienen un guión o dos guiones de separación entre letras y dígitos"*.
- **Front/rear.** NOM 5.3.5: *"Asimismo, se colocarán en la esquina superior
  izquierda y en diferente color cada una, la letra 'F' para la placa frontal y
  la letra 'T' para la placa trasera del vehículo."*
- **Dimensions.** 5.1.1 road 300 × 150 mm; 5.1.2 motorcycle 215 × 134 mm
  (**grown** from the 2000 NOM's 150 × 100 mm, 5.1.1.2).

## 3. Modelling decisions, and why

1. **One file, not 32.** Directed by the assignment and confirmed by the
   instrument: Tabla C is national. State variance is carried as a *mechanism*
   — `common.colours` (state-optional), `common.validity` (per-state trienio
   phase) and the decode table — never as per-state series.
2. **No `design.background.color` on ordinary series.** Sourced omission (the
   Acuerdo makes colour optativo). The only prescribed colour in either NOM is
   Protección Civil (*"Placa metálica de color rojo pantone 200C al 100%"*), and
   that is the only series in the file carrying a hex, marked `hex_basis:
   observed` because Pantone coordinates are licensed (PRD-PLATES §6).
3. **Hyphen is a mandatory literal**, not `[- ]` and not optional: the NOM gives
   the guión a stamped size. §2.6 rule 2 (regexes are written in printed form)
   applies; the separator-free twin is the consumer's derivation.
4. **`regex_strict` on every 2016 series, none on the 2001 series.** The
   I/Ñ/O/Q exclusion is a 2016 innovation — there is no equivalent note anywhere
   in NOM-001-SCT-2-2000, so asserting the same alphabet backwards would be
   unsourced.
5. **Three private-motorcycle series, not one.** Tabla C row 16 gives three
   orders (A00AA, 0A0AA, A0AA0) for one modality. A series is one PATTERN
   (`plates/nl.yml`'s GV precedent), so three entries.
6. **`mx-federal-police-2016` keeps the generic `regex` and pins `regex_strict`
   to the literal `PF`.** Tabla C spells the order AA-0000-A; Apéndice C
   allocates the whole block as PF-0001-A … PF-9999-Z. Tier order holds.
7. **Ambulancias + Bomberos = one series.** Two Tabla C rows, one order, one
   Apéndice A figure (34) → §2.3 says sub-entry/one series, not two.
8. **`period_evidence: enabling-instrument`** on the 2016 series (the NOM
   creates them) and **`instrument-in-force`** on the 2001 series (see §5).

## 4. The decode table

`plates/_decode/mx-entity-series.yml` carries, all from Apéndice C:

- `private_entity` — **31 rows**, one per state, each with the private-CAR
  interval (`AAA-001-A … AFZ-999-Z` = Aguascalientes, … `ZDA-001-A … ZHZ-999-Z`
  = Zacatecas) and the private-TRUCK interval, plus the NOM's own allocation
  counts.
- `private_cdmx` — 4 rows (car, truck, bus, trailer), the Ciudad de México's own
  single ranges.
- `private_border` — 7 rows (BC, BCS, Coahuila, Chiapas, Chihuahua, Sonora,
  Tamaulipas) with car, truck, bus and trailer border ranges.
- `public_border` — 7 rows, the border público-local car/truck ranges.
- `alphabet.order` — the 23-letter collating sequence a range comparison must
  actually walk. **This is the trap**: comparing `AAA…AFZ` on a 26-letter
  alphabet silently mis-assigns every interval that straddles I, O or Q.

Ranges are **allocations, not occupancy** — stated in the file header.

## 5. Period claims, stated at their real strength

| series group | claim | evidence | strength |
|---|---|---|---|
| 2016 series | `start: 2016` | NOM published 24-06-2016, in force 23-08-2016 | **strong** — instrument date. NOT a first-issue date: each state reaches the format on its own canje, so 2016 is the earliest an `AAA-000-A` plate can exist |
| 2001 series | `start: 2001, end: 2016` | NOM-2000 published 26-01-2001 + 60 days = 27-03-2001; ended by the 2016 NOM's Transitorio SEGUNDO on 23-08-2016 | `instrument-in-force` — **the format is OLDER than the instrument.** NOM-2000 numeral 5.1.4 addresses states that had already done a "canje total de placas" in 1998 or 1999, so `AAA-00-00` plates predate it. The true creation date is **unpinned** |

This is the INSTRUMENT-DATE RULE applied twice, and the 2001 case is the
textbook one: a consolidation that documents an older practice.

## 6. Folklore flags

1. **"Mexican states redesign their plates every three years."** Widely
   repeated (including in the programme's own `plates-research-us-world.md`).
   **Partly true, wrongly stated.** What is primary is a three-year *canje*
   (replacement) cycle in Acuerdo art. SÉPTIMO, whose phase differs per state,
   plus a three-year *durability* requirement on the materials (NOM 5.1.4.5,
   5.1.5.2.1, 5.3.3, 5.3.6). Neither mandates a redesign; a redesign is what
   states usually do at canje because art. TERCERO lets them. Recorded in
   `common.validity` and in the file header, never asserted as a redesign rule.
2. **"Mexico City private plates are `A12-ABC` and the CDMX series excludes
   I, O, Q."** From the same research doc, sourced to Wikipedia. **Half right.**
   The order is `A00-AAA` (Tabla C row 8) — the doc's `A12-ABC` is that same
   order written with example characters, so it agrees. But the I/Ñ/O/Q
   exclusion is **not CDMX-specific**: Apéndice C imposes it nationally, under
   every table. Corrected in the data.
3. **"Serial combinations changed 2016-06-24."** True, and now pinned: that is
   the DOF publication date of NOM-001-SCT-2-2016. The *effective* date is
   2016-08-23.
4. **"Formats: private `ABC-123-A`; public `A-123-ABC`."** Both confirmed
   verbatim from Tabla C rows 9 and 11 — the research doc's Wikipedia-sourced
   claim survives contact with the instrument. Recorded here because a
   confirmation is as valuable as a correction.
5. **Not asserted anywhere**: any claim that Mexican plates are 12″ × 6″ *by
   adoption of a US/AAMVA standard*. The NOM states 300 × 150 mm in millimetres
   and cites no US standard; the coincidence with the North American convention
   is left as an observation, not a sourced lineage.

## 7. Recorded gaps (ranked for the verifier)

1. **Two Tabla C rows contain a literal `1` where a `0` placeholder is
   expected** — row 8 "Autobuses — `00-AA-1`", rows 13/14 "Motocicleta —
   `AA1AA`". Every other row uses `0` for a digit position, so a `1` is either a
   genuine fixed literal or a DOF typesetting defect. **Those three formats are
   deliberately NOT modelled.** Resolving them needs a second edition or the
   Apéndice A figure. Affected: CDMX private bus, CDMX público-local motorcycle,
   EF público-local motorcycle (`AA1AA` half; the `0AAA0` half is unambiguous
   and was also left out for symmetry — see item 2).
2. **Not modelled, deliberate scope control** (all present in Tabla C, all
   straightforward to add if the verifier wants them): EF público-local
   remolques `00000-AA`; EF público-local motorcycle `0AAA0`; CDMX público-local
   buses/camiones/remolques `000-000`; Servicio de Escoltas CDMX `AAA-00-AA` and
   `AAA0AA`; federal paquetería `00A-0AA`, federal capacidades diferentes
   `000-A`, federal vehículos de diagnóstico `AA-A000`, federal dolly
   `A-00-000`, federal transfronterizo de pasaje `A-000-AA`, federal pasaje
   económico `A-0000-A`.
3. **Diplomatic/consular plates have no format here.** NOM 5.1.6.1 hands the
   design to the Secretaría de Relaciones Exteriores and only fixes the
   leyendas: *SRE-MD, SRE-CD, SRE-CC, SRE-TA, SRE-O1, SRE-F1*. No SRE instrument
   was pinned. **Highest-value gap.**
4. **Per-entity ranges for buses, trailers, público-local (non-border),
   motorcycles and demostración** exist in Apéndice C but were not carried into
   the decode file this pass. The private car/truck, CDMX, border-private and
   border-público tables were.
5. **`mx-federal-police-2016` is left OPEN** although the Policía Federal was
   dissolved in 2019. No instrument closing the PF block or reassigning it to
   the Guardia Nacional was found.
6. **Auto Antiguo has no age threshold** in either NOM — eligibility is state
   law, unmodelled.
7. **Class-vocabulary strain**: disability plates ("Capacidades Diferentes")
   are modelled as `specialty` because `_meta/classes.yml` has no disability
   value; federal autotransporte is `standard` following the `us-fl-apportioned`
   precedent. Both are flagged rather than papered over. A `disability` class PR
   would be the clean fix and would also serve several US files.
8. **`mx-private-dolly-2016` is ambiguous by construction**: Tabla C gives the
   SAME order `A-00000` to the CDMX and the Entidades Federativas dolly rows.
   Recorded in the series notes.
9. **Cross-series shape collisions** that no data fix can remove, recorded in
   notes so a parse API ranks rather than asserts: `A-000-AA` (CDMX private
   truck vs federal transfronterizo de pasaje); `A-0000-A` (CDMX taxi vs federal
   pasaje económico); `AAA-000-A` (state private car vs border private
   truck/bus/trailer, separated only by range); `AA-00` in the 2001 era (auto
   antiguo EF vs SCT inspection).

## 8. Lint proof

Isolated workspace (canonical `plates/` minus `_art`, plus the two drafts):

```
plates lint: 69 files, 657 series
plates lint: matching recall-only=151 strict=506 | twins regex_statutory=57 regex_strict=199 | separators emitted "-"," " forgiving 18
plates lint: OK
```

Plus 52 hand-written sample assertions (positive and negative, including
strict-twin rejection of `ABI-…`, `ABO-…`, `ABQ-…`) — all pass.

## 9. Sourcing posture / licence

DOF texts are edicts of the Mexican federal government; Ley Federal del Derecho
de Autor art. 14 fracc. VIII excludes *"los textos legislativos, reglamentarios,
administrativos o judiciales, así como sus traducciones oficiales"* from
protection. Facts extracted, quoted fragments cited per claim, no bulk text
redistributed. **No Wikipedia text or table was copied.** The Wikipedia article
`Vehicle_registration_plates_of_Mexico` was used exactly as PRD-PLATES §4
prescribes — as a finding aid, via the programme's own research dossier, whose
Wikipedia-derived claims are individually confirmed or corrected in §6 above
against the instruments themselves.

---

# APPENDIX V — INDEPENDENT VERIFICATION PASS (second researcher, 2026-08-02)

A second Opus researcher was assigned `mx, ar` in the same L3 wave and worked
the sources from scratch without reading this dossier or `mx.yml` first. This
appendix records what that pass CONFIRMED, what it ADDED, and the one claim it
thinks is WRONG. Nothing in `mx.yml` was rewritten by it; the decode table was
extended additively and every change is listed below.

## V.1 Method (so the verifier can re-run it)

The instrument was re-fetched from a SECOND Mexican federal source — the
Secretaría de Economía NOM repository,
`http://www.economia-noms.gob.mx/normas/noms/2010/001sct22016.pdf` (86 pages,
1.9 MB) — and text-extracted with `pdftotext -layout`. Apéndice C was parsed
with a purpose-written Ruby script and the resulting rows diffed against
`mx-entity-series.yml`. The canonical DOF nota was located independently by
walking `index_113.php?year=2016&month=06&day=24` and probing note codes: it is
`https://www.dof.gob.mx/nota_detalle.php?codigo=5442476&fecha=24/06/2016`,
which agrees with the citation already in the file. The predecessor was found
at `http://www.economia-noms.gob.mx/normas/noms/2001/001sct2.pdf`
(NOM-001-SCT-2-2000, signed 29 November 2000).

## V.2 CONFIRMED — independently, from a second copy of the instrument

- **Tabla C is the format source, and every pattern in `mx.yml` matches it.**
  Apéndice B Tabla C ("CONFORMACIÓN DE LOS CARACTERES DE IDENTIFICACIÓN…") was
  re-read row by row. Mandatory under §5.1.4.4.
- **Every per-entity private-car, CDMX and border range** in
  `mx-entity-series.yml` §§1–4 matched the second transcription exactly
  (spot-checked in full: Aguascalientes `AAA-001-A`–`AFZ-999-Z`, Baja
  California `AGA-001-A`–`CYZ-999-Z`, Oaxaca `THA-001-A`–`TMZ-999-Z`,
  Zacatecas `ZDA-001-A`–`ZHZ-999-Z`). Two independent transcriptions of a
  scanned federal instrument agreeing is the strongest evidence available
  short of the DOF facsimile.
- **The in-force date, 23 August 2016.** §13 verbatim: *"la presente Norma
  Oficial Mexicana entrará en vigor sesenta días naturales contados a partir de
  la fecha de su publicación en el Diario Oficial de la Federación"*.
- **The predecessor's end date.** Transitorio SEGUNDO cancels
  NOM-001-SCT-2-2000 (DOF 26-01-2001) and its modifications of 01-07-2002 and
  03-03-2003.
- **The one-series-back grammars.** The 2000 Apéndice C was read directly and
  confirms row 8 `AAA-00-00` (state private car), row 7 `000-AAA` (Distrito
  Federal private car), row 10 `00-00-AAA` (state public car), row 4 `00-000`
  (police, all-digit, no entity code) — all as `mx.yml` has them.
- **The I / Ñ / O / Q exclusion**, printed **eleven** times across Apéndice C,
  and internally corroborated by the allocations themselves (Oaxaca's public
  block runs `SJA..SRZ`, skipping I; Sonora's runs `UPA..VLZ`, skipping O).
- **Three-year plate validity is REAL and is now primary-sourced.** The 2000
  Acuerdo (DOF 25-09-2000, note code 2060390) ARTICULO SEPTIMO, verbatim:
  *"La vigencia de las placas será de tres años, contados a partir de que las
  entidades federativas, el Distrito Federal o la Secretaría hayan realizado
  sus canjes totales de placas … y así sucesivamente en los trienios
  posteriores."* The widely repeated "Mexican states redesign every three
  years" is therefore a fair paraphrase of a three-year REPLACEMENT cycle, and
  `mx.yml`'s citation of ARTICULO SEPTIMO is correct.

## V.3 ADDED to `mx-entity-series.yml` (purely additive; file re-parses, lint green)

| section | content | source |
|---|---|---|
| §5 `public_entity` | the 31-row PÚBLICO LOCAL car allocation | Apéndice C, público local AUTOMÓVILES column |
| §6 `police_entity_codes` | the 32 literal two-letter police codes | Apéndice C, "SERIES ASIGNADAS PARA LA POLICÍA…" |
| §7 `legend_abbreviations` | §5.1.4.2 columns A/B/C, 32 rows | NOM §5.1.4.2 |
| §8 `reserved_letter_tokens` | D, VE, MT, DM, AM, BM, PC with the NOTA that fixes each | Apéndice C NOTAs + Tabla C |
| §9 `verification` | this pass's record, incl. the two anomalies below | — |

**Why §5 matters most: THE DECODE KEY INVERTS.** The private-car series carries
the entity in its **leading** letter triple; the public-local car series carries
it in the **trailing** triple; the public-local truck series carries it in the
**middle** triple. Three seven-character shapes, three different decode
positions. A parse API that reuses one decoder across them will confidently
name the wrong state.

**Why §6 matters: it is the only literal geographic code Mexico prints.** And
it is *not* the §5.1.4.2 abbreviation set — Oaxaca is `AX` on a police plate
and `OAX`/`OC` in a legend; Querétaro is `ER` against `QRO`/`QT`; Quintana Roo
is `TR` against `QR`. Mexico City's police code is `DF`, a name abolished in
2016 surviving inside a 2016 instrument.

## V.4 ANOMALIES found and deliberately NOT repaired

1. **MORELOS private-truck range is internally inconsistent.** Apéndice C
   prints `UN-0001-A - NZ-9999-Z`, whose end sorts *before* its start in the
   NOM's own 23-letter alphabet. Both transcriptions read it identically, so
   the defect is in the instrument or its DOF typesetting — not in the
   extraction. Recorded on the row; a verifier with the DOF facsimile should
   settle it. Until then no consumer should range-decode a Mexican private
   truck through that row.
2. **Printed order is not monotonic in `from`.** Apéndice C prints entities in
   Spanish alphabetical order (CH sorts as its own letter, so Chiapas and
   Chihuahua precede Coahuila; Estado de México and Michoacán sit between
   Jalisco and Morelos in letter space). Consumers must sort by `from`. Sorted,
   the blocks are contiguous and non-overlapping — the first check a verifier
   should run.
3. **Digit-placeholder inconsistency in the motorcycle and Auto Antiguo rows.**
   Tabla C writes `AA1AA` where every other row uses `0` as the digit
   placeholder, and the published ranges likewise start at digit 1
   (`AA1AA - AR9BA`, `FA-1-A - FP-9-Z`). Whether digit 0 is genuinely excluded
   from those positions is **unresolved**; no claim is made either way.

## V.5 DISAGREEMENT — one claim this pass believes is wrong

**`mx.yml`'s header §2 and `common.colours` say the 2000 Acuerdo's ARTICULO
TERCERO "makes the colour combination optional" / "state-optional". The text
does not say that.** ARTICULO TERCERO was fetched in full from the DOF
(`codigo=2060390&fecha=25/09/2000`) and it is **prescriptive, for a defined
cohort**, opening:

> "ARTICULO TERCERO.- Las entidades federativas, el Distrito Federal o la
> Secretaría que durante 1998 y 1999 hayan efectuado canje total de placas, y
> requieran la manufactura de placas para reposición o ampliación, **los
> colores a utilizar de acuerdo al tipo de servicio que prestan los vehículos,
> es la siguiente**: … Transporte privado … Vehículos particulares, traslado,
> autos antiguos, diplomáticas, discapacitados y demostración Fond[o] …"

— i.e. it introduces a **colour table by service type**. No article in the
Acuerdo found by this pass makes colours optional or state-chosen; ARTICULO
CUARTO and QUINTO defer dimensions, characters, legends and materials to "la
norma correspondiente" but say nothing permissive about colour.

**What is independently certain, and what the file should rest on instead:**
the 2016 NOM itself prescribes **no** background or character colour for any
ordinary plate. Eleven pages of §5 cover materials, retroreflective intensity,
tensile strength, weathering and corrosion and never state one. §5.3.6.2 is as
close as it comes — *"Cuando las placas se fabriquen con caracteres blancos o
negros, éstos no necesariamente deben ser reflejantes"* — which presupposes a
choice without conferring it. The **only** coloured series in the Norm is
Sistema Nacional de Protección Civil (§5.1.6.5.1: plate Pantone 200 C, bars
Pantone Cool Gray 10).

**Recommended fix (verifier's call, not applied here):** keep the
colour-absent posture — it is right — but re-ground it on the NOM's silence
plus §5.3.6.2, and **downgrade the ARTICULO TERCERO citation to what it
actually is**: a service-type colour table binding on the 1998–2000 exchange
cohort, whose survival under the 2016 NOM is an **open question**. Whether that
table still governs is the single most valuable thing a human can resolve here,
because if it does, Mexican plate colour is federal law and not state choice.

## V.6 Vocabulary question for the maintainer

`mx.yml` classes the two *Capacidades Diferentes* series as `specialty`.
`_meta/classes.yml` defines `specialty` as "optional-design programs on
standard serials (US state programs)" — but these plates have their **own
serial grammars** (Tabla C rows 1 and 22: `000-A` federal, `00-A-00` CDMX,
`00-AAA` states) **and** their own mandated pictogram (§5.1.6.2). That is a
class, not an optional design. This is a live proposal for a `classes.yml`
amendment (e.g. `accessible:`), not a defect in `mx.yml` — the author had no
better term available.

## V.7 Still open after this pass

- **Diplomatic/consular plates remain unmodelled and should stay that way**
  until the SRE instrument is found. §5.1.6.1 expressly delegates design *and*
  serial to the Secretaría de Relaciones Exteriores, giving only the six
  legends `SRE-MD`, `SRE-CD`, `SRE-CC`, `SRE-TA`, `SRE-O1`, `SRE-F1`. Those are
  the search terms for a later pass.
- **Currency of the 2016 NOM.** The DOF nota for `codigo=5442476` lists no
  modification, and the SIDOF record for the same nota lists none as at
  2026-08-02. A modification published as its own nota would not necessarily
  appear there. Confidence: medium. Highest-value re-check.
- **Apéndice C's untranscribed allocations** (autobuses, remolques,
  convertidores, motocicletas ×3, demostración, ecológicos, ambulancias,
  bomberos, protección civil, escoltas) are sourced at identical quality and
  need transcription only.

**ar**: 10 series, 8 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 27707B)
