### PR TITLE
plates L3: za — za (S5W)

### DIFF
--- a/plates/_decode/za-licence-marks.yml
+++ b/plates/_decode/za-licence-marks.yml
@@ -1,0 +1,215 @@
+# plates/_decode/za-licence-marks.yml — South African LICENCE MARKS.
+#
+# THE SOURCE FINDING, and it decides the whole shape of plates/za.yml: South
+# Africa has TWO geographic dimensions on a plate, created by two different
+# limbs of ONE regulation, and a parse API that conflates them will be wrong
+# about half the country.
+#
+# Regulation 27 of the National Road Traffic Regulations, 2000 (GNR.225 of
+# 17 March 2000, made under the National Road Traffic Act 93 of 1996),
+# VERBATIM:
+#
+#   "27. Licence mark and licence number system
+#    (1) The MEC of each province shall, subject to subregulation (2), by
+#        notice in the Provincial Gazette, determine a licence mark for the
+#        province concerned.
+#    (2) (a) The MEC of a province shall by notice in the Provincial Gazette—
+#        (i)  allocate a licence mark to every registering authority in the
+#             province concerned, which licence mark shall consist of a
+#             combination of letters; or
+#        (ii) establish a licence number system for the province concerned
+#             which license number system shall consist of:
+#             (aa) a combination of three letters and three figures in any
+#                  sequence; or
+#             (bb) a combination of two letters, two figures and two letters
+#                  in any sequence:
+#        and the licence mark of the province concerned, referred to in sub
+#        regulation (1): Provided that vowels and the letter 'Q' shall not be
+#        used and the first letter shall not be the letter 'G'.
+#    (3) Every motor vehicle licensed in a province shall be allocated with a
+#        licence number and such licence number shall, subject to subregulation
+#        (5) and regulation 28, consist of the licence mark referred to in
+#        subregulation (2)(a)(i) and figures, or the letters and figures
+#        allocated from the licence number system referred to in subregulation
+#        (2)(a)(ii)."
+#
+# So the two dimensions are:
+#
+#   PROVINCIAL MARK  — reg 27(1). One per province, printed at the END of a
+#   licence number issued under a provincial licence NUMBER SYSTEM
+#   (reg 27(2)(a)(ii)). This is the "GP", "MP", "NC" suffix everyone knows.
+#
+#   REGISTERING-AUTHORITY MARK — reg 27(2)(a)(i). One per registering
+#   authority (a town/city licensing office), printed at the FRONT, followed
+#   by figures. This is the Western Cape "CA 123-456" and the pre-2023
+#   KwaZulu-Natal "ND 12345" style, and it is the DIRECT DESCENDANT of the
+#   pre-1994 four-province town-code system: those codes were allocated by
+#   the old provincial administrations and survived the 1994 reorganisation
+#   inside the two provinces that never switched to a suffix system.
+#
+# The two are mutually exclusive per province — reg 27(2)(a) is an "or" — and
+# a province may switch by a fresh notice under reg 27(4). KwaZulu-Natal did
+# exactly that in December 2023.
+#
+# WHAT IS AND IS NOT PINNED HERE (read before trusting a row):
+#   * The reg 27 text above is PRIMARY and was read twice, in the consolidated
+#     regulations and again in a Government Gazette reproduction (GG 37542,
+#     General Notice 287 of 9 April 2014), which agree word for word.
+#   * The reg 27(1) determinations themselves are NINE SEPARATE PROVINCIAL
+#     GAZETTE NOTICES. Three of the nine marks below are pinned to a
+#     government publication (FS, GP, WP). The other six are NOT: they are
+#     carried on `secondary-wikipedia` evidence and are flagged row by row.
+#     No provincial gazette index with full-text search was reachable in this
+#     pass (SAFLII is behind Cloudflare, opengazettes.org.za's search has been
+#     retired, gazettes.africa exposes no query endpoint) — recorded as the
+#     single largest gap in the South African pass.
+#   * NO complete registering-authority mark table is published anywhere this
+#     pass could reach. The Western Cape rows below are the marks the Western
+#     Cape Government itself prints as worked examples on its own fee table;
+#     they are a floor, not a census. eNaTIS publishes a "live vehicle
+#     population per registering authority" series that would settle it, and
+#     natis.gov.za refused every request (HTTP 403). Recorded as a gap.
+jurisdiction: za
+topic: licence-marks
+authority:
+  name: "MEC responsible for road traffic in each province, under reg. 27 of the National Road Traffic Regulations, 2000 (GNR.225 of 17 March 2000)"
+  url: "https://www.gov.za/sites/default/files/gcis_document/201409/37542gen287.pdf"
+sources:
+  - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # National Road Traffic Regulations 2000 consolidated to GNR.359 of 2 May 2010 — reg 27(1),(2),(3),(4),(5) verbatim; accessed 2026-08-02"
+  - "https://www.gov.za/sites/default/files/gcis_document/201409/37542gen287.pdf  # Government Gazette 37542, General Notice 287 of 9 April 2014 (Department of Transport, publication of proposed amendments FOR COMMENT) — reproduces reg 27(1)-(5) and reg 35 in identical words; accessed 2026-08-02"
+  - "https://www.policeroadstransport.fs.gov.za/wp-content/uploads/2012/09/Personalised-licence-number-system-for-the-Free-State-2002.pdf  # Free State Provincial Notice 52 of 2002, Provincial Gazette 25 of 9 April 2002, para 2(1): personalised numbers 'followed by the letters FS' — the FS mark, primary; accessed 2026-08-02"
+  - "https://cmbinary.gauteng.gov.za/Media?path=transport/Documents/Documents/GP%20Application%20Form%20-%20Personalised%20Number%20Plate.pdf&Item=658&Type=Documents&Location=/transport  # Gauteng Province form PRN1-GP, 'Application for special/personalised registration number for motor vehicle': the registration-number field is pre-printed with 'G P' — the GP mark, primary; accessed 2026-08-02"
+  - "https://www.westerncape.gov.za/mobility/service/applying-special-motor-vehicle-number-plates  # Western Cape Government: 'Personalised number plates contain the letters WP (Western Province) at the end of the number plate' + the discrete-number fee table whose worked examples are the CY/CW/CG/CK/CB/CBY/CFM registering-authority marks; accessed 2026-08-02"
+  - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa  # FINDING AID + the six unpinned provincial marks (EC, L, MP, NC, NW, ZN) and the Port Shepstone NPS->NSC change; every fact taken from it is tagged secondary-wikipedia below; accessed 2026-08-02"
+period: { start: 2000 }
+period_evidence: instrument-in-force
+period_note: >-
+  2000 is the year of the instrument that CREATES the licence-mark power read
+  here (GNR.225 of 17 March 2000), not the year the marks came into use. The
+  registering-authority marks are decades older — the Cape "C" family and the
+  Natal "N" family were allocated by the pre-1994 provincial administrations
+  and were carried across the 1994 reorganisation unchanged — and the
+  provincial marks were determined in the second half of the 1990s under the
+  Road Traffic Act 29 of 1989 and its provincial ordinances. None of those
+  earlier instruments was pinned in this pass. A decode of a physical plate is
+  therefore period-agnostic: these marks do not date a plate.
+
+# ---------------------------------------------------------------------------
+# 1. PROVINCIAL MARKS — reg 27(1). Printed at the END of the licence number.
+#    `system` records which limb of reg 27(2)(a) the province chose, because
+#    that, not the mark, is what determines the serial grammar.
+# ---------------------------------------------------------------------------
+maximal_munch: false
+provincial_marks:
+  - code: EC
+    name: "Eastern Cape"
+    system: "reg 27(2)(a)(ii)(aa) — three letters and three figures"
+    evidence: secondary-wikipedia
+    note: "Mark not traced to its provincial gazette notice in this pass."
+  - code: FS
+    name: "Free State"
+    system: "reg 27(2)(a)(ii)(aa) — three letters and three figures"
+    evidence: authority-publication
+    note: >-
+      PRIMARY. Free State Provincial Notice 52 of 2002 para 2(1)(a)-(b)
+      requires a personalised number to be "followed by the letters FS", and
+      Provincial Notice 51 of 2002 Schedule 3 para 4 requires the retro-
+      reflective sheeting to carry "the Province by way of the letters 'FS'
+      inside a 12 mm circle interspersed throughout the sheeting".
+  - code: GP
+    name: "Gauteng"
+    system: >-
+      reg 27(2)(a)(ii)(aa) three letters and three figures; a two-letter /
+      two-figure / two-letter issue under reg 27(2)(a)(ii)(bb) is reported
+      from 2023 (secondary-wikipedia — see plates/za.yml#za-gp-standard-2l2f2l)
+    evidence: authority-publication
+    note: >-
+      PRIMARY. Gauteng Province form PRN1-GP pre-prints "G P" in each of the
+      three registration-number choice fields.
+  - code: L
+    name: "Limpopo"
+    system: "reg 27(2)(a)(ii)(aa) — three letters and three figures"
+    evidence: secondary-wikipedia
+    note: >-
+      The only ONE-LETTER provincial mark, which is why plates/za.yml writes
+      it with the pattern escape (\L) rather than as the letter token. The
+      province was named Northern Province until 2003 and the mark it used
+      before the rename was not established in this pass — recorded gap.
+  - code: MP
+    name: "Mpumalanga"
+    system: "reg 27(2)(a)(ii)(aa) — three letters and three figures"
+    evidence: secondary-wikipedia
+    note: "Mark not traced to its provincial gazette notice in this pass."
+  - code: NC
+    name: "Northern Cape"
+    system: "reg 27(2)(a)(ii)(aa) — three letters and three figures"
+    evidence: secondary-wikipedia
+    note: "Mark not traced to its provincial gazette notice in this pass."
+  - code: NW
+    name: "North West"
+    system: "reg 27(2)(a)(ii)(aa) — three letters and three figures"
+    evidence: secondary-wikipedia
+    note: "Mark not traced to its provincial gazette notice in this pass."
+  - code: WP
+    name: "Western Cape"
+    system: >-
+      reg 27(2)(a)(i) — registering-authority marks plus figures. WP is
+      therefore NOT a suffix on ordinary Western Cape plates: it appears only
+      on personalised numbers issued under reg 28.
+    evidence: authority-publication
+    note: >-
+      PRIMARY. Western Cape Government, verbatim: "Personalised number plates
+      contain the letters WP (Western Province) at the end of the number
+      plate." WP stands for the historic Western Province, not for the
+      province's own name.
+  - code: ZN
+    name: "KwaZulu-Natal"
+    system: >-
+      reg 27(2)(a)(ii)(bb) two letters, two figures and two letters, from
+      1 December 2023; previously reg 27(2)(a)(i) registering-authority marks
+      plus figures
+    evidence: secondary-wikipedia
+    note: >-
+      The 1 December 2023 switch itself IS pinned to a government publication
+      (SAnews.gov.za, the Government Communication and Information System) —
+      it is the two-letter mark "ZN" that rests on Wikipedia here.
+
+# ---------------------------------------------------------------------------
+# 2. REGISTERING-AUTHORITY MARKS — reg 27(2)(a)(i). Printed at the FRONT,
+#    followed by figures. INCOMPLETE BY CONSTRUCTION: see the header. Every
+#    row here is a mark a government page prints as its own worked example.
+# ---------------------------------------------------------------------------
+registering_authority_marks_note: >-
+  This is a floor, not a census, and a consumer MUST NOT treat an unlisted
+  C-initial or N-initial mark as invalid. The mechanism is the sourced fact:
+  a Western Cape mark is two or three letters beginning with C, a pre-2023
+  KwaZulu-Natal mark is two or three letters beginning with N, and both are
+  followed by up to six figures. The full tables live in Western Cape and
+  KwaZulu-Natal provincial gazettes that this pass could not reach.
+registering_authority_marks:
+  - { code: CA,  province: WP, name: "Cape Town", evidence: corroboration-only, note: "The best-known South African mark; widely printed as 'CA 123-456'. Not pinned to a Western Cape gazette in this pass." }
+  - { code: CY,  province: WP, name: "unresolved (Western Cape)", evidence: authority-publication, note: "Western Cape Government fee table, worked example 'CY 6'." }
+  - { code: CW,  province: WP, name: "unresolved (Western Cape)", evidence: authority-publication, note: "Western Cape Government fee table, worked example 'CW 16'." }
+  - { code: CG,  province: WP, name: "unresolved (Western Cape)", evidence: authority-publication, note: "Western Cape Government fee table, worked example 'CG 131'." }
+  - { code: CK,  province: WP, name: "unresolved (Western Cape)", evidence: authority-publication, note: "Western Cape Government fee table, worked example 'CK 1441'." }
+  - { code: CB,  province: WP, name: "unresolved (Western Cape)", evidence: authority-publication, note: "Western Cape Government fee table, worked example 'CB 131'." }
+  - { code: CBY, province: WP, name: "unresolved (Western Cape)", evidence: authority-publication, note: "Western Cape Government fee table, worked examples 'CBY 3' and 'CBY 15' — a THREE-letter registering-authority mark, which is why plates/za.yml admits 1-2 letters after the leading C." }
+  - { code: CFM, province: WP, name: "unresolved (Western Cape)", evidence: authority-publication, note: "Western Cape Government fee table, worked example 'CFM 2332' — three-letter mark." }
+  - { code: CAA, province: WP, name: "Cape Town (second series)", evidence: secondary-wikipedia, note: "Reported introduced 13 April 2019 when the CA combinations were exhausted. Not pinned to a gazette." }
+  - { code: CAW, province: WP, name: "George (first series)", evidence: secondary-wikipedia, note: "Reported exhausted in late 2019." }
+  - { code: CAG, province: WP, name: "George (second series)", evidence: secondary-wikipedia, note: "Reported introduced late 2019 when CAW was exhausted." }
+  - { code: NPS, province: ZN, name: "Port Shepstone (former)", evidence: secondary-wikipedia, note: "Reported replaced by NSC on 30 June 2020." }
+  - { code: NSC, province: ZN, name: "Port Shepstone", evidence: secondary-wikipedia, note: "Reported in use from 30 June 2020 until the province moved to the ZN system on 1 December 2023." }
+
+# ---------------------------------------------------------------------------
+# 3. NON-GEOGRAPHIC TERMINAL LETTERS — the trap this table exists to prevent.
+#    These look like provincial marks and are not: they are issuance classes
+#    under reg 27(5) and reg 71(2), and they are modelled as SERIES in
+#    plates/za.yml, never decoded as geography.
+# ---------------------------------------------------------------------------
+not_geographic:
+  - { token: G,  meaning: "Department of State — reg 27(5)(a)(ii): 'the letter G followed by two letters, three figures, and the letter G'. Also the reason the reg 27(2) proviso forbids G as the FIRST letter of an ordinary licence number.", series: "plates/za.yml#za-government-g" }
+  - { token: B,  meaning: "South African Police Service — reg 27(5)(b): 'three letters, three figures, followed by the letter B'.", series: "plates/za.yml#za-police-b" }
+  - { token: D,  meaning: "Diplomatic/consular and international organisations — reg 27(5)(d): the grammar is set by the Director-General of Foreign Affairs and is not published, but the number 'shall end in the letter D'.", series: "plates/za.yml#za-diplomatic-d" }
+  - { token: ZK, meaning: "Set aside for the use by the King of the Zulu Nation — reg 27(5)(c), as substituted by GNR.865 of 28 September 2007: 'the letters ZK followed by figures or letters or combination of figures and letters'. A PREFIX, not a suffix.", series: "plates/za.yml#za-zulu-royal-zk" }
+  - { token: A,  meaning: "Motor trade (dealer) number — reg 71(2)(a): 'the letter A followed by two letters, three figures and the licence mark of the province concerned'. A dealer number therefore carries a provincial mark AND a leading A.", series: "plates/za.yml#za-dealer-a" }

--- a/plates/za.yml
+++ b/plates/za.yml
@@ -1,0 +1,1141 @@
+# plates/za.yml — South Africa (PRD-PLATES gate L3).
+#
+# EVERY grammar claim in this file comes from ONE regulation — regulation 27
+# of the National Road Traffic Regulations, 2000 (GNR.225 of 17 March 2000),
+# made by the Minister of Transport under s. 75 of the National Road Traffic
+# Act 93 of 1996 — and every colour, layout and dimension claim from
+# regulation 35 of the same instrument. Both were read in the consolidated
+# regulations (consolidated to GNR.359 of 2 May 2010) and again, word for
+# word, in a Government Gazette reproduction (GG 37542, General Notice 287 of
+# 9 April 2014). The Free State design and personalised-number claims come
+# from that province's own gazette notices, fetched in full.
+#
+# SIX STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. SOUTH AFRICA HAS ONE STATUTORY GRAMMAR AND NINE ISSUING PROVINCES, AND
+#    THE GRAMMAR IS SMALL, CLOSED AND DIRECTLY REGEX-ABLE. Reg 27(2)(a),
+#    verbatim: the MEC of a province shall "(i) allocate a licence mark to
+#    every registering authority in the province concerned, which licence mark
+#    shall consist of a combination of letters; or (ii) establish a licence
+#    number system for the province concerned which license number system
+#    shall consist of: (aa) a combination of three letters and three figures
+#    in any sequence; or (bb) a combination of two letters, two figures and
+#    two letters in any sequence: and the licence mark of the province
+#    concerned, referred to in sub regulation (1)". That is the whole of the
+#    ordinary South African plate: EITHER a town code followed by figures, OR
+#    a national serial shape followed by a two- or one-letter provincial mark.
+#    Everything else in this file is a reg 27(5) or reg 71(2) special class.
+#
+# 2. THE CHARSET IS STATUTORY AND IT IS THE PROVISO TO REG 27(2)(a)(ii),
+#    verbatim: "Provided that vowels and the letter 'Q' shall not be used and
+#    the first letter shall not be the letter 'G'." Twenty letters survive
+#    (B C D F G H J K L M N P R S T V W X Y Z), nineteen in first position.
+#    Two consequences worth stating because they are easy to get wrong:
+#    the proviso governs the SERIAL, not the provincial mark — "EC" and
+#    "ZN" both contain letters the serial may not use — and the G exclusion
+#    exists because reg 27(5)(a)(ii) reserves a leading G for departments of
+#    State. `format.regex` therefore cannot carry the charset (the lint
+#    generates vowels from `pattern`); `format.regex_strict` carries it, on
+#    every series where the proviso applies and on no other.
+#
+# 3. THE 2009 AMENDMENT IS THE ONE CLEAN ERA BOUNDARY IN THE WHOLE PASS.
+#    Sub-paragraph (ii) was SUBSTITUTED by r. 5(a) of GNR.589 of 27 May 2009
+#    (Government Gazette 32258), and that substitution is what introduced
+#    limb (bb) — the two-letter/two-figure/two-letter shape. Before 27 May
+#    2009 no South African province could lawfully issue "BC 12 DF GP". That
+#    is an ENABLING-INSTRUMENT date, and it is recorded as one; the dates on
+#    which individual provinces began ISSUING under (bb) are separate facts
+#    with separate (and weaker) evidence, recorded per series.
+#
+# 4. THE 1994 PROVINCIAL REORGANISATION IS THE ERA BOUNDARY THIS FILE CANNOT
+#    DATE, AND SAYS SO. Four provinces became nine on 27 April 1994; seven of
+#    the nine went on to adopt suffix systems under reg 27(2)(a)(ii) while the
+#    Western Cape and (until 2023) KwaZulu-Natal kept the inherited town-code
+#    system of reg 27(2)(a)(i). The provincial notices that made those choices
+#    were issued in the second half of the 1990s under the Road Traffic Act 29
+#    of 1989 and its provincial ordinances, and NOT ONE of them was reachable
+#    in this pass: SAFLII sits behind Cloudflare, opengazettes.org.za has
+#    retired its full-text search, and gazettes.africa exposes no query
+#    endpoint. Every suffix series here therefore carries period.start 2000
+#    with `period_evidence: instrument-in-force` — the date of the instrument
+#    that governs the format TODAY, expressly not the date the format began.
+#    The real start years are a recorded gap and the single most valuable
+#    target for the verifier.
+#
+# 5. THE PROVINCIAL MARK IS NOT ALWAYS TWO LETTERS AND ONE OF THEM COLLIDES
+#    WITH THE PATTERN DSL. Limpopo's mark is the single letter L, which the
+#    human-pattern language reads as "any letter". This is the first file in
+#    the dataset to use the owner's 2026-08-02 pattern escape in anger:
+#    `LLL 999 \L` means three letters, three figures and a LITERAL L.
+#
+# 6. THERE IS NO NATIONAL PLATE DESIGN, AND THE ATTEMPT TO CREATE ONE IS
+#    UNFINISHED. Reg 35(2) fixes only a palette — "yellow or white retro-
+#    reflective surface" with "black, dark blue, dark red, or dark green
+#    letters and figures, but shall display only black letters and figures in
+#    the case of a yellow retro-reflective surface" — and reg 27(2)(b) hands
+#    the logo, landscape, letter type and colours to each MEC. GG 37542 GN 287
+#    of 9 April 2014 proposed a single national plate carrying "the allocated
+#    licence number, South African Flag and the licence mark of the respective
+#    province at the end ... on a white retro-reflective surface landscape as
+#    shown in Schedule 5". It was published FOR COMMENT under s. 75(6) of the
+#    Act. Whether it was ever promulgated was not established in this pass and
+#    is NOT asserted here.
+#
+# REGEX POLICY (identical to plates/gb.yml, plates/de.yml and plates/nl.yml):
+# `format.regex` is the LINT-ROUND-TRIPPABLE regex; `format.regex_strict`
+# carries the reg 27(2)(a)(ii) proviso alphabet, which `regex` cannot.
+#
+# SEPARATOR NOTE (PRD-PLATES § 2.6): a South African plate prints NO separator
+# glyph between the serial groups. Reg 35(3) prescribes the ARRANGEMENT of the
+# groups ("with all the letters and figures in one line", or the two-line
+# forms) and never a separator character; the millimetre spacing lives in
+# SANS/SABS 1116, a paywalled SABS publication which PRD-PLATES § 6 lets us
+# build to and forbids us to reproduce. The space in every `pattern` here is
+# the conventional textual rendering of that gap, and every regex accepts it
+# as optional. The hyphen widely printed in the Western Cape ("CA 123-456") is
+# a typographic convention with no instrument behind it and is NOT written
+# into any pattern; the Western Cape regexes accept the digits with or without
+# the gap.
+jurisdiction: za
+authority:
+  name: "Department of Transport (national) and the MEC responsible for road traffic in each of the nine provinces"
+  url: "https://www.transport.gov.za/"
+binding: vehicle
+binding_note: >-
+  Reg 27(3), verbatim: "Every motor vehicle licensed in a province shall be
+  allocated with a licence number". The number is allocated to the VEHICLE on
+  licensing, not to the owner; reg 29(1)-(2) lets the MEC change it, and reg
+  28(5) lets the holder of a personalised number apply to move that number to
+  another vehicle he or she owns — the personalised regime is the one place
+  where a South African number follows a PERSON.
+instrument:
+  act:
+    citation: "National Road Traffic Act, 1996 (Act No. 93 of 1996)"
+    assented: "1996-11-12"
+    published: "1996-11-22"          # President's Office Notice No. 1892
+    commencement: "on a date fixed by the President by proclamation (s. 94(2)) — the proclamation was not pinned in this pass"
+    enabling_power: >-
+      s. 75(1), verbatim: "The Minister may after consultation with the MECs
+      make regulations ... and in particular, but without derogating from the
+      generality of this subsection, regarding— ... (b) the identification of
+      vehicles or parts of vehicles and, in relation to a motor vehicle, the
+      size and shape of the registration mark or number to be displayed in
+      terms of this Act and the means to be applied to validate such mark or
+      number and to render any such mark or number easily distinguishable,
+      whether by night or by day, when any such vehicle is operated on a
+      public road".
+    source: "https://www.gov.za/sites/default/files/gcis_document/201409/a93-96.pdf  # Act 93 of 1996 as published; s. 75(1)(b), s. 68 (unlawful acts in relation to registration plates), s. 94 short title and commencement"
+  regulations:
+    citation: "National Road Traffic Regulations, 2000, GNR.225 of 17 March 2000 (Department of Transport)"
+    repeals: "GNR.910 of 26 April 1990 (Road Traffic Regulations, 1990)"
+    consolidation_read: "as amended to GNR.359 of 2 May 2010"
+    amended_by:
+      - "R.761, GG 21425, 31 July 2000"
+      - "R.941, GG 21569, 22 September 2000"
+      - "R.726, GG 22553, 3 August 2001"
+      - "R.2116, GG 22736, 5 October 2001"
+      - "R.779, GG 23484, 4 June 2002"
+      - "R.1341, GG 25484, 25 September 2003"
+      - "R.881, GG 26598, 23 July 2004"
+      - "R.871, GG 27999, 2 September 2005"
+      - "R.1066, GG 28227, 23 November 2005"
+      - "R.1319, GG 28258, 2 December 2005"
+      - "R.92, GG 28446, 7 April 2006"
+      - "R.891, GG 29195, 4 September 2006"
+      - "R.964, GG 29260, 29 September 2006"
+      - "R.404, GG 29865, 4 May 2007"
+      - "R.865, GG 30295, 28 September 2007"
+      - "R.589, GG 32258, 27 May 2009"
+      - "R.359, GG 33168, 2 May 2010"
+    amendment_note: >-
+      The consolidation read for this pass stops at GNR.359 of 2 May 2010.
+      Amendments after 2010 are NOT reflected in any claim in this file, and a
+      verifier should treat every reg 27/35 quote as "in force as at 2 May
+      2010, unchanged as at GG 37542 of 9 April 2014" rather than as
+      necessarily current. GG 37542 GN 287 (2014) is the latest text located
+      and it reproduces reg 27(1)-(5) identically.
+    source: "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # the consolidated National Road Traffic Regulations 2000 — table of repeals, amendment table, regs 27, 28, 28A, 29, 35, 50, 71, 82, 84; accessed 2026-08-02"
+    source_host_caveat: >-
+      THE HOST IS NOT THE PUBLISHER, AND THAT IS STATED HERE RATHER THAN
+      HIDDEN. The consolidated regulations were read from the IFRC Disaster
+      Law database, which mirrors the text; no South African government or
+      free-access-to-law host served it in this pass (SAFLII and
+      lawlibrary.org.za both returned HTTP 403 behind bot protection,
+      acts.co.za paywalls the regulation pages, natis.gov.za returned 403, and
+      gov.za's own search returns no regulation documents). The mitigation is
+      corroboration rather than trust: every regulation 27 and regulation 35
+      claim in this file was independently re-read in Government Gazette
+      37542, General Notice 287 of 9 April 2014, hosted on gov.za, and the two
+      texts agree word for word. Where GN 287 does NOT reproduce a provision
+      (regs 28A, 50, 71, 82, 84 and the amendment table) the claim rests on
+      the mirror alone and is flagged for the verifier.
+  licence: >-
+    South African statutes and regulations are edicts of government. The
+    Government Printing Works republication note carried by the gazette PDFs
+    ("This gazette is also available free online at www.gpwonline.co.za")
+    accompanies the Government Gazette text quoted here. SANS/SABS 1116 is a
+    COPYRIGHTED SABS publication and is cited, never reproduced
+    (PRD-PLATES § 6).
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+common:
+  charset:
+    permitted_letters: [B, C, D, F, G, H, J, K, L, M, N, P, R, S, T, V, W, X, Y, Z]
+    excluded_letters: [A, E, I, O, U, Q]
+    first_letter_excluded: [G]
+    scope: >-
+      Reg 27(2)(a)(ii) proviso ONLY — that is, the provincial licence NUMBER
+      systems (three letters + three figures; two letters + two figures + two
+      letters). It does NOT reach the provincial mark itself, the registering-
+      authority marks of reg 27(2)(a)(i), or the reg 27(5) special classes.
+      Reg 71(2) imposes a parallel but not identical rule on motor trade
+      numbers: "shall not consist of vowels, except the letter 'A' as referred
+      to in paragraph (a), or the letter 'Q'".
+    source: "https://www.gov.za/sites/default/files/gcis_document/201409/37542gen287.pdf  # GG 37542 GN 287 of 9 April 2014 reproducing reg 27(2)(a)(ii): 'Provided that vowels and the letter \"Q\" shall not be used and the first letter shall not be the letter \"G\"'"
+  layouts:
+    note: >-
+      Reg 35(3), verbatim: "The letters and figures on a number plate shall be
+      arranged— (a) with all the letters and figures in one line; or (b) with
+      the letters preceding the figures in one line and immediately thereunder,
+      the figures and, if applicable, the last letter in one line; (c) with all
+      the letters and figures and the logo or landscape in one line; or (d)
+      with the letters or the figures and the logo or landscape in one line,
+      and immediately thereunder— (i) the figures and letters; (ii) the letters
+      and letters; or (iii) the letters and figures, and, if applicable,
+      immediately thereunder, the letters in one line."
+    source: "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 35(3)"
+  colours:
+    note: >-
+      Reg 35(2), verbatim: the number plate "(b) shall have a yellow or white
+      retro-reflective surface; (c) shall have black, dark blue, dark red, or
+      dark green letters and figures, but shall display only black letters and
+      figures in the case of a yellow retro-reflective surface; (d) may display
+      a logo or landscape if it appears on a white retro-reflective surface;
+      and (e) shall be clearly legible and visible." Para (c) was substituted
+      by GNR.404 of 4 May 2007.
+    hex_basis_note: >-
+      The Regulations NAME the colours and never number them; the chromaticity
+      lives in SANS/SABS 1116, which PRD-PLATES § 6 forbids reproducing. Every
+      hex in this file is therefore `hex_basis: observed` inside a
+      statutorily named colour — the same posture plates/gb.yml takes for BS
+      AU 145e and plates/de.yml for "grünes Kennzeichen".
+    source: "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 35(2)(b)-(e)"
+  dimensions:
+    note: >-
+      Reg 35(10), second sentence, inserted by GNR.404 of 2007, verbatim:
+      "Provided that notwithstanding the provisions of this regulation, no
+      person shall operate on a public road a motor vehicle first registered
+      on or after 1 January 2010, unless such motor vehicle is fitted with a
+      520 - 113 or 250 - 205 or 250 -165 size number plate." Millimetres. The
+      Free State separately recognises a 305 x 165 mm plate for seven-character
+      personalised numbers (Provincial Notice 278 of 2006) — a size the
+      national regulation does not list, and the discrepancy is recorded, not
+      averaged (PRD-PLATES § 5.3).
+    character_height: >-
+      Reg 35(4): 75 mm is the norm and 60 mm characters may be approved by the
+      MEC for a rear illuminated space too small for 75 mm. The Free State
+      notices name the typeface with the height: "FE modified 75mm as
+      prescribed in the standard specifications of the South African Bureau of
+      Standards, SABS 1116".
+    source: "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 35(4), 35(10)"
+  fitment:
+    note: >-
+      Reg 35(7): a number plate is affixed "(e) to the back of a motor cycle,
+      motor tricycle, motor quadrucycle or trailer; and (f) one to the back and
+      one to the front of all other motor vehicles" — so motorcycles and
+      trailers are REAR ONLY and carry the same licence number as any other
+      vehicle. From 1 January 2009 the plate must be riveted or one-way-screwed
+      within 20 mm of the edges (proviso inserted by r. 7 of GNR.589 of 27 May
+      2009). Reg 35(6)(h) requires every plate on one vehicle to display "the
+      same licence number, letter type, colours, and logo or landscape", which
+      is why `rear_differs` is false throughout this file.
+    source: "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 35(6)(h), 35(7)"
+  standard:
+    citation: >-
+      Reg 35(1), as substituted by R.17(a) of GNR.1341 w.e.f. 25 September
+      2003, verbatim: the licence number "shall be displayed on a plate, to be
+      referred to as a number plate and which complies with standard
+      specification SABS 1116: 'Retro-reflective Registration Plates for Motor
+      Vehicles', Part 2: 'Registration plates (metal)' or Part 4: 'Registration
+      plates (plastic)'." Reg 50(1) binds registered manufacturers of number
+      plates to the same two parts.
+    posture: "cited, never reproduced — SABS 1116 is a paywalled SABS publication (PRD-PLATES § 6)"
+    source: "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 35(1), reg 35(6)(i), reg 50(1)(a)"
+  font:
+    name: "FE-Schrift, modified (\"FE modified\"), 75 mm — 60 mm on the 305 x 165 mm Free State personalised plate"
+    posture: >-
+      The TYPEFACE IS NAMED IN A GAZETTE, which is unusual and worth recording:
+      Free State Provincial Notice 51 of 2002 Schedule 3 para 1 and Provincial
+      Notice 52 of 2002 Schedule 2 para 1 both read "The letter type used for
+      the number shall be FE modified 75mm as prescribed in the standard
+      specifications of the South African Bureau of Standards, SABS 1116". The
+      drawing itself is in SABS 1116 and is not reproduced. Whether the other
+      eight provinces prescribe the same face was not established.
+    source: "https://www.policeroadstransport.fs.gov.za/wp-content/uploads/2012/09/Licence-number-plate-for-the-Free-State-2002.pdf  # PN 51 of 2002, Schedule 3 para 1"
+  not_modelled:
+    - "TEMPORARY AND SPECIAL PERMITS (regs 84-86). A permit is a document, not a plate; reg 84(1) covers delivery, testing, repair, weighing and repossession, and reg 84(3) covers an owner who cannot comply with reg 35. Free State Provincial Notice 52 of 2002 para 2(2) refers to 'the temporary or special permit number system of the Free State Province', so permits DO carry numbers — but no permit-number grammar was located in any instrument reachable in this pass. Recorded gap."
+    - "MILITARY. The South African National Defence Force is a department of State and would fall under reg 27(5)(a)(iii) ('any other licence number determined by the chief executive officer by notice in the Gazette'). No such notice was located, so no military series is asserted here even though a three-letter/three-figure/M form is widely reported. Recorded gap."
+    - "HISTORIC / VINTAGE. No national historic-vehicle plate regime was located in the Act or the Regulations. Recorded gap."
+    - "EXPORT. No export-plate regime was located. Reg 35(6)(e) instead deals with FOREIGN plates: a vehicle registered in a prescribed territory other than Namibia must display the Convention distinguishing sign."
+    - "THE FULL REGISTERING-AUTHORITY MARK TABLES for the Western Cape and (pre-2023) KwaZulu-Natal. See plates/_decode/za-licence-marks.yml — a floor, not a census."
+    - "GAUTENG'S 2025 'SMART' NUMBER PLATE. The Gauteng Provincial Government's own media statement of 5 June 2025 describes a PILOT of tamper-evident decals, forensic QR codes and a digitised back-end portal on g-Fleet vehicles, six months of stress testing 'before the provincial rollout'. It changes the plate's SECURITY FEATURES, not the licence-number grammar, and it was still a pilot at that date — so it is recorded here and not modelled as a series."
+
+series:
+
+  # =========================================================================
+  # A. PROVINCIAL LICENCE NUMBER SYSTEMS — reg 27(2)(a)(ii)(aa):
+  #    "a combination of three letters and three figures in any sequence ...
+  #    and the licence mark of the province concerned".
+  #    One series per province, because the provincial mark is a LITERAL and
+  #    a series is one format (PRD-PLATES § 2.2).
+  # =========================================================================
+
+  - id: za-gp-standard-3l3f
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL 999 GP"
+      regex: '\A[A-Z]{3} ?\d{3} ?GP\z'
+      regex_strict: '\A[BCDFHJKLMNPRSTVWXYZ][BCDFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?GP\z'
+      charset:
+        notes: >-
+          Reg 27(2)(a)(ii) proviso: no vowels, no Q, and no leading G. The
+          strict twin encodes both, which `regex` cannot carry because the
+          lint generates vowels from `pattern`.
+      progression: >-
+        Reg 27 does not publish an allocation order and no Gauteng gazette
+        setting one was located. Letter-triple exhaustion is the reported
+        reason for the move to the two-letter/two-figure/two-letter shape
+        (see za-gp-standard-2l2f2l).
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      emblem: { present: false, note: "reg 27(2)(b) lets the MEC determine a logo or landscape; no Gauteng determination was located" }
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    region_encoding_mechanism: >-
+      The trailing GP is the reg 27(1) provincial mark for Gauteng and encodes
+      the province of LICENSING, not the owner's address and not the place of
+      first registration. It does not narrow further: Gauteng runs one
+      province-wide system, not per-town codes.
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(ii)(aa) three letters + three figures; reg 27(3) composition; the proviso"
+      - "https://www.gov.za/sites/default/files/gcis_document/201409/37542gen287.pdf  # GG 37542 GN 287 of 9 April 2014 reproducing reg 27 in identical words"
+      - "https://cmbinary.gauteng.gov.za/Media?path=transport/Documents/Documents/GP%20Application%20Form%20-%20Personalised%20Number%20Plate.pdf&Item=658&Type=Documents&Location=/transport  # Gauteng form PRN1-GP: the registration-number fields are pre-printed 'G P' — the GP mark"
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 35(2) colours, 35(10) sizes"
+    notes: >-
+      GAUTENG, three letters + three figures + GP. period.start 2000 is the
+      NRTR 2000 and is an instrument-in-force date, NOT the year the format
+      began: Gauteng's suffix system dates from the province's creation in the
+      1994 reorganisation, under the Road Traffic Act 29 of 1989, and the
+      provincial notice that established it was not reachable in this pass.
+      This series is not closed — the overwhelming majority of Gauteng plates
+      on the road carry it — and it runs in parallel with the newer
+      two-letter/two-figure/two-letter issue.
+
+  - id: za-ec-standard-3l3f
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL 999 EC"
+      regex: '\A[A-Z]{3} ?\d{3} ?EC\z'
+      regex_strict: '\A[BCDFHJKLMNPRSTVWXYZ][BCDFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?EC\z'
+      charset: { notes: "reg 27(2)(a)(ii) proviso — no vowels, no Q, no leading G. Note that the MARK itself contains the vowel E: the proviso governs the serial only." }
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(ii)(aa) + proviso; reg 35(2),(10)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa  # the provincial mark EC — secondary-wikipedia, untraced to its provincial gazette notice; accessed 2026-08-02"
+    notes: >-
+      EASTERN CAPE, three letters + three figures + EC. THE MARK IS THE WEAK
+      CLAIM HERE: the grammar is primary (reg 27) but the two letters "EC" rest
+      on Wikipedia and were not traced to the Eastern Cape provincial gazette
+      notice made under reg 27(1). Flagged for the verifier.
+
+  - id: za-fs-standard-3l3f
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL 999 FS"
+      regex: '\A[A-Z]{3} ?\d{3} ?FS\z'
+      regex_strict: '\A[BCDFHJKLMNPRSTVWXYZ][BCDFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?FS\z'
+      charset: { notes: "reg 27(2)(a)(ii) proviso — no vowels, no Q, no leading G" }
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      emblem:
+        present: true
+        rendered: placeholder
+        note: >-
+          THE ONLY FULLY-SOURCED PROVINCIAL DESIGN IN THIS FILE. Free State
+          Provincial Notice 51 of 2002 (Provincial Gazette 25 of 9 April 2002),
+          Schedule 1, verbatim: the background "shall be printed under the top
+          coat of the retro-reflective surface with translucent ink and shall
+          be - (a) a cheetah in the colour brown 0760 with black spots, 50 mm
+          high and 84 mm wide; (b) sky in the colour blue 0460; (c) mountain
+          range in the colour brown 0760 with black rock reeves; and (d)
+          rolling hills in the colour green 0660". The ink codes are the
+          notice's own and are NOT convertible to hex here. Schedule 3 para 4
+          adds a covert element: the retro-reflective sheeting carries the
+          manufacturer's identifier and "the Province by way of the letters
+          'FS' inside a 12 mm circle interspersed throughout the sheeting".
+          PRD-PLATES § 3 placeholder rule applies to the cheetah landscape.
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(ii)(aa) + proviso"
+      - "https://www.policeroadstransport.fs.gov.za/wp-content/uploads/2012/09/Licence-number-plate-for-the-Free-State-2002.pdf  # Free State Provincial Notice 51 of 2002, Provincial Gazette 25 of 9 April 2002, made under reg 27: para 3(c) black letters on white retro-reflective with the Schedule 1/3 landscape; para 12 metal only (SABS 1116 Part 2); para 14 'This notice takes effect on 1 June 2002'; Schedule 3 para 1 FE modified 75 mm; Schedule 3 para 4 the FS-in-a-circle sheeting mark"
+      - "https://www.policeroadstransport.fs.gov.za/wp-content/uploads/2012/09/Amendment-of-personalised-and-licence-number-plates-for-the-Free-State-2010.pdf  # Free State Provincial Notice 16 of 2010, Provincial Gazette 17 of 23 April 2010: deletes the number-plate validation label and the five-year plate-replacement rule from PN 51 of 2002"
+    notes: >-
+      FREE STATE, three letters + three figures + FS. The SERIAL grammar is the
+      national reg 27 grammar; what is province-specific and fully primary here
+      is the DESIGN: black on white with the cheetah landscape from 1 June 2002
+      (Provincial Notice 51 of 2002), metal plates only, with a four-year
+      run-out for existing plastic and for the older black-on-white and
+      black-on-yellow plates authorised by the repealed Government Notice 1579
+      of 28 November 1997. The five-year plate validity and the self-destructing
+      "number plate validation label" that PN 51 introduced were both REPEALED
+      by Provincial Notice 16 of 2010 (23 April 2010) — a rare, cleanly dated
+      reversal, recorded because a consumer reading only the 2002 notice would
+      wrongly expire every Free State plate.
+
+  - id: za-lp-standard-3l3f
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: 'LLL 999 \L'
+      regex: '\A[A-Z]{3} ?\d{3} ?L\z'
+      regex_strict: '\A[BCDFHJKLMNPRSTVWXYZ][BCDFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?L\z'
+      charset: { notes: "reg 27(2)(a)(ii) proviso — no vowels, no Q, no leading G" }
+      pattern_note: >-
+        THE PATTERN ESCAPE'S FIRST PRODUCTION USE. Limpopo's provincial mark is
+        the single letter L, which is also the human-pattern DSL's token for
+        "any letter". `\L` is the LITERAL L (owner ruling, 2026-08-02), so
+        `LLL 999 \L` reads "three letters, three figures, literal L" and the
+        round-trip is exact. Before the escape existed this series would have
+        had to be downgraded to recall-only.
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(ii)(aa) + proviso; reg 27(1) provincial mark"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa  # the one-letter provincial mark L for Limpopo — secondary-wikipedia, untraced to its provincial gazette notice; accessed 2026-08-02"
+    notes: >-
+      LIMPOPO, three letters + three figures + L. Two caveats. (1) The mark is
+      Wikipedia-derived and untraced to the Limpopo provincial gazette. (2) The
+      province was named Northern Province until its 2003 renaming and the mark
+      it used before then was not established — a plate collected in the 1990s
+      may therefore decode to a mark this file does not carry. Recorded gap.
+
+  - id: za-mp-standard-3l3f
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL 999 MP"
+      regex: '\A[A-Z]{3} ?\d{3} ?MP\z'
+      regex_strict: '\A[BCDFHJKLMNPRSTVWXYZ][BCDFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?MP\z'
+      charset: { notes: "reg 27(2)(a)(ii) proviso — no vowels, no Q, no leading G" }
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(ii)(aa) + proviso"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa  # the provincial mark MP — secondary-wikipedia, untraced; accessed 2026-08-02"
+    notes: >-
+      MPUMALANGA, three letters + three figures + MP. The province was named
+      Eastern Transvaal at its 1994 creation and renamed Mpumalanga in 1995;
+      neither the mark nor the rename's effect on it was traced to a provincial
+      gazette in this pass.
+
+  - id: za-nc-standard-3l3f
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL 999 NC"
+      regex: '\A[A-Z]{3} ?\d{3} ?NC\z'
+      regex_strict: '\A[BCDFHJKLMNPRSTVWXYZ][BCDFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?NC\z'
+      charset: { notes: "reg 27(2)(a)(ii) proviso — no vowels, no Q, no leading G" }
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(ii)(aa) + proviso"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa  # the provincial mark NC — secondary-wikipedia, untraced; accessed 2026-08-02"
+    notes: >-
+      NORTHERN CAPE, three letters + three figures + NC. A Northern Cape plate
+      is the clearest demonstration of the two-dimension trap this file guards
+      against: the province was carved out of the old Cape Province, whose
+      registering-authority marks all began with C and are still issued next
+      door in the Western Cape, so a C-initial mark and an NC suffix are the
+      SAME geography a generation apart and must never be conflated.
+
+  - id: za-nw-standard-3l3f
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL 999 NW"
+      regex: '\A[A-Z]{3} ?\d{3} ?NW\z'
+      regex_strict: '\A[BCDFHJKLMNPRSTVWXYZ][BCDFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?NW\z'
+      charset: { notes: "reg 27(2)(a)(ii) proviso — no vowels, no Q, no leading G" }
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(ii)(aa) + proviso"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa  # the provincial mark NW, and a reported new North West numbering system announced December 2015 and implemented February 2016 — secondary-wikipedia, untraced; accessed 2026-08-02"
+    notes: >-
+      NORTH WEST, three letters + three figures + NW. A change of numbering
+      system is reported for February 2016 (announced December 2015) and was
+      NOT modelled: no notice was located, and a reg 27(4) notice establishing
+      a NEW system would have had to choose between limbs (aa) and (bb), which
+      would decide whether this series should have an end year. Recorded as the
+      most likely missing series in this file.
+
+  # =========================================================================
+  # B. PROVINCIAL LICENCE NUMBER SYSTEMS — reg 27(2)(a)(ii)(bb), the limb
+  #    INSERTED by r. 5(a) of GNR.589 of 27 May 2009 (GG 32258):
+  #    "a combination of two letters, two figures and two letters in any
+  #    sequence ... and the licence mark of the province concerned".
+  # =========================================================================
+
+  - id: za-gp-standard-2l2f2l
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2023 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LL 99 LL GP"
+      regex: '\A[A-Z]{2} ?\d{2} ?[A-Z]{2} ?GP\z'
+      regex_strict: '\A[BCDFHJKLMNPRSTVWXYZ][BCDFGHJKLMNPRSTVWXYZ] ?\d{2} ?[BCDFGHJKLMNPRSTVWXYZ]{2} ?GP\z'
+      charset: { notes: "reg 27(2)(a)(ii) proviso — no vowels, no Q, no leading G; the proviso attaches to sub-para (ii) as a whole and so governs limb (bb) exactly as it governs limb (aa)" }
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(ii)(bb) and its amendment note '[Sub-para. (ii) substituted by r. 5 (a) of GNR.589 of 27 May 2009.]' — the enabling instrument"
+      - "https://www.gov.za/sites/default/files/gcis_document/201409/37542gen287.pdf  # GG 37542 GN 287 of 9 April 2014 reproducing limb (bb) verbatim"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa  # the 2023 Gauteng transition from three-letter/three-digit to two-letter/two-digit/two-letter, and the example BC 12 DF GP — secondary-wikipedia, untraced to a Gauteng provincial gazette notice; accessed 2026-08-02"
+      - "https://cmbinary.gauteng.gov.za/Media?path=transport/Documents/Documents/GP%20Application%20Form%20-%20Personalised%20Number%20Plate.pdf&Item=658&Type=Documents&Location=/transport  # the GP mark itself (Gauteng form PRN1-GP)"
+    notes: >-
+      GAUTENG, two letters + two figures + two letters + GP. THE PERIOD IS THE
+      WEAK CLAIM AND IT IS THE ONLY REASON THIS SERIES IS NOT FULLY PRIMARY.
+      The FORMAT is primary twice over (reg 27(2)(a)(ii)(bb), and GG 37542 GN
+      287 reproducing it) and could not have been issued before 27 May 2009,
+      the day GNR.589 inserted limb (bb) — that is the hard lower bound. The
+      2023 start is Wikipedia-derived: the Gauteng notice under reg 27(4)
+      establishing the new system was not located, and no Gauteng provincial
+      gazette index with full-text search was reachable. Distinct from
+      za-gp-standard-3l3f, which continues in parallel and still carries the
+      overwhelming majority of Gauteng registrations. RANKED FIRST for the
+      verifier: one Gauteng Provincial Gazette citation converts this from
+      secondary to instrument-evidenced.
+
+  - id: za-zn-standard-2l2f2l
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2023 }
+    period_evidence: secondary-first-issue
+    matching: strict
+    format:
+      pattern: "LL 99 LL ZN"
+      regex: '\A[A-Z]{2} ?\d{2} ?[A-Z]{2} ?ZN\z'
+      regex_strict: '\A[BCDFHJKLMNPRSTVWXYZ][BCDFGHJKLMNPRSTVWXYZ] ?\d{2} ?[BCDFGHJKLMNPRSTVWXYZ]{2} ?ZN\z'
+      charset: { notes: "reg 27(2)(a)(ii) proviso — no vowels, no Q, no leading G" }
+      progression: >-
+        Phased, and the phases are dated by the provincial government itself:
+        phase 1 from 1 December 2023 covers "the registration of new vehicles,
+        change of ownership, and re-registration of stolen-recovered vehicles";
+        phase 2 from 1 March 2024 opens voluntary migration, with a 24-month
+        window "after which all motor vehicles will automatically be issued
+        with a new format licence number upon licensing".
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(ii)(bb) inserted by r. 5(a) of GNR.589 of 27 May 2009 — the enabling instrument; reg 27(4) MEC may establish a new licence number system"
+      - "https://www.sanews.gov.za/south-africa/new-provincial-number-plate-system-unveiled-kzn  # SAnews.gov.za (Government Communication and Information System), 1 December 2023: KwaZulu-Natal Premier unveils the new system, 'marking an end to the traditional discrete numbering system to a more dynamic and continuous numbering system'; phase 1 from that Friday, phase 2 from 1 March 2024, 24-month migration window; accessed 2026-08-02"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa  # the ZN mark and the two-letter/two-digit/two-letter shape for KwaZulu-Natal — secondary-wikipedia; accessed 2026-08-02"
+    notes: >-
+      KWAZULU-NATAL, two letters + two figures + two letters + ZN, from
+      1 December 2023. The DATE is pinned to a government publication (SAnews,
+      GCIS) that also states the reason in the province's own words — "towns
+      running out of available numbers" — which is exactly what a
+      registering-authority-mark system does when it exhausts. The SHAPE rests
+      on reg 27(2)(a)(ii)(bb) plus Wikipedia for the choice of limb, and the
+      mark "ZN" on Wikipedia alone. Supersedes za-zn-ra-mark for NEW
+      registrations only; the old discrete numbers stay valid and on the road
+      through the migration window.
+
+  # =========================================================================
+  # C. REGISTERING-AUTHORITY MARK SYSTEMS — reg 27(2)(a)(i) + reg 27(3):
+  #    "the licence mark referred to in subregulation (2)(a)(i) and figures".
+  #    The inherited pre-1994 town-code system, surviving in two provinces.
+  # =========================================================================
+
+  - id: za-wc-ra-mark
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "CL 999999"
+      regex: '\AC[A-Z]{1,2} ?\d{1,3}(?:[- ]?\d{1,3})?\z'
+      charset:
+        notes: >-
+          NO STRICT TWIN, DELIBERATELY. The reg 27(2)(a)(ii) proviso does not
+          reach this limb, and the only thing that would narrow the regex is
+          the closed list of Western Cape registering-authority marks — which
+          is not published anywhere this pass could reach. A strict twin built
+          from the eight marks the Western Cape Government happens to print as
+          worked examples would REJECT valid plates, which is worse than no
+          twin at all. See plates/_decode/za-licence-marks.yml.
+      progression: >-
+        Sequential within a mark; a mark is replaced when it exhausts (Cape
+        Town CA -> CAA, reported 13 April 2019; George CAW -> CAG, reported
+        late 2019 — both secondary-wikipedia).
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    region_encoding_mechanism: >-
+      The LEADING letters are the reg 27(2)(a)(i) registering-authority mark
+      and they decode to the licensing OFFICE, which is a real town-level
+      decode and the most Geoguessr-useful fact in South Africa. Every Western
+      Cape mark located begins with C, inherited from the pre-1994 Cape
+      Province allocation; marks are two or three letters and are MAXIMAL-MUNCH
+      against the digits (CB and CBY both exist, so a parser must take the
+      longest alphabetic run before the first digit). The table is a floor, not
+      a census — an unlisted C-initial mark is unresolved, never invalid.
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(i) 'a combination of letters'; reg 27(3) 'the licence mark ... and figures'"
+      - "https://www.westerncape.gov.za/mobility/service/applying-special-motor-vehicle-number-plates  # Western Cape Government fee table, worked discrete-number examples 'CY 6', 'CW 16', 'CBY 3', 'CG 131', 'CBY 15', 'CK 1441', 'CB 131', 'CFM 2332' — the mark shapes and the 1-to-6-figure range; accessed 2026-08-02"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa  # the CA/CAA (Cape Town, 13 April 2019) and CAW/CAG (George, late 2019) exhaustion changes — secondary-wikipedia; accessed 2026-08-02"
+    notes: >-
+      WESTERN CAPE, registering-authority mark + up to six figures — the last
+      province that never adopted a suffix system, and the direct survival of
+      the pre-1994 Cape Province town codes. period.start 2000 is the NRTR and
+      is an instrument-in-force date: these marks are decades older than the
+      instrument that now governs them. Note the asymmetry with every suffix
+      province: "WP" is NOT on an ordinary Western Cape plate at all — it
+      appears only on personalised numbers (see za-wc-personalised). The
+      1-to-6-figure range is taken from the province's own fee table, which
+      prices discrete numbers by character count from three to six and then
+      "All others"; the six-digit full-length number is conventionally printed
+      3-3 with a hyphen ("CA 123-456") and no instrument requires that hyphen,
+      so it is not written into the pattern.
+
+  - id: za-zn-ra-mark
+    class: standard
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000, end: 2023 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "NL 999999"
+      regex: '\AN[A-Z]{1,2} ?\d{1,3}(?:[- ]?\d{1,3})?\z'
+      charset: { notes: "No strict twin, for the same reason as za-wc-ra-mark: no closed KwaZulu-Natal mark table was located." }
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 250, h: 205, unit: mm, note: "reg 35(10)" }
+        - { w: 250, h: 165, unit: mm, note: "reg 35(10)" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    region_encoding_mechanism: >-
+      Leading letters are the registering-authority mark and decode to the
+      licensing town. Every KwaZulu-Natal mark located begins with N,
+      inherited from the pre-1994 Natal allocation. Only two rows are carried
+      in the decode table (NPS -> NSC, Port Shepstone) and both are
+      secondary-wikipedia; the rest of the table is a recorded gap.
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(2)(a)(i) + reg 27(3); reg 27(4) MEC may establish a new system"
+      - "https://www.sanews.gov.za/south-africa/new-provincial-number-plate-system-unveiled-kzn  # SAnews.gov.za, 1 December 2023: the end of 'the traditional discrete numbering system', phase 1 from 1 December 2023, and 'the issue of towns running out of available numbers' as the stated reason; accessed 2026-08-02"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa  # the N-initial mark family and the Port Shepstone NPS -> NSC change of 30 June 2020 — secondary-wikipedia; accessed 2026-08-02"
+    notes: >-
+      KWAZULU-NATAL, registering-authority mark + up to six figures — CLOSED TO
+      NEW ISSUE on 1 December 2023, when the province moved to the ZN suffix
+      system. The end year is the government-announced phase-1 date and is the
+      date NEW registrations stopped receiving these numbers; existing discrete
+      numbers remain valid and on the road, and the province gave owners a
+      24-month voluntary-migration window from 1 March 2024. Distinct from
+      za-wc-ra-mark, which is the same statutory limb still open in the
+      Western Cape.
+
+  # =========================================================================
+  # D. PERSONALISED LICENCE NUMBERS — reg 28. Each province establishes and
+  #    prices its own system; the shape is always "chosen characters +
+  #    provincial mark".
+  # =========================================================================
+
+  - id: za-wc-personalised
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL WP"
+      regex: '\A[A-Z0-9]{1,7}[- ]?WP\z'
+      charset:
+        notes: >-
+          Owner-chosen alphanumerics — the reg 27(2)(a)(ii) proviso does not
+          apply to reg 28, which is why vowels and Q are admitted here and
+          nowhere else in this file. The Western Cape Government's own worked
+          examples include "JOHNNY2 - WP" and "RUN2ME - WP". A match is a
+          WELL-FORMEDNESS claim and not an availability claim: whether a
+          particular combination is free is a register question no regex can
+          answer.
+      progression: "owner-chosen; availability-checked on application (form SLN1)"
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 28(1) MEC may establish a personalised licence number system; reg 28(3) issued on application on conditions and fees the MEC determines; reg 28A cancellation"
+      - "https://www.westerncape.gov.za/mobility/service/applying-special-motor-vehicle-number-plates  # Western Cape Government, verbatim: 'Personalised number plates contain the letters WP (Western Province) at the end of the number plate'; the fee table prices 1, 2, 3 and 'All others, up to a maximum of seven alpha and/or numeric characters'; form SLN1; manufacturer Uniplate Group; accessed 2026-08-02"
+    notes: >-
+      WESTERN CAPE personalised numbers — one to seven owner-chosen
+      alphanumerics followed by WP. This is the ONLY context in which "WP"
+      appears on a Western Cape plate, because the province issues its ordinary
+      numbers under the registering-authority limb. The province distinguishes
+      PERSONALISED numbers (arbitrary characters + WP) from DISCRETE numbers
+      (short serials inside an existing registering-authority mark, e.g. "CY 6"
+      or "CFM 2332"); discrete numbers are modelled as short serials of
+      za-wc-ra-mark, not here, because they carry a town mark and not WP.
+
+  - id: za-fs-personalised
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2002 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LLL FS"
+      regex: '\A[A-Z0-9]{1,7}[- ]?FS\z'
+      charset:
+        notes: >-
+          Free State Provincial Notice 52 of 2002 para 2(1) as substituted by
+          Provincial Notice 278 of 2006, verbatim: a personalised licence
+          number "must consist of - (a) at least one, but not more than seven
+          letters, followed by the letters FS; or (b) a combination of a
+          maximum of seven letters and figures, followed by the letters FS".
+          Para 2(2) excludes any combination "that occur in the general licence
+          number system, the motor dealer number system, the temporary or
+          special permit number system of the Free State Province or be
+          offensive of nature to any person or group of persons in the
+          community" — an exclusion no regex can express, so a match here is a
+          well-formedness claim and not an availability claim.
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      plate_variants:
+        - { w: 305, h: 165, unit: mm, note: "Free State PN 278 of 2006: seven characters + FS may be displayed only on 520 x 113 mm and 305 x 165 mm plates, and the 305 x 165 mm plate uses FE modified 60 mm rather than 75 mm" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#006400"
+      emblem:
+        present: true
+        rendered: placeholder
+        note: "the same cheetah/sky/mountain/hills landscape as the ordinary Free State plate (PN 52 of 2002 Schedule 1)"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://www.policeroadstransport.fs.gov.za/wp-content/uploads/2012/09/Personalised-licence-number-system-for-the-Free-State-2002.pdf  # Free State Provincial Notice 52 of 2002, Provincial Gazette 25 of 9 April 2002, made under regs 28, 28A and 29(2): para 2(1) the six-character grammar; para 3 'dark green letters and figures on a white retro-reflective surface with a landscape as set out in Schedules 1 and 2'; para 19 metal plates only; para 21 'This notice shall take effect on 10 April 2002'; Schedule 2 para 1 FE modified 75 mm"
+      - "https://www.policeroadstransport.fs.gov.za/wp-content/uploads/2012/09/Amendment-of-personal-licence-number-system-2006.pdf  # Free State Provincial Notice 278 of 2006, Provincial Gazette 102 of 15 December 2006: six -> seven characters, the 520 x 113 / 305 x 165 restriction, FE modified 60 mm on the smaller plate, metal OR plastic; para 4 'This Notice takes effect on 1 April 2007'"
+      - "https://www.policeroadstransport.fs.gov.za/wp-content/uploads/2012/09/Amendment-of-personalised-and-licence-number-plates-for-the-Free-State-2010.pdf  # Free State Provincial Notice 16 of 2010: repeals the validation label and the plate-validity period"
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 28; reg 28(4A) and reg 27(2)(bA), both inserted by r. 2-3 of GNR.779 w.e.f. 4 June 2002, which give the Free State MEC alone the power to determine the TYPE of number plate notwithstanding reg 35"
+    notes: >-
+      FREE STATE personalised numbers — DARK GREEN characters on white with the
+      cheetah landscape, from 10 April 2002. The fully-primary series in this
+      file and the one that earns `enabling-instrument`: Provincial Notice 52
+      of 2002 creates the system, dates its own commencement, and prints its
+      own grammar. The grammar was SIX characters from 10 April 2002 and became
+      SEVEN on 1 April 2007 (PN 278 of 2006); the regex carries the current
+      seven, and a plate of exactly seven characters therefore cannot predate
+      April 2007. The Free State is also the one province with a bespoke
+      national carve-out: GNR.779 of 4 June 2002 inserted reg 27(2)(bA) and reg
+      28(4A) to let the Free State MEC determine the TYPE of plate
+      notwithstanding reg 35.
+
+  - id: za-gp-personalised
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL GP"
+      regex: '\A[A-Z0-9]{1,7}[- ]?GP\z'
+      charset:
+        notes: >-
+          Owner-chosen alphanumerics + GP. The seven-character maximum is
+          NOT stated on the form's face; it is inferred from the form's own
+          document reference ("dvds/Aansoekspe2/(7karakters)han/2") and
+          corroborated by Wikipedia, which reports seven for Gauteng,
+          KwaZulu-Natal and the Western Cape and six elsewhere. Treated as
+          secondary and flagged. As with every personalised series, a match is
+          a well-formedness claim and not an availability claim, and the regex
+          necessarily also accepts an ordinary GP-suffixed licence number of
+          the same length — the two systems share a terminal mark and only the
+          register can separate them.
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://cmbinary.gauteng.gov.za/Media?path=transport/Documents/Documents/GP%20Application%20Form%20-%20Personalised%20Number%20Plate.pdf&Item=658&Type=Documents&Location=/transport  # Gauteng Province form PRN1-GP 'Application for special/personalised registration number for motor vehicle': three choice fields each pre-printed with 'G P'; the applicant marks each character N (number) or A (alphabet); the form's own footer reference reads '(7karakters)'; accessed 2026-08-02"
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 28(1),(3),(5); reg 28A cancellation and surrender"
+    notes: >-
+      GAUTENG personalised numbers — owner-chosen characters followed by GP.
+      A DATING CURIOSITY WORTH KEEPING: the province's own current form still
+      cites "Road Traffic Act, 1989, Sec. 14" in its heading, an Act the NRTA
+      1996 replaced. That stale citation is itself evidence that the Gauteng
+      personalised system predates the NRTR 2000 and was carried forward rather
+      than created by it — which is exactly why period_evidence here is
+      instrument-in-force and not enabling-instrument.
+
+  # =========================================================================
+  # E. THE REG 27(5) SPECIAL CLASSES. These are national, not provincial, and
+  #    they are the reason a South African plate's LAST letter must never be
+  #    decoded as geography.
+  # =========================================================================
+
+  - id: za-government-g
+    class: government
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "GLL 999 G"
+      regex: '\AG[A-Z]{2} ?\d{3} ?G\z'
+      charset:
+        notes: >-
+          NO STRICT TWIN: the reg 27(2)(a)(ii) proviso governs the provincial
+          licence NUMBER SYSTEMS and does not reach reg 27(5), so no sourced
+          letter restriction applies to the two middle letters.
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+      note: >-
+        Reg 35(2)(b)-(c) admits a yellow surface with black characters as an
+        alternative for any class, and government fleets are commonly reported
+        on yellow; no instrument fixing the government colour nationally was
+        located. The Free State prescribes RED characters on white with the
+        provincial coat of arms for vehicles owned by the Free State
+        Provincial Government (PN 51 of 2002 para 5(b)) — a province-level
+        design on this national format.
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(5)(a), verbatim: the licence number of a motor vehicle 'the owner of which is a department of State, may consist of— (i) the licence number allocated to the vehicle upon licensing thereof; (ii) the letter G followed by two letters, three figures, and the letter G; or (iii) any other licence number determined by the chief executive officer by notice in the Gazette'"
+      - "https://www.gov.za/sites/default/files/gcis_document/201409/37542gen287.pdf  # GG 37542 GN 287 of 9 April 2014 reproducing reg 27(5)(a) identically"
+      - "https://www.policeroadstransport.fs.gov.za/wp-content/uploads/2012/09/Licence-number-plate-for-the-Free-State-2002.pdf  # PN 51 of 2002 para 5(b): red letters and figures on white with the Free State coat of arms for provincial-government vehicles"
+    notes: >-
+      DEPARTMENT OF STATE, G + two letters + three figures + G. Reg 27(5)(a) is
+      PERMISSIVE — "may consist of" — and limb (i) expressly allows a State
+      department to keep the ordinary licence number allocated on licensing, so
+      a government vehicle need not carry this format at all and a G-suffix
+      match is a sufficient but not necessary test for state ownership. This
+      series is also the reason the reg 27(2)(a)(ii) proviso forbids G as the
+      first letter of an ordinary licence number: the two rules exist to keep
+      the G space clear of each other.
+
+  - id: za-police-b
+    class: police
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "LLL 999 B"
+      regex: '\A[A-Z]{3} ?\d{3} ?B\z'
+      charset: { notes: "No strict twin: the reg 27(2)(a)(ii) proviso does not reach reg 27(5)(b)." }
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(5)(b), verbatim: the licence number of a motor vehicle 'the owner of which is the South African Police Service, may consist of three letters, three figures, followed by the letter B'; reg 21A/25(2)(f) confirms a SAPS-allocated number is recorded as such"
+      - "https://www.gov.za/sites/default/files/gcis_document/201409/37542gen287.pdf  # GG 37542 GN 287 of 9 April 2014 reproducing reg 27(5)(b) identically"
+    notes: >-
+      SOUTH AFRICAN POLICE SERVICE, three letters + three figures + B. The
+      shape is identical to a provincial 3+3 number and the ONLY thing that
+      distinguishes it is the terminal letter, which is why the decode table
+      carries B in its `not_geographic` list. Like reg 27(5)(a) this limb is
+      permissive ("may consist of"), so SAPS vehicles on ordinary provincial
+      numbers exist. Metropolitan police departments are municipal, not SAPS,
+      and are not covered by this limb.
+
+  - id: za-zulu-royal-zk
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "ZK 999"
+      regex: '\AZK ?[A-Z0-9]{1,6}\z'
+      regex_statutory: '\AZK ?[A-Z0-9]+\z'
+      charset:
+        notes: >-
+          Reg 27(5)(c) sets NO LENGTH LIMIT — "the letters ZK followed by
+          figures or letters or combination of figures and letters" — so the
+          statutory twin is unbounded and `regex` is deliberately narrower at
+          six characters, which is the longest serial any South African
+          provincial system issues. Narrower than the statute is still
+          `strict` (PRD-PLATES § 2.7); the outer legal bound is in
+          `regex_statutory`, which is exactly what that field is for.
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+      note: >-
+        Reg 27(2)(bB) and reg 28(4B), both inserted by r. 5(b) and r. 6 of
+        GNR.589 of 27 May 2009, empower the KwaZulu-Natal MEC to determine a
+        distinct logo or landscape, letter type, letter colour and sheeting
+        colour for these numbers. No such determination was located, so the
+        design here is the reg 35 default and is not a claim about the
+        plates actually issued.
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(5)(c) as substituted by GNR.865 of 2007: 'set aside for the use by the King of the Zulu Nation, shall consist of the letters ZK followed by figures or letters or combination of figures and letters'; reg 27(2)(bB) and reg 28(4B) inserted by GNR.589 of 27 May 2009"
+      - "https://www.gov.za/sites/default/files/gcis_document/201409/37542gen287.pdf  # GG 37542 GN 287 of 9 April 2014 reproducing reg 27(5)(c) identically"
+    notes: >-
+      NUMBERS SET ASIDE FOR THE KING OF THE ZULU NATION — the only South
+      African series tied to a traditional office rather than a government
+      department, and a genuine schema oddity: ZK is a PREFIX where every other
+      special class in reg 27(5) is a suffix. Classed `government` because the
+      vocabulary has no traditional-monarchy class and the series is a state
+      set-aside; flagged for the verifier in case a class PR is preferred. The
+      current wording was substituted by GNR.865 of 28 September 2007, which
+      means an earlier ZK provision existed in the 2000 text — hence
+      instrument-in-force at 2000 rather than a 2007 creation.
+
+  - id: za-diplomatic-d
+    class: diplomatic
+    categories: [car, van, truck, bus, motorcycle]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    # RECALL-ONLY (PRD-PLATES § 2.7): reg 27(5)(d) delegates the ENTIRE
+    # grammar to the Director-General of Foreign Affairs and fixes exactly one
+    # thing about it — that the number "shall end in the letter 'D'". No
+    # DIRCO determination was located, so the regex below is a shape net built
+    # around the one sourced fact. A match says "this string ends in D and has
+    # a diplomatic-looking shape", never "this is a valid South African
+    # diplomatic number".
+    matching: recall-only
+    format:
+      pattern: "LLL 999 D"
+      regex: '\A(?:[A-Z] )?[A-Z]{1,4} ?\d{1,4} ?D\z'
+      pattern_note: >-
+        The pattern shows one representative shape. The optional leading
+        single letter in the regex accommodates the widely-reported class
+        letter (D diplomatic, C consular, X and S for other categories) that
+        precedes the serial on the current style; that class-letter set is
+        NOT sourced to an instrument and is recorded as a gap, which is the
+        second reason this series is recall-only.
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+      note: >-
+        Reg 35(2)(c) permits dark red and dark green characters on a white
+        surface, and diplomatic plates are widely reported to use exactly
+        those two colours to separate the diplomatic from the consular
+        category. That correspondence is plausible and UNSOURCED; the default
+        black is recorded instead of guessing.
+    region_encoding: none
+    region_encoding_note: >-
+      A diplomatic number carries no provincial mark and no registering-
+      authority mark: reg 27(5)(d) takes it out of the provincial systems
+      entirely. Decoding its letters as geography is the single most likely
+      parse-API error in South Africa.
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 27(5)(d), verbatim: the licence number of a motor vehicle the owner of which is '(i) a foreign government, diplomat representing a foreign government, an international or inter-governmental organisation; (ii) a member of staff or suite of such government or organisation; or (iii) any other person or class of person determined by the Minister of Foreign Affairs, shall consist of such letters and figures as are determined by the Director-General: Department of Foreign Affairs but shall end in the letter \"D\"'"
+      - "https://www.gov.za/sites/default/files/gcis_document/201409/37542gen287.pdf  # GG 37542 GN 287 of 9 April 2014 reproducing reg 27(5)(d) identically"
+    notes: >-
+      DIPLOMATIC AND CONSULAR CORPS. The one certain fact is the terminal D,
+      and it is the whole of what the Regulations say. The Department of
+      Foreign Affairs (now DIRCO) determination that carries the real grammar —
+      country codes, class letters, serial length — was not located in this
+      pass and is the highest-value single missing document for South Africa
+      after the provincial reg 27(1) notices. Until it lands this series is a
+      recall net and is labelled as one.
+
+  # =========================================================================
+  # F. MOTOR TRADE (DEALER) NUMBERS — reg 71(2). Two shapes, one per limb,
+  #    and they mirror the two provincial systems exactly.
+  # =========================================================================
+
+  - id: za-dealer-a
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "ALL 999 LL"
+      regex: '\AA[A-Z]{2} ?\d{3} ?[A-Z]{1,2}\z'
+      regex_strict: '\AA[BCDFGHJKLMNPRSTVWXYZ]{2} ?\d{3} ?(?:EC|FS|GP|L|MP|NC|NW|WP|ZN)\z'
+      charset:
+        notes: >-
+          Reg 71(2), closing words, verbatim: "but shall not consist of vowels,
+          except the letter 'A' as referred to in paragraph (a), or the letter
+          'Q'." So the leading A is a sanctioned vowel and the two following
+          letters are drawn from the same twenty-letter set as an ordinary
+          licence number — but WITHOUT the leading-G exclusion, which reg 71
+          does not repeat. The strict twin also closes the provincial-mark
+          position to the nine marks in the decode table, six of which are
+          themselves secondary-wikipedia.
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+      note: >-
+        Reg 82(1): a motor trade number is displayed on a reg 35 plate but ONE
+        plate only, to the rear, inside the rear window where there is one, and
+        reg 82(4) forbids affixing it permanently to any vehicle — the plate is
+        bound to the BUSINESS, not the vehicle. The Free State prescribes dark
+        blue characters on white with the provincial landscape for dealer
+        plates (PN 51 of 2002 para 4(b)).
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 71(2)(a), verbatim: a motor trade number system 'shall consist of— (a) the letter \"A\" followed by two letters, three figures and the licence mark of the province concerned as contemplated in regulation 27 (1)'; reg 82(1),(4) display and non-permanence"
+      - "https://www.policeroadstransport.fs.gov.za/wp-content/uploads/2012/09/Licence-number-plate-for-the-Free-State-2002.pdf  # PN 51 of 2002 para 4(b): dark blue letters and figures on white with the landscape, for motor dealer plates"
+    notes: >-
+      MOTOR TRADE NUMBERS on the provincial limb — A + two letters + three
+      figures + provincial mark. Bound to a registered motor dealer,
+      manufacturer, builder or importer, licensed annually under regs 73-77 and
+      cancellable under reg 80. The A prefix is why A survives the vowel ban in
+      this one series and nowhere else, and it makes a dealer number
+      instantly separable from an ordinary 3+3 provincial number.
+
+  - id: za-dealer-figures
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force
+    matching: strict
+    format:
+      pattern: "9999 LL"
+      regex: '\A\d{3,4} ?[A-Z]{1,3}\z'
+      charset:
+        notes: >-
+          No strict twin: the trailing group is a registering-authority mark
+          and no closed table of those exists (see za-wc-ra-mark). Reg 71(2)'s
+          vowel/Q exclusion is written for the SYSTEM's letters and its
+          interaction with an allocated mark that already contains a vowel
+          (CA, for instance) is not resolved by the text — recorded, not
+          guessed.
+    design:
+      plate: { w: 520, h: 113, unit: mm }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      rear_differs: false
+    region_encoding: "plates/_decode/za-licence-marks.yml"
+    region_encoding_mechanism: >-
+      Here the mark TRAILS the figures, which is the mirror image of an
+      ordinary registering-authority number (mark first, figures after). A
+      parser must therefore not assume mark position from the presence of a
+      mark: "1234 CA" is a Western Cape dealer number and "CA 1234" is an
+      ordinary Cape Town registration.
+    sources:
+      - "https://disasterlaw.ifrc.org/sites/default/files/media/disaster_law/2021-06/%20ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf  # reg 71(2)(b), verbatim: 'three or four figures followed by the licence mark of the registering authority as contemplated in regulation 27 (2) (a) (i), but shall not consist of vowels, except the letter \"A\" as referred to in paragraph (a), or the letter \"Q\"'"
+    notes: >-
+      MOTOR TRADE NUMBERS on the registering-authority limb — three or four
+      figures followed by the town mark. The counterpart of za-dealer-a for the
+      provinces that never adopted a suffix system, and the only South African
+      series where the geographic token comes LAST while the serial comes
+      FIRST. Distinct from za-dealer-a in both shape and statutory limb.


### PR DESCRIPTION
**PRD-PLATES gate L3 (S5W; manifest branch s4w-plates/l3-manifest).** Researcher-drafted to the L1/L2 standard: primary instruments quoted verbatim (native-language gazettes read in the original), instrument-dated periods with honest period_evidence, folklore flagged not asserted, non-Latin scripts modelled as decode/field facts with the ASCII projection stated. Independent staged lint over origin/main with ALL 28 wave files: `plates lint: 123 files, 1360 series ... OK`.

**za**: 20 series, 12 pinned sources, lint green.

---

# Research dossier — ZA (South Africa), PRD-PLATES gate L3

Researcher pass, 2026-08-02. Draft only: nothing was written to
`/Users/javi/GitHub/vehiclesdb`. Deliverables:

| file | what it is |
|---|---|
| `za.yml` | 20 series — the jurisdiction file, to land as `plates/za.yml` |
| `za-licence-marks.yml` | the two-dimension decode table, to land as `plates/_decode/za-licence-marks.yml` |
| `lint-proof-za.txt` | `ruby scripts/lint_plates.rb` + a 43-case behaviour check, both green |

Lint result with the drafts in place: **96 files, 1047 series, OK** (baseline
before the drafts: 95 files, 1027 series, OK — so 20 series and 1 sidecar
added, nothing else disturbed).

---

## 1. The finding that decides the file: South Africa has ONE grammar and TWO geographies

Regulation 27 of the **National Road Traffic Regulations, 2000** (GNR.225 of
17 March 2000, made under s. 75 of the National Road Traffic Act 93 of 1996)
is the whole of the ordinary South African plate, and it is small, closed and
directly regex-able. Verbatim, reg 27(2)(a):

> The MEC of a province shall by notice in the Provincial Gazette—
> (i) allocate a licence mark to every registering authority in the province
> concerned, which licence mark shall consist of a combination of letters; or
> (ii) establish a licence number system for the province concerned which
> license number system shall consist of: (aa) a combination of three letters
> and three figures in any sequence; or (bb) a combination of two letters, two
> figures and two letters in any sequence: and the licence mark of the
> province concerned, referred to in sub regulation (1): Provided that vowels
> and the letter "Q" shall not be used and the first letter shall not be the
> letter "G".

That single "or" between limbs (i) and (ii) is the reason South African plates
look like two different countries:

* **limb (ii) provinces** print a serial then a provincial mark — `BCD 123 GP`
* **limb (i) provinces** print a town mark then figures — `CA 123-456`

and the two are *the same geography a generation apart*. The limb-(i) marks
are the pre-1994 four-province town codes (the Cape "C" family, the Natal "N"
family), carried across the 1994 reorganisation unchanged in the two provinces
that never switched. A parse API that decodes a trailing two-letter group as
"province" and a leading two-letter group as "province" with one table will be
wrong about Cape Town, Durban and the Northern Cape simultaneously. Hence the
decode file's two separate tables and its `not_geographic` list.

**Assignment question answered:** the brief asked whether to model per-province
series inside one `za.yml` with a province dimension, or a mechanism. The
answer the law forces is *both, and split by SYSTEM not by province*: the
provincial mark is a **literal** in the serial (`GP`, `MP`, `L`), so it cannot
be a runtime dimension without breaking the round-trip, and each province
therefore gets its own series under the national grammar. The registering-
authority marks *are* a genuine open dimension and are modelled as a mechanism
plus a partial table. South Africa is **not** federated in the `us-fl` /
`au-nsw` sense — the grammar is national and only its parameters are
provincial — so one `za.yml` is correct and per-province files would be wrong.

## 2. The era boundaries, and which of them are dated

| boundary | date | evidence tier | how it is recorded |
|---|---|---|---|
| the two-letter/two-figure/two-letter system becomes lawful | **27 May 2009** | primary — sub-para (ii) *substituted* by r. 5(a) of **GNR.589** (GG 32258) | `enabling-instrument` in the header; the hard lower bound for `za-gp-standard-2l2f2l` and `za-zn-standard-2l2f2l` |
| KwaZulu-Natal leaves the town-code system | **1 December 2023** | government publication — SAnews.gov.za (GCIS) | `secondary-first-issue`; `za-zn-ra-mark` gets `period.end: 2023` |
| Gauteng starts issuing `LL 99 LL GP` | 2023 | **Wikipedia only** | `secondary-wikipedia`, flagged in `notes` as the file's weakest period |
| Free State personalised system created | **10 April 2002** | primary — FS Provincial Notice 52 of 2002, which dates its own commencement | `enabling-instrument` |
| Free State personalised widens 6 → 7 characters | **1 April 2007** | primary — FS Provincial Notice 278 of 2006 | recorded in `notes`; a 7-character FS plate cannot predate it |
| the 1994 provincial reorganisation and the suffix systems it produced | **not dated** | — | every suffix series carries `period.start: 2000` + `instrument-in-force` and says in terms that this is the governing instrument, not the format's birth |

**The instrument-date rule applied, explicitly.** Seven provinces' suffix
systems plainly predate GNR.225 — they were created in the second half of the
1990s under the Road Traffic Act 29 of 1989 and the provincial ordinances that
followed the 1994 reorganisation. GNR.225 *documents* rather than *creates*
them, so every one of those series carries `instrument-in-force` at 2000 and
none claims 2000 as a start. The same reasoning gives `instrument-in-force` to
the reg 27(5) classes (government G, police B, Zulu royal ZK) and to both
registering-authority series: the "substituted by GNR.865 of 2007" marginal
note on reg 27(5)(c) proves an earlier ZK provision existed in the 2000 text,
which is exactly the "instrument documents older practice" case.

## 3. Sources pinned (12 unique URLs; all accessed 2026-08-02)

**Primary — statute and regulations**

1. `https://www.gov.za/sites/default/files/gcis_document/201409/a93-96.pdf` —
   National Road Traffic Act 93 of 1996 as published (President's Office
   Notice 1892, 22 November 1996). s. 75(1)(b) enabling power quoted verbatim
   in the file; s. 68 (unlawful acts in relation to registration plates);
   s. 94 commencement by proclamation.
2. `https://disasterlaw.ifrc.org/.../ROAD%20TRAFFIC%20REGULATIONS,%202000.pdf`
   — the consolidated **National Road Traffic Regulations 2000**, consolidated
   to GNR.359 of 2 May 2010, carrying the table of repeals, the seventeen-row
   amendment table, and regs 27, 28, 28A, 29, 35, 50, 71, 82, 84 in full.
   **HOST CAVEAT — read §6.**
3. `https://www.gov.za/sites/default/files/gcis_document/201409/37542gen287.pdf`
   — **Government Gazette 37542, General Notice 287 of 9 April 2014**,
   Department of Transport, "Publication of the National Road Traffic
   Regulations for comments" under s. 75(6). Reproduces reg 27(1)–(5) and
   reg 35 **word for word identically** to source 2. This is the corroboration
   that makes source 2 safe to rely on.

**Primary — provincial instruments (Free State, the only province whose
gazette notices were reachable)**

4. `.../Licence-number-plate-for-the-Free-State-2002.pdf` — **Provincial Notice
   51 of 2002**, Provincial Gazette 25 of 9 April 2002, made "Under regulation
   27". Black on white with the cheetah landscape; metal only; dealer plates
   dark blue; provincial-government plates red with the coat of arms; "FE
   modified 75mm"; the `FS`-in-a-12 mm-circle covert sheeting mark; effective
   1 June 2002; repeals GN 1579 of 28 November 1997.
5. `.../Personalised-licence-number-system-for-the-Free-State-2002.pdf` —
   **Provincial Notice 52 of 2002**, same gazette, made under regs 28, 28A and
   29(2). The personalised grammar verbatim; **dark green** characters;
   effective 10 April 2002.
6. `.../Amendment-of-personal-licence-number-system-2006.pdf` — **Provincial
   Notice 278 of 2006**, Provincial Gazette 102 of 15 December 2006. Six → seven
   characters; the 520 × 113 / 305 × 165 mm restriction; FE modified 60 mm on
   the smaller plate; metal **or** plastic; effective 1 April 2007.
7. `.../Amendment-of-personalised-and-licence-number-plates-for-the-Free-State-2010.pdf`
   — **Provincial Notice 16 of 2010**, Provincial Gazette 17 of 23 April 2010.
   Repeals the number-plate validation label and the five-year plate-validity
   rule.

**Authority publications (not instruments, but the issuing government's own)**

8. `https://www.westerncape.gov.za/mobility/service/applying-special-motor-vehicle-number-plates`
   — Western Cape Government. `WP` on personalised plates verbatim; the
   seven-character maximum; form SLN1; and the discrete-number fee table whose
   worked examples (`CY 6`, `CW 16`, `CBY 3`, `CG 131`, `CBY 15`, `CK 1441`,
   `CB 131`, `CFM 2332`) are the only government-published evidence of Western
   Cape registering-authority mark shapes located anywhere in this pass.
9. `https://cmbinary.gauteng.gov.za/.../GP%20Application%20Form%20-%20Personalised%20Number%20Plate.pdf`
   — Gauteng Province form **PRN1-GP**. Three choice fields pre-printed `G P`;
   the applicant marks each character N or A; the form's own footer reference
   reads `(7karakters)`; and the heading still cites "Road Traffic Act, 1989,
   Sec. 14".
10. `https://www.sanews.gov.za/south-africa/new-provincial-number-plate-system-unveiled-kzn`
    — SAnews.gov.za (Government Communication and Information System),
    1 December 2023. The KZN switch, its two phases (1 December 2023 /
    1 March 2024), the 24-month migration window, and the province's own
    stated reason: "towns running out of available numbers".
11. `https://www.transport.gov.za/` — the national authority URL.

**Finding aid (Wikipedia rule, PRD-PLATES §4)**

12. `https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_South_Africa`

## 4. The Wikipedia rule, accounted for in one pass

The article was mined as a finding aid and **carries no citations at all** —
its reference section is empty of URLs, so there were no instruments to chase
from it. What it does supply is the provincial mark table and a handful of
dates, and every fact taken from it is tagged so it can be enumerated and
reversed. Nothing was copied: the tables in `za-licence-marks.yml` are in our
schema and our ordering, keyed to which limb of reg 27(2)(a) each province
chose — a column the article does not have and which is the point of the file.

Facts carried on Wikipedia evidence, **exhaustively**:

| fact | where | tag |
|---|---|---|
| provincial marks `EC`, `L`, `MP`, `NC`, `NW`, `ZN` | decode `provincial_marks[].evidence` | `secondary-wikipedia` |
| Gauteng adopts `LL 99 LL GP` in 2023 | `za-gp-standard-2l2f2l.period_evidence` | `secondary-wikipedia` |
| KZN's choice of limb (bb) and the `ZN` mark | `za-zn-standard-2l2f2l.sources` | noted in `notes` (the *date* is government-sourced) |
| Cape Town `CA`→`CAA` 13 April 2019; George `CAW`→`CAG` late 2019 | decode `registering_authority_marks` | `secondary-wikipedia` |
| Port Shepstone `NPS`→`NSC` 30 June 2020 | decode `registering_authority_marks` | `secondary-wikipedia` |
| the seven-character personalised maximum in GP | `za-gp-personalised.format.charset.notes` | stated as secondary in the note |
| North West's reported Feb-2016 new system | `za-nw-standard-3l3f.notes` | **not modelled**, recorded as the most likely missing series |

`secondary-wikipedia` is not yet in the corpus's `period_evidence` values, but
it is the value PRD-PLATES §4 names in terms, and the §4 condition (1) breach
test is "an untagged Wikipedia-derived fact". Using the tier already in use
would have made these facts unenumerable, which is the one thing §4 forbids.
**Verifier decision needed:** accept `secondary-wikipedia` into the vocabulary,
or re-map to `corroboration-only` — one `sed`, either way.

## 5. Folklore flags

* **"South Africa's Intelligent Number Plate has been rolling out since
  1 February 2000."** Repeated widely and in the Wikipedia article. **Not
  asserted.** No instrument was located. What *was* located is a different and
  real thing: GG 37542 GN 287 of 9 April 2014 proposed a single national plate
  bearing "the allocated licence number, South African Flag and the licence
  mark of the respective province at the end … on a white retro-reflective
  surface landscape as shown in Schedule 5" — published **for comment** under
  s. 75(6). Whether it was ever promulgated is unestablished and is not
  claimed. Recorded in the file header as structural fact 6.
* **"Gauteng's 2025 smart plates are a new number format."** They are not. The
  Gauteng Provincial Government's own media statement of 5 June 2025 describes
  a **pilot** of tamper-evident decals, forensic QR codes and a digitised
  back-end portal, on g-Fleet vehicles, for six months of stress testing
  "before the provincial rollout" — a security/manufacturing change, with no
  grammar change stated. Recorded under `common.not_modelled`.
* **Diplomatic class letters `D`/`C`/`X`/`S` and red-vs-green characters.**
  Plausible, widely repeated, and **unsourced to any instrument**. Reg 27(5)(d)
  fixes exactly one thing — the number "shall end in the letter 'D'" — and
  hands everything else to the Director-General of Foreign Affairs. The series
  is therefore `recall-only` and its design records black rather than guessing
  at the colour split.
* **A three-letter/three-figure/`M` military series.** Widely reported; no
  gazette located. Reg 27(5)(a)(iii) is the route it would have to take. **Not
  modelled**, recorded as a gap rather than invented.
* **The Western Cape hyphen (`CA 123-456`).** Universally printed, in no
  instrument. Not written into any `pattern`; the two registering-authority
  regexes accept the six figures with or without the gap, via a separator-only
  class (`[- ]?`, PRD-PLATES §2.8), so both printed forms match and the
  separator-free twin still derives soundly.

## 6. Sourcing failures, stated plainly

The single structural problem with South Africa is that **provincial gazettes
are effectively unsearchable from a script**, and that is where the reg 27(1)
determinations live:

| route | outcome |
|---|---|
| SAFLII (`saflii.org/za/gaz/...`) | HTTP 403, Cloudflare interstitial, both curl and WebFetch |
| `lawlibrary.org.za` (AfricanLII / Laws.Africa) | `/legislation/` 200 but every `/akn/...` and `/gazettes/...` path 403 |
| `opengazettes.org.za` | browse works, coverage ends 2021, **full-text search retired** (redirects to gazettes.africa) |
| `gazettes.africa` | per-province, per-year listings work and are complete, but expose **no query endpoint** — listings carry gazette numbers and dates only, no notice titles, so locating one notice means downloading hundreds of PDFs |
| `natis.gov.za` (eNaTIS statistics, incl. the live-vehicle-population-per-registering-authority series that would settle the mark tables) | HTTP 403 to everything |
| `acts.co.za` | hosts the R.225 regulation pages but paywalls the text ("You need a subscription to continue") |
| `gov.za` search | JS-rendered; returns facets only |
| WebSearch tool | session budget exhausted (200/200) before this jurisdiction started; Brave/Yahoo via curl substituted, Bing/DuckDuckGo/Ecosia/Mojeek/searx all blocked or geo-broken |

The Free State was the one province that publishes its own road-traffic
notices as PDFs on a departmental site
(`policeroadstransport.fs.gov.za/?page_id=1923`), which is why the Free State
is disproportionately well-sourced in the file. **A verifier with the same
page pattern for the other eight provincial departments would close most of
the gaps below in an afternoon.**

**Host caveat, restated because it matters.** The consolidated regulations came
from the IFRC Disaster Law mirror, not a South African government host. The
mitigation is corroboration, not trust: regs 27 and 35 were re-read in full on
gov.za (GG 37542 GN 287) and agree word for word. Regs 28A, 50, 71, 82 and 84,
and the amendment table, rest on the mirror alone. This is recorded inside
`za.yml` at `instrument.regulations.source_host_caveat` so a consumer never has
to read this dossier to learn it.

## 7. Gaps, ranked for the verifier

1. **The nine reg 27(1) provincial-mark notices.** Six of nine marks (EC, L,
   MP, NC, NW, ZN) are Wikipedia-derived. Highest value per unit of effort.
2. **The Gauteng reg 27(4) notice establishing the `LL 99 LL GP` system.** One
   citation converts the file's weakest period claim from `secondary-wikipedia`
   to instrument-evidenced.
3. **The DIRCO determination under reg 27(5)(d).** The only document that can
   turn `za-diplomatic-d` from a recall net into a real series.
4. **The Western Cape and KwaZulu-Natal registering-authority mark tables.**
   eNaTIS's live-vehicle-population-per-registering-authority series is the
   known source; natis.gov.za refused every request.
5. **North West's reported February 2016 system change.** If real, this file is
   missing a series and `za-nw-standard-3l3f` is missing an end year.
6. **Pre-2000 provincial notices** — the actual start years for all seven
   suffix systems, and the Northern Province mark that preceded Limpopo's `L`.
7. **The NRTA 1996 commencement proclamation** (s. 94(2)) and the NRTR
   commencement notice (GNR.727 of 3 August 2001 is listed in the front matter
   but its text was not read).
8. **Post-2010 amendments to the NRTR.** The consolidation read stops at
   GNR.359 of 2 May 2010; GG 37542 (2014) is the latest text located.
9. **SANS/SABS 1116 Parts 2 and 4** — the plate geometry, chromaticity and the
   "FE modified" letterform. Paywalled SABS publication; cite-never-embed under
   PRD-PLATES §6. The render layer will need the statutory drawing, which is
   inside 1116 and therefore **not** available on the German
   PD-VzKat/§5(1) UrhG basis that made FE-Schrift usable for `de.yml`. Flagged
   for the art/render tier: South Africa names FE-Schrift in a gazette but does
   not publish it in one.

## 8. Schema notes worth carrying back to the PRD

* **The pattern escape earned its keep on its first outing.** Limpopo's mark is
  the bare letter `L`. `za-lp-standard-3l3f` is the corpus's first
  `\L` use — `LLL 999 \L` — and without the 2026-08-02 owner ruling the series
  would have had to be `recall-only` with a regex that lies. Verified by the
  behaviour check: `BCD 123 L` matches, `BCD 123 B` (police) does not.
* **`regex_statutory` used for a genuine statutory-vs-issued gap.** Reg 27(5)(c)
  sets **no length limit** on Zulu royal numbers ("the letters ZK followed by
  figures or letters or combination of figures and letters"). `regex` bounds
  the serial at six (the longest any provincial system issues) and
  `regex_statutory` carries the unbounded legal form. Narrower than the statute
  is still `strict` per §2.7 — this is the textbook case that field exists for.
* **"in any sequence" was deliberately NOT turned into a permutation union.**
  Both limbs of reg 27(2)(a)(ii) say the letters and figures may be "in any
  sequence", which literally licenses twenty arrangements of three letters and
  three figures. No province was observed issuing anything but letters-then-
  figures, and building a twenty-alternative `regex_statutory` on a reading of
  four words would be invention dressed as evidence. The phrase is quoted in
  the header and in `common.charset` and left there.
* **Two systems, provably disjoint under their strict grammars.** A dealer
  number (`ABC 123 GP`) matches `za-gp-standard-3l3f`'s loose `regex` but is
  rejected by its `regex_strict` (leading vowel), while `za-dealer-a`'s
  `regex_strict` accepts it. The tier order does the disambiguation with no
  special-casing — a good argument for the parse API's ranking design, and it
  is in the behaviour check as a regression.
* **`personalized` is the corpus spelling.** `_meta/classes.yml` uses the
  US form; the first draft used `personalised` and the lint caught all three.
  Noted for the next delegate writing a Commonwealth jurisdiction.
* **Possible class-vocabulary PR:** `za-zulu-royal-zk` is classed `government`
  because there is no traditional-monarchy class. It is a state set-aside for a
  hereditary office, not a government fleet, and it is the only prefix-form
  special class in South Africa. Flagged rather than decided.

## 9. What a verifier should re-derive first

1. Re-read reg 27 and reg 35 in GG 37542 GN 287 on gov.za (2 minutes) — this
   independently re-establishes every grammar, colour, layout and dimension
   claim in the file without touching the mirror.
2. Re-derive the charset from the proviso and check it against the seven
   `regex_strict` values: 20 letters `BCDFGHJKLMNPRSTVWXYZ`, 19 in first
   position (no `G`).
3. Check the Free State chain (PN 51/2002 → PN 128 & 279/2006 → PN 16/2010 for
   licence plates; PN 52/2002 → PN 278/2006 → PN 16/2010 for personalised).
   PN 128 and PN 279 of 2006 are *referenced* in PN 16 of 2010 and were **not**
   fetched — the one gap inside the otherwise complete Free State chain.
4. Hunt gap 1 and gap 2 above. Everything else in the file is either primary or
   labelled.

