### PR TITLE
plates L3: ca-east — ca-on ca-qc ca-ns ca-nb ca-pe ca-nl (S5W)

### DIFF
--- a/plates/ca-nb.yml
+++ b/plates/ca-nb.yml
@@ -1,0 +1,537 @@
+# plates/ca-nb.yml — New Brunswick, Canada (PRD-PLATES gate L2/L3, Canada east wave).
+#
+# NEW BRUNSWICK PUTS THE PLATE'S CONTENT IN THE ACT, WHICH ONTARIO AND
+# NEWFOUNDLAND AND LABRADOR DO NOT. Motor Vehicle Act s. 29(2), verbatim: "Every
+# registration plate shall have displayed upon it the registration number
+# assigned to the vehicle for which it is issued, THE NAME OF THE PROVINCE, WHICH
+# MAY BE ABBREVIATED, THE NUMBER OF THE YEAR FOR WHICH IT IS ISSUED, and such
+# other information as the Minister may by order require." A statutory content
+# rule with three mandatory elements — and the third of them, the year, is a
+# legacy of the annual-plate era that the modern permanent plate satisfies through
+# the s. 31 validation sticker rather than by embossing a year.
+#
+# FOUR STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. NEW BRUNSWICK BECAME A ONE-PLATE PROVINCE BY STATUTE IN 2019, AND THE
+#    AMENDMENT IS DATEABLE. MVA s. 29(1), as it now reads: "On registering a
+#    vehicle, the Registrar shall issue to the owner (a) ONE registration plate
+#    (i) for a motorcycle, an antique vehicle, a trailer or a semi-trailer, and
+#    (ii) for a vehicle that has a gross mass of less than 4 500 kg, and (b) TWO
+#    registration plates for a vehicle that has a gross mass of 4 500 kg or more".
+#    The section carries the amendment history "1955, c.13, s.20; 1977, c.M-11.1,
+#    s.17; 2009, c.4, s.1; 2019, c.6, s.5", and s. 30 — the attachment rule — was
+#    substituted by the same 2019 statute. The secondary record dates the front
+#    plate's abolition to 15 July 2019; the STATUTE independently shows a 2019
+#    amendment to the very subsection that would have to change, which is a rare
+#    case of a secondary date being corroborated by an instrument's own history
+#    line rather than merely repeated.
+#
+# 2. THE LEGIBILITY TEST IS A DISTANCE IN THE ACT. s. 29(3), verbatim: "Such
+#    registration plate and the required letters and numerals thereon, except the
+#    year number for which issued, shall be of sufficient size to be plainly
+#    readable from a distance of THIRTY METRES during daylight." A statutory
+#    legibility distance, with the year number expressly carved out of it.
+#
+# 3. THE PLATE IS THE CROWN'S AND THE FIRST LETTER IS A CLASS CODE. s. 29(4):
+#    "Registration plates issued to any person under this section shall remain at
+#    all times the property of the Crown." Separately — and this is the parse-
+#    relevant fact — New Brunswick reserves FIRST LETTERS by class: C for
+#    commercial, D for dealer, F for farm, H for taxi, L for truck, T for trailer,
+#    A for antique. Those reservations are the en.wikipedia article's, are tagged
+#    `secondary-wikipedia`, and are the closest thing New Brunswick has to Québec's
+#    statutory prefix table.
+#
+# 4. NO NEW BRUNSWICK INSTRUMENT LOCATED IN THIS PASS STATES A COLOUR, A DIMENSION
+#    OR A SERIAL GRAMMAR. s. 29(2) delegates everything beyond the three mandatory
+#    elements to ministerial order, and no such order was located. General
+#    Regulation 83-42 under the Act was NOT fetched (see `instrument.fetch_note`)
+#    and is the first place a verifier should look.
+#
+# SEPARATOR NOTE (PRD-PLATES §2.6): a New Brunswick plate prints a gap between
+# groups, not a glyph. Every `pattern` spells the emitted space and every regex
+# accepts it as optional.
+jurisdiction: ca-nb
+authority:
+  name: Motor Vehicle Branch, Department of Justice and Public Safety (New Brunswick); registration transacted through Service New Brunswick
+  url: "https://laws.gnb.ca/en/showfulldoc/cs/M-17"
+  url_note: "the Act itself is the authority citation because no New Brunswick agency plate page could be reached — laws.gnb.ca, www2.gnb.ca and www1.gnb.ca all returned HTTP 403 to every attempt on 2026-08-02 (see instrument.fetch_note)"
+binding: vehicle
+binding_note: >-
+  MVA s. 29(2) assigns the registration number "to the VEHICLE for which it is
+  issued" — vehicle-bound, and the opposite of the Ontario and Nova Scotia
+  owner-bound model in plates/ca-on.yml and plates/ca-ns.yml. s. 29(4) still makes
+  the physical plate Crown property. s. 32(1)(b) contemplates surrendering the
+  plate of a vehicle properly registered in another province as the price of a
+  free reciprocal New Brunswick registration.
+instrument:
+  statute: "Motor Vehicle Act, R.S.N.B. 1973, c. M-17 — ss. 29 (issuance and content of registration plates), 30 (attachment), 31 (validation stickers), 32 (reciprocal arrangements), 33 (term and expiry), 35(2) (special-plate fees)"
+  currency: "the consolidation read is marked 'Current to 1 January 2024'"
+  key_amendments:
+    - "2019, c. 6, ss. 4-9 — re-headed and substituted ss. 29, 30 and 31; this is the amendment that moved New Brunswick to a single rear plate for vehicles under 4 500 kg"
+    - "2025, c. 6, s. 1 — most recent amendment to s. 30 (attachment)"
+    - "2009, c. 4, ss. 1-2 — previous substitution of ss. 29 and 31"
+  regulations_not_read:
+    - "N.B. Reg. 83-42 (General) — the principal regulation under the Act, 21 regulations deep in the Act's own regulation table. NOT FETCHED (gnb.ca 403). Any New Brunswick plate colour, dimension or serial rule that exists in delegated legislation is most likely here."
+  fetch_note: >-
+    EVERY gnb.ca HOST REFUSED THIS RESEARCH SESSION. laws.gnb.ca returned HTTP 403
+    to curl and to WebFetch, in English and in French, over HTTP and HTTPS;
+    www2.gnb.ca and www1.gnb.ca did the same. The consolidated Motor Vehicle Act
+    quoted throughout this file was therefore read through the Internet Archive's
+    copy (snapshot 20251201033750). Recorded so a verifier knows every New
+    Brunswick quotation here came through an archive, and so that N.B. Reg. 83-42
+    is flagged as unread rather than silently absent.
+  sources:
+    - "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # Motor Vehicle Act consolidation current to 1 January 2024, read 2026-08-02 — ss. 29(1)-(4), 30(1)-(2), 31(1)-(3), 32, 33 quoted in this file"
+    - "https://laws.gnb.ca/en/showfulldoc/cs/M-17  # the official consolidation the archive copy is of; HTTP 403 from this location, see fetch_note"
+  licence: >-
+    The Motor Vehicle Act is an EDICT OF GOVERNMENT and its text is
+    uncopyrightable (PRD-PLATES §4). Every verbatim quotation in this file is of
+    statutory text.
+
+artwork_risk:
+  posture: unresearched
+  basis: >-
+    No New Brunswick copyright statement could be read, because no gnb.ca page
+    could be reached. The province's posture on plate ARTWORK is therefore
+    genuinely unknown rather than assumed favourable or adverse, and is recorded
+    as `unresearched` per PRD-PLATES §7.1's vocabulary.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies with extra force here, since nothing
+    is known. The provincial wordmark (the red galley device with "New" /
+    "Nouveau" / "Brunswick" / "CANADA") is rendered `placeholder`; it is a
+    government wordmark and is likely to carry trade-mark protection independent
+    of copyright.
+
+common:
+  statutory_content:
+    text: >-
+      MVA s. 29(2), verbatim: "Every registration plate shall have displayed upon
+      it the registration number assigned to the vehicle for which it is issued,
+      the name of the Province, which may be abbreviated, the number of the year
+      for which it is issued, and such other information as the Minister may by
+      order require."
+    consequence: >-
+      Three mandatory elements — number, province name, year — and an open
+      ministerial residue. The YEAR element is satisfied in practice by the s. 31
+      validation sticker rather than by an embossed year; s. 31(1) lets the
+      Minister authorise "a sticker or stickers instead of a registration plate or
+      plates", and s. 29(3) expressly excludes "the year number for which issued"
+      from the thirty-metre legibility test, which only makes sense if the year is
+      carried by something smaller than the serial.
+    source: "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 29(2),(3); s. 31(1),(1.1),(2)"
+  display:
+    text: >-
+      MVA s. 30(1), verbatim: "A registration plate issued under paragraph 29(1)(a)
+      shall be attached to the vehicle in the REAR and registration plates issued
+      under paragraph 29(1)(b) shall be attached to the vehicle, one in the front
+      and the other in the rear." s. 30(2): a plate shall at all times "(a) be
+      securely fastened to the vehicle for which it is issued so as to prevent the
+      plate from swinging, (b) be fastened in a horizontal position at a height of
+      at least 30 cm from the ground measuring from the bottom of the plate, (c) be
+      in a place and position so that the plate is clearly visible, and (d) be
+      maintained free from foreign materials and in a condition so that the plate is
+      clearly legible to a person on the highway in front or in rear of the
+      vehicle."
+    note: "30 cm is the same minimum height Nova Scotia (300 mm), Prince Edward Island (300 mm) and Newfoundland and Labrador (30 centimetres) enact. Four Atlantic statutes, one figure."
+    source: "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 30(1),(2), substituted by 2019, c. 6, ss. 6-7 and amended by 2025, c. 6, s. 1"
+  plate_count:
+    text: >-
+      MVA s. 29(1), verbatim: "On registering a vehicle, the Registrar shall issue
+      to the owner (a) one registration plate (i) for a motorcycle, an antique
+      vehicle, a trailer or a semi-trailer, and (ii) for a vehicle that has a gross
+      mass of less than 4 500 kg, and (b) two registration plates for a vehicle that
+      has a gross mass of 4 500 kg or more, excluding a vehicle under subparagraph
+      (a)(i), but the Minister may order that only one registration plate shall be
+      issued for a vehicle for the registration year or years specified in the
+      order."
+    source: "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 29(1), substituted by 2019, c. 6, s. 5"
+  expiry:
+    text: >-
+      MVA s. 33(1), verbatim: "Unless the regulations provide otherwise, every
+      vehicle registration under this Act, other than the registration of a
+      commercial vehicle, and every registration certificate and registration plate
+      issued under this Act for such vehicle, shall expire at midnight on the
+      THIRTY-FIRST DAY OF MARCH of each year."
+    note: "A fixed provincial expiry date rather than a staggered birthday system — the opposite of Ontario and Québec. Commercial vehicles are carved out to regulation by s. 33(2)(b)."
+    source: "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 33(1),(2)"
+  antique_definition:
+    text: 'MVA s. 1, verbatim: "\"antique vehicle\" means a motor vehicle that is at least twenty-five years old and has been restored to original condition; (ancien modèle)"'
+    note: >-
+      TWENTY-FIVE YEARS, not Ontario's thirty (HTA s. 7(1.1)) — and note the
+      stronger second limb: New Brunswick requires the vehicle to have been RESTORED
+      TO ORIGINAL CONDITION, where Ontario asks only that it be "substantially
+      unchanged or unmodified". Two Canadian provinces, two statutory antique tests,
+      neither reconcilable with the other.
+    source: "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 1 definitions"
+  class_first_letters:
+    note: >-
+      TAGGED SECONDARY, and the nearest New Brunswick equivalent of Québec's
+      statutory prefix table. The en.wikipedia article states that the following
+      first letters are reserved by class and therefore do not appear in the
+      ordinary passenger run: C (commercial), D (dealer), F (farm), H (taxi),
+      L (truck), T (trailer), A (antique). No New Brunswick instrument located in
+      this pass states any of it. The reservations are encoded in the passenger
+      series' `regex_strict` and nowhere else.
+    reserved: { C: commercial, D: dealer, F: farm, H: taxi, L: truck, T: trailer, A: antique }
+    source: "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # TAGGED SECONDARY (PRD-PLATES §4, owner override 2026-08-02), read 2026-08-02: the per-class serial tables and their first-letter reservations"
+  dimensions:
+    note: >-
+      NO NEW BRUNSWICK INSTRUMENT PRESCRIBES A PLATE SIZE. s. 29(3) states a
+      LEGIBILITY DISTANCE (thirty metres in daylight) instead, which is a
+      functional standard rather than a dimensional one — an unusual and rather
+      elegant drafting choice, and the only size-adjacent rule in the Act. The
+      6 in x 12 in North American convention is recorded on the series below as
+      `plate_basis: convention`.
+
+classes_not_modelled:
+  seasonal:
+    exists: true
+    mechanism: "The en.wikipedia article carries a 'Seasonal plates' section for New Brunswick, and MVA s. 35(2) empowers regulations 'fixing or altering fees in relation to the issuance or holding of SPECIAL PLATES', with the proceeds capable of going to a special purpose account or trust — the statutory hook for New Brunswick's specialty programmes generally."
+    why_not_modelled: "No serial grammar, colour or period was captured for the seasonal series in this pass, and no instrument describes it. Recorded as a gap."
+    sources:
+      - "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 35(2): the special-plate fee power"
+  firefighter_and_specialty:
+    exists: true
+    mechanism: "The article carries 'Firefighter plates' and a 'Specialty plates' section for New Brunswick; MVA s. 35(2) is again the statutory hook."
+    why_not_modelled: "PRD-PLATES §2.5 excludes the specialty-design catalogue from v1, and no primary describes any of these. Recorded as a gap."
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # the specialty and firefighter sections, read 2026-08-02"
+  prorated:
+    exists: true
+    mechanism: "The article carries a 'Prorated plates' section — New Brunswick participates in the International Registration Plan as every Canadian province does."
+    why_not_modelled: "IRP plates are the commercial series under an apportionment regime; no distinct New Brunswick grammar was located. Contrast plates/ca-qc.yml, where the PRP vignette is prescribed by Règlement art. 112.1."
+
+series:
+
+  # =========================================================================
+  # THE CURRENT PASSENGER SERIES — three letters, three numerals, plain base.
+  # =========================================================================
+  - id: ca-nb-standard-2011
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2011 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_strict: '\A[BEGIJKMNOPQRSUVWXYZ][A-Z]{2} ?\d{3}\z'
+      charset:
+        reserved_first_letters: [A, C, D, F, H, L, T]
+        notes: >-
+          TAGGED SECONDARY — see `common.class_first_letters`. `regex_strict`
+          removes the seven reserved class letters from the FIRST position only and
+          leaves positions two and three unconstrained, because the article states
+          no exclusion for them. That is a deliberately partial strict twin, and
+          saying so is the point: a strict twin narrower than the truth would be
+          worse than none.
+      progression: "the article's issuance record runs JEA 000 upward through the J and K blocks; there is NO date and NO region signal in a New Brunswick serial"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      plate_note: "NOT a New Brunswick legal claim — the Act states a legibility distance, not a size. See `common.dimensions`."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      colour_note: >-
+        EMBOSSED RED ON REFLECTIVE WHITE, which makes New Brunswick the only
+        red-serial standard plate in the Canada east wave and therefore trivially
+        separable from Nova Scotia and Newfoundland and Labrador on sight, though
+        NOT from a string — all three provinces run ABC 123. No instrument states
+        either colour; both are observed and the claim itself is the article's.
+      legend_top: "New Brunswick / Nouveau-Brunswick provincial wordmark, screened, centred above the serial"
+      legend_bottom_options: []
+      slogan_note: "the 2011 base carries NO slogan. Its immediate predecessor carried the bilingual 'Be... in this place ᐧ Être... ici on le peut'; dropping it is the visible difference between the two series."
+      emblem: { present: true, rendered: placeholder, description: "the provincial wordmark: a red galley graphic with 'New' to the left, 'Nouveau' to the right and 'Brunswick' and 'CANADA' below" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR, for a vehicle under 4 500 kg (MVA ss. 29(1)(a)(ii), 30(1)) — front plates were abolished by 2019, c. 6, s. 5; see notes"
+    sources:
+      - "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 29(1)(a)(ii) (one plate under 4 500 kg), s. 29(2) (the statutory content rule), s. 29(3) (thirty-metre legibility), s. 29(4) (Crown property), s. 30(1)-(2) (rear attachment, 30 cm, legibility), s. 33(1) (31 March expiry)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # TAGGED SECONDARY: the 2011 base, the ABC 123 format, the removal of the slogan, the issuance range from JEA 000, the red-on-white colours, and the 15 July 2019 abolition of front plates (which the article footnotes to CBC News, 18 June 2019)"
+    notes: >-
+      THE CURRENT NEW BRUNSWICK PLATE. THE DISPLAY RULE IS PRIMARY AND THE FORMAT
+      IS NOT — the split is worth stating because the display rule is the more
+      unusual fact. New Brunswick abolished the front plate in 2019, and this file
+      does not take that from the newspaper the article cites: MVA s. 29(1) as
+      consolidated puts a vehicle under 4 500 kg squarely in the one-plate limb, and
+      the section's own amendment history line ends "2019, c. 6, s. 5", with s. 30
+      substituted by ss. 6-7 of the same statute. The instrument corroborates the
+      secondary's date to the year. THE FORMAT AND THE 2011 BASE ARE THE ARTICLE'S,
+      unfootnoted, hence `period_evidence: secondary-wikipedia`. PARSE CAUTION: New
+      Brunswick, Nova Scotia and Newfoundland and Labrador all currently issue
+      ABC 123, so a bare three-letter three-numeral string is not diagnostic of any
+      of them; the province is recoverable only from the plate IMAGE (red serial and
+      the galley wordmark here, blue serial and the Bluenose in Nova Scotia, blue
+      serial and the pitcher plant in Newfoundland and Labrador).
+
+  - id: ca-nb-standard-2009
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2009, end: 2011 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_strict: '\A[BEGIJKMNOPQRSUVWXYZ][A-Z]{2} ?\d{3}\z'
+      charset: { reserved_first_letters: [A, C, D, F, H, L, T], notes: "as ca-nb-standard-2011" }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      legend_bottom_options: ["Be... in this place ᐧ Être... ici on le peut"]
+      slogan_note: >-
+        THE ONLY BILINGUAL SLOGAN IN THE CANADA EAST WAVE, and it is bilingual in a
+        way no other plate here is: English and French SIDE BY SIDE on one plate,
+        separated by a raised dot, rather than English and French plates issued as
+        alternatives (Ontario's YOURS TO DISCOVER / TANT À DÉCOUVRIR, Prince Edward
+        Island's PRINCE EDWARD ISLAND / ÎLE-DU-PRINCE-ÉDOUARD). New Brunswick is
+        Canada's only constitutionally bilingual province and its plate said so.
+      band: { side: top, color: "#FFC72C", note: "curved gold and sky-blue bands across the top of the plate, carrying the provincial wordmark. Observed, per the article; no instrument describes it." }
+      emblem: { present: true, rendered: placeholder, description: "the provincial wordmark on the bands: red galley with small blue waves" }
+      rear_differs: false
+      display: "TWO plates, front and rear — this series predates the 2019 abolition of the front plate, so a 2009-2011 New Brunswick vehicle was plated fore and aft when new"
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # TAGGED SECONDARY: the 2009-2011 banded base with the bilingual slogan, format ABC 123, issuance GXA 000 to GZZ 999 and JAA 000 to JDZ 999"
+      - "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 29(1) BEFORE the 2019 substitution is not reproduced in the consolidation, but the section's history line ('2009, c.4, s.1; 2019, c.6, s.5') establishes that the plate-count rule was substituted twice in the relevant window — which is why this series' display note is stated as a consequence of the amendment rather than quoted"
+    notes: >-
+      ONE SERIES BACK, and cut on DESIGN alone: the format is identical to
+      ca-nb-standard-2011 and only the base changed when the slogan and the gold and
+      sky-blue bands were dropped. PRD-PLATES §2.3 makes that its own series and
+      also means no parse API can tell the two apart from a string. Both boundaries
+      are the article's, unfootnoted. The display note is an INFERENCE from the
+      dated amendment history and is labelled as one.
+
+  # =========================================================================
+  # COMMERCIAL — first letter C, reserved.
+  # =========================================================================
+  - id: ca-nb-commercial-2011
+    class: standard
+    categories: [truck, van]
+    period: { start: 2011 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "CLL 999"
+      regex: '\AC[A-Z]{2} ?\d{3}\z'
+      charset: { notes: "the literal C in position 1 is the class reservation; the two letters and three numerals that follow are the article's. NOTE that this shape is INSIDE the passenger shape LLL 999 — the class signal is the letter itself, which is why the passenger series' strict twin excludes C from position 1." }
+      progression: "CRA 001 upward per the article's issuance record"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      emblem: { present: true, rendered: placeholder, description: "provincial wordmark" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate REAR under 4 500 kg; TWO plates, front and rear, at 4 500 kg or more (MVA ss. 29(1), 30(1)) — so the same New Brunswick commercial series appears in one-plate and two-plate form depending on mass, which is a genuine modelling wrinkle and is recorded rather than flattened"
+    sources:
+      - "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 29(1)(b): two plates at 4 500 kg or more; s. 33(2)(b): commercial-vehicle registration periods are set by regulation rather than by the 31 March rule"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # TAGGED SECONDARY: the CAB 123 commercial format from 2011 and the C reservation"
+    notes: >-
+      `class: standard` because the vocabulary has no commercial member; the C
+      reservation and the category list carry the meaning. THE 4 500 KG HINGE IS
+      THE PRIMARY PART: the same commercial serial wears one plate or two according
+      to a statutory mass threshold, so plate COUNT is a mass signal in New
+      Brunswick in a way it is not in Ontario (always two) or Québec (always one).
+
+  # =========================================================================
+  # HEAVY TRUCK — first letter L.
+  # =========================================================================
+  - id: ca-nb-truck-2003
+    class: standard
+    categories: [truck, tractor]
+    period: { start: 2003 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: '\L999999'
+      regex: '\AL\d{6}\z'
+      charset:
+        notes: >-
+          The literal L is the class reservation. NOTE THE PATTERN ESCAPE: `L` is
+          the human-pattern DSL's own token for "any letter", so a plate that PRINTS
+          an L writes `\L` (PRD-PLATES §2.2, owner ruling 2026-08-02) — the same
+          collision Québec's heavy-truck prefix causes in plates/ca-qc.yml, and for
+          the same reason: two provinces independently chose L for "lourd"/"large".
+          Written in single quotes so YAML does not eat the backslash.
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      emblem: { present: true, rendered: placeholder, description: "provincial wordmark" }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # TAGGED SECONDARY: the L123456 truck format, replacing L12-345 from 1991"
+      - "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 29(1)(b): a truck at or above 4 500 kg carries two plates"
+    notes: >-
+      period.start 2003 is the article's boundary between the L12-345 and L123456
+      forms and is unfootnoted. Authored because the all-numeric six-digit body
+      after a fixed L is genuinely distinctive and because the two Canadian
+      provinces that reserve L for trucks (New Brunswick and Québec) produce
+      COLLIDING strings — L123456 is a valid shape in both — which a parse API must
+      be told rather than left to discover.
+
+  # =========================================================================
+  # MOTORCYCLE — three letters, two numerals, one plate.
+  # =========================================================================
+  - id: ca-nb-motorcycle-2009
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2009 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL99"
+      regex: '\A[A-Z]{3} ?\d{2}\z'
+      charset: { notes: "three letters, two numerals, printed as one block; the article's issuance record runs into the Y and Z blocks, which suggests the run is nearing exhaustion" }
+    design:
+      plate_note: "reduced motorcycle size; no New Brunswick instrument states one and no measured figure was obtained. Deliberately absent rather than guessed."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      emblem: { present: true, rendered: placeholder, description: "provincial wordmark" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR — a motorcycle is in the one-plate limb at MVA s. 29(1)(a)(i) REGARDLESS OF MASS, which is a separate statutory route from the 4 500 kg rule and is why a motorcycle never carried a front plate even before 2019"
+    sources:
+      - "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 29(1)(a)(i): one plate for a motorcycle, an antique vehicle, a trailer or a semi-trailer — a mass-independent limb"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # TAGGED SECONDARY: the ABC12 motorcycle format from 2009 and its issuance range"
+    notes: >-
+      THE ONE-PLATE LIMB IS PRIMARY AND IT IS THE INTERESTING PART: s. 29(1)(a)(i)
+      gives motorcycles, antique vehicles, trailers and semi-trailers a single plate
+      by CLASS, not by mass, so those four classes were unaffected by the 2019
+      change that abolished the front plate for everything under 4 500 kg. Format
+      and period are the article's.
+
+  # =========================================================================
+  # TRAILER — first letter T.
+  # =========================================================================
+  - id: ca-nb-trailer-2003
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 2003 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "TLL 999"
+      regex: '\AT[A-Z]{2} ?\d{3}\z'
+      charset: { notes: "the literal T is the class reservation; the two letters and three numerals are the article's" }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      emblem: { present: true, rendered: placeholder, description: "provincial wordmark" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR (MVA ss. 29(1)(a)(i), 30(1)) — a trailer and a semi-trailer are in the mass-independent one-plate limb"
+    sources:
+      - "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 29(1)(a)(i): one plate for a trailer or semi-trailer"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # TAGGED SECONDARY: the TAB 123 trailer format, replacing TA1-234"
+    notes: >-
+      The T reservation and the arrangement are the article's; the one-plate rule is
+      statutory. period.start 2003 is the article's boundary and is unfootnoted.
+
+  # =========================================================================
+  # ANTIQUE — the statutory 25-year class.
+  # =========================================================================
+  - id: ca-nb-antique-2003
+    class: historic
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2003 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LL9 999"
+      regex: '\A[A-Z]{2}\d ?\d{3}\z'
+      charset: { notes: "two letters, digit, three numerals; the article's issuance record runs AA1 001 upward, so the leading A is in practice the class reservation even though the arrangement is nominally two free letters" }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      emblem: { present: true, rendered: placeholder, description: "provincial wordmark" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR (MVA ss. 29(1)(a)(i), 30(1))"
+    eligibility:
+      text: 'MVA s. 1, verbatim: "\"antique vehicle\" means a motor vehicle that is at least twenty-five years old and has been restored to original condition; (ancien modèle)"'
+      note: "See `common.antique_definition` for the comparison with Ontario's thirty-year, substantially-unmodified test. New Brunswick's is younger AND stricter — a lower age bar with a restoration requirement."
+    sources:
+      - "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 1 (the 25-year restored-to-original definition, verbatim above); s. 29(1)(a)(i) (one plate for an antique vehicle); s. 1 'fictitious registration plate' definition, whose carve-outs expressly contemplate an out-of-year plate on 'a motorcycle, an antique vehicle, a trailer, a semi-trailer or a vehicle that has a gross mass of less than 4 500 kg' fitted to the FRONT — the statutory residue of the abolished front plate"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # TAGGED SECONDARY: the AB1 234 antique format from 2003 and its issuance range"
+    notes: >-
+      AUTHORED FOR THE STATUTORY DEFINITION, which is the strongest fact about the
+      class and one of the few genuinely comparative facts in this wave: twenty-five
+      years and restored to original, against Ontario's thirty years and
+      substantially unmodified. THE HIDDEN GEM IS IN THE DEFINITIONS SECTION: New
+      Brunswick's definition of "fictitious registration plate" carves out "a
+      registration plate not furnished and issued for the current registration year
+      that is attached to the FRONT of a motorcycle, an antique vehicle, a trailer,
+      a semi-trailer or a vehicle that has a gross mass of less than 4 500 kg" —
+      i.e. after 2019 it is lawful to keep an expired plate on the front of your
+      car, and the legislature said so in a definition rather than in an operative
+      section. Format and period are the article's.
+
+  # =========================================================================
+  # DEALER — first letter D.
+  # =========================================================================
+  - id: ca-nb-dealer-2009
+    class: dealer
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2009 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "D99 999"
+      regex: '\AD\d{2} ?\d{3}\z'
+      charset: { notes: "the literal D is the class reservation; five numerals follow. The article's issuance record reaches D21 547." }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      emblem: { present: true, rendered: placeholder, description: "provincial wordmark" }
+      band: { side: none }
+      rear_differs: false
+    binding: business
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # TAGGED SECONDARY: the D12 345 dealer format from 2009, the D reservation and the issuance range"
+      - "https://web.archive.org/web/20251201033750/https://laws.gnb.ca/en/showfulldoc/cs/M-17/  # MVA s. 35(2): the special-plate fee power, the nearest statutory hook located for the dealer regime; the Act's plate sections do not describe dealer plates"
+    notes: >-
+      ENTIRELY SECONDARY, AND AUTHORED ANYWAY because the D-prefix-plus-five-numerals
+      shape is distinctive and because a dealer plate is a `binding: business` object
+      that a consumer must not read as a vehicle registration. No New Brunswick
+      instrument located in this pass describes a dealer plate — N.B. Reg. 83-42 is
+      the likely home of the regime and was unreachable (see
+      `instrument.fetch_note`). A verifier should re-pin this from that regulation
+      before the file is applied.
+
+  # =========================================================================
+  # OFF-ROAD / ATV.
+  # =========================================================================
+  - id: ca-nb-atv-2003
+    class: standard
+    categories: [atv]
+    period: { start: 2003 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LL9 999"
+      regex: '\A[A-Z]{2}\d ?\d{3}\z'
+      charset: { notes: "same arrangement as the antique series — two letters, digit, three numerals — and therefore INDISTINGUISHABLE from it as a string. The article's ATV issuance record runs into the Y block while the antique run is in the A block, so in practice the first letter separates them; that is an allocation fact, not a grammar fact, and is not encoded." }
+    design:
+      plate_note: "no size located; deliberately absent"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      emblem: { present: true, rendered: placeholder, description: "provincial wordmark" }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_New_Brunswick  # TAGGED SECONDARY: the AB1-234 ATV format from 2003 (AB12345 from 1986) and the issuance range to YE6 025"
+    notes: >-
+      AUTHORED WITH ITS OWN COLLISION STATED: the New Brunswick ATV and antique
+      series share an arrangement, so a parse API given "AB1 234" must return BOTH
+      candidates and rank them by allocation block rather than by grammar. That is
+      exactly the situation `matching: strict` is for — each regex is at or inside
+      its own series' issuing grammar, and the ambiguity is real rather than an
+      artefact of over-broad regexes. `class: standard` because the vocabulary has
+      no off-road member. Off-road registration in New Brunswick sits under the
+      Off-Road Vehicle Act rather than the Motor Vehicle Act, which was NOT consulted
+      in this pass; recorded gap.

--- a/plates/ca-nl.yml
+++ b/plates/ca-nl.yml
@@ -1,0 +1,743 @@
+# plates/ca-nl.yml — Newfoundland and Labrador, Canada (PRD-PLATES gate L2/L3,
+# Canada east wave).
+#
+# NEWFOUNDLAND AND LABRADOR DOES NOT CALL IT A LICENCE PLATE OR A NUMBER PLATE.
+# The Highway Traffic Act's term of art is IDENTIFICATION PLATE, defined at s. 2:
+# "'identification plate' means an identification plate issued under this Act in
+# respect of a vehicle". "Number plate" appears exactly once in the whole
+# consolidation, in the marginal note to s. 32 ("number plate capable of being
+# confused with identification plate or marker"). The province also issues
+# MARKERS and DECALS as separate objects under s. 34. A consumer searching this
+# jurisdiction's law for "licence plate" will find nothing; that is recorded here
+# so nobody repeats the search.
+#
+# FOUR STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. THE PLATE'S ENTIRE CONTENT IS THE REGISTRAR'S, IN ONE SENTENCE. HTA s. 16(2),
+#    verbatim: "The registrar shall issue, in respect of a vehicle that has been
+#    registered, (a) a numbered vehicle licence in a form prescribed by the
+#    registrar; and (b) ONE OR MORE IDENTIFICATION PLATES AS DETERMINED BY THE
+#    REGISTRAR, AND THE IDENTIFICATION PLATES SHALL BE DISTINCTIVE AND NUMBERED AS
+#    THE REGISTRAR MAY DETERMINE." That is the whole statutory specification: how
+#    many plates, what they look like and how they are numbered are all one
+#    official's discretion. s. 16(4) adds that the registrar "may issue different
+#    vehicle licences and identification plates in respect of different classes of
+#    vehicles or in respect of the same class of vehicle used for different
+#    purposes" — the statutory basis for the class-letter system in
+#    `common.class_letters`, without naming a single letter.
+#
+# 2. PLATE COUNT IS A CLASS SIGNAL AND THE ACT MAKES IT VISIBLE. s. 30(2),
+#    verbatim: a driver or owner shall ensure that "(a) where ONE plate is issued,
+#    that the plate is clearly visible from the REAR of the vehicle; and (b) where
+#    2 plates are issued, one plate is clearly visible from the FRONT of the
+#    vehicle and the other plate is clearly visible from the rear." The Act never
+#    says WHICH classes get two — that is s. 16(2)(b) discretion — but the
+#    secondary record is consistent that buses, trucks, emergency vehicles and
+#    government vehicles carry two while private cars carry one.
+#
+# 3. THE CLASS LETTER IS THE ONLY DECODE, AND IT IS ENTIRELY SECONDARY. Every
+#    Newfoundland and Labrador series shares one three-letter three-numeral
+#    skeleton and is separated only by its leading letter or letter pair — A/H/J
+#    private car, B bus, C truck, D dealer, E emergency, F farm, G government,
+#    K trail bike, M motorcycle, PR apportioned, S snowmobile, T trailer, TX taxi,
+#    W tow truck, X heavy machinery, V off-road and veteran, VO1/VO2 amateur radio,
+#    AA antique, FF firefighter. NO INSTRUMENT STATES ANY OF IT. The table is
+#    inlined in `common.class_letters`, tagged `secondary-wikipedia`, and every
+#    series below that relies on it says so.
+#
+# 4. THE BASE HAS CHANGED FOUR TIMES SINCE 2007 WITHOUT THE FORMAT MOVING ONCE.
+#    The pitcher-plant base ran from April 2007, was interrupted by the
+#    "COME HOME 2022" base for calendar 2022, resumed in January 2023, was
+#    interrupted again by the "1949 - 2024 / 75" confederation-anniversary base for
+#    calendar 2024, and resumed in November 2025 with the province name in black.
+#    Four bases, one format (ABC 123), continuous serial allocation across all of
+#    them. Each interruption is authored as its own series because the DESIGN and
+#    the PERIOD both differ (PRD-PLATES §2.3), and they overlap the pitcher-plant
+#    series by construction — the parallel-issuance case §2.2 contemplates.
+#
+# SEPARATOR NOTE (PRD-PLATES §2.6): the serial prints as a gap. Every `pattern`
+# spells the emitted space; every regex accepts it as optional.
+jurisdiction: ca-nl
+authority:
+  name: Motor Registration Division, Department of Digital Government and Service NL
+  url: "https://www.gov.nl.ca/motorregistration/plates/"
+binding: vehicle
+binding_note: >-
+  HTA s. 16(2) issues identification plates "in respect of A VEHICLE that has been
+  registered", and s. 33 lets a traffic officer seize a plate "that was not issued
+  for it". The physical plate is the Crown's: s. 28(1), verbatim, "Every licence,
+  identification plate, marker and permit that the registrar issues is and remains
+  the property of the Crown and shall be returned to the registrar on the
+  registrars request." (The consolidation prints "registrars" without an
+  apostrophe; quoted as found.) s. 28(2) is unusual and worth carrying: a person
+  who FINDS an unexpired plate that is not theirs "shall return the plate or
+  licence to the registrar or nearest traffic officer."
+instrument:
+  statute: "Highway Traffic Act, RSNL1990 c. H-3 — ss. 2 (definitions), 16 (registration and issuance of identification plates), 28 (Crown property), 30 (attachment), 31 (kept clean), 32 (confusable plates), 33 (seizure), 34 (other plates and markers), 35 (lost or mutilated), 41(3), 195 (regulations)"
+  sources:
+    - "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # Highway Traffic Act, RSNL1990 c. H-3, full consolidated text, fetched 2026-08-02 — every statutory quotation in this file"
+  licence: >-
+    The Highway Traffic Act is an EDICT OF GOVERNMENT and its text is
+    uncopyrightable (PRD-PLATES §4). Every verbatim statutory quotation here is of
+    that text.
+  regulations_not_read: >-
+    HTA s. 34 empowers the registrar to "issue other plates or markers that may be
+    prescribed in regulations made under section 195, in addition to the
+    identification plates referred to in section 16, which shall be displayed on
+    the vehicle in the manner that may be prescribed in the regulations." The
+    Motor Vehicle Registration Regulations under s. 195 were NOT located or read in
+    this pass and are the first place a verifier should look for anything about
+    plate appearance, colour or class letters. Recorded as the principal gap in
+    this file.
+
+artwork_risk:
+  posture: crown-copyright-asserted
+  basis: >-
+    Newfoundland and Labrador asserts Crown copyright: gov.nl.ca pages close with
+    "This page and all contents are copyright, Government of Newfoundland and
+    Labrador, all rights reserved." No provincial open licence covering plate
+    ARTWORK was located. The statute TEXT is free as an edict of government.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies. The pitcher plant (the provincial
+    floral emblem, and the centrepiece of the provincial wordmark), the whale
+    graphic of the 2022 base, the provincial flag sections and the half maple leaf
+    of the 2024 base are all rendered `placeholder`. The pitcher-plant wordmark is
+    a government identifier likely to carry trade-mark protection independent of
+    copyright; unresearched, flagged.
+
+common:
+  terminology:
+    note: >-
+      THE STATUTE'S OWN WORD IS "IDENTIFICATION PLATE" — see the file header. HTA
+      s. 2, verbatim: "'identification plate' means an identification plate issued
+      under this Act in respect of a vehicle". The definition of "fictitious
+      identification plate or marker" then shows the family: "an identification
+      plate, STICKER OR MARKER which has not been issued under this Act or which has
+      not been issued for the registration year in which it is used or which is
+      attached to a vehicle other than that for which it was issued". Plates,
+      stickers and markers are three statutory objects, and snowmobile registrations
+      in this province are DECALS rather than plates (secondary).
+    source: "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 2 definitions"
+  issuance:
+    text: >-
+      HTA s. 16(2), verbatim: "The registrar shall issue, in respect of a vehicle
+      that has been registered, (a) a numbered vehicle licence in a form prescribed
+      by the registrar; and (b) one or more identification plates as determined by
+      the registrar, and the identification plates shall be distinctive and numbered
+      as the registrar may determine." s. 16(4), verbatim: "The registrar may issue
+      different vehicle licences and identification plates in respect of different
+      classes of vehicles or in respect of the same class of vehicle used for
+      different purposes."
+    consequence: >-
+      NOTHING ABOUT A NEWFOUNDLAND AND LABRADOR PLATE IS PRESCRIBED BY LAW except
+      that the registrar prescribes it. That is the weakest statutory frame in the
+      Canada east wave — weaker than Ontario's (which at least fixes display),
+      weaker than New Brunswick's and Prince Edward Island's (which fix content),
+      and far weaker than Nova Scotia's and Québec's. Consequently EVERY `format`
+      in this file is a secondary claim and every one says so.
+    source: "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 16(2),(4)"
+  display:
+    text: >-
+      HTA s. 30(1), verbatim: "A driver, owner, or a person having care or control
+      of a vehicle shall ensure that identification plates are securely fastened at
+      all times to the vehicle for which they are issued so as to prevent the plates
+      from swinging and are at a height of not less than 30 CENTIMETRES from the
+      ground measured from the bottom of each plate and in a place and position so
+      that the plate is clearly visible." s. 30(2): "(a) where one plate is issued,
+      that the plate is clearly visible from the rear of the vehicle; and (b) where
+      2 plates are issued, one plate is clearly visible from the front of the
+      vehicle and the other plate is clearly visible from the rear."
+    cleanliness: >-
+      s. 31, verbatim: "Each identification plate shall be kept free from dirt and
+      shall be so affixed and maintained that the numbers on it may at all times be
+      plainly visible and clearly legible and that the view of the plate shall not
+      be obstructed or obscured."
+    confusable: >-
+      s. 32, verbatim: "A plate or number capable of being confused with an
+      identification plate or the number on a plate shall not be exposed upon a part
+      of a vehicle."
+    note: "30 cm is the same minimum height as Nova Scotia (300 mm), New Brunswick (30 cm) and Prince Edward Island (300 mm). Four Atlantic statutes, one number, independently enacted — recorded in each file."
+    source: "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA ss. 30(1)-(2), 31, 32, 33"
+  dimensions:
+    note: >-
+      NO NEWFOUNDLAND AND LABRADOR INSTRUMENT PRESCRIBES A PLATE SIZE. s. 16(2)(b)
+      leaves it to the registrar and the Act says nothing more. The 6 in x 12 in
+      North American convention is recorded on the series below as
+      `plate_basis: convention`.
+  charset:
+    note: >-
+      NO INSTRUMENT STATES A SERIAL ALPHABET OR ANY LETTER EXCLUSION, and no
+      secondary states one either — the Newfoundland and Labrador article, unlike
+      the Ontario, Nova Scotia and Québec articles, carries NO excluded-letter
+      claim. No `regex_strict` is authored anywhere in this file, and the absence is
+      a finding rather than an omission.
+  class_letters:
+    note: >-
+      TAGGED SECONDARY (PRD-PLATES §4, owner override 2026-08-02) — the whole table.
+      Inlined rather than put in `plates/_decode/` because PRD-PLATES §2.4 sends
+      LARGE, CLOSED, PRIMARY-SOURCED lists to a decode file and this is small
+      (nineteen rows) and not primary. It decodes VEHICLE CLASS, never geography:
+      a Newfoundland and Labrador serial encodes no region and no date.
+    rows:
+      - { code: "A", meaning: "private car", note: "AAA-001 from 1982, exhausted at AZZ-999 in 1998" }
+      - { code: "H", meaning: "private car", note: "the block after A — HAB-001 from autumn 1996, exhausted at HZZ-999 in summer 2013" }
+      - { code: "J", meaning: "private car", note: "the block after H — JAA-001 from summer 2013, current" }
+      - { code: "AA", meaning: "antique auto", note: "'Antique Auto' screened to the left of the serial; the article states cars must be at least 25 years old — the same age bar New Brunswick puts in its Act (MVA s. 1) and five years below Ontario's" }
+      - { code: "B", meaning: "bus", note: "BA for public-use buses, BP for private-use; two plates" }
+      - { code: "C", meaning: "truck / heavy vehicle", note: "pickups, SUVs and large vans; CAA-001 from 1982, exhausted at CZZ-999 in 2017, then CA0 001 onward; CR marks large mobile cranes; two plates" }
+      - { code: "D", meaning: "dealer" }
+      - { code: "E", meaning: "emergency vehicle", note: "fire and police, provincial or municipal; also search and rescue; two plates" }
+      - { code: "F", meaning: "farm vehicle", note: "FA farm tractors, FE farm equipment, FT farm trucks" }
+      - { code: "FF", meaning: "firefighter", note: "fire-department crest to the left of the serial" }
+      - { code: "G", meaning: "government vehicle", note: "GM municipal, GP provincial, GF federal; two plates" }
+      - { code: "K", meaning: "trail bike", note: "dual-purpose on/off-road motorcycles; same size and base as the motorcycle plate" }
+      - { code: "M", meaning: "motorcycle", note: "MCA-001 from 1982" }
+      - { code: "PR", meaning: "apportioned (International Registration Plan)", note: "transport trucks; PRP-001 from 1982, reached PRZ-999 in 2012, then PRA-001 onward" }
+      - { code: "S", meaning: "snowmobile", note: "issued as DECALS, not plates; older ones may be all-numeric; the current decal is black on white" }
+      - { code: "T", meaning: "trailer", note: "TAA-001 from 1982; TX is carved out for taxis" }
+      - { code: "TX", meaning: "licensed taxi", note: "supplemented by a municipal taxi licence sticker" }
+      - { code: "V", meaning: "off-road (quads and UTVs) in the VLL-999 shape; VETERAN in the V9999 shape", note: "ONE LETTER, TWO PROGRAMMES, DISTINGUISHED ONLY BY THE SHAPE OF WHAT FOLLOWS — the sharpest ambiguity in this table and the reason the two are authored as separate series" }
+      - { code: "VA", meaning: "veteran motorcycle" }
+      - { code: "VO1 / VO2", meaning: "amateur radio", note: "VO1 for the island of Newfoundland, VO2 for Labrador — the plate reproduces the holder's federal callsign and is NOT issued sequentially; per the article's citation to ISED's RIC-9 call-sign policy, plates run 5 or 6 characters" }
+      - { code: "W", meaning: "tow truck", note: "displayed IN ADDITION to a C-series plate — a genuine two-plate-two-series case" }
+      - { code: "X", meaning: "heavy machinery", note: "tractors, backhoes, forklifts" }
+    source: "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY, read 2026-08-02: the whole 'Vehicle class' table, its per-letter notes and its last-issued serials. No Newfoundland and Labrador instrument states any of it."
+    source_statute: "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 16(4): the registrar 'may issue different vehicle licences and identification plates in respect of different classes of vehicles' — the statutory power the table above is an exercise of, and the only primary that touches it"
+
+classes_not_modelled:
+  electric:
+    exists: false
+    mechanism: >-
+      A PROTOTYPE THAT NEVER SHIPPED, and the government announced it. In November
+      2019 the Government of Newfoundland and Labrador published "Provincial
+      Government Highlights Prototype of Electric Vehicle Licence Plates" — a green
+      serial on white with the provincial wordmark — announced by the Premier at the
+      Drive Electric NL Electric Vehicle Showcase. The article states that as of
+      2023 the design had not been made available and that electric vehicles simply
+      use ordinary series plates.
+    why_not_modelled: >-
+      A DESIGN THAT WAS NEVER ISSUED IS NOT A SERIES. Recorded because the
+      government primary exists, because three of the six jurisdictions in this wave
+      DO have an electric series (Ontario, Québec, Prince Edward Island) and a
+      consumer will ask, and because the honest answer is "announced, prototyped,
+      not issued".
+    sources:
+      - "https://www.gov.nl.ca/releases/2019/exec/1120n06/  # Government of Newfoundland and Labrador news release, 20 November 2019, cited by the article. NOT FETCHED in this pass — cited as the known government primary, unread."
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the prototype's description and the statement that it had not been issued as of 2023"
+  snowmobile:
+    exists: true
+    mechanism: "The S block in `common.class_letters` is issued as DECALS rather than plates, per the article, which also notes that older ones may be all-numeric and that the colour changed from orange-on-white to black-on-white."
+    why_not_modelled: >-
+      A decal is not an identification plate. HTA s. 2's definition of "fictitious
+      identification plate or marker" distinguishes "an identification plate,
+      sticker or marker", so the statute knows the difference too. Modelling a decal
+      as a plate series would misrepresent the object.
+  antique_firefighter_farm_emergency:
+    exists: true
+    mechanism: "The AA, FF, F and E blocks in `common.class_letters` — all real, all with last-issued serials recorded in the article."
+    why_not_modelled: >-
+      Their arrangements are inconsistent in the secondary itself: the antique
+      block's last issue is given as "4433" and the firefighter block's as "6163FF",
+      neither of which fits the LLL 999 skeleton every other block follows. Rather
+      than reconcile two shapes the source does not explain, the blocks are recorded
+      in the class table and no series is authored. A verifier with a photograph can
+      settle each in one edit.
+  tow_truck_second_plate:
+    exists: true
+    mechanism: >-
+      The W block, per the article: "Tow trucks display a SECOND plate (in addition
+      to a 'C' series plate)." That is one vehicle wearing two plates from two
+      different series simultaneously — a schema-relevant case, and the only one of
+      its kind found in the Canada east wave.
+    why_not_modelled: >-
+      Recorded rather than authored because the pairing rule, not the serial, is the
+      interesting part, and no instrument states either. A parse API asked about a
+      W-series string must be told the vehicle also carries a C-series plate, which
+      is what this entry is for.
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD SERIES — the pitcher-plant base.
+  # =========================================================================
+  - id: ca-nl-standard-2007
+    class: standard
+    categories: [car, van]
+    period: { start: 2007 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset:
+        notes: >-
+          Three letters, three numerals. NO EXCLUSION IS STATED BY ANY SOURCE — see
+          `common.charset` — so no strict twin is authored. The FIRST LETTER is the
+          class code (`common.class_letters`): private cars run in the A, H and J
+          blocks, and the J block is current.
+        private_car_blocks: [A, H, J]
+      progression: >-
+        Continuous across base changes: the article's record runs HMV 001 to JPZ 999
+        and then JTD 001 to JWY 999 on this base, with the JRA-JTC and JUH-JVV
+        stretches falling inside the 2022 and 2024 commemorative bases. THE SERIAL
+        RUN IGNORES THE BASE, which is why the commemorative series below overlap
+        this one instead of interrupting it.
+      separator_note: "a printed gap; `pattern` spells the emitted space and `regex` accepts it as optional"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      colour_note: "embossed blue serial on white. No instrument states either colour — HTA s. 16(2)(b) leaves the whole appearance to the registrar. Both hexes observed."
+      legend_bottom_options: ["Newfoundland Labrador"]
+      emblem: { present: true, rendered: placeholder, description: "the provincial wordmark, screened centre-bottom: a pitcher plant with 'Newfoundland' and 'Labrador' below it" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR, for a private car (HTA s. 30(2)(a)); the count itself is registrar's discretion under s. 16(2)(b)"
+      spec_history:
+        - { from: 2007, to: 2025, note: "provincial wordmark in blue" }
+        - { from: 2025, note: "same base with the province name in BLACK, per the article — a wordmark colour change inside one design, recorded here rather than cut as a series (PRD-PLATES §2.3)" }
+    sources:
+      - "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 16(2)(b) (the registrar determines number, distinctiveness and numbering), s. 16(4) (different plates for different classes), s. 28(1) (Crown property), s. 30(1)-(2) (30 cm, one plate rear / two plates front and rear), s. 31 (kept clean)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the pitcher-plant base from April 2007, the ABC 123 format, the December 2021 / January 2023 and December 2022 / January 2024 interruptions, the November 2025 resumption with a black province name, and the issuance ranges"
+    notes: >-
+      THE CURRENT NEWFOUNDLAND AND LABRADOR PLATE, ON THE WEAKEST STATUTORY FRAME IN
+      THE WAVE. HTA s. 16(2)(b) is the entire law of this plate's appearance — "one
+      or more identification plates as determined by the registrar ... distinctive
+      and numbered as the registrar may determine" — so period, format and colours
+      are all the article's and the grade is `secondary-wikipedia` throughout.
+      period.start 2007 is the article's April 2007 date, unfootnoted. THE SERIES IS
+      NOT ENDED AT EITHER COMMEMORATIVE INTERRUPTION and that is a deliberate
+      modelling decision: the serial run continued straight through both, so what
+      happened in 2022 and 2024 was a parallel base rather than a succession. The
+      two commemorative series therefore OVERLAP this one, legally under
+      PRD-PLATES §2.2 and with distinct notes. PARSE CAUTION: ABC 123 is also the
+      current shape in Nova Scotia and New Brunswick, so a bare string is not
+      diagnostic; the province is recoverable only from the image, or from the class
+      letter if the consumer has the block table in `common.class_letters`.
+
+  - id: ca-nl-comehome-2022
+    class: standard
+    categories: [car, van]
+    period: { start: 2022, end: 2022 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset: { notes: "identical to ca-nl-standard-2007 — the base changed and the mark did not" }
+      progression: "JRA 001 to JTC 999 per the article, i.e. a contiguous slice of the ordinary J-block run"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, note: "white-to-teal gradient, per the article" }
+      foreground: "#003DA5"
+      legend_bottom_options: ["COME HOME 2022"]
+      emblem: { present: true, rendered: placeholder, description: "a screened blue whale graphic; the provincial wordmark screened in red at the top" }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the January-December 2022 'COME HOME 2022' base, its whale graphic and teal gradient, and the JRA 001 to JTC 999 range"
+    notes: >-
+      A COMMEMORATIVE BASE THAT REPLACED THE STANDARD BASE FOR A CALENDAR YEAR, for
+      Newfoundland and Labrador's 2022 Come Home Year. Its own series because both
+      the design and the period differ (PRD-PLATES §2.3), and it deliberately
+      overlaps ca-nl-standard-2007 because the serial run never broke: JRA-JTC is a
+      slice of the ordinary J allocation that happens to have been struck on a
+      different base. Entirely secondary, and the only Canadian series in this wave
+      whose whole existence is a one-year tourism campaign.
+
+  - id: ca-nl-anniversary-2024
+    class: standard
+    categories: [car, van]
+    period: { start: 2024, end: 2024 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset: { notes: "identical to ca-nl-standard-2007" }
+      progression: "JUH 001 to JVV 999 per the article — again a contiguous slice of the J-block run"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      colour_note: "embossed BLACK serial, per the article — the only black-serial Newfoundland and Labrador base recorded, and the only black standard serial in the Canada east wave"
+      legend_bottom_options: ["1949 - 2024"]
+      emblem: { present: true, rendered: placeholder, description: "screened blue and grey sections of the provincial flag, a screened red half maple leaf, the pitcher-plant wordmark at the top and a screened '75' in the centre" }
+      band: { side: none }
+      rear_differs: false
+    commemorates: "the 75th anniversary of Newfoundland and Labrador's entry into Canadian Confederation on 31 March 1949"
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the January-December 2024 anniversary base, its flag and half-maple-leaf graphics, the '1949 - 2024' and '75' legends, and the JUH 001 to JVV 999 range"
+    notes: >-
+      THE SECOND ONE-YEAR COMMEMORATIVE BASE, on the same logic as
+      ca-nl-comehome-2022 and overlapping ca-nl-standard-2007 for the same reason.
+      Worth authoring separately rather than folding into a single "commemorative"
+      series because the colours differ sharply — black serial here against blue on
+      every other Newfoundland and Labrador base — so a photograph is decisive even
+      though a string is not. Entirely secondary.
+
+  - id: ca-nl-standard-1993
+    class: standard
+    categories: [car, van]
+    period: { start: 1993, end: 2007 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      charset: { notes: "as the current series; the private-car blocks in this period were A (to AZZ-999 in 1998) and then H" }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      colour_note: "embossed RED serial on white, per the article — a different serial colour from both its predecessor (blue) and its successor (blue), which makes this base unusually easy to place"
+      legend_bottom_options: ["A WORLD OF DIFFERENCE"]
+      emblem: { present: true, rendered: placeholder, description: "a screened Viking ship with a red sail against a yellow sunset, at the bottom of the plate; 'Newfoundland & Labrador' screened in red at the top" }
+      band: { side: none }
+      rear_differs: false
+      display_note: >-
+        THE ONE PLATE-COUNT FACT THE ARTICLE DATES: front and rear plates were
+        required for private cars until 1997, on the A block. So a Newfoundland and
+        Labrador private car of this vintage may lawfully carry two plates where a
+        modern one carries one — and HTA s. 30(2) accommodates both without saying
+        which applies when, because the count is s. 16(2)(b) discretion.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the mid-1993 'A WORLD OF DIFFERENCE' Viking-ship base, its red serial, the ATA 001 to AZF 999 and AZG 001 to AZZ 999 / HBD 001 to HEP 999 ranges, the September 1996 - September 1997 Cabot 500 interruption, and the front-plate requirement to 1997"
+      - "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 30(2): the statutory rule that accommodates one-plate and two-plate vehicles without prescribing which class gets which"
+    notes: >-
+      ONE SERIES BACK, and it carries the wave's clearest example of a PLATE-COUNT
+      CHANGE inside a single design: private cars in this province wore two plates
+      until 1997 and one thereafter, on the same base. Also interrupted, exactly as
+      the current base is: a "CABOT / Celebrate 500 Years" base ran September 1996 to
+      September 1997 on the H block. That interruption is NOT authored as a series
+      here — the L2/L3 scope is the current series plus one back, and a
+      commemorative base inside a superseded base is L4 work — but it is recorded so
+      a verifier knows it was seen and skipped deliberately.
+
+  # =========================================================================
+  # TRUCK / HEAVY VEHICLE — the C block, and the block that ran out.
+  # =========================================================================
+  - id: ca-nl-truck-c
+    class: standard
+    categories: [truck, van]
+    period: { start: 1982 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "CLL 999"
+      regex: '\AC[A-Z]{2} ?\d{3}\z'
+      charset: { notes: "the literal C is the class letter (`common.class_letters`). The article records the CR pair as marking large mobile crane units — a sub-block, not a separate series." }
+      progression: "CAA-001 from 1982 to CZZ-999 in 2017, then the CA0 001 shape below"
+    variants:
+      - name: "post-exhaustion truck arrangement"
+        format: { pattern: "CL9 999", regex: '\AC[A-Z]\d ?\d{3}\z' }
+        note: >-
+          The article states that when the C block exhausted at CZZ-999 in 2017 the
+          province moved to CA0 001 onward, i.e. it swapped the third character from
+          a letter to a digit rather than opening a new letter. A variant rather than
+          a series because the base, the class and the period are unchanged; the
+          current issue quoted by the article, CL7-999, fits this shape.
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      emblem: { present: true, rendered: placeholder, description: "the pitcher-plant wordmark, as the standard base" }
+      band: { side: none }
+      rear_differs: false
+      display: "TWO plates, front and rear, per the article — so HTA s. 30(2)(b) applies and a C-plated vehicle is plated fore and aft"
+    scope_note: >-
+      TAGGED SECONDARY, AND IT MATTERS FOR THE PARSE LAYER: the article says the C
+      block covers "pickup trucks, SUVs and large vans" and adds that "some trucks
+      and vans may now be registered as private cars". So the C letter is evidence of
+      a truck registration and its absence is NOT evidence against one — the same
+      shape of caution Ontario needs for its commercial pickups.
+    sources:
+      - "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 16(4): the registrar may issue different plates for different classes — the only primary behind the C block; s. 30(2)(b): the two-plate display rule this class falls under"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the C block, its 1982 start, its 2017 exhaustion at CZZ-999, the CA0 001 successor shape, the CR crane sub-block, the two-plate requirement and the current issue CL7-999"
+    notes: >-
+      THE BLOCK-EXHAUSTION CASE OF THIS FILE, and the reason it is authored with a
+      variant rather than a second series: Newfoundland and Labrador did not change
+      the base or the class when CZZ-999 ran out in 2017, it changed one character
+      class inside the same allocation. period.start 1982 is the article's start for
+      the C block and is `secondary-wikipedia` like everything else here; note it is
+      a claim about the BLOCK, which has outlived four bases, not about a design.
+      `class: standard` because the vocabulary has no truck member.
+
+  # =========================================================================
+  # MOTORCYCLE — the M block.
+  # =========================================================================
+  - id: ca-nl-motorcycle-m
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1982 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "MLL 999"
+      regex: '\AM[A-Z]{2} ?\d{3}\z'
+      charset: { notes: "the literal M is the class letter. The K block (trail bikes) shares the plate size and base per the article and is a separate letter, not a variant of this series." }
+      progression: "MCA-001 from 1982; the article's current issue is MEO-723"
+    design:
+      plate_note: "reduced motorcycle size; no instrument states one and no measured figure was obtained. Deliberately absent rather than guessed."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR (HTA s. 30(2)(a))"
+    sources:
+      - "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 30(2)(a): where one plate is issued it must be visible from the rear"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the M block from 1982 (MCA-001) and the K trail-bike block sharing its size and base"
+    notes: >-
+      Entirely secondary but for the display rule. Authored because the M letter is a
+      clean class signal and because Newfoundland and Labrador's separate K block for
+      DUAL-PURPOSE trail bikes is a distinction no other jurisdiction in this wave
+      draws — recorded in `common.class_letters` rather than authored, since its
+      arrangement is unstated beyond the example KAP-048.
+
+  # =========================================================================
+  # TRAILER — the T block, with a carve-out for taxis.
+  # =========================================================================
+  - id: ca-nl-trailer-t
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 1982 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "TLL 999"
+      regex: '\AT[A-Z]{2} ?\d{3}\z'
+      charset:
+        notes: >-
+          The literal T is the class letter, and the second letter is NOT free: the
+          article states TX is reserved for taxi plates, so a T-series trailer plate
+          never has X in position two. That reservation is NOT encoded in `regex` —
+          it would need a strict twin and none is authored in this file — but it is
+          the reason ca-nl-taxi-tx exists as its own series and why the two regexes
+          overlap on paper while never colliding in issue.
+      progression: >-
+        The article's account is unusually detailed and worth carrying because it is
+        a genuine allocation history: TAA-001 from 1982; a jump from TET-999 to
+        TVT-001 when the flag base arrived in 2001; TZZ-999 reached, then a jump BACK
+        to TEV-001 on the pitcher-plant base in 2008. Newfoundland and Labrador
+        reuses the gaps it leaves.
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR (HTA s. 30(2)(a))"
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the T block from 1982, the TET/TVT and TZZ/TEV jumps, the TX taxi reservation and the current issue TMJ-999"
+      - "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 16(4): the class-plate power"
+    notes: >-
+      AUTHORED FOR THE ALLOCATION HISTORY as much as for the format: the T block
+      jumped forward in 2001 and backward in 2008, which means a Newfoundland and
+      Labrador trailer serial is NOT monotonic in time and a consumer must not read
+      one as a date proxy. Entirely secondary.
+
+  # =========================================================================
+  # TAXI — the TX carve-out.
+  # =========================================================================
+  - id: ca-nl-taxi-tx
+    class: taxi
+    categories: [car, van]
+    period: { start: 1982 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "TXL 999"
+      regex: '\ATX[A-Z] ?\d{3}\z'
+      charset: { notes: "the literal TX is the class marker, carved out of the T (trailer) block. One free letter and three numerals follow." }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    supplement: "the article states a TX plate is 'supplemented with a MUNICIPAL taxi licence sticker' — so the provincial plate identifies the class and a municipality licenses the operation, a two-level arrangement worth recording because a photograph will show both"
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the TX block, its carve-out from T, the municipal sticker and the current issue TXP-999"
+      - "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 16(4): different plates for 'the same class of vehicle USED FOR DIFFERENT PURPOSES' — the limb of the power a taxi plate is issued under, since a taxi is an ordinary car put to a different use"
+    notes: >-
+      THE ONE SERIES IN THIS FILE WHOSE STATUTORY BASIS IS THE SECOND LIMB OF
+      s. 16(4) — "the same class of vehicle used for different purposes" — which is
+      exactly what a taxi is. `class: taxi` is a first-class member of
+      _meta/classes.yml and this is its Canadian instance in the wave: Québec
+      withdrew its T prefix when it deregulated (plates/ca-qc.yml
+      classes_not_modelled.taxi), New Brunswick reserves H for taxis without a
+      documented grammar, and Newfoundland and Labrador still issues.
+
+  # =========================================================================
+  # DEALER — the D block.
+  # =========================================================================
+  - id: ca-nl-dealer-d
+    class: dealer
+    categories: [car, van, truck]
+    period: { start: 1982 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "DLL 999"
+      regex: '\AD[A-Z]{2} ?\d{3}\z'
+      charset: { notes: "the literal D is the class letter" }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    binding: business
+    permitted_use: "the article states the D block is 'issued to auto dealers for test driving and transporting cars' — no instrument located states a permitted-use rule, in sharp contrast to Prince Edward Island (HTA s. 41, quoted in plates/ca-pe.yml) and Québec (Règlement art. 152, quoted in plates/ca-qc.yml)"
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the D block, its permitted use and the current issue DAW-768"
+      - "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 16(4) (the class-plate power) and s. 22 (the registrar's dealer-plate provisions referenced at 'store and use identification plates and dealer plates in accordance with this Act and the regulations') — the Act knows the term 'dealer plates' but never describes one"
+    notes: >-
+      THE ACT USES THE PHRASE "DEALER PLATES" AND NEVER DEFINES IT — the dealer
+      provisions require a dealer to "store and use identification plates and dealer
+      plates in accordance with this Act and the regulations" and to account for
+      "the dealer's inventory of dealer plates, identification plates and markers",
+      so the class is statutory in NAME while every visible property of it is
+      secondary. `binding: business` for the usual reason: the plate belongs to the
+      trade, not to a vehicle.
+
+  # =========================================================================
+  # GOVERNMENT — the G block, with three sub-blocks by level of government.
+  # =========================================================================
+  - id: ca-nl-government-g
+    class: government
+    categories: [car, van, truck]
+    period: { start: 1982 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "GLL 999"
+      regex: '\AG[A-Z]{2} ?\d{3}\z'
+      regex_strict: '\AG[MPF][A-Z] ?\d{3}\z'
+      charset:
+        notes: >-
+          The literal G is the class letter and the SECOND letter encodes the level
+          of government: GM municipal, GP provincial, GF federal, per the article.
+          `regex_strict` encodes that three-way second-letter restriction; `regex`
+          does not, so a consumer who distrusts the secondary loses nothing. This is
+          the only strict twin in the whole file, and it exists because this is the
+          only Newfoundland and Labrador block whose SECOND character is documented
+          as constrained.
+        second_letter: { M: municipal, P: provincial, F: federal }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "TWO plates, front and rear, per the article — HTA s. 30(2)(b)"
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the G block, the GM/GP/GF sub-blocks by level of government, the two-plate requirement and the current issues GMO-320, GPR-292 and GFM-154"
+      - "https://www.assembly.nl.ca/legislation/sr/statutes/h03.htm  # HTA s. 16(4) (the class-plate power); s. 30(2)(b) (two-plate display)"
+    notes: >-
+      A THREE-LEVEL DECODE IN ONE CHARACTER — municipal, provincial and FEDERAL
+      vehicles all plated by the province, distinguished by the second letter. That
+      is worth authoring and worth a strict twin, and it is also the file's clearest
+      illustration of how much decode Newfoundland and Labrador packs into a
+      skeleton that carries no region and no date. Entirely secondary; the E block
+      (emergency vehicles, including provincially and municipally owned fire and
+      police) is recorded in `common.class_letters` but not authored, because its
+      relationship to G is not explained by the source.
+
+  # =========================================================================
+  # AMATEUR RADIO — a federal callsign on a provincial plate.
+  # =========================================================================
+  - id: ca-nl-amateur-radio-vo
+    class: personalized
+    categories: [car, van]
+    period: { start: 1982 }
+    period_evidence: secondary-wikipedia
+    matching: recall-only
+    format:
+      pattern: "VO1LLL"
+      regex: '\AVO[12] ?[A-Z0-9]{2,3}\z'
+      charset:
+        notes: >-
+          The pattern spells the VO1 (island) form as the canonical printed example; `regex` admits VO2 (Labrador) equally. VO1 is the Innovation, Science and Economic Development Canada amateur
+          callsign prefix for the island of Newfoundland and VO2 for Labrador, so
+          this plate reproduces a FEDERAL identifier on a provincial plate — the same
+          structure as Québec's VA2/VE2 series (plates/ca-qc.yml
+          ca-qc-amateur-radio), which is no coincidence: both provinces simply print
+          the callsign. The article states plates "may vary between 5 and 6
+          characters, as operators may conditionally be issued a shorter callsign",
+          citing ISED's RIC-9 call-sign policy, and that these plates are NOT issued
+          sequentially because callsigns are chosen.
+      recall_reason: >-
+        `matching: recall-only` because the suffix alphabet is not stated anywhere:
+        RIC-9 governs callsign suffixes and was not read in this pass, so `regex`
+        accepts any two or three serial characters after the prefix, which is
+        certainly wider than what ISED assigns. A match is a shape hit and nothing
+        more (PRD-PLATES §2.7).
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the VO1 (Newfoundland) and VO2 (Labrador) blocks, the callsign-matching rule, the non-sequential issuance and the 5-to-6-character range"
+      - "https://ised-isde.canada.ca/site/spectrum-management-telecommunications/en/licences-and-certificates/radiocom-information-circulars-ric/ric-9-call-sign-policy-and-special-event-prefixes  # ISED Canada, RIC-9 'Call Sign Policy and Special Event Prefixes' — the federal instrument that actually allocates these strings, cited by the article. NOT FETCHED in this pass; cited as the known primary, unread. A verifier who reads it can promote this series to `matching: strict` with a real suffix alphabet."
+    notes: >-
+      THE ONLY SERIES IN THE CANADA EAST WAVE WHOSE SERIAL IS ALLOCATED BY A
+      DIFFERENT LEVEL OF GOVERNMENT — Innovation, Science and Economic Development
+      Canada assigns the callsign and the province merely prints it, exactly as in
+      Québec. The VO1/VO2 split is also the only GEOGRAPHIC decode anywhere in this
+      file: VO1 is the island, VO2 is Labrador, and that distinction survives on the
+      plate because it survives in the federal callsign. `class: personalized` is the
+      least-wrong vocabulary member — the holder does not choose the string freely,
+      but it is theirs rather than the registrar's — and the choice is flagged for a
+      verifier, as it is on the Québec twin.
+
+  # =========================================================================
+  # VETERAN — the V block's second, numeric meaning.
+  # =========================================================================
+  - id: ca-nl-veteran-v
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2007 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "V9999"
+      regex: '\AV ?\d{4}\z'
+      charset:
+        notes: >-
+          THE V LETTER MEANS TWO THINGS IN THIS PROVINCE AND ONLY THE SHAPE
+          SEPARATES THEM: V followed by two letters and three numerals is an
+          OFF-ROAD plate (quads and UTVs, the VBC-123 form); V followed by four
+          numerals is a VETERAN plate. That is the sharpest ambiguity in
+          `common.class_letters` and the reason the veteran series is authored with
+          an all-numeric body while the off-road form is left in the class table.
+    variants:
+      - name: "veteran motorcycle"
+        format: { pattern: "VA999", regex: '\AVA ?\d{3}\z' }
+        note: "the article records VA as the veteran MOTORCYCLE block, in the VA123 shape — a third meaning for a V-initial string, and a fourth if the Québec VA2 amateur block is in the consumer's candidate set"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Newfoundland_and_Labrador  # TAGGED SECONDARY: the V (V1234) veteran block and the VA (VA123) veteran motorcycle block, with current issues V3223 and VA644"
+    notes: >-
+      AUTHORED FOR THE AMBIGUITY, WHICH IS THE POINT. A parse API handed "V1234"
+      must return a Newfoundland and Labrador VETERAN candidate; handed "VBC 123" it
+      must return an OFF-ROAD candidate; handed "VA644" a veteran-motorcycle
+      candidate; and handed "VA2 AB" a QUÉBEC amateur-radio candidate. Four readings
+      of a V-initial Canadian string, three of them in this province. period.start
+      2007 is a FLOOR rather than a start: no source dates the veteran programme, and
+      2007 is the earliest base on which the article records it. `class: specialty`
+      for the usual vocabulary reason. Entirely secondary.

--- a/plates/ca-ns.yml
+++ b/plates/ca-ns.yml
@@ -1,0 +1,808 @@
+# plates/ca-ns.yml — Nova Scotia, Canada (PRD-PLATES gate L2/L3, Canada east wave).
+#
+# THE SURPRISE OF THE CANADA EAST WAVE: Nova Scotia legislates its plate DESIGNS.
+# Ontario, New Brunswick, Prince Edward Island and Newfoundland and Labrador all
+# leave the appearance of a plate to ministerial discretion and publish nothing.
+# Nova Scotia makes a regulation per plate type and the regulation states the
+# MILLIMETRE DIMENSIONS, THE FIELD COLOUR, THE LETTERING COLOUR, THE LEGENDS and,
+# in one case, THE SERIAL GRAMMAR. Four of the series below therefore carry
+# design claims quoted from an instrument rather than observed from a photograph,
+# which is rarer in this dataset than it should be.
+#
+# FIVE STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. THE ACT DELEGATES THE PLATE'S CONTENT TO THE MINISTER, IN TERMS. Motor
+#    Vehicle Act s. 19(2), verbatim: "Every number plate shall have displayed upon
+#    it the registration number assigned to the owner and such other matter as the
+#    Minister may determine." s. 19(1): "The Department shall also furnish to
+#    every owner whose vehicle is registered the number of number plates assigned
+#    to the owner in the regulations." So: the NUMBER of plates is regulatory, the
+#    CONTENT is ministerial, and the composition of the registration number itself
+#    is stated nowhere at all. Nova Scotia then exercises that ministerial power by
+#    MAKING REGULATIONS ANYWAY, which is why this file has instrument-sourced
+#    colours.
+#
+# 2. NOVA SCOTIA IS A ONE-PLATE PROVINCE WITH A LONG EXCEPTION LIST AND AN
+#    INVERSION. Number Plates Regulations (N.S. Reg. 173/95) s. 1, verbatim:
+#    the Department assigns "(a) two number plates, bearing the same numbers, to a
+#    camper, farm truck, commercial fisherman truck, service truck, self-powered
+#    miscellaneous equipment, a vehicle to bear firefighter plates or antique
+#    plates or a vehicle to bear personalized plates, other than a motorcycle; and
+#    (b) except as provided in clause (a), one number plate to a motor vehicle."
+#    THE INVERSION IS s. 2(2): "Where the Department furnishes an owner of a heavy
+#    commercial motor vehicle with one number plate, the owner shall attach the
+#    number plate to the FRONT of the vehicle" — against s. 2(1), which puts the
+#    single plate of a passenger or light commercial vehicle on the REAR. Nova
+#    Scotia, Florida, Prince Edward Island and Québec all invert for heavy
+#    vehicles, each by its own route.
+#
+# 3. THE PLATE SIZE IS IN THE REGULATIONS, IN CENTIMETRES, REPEATEDLY. Personalized
+#    Number Plates Regulations s. 7(2)(a): "measure 15.24 cm in width by 30.48 cm
+#    in length"; s. 7(1)(a) for a motorcycle: "measure 10.16 cm in width by
+#    17.78 cm in length". Conservation Number Plates Regulations s. 2(1)(a) and
+#    Honorary Consul Number Plates Regulations s. 3(a) repeat the 15.24 x 30.48
+#    figure. NOTE THE AXES, WHICH READ ODDLY AND ARE QUOTED AS FOUND: the
+#    regulations call 15.24 cm the WIDTH and 30.48 cm the LENGTH, i.e. 6 in by
+#    12 in with the conventional US axis-naming inverted — the same oddity
+#    plates/us-fl.yml records for § 320.06(3)(a) F.S. This file records the plate
+#    as 30.48 cm across by 15.24 cm tall, which is the physical truth, and says so.
+#
+# 4. ONE NOVA SCOTIA SERIES HAS A STATUTORY SERIAL GRAMMAR, AND IT IS THE
+#    FIREFIGHTER PLATE. Number Plates for Firefighters Regulations (N.S. Reg.
+#    49/91, Ministerial Order dated 18 March 1991), verbatim: plates issued after
+#    "the lst day of April, 1991" for firefighters shall have "(c) a depiction of
+#    the Fire Department's symbol ... at the left of THREE LETTERS AND ONE NUMBER
+#    used as the registration number assigned to the owner; (d) the background
+#    colour of the number plate shall be white, the Fire Department symbol and all
+#    other letters, numbers and marks shall be blue". A format, a colour pair and
+#    a commencement date, in one Ministerial Order. (The "lst" is the
+#    consolidation's own typography for "1st" and is quoted as found.)
+#
+# 5. THE ORDINARY PASSENGER PLATE'S DESIGN IS DESCRIBED IN LAW SIDEWAYS. No Nova
+#    Scotia regulation describes the STANDARD plate — but the Personalized Number
+#    Plates Regulations describe the personalized plate as the standard plate with
+#    a chosen serial, and in doing so state the standard design: s. 7(2)(b)-(d),
+#    verbatim: "bear a depiction of the Bluenose on a silver-white field"; "bear
+#    the words 'NOVA SCOTIA' at the top, in blue lettering"; "bear the words
+#    'CANADAS OCEAN PLAYGROUND' at the bottom, in blue lettering". That is the
+#    Bluenose base, in a regulation, and it is why ca-ns-standard-1989's colours
+#    are not merely observed. (The regulation omits the apostrophe in "CANADAS";
+#    quoted as found.)
+#
+# SEPARATOR NOTE (PRD-PLATES §2.6): a Nova Scotia plate prints a GAP, not a glyph.
+# The Personalized regulations confirm it from the authority's own side — a
+# personalized designation is "composed of a sequence of at least 2 and no more
+# than 7 numerals and letters ... WITH OR WITHOUT SPACES between the numerals and
+# letters", i.e. the space is optional even to the Registrar. Every `pattern` here
+# spells the emitted space; every regex accepts it as optional.
+jurisdiction: ca-ns
+authority:
+  name: Registry of Motor Vehicles, Nova Scotia (Service Nova Scotia); regulations made by the Minister and the Governor in Council under the Motor Vehicle Act
+  url: "https://novascotia.ca/just/regulations/regs/mvnumber.htm"
+binding: owner
+binding_note: >-
+  THE NOVA SCOTIA PLATE IS ASSIGNED TO THE OWNER, NOT THE VEHICLE, AND THE ACT
+  SAYS SO IN ITS OWN WORDS. MVA s. 19(1): the Department furnishes plates "to every
+  owner whose vehicle is registered ... the number of number plates assigned TO THE
+  OWNER". s. 19(2): the plate displays "the registration number assigned TO THE
+  OWNER". The Personalized Number Plates Regulations s. 4(2) go further: "A person
+  may apply for personalized number plates without registering a motor vehicle, but
+  personalized number plates that are not used for vehicle registration must not be
+  attached to a motor vehicle." A Nova Scotia plate can exist with no vehicle behind
+  it. Same posture as plates/ca-on.yml and plates/ch.yml; opposite of the Québec
+  association model in plates/ca-qc.yml.
+instrument:
+  statute: "Motor Vehicle Act, R.S.N.S. 1989, c. 293 — ss. 10 (classification and plate-count regulations), 19 (number plate), 20 (display), 36(1) and 38 (ministerial number-plate powers), 302(1)"
+  regulations:
+    - "Number Plates Regulations — O.I.C. 95-864 (21 November 1995, effective 1 November 1995), N.S. Reg. 173/95, as amended by O.I.C. 2005-248 (9 June 2005), N.S. Reg. 123/2005"
+    - "Personalized Number Plates Regulations — O.I.C. 2005-248 (9 June 2005), N.S. Reg. 124/2005"
+    - "Number Plates for Firefighters Regulations — N.S. Reg. 49/91, Ministerial Order dated 18 March 1991, made under MVA s. 36(1)"
+    - "Number Plates for Farmers and Fishermen Regulations — made under MVA s. 38"
+    - "Conservation Number Plates Regulations — O.I.C. 2003-105 (21 March 2003), N.S. Reg. 54/2003, made under MVA s. 38"
+    - "Honorary Consul Number Plates Regulations — N.S. Reg. 117/2020, in force 8 September 2020 (Royal Gazette Part II, 25 September 2020)"
+    - "Veterans' Number Plates Regulations — O.I.C. 2002-606 (20 December 2002), N.S. Reg. 163/2002, amended to O.I.C. 2024-342 (10 September 2024), N.S. Reg. 194/2024"
+    - "Means of identification of Province-, municipality- and volunteer-owned vehicles — O.I.C. 90-945 (effective 1 August 1990), N.S. Reg. 224/1990, amended to O.I.C. 2002-444 (effective 27 September 2002), N.S. Reg. 122/2002, made under MVA ss. 38(1) and 302(1)"
+  reg_making_power: >-
+    MVA s. 10(1), verbatim: "Subject to the approval of the Governor in Council,
+    the Minister may make regulations dividing vehicles into various classes,
+    prescribing conditions governing the registration and operation of each class,
+    providing for the NUMBER of number plates to be affixed to each vehicle in each
+    class, providing for the LOCATION of the number plates to be affixed to each
+    vehicle in each class and providing penalties for violation of such
+    regulations." s. 10(2): "Such regulations upon publication in the Royal Gazette
+    shall have the same force and effect as if the regulations were contained in
+    this Act." NOTE WHAT s. 10(1) REACHES: number and location. Not composition,
+    not colour — those arrive through the s. 19(2) ministerial-determination route
+    and ss. 36(1)/38.
+  fetch_note: >-
+    nslegislature.ca WAS UNREACHABLE FROM THIS LOCATION on 2026-08-02: the TLS
+    handshake to 64.15.49.119:443 timed out on every attempt, direct and via
+    WebFetch. The consolidated Motor Vehicle Act PDF quoted here was therefore read
+    through the Internet Archive's copy of the official file (snapshot
+    20251124192915), whose own footer reads "NOVEMBER 24, 2025". The REGULATIONS
+    were read directly from novascotia.ca, which was reachable. Recorded so a
+    verifier knows which quotations came through an archive.
+  sources:
+    - "https://web.archive.org/web/20251124192915/https://nslegislature.ca/sites/default/files/legc/statutes/motor%20vehicle.pdf  # Motor Vehicle Act consolidation as at 24 November 2025, read 2026-08-02 — ss. 10, 19, 20 quoted above"
+    - "https://nslegislature.ca/sites/default/files/legc/statutes/motor%20vehicle.pdf  # the official file the archive copy is of; UNREACHABLE from this location, see fetch_note"
+    - "https://novascotia.ca/just/regulations/regs/mvnumber.htm  # Number Plates Regulations, N.S. Reg. 173/95, ss. 1 and 2(1)-(4) — read 2026-08-02"
+  licence: >-
+    The Nova Scotia Registry of Regulations serves these consolidations with the
+    notice "This consolidation is unofficial and is for reference only" and a
+    Crown copyright assertion. The TEXT of a statute or regulation is an EDICT OF
+    GOVERNMENT and uncopyrightable (PRD-PLATES §4); the quotations here are of that
+    text. Where a regulation refers to a Schedule "A" DEPICTION of the plate, the
+    depiction is not reproduced (PRD-PLATES §6: cite, never embed), and in several
+    cases the Registry itself states "Hard copy may be obtained from the Registry
+    of Regulations" — the drawing is not online at all.
+
+artwork_risk:
+  posture: crown-copyright-asserted
+  basis: >-
+    Nova Scotia asserts Crown copyright on its regulation consolidations
+    ("This electronic version is copyright © 2009 / 2011, Province of Nova Scotia,
+    all rights reserved. It is for your personal use and may not be copied for the
+    purposes of resale"). The edicts-of-government principle frees the regulation
+    TEXT, which is what this file uses. The Schedule "A" plate DEPICTIONS attached
+    to each plate regulation are not reproduced and several are not published
+    online at all.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies. The Bluenose depiction, the
+    provincial crest, the Fire Department symbol and the piping plover are all
+    rendered `placeholder`. The Bluenose is additionally a provincial emblem with
+    protection independent of copyright; unresearched, flagged.
+
+common:
+  plate_count:
+    two_plate_classes:
+      text: >-
+        Number Plates Regulations s. 1, verbatim: the Department shall assign
+        "(a) two number plates, bearing the same numbers, to a camper, farm truck,
+        commercial fisherman truck, service truck, self-powered miscellaneous
+        equipment, a vehicle to bear firefighter plates or antique plates or a
+        vehicle to bear personalized plates, other than a motorcycle; and
+        (b) except as provided in clause (a), one number plate to a motor vehicle."
+      note: "Clause 1(a) was amended by O.I.C. 2005-248, N.S. Reg. 123/2005 — the same Order in Council that made the Personalized Number Plates Regulations, which is why personalized plates entered the two-plate list in 2005."
+    display:
+      text: >-
+        Number Plates Regulations s. 2, verbatim: "(1) Where the Department
+        furnishes an owner of a passenger or light commercial motor vehicle with
+        one number plate, the owner shall attach the number plate to the REAR of
+        the vehicle ... (2) Where the Department furnishes an owner of a heavy
+        commercial motor vehicle with one number plate, the owner shall attach the
+        number plate to the FRONT of the vehicle ... (3) Where the Department
+        furnishes the owner of a motor vehicle with two personalized plates, the
+        owner shall attach one number plate to the rear of the vehicle ...
+        (4) Where the Department furnishes an owner of a camper, farm truck,
+        commercial fisherman truck, service truck, self-powered miscellaneous
+        equipment [or] a vehicle to bear firefighter plates or antique plates with
+        two number plates bearing the same number, the owner shall attach one
+        number plate to the front of the motor vehicle and one number plate to the
+        rear".
+    mounting:
+      text: >-
+        MVA s. 20(2), verbatim: "Every number plate assigned to an owner and
+        required to be attached to a vehicle shall at all times be securely
+        fastened to the vehicle so as to prevent the plate from swinging and at a
+        height not less than 300 millimetres from the ground, measuring from the
+        bottom of the plate, in a place and position to be clearly visible, and
+        shall be maintained free from foreign materials and in a condition to be
+        clearly legible."
+      note: "300 mm minimum height is the same figure New Brunswick (MVA s. 30(2)(b), 30 cm), Prince Edward Island (HTA s. 21(3), 300 mm) and Newfoundland and Labrador (HTA s. 30(1), 30 centimetres) all use. Four Atlantic statutes, one number, independently enacted."
+    source: "https://novascotia.ca/just/regulations/regs/mvnumber.htm  # N.S. Reg. 173/95 ss. 1, 2(1)-(4)"
+    source_statute: "https://web.archive.org/web/20251124192915/https://nslegislature.ca/sites/default/files/legc/statutes/motor%20vehicle.pdf  # MVA ss. 19(1)-(3), 20(1)-(2)"
+  dimensions:
+    standard: { w_cm: 30.48, h_cm: 15.24, w_in: 12, h_in: 6 }
+    motorcycle: { w_cm: 17.78, h_cm: 10.16, w_in: 7, h_in: 4 }
+    restricted_motorcycle: { w_in: 8, h_in: 5 }
+    axis_note: >-
+      THE REGULATIONS NAME THE AXES THE OTHER WAY ROUND AND ARE QUOTED AS FOUND:
+      "15.24 cm in width by 30.48 cm in length" (Personalized reg s. 7(2)(a);
+      Conservation reg s. 2(1)(a); Honorary Consul reg s. 3(a)) and "10.16 cm in
+      width by 17.78 cm in length" for a motorcycle plate (Personalized reg
+      s. 7(1)(a)). The Restricted plate regulation instead says "a single six inch
+      by twelve inch number plate" and "a single five inch by eight inch number
+      plate" for a motorcycle (N.S. Reg. 224/1990 s. 1(a)-(b)) — inches, and a
+      DIFFERENT motorcycle size from the personalized regulation's. Both are
+      recorded; neither is reconciled, because they are two instruments about two
+      plate types and averaging them would be invention (PRD-PLATES §5.3).
+    source: "https://novascotia.ca/just/regulations/regs/mvprsnum.htm  # Personalized reg s. 7(1)(a), 7(2)(a)"
+    source_secondary: "https://novascotia.ca/just/regulations/regs/mvrvehid.htm  # N.S. Reg. 224/1990 s. 1(a)-(b): the six-by-twelve and five-by-eight inch RESTRICTED plates"
+  charset:
+    statutory: >-
+      NO NOVA SCOTIA INSTRUMENT STATES A SERIAL ALPHABET for ordinary plates. The
+      closest is the Personalized Number Plates Regulations s. 5(c)(ii), which lets
+      the Registrar refuse a designation that "contains characters other than
+      numerals, letters and spaces" — a negative statement of the alphabet, and the
+      only one located. It is quoted on ca-ns-personalized-2005 and is the basis of
+      that series' regex.
+    excluded_letters_secondary: [I, O, Q]
+    excluded_note: >-
+      TAGGED SECONDARY: the en.wikipedia Nova Scotia article states that I, O and Q
+      are not used in the ABC-123 serial format, citing a collector site. No
+      instrument says so. Encoded ONLY in `regex_strict`.
+    source: "https://novascotia.ca/just/regulations/regs/mvprsnum.htm  # Personalized reg s. 5(c)(ii)"
+    source_secondary: "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nova_Scotia  # TAGGED SECONDARY (PRD-PLATES §4, owner override 2026-08-02), read 2026-08-02"
+
+classes_not_modelled:
+  conservation:
+    exists: true
+    mechanism: >-
+      Conservation Number Plates Regulations s. 2(1), verbatim: on application "a
+      person may be issued a special number plate that (a) is 15.24 cm in width by
+      30.48 cm in length; (b) shows a multi-coloured piping plover followed by blue
+      letters and numerals on a silver-white field; and (c) bears the words 'NOVA
+      SCOTIA' at the top and 'CONSERVATION - SPECIES AT RISK' at the bottom, and is
+      otherwise in general accordance with the number plate depicted in Schedule
+      'A'." s. 3: available only for a passenger motor vehicle or a commercial motor
+      vehicle registered for 5 000 kg or less.
+    why_not_modelled: >-
+      THE REGULATION GIVES THE SIZE, THE COLOURS AND THE LEGENDS AND NEVER THE
+      SERIAL GRAMMAR — "blue letters and numerals" is an alphabet, not a shape. No
+      count, no arrangement, no order. Authoring a regex would be invention, so the
+      class is recorded here in full instead. This is the most complete design
+      description in the file for a series that cannot be authored.
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/mvconsnp.htm  # Conservation Number Plates Regulations, O.I.C. 2003-105 (21 March 2003), N.S. Reg. 54/2003, ss. 1-3, read 2026-08-02"
+  consular:
+    exists: true
+    mechanism: >-
+      Honorary Consul Number Plates Regulations s. 3, verbatim: on application "a
+      person may be issued a special number plate that (a) is 15.24 cm in width by
+      30.48 cm in length; and (b) bears the words 'NOVA SCOTIA' at the top and
+      'HONORARY CONSUL' at the bottom, and is otherwise in general accordance with
+      the number plate depicted in Schedule A." s. 4: eligibility is appointment as
+      an Honorary Consul for the district of Nova Scotia. s. 5: retention depends on
+      maintaining that status at each permit renewal. s. 6: passenger vehicles only.
+    why_not_modelled: "Same gap as conservation: size, legends and eligibility, no serial grammar and no colour. Recorded, not invented."
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/MVhonconsulnp.htm  # Honorary Consul Number Plates Regulations, N.S. Reg. 117/2020, in force 8 September 2020, ss. 1-6, read 2026-08-02"
+  veteran:
+    exists: true
+    mechanism: >-
+      Veterans' Number Plates Regulations, O.I.C. 2002-606 (20 December 2002),
+      N.S. Reg. 163/2002, amended to N.S. Reg. 194/2024. The regulation defines
+      "veteran" expansively — service in the Canadian Armed Forces, the armed forces
+      of another Commonwealth country or of a wartime ally, the RCMP as a regular
+      member, wartime service in the Merchant Navy or Ferry Command, and service as
+      a peace officer on a "special duty operation" — and has sections headed
+      "Issuance of veteran's number plate", "Description of veteran's number plate",
+      "Certification", "Schedule A" and "Schedule B".
+    why_not_modelled: >-
+      The consolidation's description section and both Schedules were NOT captured
+      in the fetch of 2026-08-02 (the page's body was retrieved down to the
+      definitions and the table of contents only). Rather than guess from the
+      headings, the class is recorded and flagged: a verifier should re-fetch
+      mvvetnp.htm and author the series from s. 3 and the "Description" section.
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/mvvetnp.htm  # Veterans' Number Plates Regulations — definitions and structure read 2026-08-02; the description section is a recorded gap"
+  restricted_government:
+    exists: true
+    mechanism: >-
+      N.S. Reg. 224/1990 s. 1, verbatim: the means of identification of a vehicle
+      "while owned by the Province of Nova Scotia, a city, town or municipality, an
+      emergency vehicle while owned by a volunteer fire department or a search and
+      rescue vehicle ... shall be (a) in respect of a motor vehicle or trailer, a
+      single six inch by twelve inch number plate attached to the REAR of the motor
+      vehicle or trailer, showing BLACK numerals and letters on a SILVER-WHITE
+      field and bearing the word 'RESTRICTED' at the top and the words 'NOVA SCOTIA'
+      at the bottom; and (b) in respect of a motorcycle, a single five inch by eight
+      inch number plate attached to the rear of the motorcycle showing black
+      numerals and letters on a silver-white field and bearing the word 'RESTRICTED'
+      at the top and the words 'NOVA SCOTIA' at the bottom." s. 2: no fee for a fire
+      emergency vehicle or a search-and-rescue vehicle under an Emergency Measures
+      Organization agreement. s. 3: the vehicle permit "shall state 'restricted'".
+    why_not_modelled: >-
+      A complete design in law — size, colours, legends, position — and NO SERIAL
+      GRAMMAR. The en.wikipedia article reports an R12345 arrangement for Nova
+      Scotia restricted plates, unfootnoted; that alone is too thin to author a
+      government series on when the instrument itself is silent, so the class is
+      recorded here with the instrument's text intact. A verifier who accepts the
+      secondary can promote it in one edit.
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/mvrvehid.htm  # N.S. Reg. 224/1990 ss. 1-5, made under MVA ss. 38(1) and 302(1), effective 1 August 1990, amended to N.S. Reg. 122/2002, read 2026-08-02"
+  camper_and_accessible:
+    exists: true
+    mechanism: >-
+      A camper is a two-plate class under Number Plates Regulations s. 1(a) and has
+      its own fee regulation (Registration Fees for Campers Regulations, O.I.C.
+      77-763, effective 1 November 1977, N.S. Reg. 62/77, amended to N.S. Reg.
+      132/2015). Accessible ("Handicap") plates exist and the article reports a
+      1A-23 arrangement from 1981.
+    why_not_modelled: "No design or serial regulation located for either; the camper regulation prescribes FEES, not appearance. Recorded as gaps."
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/mvcamper.htm  # Registration Fees for Campers Regulations — cited as the instrument that creates the class; fees only"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD SERIES — the Bluenose base, and its colours are in a
+  # regulation (see header fact 5).
+  # =========================================================================
+  - id: ca-ns-standard-1989
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 1989 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]{3} ?\d{3}\z'
+      charset:
+        excluded: [I, O, Q]
+        notes: "TAGGED SECONDARY — see `common.charset`. No Nova Scotia instrument states any exclusion; encoded only in `regex_strict`."
+      progression: "the article's issuance record runs BRT 001 (1989) through the F, G and H letter blocks; there is NO date and NO region signal in a Nova Scotia serial"
+      separator_note: "a printed gap, not a glyph; the Personalized regulation's 'with or without spaces' language (s. 7(2)(e)) is the authority's own confirmation that the space is optional"
+    design:
+      plate: { w: 30.48, h: 15.24, unit: cm, w_in: 12, h_in: 6 }
+      plate_note: "SOURCED, not conventional: the Personalized Number Plates Regulations s. 7(2)(a) prescribe '15.24 cm in width by 30.48 cm in length' for a plate on this base. See `common.dimensions.axis_note` for why the axes are recorded transposed."
+      background: { color: "#F2F2F2", finish: retroreflective, hex_basis: observed, spec_note: "the regulation names the field 'silver-white' (Personalized reg s. 7(2)(b)) and gives no coordinate; the hex is an sRGB reading of that name and is marked observed" }
+      foreground: "#003C71"
+      colour_spec_note: >-
+        THE COLOURS ARE NAMED IN A REGULATION, WHICH IS RARE IN THIS DATASET.
+        Personalized Number Plates Regulations s. 7(2), verbatim: a plate on this
+        base must "(b) bear a depiction of the Bluenose on a silver-white field;
+        (c) bear the words 'NOVA SCOTIA' at the top, in blue lettering; (d) bear the
+        words 'CANADAS OCEAN PLAYGROUND' at the bottom, in blue lettering". Named,
+        not numbered — so both hexes remain `hex_basis: observed` inside a
+        regulated colour name, the same posture plates/gb.yml takes for the British
+        statutory "yellow".
+      legend_top: "NOVA SCOTIA"
+      legend_bottom_options: ["CANADA'S OCEAN PLAYGROUND"]
+      legend_note: "the regulation prints it without the apostrophe — 'CANADAS OCEAN PLAYGROUND' — and is quoted that way in `colour_spec_note`; the plate itself shows the apostrophe"
+      emblem: { present: true, rendered: placeholder, description: "the schooner Bluenose, screened in the centre of the field — prescribed by Personalized reg s. 7(2)(b) and therefore a REGULATED design element, not an observed one" }
+      band: { side: none }
+      rear_differs: false
+      display: "one plate, REAR, for a passenger or light commercial vehicle (Number Plates Regulations ss. 1(b), 2(1)); FRONT for a heavy commercial vehicle issued a single plate (s. 2(2))"
+      spec_history:
+        - { from: 1989, to: 2011, note: "embossed blue serial on reflective white with border lines around the plate and around the top corners" }
+        - { from: 2011, note: "border lines removed and narrower serial dies introduced; the mark, the format and the colours are unchanged, so this is a specification change inside one design (PRD-PLATES §2.3) and not a second series" }
+    region_encoding: none
+    sources:
+      - "https://web.archive.org/web/20251124192915/https://nslegislature.ca/sites/default/files/legc/statutes/motor%20vehicle.pdf  # MVA s. 19(1),(2): plates are furnished to the OWNER and display 'the registration number assigned to the owner and such other matter as the Minister may determine'; s. 20(2): the 300 mm mounting rule"
+      - "https://novascotia.ca/just/regulations/regs/mvnumber.htm  # Number Plates Regulations, N.S. Reg. 173/95 ss. 1(b), 2(1): one plate, on the rear, for a passenger or light commercial motor vehicle"
+      - "https://novascotia.ca/just/regulations/regs/mvprsnum.htm  # Personalized Number Plates Regulations, N.S. Reg. 124/2005 s. 7(2)(a)-(d): the 15.24 x 30.48 cm size, the silver-white field, the Bluenose depiction and the blue NOVA SCOTIA / CANADAS OCEAN PLAYGROUND legends — quoted verbatim above"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nova_Scotia  # TAGGED SECONDARY: the ABC 123 format from 1979, the Bluenose base from 1989, the 2011 die-and-border change, the issuance ranges and the I/O/Q exclusion"
+    notes: >-
+      THE CURRENT NOVA SCOTIA PLATE, AND THE BEST-EVIDENCED DESIGN IN THE CANADA
+      EAST WAVE. Its SIZE, FIELD COLOUR, LETTERING COLOUR, LEGENDS and CENTRAL
+      GRAPHIC are all quoted from N.S. Reg. 124/2005 — sideways, because that
+      regulation describes the personalized plate, and a Nova Scotia personalized
+      plate is this plate with a chosen serial. Its PERIOD and its FORMAT are not:
+      1989 and ABC 123 are the en.wikipedia article's, hence
+      `period_evidence: secondary-wikipedia`. THE FORMAT PREDATES THE BASE and that
+      is why the series is cut at 1989 rather than 1979: the article dates ABC-123
+      to 1979 and the Bluenose base to 1989, and PRD-PLATES §2.3 makes a design
+      change with a distinct period its own series. The predecessor is authored
+      below. NOTE FOR THE PARSE LAYER: three letters and three numerals is the most
+      common plate shape in North America, so a bare ABC 123 string is very weakly
+      diagnostic of Nova Scotia — it collides with the current Newfoundland and
+      Labrador and New Brunswick series in this very wave.
+
+  - id: ca-ns-standard-1979
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 1979, end: 1989 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3} ?\d{3}\z'
+      regex_strict: '\A[ABCDEFGHJKLMNPRSTUVWXYZ]{3} ?\d{3}\z'
+      charset: { excluded: [I, O, Q], notes: "as ca-ns-standard-1989" }
+    design:
+      plate: { w: 30.48, h: 15.24, unit: cm, plate_basis: convention }
+      plate_note: "the 1979 base predates every plate regulation quoted in this file, so its size is the North American convention rather than a sourced figure"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "NOVA SCOTIA"
+      legend_bottom_options: ["CANADA'S OCEAN PLAYGROUND"]
+      emblem: { present: false, rendered: placeholder, note: "no Bluenose on this base — that is the whole difference from ca-ns-standard-1989" }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nova_Scotia  # TAGGED SECONDARY: ABC-123 introduced 1979 on the 1975 base, AAA-001 to BRS-999, superseded by the Bluenose base in 1989; the 1986 change from steel to aluminium happened inside this run"
+      - "https://web.archive.org/web/20251124192915/https://nslegislature.ca/sites/default/files/legc/statutes/motor%20vehicle.pdf  # MVA s. 19(3): the Registrar may require the return of plates 'upon the termination of the lawful use thereof' — the mechanism by which a superseded Nova Scotia plate leaves the road"
+    notes: >-
+      ONE SERIES BACK. The FORMAT is identical to the current series and only the
+      DESIGN differs, which is exactly the PRD-PLATES §2.3 test for a separate
+      series and also the reason a parse API cannot distinguish the two from a
+      string. Both boundaries are the article's, unfootnoted. The 1986 switch from
+      steel to aluminium is recorded here rather than cut as a series: a material
+      change with no consumer-visible consequence.
+
+  # =========================================================================
+  # PERSONALIZED — the regulation that describes every other Nova Scotia plate.
+  # =========================================================================
+  - id: ca-ns-personalized-2005
+    class: personalized
+    categories: [car, van, truck, bus, motorcycle, motorhome]
+    period: { start: 2005 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]{2,7}\z'
+      charset:
+        notes: >-
+          AUTHORITY-SOURCED END TO END. Personalized Number Plates Regulations
+          s. 7(2)(e), verbatim: the plate must "bear a plate designation, selected
+          by the applicant and approved by the Registrar, composed of a sequence of
+          at least 2 and no more than 7 numerals and letters, in blue lettering,
+          with or without spaces between the numerals and letters." s. 5(c)(ii)
+          gives the alphabet negatively: the Registrar may refuse a designation
+          that "contains characters other than numerals, letters and spaces."
+          Together those two clauses ARE this regex.
+      refusal_rules:
+        text: >-
+          s. 5, verbatim, the grounds on which the Registrar may refuse: the
+          designation "(i) has been previously issued, (ii) contains characters
+          other than numerals, letters and spaces, (iii) contains a combination of
+          characters assigned to other types of number plates, (iv) in the opinion
+          of the Registrar, contains a combination of characters that expresses or
+          implies a word, phrase or idea that is or may be considered offensive or
+          not in good taste, or (v) in the opinion of the Registrar, contains a
+          combination of characters that states or suggests an official authority
+          or is otherwise potentially misleading".
+        note: >-
+          GROUND (iii) IS THE INTERESTING ONE FOR A PARSE API: Nova Scotia
+          explicitly reserves, against vanity applicants, "a combination of
+          characters assigned to other types of number plates" — so a personalized
+          Nova Scotia plate should never collide with the FM, firefighter,
+          restricted or commercial shapes in this file. That is a stated
+          disjointness guarantee, and no other jurisdiction in the Canada east
+          wave gives one.
+    design:
+      plate: { w: 30.48, h: 15.24, unit: cm, w_in: 12, h_in: 6 }
+      background: { color: "#F2F2F2", finish: retroreflective, hex_basis: observed, spec_note: "s. 7(2)(b): 'a depiction of the Bluenose on a silver-white field'" }
+      foreground: "#003C71"
+      colour_spec_note: "s. 7(2)(c)-(e): 'NOVA SCOTIA' at the top in blue lettering, 'CANADAS OCEAN PLAYGROUND' at the bottom in blue lettering, and the designation itself 'in blue lettering'"
+      legend_top: "NOVA SCOTIA"
+      legend_bottom_options: ["CANADA'S OCEAN PLAYGROUND"]
+      emblem: { present: true, rendered: placeholder, description: "the Bluenose, prescribed by s. 7(2)(b)" }
+      band: { side: none }
+      rear_differs: false
+      display: "TWO plates — a personalized vehicle is in the two-plate list at Number Plates Regulations s. 1(a), and s. 2(3) requires at least one of them on the rear"
+    variants:
+      - name: "motorcycle personalized"
+        format: { pattern: "LLLLLL", regex: '\A[A-Z0-9]{2,6}\z' }
+        note: >-
+          s. 7(1), verbatim: a motorcycle personalized plate must "(a) measure
+          10.16 cm in width by 17.78 cm in length; (b) bear a silver-white field;
+          (c) bear the words 'NOVA SCOTIA' at the top, in blue lettering;
+          (d) bear a plate designation ... composed of a sequence of at least 2 and
+          no more than 6 numerals and letters, in blue lettering, with or without
+          spaces". NOTE: no Bluenose and no bottom legend on the motorcycle plate —
+          the regulation omits both, and the omission is a design fact. Also note
+          s. 1(a): a motorcycle is expressly EXCLUDED from the two-plate rule.
+    eligibility:
+      text: >-
+        s. 3, verbatim: "Personalized plates may be used for all of the following
+        types of motor vehicles: (a) a bus with a registered weight of 5000 kg or
+        less; (b) a camper; (c) a motorcycle; (d) a commercial motor vehicle with a
+        registered weight of 5000 kg or less, other than an ambulance or a hearse;
+        (e) a passenger vehicle."
+      no_vehicle_needed: "s. 4(2), verbatim: 'A person may apply for personalized number plates without registering a motor vehicle, but personalized number plates that are not used for vehicle registration must not be attached to a motor vehicle.'"
+    expiry:
+      text: >-
+        s. 9 sets a genuinely unusual pair of rules. For a MOTORCYCLE registered
+        with a personalized plate, initial registration expires "at 11:59 p.m. on
+        December 31 of the calendar year in which the registration is made, if
+        payment for the initial registration occurs between January 1 and October 1
+        of that calendar year", or on 31 December of the FOLLOWING year if payment
+        falls between 1 November and 31 December. For a bus, camper, commercial
+        motor vehicle or passenger vehicle it expires "in the following calendar
+        year at 11:59 p.m. on the last day of the month in which payment for the
+        initial registration occurred". In both cases a plate REPLACING an existing
+        one inherits the current validation sticker's expiry.
+      gap_note: "s. 9(1)(a) leaves 2-31 October unaddressed on its face — the two limbs read 'January 1 and October 1' and 'November 1 and December 31'. Recorded as found; not repaired."
+    recall: "s. 8: 'The Registrar may recall a personalized number plate for any reason set out in clause 5(c).'"
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/mvprsnum.htm  # Personalized Number Plates Regulations, O.I.C. 2005-248 (9 June 2005), N.S. Reg. 124/2005, ss. 1-9 — every quotation above, read 2026-08-02"
+      - "https://novascotia.ca/just/regulations/regs/mvnumber.htm  # Number Plates Regulations s. 1(a) as amended by N.S. Reg. 123/2005: personalized vehicles joined the two-plate list by the SAME Order in Council; s. 2(3): one of the two goes on the rear"
+      - "https://web.archive.org/web/20251124192915/https://nslegislature.ca/sites/default/files/legc/statutes/motor%20vehicle.pdf  # MVA s. 19(2): 'such other matter as the Minister may determine' — the statutory hook this regulation hangs on"
+    notes: >-
+      THE KEYSTONE REGULATION OF THIS FILE. It is the source of the standard
+      plate's colours, the standard plate's size, the motorcycle plate's size, the
+      only stated Nova Scotia serial alphabet, and the only stated disjointness
+      guarantee between vanity serials and other plate types. period.start 2005 is
+      `enabling-instrument` and earned: O.I.C. 2005-248 dated 9 June 2005 made
+      N.S. Reg. 124/2005 and, in the same Order, amended the Number Plates
+      Regulations to put personalized vehicles in the two-plate class — two
+      instruments moving together, which is what a real programme start looks like.
+      It is NOT a claim that Nova Scotia had no vanity plates before 2005; it is a
+      claim about THIS regime.
+
+  # =========================================================================
+  # FIREFIGHTER — the one Nova Scotia series with a STATUTORY SERIAL GRAMMAR.
+  # =========================================================================
+  - id: ca-ns-firefighter-1991
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 1991 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LLL9"
+      regex: '\A[A-Z]{3} ?\d\z'
+      charset:
+        notes: >-
+          THE GRAMMAR IS IN THE INSTRUMENT. N.S. Reg. 49/91 clause (c), verbatim:
+          "a depiction of the Fire Department's symbol shall be at the left of
+          THREE LETTERS AND ONE NUMBER used as the registration number assigned to
+          the owner." Three letters, one number, in a Ministerial Order — the only
+          Nova Scotia serial grammar this pass located in any instrument. The
+          separator is not mentioned; `regex` accepts an optional space because the
+          plate prints a gap and because the Personalized regulation shows the
+          Registrar treats spaces as optional generally.
+    design:
+      plate: { w: 30.48, h: 15.24, unit: cm, plate_basis: convention, note: "N.S. Reg. 49/91 states no size; the two-plate rule at Number Plates Regulations s. 1(a) implies an ordinary-size plate" }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, spec_note: "clause (d), verbatim: 'the background colour of the number plate shall be white'" }
+      foreground: "#003C71"
+      colour_spec_note: "clause (d), verbatim: 'the Fire Department symbol and all other letters, numbers and marks shall be blue'. Named, not numbered — hexes observed inside a regulated colour name."
+      legend_top: "NOVA SCOTIA"
+      legend_bottom_options: ["FIREFIGHTER"]
+      legend_spec_note: "clauses (a) and (b), verbatim: 'the words \"NOVA SCOTIA\" shall be at the top of the number plate' / 'the word \"FIREFIGHTER\" shall be at the bottom on the number plate'"
+      emblem: { present: true, rendered: placeholder, description: "the Fire Department's symbol, prescribed by clause (c) to sit at the LEFT of the serial" }
+      band: { side: none }
+      rear_differs: false
+      display: "TWO plates, front and rear — firefighter plates are in the two-plate list at Number Plates Regulations s. 1(a) and s. 2(4)"
+    eligibility: >-
+      The Ministerial Order's own operative words: plates issued after 1 April 1991
+      "in the case of firefighters employed within the Province of Nova Scotia for
+      passenger motor vehicles and commercial motor vehicles registered for a weight
+      of 5000 kilograms or less shall have the following appearance". Note the
+      "employed within the Province" qualifier — the Order does not on its face
+      extend to volunteer firefighters, who have their own regulation
+      (mvvolfir.htm, not fetched in this pass; recorded as a gap).
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/mvnpfire.htm  # Number Plates for Firefighters Regulations, N.S. Reg. 49/91, Ministerial Order dated 18 March 1991 made under MVA s. 36(1), clauses (a)-(e) — every quotation above, read 2026-08-02"
+      - "https://novascotia.ca/just/regulations/regs/mvnumber.htm  # Number Plates Regulations ss. 1(a), 2(4): firefighter plates are a two-plate class, front and rear"
+    notes: >-
+      A FORMAT, A COLOUR PAIR, A LEGEND PAIR AND A COMMENCEMENT DATE, ALL IN ONE
+      MINISTERIAL ORDER — which is why this modest specialty plate is the only Nova
+      Scotia series in this file whose `format` is not a secondary claim.
+      period.start 1991 is `enabling-instrument` and reads off the Order's own
+      words: plates "issued after the lst day of April, 1991" (the consolidation's
+      typography for "1st", quoted as found). `class: specialty` rather than a
+      bespoke value: the vocabulary has no firefighter member, and PRD-PLATES §2.3
+      forbids inventing one ad hoc; the plate is an optional design on an ordinary
+      allocation, which is what `specialty` means.
+
+  # =========================================================================
+  # FARMERS AND FISHERMEN — the FM plate. Grammar half-stated, hence recall-only.
+  # =========================================================================
+  - id: ca-ns-fm-farmer-fisherman
+    class: agricultural
+    categories: [truck, van]
+    period: { start: 1989 }
+    period_evidence: statutory-authority-undated
+    matching: recall-only
+    format:
+      pattern: "FM 9999"
+      regex: '\AFM ?\d{1,6}\z'
+      charset:
+        notes: >-
+          THE INSTRUMENT SAYS HALF OF IT AND THIS FILE DOES NOT INVENT THE OTHER
+          HALF. Number Plates for Farmers and Fishermen Regulations s. 3, verbatim:
+          an FM number plate must "(a) have dimensions of 15.24 cm in width by 30.48
+          in length; (b) bear the words 'Nova Scotia' at the top; (c) bear the
+          letters 'FM' followed by RANDOM NUMBERS; and (d) be in general accordance
+          with the number plate depicted in Schedule A." The FM prefix is primary.
+          "Random numbers" states neither a count nor a range, so `regex` accepts
+          one to six digits and the series is `matching: recall-only`: a hit is a
+          shape hit, not a validity claim (PRD-PLATES §2.7).
+      dimension_note: "s. 3(a) reads '15.24 cm in width by 30.48 in length' — the unit is missing from the second figure in the consolidation. Quoted as found; read as 30.48 cm by comparison with the identically worded Personalized, Conservation and Honorary Consul regulations."
+    design:
+      plate: { w: 30.48, h: 15.24, unit: cm, w_in: 12, h_in: 6 }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, spec_note: "the regulation states no colour — only the size, the top legend and the FM prefix" }
+      foreground: "#003C71"
+      legend_top: "Nova Scotia"
+      legend_note: "s. 3(b) prints it in mixed case — 'Nova Scotia' — where the firefighter, restricted, conservation and honorary-consul regulations all print 'NOVA SCOTIA' in capitals. Quoted as found in each case; whether the plates differ typographically is not established."
+      emblem: { present: false, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "TWO plates, front and rear — a farm truck and a commercial fisherman truck are both in the two-plate list at Number Plates Regulations s. 1(a) and s. 2(4)"
+    eligibility:
+      text: >-
+        s. 2 defines "farmer" as a person "(i) who resides on a farm and derives the
+        major part of their income from that farm, or (ii) who operates a farm that
+        gives employment to 1 or more persons on a full-time basis", and "fisherman"
+        as a person holding "a valid commercial fishing vessel registration under the
+        Fisheries Act (Canada) and a valid registration card issued under Section 36
+        of the Revenue Act Regulations", or "an aquaculture licence issued under the
+        Fisheries and Coastal Resources Act". s. 5(2): the plate may be displayed
+        only on "(a) a commercial truck that is owned or leased by the farmer or
+        fisherman ...; or (b) a passenger van with a minimum seating capacity of 7".
+      use_restrictions: >-
+        s. 6, verbatim in part: a driver must not use an FM-plated vehicle "(a) to
+        transport any passenger for gain; (b) as transportation to or from the
+        driver's employment, other than employment related to the farmer's farm
+        business; (c) to carry goods for gain, unless the goods are for the use of or
+        products of a farm that is located in the Province" — and the parallel rule
+        at s. 6(2) for a fisherman.
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/mvplatesfarmer.htm  # Number Plates for Farmers and Fishermen Regulations, made under MVA s. 38, ss. 2-6 — every quotation above, read 2026-08-02"
+      - "https://novascotia.ca/just/regulations/regs/mvnumber.htm  # Number Plates Regulations ss. 1(a), 2(4): farm trucks and commercial fisherman trucks are a two-plate class"
+    notes: >-
+      A PLATE THAT DECODES AN OCCUPATION — the FM prefix says the holder is a farmer
+      or a commercial fisherman, and Nova Scotia is the only jurisdiction in this
+      wave to put such a thing in a regulation. `matching: recall-only` is the
+      honest grade and the reason is stated in `charset.notes`: "random numbers" is
+      not a grammar. PERIOD IS THE WEAK PART: the consolidation as served carries no
+      Order in Council date, no N.S. Reg. number and no in-force date in the portion
+      retrieved on 2026-08-02, so `period_evidence: statutory-authority-undated` and
+      1989 is the year of the Motor Vehicle Act's own revision (R.S.N.S. 1989,
+      c. 293) under which the regulation is made — a floor, not a start. A verifier
+      should replace it with the Order in Council date from the Registry of
+      Regulations' legislative-history table.
+
+  # =========================================================================
+  # MOTORCYCLE — six numerals, small plate.
+  # =========================================================================
+  - id: ca-ns-motorcycle-1998
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1998 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "999999"
+      regex: '\A\d{6}\z'
+      charset: { notes: "all-numeric; no letters reported and none excluded. The all-numeric shape is why a Nova Scotia motorcycle plate is trivially separable from every other series in this file." }
+      progression: "the article's issuance record runs from 97600 upward, i.e. the six-digit run continues the previous five-digit numbering rather than restarting"
+    design:
+      plate: { w: 17.78, h: 10.16, unit: cm, w_in: 7, h_in: 4 }
+      plate_note: "SOURCED: Personalized Number Plates Regulations s. 7(1)(a) prescribes '10.16 cm in width by 17.78 cm in length' for a motorcycle plate. NOTE THE CONFLICT with N.S. Reg. 224/1990 s. 1(b), which gives a RESTRICTED motorcycle plate as 'five inch by eight inch' (12.7 x 20.32 cm). Two instruments, two plate types, two sizes; recorded, not reconciled."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, spec_note: "the Personalized reg calls the motorcycle field 'silver-white' (s. 7(1)(b))" }
+      foreground: "#003C71"
+      legend_top: "NOVA SCOTIA"
+      emblem: { present: false, rendered: placeholder, note: "the Personalized reg's motorcycle description omits both the Bluenose and the bottom legend, which the standard-plate description has — an instrument-level confirmation that the small plate carries neither" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR — a motorcycle is expressly excluded from the two-plate rule by Number Plates Regulations s. 1(a) and falls to s. 1(b) and s. 2(1)"
+    expiry: "the article states all Nova Scotia motorcycle plates expire on 31 December, which the Personalized reg s. 9(1) independently corroborates for personalized motorcycle plates (expiry '11:59 p.m. on December 31')"
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/mvprsnum.htm  # Personalized Number Plates Regulations s. 7(1)(a)-(d): the 10.16 x 17.78 cm motorcycle plate, its silver-white field, its blue 'NOVA SCOTIA' top legend and the absence of any bottom legend or Bluenose; s. 9(1): the 31 December expiry"
+      - "https://novascotia.ca/just/regulations/regs/mvnumber.htm  # Number Plates Regulations s. 1(a): 'other than a motorcycle' — the exclusion that makes this a one-plate class"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nova_Scotia  # TAGGED SECONDARY: the six-digit format from 1998, its issuance range, and the 31 December expiry"
+    notes: >-
+      THE SIZE AND THE FIELD COLOUR ARE INSTRUMENT-SOURCED AND THE FORMAT IS NOT.
+      1998 and the six-digit shape are the article's. What the regulation adds, and
+      what makes this series worth authoring rather than folding into the standard
+      series, is that the Nova Scotia motorcycle plate is a genuinely different
+      object: a different size, a one-plate class by express exclusion, and no
+      Bluenose and no bottom legend — four differences, all sourced.
+
+  # =========================================================================
+  # COMMERCIAL — yellow, and now heavy vehicles only.
+  # =========================================================================
+  - id: ca-ns-commercial-1978
+    class: standard
+    categories: [truck, van, semitrailer]
+    period: { start: 1978 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "99 999 L"
+      regex: '\A\d{2} ?\d{3} ?[A-Z]\z'
+      charset: { notes: "two digits, three digits, one letter; the letter is the block marker and the article's issuance record runs A through D. No exclusion stated." }
+      progression: "10-000-A upward through the A, B, C and D blocks per the article"
+    design:
+      plate: { w: 30.48, h: 15.24, unit: cm, plate_basis: convention }
+      background: { color: "#FFD100", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      colour_note: >-
+        BLACK ON YELLOW, and it is the only non-white Nova Scotia field in this
+        file. NO INSTRUMENT STATES IT — the Registration Fees for Commercial Motor
+        Vehicles Regulations prescribe fees, not appearance — so both hexes are
+        observed and the colour claim itself is the article's.
+      legend_top: "NOVA SCOTIA"
+      legend_bottom_options: ["COMMERCIAL"]
+      emblem: { present: false, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: >-
+        A heavy commercial motor vehicle issued a SINGLE plate carries it on the
+        FRONT — Number Plates Regulations s. 2(2), verbatim: "Where the Department
+        furnishes an owner of a heavy commercial motor vehicle with one number
+        plate, the owner shall attach the number plate to the front of the vehicle
+        and keep it so attached at all times while the vehicle is registered under
+        the Act." The inverse of the passenger rule at s. 2(1) and a real
+        photographic signal.
+      spec_history:
+        - { from: 1978, to: 2012, note: "border lines around the plate and around the top corners" }
+        - { from: 2012, note: "border lines removed; format, colours and legends unchanged" }
+    scope_note: >-
+      TAGGED SECONDARY, AND IMPORTANT FOR THE PARSE LAYER: the article states this
+      series is now issued only to commercial vehicles ABOVE 5 000 kg, and that
+      lighter commercial vehicles have taken ordinary passenger plates since 1986.
+      So a Nova Scotia van or light truck normally wears ca-ns-standard-1989, not
+      this. The 5 000 kg line is independently corroborated by the Personalized
+      Number Plates Regulations s. 3(d), which lets a commercial motor vehicle of
+      "5000 kg or less" take a personalized plate — the same threshold, in an
+      instrument.
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/mvnumber.htm  # Number Plates Regulations s. 2(2): the front-plate rule for a heavy commercial motor vehicle, verbatim above"
+      - "https://novascotia.ca/just/regulations/regs/mvprsnum.htm  # Personalized reg s. 3(d): the 5 000 kg commercial threshold, in an instrument"
+      - "https://novascotia.ca/just/regulations/regs/mvregcom.htm  # Registration Fees for Commercial Motor Vehicles Regulations — cited as the instrument that creates the class; fees only, no appearance"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nova_Scotia  # TAGGED SECONDARY: the 12-345-A format from 1978, the black-on-yellow colours, the 2012 border change, the issuance ranges and the above-5000-kg scope"
+    notes: >-
+      YELLOW IS THE SIGNAL AND THE SIGNAL IS UNSOURCED — stated plainly because it
+      is the most visually distinctive claim in this file and the only one resting
+      entirely on a secondary. `class: standard` because the vocabulary has no
+      commercial member. The 5 000 kg threshold is the one part of the scope note a
+      regulation corroborates.
+
+  # =========================================================================
+  # ANTIQUE — a letter and three numerals.
+  # =========================================================================
+  - id: ca-ns-antique-2009
+    class: historic
+    categories: [car, van, truck]
+    period: { start: 2009 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "L999"
+      regex: '\A[A-Z] ?\d{3}\z'
+      charset: { notes: "one letter, three numerals; the article's issuance record runs A001 upward. The four-character shape makes this the shortest ordinary Nova Scotia serial and separates it cleanly from every other series here." }
+    design:
+      plate: { w: 30.48, h: 15.24, unit: cm, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "NOVA SCOTIA"
+      legend_bottom_options: ["CANADA'S OCEAN PLAYGROUND"]
+      legend_side: "ANTIQUE AUTO, to the left of the serial"
+      emblem: { present: false, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "TWO plates, front and rear — antique plates are in the two-plate list at Number Plates Regulations s. 1(a) and s. 2(4)"
+    sources:
+      - "https://novascotia.ca/just/regulations/regs/mvnumber.htm  # Number Plates Regulations ss. 1(a), 2(4): 'a vehicle to bear ... antique plates' is a two-plate class, front and rear — the one PRIMARY fact about this series"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nova_Scotia  # TAGGED SECONDARY: the four-digit antique format 1966-2009 and the A123 format from 2009, with issuance ranges"
+    notes: >-
+      AUTHORED BECAUSE THE REGULATION NAMES THE CLASS. Number Plates Regulations
+      s. 1(a) puts "a vehicle to bear ... antique plates" in the two-plate list, so
+      Nova Scotia law knows the class exists and how it is displayed; everything
+      else — the 2009 start, the L999 arrangement, the ANTIQUE AUTO side legend —
+      is the article's. No Nova Scotia regulation defines an antique vehicle for
+      plate purposes in any instrument located in this pass, which is a recorded
+      gap: contrast Ontario, where HTA s. 7(1.1) states a 30-year test in the Act.
+
+  # =========================================================================
+  # OFF-HIGHWAY / ATV.
+  # =========================================================================
+  - id: ca-ns-offhighway-1989
+    class: standard
+    categories: [atv]
+    period: { start: 1989 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LL 999"
+      regex: '\A[A-Z]{2} ?\d{3}\z'
+      charset: { notes: "two letters, three numerals; the article's issuance record runs AA 001 upward" }
+    design:
+      plate_note: "no size located in any instrument or secondary; deliberately absent rather than guessed"
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      colour_note: "red serial on white with red border lines, per the article. No instrument states it; both hexes observed."
+      legend_top: "NOVA SCOTIA"
+      legend_bottom_options: ["OFF-HIGHWAY"]
+      emblem: { present: false, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nova_Scotia  # TAGGED SECONDARY: the AB 123 off-highway format from 1989, red on white with red border lines, 'NOVA SCOTIA' / 'OFF-HIGHWAY' legends, issuance range to MS 999"
+    notes: >-
+      THE THINNEST-SOURCED SERIES IN THIS FILE and it is authored anyway, for two
+      reasons: the two-letter-three-numeral shape is distinctive enough to be worth
+      recognising, and RED lettering appears on no other Nova Scotia plate here, so
+      a photograph is diagnostic even where a string is not. Off-highway vehicles in
+      Nova Scotia are registered under the Off-highway Vehicles Act rather than the
+      Motor Vehicle Act, which is why none of the Motor Vehicle Act regulations
+      quoted elsewhere in this file reaches them — that statute was NOT consulted in
+      this pass and is a recorded gap. `class: standard` because the vocabulary has
+      no off-road member.

--- a/plates/ca-on.yml
+++ b/plates/ca-on.yml
@@ -1,0 +1,881 @@
+# plates/ca-on.yml — Ontario, Canada (PRD-PLATES gate L2/L3, Canada east wave).
+#
+# FEDERATED JURISDICTION, per-province file, exactly as the US states are cut
+# (us-fl.yml is the exemplar). Canada has NO federal plate mandate: every
+# province and territory registers vehicles under its own statute and issues its
+# own plates. There is no Canadian analogue of the EU band, no national colour
+# rule and no national format.
+#
+# FIVE STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. AN ONTARIO PLATE BINDS TO THE OWNER, NOT THE VEHICLE — and the statute says
+#    so twice. HTA s. 11(1), verbatim: "Upon the holder of a permit ceasing to be
+#    the owner or lessee of the motor vehicle or trailer referred to in the
+#    permit, he, she or it shall, (a) remove his, her or its number plates from
+#    the vehicle; (b) retain the plate portion of the permit". And s. 11(3):
+#    "a person to whom number plates have been issued under subsection 7 (7) for
+#    a vehicle the person no longer owns or leases may affix the number plates to
+#    a similar class of vehicle that the person owns or leases where it is done
+#    in accordance with the prescribed requirements." That is the Swiss pattern
+#    (plates/ch.yml, `binding: owner`) arriving in Canada by a different route,
+#    and it is decisive for any consumer that treats a plate as a vehicle key:
+#    an Ontario plate number identifies a REGISTRATION HELD BY A PERSON, and it
+#    moves between that person's vehicles of the same class.
+#
+# 2. THE COMPOSITION OF AN ONTARIO PLATE NUMBER IS IN NO STATUTE AND NO
+#    REGULATION. HTA s. 7(1)(b)(i) requires "number plates issued in accordance
+#    with the regulations showing the number of the permit issued for the
+#    vehicle"; the regulation-making power in s. 7(24) reaches issuance,
+#    validation, display, fees, surrender, classification and "(o) prescribing
+#    the criteria for the issuance, retention and return of a number plate
+#    bearing a requested number" — and NEVER the letters and digits a plate is
+#    made of. R.R.O. 1990, Reg. 628 (Vehicle Permits) was read end to end on
+#    2026-08-02: it contains NO colour, NO dimension, NO character metric and NO
+#    serial grammar. The serial system is therefore an ADMINISTRATIVE allocation
+#    by the Ministry, exactly as the DVLA memory tags are in plates/gb.yml and
+#    the district codes are in plates/de.yml. Every `format` below that is not
+#    quoted from an Ontario government page is graded as a secondary claim and
+#    says so.
+#
+# 3. THE ONE FORMAT FACT ONTARIO PUBLISHES ITSELF IS THE PERSONALIZED CHARACTER
+#    COUNT. ServiceOntario, verbatim: "Personalized passenger and commercial
+#    plates may have 2 to 8 characters. Personalized motorcycle plates may have
+#    2 to 5 characters." Everything else about Ontario serial shape in this file
+#    (ABCD 123, AB 12345, the motorcycle and trailer arrangements, the excluded
+#    letters G/I/O/Q/U) rests on the en.wikipedia Ontario article's tables, is
+#    tagged `secondary-wikipedia` per PRD-PLATES §4, and is flagged in terms.
+#
+# 4. FRONT AND REAR ARE PRESCRIBED, AND THE VALIDATION STICKER MOVES BETWEEN
+#    THEM BY VEHICLE CLASS. O. Reg. 628 s. 9(3), verbatim: "The number plates for
+#    a motor vehicle, other than a motorcycle or a motor assisted bicycle, shall
+#    be attached to and exposed in a conspicuous position on the front and rear
+#    of the motor vehicle." s. 9(4): "The number plate for a motorcycle, motor
+#    assisted bicycle or trailer shall be attached to and exposed in a
+#    conspicuous position on the rear of the vehicle." s. 9(1): validation goes
+#    "in the upper right corner of the number plate exposed on the FRONT of the
+#    motor vehicle" for a commercial motor vehicle and "on the REAR" in all other
+#    cases. Ontario is a two-plate province and the sticker corner is a real
+#    class signal.
+#
+# 5. THE 2020 BLUE PLATE IS A GENUINE FOUR-MONTH SERIES AND IS MODELLED AS ONE.
+#    It was announced by the Government of Ontario in April 2019, entered issue
+#    in February 2020, was recalled and then abandoned in May 2020, and the white
+#    "Yours to Discover" base resumed. Overlapping series are legal under
+#    PRD-PLATES §2.2 when the notes are distinct; here they are distinct because
+#    the two really were issued in parallel while blue stock was exhausted.
+#
+# SEPARATOR NOTE (PRD-PLATES §2.6): an Ontario plate prints NO separator glyph
+# between the letter group and the digit group. What sits in the gap is a
+# SCREENED CROWN GRAPHIC (an emblem, carried in `design.emblem`, never in the
+# serial — the `never_separator` reasoning in _meta/separators.yml §4 exactly).
+# Every `pattern` here spells that gap as the emitted SPACE and every regex
+# accepts it as optional, which is also how ServiceOntario writes plate numbers.
+jurisdiction: ca-on
+authority:
+  name: Ministry of Transportation of Ontario (MTO); plates and permits issued through ServiceOntario
+  url: "https://www.ontario.ca/page/personalized-licence-plate"
+binding: owner
+binding_note: >-
+  HTA s. 11(1)(a) and s. 11(3) (quoted in the header) make the Ontario plate a
+  possession of the REGISTRANT. On sale the seller strips the plates and keeps
+  the plate portion of the permit; the plates may then go on another vehicle of
+  a similar class that the same person owns or leases. A consumer keying on
+  "which vehicle wears this plate" must therefore treat the answer as
+  time-varying. HTA s. 12(2) adds the ownership twist: "Every number plate is
+  the property of the Crown and shall be returned to the Ministry when required
+  by the Registrar."
+instrument:
+  statute: "Highway Traffic Act, R.S.O. 1990, c. H.8, ss. 7, 11, 12, 13 (Part II — Permits)"
+  regulation: "R.R.O. 1990, Reg. 628 (VEHICLE PERMITS), made under the Highway Traffic Act"
+  regulation_currency: "e-Laws consolidated text as served on 2026-08-02; Reg. 628 s. 1 carries amendments to O. Reg. 170/23"
+  reg_making_power: >-
+    HTA s. 7(24), verbatim opening: "The Lieutenant Governor in Council may make
+    regulations respecting any matter ancillary to the provisions of this Part
+    with respect to permits and number plates and in particular, ... (b)
+    respecting the issuance and validation of permits and the issuance of number
+    plates; ... (e) governing the manner of displaying number plates on motor
+    vehicles and trailers or any class or type of either of them; ... (k)
+    requiring the surrender of number plates; (l) classifying permits, providing
+    for the issuing or validating of any class of permit and the requirements
+    therefor and for the issuing of number plates and evidence of validation and
+    the requirements therefor; ... (o) prescribing the criteria for the issuance,
+    retention and return of a number plate bearing a requested number."
+    NOTE WHAT IS ABSENT: no power over the COMPOSITION of a mark, no power over
+    colour, no power over dimensions.
+  sources:
+    - "https://www.ontario.ca/laws/statute/90h08  # HTA ss. 7(1),(7),(7.1),(7.2),(24); 11(1),(3); 12(1),(2),(2.4); 13(1),(2) — read via the e-Laws document service on 2026-08-02"
+    - "https://www.ontario.ca/laws/regulation/900628  # R.R.O. 1990, Reg. 628 (Vehicle Permits) ss. 6, 9, 10, 13-13.4 — read via the e-Laws document service on 2026-08-02"
+  licence: >-
+    e-Laws content is published by the King's Printer for Ontario under the
+    Government of Ontario's Open Government Licence. Independently, statutes and
+    regulations are EDICTS OF GOVERNMENT and their text is uncopyrightable
+    (PRD-PLATES §4) — every verbatim quotation in this file is from that class of
+    material or from a ServiceOntario public information page.
+
+# ---------------------------------------------------------------------------
+# artwork_risk — carried here even though PRD-PLATES §7.1 makes it mandatory
+# only for US states, because the Canadian posture differs from every US state
+# and a renderer must not guess.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: crown-copyright-asserted
+  basis: >-
+    Ontario asserts Crown copyright. Every ontario.ca page fetched for this file
+    closes with the notice "King's Printer for Ontario, 2012 - to 26". Canada has
+    no US-style federal-works exclusion and no Canadian equivalent of
+    {{PD-FLGov}}; Crown copyright in Canada subsists under s. 12 of the federal
+    Copyright Act and provincial Crown copyright is claimed in practice. The
+    edicts-of-government principle still frees the TEXT of the Highway Traffic
+    Act and Reg. 628, which is why this file quotes them freely; it does not free
+    plate ARTWORK, the trillium graphic or the Ontario crown device.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies without exception. The crown
+    separator, the stylized white trillium of the 2020 base and the provincial
+    wordmark are all rendered `placeholder` until affirmatively cleared per
+    emblem. The Ontario crown is additionally a royal device with protection
+    independent of copyright; that question is unresearched and flagged.
+  photograph_caution: >-
+    Commons photographs of Ontario plates carry the PHOTOGRAPHER's licence, not a
+    licence over the design (PRD-PLATES §6). Our renders are generated from this
+    data, never derived from a photograph, so those obligations never attach.
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once, referenced per series.
+# ---------------------------------------------------------------------------
+common:
+  display:
+    two_plates: >-
+      O. Reg. 628 s. 9(3), verbatim: "The number plates for a motor vehicle,
+      other than a motorcycle or a motor assisted bicycle, shall be attached to
+      and exposed in a conspicuous position on the front and rear of the motor
+      vehicle."
+    one_plate: >-
+      O. Reg. 628 s. 9(4), verbatim: "The number plate for a motorcycle, motor
+      assisted bicycle or trailer shall be attached to and exposed in a
+      conspicuous position on the rear of the vehicle."
+    year_of_manufacture_single: >-
+      O. Reg. 628 s. 9(3.1): "Where the number plates attached to the vehicle are
+      year-of-manufacture plates, and only one plate was issued by the Ministry in
+      that year for display on a motor vehicle, that plate shall be attached to
+      and exposed in a conspicuous position at the rear of the vehicle."
+    validation_sticker: >-
+      O. Reg. 628 s. 9(1), verbatim: evidence of validation "shall be affixed,
+      (a) where the permit is for a commercial motor vehicle, in the upper right
+      corner of the number plate exposed on the front of the motor vehicle; and
+      (b) in all other cases, in the upper right corner of the number plate
+      exposed on the rear of the motor vehicle." s. 9(2): a RUO sticker goes "in
+      the upper left corner of the number plate exposed on the front of the bus."
+    dealer_exclusion: "O. Reg. 628 s. 9(5): section 9 does not apply to Dealer, Service, Dealer and Service, or Manufacturer permits and number plates."
+    legibility: >-
+      HTA s. 13(2), verbatim: "Every number plate shall be kept free from dirt and
+      obstruction and shall be affixed so that the entire number plate, including
+      the numbers, is plainly visible at all times, and the view of the number
+      plate shall not be obscured or obstructed by spare tires, bumper bars, any
+      part of the vehicle, any attachments to the vehicle or the load carried."
+      s. 13(3.0.1) and s. 13(3.1) extend the rule to anything defeating a red
+      light camera system or an electronic toll system.
+    no_other_numbers: >-
+      HTA s. 13(1), verbatim: "No number other than that upon the number plate
+      furnished by the Ministry shall be exposed on any part of a motor vehicle or
+      trailer in such a position or manner as to confuse the identity of the
+      number plate."
+    firefighter_sticker: >-
+      HTA s. 12.1 (s. 7(12.1)): a firefighter may be issued "a sticker, that
+      indicates that the vehicle is registered to or leased by a firefighter, to be
+      attached to the lower left hand corner of the FRONT number plate". A sticker
+      on an ordinary plate, not a series — recorded here rather than invented as one.
+    source: "https://www.ontario.ca/laws/regulation/900628  # Reg. 628 ss. 9(1)-(5), 6(1)-(4)"
+    source_statute: "https://www.ontario.ca/laws/statute/90h08  # HTA ss. 7(12.1), 13(1),(2),(3.0.1),(3.1)"
+  validation:
+    rule: >-
+      O. Reg. 628 s. 6(1): "For the purposes of clause 7 (1) (c) of the Act,
+      evidence of the current validation of a permit is required to be affixed to
+      the number plate of a motor vehicle." s. 6(2) exempts the classes listed in
+      Schedule 4.
+    sticker_abolition_2022: >-
+      Ontario eliminated licence-plate renewal STICKERS for passenger vehicles,
+      light commercial vehicles, motorcycles and mopeds in 2022; renewal itself
+      remains mandatory and is now automatic for eligible plates. ServiceOntario,
+      verbatim from the registration page: "Your passenger vehicle, light
+      commercial vehicle, motorcycle or moped license plate will renew
+      automatically". Commercial vehicles over 3,000 kg still validate annually.
+      RECORDED AS A FACT ABOUT THE STICKER, NOT ABOUT THE PLATE: no series in this
+      file changes at 2022, because the plate did not.
+    source: "https://www.ontario.ca/page/register-vehicle-permit-and-licence-plate  # accessed 2026-08-02"
+  charset:
+    excluded_letters_current: [G, I, O, Q, U]
+    excluded_note: >-
+      SECONDARY, TAGGED. The en.wikipedia Ontario article states that G, I, O, Q
+      and U are not used in the current four-letter passenger serial format,
+      citing the collector site allaboutlicenseplates.com. No Ontario government
+      page states any letter exclusion, and Reg. 628 states none. The exclusion is
+      encoded ONLY in `regex_strict`; `regex` never carries it, so a consumer who
+      distrusts the secondary loses nothing.
+    statutory_alphabet_absent: >-
+      NEGATIVE FINDING, recorded so nobody repeats the hunt: neither the Highway
+      Traffic Act nor R.R.O. 1990 Reg. 628 states an alphabet, a length, or a
+      character set for an Ontario number plate. The only length statement located
+      from a government source anywhere in this pass is the personalized-plate
+      count on the ServiceOntario page (2-8 / 2-5), which is why
+      `ca-on-personalized` is the only series in this file whose `regex` is
+      authority-sourced end to end.
+    source: "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # FINDING AID + tagged secondary (PRD-PLATES §4, owner override 2026-08-02): passenger/commercial/motorcycle/trailer serial formats and the excluded-letter sets; article read 2026-08-02"
+  dimensions:
+    note: >-
+      NO ONTARIO PRIMARY PRESCRIBES A PLATE SIZE. The 6 in x 12 in
+      (152.4 x 304.8 mm) North American plate is the continental convention and is
+      recorded on the series below as `plate_basis: convention`, never as an
+      Ontario legal claim. Contrast Nova Scotia (plates/ca-ns.yml), where the size
+      IS in the regulations in centimetres — that is what a sourced dimension looks
+      like, and Ontario has no equivalent.
+    folklore_caution: >-
+      The "1956 AMA / AAMVA standardization agreement" that supposedly fixed
+      6 x 12 in is UNCITED in its Wikipedia source and is copied verbatim across
+      the Canada, US and Puerto Rico articles (circular). PRD-PLATES §4 records it
+      as commonly repeated, unsourced. It is NOT relied on here.
+
+# ---------------------------------------------------------------------------
+# Classes Ontario HAS but this file deliberately does not model, each with the
+# primary that proves the class exists and the reason no `format` is authored.
+# ---------------------------------------------------------------------------
+classes_not_modelled:
+  dealer:
+    exists: true
+    mechanism: >-
+      O. Reg. 628 s. 13(1): "Upon filing satisfactory evidence as to the need for
+      it, a Dealer permit and number plate may be issued to a dealer in motor
+      vehicles, other than motorcycles and motor assisted bicycles". s. 13(2)-(7)
+      confine its use to inventory offered for sale, private use in Ontario and
+      purposes related to the sale, and forbid its use on a loaded commercial
+      vehicle (with a 2020 pick-up-truck carve-out at s. 13(6), O. Reg. 734/20).
+      Parallel regimes: s. 13.1 Service permit and number plate; s. 13.2 Dealer
+      and Service; Manufacturer permits and plates are named in s. 8.2(e) and
+      s. 9(5).
+    why_not_modelled: >-
+      NEITHER THE FORMAT NOR THE COLOUR OF AN ONTARIO DEALER, SERVICE OR
+      MANUFACTURER PLATE IS PUBLISHED IN ANY PRIMARY LOCATED IN THIS PASS.
+      Reg. 628 prescribes eligibility and permitted use and never appearance, and
+      the ServiceOntario page for these plates describes who may hold them and
+      what they cost, not what they look like. Recorded as a gap.
+    sources:
+      - "https://www.ontario.ca/laws/regulation/900628  # Reg. 628 ss. 13, 13.1, 13.2, 9(5)"
+      - "https://www.ontario.ca/page/get-manufacturer-licence-plate-dealer-plate-or-service-plate  # ServiceOntario, accessed 2026-08-02: eligibility and fees only, no format and no colour"
+  year_of_manufacture:
+    exists: true
+    mechanism: >-
+      HTA s. 7(7.2), verbatim: subsection (7.1) applies to number plates that
+      "(a) are Ontario number plates that were issued during the year of
+      manufacture of the motor vehicle; (b) are in a condition satisfactory to the
+      Ministry; and (c) show no numbers that duplicate the number of any other
+      existing permit." s. 7(7.1): where such plates are used, "the number of the
+      permit shall be the same as the number shown on those number plates."
+      ServiceOntario adds the eligibility rule verbatim: the vehicle must weigh
+      "under 3,000 kg", be "a passenger or light commercial vehicle from 1973 and
+      earlier, or ... a motorcycle from 1975 and earlier", and be unmodified; the
+      plate must be "manufactured in Ontario", "from the same year as the vehicle",
+      and is compared against an original "to make sure that the requested plate
+      has the same material used, colour scheme, layout and numbering sequence."
+    why_not_modelled: >-
+      A YEAR-OF-MANUFACTURE PLATE HAS NO FORMAT OF ITS OWN — it is a genuine
+      historic Ontario plate of whatever year, re-authorised. Modelling it would
+      mean authoring every Ontario series back to 1911, which is L4 scope
+      (PRD-PLATES §7). The class is recorded because the STATUTE creates it and
+      because a parse API must know that a pre-1973 Ontario shape on a modern road
+      is lawful and dates the VEHICLE, not the registration.
+    sources:
+      - "https://www.ontario.ca/laws/statute/90h08  # HTA s. 7(7.1), (7.2)"
+      - "https://www.ontario.ca/page/get-year-manufacture-licence-plate  # ServiceOntario, updated 14 January 2026, accessed 2026-08-02"
+  specialty_graphics:
+    exists: true
+    mechanism: >-
+      ServiceOntario, verbatim: "You can choose to include graphics on your licence
+      plate" and "There are over 60 graphics available to choose from." Graphic
+      plates are PERSONALIZED plates with a smaller character budget: "2 to 8
+      characters (letters and/or numbers) without a graphic - $310 / 2 to 6
+      characters (letters and/or numbers) with a graphic - $336.40".
+    why_not_modelled: >-
+      PRD-PLATES §2.5 excludes the individual specialty DESIGN catalogue from v1;
+      L2 indexes programs, L4 does designs. The graphic budget is carried instead
+      as a variant on `ca-on-personalized`, where it belongs, because the SERIAL
+      grammar is what changes.
+    sources:
+      - "https://www.ontario.ca/page/personalized-licence-plate  # ServiceOntario, accessed 2026-08-02: graphics, fees and the 8/6/5-character budgets"
+      - "https://www.ontario.ca/page/choose-licence-plate-graphic  # the official graphic chooser, accessed 2026-08-02"
+  veteran:
+    exists: true
+    mechanism: "ServiceOntario states the Veteran licence plate design as an option a green plate cannot take: 'Green licence plates are not customizable with the Veteran licence plate design or other personalized licence plate design.'"
+    why_not_modelled: "No format or colour published in any primary located; an ordinary serial on an alternative design. Recorded as a gap."
+    sources:
+      - "https://www.ontario.ca/page/get-green-licence-plate  # ServiceOntario, updated 10 July 2025, accessed 2026-08-02"
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD PASSENGER SERIES — four letters, three numerals.
+  # =========================================================================
+  - id: ca-on-standard-1997
+    class: standard
+    categories: [car, van, bus]
+    period: { start: 1997 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLLL 999"
+      regex: '\A[A-Z]{4} ?\d{3}\z'
+      regex_strict: '\A[ABCDEFHJKLMNPRSTVWXYZ]{4} ?\d{3}\z'
+      charset:
+        excluded: [G, I, O, Q, U]
+        notes: >-
+          See `common.charset`. The exclusion is a TAGGED SECONDARY and lives only
+          in `regex_strict`. No Ontario statute, regulation or government page
+          states any letter exclusion.
+      structure:
+        - "characters 1-4: letter block, allocated sequentially by the Ministry"
+        - "characters 5-7: numerals 001-999 within the letter block"
+      progression: >-
+        Sequential: the article's issuance record runs AAAA-001 upward, with a
+        separate F-block reserved since April 2019 for the French-slogan plate and
+        GV/GW/VE reserved for the Green Vehicle programme (own series below).
+        THERE IS NO DATE OR REGION SIGNAL IN AN ONTARIO PASSENGER PLATE — no
+        equivalent of the DVLA age identifier and no equivalent of a German
+        district code. A parse API must not infer either.
+      separator_note: >-
+        The gap between the letter block and the numeral block is occupied by a
+        SCREENED CROWN GRAPHIC, not by a glyph. It is an emblem (see
+        `design.emblem`) and is never part of the serial. `pattern` renders the gap
+        as the emitted space; both regexes accept it as optional.
+    design:
+      plate: { w: 12, h: 6, unit: in, w_mm: 304.8, h_mm: 152.4, plate_basis: convention }
+      plate_note: "NOT an Ontario legal claim — see `common.dimensions`. No Ontario instrument prescribes a plate size."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      colour_note: >-
+        Blue on reflective white. NEITHER COLOUR IS IN ANY ONTARIO INSTRUMENT: the
+        Highway Traffic Act and Reg. 628 are silent on colour. Both hexes are
+        `hex_basis: observed` and should be treated as unverified pending an MTO
+        specification.
+      legend_top: "ONTARIO"
+      legend_bottom_options: ["YOURS TO DISCOVER", "TANT À DÉCOUVRIR"]
+      legend_note: >-
+        The French-slogan plate is the SAME series in a different bottom legend,
+        allocated its own serial blocks (F-block exclusively since April 2019 per
+        the article). It is recorded as a variant rather than a series because
+        format and period are identical — the PRD-PLATES §2.3 test.
+      emblem: { present: true, rendered: placeholder, description: "provincial crown device, screened, between the letter and numeral groups" }
+      band: { side: none }
+      rear_differs: false
+      display: "front and rear (O. Reg. 628 s. 9(3)); validation, when required, in the upper right corner of the REAR plate (s. 9(1)(b))"
+      spec_history:
+        - { from: 1997, to: 2020, note: "embossed blue serial on reflective white, screened crown separator" }
+        - { from: 2020, note: "white base resumed after the blue base was abandoned in May 2020, with a more durable coating; the mark, the format and the colours are unchanged" }
+    variants:
+      - name: "French slogan (TANT À DÉCOUVRIR)"
+        format: { pattern: "LLLL 999", regex: '\A[A-Z]{4} ?\d{3}\z' }
+        note: "introduced 2008; per the article, exclusively F-block serials since April 2019. Same design but for the bottom legend."
+    region_encoding: none
+    region_encoding_note: "An Ontario plate encodes NO geography and NO date. There is no county legend, no regional prefix and no age identifier."
+    sources:
+      - "https://www.ontario.ca/laws/statute/90h08  # HTA s. 7(1)(b)(i): the plate shows 'the number of the permit issued for the vehicle'; s. 7(24) regulation-making power, which reaches display and never composition"
+      - "https://www.ontario.ca/laws/regulation/900628  # R.R.O. 1990, Reg. 628 s. 9(1),(3): front-and-rear display and the rear-plate validation corner"
+      - "https://www.ontario.ca/page/register-vehicle-permit-and-licence-plate  # ServiceOntario: 'Vehicle permits and licence plates are issued immediately'; automatic renewal for passenger, light commercial, motorcycle and moped plates"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY (PRD-PLATES §4): the ABCD-123 format, its 1997 start, and the G/I/O/Q/U exclusion. Read 2026-08-02. The article's own citation for the exclusion is a collector site, not a government source."
+    notes: >-
+      THE CURRENT ONTARIO PASSENGER PLATE, and the whole of it rests on a
+      SECONDARY for its start year — which is stated here rather than hidden.
+      period.start 1997 is the en.wikipedia table's date for the switch from
+      123-ABC to ABCD-123; the article footnotes the SERIAL RANGE to a collector
+      forum and the exclusion to a collector site, and dates the format change
+      itself with no footnote at all. No MTO or ServiceOntario page dates any
+      Ontario base or format, and the statute and regulation are silent on
+      composition (`common.charset.statutory_alphabet_absent`). So
+      `period_evidence: secondary-wikipedia` and 1997 is a flagged claim, not an
+      asserted fact (PRD-PLATES §9: primary-source-or-marked). WHAT IS
+      INDEPENDENTLY SOLID: that this format is CURRENT ISSUE is confirmed by
+      ServiceOntario's own personalized-plate page, which prices passenger plates
+      at "2 to 8 characters" and therefore presupposes a seven-character standard
+      arrangement; and the display, validation and ownership rules on this series
+      are all quoted from the Act and the regulation. THE ID IS DATED because the
+      1997 boundary is at least consistently reported across the article's own
+      issuance ranges; if a primary lands that moves it, the dated id gains a
+      former-id alias under the PRD-QUALITY I-5/I-6 contract rather than moving.
+
+  # =========================================================================
+  # ONE SERIES BACK — three numerals, three letters (1986-1997).
+  # =========================================================================
+  - id: ca-on-standard-1986
+    class: standard
+    categories: [car, van, bus]
+    period: { start: 1986, end: 1997 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      regex_strict: '\A\d{3} ?[ABCDEFHJKLMNPRSTVWXYZ]{3}\z'
+      charset:
+        excluded: [G, I, O, Q, U]
+        notes: "the article states G, I, Q and U were unused in this format and that O was discontinued after the ZZO series in 1997 — so the strict twin here excludes all five, which is a DELIBERATE OVER-NARROWING for the tail of the run and is flagged rather than silently applied."
+      separator_note: "crown graphic in the gap, as on the current series"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "ONTARIO"
+      legend_bottom_options: ["YOURS TO DISCOVER"]
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    region_encoding: none
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY: 123-ABC issued 1986-1997, ranges 001-AAA to 999-ZZZ; the 1994 switch to screened reflective plates inside the same format"
+      - "https://www.ontario.ca/laws/statute/90h08  # HTA s. 11(3): plates of this vintage remain lawfully transferable between the holder's vehicles of a similar class, which is why the series has no hard end for DISPLAY purposes"
+    notes: >-
+      THE IMMEDIATELY PRIOR PASSENGER FORMAT, authored because PRD-PLATES scopes
+      L2/L3 at the current series plus ONE back, and because Ontario plates are
+      permanent: since 1973 the province has not re-plated annually, so
+      123-ABC plates remain lawfully displayed in quantity. The period END is an
+      ISSUANCE end, not a validity end — a distinction that matters more in
+      Ontario than in most jurisdictions and is the reason this series is not
+      marked `ended: true`. Both boundary years are the article's, unfootnoted,
+      hence `secondary-wikipedia`. The 1994 change from embossed to screened
+      reflective plates happened INSIDE this format and is not cut as a series:
+      format, period and colours were unchanged and only the manufacturing method
+      moved (PRD-PLATES §2.3).
+
+  # =========================================================================
+  # THE 2020 BLUE BASE — a real four-month series, announced, issued, recalled.
+  # =========================================================================
+  - id: ca-on-standard-blue-2020
+    class: standard
+    categories: [car, van, bus]
+    period: { start: 2020, end: 2020 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLLL 999"
+      regex: '\A[A-Z]{4} ?\d{3}\z'
+      regex_strict: '\A[ABCDEFHJKLMNPRSTVWXYZ]{4} ?\d{3}\z'
+      charset: { excluded: [G, I, O, Q, U], notes: "identical to ca-on-standard-1997 — the MARK did not change, only the base" }
+      separator_note: "the crown moved to the bottom right and a stylized white trillium took the separator position; still a graphic, still never part of the serial"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#1B3A6B", finish: retroreflective, hex_basis: observed, note: "two-hue blue" }
+      foreground: "#FFFFFF"
+      legend_top: "Ontario"
+      legend_bottom_options: ["A PLACE TO GROW", "EN PLEIN ESSOR"]
+      emblem: { present: true, rendered: placeholder, description: "stylized white trillium as separator; crown at bottom right" }
+      band: { side: none }
+      rear_differs: false
+      material: "synthetic, not embossed"
+    sources:
+      - "https://news.ontario.ca/mgs/en/2019/04/open-for-business-and-a-place-to-grow-new-licence-plate-and-drivers-licence-to-reflect-ontarios-opti-2.html  # Government of Ontario news release, 15 April 2019, announcing the redesign and the 'A Place to Grow' slogan. FETCH FAILED on 2026-08-02: news.ontario.ca served no body to either the direct fetch or the Wayback copy attempted; the release is cited as the article's own primary and is NOT quoted here because it was not read."
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY: issue from 1 February 2020, initial batch recalled after 4 March 2020, design scrapped 6 May 2020, blue stock exhausted through early June; serials CMAA-001 onward; the French 'EN PLEIN ESSOR' variant on F-block serials"
+    notes: >-
+      THE BLUE PLATE. Its own series because BOTH the design and the period differ
+      from ca-on-standard-1997 while the format does not (PRD-PLATES §2.3), and
+      because a consumer holding a photograph of a blue Ontario plate needs to be
+      told it is a four-month artefact rather than a current base. OVERLAP IS
+      DELIBERATE AND REAL: white "Yours to Discover" plates never stopped being
+      issued in French-slogan blocks and resumed in full in May 2020 while blue
+      stock ran out, so this series and ca-on-standard-1997 genuinely overlap in
+      2020 — the parallel-issuance case PRD-PLATES §2.2 contemplates. EVERY DATE
+      HERE IS SECONDARY. The Government of Ontario's own April 2019 announcement
+      and its February 2020 update are cited by the article and were BOTH
+      unreachable on 2026-08-02 (news.ontario.ca returned an empty body to the
+      direct fetch, to WebFetch and to the Wayback attempt), so nothing from them
+      is quoted. A verifier with Canadian network access should re-pin this
+      series first: it is the one series in this file where a government primary
+      is known to exist and known to be unread.
+
+  # =========================================================================
+  # GREEN VEHICLE PLATES — the Ontario electric series. A REAL parse signal:
+  # unlike Britain's green flash, the Ontario green plate changes the SERIAL.
+  # =========================================================================
+  - id: ca-on-green-2010
+    class: electric
+    categories: [car, van, truck]
+    period: { start: 2010 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLLL 999"
+      regex: '\A[A-Z]{4} ?\d{3}\z'
+      regex_strict: '\A(?:GV|GW|VE)[ABCDEFHJKLMNPRSTVWXYZ]{2} ?\d{3}\z'
+      charset:
+        notes: >-
+          The two-letter programme prefix is what makes this series parseable. GV
+          and GW carry the English "GREEN VEHICLE" legend and VE the French
+          "VÉHICULE ÉCOLOGIQUE" legend, per the article's issuance table. CONTRAST
+          plates/gb.yml `gb-green-zev-2020`, where the mark is unchanged and a
+          British ZEV is NOT identifiable from its registration string. Ontario's
+          is.
+      progression: "GVAA-001 onward, continuing into the GW block; VEAA-001 onward for the French legend"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#00843D"
+      colour_note: "green serial on white. No Ontario instrument states either colour; both are `hex_basis: observed`."
+      legend_top: "ONTARIO"
+      legend_bottom_options: ["GREEN VEHICLE", "VÉHICULE ÉCOLOGIQUE"]
+      emblem: { present: true, rendered: placeholder, description: "trillium graphic as separator" }
+      band: { side: none }
+      rear_differs: false
+    eligibility: >-
+      ServiceOntario, verbatim: eligible are "plug-in hybrid electric vehicles
+      (PHEV)", "battery electric vehicles (BEV)", "hydrogen fuel cell vehicles
+      (HFCVs)", "used 2010 or later model year PHEVs and BEVs" and vehicles running
+      in Ontario pilot programmes. Explicitly NOT eligible: "low-speed vehicles,
+      e-bikes, motorcycles, off-road vehicles, conventional hybrid electric vehicle
+      (HEVs), vehicles that have been converted to plug-in capability, commercial
+      vehicles with a registered gross weight (RGW) of more than 4,500 kg". Note
+      the PHEV inclusion — the Ontario test is a plug, not a tailpipe, which is the
+      exact inverse of the British reg. 16(11)(a) "cannot produce any tailpipe
+      emissions" test.
+    privilege: >-
+      ServiceOntario, verbatim: vehicles with green plates may drive in "High
+      Occupancy Vehicle (HOV) lanes with any number of occupants" and in "High
+      Occupancy Toll (HOT) lanes on 400-series highways and the Queen Elizabeth Way
+      (QEW) at no cost with any number of occupants". Since 25 November 2024
+      commercial vehicles of 3,001-4,500 kg are eligible.
+    restrictions: >-
+      ServiceOntario, verbatim: "Green vehicle licence plates are available at any
+      ServiceOntario centre. Online orders and personalized green vehicle licence
+      plates are not available." and "Green licence plates are not customizable
+      with the Veteran licence plate design or other personalized licence plate
+      design." The plates are OPTIONAL and cost the same as ordinary plates — so a
+      green plate proves an eligible powertrain and its absence proves nothing.
+    sources:
+      - "https://www.ontario.ca/page/get-green-licence-plate  # ServiceOntario, published 21 January 2022, updated 10 July 2025, accessed 2026-08-02: the eligibility list verbatim, the HOV/HOT privilege, the 25 November 2024 commercial extension, the no-online-order and no-personalization rules, and 'The plates are optional and cost the same as regular licence plates.'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY: the 2010 first-issue year and the GV / GW / VE prefix blocks with their issuance ranges"
+    notes: >-
+      ONTARIO'S GREEN PLATE IS A SERIAL SIGNAL, NOT A DECORATION — the single most
+      consumer-useful fact in this file, and the reason this series is authored
+      rather than folded into the standard series. The ELIGIBILITY, PRIVILEGE and
+      RESTRICTION text above is quoted from ServiceOntario and is as good as
+      Ontario evidence gets. The PERIOD is not: 2010 is the article's first-issue
+      year with no footnote, hence `period_evidence: secondary-wikipedia`. The
+      former MTO programme page (mto.gov.on.ca/english/vehicles/electric/
+      green-licence-plate.shtml), which the article cites, is dead; its content
+      moved to the ontario.ca page cited above, which does not date the programme.
+
+  # =========================================================================
+  # COMMERCIAL — two letters, five numerals. A DIFFERENT PLATE AND A DIFFERENT
+  # STICKER CORNER, both of which follow from the regulation.
+  # =========================================================================
+  - id: ca-on-commercial-2011
+    class: standard
+    categories: [truck, van]
+    period: { start: 2011 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LL 99999"
+      regex: '\A[A-Z]{2} ?\d{5}\z'
+      charset:
+        notes: >-
+          No letter exclusion is stated for the commercial format by any source
+          located, so NO `regex_strict` is authored — the absence is deliberate and
+          is not the same as "no exclusions exist". PRD-PLATES §2.7: a missing
+          strict twin does not weaken `matching: strict`.
+      progression: "AA-10001 upward per the article's issuance record; a separate D-block (DA-10001 onward) carries the French slogan"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "ONTARIO"
+      legend_bottom_options: ["YOURS TO DISCOVER", "TANT À DÉCOUVRIR"]
+      emblem: { present: true, rendered: placeholder, description: "crown separator" }
+      band: { side: none }
+      rear_differs: false
+      display: "front and rear (O. Reg. 628 s. 9(3)); validation in the upper right corner of the FRONT plate (s. 9(1)(a)) — the inverse of a passenger vehicle, and a class signal a photograph carries"
+    pickup_truck_rule: >-
+      ServiceOntario, verbatim: "In Ontario, under the Highway Traffic Act all
+      vehicles defined as pickup trucks are classed as commercial vehicles
+      regardless of their intended use." So an ordinary private pick-up wears a
+      commercial plate in Ontario, and a consumer inferring "commercial use" from
+      this series will be wrong a great deal of the time.
+    sources:
+      - "https://www.ontario.ca/laws/regulation/900628  # Reg. 628 s. 9(1)(a): the commercial validation sticker goes on the FRONT plate; s. 8.0.1: CVOR certificate condition on issuing plates or validation for certain commercial vehicles"
+      - "https://www.ontario.ca/page/get-green-licence-plate  # ServiceOntario, accessed 2026-08-02, for the pickup-truck classification quoted above and the 4,500 kg RGW ceiling"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY: the AB-12345 commercial format from 2011 and its issuance ranges; the DA French block"
+    notes: >-
+      ONTARIO'S COMMERCIAL PLATE IS A STANDARD-CLASS PLATE ON A DIFFERENT SERIAL
+      SHAPE, which is why `class: standard` and not a bespoke value: the
+      _meta/classes.yml vocabulary has no "commercial" member and inventing one ad
+      hoc is forbidden. What separates it from ca-on-standard-1997 is format and
+      the front-plate sticker corner, both recorded. period.start 2011 is the
+      article's, unfootnoted.
+
+  # =========================================================================
+  # MOTORCYCLE — rear only, small plate, its own serial line.
+  # =========================================================================
+  - id: ca-on-motorcycle-2024
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2024 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "99L9L"
+      regex: '\A\d{2}[A-Z]\d[A-Z]\z'
+      charset: { notes: "no exclusion stated by any source located; no strict twin authored" }
+      layout_note: "no separator and no gap: the Ontario motorcycle serial is printed as one five-character block under a screened 'ONT' legend"
+    design:
+      plate_note: "reduced motorcycle size; no Ontario instrument states it, and no measured figure was obtained. Deliberately absent rather than guessed."
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "ONT"
+      emblem: { present: false, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "REAR ONLY — O. Reg. 628 s. 9(4), verbatim: 'The number plate for a motorcycle, motor assisted bicycle or trailer shall be attached to and exposed in a conspicuous position on the rear of the vehicle.'"
+    sources:
+      - "https://www.ontario.ca/laws/regulation/900628  # Reg. 628 s. 9(4): rear-only display for a motorcycle or motor assisted bicycle"
+      - "https://www.ontario.ca/page/personalized-licence-plate  # ServiceOntario, accessed 2026-08-02: 'Personalized motorcycle plates may have 2 to 5 characters.' — a GOVERNMENT statement that the motorcycle serial budget is five, which independently corroborates the five-character shape below"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY: the 12A3B arrangement from 2024 and its issuance range"
+    notes: >-
+      THE CURRENT ONTARIO MOTORCYCLE SERIES, and the one series in this file whose
+      LENGTH is corroborated by a government source: ServiceOntario prices
+      personalized motorcycle plates at "2 to 5 characters", which is exactly the
+      five-character budget the standard motorcycle serial uses. The specific
+      ARRANGEMENT (two digits, letter, digit, letter) and the 2024 start are the
+      article's and are unfootnoted. Ontario has cycled through six five-character
+      motorcycle arrangements since 1996 (AB123, 1A234, 123A4, 1234A, 1A2B3,
+      12A3B); only the current one and its immediate predecessor are authored, per
+      the L2/L3 scope rule.
+
+  - id: ca-on-motorcycle-2013
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2013, end: 2024 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "9L9L9"
+      regex: '\A\d[A-Z]\d[A-Z]\d\z'
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "ONT"
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY: the 1A2B3 arrangement, 2013-2024, ranges 0A0A1 onward"
+      - "https://www.ontario.ca/laws/regulation/900628  # Reg. 628 s. 9(4): the same rear-only rule applies"
+    notes: >-
+      ONE SERIES BACK for motorcycles. Authored because Ontario plates are
+      permanent and 1A2B3 machines are still on the road; the end year is an
+      ISSUANCE end, not a validity end, exactly as on ca-on-standard-1986. Both
+      boundaries are the article's, unfootnoted.
+
+  # =========================================================================
+  # TRAILER — rear only, permanent (no annual validation since 1980).
+  # =========================================================================
+  - id: ca-on-trailer-2025
+    class: trailer
+    categories: [trailer]
+    period: { start: 2025 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LL9 99L"
+      regex: '\A[A-Z]{2}\d ?\d{2}[A-Z]\z'
+      charset: { notes: "no exclusion stated by any located source for the current trailer format" }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "ONTARIO"
+      legend_side: "TRAILER, screened vertically at the left"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "REAR ONLY (O. Reg. 628 s. 9(4))"
+    validation: "HTA s. 7(4): a trailer needs a permit and 'there is displayed on the trailer, in the prescribed manner, a number plate showing the number of the permit issued for the trailer.' Ontario trailer plates carry a one-time fee rather than annual validation."
+    sources:
+      - "https://www.ontario.ca/laws/statute/90h08  # HTA s. 7(4): the trailer permit and plate requirement"
+      - "https://www.ontario.ca/laws/regulation/900628  # Reg. 628 s. 9(4): rear-only display for a trailer"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY: the AB1-23C trailer arrangement from 2025 and its ranges"
+    notes: >-
+      THE CURRENT ONTARIO TRAILER SERIES. period.start 2025 is the article's,
+      unfootnoted, and is the youngest claim in this file — a verifier should treat
+      it as the least settled. The trailer plate is genuinely permanent, which is
+      why its predecessor below carries an issuance end and no `ended: true`.
+
+  - id: ca-on-trailer-2002
+    class: trailer
+    categories: [trailer]
+    period: { start: 2002, end: 2025 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "L99 99L"
+      regex: '\A[A-Z]\d{2} ?\d{2}[A-Z]\z'
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "ONTARIO"
+      legend_side: "TRAILER, screened vertically at the left"
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY: the A12-34B trailer arrangement, 2002-2025, ranges A10-01A to Z99-99Z"
+      - "https://www.ontario.ca/laws/regulation/900628  # Reg. 628 s. 9(4)"
+    notes: >-
+      ONE SERIES BACK for trailers, and the bulk of the Ontario trailer fleet: the
+      A12-34B range ran twenty-three years and to exhaustion (Z99-99Z), which is
+      why the successor above changed shape. Both boundaries are the article's.
+
+  # =========================================================================
+  # HISTORIC — the class the STATUTE defines, unusually.
+  # =========================================================================
+  - id: ca-on-historic-2007
+    class: historic
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2007 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "9H9999"
+      regex: '\A\dH\d{4}\z'
+      charset: { notes: "the literal H in position 2 is the programme marker; the rest is numeric. The pattern spells H as an ordinary literal letter, which the §2.6 alphabet permits without an escape (the escape is only needed for the DSL's own 9 and L tokens)." }
+      progression: "1H0001 upward per the article's issuance record"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "ONTARIO"
+      legend_side: "HISTORIC, screened vertically at the left"
+      emblem: { present: true, rendered: placeholder, description: "crown separator" }
+      band: { side: none }
+      rear_differs: false
+    eligibility: >-
+      HTA s. 7(1.1), verbatim: "'historic vehicle' means a motor vehicle that,
+      (a) is at least 30 years old, and (b) is substantially unchanged or
+      unmodified from the original manufacturer's product." Reg. 628 s. 1(1)
+      carries its own definition "despite the definition in subsection 7 (1.1) of
+      the Act" for registration purposes. A HISTORIC plate is NOT a
+      year-of-manufacture plate — see `classes_not_modelled.year_of_manufacture`.
+    sources:
+      - "https://www.ontario.ca/laws/statute/90h08  # HTA s. 7(1.1): the 30-year, substantially-unmodified statutory definition"
+      - "https://www.ontario.ca/laws/regulation/900628  # Reg. 628 s. 1(1) 'historic vehicle', which overrides the Act's definition for registration purposes"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY: the 1H2345 arrangement from 2007 and its issuance range; the 1969 origin of the class and the 1973 switch to permanent plates"
+    notes: >-
+      THE ELIGIBILITY TEST IS STATUTORY AND THE FORMAT IS NOT — the split this
+      whole file is built around, in one series. HTA s. 7(1.1) states the 30-year
+      rule in terms; nothing in the Act or the regulation says a historic plate
+      reads 1H2345, and 2007 is the article's unfootnoted date.
+
+  # =========================================================================
+  # DIPLOMATIC — red plates, and a FEDERAL rule sits over the provincial series.
+  # =========================================================================
+  - id: ca-on-diplomatic-1994
+    class: diplomatic
+    categories: [car, van]
+    period: { start: 1994 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      charset: { notes: "no exclusion located. NOTE THE COLLISION RISK a parse API must handle: the printed serial shape is identical to ca-on-standard-1986, and only the PLATE COLOUR distinguishes them. A string alone cannot separate the two." }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#C8102E", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      colour_note: "white on reflective red. The article states the red is EXCLUSIVE to diplomatic plates in Ontario. No instrument states the colour; `hex_basis: observed`."
+      legend_top: "ONTARIO"
+      legend_bottom_options: ["YOURS TO DISCOVER"]
+      emblem: { present: true, rendered: placeholder, description: "crown separator" }
+      band: { side: none }
+      rear_differs: false
+    federal_overlay: >-
+      Global Affairs Canada's Office of Protocol sets the rule that foreign
+      representatives and accredited family members must obtain the provincial
+      diplomatic plate when registering a passenger vehicle, within 30 days of
+      taking up residence, and that the rule does not extend to motorcycles. The
+      GAC guidance page was FETCHED on 2026-08-02 and returned a navigation shell
+      only (736 characters, no policy body), so the rule is recorded here from the
+      article's summary of it and is NOT quoted. Flagged for the verifier.
+    sources:
+      - "https://www.international.gc.ca/protocol-protocole/policies-politiques/licence-plates-guidelines_lignes-directrices-plaques-immatriculation.aspx?lang=eng  # Global Affairs Canada, 'Issuance of Licence Plates to Foreign Representatives, including Honorary Consular Officers' — FETCHED 2026-08-02, returned a navigation shell with no policy body; cited as the known federal primary, unread"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario  # TAGGED SECONDARY: the 1994 base, the 123-ABC diplomatic format, the red-is-exclusive claim, and the 30-day / no-motorcycle federal rule"
+    notes: >-
+      THE WEAKEST-SOURCED SERIES IN THIS FILE, and it says so. Ontario publishes
+      nothing about diplomatic plates; the federal page that would govern them was
+      unreadable from this location. Everything here is the article's. It is
+      authored anyway because the class vocabulary has a `diplomatic` member, the
+      colour is genuinely diagnostic on the road, and the SERIAL COLLISION with
+      ca-on-standard-1986 is a fact a parse API needs stated rather than
+      discovered. A verifier should re-pin this from Global Affairs Canada before
+      the file is applied.
+
+  # =========================================================================
+  # PERSONALIZED — the ONE series whose grammar is authority-sourced end to end.
+  # =========================================================================
+  - id: ca-on-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 1998 }
+    period_evidence: statutory-authority-undated
+    matching: strict
+    format:
+      pattern: "LLLLLLLL"
+      regex: '\A[A-Z0-9]{2,8}\z'
+      charset:
+        notes: >-
+          ServiceOntario, verbatim: "A personalized licence plate message may
+          contain almost any combination of letters and numbers." and
+          "Personalized passenger and commercial plates may have 2 to 8
+          characters. Personalized motorcycle plates may have 2 to 5 characters."
+          The refusal rules are equally quotable and are real charset constraints:
+          the Ministry rejects "combinations with: more than 4 identical characters
+          in sequence" and "interchangeable letters or numbers (such as S/5, A/4,
+          G/6, Q/O) — for example, if a plate has been issued with an 'S' in its
+          combination and an identical plate request is submitted substituting the
+          'S' with a '5', that plate will not be approved". Neither rule is
+          encoded in a regex: the first is expressible but would narrow the series
+          against a discretionary standard, and the second is a COLLISION rule
+          against the existing issue rather than a property of the string.
+      length_note: "2-8 for passenger and commercial; 2-5 for motorcycle (variant below); 2-6 when a graphic is chosen (ServiceOntario fee table)."
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "ONTARIO"
+      legend_bottom_options: ["YOURS TO DISCOVER", "TANT À DÉCOUVRIR"]
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      graphics_note: "ServiceOntario: 'There are over 60 graphics available to choose from.' The graphic occupies plate area and costs two characters of serial budget."
+    variants:
+      - name: "motorcycle personalized"
+        format: { pattern: "LLLLL", regex: '\A[A-Z0-9]{2,5}\z' }
+        note: "ServiceOntario, verbatim: 'Personalized motorcycle plates may have 2 to 5 characters.' and 'Personalized licence plates cannot be registered to limited speed motorcycles.'"
+      - name: "personalized with graphic"
+        format: { pattern: "LLLLLL", regex: '\A[A-Z0-9]{2,6}\z' }
+        note: "ServiceOntario fee table: '2 to 6 characters (letters and/or numbers) with a graphic - $336.40', against '2 to 8 characters ... without a graphic - $310'."
+    transfer_rule: >-
+      ServiceOntario, verbatim: "A personalized licence plate can be transferred
+      only once to another person before it is attached to a vehicle. Once the
+      plate is registered to a vehicle, it cannot be transferred again." — which
+      sits on top of the ordinary Ontario owner-binding rule (HTA s. 11(3)).
+    sources:
+      - "https://www.ontario.ca/page/personalized-licence-plate  # ServiceOntario, accessed 2026-08-02: the 2-8 / 2-5 / 2-6 character budgets verbatim, the 'almost any combination of letters and numbers' statement, the four-identical-character and interchangeable-character refusal rules, the gift/transfer rule and the fee table"
+      - "https://www.ontario.ca/laws/statute/90h08  # HTA s. 7(24)(o): the Lieutenant Governor in Council may make regulations 'prescribing the criteria for the issuance, retention and return of a number plate bearing a requested number' — the statutory hook for the whole programme; HTA s. 12(3)(a) confirms 'number plate' includes 'a number plate bearing a requested number'"
+    notes: >-
+      THE ONLY ONTARIO SERIES WHOSE REGEX IS AUTHORITY-SOURCED END TO END. The
+      statute creates the class (s. 7(24)(o), s. 12(3)(a)) and ServiceOntario
+      publishes the exact character budgets, so `regex` here is a real claim rather
+      than a reported shape. PERIOD IS THE WEAK PART and is graded honestly:
+      `statutory-authority-undated`. HTA s. 7(24)(o) and s. 12(3)(a) both entered
+      the Act by 1999, c. 12, Sched. R, in force 1 January 2001 per the e-Laws
+      amendment table, and Ontario's requested-number programme demonstrably
+      predates that consolidation. 1998 is recorded as a conservative start with no
+      primary behind the exact year; a verifier should either pin it or replace it
+      with the 2001 in-force date and re-grade to `enabling-instrument`. THE
+      OVERLAP with every other Ontario series is by construction — a personalized
+      plate is an ordinary plate with a chosen serial, so its regex deliberately
+      swallows the standard shapes, and `matching: strict` is still correct because
+      the authority really does issue any 2-8 alphanumeric string.

--- a/plates/ca-pe.yml
+++ b/plates/ca-pe.yml
@@ -1,0 +1,592 @@
+# plates/ca-pe.yml — Prince Edward Island, Canada (PRD-PLATES gate L2/L3, Canada east wave).
+#
+# THE SMALLEST CANADIAN PROVINCE AND, PER PLATE, THE MOST INVENTIVE: Prince
+# Edward Island has changed its base design roughly every decade since 1973, has
+# won the Automobile License Plate Collectors Association's "Plate of the Year"
+# once, once coded its serials BY COUNTY, and in 2022 became the only province in
+# this wave to issue a distinct electric-vehicle base rather than a colour change
+# or a prefix. It is also the province whose current base has a GOVERNMENT NEWS
+# RELEASE behind it, which is more than Ontario, Nova Scotia or New Brunswick can
+# say.
+#
+# FOUR STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. THE ACT STATES THE PLATE'S CONTENT AND ONE PLATE ONLY. Highway Traffic Act
+#    s. 20(1), verbatim: "The Registrar, upon registering a vehicle, shall issue A
+#    NUMBER PLATE for the vehicle to its owner." Singular. s. 20(2), verbatim:
+#    "Every number plate shall have displayed thereon the registration number
+#    assigned to the vehicle for which it is issued, the name of the province,
+#    which may be abbreviated, the number of the year for which it is issued, and
+#    such other information as the Minister may by order require." That is
+#    word-for-word New Brunswick's MVA s. 29(2) — two Maritime statutes with an
+#    identical content rule, which is a shared drafting ancestry rather than a
+#    coincidence, and worth recording because it means the same three mandatory
+#    elements govern both provinces.
+#
+# 2. THE TRUCK-TRACTOR INVERSION IS IN THE ACT, IN TWO LINES. s. 21(1.1): "Subject
+#    to subsection (2), the number plate issued for a motor vehicle shall be
+#    attached to the REAR thereof." s. 21(2): "The number plate issued for a
+#    truck-tractor shall be attached to the FRONT thereof." Florida
+#    (§ 320.0706 F.S.), Nova Scotia (N.S. Reg. 173/95 s. 2(2)) and Québec
+#    (Règlement art. 8) each reach the same result by a different route; Prince
+#    Edward Island states it in the barest possible form.
+#
+# 3. THE PLATE FOLLOWS THE OWNER, AND s. 21(4) SAYS SO. Verbatim: "Where the
+#    ownership of a registered vehicle passes from the registered owner, the vendor
+#    shall detach and RETAIN the number plates FOR HIS USE ON A VEHICLE REGISTERED
+#    IN HIS NAME." s. 21(5) then gives a purchaser seven days to run a newly bought
+#    vehicle on a plate already issued to them for the same class of vehicle. Same
+#    posture as Ontario (plates/ca-on.yml) and Nova Scotia (plates/ca-ns.yml);
+#    opposite of New Brunswick, whose MVA s. 29(2) assigns the number to the
+#    vehicle.
+#
+# 4. STACKED CHARACTERS ARE REAL HERE, AND THEY ARE PART OF THE SERIAL. Prince
+#    Edward Island's commercial and service-vehicle plates print a two-letter class
+#    code STACKED at the left of the plate — "CV" and "SV" — in half-height
+#    characters. AAMVA Ed. 3 is explicit that "If stacked characters are used, they
+#    are part of the official license plate number. No more than two characters are
+#    to be stacked", and this file follows it: the stacked pair is spelled in the
+#    pattern as ordinary leading characters, and the fact that it is printed
+#    stacked is recorded in `design`. A normaliser that drops stacked characters
+#    will silently corrupt every Prince Edward Island commercial plate.
+#
+# SEPARATOR NOTE (PRD-PLATES §2.6): the gap in a Prince Edward Island serial is
+# occupied by the PROVINCIAL CREST — a graphic separator, like Ontario's crown.
+# It is an emblem (see `design.emblem`), never part of the serial. Every `pattern`
+# spells the gap as the emitted space; every regex accepts it as optional.
+jurisdiction: ca-pe
+authority:
+  name: Highway Safety Division, Department of Transportation and Infrastructure (Prince Edward Island); registration transacted through Access PEI
+  url: "https://www.princeedwardisland.ca/en/information/transportation-and-infrastructure/highway-safety"
+binding: owner
+binding_note: >-
+  HTA s. 21(4), verbatim: "Where the ownership of a registered vehicle passes from
+  the registered owner, the vendor shall detach and retain the number plates for
+  his use on a vehicle registered in his name." s. 21(5): a purchaser "may attach
+  to the vehicle any valid number plate issued to the person for the same class of
+  vehicle as the purchased vehicle and may operate the vehicle with such plate
+  attached for a period of up to seven days pending the registration of the
+  transfer of ownership." The plate is the registrant's. s. 20(3) still makes it
+  Crown property: "Number plates issued to any person under this section shall
+  remain at all times the property of the Crown."
+instrument:
+  statute: "Highway Traffic Act, R.S.P.E.I. 1988, c. H-5 — ss. 1 (definitions, incl. 'number plate' and 'restricted number plate'), 20 (number plate), 21 (attachment), 41-42 (dealer's number plates), 60-62 (use, lending, offences)"
+  currency: "the consolidation read is marked 'Current to: May 29, 2026'"
+  sources:
+    - "https://www.princeedwardisland.ca/sites/default/files/legislation/h-05-highway_traffic_act.pdf  # Highway Traffic Act consolidation, current to 29 May 2026, fetched and text-extracted 2026-08-02 — every statutory quotation in this file"
+  licence: >-
+    The Highway Traffic Act is an EDICT OF GOVERNMENT and its text is
+    uncopyrightable (PRD-PLATES §4). Every verbatim quotation of statute in this
+    file is of that text.
+  fetch_note: >-
+    princeedwardisland.ca serves the STATUTE PDF freely but sits behind a Radware
+    bot-defence on its HTML pages: the 16 November 2022 news release announcing the
+    current base returned a security-verification page to a direct fetch and to
+    WebFetch on 2026-08-02, and was read instead through the Internet Archive
+    (snapshot 20231201163420). The release's text quoted in this file came through
+    that archive copy.
+
+artwork_risk:
+  posture: crown-copyright-asserted
+  basis: >-
+    Prince Edward Island asserts Crown copyright on its web content. No provincial
+    open licence covering plate ARTWORK was located. The statute TEXT is free as an
+    edict of government and is quoted freely; nothing else is assumed.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies. The provincial escutcheon used as
+    the serial separator, the Province House facsimile on the 2013 base and the
+    provincial coat of arms are rendered `placeholder`. The escutcheon and arms
+    carry protection independent of copyright; unresearched, flagged.
+
+common:
+  statutory_content:
+    text: >-
+      HTA s. 20(2), verbatim: "Every number plate shall have displayed thereon the
+      registration number assigned to the vehicle for which it is issued, the name
+      of the province, which may be abbreviated, the number of the year for which it
+      is issued, and such other information as the Minister may by order require."
+    definition: >-
+      HTA s. 1(l), verbatim: "'number plate' includes any proof of registration
+      issued by the department and required to be affixed to a motor vehicle,
+      trailer or semi-trailer." A definition wide enough to swallow a sticker, which
+      is how the annual "number of the year" element in s. 20(2) is satisfied on a
+      permanent plate.
+    source: "https://www.princeedwardisland.ca/sites/default/files/legislation/h-05-highway_traffic_act.pdf  # HTA ss. 1(l), 20(1)-(5)"
+  display:
+    text: >-
+      HTA s. 21, verbatim in part: "(1.1) Subject to subsection (2), the number
+      plate issued for a motor vehicle shall be attached to the rear thereof.
+      (2) The number plate issued for a truck-tractor shall be attached to the front
+      thereof. (3) Every number plate shall at all times be securely fastened in a
+      horizontal position to the vehicle for which it is issued so as to prevent the
+      plate from swinging and at a height of not less than 300 mm from the ground
+      measuring from the bottom of such plate, in a place and position clearly
+      visible and legible and shall be maintained free from foreign materials."
+    obscuring: >-
+      s. 21(3.1), verbatim: "No person shall operate a vehicle on a highway if the
+      number plate displayed on the vehicle is covered, in whole or in part, by any
+      covering, device, sticker, inscription, sign or other thing placed on or
+      around the number plate which conceals, or reduces the legibility of, any
+      information contained on the number plate, INCLUDING THE REGISTRATION
+      EXPIRATION STICKER." Note the closing words: Prince Edward Island expressly
+      protects the sticker as part of the readable plate.
+    must_display: >-
+      s. 20(5), verbatim: "No person shall operate on a highway a vehicle which does
+      not display (a) a valid number plate; (b) a valid transit permit issued
+      pursuant to section 52 of this Act; or (c) a valid temporary permit issued
+      pursuant to regulations passed under clause 312(c) of this Act."
+    source: "https://www.princeedwardisland.ca/sites/default/files/legislation/h-05-highway_traffic_act.pdf  # HTA ss. 20(5), 21(1)-(5), 60, 61"
+  dimensions:
+    note: >-
+      NO PRINCE EDWARD ISLAND INSTRUMENT PRESCRIBES A PLATE SIZE. The Act states a
+      minimum MOUNTING HEIGHT (300 mm) and nothing about the plate itself. The
+      6 in x 12 in North American convention is recorded on the series below as
+      `plate_basis: convention`. Contrast plates/ca-ns.yml, where the size is in the
+      regulations in centimetres.
+  charset:
+    note: >-
+      NO PRINCE EDWARD ISLAND INSTRUMENT STATES A SERIAL ALPHABET OR ANY LETTER
+      EXCLUSION. The Act delegates everything past the three s. 20(2) elements to
+      ministerial order and no such order was located. Every arrangement in this
+      file is therefore `secondary-wikipedia`, and no `regex_strict` is authored
+      anywhere in this file — the absence is deliberate and is not a claim that no
+      exclusions exist.
+    historical_county_coding: >-
+      RECORDED BECAUSE IT IS THE ONLY GEOGRAPHIC DECODE PRINCE EDWARD ISLAND HAS
+      EVER HAD, and because it is long dead: on the 1993-1997 "Anne of Green Gables"
+      base the first character coded the COUNTY OF ISSUANCE — K for Kings County, P
+      for Prince County, Q for Queens County, with Queens overflowing into Q1 234
+      and QB C12 forms after QZ 999. The 1997 base dropped county coding entirely.
+      A parse API must not read a modern Prince Edward Island serial as geographic;
+      it must read a 1993-1997 one that way. Both facts are the article's.
+    source_secondary: "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Prince_Edward_Island  # TAGGED SECONDARY (PRD-PLATES §4, owner override 2026-08-02), read 2026-08-02: every serial arrangement in this file, the county coding and the base dates"
+
+classes_not_modelled:
+  motorcycle:
+    exists: true
+    mechanism: >-
+      Prince Edward Island issues motorcycle plates; the article's own table carries
+      a motorcycle row for the current 2013-present base with the SERIAL FORMAT CELL
+      EMPTY, and gives A1 23 for the 1997-2007 base.
+    why_not_modelled: >-
+      NO CURRENT ARRANGEMENT IS STATED BY ANY SOURCE, primary or secondary. The 2022
+      base's motorcycle form is unrecorded even in the secondary. Inventing one was
+      declined; recorded as a gap, and it is the largest single gap in this file.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Prince_Edward_Island  # the motorcycle row, whose current-base serial cell is blank"
+  personalized:
+    exists: true
+    mechanism: >-
+      The article records personalized plates from 2013 with the option of the
+      Province House graphic, describing the serial budget only as "unlimited" and
+      the rule as "Any personalized plates are allowed so long as text is not
+      offensive; can also be low digit."
+    why_not_modelled: >-
+      "Unlimited" is not a grammar and no Prince Edward Island instrument or agency
+      page stating a character budget could be read (the province's HTML pages sit
+      behind a bot defence — see `instrument.fetch_note`). Contrast
+      plates/ca-on.yml, where ServiceOntario publishes 2-8 and 2-5, and
+      plates/ca-ns.yml, where the regulation publishes 2-7 and 2-6. Recorded as a
+      gap rather than guessed.
+  conservation_and_food_island:
+    exists: true
+    mechanism: >-
+      Government of Prince Edward Island news release, 16 November 2022, verbatim:
+      "Since 2013, Island residents have been able to purchase a wildlife
+      conservation plate and the funds from the sale of those plates are donated to
+      the Wildlife Conservation Fund. Conservation plates will still be available in
+      the new plate design. Additionally, Island residents will have the new option
+      to purchase a Canada's Food Island license plate. All proceeds from the sale
+      of these plates will be donated to Island Food Banks." Fees, same release:
+      "$5 for a new license plate and $10 for a conservation or Canada's Food Island
+      plate".
+    why_not_modelled: >-
+      PRD-PLATES §2.5 keeps individual specialty DESIGNS out of v1, and neither
+      programme's serial grammar is stated anywhere. The programmes are indexed here
+      with the government's own words instead.
+    sources:
+      - "https://web.archive.org/web/20231201163420/https://www.princeedwardisland.ca/en/news/province-unveils-new-license-plates  # Government of Prince Edward Island news release 'Province unveils new license plates', 16 November 2022, read via the Internet Archive 2026-08-02"
+  prorate_irp:
+    exists: true
+    mechanism: "The article records a P-prefixed PRP series (P1 234) running on every base since 1997 — Prince Edward Island's International Registration Plan plates."
+    why_not_modelled: "The current-base arrangement is carried in the article as a rowspan from the 1997 form and is not separately stated; the P prefix is not corroborated by any instrument. Recorded as a gap."
+
+series:
+
+  # =========================================================================
+  # THE CURRENT STANDARD SERIES — 2022, and it has a news release behind it.
+  # =========================================================================
+  - id: ca-pe-standard-2022
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2022 }
+    period_evidence: agency-stated-date
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3} ?[A-Z]{3}\z'
+      charset:
+        notes: >-
+          Three numerals, the crest, three letters. No exclusion is stated by any
+          source and no `regex_strict` is authored — see `common.charset`.
+      progression: >-
+        The 16 November 2022 news release explains the change in the Minister's own
+        words: "It has been almost a decade since Prince Edward Island introduced a
+        new license plate design and it is time for a refresh. The traditional,
+        simple design will allow greater visibility AS WE START GETTING INTO 6-DIGIT
+        NUMBERING." That is an agency statement that the serial LENGTHENED to six
+        characters with this base — the predecessor ran five and six — and it is the
+        only progression claim in this file from a government source.
+      separator_note: "the gap carries the provincial crest, a graphic; `pattern` spells the emitted space and `regex` accepts it as optional"
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#00843D"
+      colour_note: >-
+        GREEN LETTERS ON WHITE, per the article; the news release describes the
+        design only as "traditional, simple" and gives no colour. Both hexes are
+        observed. Prince Edward Island is the only province in the Canada east wave
+        whose STANDARD plate is green-on-white — which matters, because green is the
+        ELECTRIC-vehicle signal in Ontario and Québec. A green Prince Edward Island
+        serial means nothing about powertrain; the Island's EV plate inverts the
+        colours instead (see ca-pe-electric-2022).
+      legend_top: "PRINCE EDWARD ISLAND"
+      legend_bottom_options: ["CANADA"]
+      emblem: { present: true, rendered: placeholder, description: "provincial crest as the serial separator; a small Canadian flag at bottom left" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR (HTA ss. 20(1), 21(1.1)); FRONT for a truck-tractor (s. 21(2))"
+    variants:
+      - name: "French-language base (ÎLE-DU-PRINCE-ÉDOUARD)"
+        format: { pattern: "999 LLL", regex: '\A\d{3} ?[A-Z]{3}\z' }
+        note: >-
+          Per the article, the same base with 'ÎLE-DU-PRINCE-ÉDOUARD' screened at
+          the top, "available as an alternate choice for Francophone Prince Edward
+          Islanders" — an alternative BASE, not an alternative slogan, which is how
+          Prince Edward Island differs from Ontario's two-slogan approach.
+    rollout:
+      first_available: "late December 2022"
+      text: >-
+        News release, verbatim: "The cost will remain at $5 for a new license plate
+        and $10 for a conservation or Canada's Food Island plate and will be
+        available in LATE DECEMBER 2022 at Access PEI locations across the province.
+        People will not be required to purchase a new design plate upon renewal if
+        their current plate is in good condition."
+      note: >-
+        THE LAST SENTENCE IS THE MODELLING FACT: there is no forced re-plating, so
+        the 2013 base below is not merely still on the road but still LAWFULLY
+        CURRENT, and the two series genuinely overlap. That is the parallel-issuance
+        case PRD-PLATES §2.2 contemplates.
+    sources:
+      - "https://web.archive.org/web/20231201163420/https://www.princeedwardisland.ca/en/news/province-unveils-new-license-plates  # Government of Prince Edward Island news release, 16 November 2022: the new design, the first-ever distinct electric-vehicle plate, the 6-digit numbering statement, the late-December-2022 availability, the fees and the no-forced-replacement rule — all quoted above. Read via the Internet Archive 2026-08-02; the live page is behind a bot defence."
+      - "https://www.princeedwardisland.ca/sites/default/files/legislation/h-05-highway_traffic_act.pdf  # HTA s. 20(1) (one plate), s. 20(2) (the content rule), s. 20(3) (Crown property), s. 21(1.1),(2) (rear, and front for a truck-tractor), s. 21(3),(3.1) (300 mm, no obscuring)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Prince_Edward_Island  # TAGGED SECONDARY: the 123 ABC arrangement, the green-on-white colours, the crest separator and the French-language alternate base"
+    notes: >-
+      THE BEST-DATED STANDARD SERIES IN THE CANADA EAST WAVE, and it took the
+      smallest province to produce it: a government news release, dated 16 November
+      2022, announcing the base, its availability "in late December 2022", its fee,
+      the parallel electric plate and the fact that no motorist is forced to
+      re-plate. Hence `period_evidence: agency-stated-date` rather than
+      `secondary-wikipedia`, which every other standard series in this wave carries.
+      What the release does NOT give is the serial ARRANGEMENT: 123 ABC is the
+      article's, and the release supports only the LENGTH ("as we start getting into
+      6-digit numbering"). That split is the honest state of the evidence and is why
+      `format` is not graded as highly as `period`.
+
+  - id: ca-pe-standard-2013
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2013 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "99 9LL"
+      regex: '\A\d{2} ?\d[A-Z]{2}\z'
+      charset: { notes: "no exclusion stated; no strict twin authored" }
+      progression: "the article's issuance record runs 10 1AA to 99 9ZZ on this arrangement, then A1 01A to C7 56G on the second, which is why the 2022 base moved to six characters"
+    variants:
+      - name: "six-character arrangement on the same base"
+        format: { pattern: "L9 99L", regex: '\A[A-Z]\d ?\d{2}[A-Z]\z' }
+        note: "the article records A1 23B alongside 12 3AB on the 2013 base, the second taking over when the first exhausted at 99 9ZZ. A variant rather than a series because the base, the period and everything else are identical (PRD-PLATES §2.3)."
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#8B6F47"
+      colour_note: "embossed LIGHT BROWN numerals on reflective white, per the article — a genuinely unusual serial colour and one no other plate in this dataset carries. Observed; no instrument states it."
+      legend_top: "PRINCE EDWARD ISLAND"
+      legend_bottom_options: ["Birthplace of Confederation", "Berceau de la Confédération"]
+      emblem: { present: true, rendered: placeholder, description: "a screened facsimile of Province House at the left and the provincial coat of arms in the centre" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR (HTA ss. 20(1), 21(1.1))"
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Prince_Edward_Island  # TAGGED SECONDARY: the 2013 Province House base, the light-brown serial, the 12 3AB and A1 23B arrangements, the bilingual Birthplace of Confederation / Berceau de la Confédération slogans and the issuance ranges"
+      - "https://web.archive.org/web/20231201163420/https://www.princeedwardisland.ca/en/news/province-unveils-new-license-plates  # the 2022 release's 'almost a decade since Prince Edward Island introduced a new license plate design' corroborates a 2013-vintage predecessor to the year, from a government source"
+    notes: >-
+      ONE SERIES BACK, and the only series in this file whose date is corroborated
+      SIDEWAYS BY A GOVERNMENT SOURCE: the 2022 news release says the previous design
+      had been in service "almost a decade", which puts its introduction in 2013 and
+      matches the article exactly. The grade stays `secondary-wikipedia` because the
+      release does not name the year, but the corroboration is real and is recorded.
+      STILL CURRENT ON THE ROAD BY DESIGN: the release states motorists "will not be
+      required to purchase a new design plate upon renewal if their current plate is
+      in good condition", so this series has no end year — the overlap with
+      ca-pe-standard-2022 is the province's own policy, not a modelling artefact.
+
+  # =========================================================================
+  # ELECTRIC — the first distinct EV BASE in the Canada east wave.
+  # =========================================================================
+  - id: ca-pe-electric-2022
+    class: electric
+    categories: [car, van, truck]
+    period: { start: 2022 }
+    period_evidence: agency-stated-date
+    matching: strict
+    format:
+      pattern: "999 9EV"
+      regex: '\A\d{3} ?\dEV\z'
+      charset:
+        notes: >-
+          THE LITERAL "EV" IS THE PROGRAMME MARKER and sits at the END of the serial
+          rather than the start — the inverse of Ontario's leading GV/GW/VE block.
+          Three numerals, the crest, a numeral and the letters EV. The arrangement is
+          the article's; the EXISTENCE of the class is the government's.
+      format_note: >-
+        THE THIRD CANADIAN APPROACH TO ELECTRIC PLATES, and this file now records
+        all three: Ontario changes the SERIAL (a GV/GW/VE prefix — parseable from a
+        string); Québec changes the LETTERING COLOUR and leaves the serial alone
+        (parseable from an image only); Prince Edward Island changes BOTH — a
+        distinct green base AND a literal EV in the serial. Britain, for comparison,
+        changes neither (plates/gb.yml gb-green-zev-2020: a green flash beside an
+        unchanged mark).
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#00843D", finish: retroreflective, hex_basis: observed }
+      foreground: "#FFFFFF"
+      colour_note: >-
+        WHITE SERIAL ON A GREEN FIELD — the standard base inverted, which is an
+        elegant piece of design and a strong photographic signal. Observed, per the
+        article; the news release confirms the plate exists and describes no colour.
+      legend_top: "PRINCE EDWARD ISLAND"
+      legend_bottom_options: ["ELECTRIC VEHICLE"]
+      emblem: { present: true, rendered: placeholder, description: "provincial escutcheon in the centre as the serial separator; Canadian flag at bottom left" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR (HTA ss. 20(1), 21(1.1))"
+    variants:
+      - name: "French-language electric base"
+        format: { pattern: "999 9EV", regex: '\A\d{3} ?\dEV\z' }
+        note: "the article records a French counterpart, as for the standard base"
+    sources:
+      - "https://web.archive.org/web/20231201163420/https://www.princeedwardisland.ca/en/news/province-unveils-new-license-plates  # Government of Prince Edward Island news release, 16 November 2022, verbatim: 'The province of Prince Edward Island is introducing a new design for its license plates and FOR THE FIRST TIME, THERE WILL BE A DISTINCT PLATE FOR ELECTRIC VEHICLES.' — the agency's own words, and the basis for period.start and for period_evidence"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Prince_Edward_Island  # TAGGED SECONDARY: the white-on-green design, the ELECTRIC VEHICLE slogan, the 123 4EV arrangement and the French counterpart"
+    notes: >-
+      "FOR THE FIRST TIME, THERE WILL BE A DISTINCT PLATE FOR ELECTRIC VEHICLES" —
+      the government's own sentence, which dates this series to the same 16 November
+      2022 release as the standard base and earns `period_evidence:
+      agency-stated-date`. The ARRANGEMENT is the article's. Authored as its own
+      series rather than a variant because BOTH the design and the format differ from
+      ca-pe-standard-2022, which is the PRD-PLATES §2.3 test twice over.
+
+  # =========================================================================
+  # COMMERCIAL — and the stacked-character case.
+  # =========================================================================
+  - id: ca-pe-commercial-2013
+    class: standard
+    categories: [truck, van]
+    period: { start: 2013 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "CVL9 999"
+      regex: '\ACV[A-Z]\d ?\d{3}\z'
+      charset:
+        notes: >-
+          THE STACKED PAIR IS PART OF THE SERIAL. The article records the format as
+          CVC1 234 with the note "Letters CV are stacked on left" — two half-height
+          characters printed one above the other at the left edge, followed by the
+          rest of the serial at full height. AAMVA Ed. 3: "If stacked characters are
+          used, they are part of the official license plate number. No more than two
+          characters are to be stacked." This file therefore spells CV as ordinary
+          leading characters in `pattern` and `regex`, and records the stacking in
+          `design.stacked_characters`. A NORMALISER THAT DROPS THEM WILL CORRUPT
+          EVERY PRINCE EDWARD ISLAND COMMERCIAL PLATE, which is why the fact is
+          stated twice.
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#8B6F47"
+      legend_top: "PRINCE EDWARD ISLAND"
+      legend_bottom_options: ["Birthplace of Confederation"]
+      emblem: { present: true, rendered: placeholder, description: "Province House facsimile at the left" }
+      stacked_characters: { present: true, count: 2, content: "CV", position: "left edge, half height, one above the other", note: "part of the official plate number per AAMVA Ed. 3 §, recorded here so a renderer lays them out correctly and a parser does not discard them" }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR (HTA ss. 20(1), 21(1.1)); FRONT if the vehicle is a truck-tractor (s. 21(2)) — which in a commercial fleet is common, so the front-plate case is not exotic here"
+    sources:
+      - "https://www.princeedwardisland.ca/sites/default/files/legislation/h-05-highway_traffic_act.pdf  # HTA s. 21(2): the truck-tractor front-plate rule, which bites hardest on this class"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Prince_Edward_Island  # TAGGED SECONDARY: the CVC1 234 commercial format on the 2013 base and the stacked-CV note"
+      - "https://www.aamva.org/getmedia/646bcc8a-219b-47d8-b5cd-726240473163/License-Plate-Standard-Edition-3_September-2025-Update.pdf  # AAMVA License Plate Standard Edition 3 (September 2025): stacked characters are part of the official plate number, maximum two. Voluntary recommended practice, not law in any Canadian province — cited for the NORMALISATION rule, not as a Prince Edward Island requirement."
+    notes: >-
+      THE STACKED-CHARACTER CASE OF THE CANADA EAST WAVE. `class: standard` because
+      the vocabulary has no commercial member. Format and period are the article's;
+      the display rule is statutory. Note that the article's own rendering, "CVC1
+      234", is ambiguous about where the stacked pair ends — this file reads it as
+      CV stacked plus C1 234, which is the reading the accompanying note ("Letters CV
+      are stacked on left") supports, and flags the reading as a modelling decision
+      so a verifier can check it against a photograph.
+
+  # =========================================================================
+  # SERVICE VEHICLE — the second stacked-pair series.
+  # =========================================================================
+  - id: ca-pe-service-2013
+    class: government
+    categories: [car, van, truck]
+    period: { start: 2013 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "SV99 999"
+      regex: '\ASV\d{2} ?\d{3}\z'
+      charset: { notes: "SV stacked at the left, then five numerals. Same stacked-character treatment as ca-pe-commercial-2013 and the same warning applies." }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#8B6F47"
+      legend_top: "PRINCE EDWARD ISLAND"
+      legend_bottom_options: ["Birthplace of Confederation"]
+      emblem: { present: true, rendered: placeholder }
+      stacked_characters: { present: true, count: 2, content: "SV", position: "left edge, half height" }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Prince_Edward_Island  # TAGGED SECONDARY: the SV12 345 service-vehicle format on the 2013 base, with SV stacked; the earlier SV A12 form on the 1997-2012 bases"
+    notes: >-
+      `class: government` is the least-wrong member of the vocabulary for a Prince
+      Edward Island "Service Vehicle" plate, and the choice is flagged: the article
+      does not say who holds them, and no instrument names the class. If a verifier
+      establishes that the class is commercial rather than governmental, the class
+      value moves and the id stays (PRD-QUALITY I-5/I-6). Entirely secondary.
+
+  # =========================================================================
+  # TRAILER.
+  # =========================================================================
+  - id: ca-pe-trailer-2013
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 2013 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: 'T\LR99T99'
+      regex: '\ATLR\d{2}T\d{2}\z'
+      charset: { notes: "the literal TLR opens the serial and a further literal T sits between the two digit pairs — an unusual shape, and the article gives it as TLR12T34 with no note about stacking. NOTE THE PATTERN ESCAPE: the L in TLR is a literal L, so the pattern writes `\L` (PRD-PLATES §2.2, owner ruling 2026-08-02), single-quoted so YAML keeps the backslash" }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#8B6F47"
+      legend_top: "PRINCE EDWARD ISLAND"
+      legend_bottom_options: ["Birthplace of Confederation"]
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "ONE plate, REAR — HTA s. 1(l) brings a trailer and a semi-trailer inside the definition of 'number plate', and s. 21(1.1) puts the plate on the rear"
+    sources:
+      - "https://www.princeedwardisland.ca/sites/default/files/legislation/h-05-highway_traffic_act.pdf  # HTA s. 1(l): 'number plate' includes proof of registration required to be affixed to 'a motor vehicle, trailer or semi-trailer'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Prince_Edward_Island  # TAGGED SECONDARY: the TLR12T34 trailer format on the 2013 base, replacing 12 3AT from 1997"
+    notes: >-
+      THE ODDEST SERIAL SHAPE IN THE CANADA EAST WAVE — a three-letter literal
+      prefix and an infixed literal T — and it is entirely secondary. Authored
+      because a shape that unusual is highly diagnostic when it appears, and because
+      recording it costs nothing that a flag does not cover.
+
+  # =========================================================================
+  # DEALER — the one non-passenger class the ACT describes.
+  # =========================================================================
+  - id: ca-pe-dealer
+    class: dealer
+    categories: [car, van, truck, trailer]
+    period: { start: 1988 }
+    period_evidence: statutory-authority-undated
+    matching: strict
+    format:
+      pattern: 'D\LR9999'
+      regex: '\ADLR ?\d{4}\z'
+      charset: { notes: "the literal DLR is the class marker; four numerals follow. The L is escaped as `\L` in the pattern because L is the DSL's letter token (PRD-PLATES §2.2). The arrangement is the article's; that the plate must carry a distinguishing letter or device is STATUTORY — see `statutory_basis`." }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFD100", finish: retroreflective, hex_basis: observed }
+      foreground: "#C8102E"
+      colour_note: "RED SERIAL ON REFLECTIVE YELLOW per the article — the only non-white field in this file and instantly diagnostic. Observed; no instrument states it."
+      legend_top: "Prince Edward Island"
+      legend_bottom_options: ["Dealer"]
+      emblem: { present: false, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    binding: business
+    statutory_basis:
+      text: >-
+        HTA s. 41, verbatim: "Dealer's number plates shall bear letters or other
+        devices thereon to distinguish them from number plates issued to persons
+        other than dealers; such dealer's number plates shall be TRANSFERABLE FROM
+        ONE VEHICLE TO ANOTHER VEHICLE BY THE DEALER, but vehicles with a dealer's
+        number plate displayed thereon shall not be used for any other purpose than
+        for the trial and adjustment of the vehicle, or for its demonstration to a
+        prospective buyer, or for some purpose incidental to the motor vehicle
+        business of the dealer, and in no case shall a motor vehicle trailer or
+        semi-trailer displaying the dealer's number plates be rented for hire or used
+        by any person for the purpose of conveying passengers or freight or be
+        operated for private use."
+      note: >-
+        A STATUTE THAT REQUIRES A CLASS MARKER WITHOUT NAMING IT — "letters or other
+        devices thereon to distinguish them" — which is exactly the level of
+        specificity the Prince Edward Island Act operates at throughout, and which
+        the article's DLR prefix is consistent with. s. 42(1) then makes it an
+        offence to operate a dealer-plated vehicle on a highway at all, except as
+        s. 42(2) provides.
+    sources:
+      - "https://www.princeedwardisland.ca/sites/default/files/legislation/h-05-highway_traffic_act.pdf  # HTA ss. 41-42: the distinguishing-marker requirement, the transferability rule, the permitted-use list and the operating prohibition — quoted above; s. 35 (dealer's trade licence and number plate); s. 51 (regulations respecting dealer's number plates and licences)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Prince_Edward_Island  # TAGGED SECONDARY: the DLR1234 arrangement and the red-on-yellow colours"
+    notes: >-
+      THE ONLY PRINCE EDWARD ISLAND NON-PASSENGER CLASS THE ACT ITSELF DESCRIBES,
+      and the description is a good one: s. 41 requires a distinguishing marker,
+      makes the plate transferable between vehicles by the dealer (hence `binding:
+      business`), and enumerates the permitted uses. period.start 1988 is the year
+      of the Revised Statutes edition the section sits in (R.S.P.E.I. 1988, c. H-5,
+      itself carrying "R.S.P.E.I. 1974, Cap. H-6, s.41") — a FLOOR, not a start,
+      hence `statutory-authority-undated`. The DLR arrangement and the colours are
+      the article's.
+
+  # =========================================================================
+  # VOLUNTEER FIREFIGHTER.
+  # =========================================================================
+  - id: ca-pe-firefighter-2013
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2013 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "99 9FL"
+      regex: '\A\d{2} ?\dF[A-Z]\z'
+      charset: { notes: "two numerals, the crest, a numeral and the literal F followed by one letter. The article records the letter blocks in use as FD to FS, which is an allocation fact rather than a grammar fact and is not encoded." }
+    design:
+      plate: { w: 12, h: 6, unit: in, plate_basis: convention }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#8B6F47"
+      legend_top: "PRINCE EDWARD ISLAND"
+      legend_bottom_options: ["Birthplace of Confederation"]
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Prince_Edward_Island  # TAGGED SECONDARY: the volunteer-firefighter series from 1993 (A12), through 1A1 on the 1997 and 2007 bases, to 12 3FA on the 2013 base with blocks FD to FS"
+    notes: >-
+      `class: specialty` for the same reason as Nova Scotia's firefighter plate: the
+      vocabulary has no firefighter member and PRD-PLATES §2.3 forbids inventing
+      one. Entirely secondary. Worth authoring because the embedded literal F makes
+      the shape recognisable, and because the Canada east wave now carries a
+      firefighter series in two provinces — Nova Scotia's with a statutory grammar
+      (LLL9, N.S. Reg. 49/91) and Prince Edward Island's with none — which is a
+      useful contrast for a verifier calibrating how much these secondaries are
+      worth.

--- a/plates/ca-qc.yml
+++ b/plates/ca-qc.yml
@@ -1,0 +1,1036 @@
+# plates/ca-qc.yml — Québec, Canada (PRD-PLATES gate L2/L3, Canada east wave).
+#
+# QUÉBEC IS THE BEST-LEGISLATED PLATE JURISDICTION IN CANADA AND ONE OF THE BEST
+# IN THIS DATASET. Where Ontario, Nova Scotia and New Brunswick leave the whole
+# serial system to administrative discretion, Québec puts the CLASS PREFIX TABLE
+# IN A REGULATION and the SERIAL ALPHABET IN THE CODE ITSELF. Everything below
+# that carries a prefix — F, L, R, A, C, V, X, M, CC, CD, VA2, VE2 — is quoted
+# from the Règlement sur l'immatriculation des véhicules routiers, article by
+# article. That is a closed, primary, statutory decode table, and it is why this
+# file has more `enabling-instrument` grades than any other Canadian file.
+#
+# ALL LEGAL SOURCES HERE ARE FRENCH-ONLY IN PRACTICE AND ARE QUOTED IN FRENCH.
+# LégisQuébec serves an English version of the Code de la sécurité routière, but
+# the Règlement sur l'immatriculation is consulted and quoted here in its French
+# text, which is the version LégisQuébec marks "Ce document a valeur officielle."
+# Every quotation is followed by a translation note in English; the translations
+# are ours and are labelled as such, never presented as the instrument's words.
+#
+# FIVE STRUCTURAL FACTS THAT SHAPE THIS FILE
+#
+# 1. THE SERIAL ALPHABET IS STATUTORY, WHICH IS RARE. CSR art. 32.1 al. 1,
+#    verbatim: « Tout numéro de plaque d'immatriculation se compose de lettres
+#    majuscules de l'alphabet latin, de chiffres arabes ou d'une combinaison des
+#    deux. Il doit être compatible avec le système de numérotation des plaques
+#    établi par la Société et doit être facile à lire. » (OUR TRANSLATION: every
+#    plate number is composed of uppercase letters of the Latin alphabet, Arabic
+#    numerals, or a combination of the two; it must be compatible with the
+#    numbering system established by the Société and must be easy to read.) That
+#    is the outer legal bound for every Québec serial, and it is exactly the
+#    dataset-wide serial alphabet from _meta/separators.yml — so no
+#    `serial_alphabet:` declaration is needed here, and its absence is a sourced
+#    finding rather than a default.
+#
+# 2. THE CLASS PREFIX IS THE DECODE, AND IT IS IN THE REGULATION. Règlement
+#    arts. 97-141 assign a prefix per vehicle class: no prefix for a private
+#    passenger vehicle (art. 97), M or none for a motorcycle or moped (art. 100),
+#    F or FZ for commercial (art. 102), L for trucks and farm vehicles over
+#    3 000 kg (art. 110), R or U for trailers (art. 113), A/AE/AP/AU for buses
+#    (art. 114), C for restricted-circulation vehicles (arts. 124, 136, 137), V
+#    for off-road (arts. 139-141), X for removable dealer plates (art. 159), CD
+#    for diplomatic (art. 98), CC for consular (art. 99), VA2/VE2 for licensed
+#    radio amateurs (art. 97 al. 2). THE PREFIXES ARE PRIMARY. The digit-and-
+#    letter arrangement that follows each prefix is NOT in any instrument and is
+#    graded `secondary-wikipedia` wherever it appears below.
+#
+# 3. THE GREEN-LETTERING PLATE HAS A DATE IN THE REGULATION — the single
+#    strongest period claim in the Canada east wave. Règlement art. 7.1,
+#    verbatim: « La Société délivre, pour un véhicule routier à propulsion
+#    électrique équipé d'une batterie rechargeable par branchement au réseau
+#    électrique ou alimenté par une pile à hydrogène, une plaque d'immatriculation
+#    avec lettrage vert. Cette plaque est délivrée pour tout véhicule routier visé
+#    au premier alinéa immatriculé à compter du 26 octobre 2017 ou, si le véhicule
+#    n'en est pas déjà muni, lors du remplacement de la plaque. » Inserted by
+#    décret 968-2017, art. 1. A DAY, IN THE INSTRUMENT, FOR A DESIGN. See
+#    ca-qc-electric-2017 for the disagreement this creates with the secondary
+#    record, which is recorded and not averaged (PRD-PLATES §5.3).
+#
+# 4. QUÉBEC IS A ONE-PLATE PROVINCE, REAR, WITH ONE STATUTORY INVERSION.
+#    CSR art. 30 al. 1, verbatim: « Le propriétaire d'un véhicule routier doit
+#    fixer solidement la plaque d'immatriculation qui lui a été délivrée à
+#    l'arrière du véhicule ou à tout autre endroit déterminé par règlement. »
+#    Al. 2 contemplates two copies where a regulation prescribes them. The
+#    inversion is Règlement art. 8: the plate of a tractor unit built to draw a
+#    trailer « doit être fixée à l'AVANT de ce véhicule » — front-only, the same
+#    outlier shape as Florida's truck-tractor rule and Prince Edward Island's.
+#
+# 5. THE SAAQ WEBSITE COULD NOT BE READ FROM THIS LOCATION, AND THAT IS RECORDED
+#    RATHER THAN WORKED AROUND. Every saaq.gouv.qc.ca URL attempted on 2026-08-02
+#    (French and English, direct, and through WebFetch) 303-redirected to
+#    messages.saaq.gouv.qc.ca and served: « ACCÈS REFUSÉ (ERREUR 403) — Nous
+#    sommes désolés. Nous ne pouvons pas vous donner accès à cette page pour le
+#    moment. Cela peut être dû à un problème de connexion ou à des restrictions
+#    spécifiques appliquées dans certains pays. » The SAAQ is GEO-BLOCKED. No
+#    SAAQ page is quoted anywhere in this file; the agency's own plate-category
+#    page is cited as a known, unread source on the series it would corroborate.
+#
+# SEPARATOR NOTE (PRD-PLATES §2.6): Québec prints a GAP between groups, not a
+# glyph — the plates read "H32 KGA" with white space. Every `pattern` spells the
+# emitted SPACE and every regex accepts it as optional. Règlement art. 139 al. 2
+# and art. 141 al. 2 are the one place a Québec instrument mentions a printed
+# separator at all: a personalized plate on an all-terrain vehicle or a snowmobile
+# « porte le préfixe “V” suivi d'un trait d'union » (bears the prefix V followed
+# by a HYPHEN). That hyphen is an emitted separator under §2.6 and is spelled as
+# one on ca-qc-personalized's off-road variant.
+jurisdiction: ca-qc
+authority:
+  name: Société de l'assurance automobile du Québec (SAAQ)
+  url: "https://saaq.gouv.qc.ca/en/vehicle-registration/categories-licence-plates/"
+  url_note: "CITED, NOT READ — saaq.gouv.qc.ca is geo-blocked from this location (see header fact 5). Every claim in this file comes from LégisQuébec or is tagged secondary."
+binding: vehicle
+binding_note: >-
+  A Québec plate is ASSOCIATED with a vehicle and the association is what makes
+  it valid: Règlement art. 5, verbatim: « Une plaque d'immatriculation, autre
+  qu'une plaque d'immatriculation amovible, est valide tant qu'elle est associée
+  à un véhicule routier. » (OUR TRANSLATION: a registration plate, other than a
+  removable plate, is valid as long as it is associated with a road vehicle.)
+  BUT THE HOLDER MAY MOVE IT: Règlement art. 7 al. 2 §2 lets an owner ask the
+  Société « d'associer au véhicule une plaque d'immatriculation dont il est
+  titulaire » (to associate with the vehicle a plate of which he is the holder),
+  and CSR art. 43 says that on selling to a dealer and buying another vehicle
+  « le cédant ... doit conserver la plaque d'immatriculation » — the seller KEEPS
+  the plate. So `binding: vehicle` is right for the CURRENT state (one plate, one
+  vehicle, recorded in the register) while the plate itself is portable within
+  the holder's fleet, subject to Règlement art. 7 al. 3: the plate must be of a
+  category matching the declared use. Contrast plates/ca-on.yml, where the Act
+  makes the plate the registrant's outright (`binding: owner`). CSR art. 10.3:
+  « Toute plaque d'immatriculation délivrée par la Société demeure sa propriété. »
+instrument:
+  code: "Code de la sécurité routière, RLRQ chapitre C-24.2 (CSR) — arts. 10.1, 10.3, 10.4, 28, 30, 31, 32, 32.1-32.4, 33, 34, 37-39, 42, 43, 50, 54, 54.1, 54.2, 57"
+  regulation: "Règlement sur l'immatriculation des véhicules routiers, RLRQ chapitre C-24.2, r. 29, made under CSR arts. 618, 619.1, 619.3 and 621 al. 1 §§1, 28, 29"
+  regulation_base: "D. 1420-91 (décret 1420-91); D. 1876-92, a. 1"
+  regulation_currency: "« À jour au 1er avril 2026. Ce document a valeur officielle. » — LégisQuébec's own currency and authority statement on the regulation, read 2026-08-02"
+  key_amendments:
+    - "D. 968-2017, a. 1 — inserted art. 7.1 (green-lettering plate for plug-in electric and hydrogen fuel-cell vehicles)"
+    - "L.Q. 2018, c. 18, a. 35 — inserted arts. 7.2 to 7.7 (the personalized-plate regime: eligibility, activation, validity, number reuse, management fees)"
+    - "D. 997-2022 — inserted art. 7.1.1 (paper « provisoire » plate) and art. 9.1 (where it is displayed); amended arts. 7, 7.1, 7.7"
+  sources:
+    - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement sur l'immatriculation des véhicules routiers, full French text, accessed 2026-08-02"
+    - "https://www.legisquebec.gouv.qc.ca/fr/document/lc/C-24.2  # Code de la sécurité routière, full French text, accessed 2026-08-02"
+  licence: >-
+    LégisQuébec is published by the Éditeur officiel du Québec / Les Publications
+    du Québec. Statutes and regulations are EDICTS OF GOVERNMENT and their text is
+    uncopyrightable (PRD-PLATES §4); every verbatim quotation in this file is from
+    that class of material. Translations into English are OURS and are marked.
+
+artwork_risk:
+  posture: crown-copyright-asserted
+  basis: >-
+    Québec asserts Crown copyright (« © Gouvernement du Québec ») across its
+    sites, and the SAAQ additionally geo-blocks access, so no assessment of the
+    plate ARTWORK's licence was possible. The instrument TEXT is free as an edict
+    of government and is quoted freely here. Nothing else is assumed.
+  emblem_rule: >-
+    PRD-PLATES §3 placeholder default applies without exception. The fleur-de-lys
+    and the « Je me souviens » wordmark are rendered `placeholder`. The fleur-de-
+    lys as used on Québec plates is an element of the provincial flag and arms and
+    carries protection independent of copyright; unresearched, flagged.
+
+common:
+  serial_alphabet_statutory:
+    text: >-
+      CSR art. 32.1 al. 1, verbatim: « Tout numéro de plaque d'immatriculation se
+      compose de lettres majuscules de l'alphabet latin, de chiffres arabes ou
+      d'une combinaison des deux. Il doit être compatible avec le système de
+      numérotation des plaques établi par la Société et doit être facile à lire. »
+    translation_note: "OUR TRANSLATION: every plate number consists of uppercase Latin letters, Arabic numerals, or a combination of the two; it must be compatible with the numbering system established by the Société and must be easy to read."
+    consequence: >-
+      This is the `regex_statutory` bound for the whole jurisdiction. It is stated
+      once here and referenced rather than repeated on every series, because it is
+      the SAME bound everywhere: uppercase A-Z and 0-9, any length, subject only
+      to SAAQ's own numbering system and to legibility.
+    source: "https://www.legisquebec.gouv.qc.ca/fr/document/lc/C-24.2  # CSR art. 32.1 al. 1"
+  inscriptions:
+    text: "CSR art. 32 al. 1, verbatim: « Une plaque d'immatriculation ne peut porter une inscription autre que celles déterminées par la Société. »"
+    translation_note: "OUR TRANSLATION: a registration plate may not bear any inscription other than those determined by the Société."
+    consequence: "The legends, slogan and graphics on a Québec plate are SAAQ's administrative choice, not law — which is why every colour and legend claim below is `hex_basis: observed` or tagged secondary."
+    source: "https://www.legisquebec.gouv.qc.ca/fr/document/lc/C-24.2  # CSR art. 32 al. 1-2"
+  display:
+    rear_default:
+      text: "CSR art. 30, verbatim: « Le propriétaire d'un véhicule routier doit fixer solidement la plaque d'immatriculation qui lui a été délivrée à l'arrière du véhicule ou à tout autre endroit déterminé par règlement. Toutefois, si un règlement prescrit la délivrance de deux exemplaires de la plaque d'immatriculation, ceux-ci doivent être fixés l'un à l'avant et l'autre à l'arrière du véhicule. »"
+      translation_note: "OUR TRANSLATION: the owner must securely fix the plate issued to him to the REAR of the vehicle or at any other place determined by regulation; where a regulation prescribes two copies, one goes at the front and the other at the rear."
+    tractor_unit_front:
+      text: "Règlement art. 8, verbatim: « La plaque d'immatriculation d'un véhicule automobile composant un ensemble de véhicules routiers, lorsque ce véhicule a été essentiellement conçu pour tirer une remorque doit être fixée à l'avant de ce véhicule. »"
+      translation_note: "OUR TRANSLATION: the plate of a motor vehicle forming part of a road-train, where that vehicle was essentially designed to draw a trailer, must be fixed to the FRONT of that vehicle."
+      note: "The Florida / Prince Edward Island truck-tractor inversion, in Québec law. A front-only plate on a tractor unit is correct, not a fault."
+    snowmobile: "Règlement art. 9: a snowmobile's plate goes at the rear or on the outer left vertical surface of the track tunnel, as close to the rear as possible."
+    legibility:
+      text: "CSR art. 32 al. 2, verbatim: « La plaque d'immatriculation doit être libre de tout objet ou de toute matière pouvant en empêcher la lecture. Elle doit, en outre, lorsqu'elle est apposée à l'arrière du véhicule, être suffisamment éclairée. » CSR art. 33 lets a peace officer require the driver to CLEAN the plate."
+    confusable_plates: "CSR art. 34 forbids fixing any plate or sticker that could be confused with a SAAQ plate or control sticker."
+    source: "https://www.legisquebec.gouv.qc.ca/fr/document/lc/C-24.2  # CSR arts. 30, 32, 33, 34"
+    source_regulation: "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement arts. 8, 9, 9.1, 10"
+  class_prefixes:
+    note: >-
+      THE CLOSED, PRIMARY, STATUTORY PREFIX TABLE. Inline rather than in a
+      _decode file because it is small (thirteen rows) and because it decodes
+      VEHICLE CLASS rather than geography — a Québec plate encodes NO region and
+      NO date, and a parse API must not infer either.
+    rows:
+      - { prefix: "(none)", meaning: "véhicule de promenade / motorized home ≤ 3 000 kg owned by a natural person and used mainly for personal purposes", article: "art. 97 al. 1" }
+      - { prefix: "VA2, VE2", meaning: "passenger vehicle of a licensed radio amateur", article: "art. 97 al. 2" }
+      - { prefix: "CD", meaning: "diplomatic corps — official vehicle of a foreign state with a permanent mission to an intergovernmental international organization established in Québec, and related categories", article: "art. 98" }
+      - { prefix: "CC", meaning: "consular corps — official vehicle of a foreign state with a consular post in Québec headed by a career consular officer, and related categories", article: "art. 99" }
+      - { prefix: "M or none", meaning: "cyclomoteur (moped) and motocyclette (motorcycle)", article: "art. 100" }
+      - { prefix: "F, FZ", meaning: "commercial vehicle, farm vehicle, driving-school vehicle, school-transport vehicle, snow blower, ambulance, hearse, tool-vehicle, tow truck, motorized home > 3 000 kg (excluding mopeds and motorcycles)", article: "art. 102" }
+      - { prefix: "L", meaning: "camion (truck) and farm vehicle over 3 000 kg net mass", article: "art. 110" }
+      - { prefix: "PRP (sticker)", meaning: "vignette bearing the letters PRP for vehicles admitted to proportional (IRP) registration and used in Québec plus at least one other jurisdiction", article: "art. 112.1" }
+      - { prefix: "R, U", meaning: "remorque (trailer); U is the retired form for farm trailers registered before 1 January 1989", article: "art. 113" }
+      - { prefix: "A, AE, AP, AU", meaning: "autobus or minibus", article: "art. 114" }
+      - { prefix: "C", meaning: "restricted circulation — vehicles used in a locality not linked to the general Québec road network (art. 124), farm tractors on a public road (art. 136), artisan-built vehicles and the like (art. 137)", article: "arts. 124, 136, 137" }
+      - { prefix: "V", meaning: "vehicles used exclusively on private land or roads including metal-tracked vehicles (art. 139), vehicles used exclusively in stations, ports and airports (art. 140), snowmobiles of 450 kg or less (art. 141)", article: "arts. 139, 140, 141" }
+      - { prefix: "X", meaning: "plaque d'immatriculation amovible — the removable plate issued to a dealer, manufacturer or body-builder under arts. 143 and 149", article: "art. 159" }
+    verbatim_samples:
+      - "art. 100: « La plaque d'immatriculation d'un cyclomoteur et d'une motocyclette porte le préfixe “M” ou aucun préfixe. »"
+      - "art. 110: « La plaque d'immatriculation d'un camion et d'un véhicule de ferme dont la masse nette est de plus de 3 000 kg porte le préfixe “L”. »"
+      - "art. 113: « La plaque d'immatriculation d'une remorque porte le préfixe “R” ou “U”. »"
+      - "art. 114: « La plaque d'immatriculation d'un autobus ou d'un minibus porte le préfixe “A”, “AE”, “AP” ou “AU”. »"
+      - "art. 159: « Au moment de l'immatriculation des catégories de véhicules routiers mentionnées à l'un des articles 143 et 149, la Société délivre un certificat d'immatriculation et une plaque d'immatriculation amovible portant le préfixe “X” à la personne au nom de laquelle est effectuée l'immatriculation de ces catégories. »"
+    retired_prefixes_note: >-
+      SECONDARY, TAGGED, AND USEFUL FOR OLD PLATES: the en.wikipedia Québec article
+      lists retired prefixes — U (farm trailers before 1989) -> R; GQ (Government
+      of Québec), GP (Sûreté du Québec), G (Government of Canada), CO and H
+      (hearse), AM and H (ambulance), ZZ (short-term rental), Z and FZ (long-term
+      commercial lease) — all folded into F. The FZ survival in art. 102 is
+      confirmed by the regulation; the rest are the article's and are not asserted.
+      The T (taxi) prefix was withdrawn when Québec deregulated the taxi industry;
+      the article dates the end of issuance to 10 October 2020 and the phase-out to
+      13 October 2020 and 31 March 2021, citing Transports Québec, and this file
+      does not author a taxi series because no grammar and no primary date were
+      obtained.
+    source: "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement arts. 97-114, 124, 136, 137, 139-141, 159 — every prefix above quoted from its own article"
+    source_secondary: "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY (PRD-PLATES §4, owner override 2026-08-02), read 2026-08-02: the retired-prefix list, the XA motorcycle-dealer form, and every digit-and-letter arrangement in this file"
+  dimensions:
+    note: >-
+      NO QUÉBEC INSTRUMENT PRESCRIBES A PLATE SIZE. The Règlement and the CSR were
+      both searched: neither states a dimension, a character height or a colour.
+      The 30 x 15 cm standard plate and the 20 x 10 cm small (motorcycle, moped,
+      off-road) plate are the article's and are recorded on the series below as
+      `plate_basis: secondary-wikipedia`, never as a Québec legal claim.
+    source_secondary: "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # 30 cm x 15 cm standard and 20 cm x 10 cm small, blue-on-white standard and green-on-white electric"
+
+classes_not_modelled:
+  temporary:
+    exists: true
+    mechanism: >-
+      Règlement art. 7.1.1, verbatim: « Lorsqu'une plaque d'immatriculation ne peut
+      être délivrée sur support métallique au moment de l'immatriculation, la
+      Société délivre, en attendant, une plaque d'immatriculation portant la
+      mention "provisoire" et, le cas échéant, les mentions suivantes: 1° "plaque
+      verte", s'il s'agit d'un véhicule routier à propulsion électrique ...;
+      2° "PRP", s'il s'agit d'un véhicule routier qui satisfait aux conditions pour
+      l'immatriculation proportionnelle. » Art. 9.1: it is affixed « dans la partie
+      supérieure gauche de la lunette arrière du véhicule ou, si elle ne peut
+      l'être, dans la partie supérieure gauche du pare-brise » — inside the rear
+      window, or the windscreen. Inserted by D. 997-2022.
+    translation_note: "OUR TRANSLATION: where a metal plate cannot be issued at registration, the Société issues in the meantime a plate bearing the word « provisoire » and, where applicable, « plaque verte » or « PRP »."
+    why_not_modelled: >-
+      The instrument prescribes the LEGENDS and the POSITION and never the serial.
+      A « provisoire » plate carries the registration number the vehicle is being
+      given, so its grammar is whichever series applies — modelling it would mean
+      authoring a union with no independent content. Recorded as a gap.
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement arts. 7.1.1, 9.1, 13 §14 (the validity dates that must be recorded for a provisoire plate)"
+  proportional_irp:
+    exists: true
+    mechanism: >-
+      Règlement art. 112.1: trucks, tractor vehicles, buses and certain others
+      admitted to proportional registration and operating in Québec plus at least
+      one other jurisdiction carry « une vignette portant les lettres “PRP” ».
+      Art. 2.2 treats a vehicle as registered in conformity with the CSR where its
+      plate « porte le préfixe “PRP”, le mot "APPORTIONNED" ou est muni d'une
+      vignette portant le préfixe "PRP" ».
+    why_not_modelled: >-
+      PRP is a STICKER ON an existing plate, not a plate series: the underlying
+      serial is the F or L series serial. Authoring it would double-count.
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement arts. 2.2, 112.1, 60.38"
+  taxi:
+    exists: false
+    mechanism: >-
+      The T prefix was withdrawn with the modernization of the Québec taxi
+      industry; taxis now carry ordinary or F plates. The regulation as consulted
+      on 2026-08-02 contains NO T prefix — the negative is checked, not assumed —
+      and directs the reader to arts. 18 and 19 of the Règlement sur le transport
+      rémunéré de personnes par automobile (chapitre T-11.2, r. 4).
+    why_not_modelled: "Class no longer issued; no primary dating the withdrawal was obtained (the article's 2020-2021 dates cite Transports Québec pages not fetched). Recorded as a gap for L4."
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # the regulation's own cross-reference to chapitre T-11.2, r. 4; no T prefix appears anywhere in arts. 97-141"
+
+series:
+
+  # =========================================================================
+  # CURRENT PASSENGER — ABC 12D, since about 15 September 2023.
+  # =========================================================================
+  - id: ca-qc-passenger-2023
+    class: standard
+    categories: [car, van, motorhome]
+    period: { start: 2023 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL 99L"
+      regex: '\A[A-Z]{3} ?\d{2}[A-Z]\z'
+      regex_strict: '\A[ACEFGHJKLMNPRTVWXYZ][ABCDEFGHJKLMNPQRSTVWXYZ]{2} ?\d{2}[ABCDEFGHJKLMNPQRSTVWXYZ]\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      charset:
+        excluded_everywhere: [I, O, U]
+        excluded_first_letter: [B, D, I, O, Q, S, U]
+        notes: >-
+          TAGGED SECONDARY. The article states that I, O and U have been unused in
+          Québec serials since 1996 and that B, D, Q and S are not used as first
+          letters in this format. No SAAQ page could be read to corroborate it
+          (geo-block) and CSR art. 32.1 imposes only the Latin-uppercase-plus-
+          Arabic-numerals rule. Encoded ONLY in `regex_strict`.
+      statutory_note: >-
+        `regex_statutory` is CSR art. 32.1 al. 1 and nothing more: uppercase Latin
+        letters, Arabic numerals, or a combination, of unbounded length, printed
+        with the ordinary Québec group gap. It is the honest outer bound for a
+        Québec plate of unknown class and vintage — deliberately very wide, because
+        the statute really is that wide.
+      progression: "AAA 01A upward per the article's issuance record"
+      separator_note: "printed as a gap, no glyph; `pattern` spells the emitted space and both regexes accept it as optional"
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      colour_note: "blue on white. NO QUÉBEC INSTRUMENT STATES A COLOUR — CSR art. 32 leaves every inscription to SAAQ. Both hexes are observed."
+      legend_top: "Québec"
+      legend_bottom_options: ["Je me souviens"]
+      emblem: { present: true, rendered: placeholder, description: "fleur-de-lys beside the province name" }
+      band: { side: none }
+      rear_differs: false
+      display: "REAR ONLY (CSR art. 30 al. 1)"
+    region_encoding: none
+    region_encoding_note: "A Québec plate encodes NO geography and NO date — only class, through the prefix table, and a private passenger plate has no prefix at all."
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 97 al. 1: « la plaque d'immatriculation des véhicules routiers suivants appartenant à une personne physique et utilisés principalement à des fins personnelles ne porte aucun préfixe: 1° un véhicule de promenade; 2° une habitation motorisée qui a une masse nette de 3 000 kg ou moins » — the primary basis for the NO-PREFIX shape of this series"
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/lc/C-24.2  # CSR art. 32.1 al. 1 (the serial alphabet, hence regex_statutory); art. 30 (rear display); art. 10.3 (plates remain SAAQ property)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the ABC 12D arrangement, its circa-15-September-2023 start, the B/D/Q/S first-letter exclusion and the I/O/U exclusion. The article's own citations for the change are two Le Soleil articles (15 and 25 September 2023), which were not fetched."
+    notes: >-
+      THE CURRENT QUÉBEC PASSENGER PLATE. The SHAPE of the series is primary — art.
+      97 says in terms that a private passenger plate carries no prefix, which is
+      why `regex` has no prefix and why that absence is a claim rather than an
+      omission. The ARRANGEMENT and the DATE are not: ABC 12D and its September
+      2023 start are the article's, sourced there to Le Soleil, and are graded
+      `secondary-wikipedia`. WHY 2023 AND NOT 2022 IS THE INTERESTING PART: Québec
+      ran the immediately preceding 12A BCD arrangement for roughly nine months
+      before withdrawing it, the article says, because too many offensive letter
+      combinations were reachable. That makes "one series back" ambiguous in
+      Québec, so this file authors TWO predecessors and says why (see
+      ca-qc-passenger-2022 and ca-qc-passenger-2009).
+
+  - id: ca-qc-passenger-2022
+    class: standard
+    categories: [car, van, motorhome]
+    period: { start: 2022, end: 2023 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "99L LLL"
+      regex: '\A\d{2}[A-Z] ?[A-Z]{3}\z'
+      regex_strict: '\A\d{2}[ACEFGHJKLMNPRTVWXYZ] ?[ABCDEFGHJKLMNPQRSTVWXYZ]{3}\z'
+      charset: { excluded_everywhere: [I, O, U], excluded_first_letter: [B, D, Q, S], notes: "as ca-qc-passenger-2023; the first LETTER is at position 3 in this arrangement" }
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      legend_bottom_options: ["Je me souviens"]
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: 12A BCD issued December 2022 to circa 15 September 2023, ranges 01A AAA to 99R AHH, discontinued 'due to the possibility of too many inappropriate combinations of letters'"
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/lc/C-24.2  # CSR art. 32.1 al. 2: the statutory power behind that withdrawal — a plate number must not, « y compris par la lecture en sens inverse », carry an expression or message falsely suggesting a public authority or otherwise prohibited"
+    notes: >-
+      THE NINE-MONTH ARRANGEMENT. Authored because it is genuinely in circulation
+      and because its withdrawal is the clearest illustration in this file of CSR
+      art. 32.1 al. 2, which polices plate numbers for offensive and misleading
+      readings INCLUDING READ BACKWARDS — a statutory rule that bites on ordinary
+      serials, not only on personalized ones. Both boundaries are the article's,
+      unfootnoted for the start and footnoted to Le Soleil for the end.
+
+  - id: ca-qc-passenger-2009
+    class: standard
+    categories: [car, van, motorhome]
+    period: { start: 2009, end: 2022 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "L99 LLL"
+      regex: '\A[A-Z]\d{2} ?[A-Z]{3}\z'
+      regex_strict: '\A[BDEGHJKMNPQSWXYZ]\d{2} ?[ABCDEFGHJKLMNPQRSTVWXYZ]{3}\z'
+      charset:
+        excluded_everywhere: [I, O, U]
+        excluded_first_letter: [A, C, F, I, L, O, R, T, U, V]
+        notes: >-
+          TAGGED SECONDARY: the article states A, C, F, L, R, T and V were not used
+          as first letters in this format — which is exactly the set of CLASS
+          PREFIXES the regulation reserves (arts. 102, 110, 113, 124, 139, 159 and
+          the A bus block), so the exclusion is corroborated by the primary prefix
+          table even though the article does not say so. That corroboration is the
+          strongest secondary-to-primary link in this file and is why this series'
+          strict twin is trustworthy.
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      legend_bottom_options: ["Je me souviens"]
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: B12 CDE issued September 2009 to December 2022, ranges B01 AAA to Z99 ZZZ, first letters A/C/F/L/R/T/V unused"
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement arts. 102, 110, 113, 114, 124, 139, 159 — the reserved class prefixes F, L, R, A, C, V and X, which independently explain the excluded first letters above"
+    notes: >-
+      THIRTEEN YEARS AND THE BULK OF THE QUÉBEC FLEET. Authored as a second
+      predecessor, against the ordinary one-back rule, because the 2022 series ran
+      only nine months: in practice the plate a consumer meets behind a Québec car
+      is far more likely to be B12 CDE than 12A BCD. The exclusion set is the one
+      place in this file where a secondary claim is independently corroborated by
+      the primary regulation, and that is recorded in `charset.notes` rather than
+      left for a verifier to notice.
+
+  # =========================================================================
+  # ELECTRIC — green lettering, with a DAY in the regulation.
+  # =========================================================================
+  - id: ca-qc-electric-2017
+    class: electric
+    categories: [car, van, truck, bus]
+    period: { start: 2017 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LLL 99L"
+      regex: '\A[A-Z]{3} ?\d{2}[A-Z]\z'
+      charset:
+        notes: >-
+          THE MARK IS THE ORDINARY MARK OF THE VEHICLE'S CLASS — art. 7.1 changes
+          the LETTERING COLOUR and nothing else. A green-lettered Québec plate on a
+          passenger car carries a passenger serial; on a commercial vehicle it
+          carries an F serial; on a bus an A serial. `regex` here encodes the
+          current PASSENGER arrangement because that is the overwhelmingly common
+          case; the other classes' arrangements are in their own series and a
+          green-lettered example of each is legal.
+      format_note: >-
+        CONTRAST plates/gb.yml `gb-green-zev-2020` (a green flash, mark unchanged,
+        powertrain UNPARSEABLE) and plates/ca-on.yml `ca-on-green-2010` (a GV/GW/VE
+        serial prefix, powertrain PARSEABLE). Québec sits between them: the serial
+        is unchanged, so a Québec EV is not identifiable from its plate STRING, but
+        it is identifiable from the plate IMAGE, because the lettering is green.
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#008C45"
+      colour_note: >-
+        The regulation says « lettrage vert » — GREEN LETTERING — and gives no
+        coordinate, no shade and no background colour. The hex is observed; the
+        FACT of greenness is primary. That split is recorded deliberately.
+      legend_top: "Québec"
+      legend_bottom_options: ["Je me souviens"]
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    eligibility:
+      text: >-
+        Règlement art. 7.1 al. 1, verbatim: « La Société délivre, pour un véhicule
+        routier à propulsion électrique équipé d'une batterie rechargeable par
+        branchement au réseau électrique ou alimenté par une pile à hydrogène, une
+        plaque d'immatriculation avec lettrage vert. »
+      translation_note: "OUR TRANSLATION: the Société issues, for a road vehicle with electric propulsion equipped with a battery rechargeable by connection to the electrical grid or powered by a hydrogen fuel cell, a registration plate with GREEN LETTERING."
+      note: "The Québec test is a PLUG OR A FUEL CELL — so a plug-in hybrid qualifies, as in Ontario, and unlike Britain's tailpipe test."
+    rollout:
+      text: >-
+        Règlement art. 7.1 al. 2, verbatim: « Cette plaque est délivrée pour tout
+        véhicule routier visé au premier alinéa immatriculé à compter du 26 octobre
+        2017 ou, si le véhicule n'en est pas déjà muni, lors du remplacement de la
+        plaque. »
+      translation_note: "OUR TRANSLATION: this plate is issued for every vehicle covered by the first paragraph registered ON OR AFTER 26 OCTOBER 2017 or, if the vehicle does not already carry one, when the plate is replaced."
+      first_issue: "2017-10-26"
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 7.1, inserted by D. 968-2017, a. 1 and amended by D. 997-2022, a. 8 — the green-lettering rule and the 26 October 2017 date, both verbatim above"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY, AND IN DISAGREEMENT: the article dates a green Québec electric plate to 2011 with an 'E00 VEA' passenger form, an 'A00000' bus form and an 'FVE0000' commercial form, citing a dead SAAQ page. Recorded, not averaged — see notes."
+    notes: >-
+      THE STRONGEST PERIOD CLAIM IN THE CANADA EAST WAVE: a DAY, in the
+      instrument, for a design — « à compter du 26 octobre 2017 ». Hence
+      `period_evidence: enabling-instrument`. THE DISAGREEMENT IS RECORDED AND NOT
+      RESOLVED, per PRD-PLATES §5.3: the en.wikipedia article says Québec issued a
+      green electric plate from 2011, six years earlier, with distinct serial forms
+      (E00 VEA and so on), and cites a SAAQ page that no longer exists and could
+      not be reached from this location anyway. Two readings fit the evidence — a
+      voluntary 2011 SAAQ programme that D. 968-2017 later made regulatory, or an
+      article error — and nothing available here distinguishes them. This file
+      dates the series from the instrument, records the 2011 claim in the sources,
+      and does NOT author the 2011 forms. A verifier with SAAQ access should settle
+      it; if the 2011 programme is real it becomes its own predecessor series.
+
+  # =========================================================================
+  # MOTORCYCLE / MOPED — the M prefix is primary, the arrangement is not.
+  # =========================================================================
+  - id: ca-qc-motorcycle-2008
+    class: motorcycle
+    categories: [motorcycle, moped, scooter]
+    period: { start: 2008 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "99999L"
+      regex: '\A\d{5}[A-Z]\z'
+      charset:
+        notes: >-
+          Note what the regulation does and does not give. Art. 100 is primary and
+          says the plate « porte le préfixe “M” ou aucun préfixe » — M OR NO PREFIX
+          — so a Québec motorcycle plate legally may carry an M and legally may
+          not. The current arrangement reported by the article carries none, which
+          is consistent with the article and with the regulation, and `regex`
+          encodes the no-prefix form. An M-prefixed Québec motorcycle plate
+          (MAA 001-era) is lawful and out of this series' regex; that is the
+          correct-but-incomplete case PRD-PLATES §2.7 calls `strict`.
+      progression: "10001A upward per the article's issuance record"
+    design:
+      plate: { w: 20, h: 10, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "REAR ONLY (CSR art. 30 al. 1)"
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 100 (the M-or-no-prefix rule, verbatim above) and art. 7.2 §2 (motorcycles, mopeds and motorized homes ≤ 3 000 kg are eligible for a personalized plate)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the 12345A arrangement from 2008 and its issuance range; the shared motorcycle/moped series since 1989"
+    notes: >-
+      ONE SERIES FOR MOTORCYCLES AND MOPEDS, which is the regulation's own cut —
+      art. 100 names « un cyclomoteur et une motocyclette » in one breath and gives
+      them one prefix rule. The arrangement and the 2008 start are the article's.
+      Québec's older M-prefixed motorcycle plates (M-12345, M-B1234, MBC 123) are
+      still revalidated per the article and are deliberately NOT authored: no
+      primary dates them and L4 owns the pre-2000 world.
+
+  # =========================================================================
+  # COMMERCIAL — the F prefix, primary, art. 102.
+  # =========================================================================
+  - id: ca-qc-commercial-f-2001
+    class: standard
+    categories: [truck, van, machine]
+    period: { start: 2001 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "FLL9999"
+      regex: '\AF[A-Z]{2}\d{4}\z'
+      charset:
+        notes: >-
+          The literal F is PRIMARY (art. 102). The two letters and four digits that
+          follow are the article's. Art. 102 also allows FZ, which the retired-
+          prefix note in `common.class_prefixes` says was the long-term commercial
+          lease form; an FZ plate matches this regex by construction because Z is a
+          letter, and that is a happy accident rather than a modelled fact.
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      legend_bottom_options: ["Je me souviens"]
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    covered_classes:
+      text: >-
+        Règlement art. 102, opening verbatim: « À l'exception d'un cyclomoteur et
+        d'une motocyclette, la plaque d'immatriculation des véhicules routiers
+        suivants porte le préfixe "F" ou "FZ": 1° un véhicule commercial; ... »
+      translation_note: "OUR TRANSLATION: except for a moped and a motorcycle, the plate of the following road vehicles bears the prefix F or FZ: commercial vehicles, and (per the enumerated paragraphs) farm vehicles, driving-school vehicles, school-transport vehicles, snow blowers, ambulances, hearses, tool-vehicles, tow trucks and motorized homes over 3 000 kg."
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 102 (the F/FZ prefix, verbatim above) and arts. 103-108.3 (the fee schedule that enumerates the covered classes)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the FBC1234 arrangement from 2001 and its issuance range FAA1001 onward"
+    notes: >-
+      THE PREFIX IS LAW AND THE REST IS REPORTED — the split this file exists to
+      make legible. `class: standard` because _meta/classes.yml has no "commercial"
+      member and inventing one ad hoc is forbidden; the category list is what
+      narrows it. A consumer reading an F prefix off a Québec plate is reading a
+      REGULATED CLASS SIGNAL, which is more than any Ontario or Atlantic plate
+      offers.
+
+  # =========================================================================
+  # HEAVY TRUCK — the L prefix, primary, art. 110.
+  # =========================================================================
+  - id: ca-qc-truck-l
+    class: standard
+    categories: [truck, tractor]
+    period: { start: 1991 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: '\L999999'
+      regex: '\AL\d{6}\z'
+      charset:
+        notes: >-
+          The literal L is PRIMARY (art. 110); the six digits are the article's.
+          NOTE THE PATTERN ESCAPE: `L` is the human-pattern DSL's own token for
+          "any letter", so a plate that PRINTS an L must write `\L` (PRD-PLATES
+          §2.2, owner ruling 2026-08-02). This is the only series in the Canada
+          east wave that needs it, and it needs it because Québec's heavy-truck
+          prefix happens to collide with the DSL. Written in single quotes so YAML
+          does not eat the backslash.
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "REAR, unless the vehicle is a tractor unit built to draw a trailer, in which case the plate goes on the FRONT (Règlement art. 8)"
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 110, verbatim: « La plaque d'immatriculation d'un camion et d'un véhicule de ferme dont la masse nette est de plus de 3 000 kg porte le préfixe “L”. » — the article carries the base citation D. 1420-91 with no later amendment to the prefix"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the L123456 arrangement"
+    notes: >-
+      period.start 1991 IS THE REGULATION'S OWN DATE AND IS GRADED HONESTLY:
+      D. 1420-91 is the décret that made the Règlement sur l'immatriculation des
+      véhicules routiers, and art. 110 carries that base citation with no amending
+      décret against it, so 1991 is the earliest date at which THIS PREFIX RULE was
+      in force. It is an `enabling-instrument` claim about the PREFIX, not about
+      the six-digit arrangement, which is the article's and is undated. Where the
+      two disagree — and here they cannot, because the article gives no date — the
+      instrument wins. The same reasoning fixes 1991 on the trailer, bus, restricted
+      and off-road series below.
+
+  # =========================================================================
+  # TRAILER — the R prefix, primary, art. 113.
+  # =========================================================================
+  - id: ca-qc-trailer-r-2007
+    class: trailer
+    categories: [trailer, semitrailer]
+    period: { start: 2007 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "RL9999L"
+      regex: '\AR[A-Z]\d{4}[A-Z]\z'
+      charset: { notes: "the literal R is PRIMARY (art. 113); the letter-four digits-letter body is the article's. Art. 113 also allows U, which the article identifies as the retired farm-trailer form replaced by R — a U plate does NOT match this regex and that is deliberate." }
+      progression: "RA0001A upward per the article's issuance record"
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 113, verbatim: « La plaque d'immatriculation d'une remorque porte le préfixe “R” ou “U”. »; art. 143 §1 (a trailer or trailer chassis may instead be registered under a removable X plate); art. 10 §1 (where a removable plate goes on a trailer)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the RB1234C arrangement from 2007 and its issuance range"
+    notes: >-
+      TRAILERS HAVE TWO LAWFUL QUÉBEC REGIMES AND BOTH ARE IN THE REGULATION: an
+      R-prefixed plate of their own (art. 113), or a dealer's removable X plate
+      under art. 143 §1 for trailers held for sale. The second is modelled as
+      ca-qc-dealer-x. The 2007 start and the arrangement are the article's.
+
+  # =========================================================================
+  # BUS — the A prefix family, primary, art. 114.
+  # =========================================================================
+  - id: ca-qc-bus-a
+    class: standard
+    categories: [bus, coach]
+    period: { start: 1991 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "A99999"
+      regex: '\AA\d{5}\z'
+      charset:
+        notes: >-
+          The A prefix is PRIMARY (art. 114), which also allows AE, AP and AU. The
+          article says the AE (school bus), AP and AU forms have been treated as A
+          plates since the 1980s but that AP appears on police buses and AU on buses
+          used as fire or emergency vehicles — an inconsistency in the secondary
+          that is recorded rather than resolved. `regex` covers the A form only;
+          AE/AP/AU plates do not match it, deliberately, because their arrangements
+          are unknown.
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 114, verbatim: « La plaque d'immatriculation d'un autobus ou d'un minibus porte le préfixe “A”, “AE”, “AP” ou “AU”. »; arts. 115-121.1 (the fee schedule distinguishing school buses and private buses)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the A 12345 arrangement, the AP police-bus and AU emergency-bus forms, and the claim that AE/AP/AU were folded into A in the 1980s"
+    notes: >-
+      period.start 1991 is D. 1420-91, the décret that made the regulation, for the
+      same reason as ca-qc-truck-l: art. 114 carries only the base citation. The
+      A-family prefixes are law; the five-digit body is reported.
+
+  # =========================================================================
+  # RESTRICTED CIRCULATION — the C prefix, primary, arts. 124 / 136 / 137.
+  # =========================================================================
+  - id: ca-qc-restricted-c
+    class: standard
+    categories: [car, truck, tractor, machine]
+    period: { start: 1991 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "C999999"
+      regex: '\AC\d{6}\z'
+      charset: { notes: "the literal C is PRIMARY (arts. 124, 136, 137); the six digits are the article's" }
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    restriction:
+      text: >-
+        Règlement art. 138, verbatim: « La circulation des véhicules routiers visés
+        à l'article 137 se limite aux chemins publics dans les zones où la vitesse
+        maximale n'est pas supérieure à 70 km/h, à la condition que ce chemin public
+        ne soit pas une autoroute ou un chemin à accès limité; toutefois, ces
+        véhicules routiers peuvent traverser à angle droit les routes où la vitesse
+        maximale est supérieure à 70 km/h autres que les autoroutes et les chemins à
+        accès limité. »
+      translation_note: "OUR TRANSLATION: vehicles under art. 137 are confined to public roads in zones where the speed limit is not more than 70 km/h and which are not motorways or limited-access roads; they may cross such roads at right angles."
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 124 (remote-locality vehicles), art. 136 (« La plaque d'immatriculation d'un tracteur de ferme utilisé sur un chemin public porte le préfixe “C”. »), art. 137 (artisan-built vehicles and the like), art. 138 (the 70 km/h restriction, verbatim above)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the C123456 arrangement and the C012345 tractor form"
+    notes: >-
+      A GENUINELY UNUSUAL CLASS, and the reason it is authored: the C plate is the
+      only Québec series whose LEGAL EFFECT is a road restriction rather than a fee
+      band. Art. 124 covers vehicles in localities not connected to the general
+      Québec road network — a real Québec geography problem — and arts. 136-137
+      cover farm tractors and artisan-built vehicles. The restriction text above is
+      primary. The arrangement is the article's.
+
+  # =========================================================================
+  # OFF-ROAD — the V prefix, primary, arts. 139-141.
+  # =========================================================================
+  - id: ca-qc-offroad-v
+    class: standard
+    categories: [atv, snowmobile, machine]
+    period: { start: 1991 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "V99999L"
+      regex: '\AV\d{5}[A-Z]\z'
+      charset: { notes: "the literal V is PRIMARY (arts. 139, 140, 141); the body is the article's, which reports both V12345A and VA12345 forms — the second is carried as a variant" }
+    variants:
+      - name: "VA-block off-road form"
+        format: { pattern: "VL99999", regex: '\AV[A-Z]\d{5}\z' }
+        note: "the article's second reported off-road arrangement; same prefix, different body"
+    design:
+      plate: { w: 20, h: 10, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "for a snowmobile: rear, or the outer left vertical surface of the track tunnel as close to the rear as possible (Règlement art. 9)"
+    legal_effect:
+      text: >-
+        CSR art. 421.1, verbatim: « Nul ne peut conduire sur un chemin public un
+        véhicule routier exempté de l'immatriculation en vertu de l'un des
+        paragraphes 6° à 8° de l'article 14 ou de l'article 15 ou muni d'une plaque
+        d'immatriculation de la catégorie prévue par règlement, délivrée pour un
+        véhicule routier en usage exclusivement sur un terrain ou un chemin privé et
+        non destiné à circuler sur les chemins publics. »
+      translation_note: "OUR TRANSLATION: nobody may drive on a public road a vehicle bearing a plate of the regulated category issued for a vehicle used exclusively on private land or roads and not intended for public roads."
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 139 (private-land and metal-tracked vehicles), art. 140 (stations, ports and airports), art. 141 (snowmobiles of 450 kg or less), art. 9 (snowmobile plate position)"
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/lc/C-24.2  # CSR art. 421.1: driving a V-plated vehicle on a public road is an offence, verbatim above"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the V12345A and VA12345 arrangements"
+    notes: >-
+      THE V PLATE IS A PROHIBITION, NOT A PERMISSION — CSR art. 421.1 makes driving
+      one on a public road an offence in terms, which is the sharpest legal
+      consequence attached to any prefix in the Québec table and the reason this
+      series is authored rather than folded away. `class: standard` because the
+      vocabulary has no off-road member; the category list carries the meaning.
+
+  # =========================================================================
+  # DIPLOMATIC — CD, art. 98.
+  # =========================================================================
+  - id: ca-qc-diplomatic-cd
+    class: diplomatic
+    categories: [car, van]
+    period: { start: 1991 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "CD 9999"
+      regex: '\ACD ?\d{4}\z'
+      charset: { notes: "the literal CD is PRIMARY (art. 98); the four digits are the article's" }
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    eligibility:
+      text: >-
+        Règlement art. 98, opening verbatim: « Peut porter le préfixe “CD”, la
+        plaque d'immatriculation d'un véhicule de promenade: 1° qui est un véhicule
+        officiel appartenant à un État étranger qui a une représentation permanente
+        accréditée auprès d'une organisation internationale gouvernementale ayant
+        conclu une entente avec le gouvernement relative à son établissement au
+        Québec; ... »
+      translation_note: "OUR TRANSLATION: a passenger vehicle's plate MAY bear the CD prefix where the vehicle is an official vehicle belonging to a foreign state with a permanent mission accredited to an intergovernmental international organization that has an establishment agreement with the government of Québec, and in the further cases the article enumerates."
+      cap: "Art. 98 in fine caps at TWO the number of vehicles registrable on a CD plate by a person within its paragraphs 3 or 4."
+      permissive_note: "NOTE THE VERB: « PEUT porter » — MAY bear. Unlike arts. 100, 110, 113 and 114, which say « porte » (bears), the diplomatic and consular prefixes are permissive. A diplomatic vehicle in Québec may lawfully wear an ordinary plate."
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 98, verbatim above, with the two-vehicle cap"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the CD 1234 arrangement and a CD 12VE electric form said to date from 2011"
+    notes: >-
+      THE PERMISSIVE VERB IS THE FINDING. Québec's diplomatic and consular prefixes
+      are the only two in the whole art. 97-159 table introduced by « Peut porter »
+      rather than « porte », so a CD plate is evidence of a diplomatic vehicle while
+      the absence of one is evidence of nothing. That is stated here because a parse
+      API that treats prefix rules as exhaustive will get exactly this pair wrong.
+      period.start 1991 is D. 1420-91.
+
+  - id: ca-qc-consular-cc
+    class: consular
+    categories: [car, van]
+    period: { start: 1991 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "CC 9999"
+      regex: '\ACC ?\d{4}\z'
+      charset: { notes: "the literal CC is PRIMARY (art. 99); the four digits are the article's" }
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    eligibility:
+      text: >-
+        Règlement art. 99, opening verbatim: « Peut porter le préfixe “CC”, la
+        plaque d'immatriculation d'un véhicule de promenade: 1° qui est un véhicule
+        officiel appartenant à un État étranger qui a un poste consulaire établi au
+        Québec, dirigé par un fonctionnaire consulaire de carrière au sens de la
+        Convention de Vienne sur les relations consulaires conclue le 24 avril
+        1963; ... »
+      translation_note: "OUR TRANSLATION: a passenger vehicle's plate MAY bear the CC prefix where the vehicle is an official vehicle of a foreign state with a consular post established in Québec headed by a CAREER consular officer within the meaning of the Vienna Convention on Consular Relations of 24 April 1963."
+      cap: "Art. 99 in fine: at most two vehicles for a person within paragraph 3, and one for a person within paragraph 4."
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 99, verbatim above, with its caps"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the CC 1234 arrangement"
+    notes: >-
+      A REGULATION THAT CITES A TREATY BY DATE — art. 99 pins the career-consular-
+      officer test to the Vienna Convention on Consular Relations of 24 April 1963,
+      which is the kind of precision this dataset exists to preserve. Separate from
+      ca-qc-diplomatic-cd because the regulation separates them, because the
+      eligibility tests differ, and because the vocabulary has distinct `diplomatic`
+      and `consular` members for exactly this. Same permissive verb, same
+      consequence. period.start 1991 is D. 1420-91.
+
+  # =========================================================================
+  # DEALER / REMOVABLE — the X prefix, art. 159.
+  # =========================================================================
+  - id: ca-qc-dealer-x
+    class: dealer
+    categories: [car, van, truck, motorcycle, trailer]
+    period: { start: 1991 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "X 99999"
+      regex: '\AX ?\d{5}\z'
+      charset: { notes: "the literal X is PRIMARY (art. 159); the five digits are the article's, which also reports an X123456 six-digit form and an XA12345 form for motorcycles, mopeds and off-road vehicles — both carried as variants" }
+    variants:
+      - name: "six-digit removable plate"
+        format: { pattern: "X999999", regex: '\AX\d{6}\z' }
+        note: "the article's second reported removable-plate arrangement"
+      - name: "XA removable plate (motorcycle, moped, off-road)"
+        format: { pattern: "XL99999", regex: '\AX[A-Z]\d{5}\z' }
+        note: "the article states XA is used on the small motorcycle plate; the regulation names only the X prefix"
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+      display: "Règlement art. 10: a removable plate obtained under arts. 143 and 159 goes on the rear of the trailer or trailer chassis, or on the front of the vehicle carrying road vehicles piggyback, as the article prescribes per case"
+    binding: business
+    holder_rule:
+      text: >-
+        Règlement art. 150, verbatim: « La personne au nom de laquelle est effectuée
+        l'immatriculation des catégories de véhicules routiers visés à l'article 149
+        doit être un commerçant, un fabricant ou un carrossier. Si elle est un
+        commerçant, elle doit, pour obtenir cette immatriculation, fournir la preuve
+        qu'elle est titulaire d'un permis de commerçant de véhicules routiers délivré
+        en vertu de la Loi sur la protection du consommateur (chapitre P-40.1). »
+      translation_note: "OUR TRANSLATION: the person in whose name the art. 149 categories are registered must be a dealer, a manufacturer or a body-builder; a dealer must prove they hold a road-vehicle dealer's permit under the Consumer Protection Act."
+    use_restriction:
+      text: >-
+        Règlement art. 152, opening verbatim: « Un véhicule visé à l'un des
+        paragraphes 1 à 3 de l'article 149 prêté par le commerçant, le fabricant ou
+        le carrossier et sur lequel est fixée une plaque d'immatriculation amovible
+        doit être utilisé uniquement aux fins suivantes: 1° démontrer son état de
+        fonctionnement ou son état de performance dans le cadre d'un prêt de moins
+        de 6 jours; ... » Art. 153 requires the driver of a loaned vehicle to carry
+        a document naming the lender. Art. 145: a trailer on a removable plate may
+        only be towed within Québec and « sans porter de chargement » — unloaded.
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement arts. 143-148 (trailer/carrier removable registration), 149-158 (dealer, manufacturer and body-builder removable registration), 159-161 (the X prefix and multiple plates), 10 (display)"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the X 12345, X123456 and XA12345 arrangements"
+    notes: >-
+      THE BEST-DOCUMENTED DEALER REGIME IN THE CANADA EAST WAVE — and the contrast
+      with Ontario is the point: plates/ca-on.yml cannot author an Ontario dealer
+      series at all, because Reg. 628 prescribes eligibility and never appearance,
+      whereas Québec's art. 159 names the prefix in the instrument. `binding:
+      business` because the plate is registered to the trader, not to a vehicle:
+      art. 143 and art. 149 register CATEGORIES of vehicle against a person, and
+      art. 160 makes the trader buy one plate per vehicle to be put on the road at
+      once. period.start 1991 is D. 1420-91.
+
+  # =========================================================================
+  # AMATEUR RADIO — VA2 / VE2, art. 97 al. 2. A CALLSIGN ON A PLATE.
+  # =========================================================================
+  - id: ca-qc-amateur-radio
+    class: personalized
+    categories: [car, van]
+    period: { start: 1991 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "VE2 LLL"
+      regex: '\A(?:VA|VE)2 ?[A-Z]{2,3}\z'
+      charset:
+        notes: >-
+          VA2 and VE2 are PRIMARY (art. 97 al. 2). They are also the Canadian
+          amateur-radio callsign prefixes for Québec, which is why the plate reads
+          as a callsign: the two or three letters that follow are the operator's own
+          suffix. The 2-or-3-letter body is the article's.
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      legend_bottom_options: ["Je me souviens"]
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    eligibility:
+      text: "Règlement art. 97 al. 2, verbatim: « Malgré le premier alinéa, une plaque portant le préfixe “VA2” ou “VE2” peut être délivrée au propriétaire d'un véhicule de promenade, titulaire d'une licence de radio-amateur. »"
+      translation_note: "OUR TRANSLATION: despite the first paragraph, a plate bearing the prefix VA2 or VE2 may be issued to the owner of a passenger vehicle who holds an amateur-radio licence."
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement art. 97 al. 2, verbatim above"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec  # TAGGED SECONDARY: the VA2 AB / VA2 ABC / VE2 AB / VE2 ABC forms"
+    notes: >-
+      A CALLSIGN PLATE, AND THE ONLY QUÉBEC SERIES WHOSE SERIAL IS DETERMINED
+      OUTSIDE QUÉBEC — the suffix comes from the holder's federal amateur-radio
+      licence, so Innovation, Science and Economic Development Canada, not the SAAQ,
+      effectively allocates it. `class: personalized` is the least-wrong member of
+      the vocabulary: the holder does not choose the string freely, but the string
+      is theirs and not the Société's, which is what separates this from every
+      sequential series in the file. Recorded so a verifier can rule otherwise
+      knowingly. period.start 1991 is D. 1420-91.
+
+  # =========================================================================
+  # PERSONALIZED — a full statutory regime, and a deliberately over-broad regex.
+  # =========================================================================
+  - id: ca-qc-personalized-2018
+    class: personalized
+    categories: [car, van, motorcycle, moped, atv, snowmobile, motorhome]
+    period: { start: 2018 }
+    period_evidence: enabling-statute
+    matching: recall-only
+    format:
+      pattern: "LLLLLLL"
+      regex: '\A[A-Z0-9]+\z'
+      charset:
+        notes: >-
+          `regex` IS THE STATUTE AND NOTHING NARROWER, which is exactly why this
+          series is `recall-only`. CSR art. 32.1 al. 1 gives uppercase Latin letters
+          and Arabic numerals with NO LENGTH BOUND; SAAQ certainly imposes one in
+          practice, and the SAAQ page that would state it is geo-blocked from this
+          location (header fact 5). Rather than invent a maximum, this file ships
+          the statutory bound and labels the match as a shape hit. A match here says
+          "this string could be a Québec personalized plate", never "this is one".
+      prohibitions:
+        text: >-
+          CSR art. 32.1 al. 2, verbatim opening: « Le numéro d'une plaque
+          d'immatriculation ne doit pas porter à confusion avec celui d'une autre
+          plaque et, dans le cas d'un numéro personnalisé, comporter une expression
+          ou un message, y compris par la lecture en sens inverse: 1° qui laisse
+          faussement croire que le propriétaire du véhicule routier est une autorité
+          publique ou y est lié; ... »
+        translation_note: "OUR TRANSLATION: a plate number must not be confusable with another plate's and, for a personalized number, must not carry an expression or message — INCLUDING WHEN READ BACKWARDS — that falsely suggests the owner is or is linked to a public authority, and the further cases the article enumerates."
+        note: "The read-backwards rule is unusual enough to be worth stating: Québec polices the MIRROR of the string as well as the string."
+    design:
+      plate: { w: 30, h: 15, unit: cm, plate_basis: secondary-wikipedia }
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003DA5"
+      legend_top: "Québec"
+      legend_bottom_options: ["Je me souviens"]
+      emblem: { present: true, rendered: placeholder }
+      band: { side: none }
+      rear_differs: false
+    variants:
+      - name: "off-road personalized (ATV or snowmobile) — the ONE Québec plate with a printed hyphen"
+        format: { pattern: "V-LLLLL", regex: '\AV-[A-Z0-9]+\z' }
+        note: >-
+          Règlement art. 139 al. 2, verbatim: « Malgré le premier alinéa, une plaque
+          d'immatriculation personnalisée apposée sur un véhicule tout-terrain porte
+          le préfixe "V" suivi d'un trait d'union. » Art. 141 al. 2 says the same for
+          a snowmobile of 450 kg or less. OUR TRANSLATION: a personalized plate on an
+          all-terrain vehicle (or such a snowmobile) bears the prefix V FOLLOWED BY A
+          HYPHEN. That hyphen is an emitted separator under PRD-PLATES §2.6 and is
+          the only printed separator glyph any Québec instrument prescribes.
+    eligibility:
+      text: >-
+        Règlement art. 7.2, verbatim: « Seules les personnes qui ne sont pas des
+        personnes morales peuvent obtenir une plaque d'immatriculation personnalisée.
+        Une telle plaque ne peut être associée qu'aux véhicules routiers suivants,
+        sauf s'ils sont mis au rancart: 1° les véhicules de promenade, pour lesquels
+        le présent règlement ne prévoit pas que la plaque d'immatriculation porte un
+        préfixe; 2° les motocyclettes, les cyclomoteurs et les habitations motorisées
+        d'une masse nette de 3 000 kg ou moins; 3° les véhicules tout-terrain et les
+        motoneiges d'une masse nette de 450 kg ou moins. »
+      translation_note: "OUR TRANSLATION: only persons who are NOT legal persons (i.e. not corporations) may obtain a personalized plate, and it may only be associated with: passenger vehicles for which this regulation prescribes no prefix; motorcycles, mopeds and motorized homes of 3 000 kg or less; and all-terrain vehicles and snowmobiles of 450 kg or less."
+      note: "No corporate vanity plates in Québec — a hard eligibility rule stated in the instrument, and one that distinguishes Québec from Ontario, where a business may hold one."
+    lifecycle:
+      activation: "Règlement art. 7.3: the plate must be ACTIVATED before it is fixed to a vehicle, within 48 months of receipt, failing which the number becomes available to somebody else the next day. CSR art. 54.1 makes driving on an unactivated personalized plate an offence ($100-$200)."
+      validity: "Règlement art. 7.4: a personalized plate loses validity 48 months after the holder tells the Société they no longer wish to associate it with the vehicle, after a prohibition on putting the vehicle on the road, or after the vehicle is transferred — unless the holder re-associates it in time."
+      reuse: "Règlement art. 7.5: invalidation frees the number for reuse; where invalidation follows non-payment of the management fee under CSR art. 32.3 the number is held for 48 months. Art. 7.6: a number declared lost or stolen is held for 60 months."
+      fees: "Règlement art. 7.7: management fees under CSR art. 32.3 are payable annually in the three-month window ending on the holder's BIRTHDAY."
+      non_transferable: "Règlement art. 7.3 al. 3: a personalized plate may neither be associated with a vehicle the applicant does not own nor transferred to another person. Contrast Ontario, where ServiceOntario permits exactly one pre-attachment transfer."
+    sources:
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/rc/C-24.2,%20r.%2029  # Règlement arts. 7.2-7.7 (inserted by L.Q. 2018, c. 18, a. 35, with art. 7.7 amended by D. 997-2022, a. 10) and arts. 139 al. 2, 141 al. 2 (the V-hyphen off-road form)"
+      - "https://www.legisquebec.gouv.qc.ca/fr/document/lc/C-24.2  # CSR art. 10.4 (the power to issue a personalized plate), art. 32.1 (the alphabet and the prohibited-message rule, verbatim above), arts. 32.2-32.4 (activation, management fees, replacement on invalidation), arts. 54.1-54.2 (the offences)"
+    notes: >-
+      A COMPLETE STATUTORY VANITY REGIME — eligibility, activation, validity,
+      number reuse, fees and offences, all in the instrument, which is more than any
+      other jurisdiction in the Canada east wave publishes. period.start 2018 is
+      `enabling-statute`: L.Q. 2018, c. 18, a. 35 inserted arts. 7.2 to 7.7 and is
+      the enacting instrument for the regime AS IT NOW STANDS. It is NOT a claim
+      that Québec had no personalized plates before 2018 — CSR art. 10.4 predates
+      it — and the file says so rather than implying otherwise. `matching:
+      recall-only` is the deliberate consequence of the geo-block: with no readable
+      SAAQ length rule, the only defensible regex is the statutory alphabet, and a
+      regex that wide must not be sold as a validity claim (PRD-PLATES §2.7).


### PR DESCRIPTION
**PRD-PLATES gate L3 (S5W; manifest branch s4w-plates/l3-manifest).** Researcher-drafted to the L1/L2 standard: primary instruments quoted verbatim (native-language gazettes read in the original), instrument-dated periods with honest period_evidence, folklore flagged not asserted, non-Latin scripts modelled as decode/field facts with the ASCII projection stated. Independent staged lint over origin/main with ALL 28 wave files: `plates lint: 123 files, 1360 series ... OK`.

**ca-on**: 12 series, 11 pinned sources, lint green.

---

# Research dossier — Ontario (`ca-on`)

PRD-PLATES gate L2/L3, Canada east wave. Researcher pass, 2026-08-02.
Deliverable: `ca-on.yml` (12 series, lint-green).
**Not applied.** A human session verifies and applies (PRD-PLATES §5.3).

---

## 1. What was secured, and how

### 1.1 The e-Laws access problem, and its solution — reusable

`ontario.ca/laws` is a React single-page application. Every conventional route
returns the same 54 243-byte JavaScript shell:

| attempt | result |
|---|---|
| `curl https://www.ontario.ca/laws/regulation/900628` | SPA shell |
| `WebFetch` on the same URL | SPA shell (renders no JS) |
| `https://www.e-laws.gov.on.ca/html/regs/english/elaws_regs_900628_e.htm` (legacy) | 302 → SPA shell |
| `.../900628/pdf`, `/print`, `?print=true`, `.xml`, `/v20` | SPA shell |
| `https://www.canlii.org/en/on/laws/regu/rro-1990-reg-628/latest/...` | HTTP 403 (Datadome) |

**The route that works**, extracted from the SPA bundle
`/laws/static/js/main.ff30c9b4.js`:

```
https://www.ontario.ca/laws/api/v2/legislation/{lang}/doc-search/{type}/{code}
```

with `lang` ∈ {`en`,`fr`}, `type` ∈ {`statute`,`regulation`}, `code` the e-Laws
identifier. It returns JSON with `content` (full HTML of the consolidation),
`volume`, `title`, `history` and `contentTable`. It requires a browser-shaped
`User-Agent` and a `Referer` on `ontario.ca`; the shorter
`/laws/api/v2/regulation/900628` path exists but 403s.

Verified fetches:
* `.../en/doc-search/statute/90h08` → Highway Traffic Act, 1 025 653 chars of text
* `.../en/doc-search/regulation/900628` → R.R.O. 1990, Reg. 628, 88 653 chars

**This unblocks every Ontario statute and regulation for later waves.** Recorded
here rather than only in the YAML because it is a tooling fact, not a plate fact.

### 1.2 Sources actually read (all 2026-08-02)

| # | URL | class | what it gave |
|---|---|---|---|
| 1 | `ontario.ca/laws/statute/90h08` (via the API above) | PRIMARY, edict | HTA ss. 7(1),(1.1),(4),(7),(7.1),(7.2),(8),(12.1),(24); 11(1),(3); 12(1)-(3); 13(1)-(3.1) |
| 2 | `ontario.ca/laws/regulation/900628` (via the API) | PRIMARY, edict | Reg. 628 ss. 1(1), 6(1)-(4), 9(1)-(5), 10, 13-13.2 |
| 3 | `ontario.ca/page/personalized-licence-plate` | AUTHORITY | the 2–8 / 2–5 / 2–6 character budgets; the refusal rules; graphics; the gift/transfer rule; fees |
| 4 | `ontario.ca/page/get-green-licence-plate` | AUTHORITY | the full eligibility and non-eligibility lists; HOV/HOT privilege; the 25 Nov 2024 commercial extension; "optional and cost the same"; no online order; no personalization |
| 5 | `ontario.ca/page/get-year-manufacture-licence-plate` | AUTHORITY | the year-of-manufacture eligibility rules verbatim |
| 6 | `ontario.ca/page/get-manufacturer-licence-plate-dealer-plate-or-service-plate` | AUTHORITY | confirms the classes exist; **no format, no colour** |
| 7 | `ontario.ca/page/register-vehicle-permit-and-licence-plate` | AUTHORITY | automatic renewal for passenger/light commercial/motorcycle/moped; plates issued immediately |
| 8 | `ontario.ca/page/choose-licence-plate-graphic` | AUTHORITY | the official graphic chooser |
| 9 | `en.wikipedia.org/wiki/Vehicle_registration_plates_of_Ontario` | SECONDARY (tagged) | every serial arrangement and every base date in the file |

Wikipedia was used as PRD-PLATES §4's **mandatory finding aid** and, under the
owner's 2026-08-02 override, as a tagged fact source. Its citation list was
mined systematically (40 distinct URLs); the government-primary ones it names
are handled in §3 below.

---

## 2. The two structural findings

### 2.1 An Ontario plate binds to the OWNER — and the Act says so twice

HTA s. 11(1): on ceasing to own or lease the vehicle the permit holder shall
"(a) remove his, her or its number plates from the vehicle; (b) retain the plate
portion of the permit". HTA s. 11(3): those plates may then be affixed "to a
similar class of vehicle that the person owns or leases".

This puts Ontario with Switzerland (`plates/ch.yml`), Nova Scotia and Prince
Edward Island, against Québec and New Brunswick. It is decisive for any consumer
that treats a plate string as a vehicle key. `binding: owner` is set with both
subsections quoted.

### 2.2 Nothing about the Ontario serial is law

HTA s. 7(24) is the plate regulation-making power. It reaches issuance,
validation, display, fees, surrender, classification, and — at (o) — "the
criteria for the issuance, retention and return of a number plate bearing a
requested number". **It never reaches the composition of a mark.** R.R.O. 1990,
Reg. 628 was read end to end: it contains no colour, no dimension, no character
metric and no serial grammar. Searches for `colour|color|reflect|dimension|
millimet|blue|white|characters` in the full regulation text return **zero hits**.

Consequence, stated in the file header and repeated per series: Ontario's serial
system is administrative, exactly like the DVLA memory tags (`plates/gb.yml`) and
the German district codes (`plates/de.yml`). Every `format` in `ca-on.yml` except
`ca-on-personalized` is graded `secondary-wikipedia`.

The **one** Ontario government statement of serial LENGTH located anywhere:
ServiceOntario, verbatim — *"Personalized passenger and commercial plates may
have 2 to 8 characters. Personalized motorcycle plates may have 2 to 5
characters."* That is the sole authority-sourced regex in the file, and it
independently corroborates the five-character motorcycle series.

---

## 3. Gaps, and the ranked verifier targets

1. **`news.ontario.ca` is unreachable and it matters most.** The Government of
   Ontario's own 15 April 2019 release announcing the blue base, its February 2020
   update, and the 2022 sticker-abolition release were all attempted — direct
   `curl`, `WebFetch`, and Wayback — and all returned an empty body (16 chars) or
   a rate-limited archive. `ca-on-standard-blue-2020` therefore quotes **nothing**
   from them. **This is the single highest-value verifier target**: it is the only
   Ontario series where a government primary is known to exist and known to be
   unread.
2. **`ca-on-diplomatic-1994` is the weakest series in the file.** Global Affairs
   Canada's plate guidance page returned a 736-character navigation shell with no
   policy body. Everything on that series is the article's. Re-pin from GAC.
3. **Dealer / Service / Manufacturer plates are not modelled.** Reg. 628 ss. 13,
   13.1, 13.2 prescribe eligibility and permitted use and never appearance;
   ServiceOntario's page gives fees. No format, no colour. Recorded in
   `classes_not_modelled.dealer`.
4. **Military plates** — not researched; Ontario/DND arrangement unknown.
5. **`ca-on-personalized` period.** 1998 is a conservative floor with no primary.
   HTA s. 7(24)(o) and s. 12(3)(a) both entered by 1999, c. 12, Sched. R, in force
   1 January 2001 per the e-Laws amendment table. A verifier should either pin the
   real programme start or substitute 2001 and re-grade to `enabling-instrument`.
6. **Plate dimensions.** No Ontario instrument states one. Recorded as
   `plate_basis: convention`, never as a legal claim.
7. **Trailer 2025 start** is the youngest and least settled claim in the file.

---

## 4. Folklore flagged, not asserted

* **The "1956 AMA/AAMVA standardization agreement"** fixing 6 × 12 in. The
  Ontario article repeats it in its own words; PRD-PLATES §4 already records it
  as uncited (a `citation needed` since 2017, copied across the Canada, US and
  Puerto Rico articles — circular). **Not relied on.** `common.dimensions.folklore_caution`
  states it in terms.
* **The G/I/O/Q/U exclusion.** Universally repeated; the article's own citation
  is a collector site (`allaboutlicenseplates.com`), not a government source. Kept
  out of `regex` and confined to `regex_strict`, with the grading stated in
  `common.charset.excluded_note`.
* **Serial ranges** ("CPAA-001 to DLPH-458 as of June 21, 2026") are footnoted in
  the article to a *RedFlagDeals forum thread*. They are used only as
  `progression` prose, never as period or format evidence.
* **The 1997 format-change year itself carries no footnote in the article.** It is
  recorded as `secondary-wikipedia` and flagged in `ca-on-standard-1997.notes`.

---

## 5. Modelling decisions a verifier will want to challenge

| decision | why |
|---|---|
| `ca-on-standard-blue-2020` is its own series and OVERLAPS `ca-on-standard-1997` | design + period both differ (§2.3); the overlap is real (white plates never stopped, blue stock ran out through June) |
| The 2022 sticker abolition cuts NO series | the sticker changed, the plate did not. Recorded in `common.validation` |
| Commercial and green plates carry `class: standard` / `class: electric` rather than invented classes | `_meta/classes.yml` has no "commercial" member and §2.3 forbids ad-hoc vocabulary growth |
| The crown separator is an EMBLEM, never a separator character | `_meta/separators.yml` §4 reasoning; the gap is spelled as the emitted space |
| Two motorcycle and two trailer series (current + one back) | Ontario plates are permanent since 1973, so superseded formats remain lawfully displayed in quantity — the period `end` is an ISSUANCE end, and no series carries `ended: true` |

---

## 6. Lint

Copied `plates/` (excluding `_art`) plus `scripts/lint_plates.rb` to a scratch
workspace, added `ca-on.yml`, ran `ruby scripts/lint_plates.rb`:

```
plates lint: 97 files, 1059 series
plates lint: matching recall-only=220 strict=839 | twins regex_statutory=83 regex_strict=326
plates lint: OK
```

Green on the first run. No round-trip, separator, class-vocabulary, period-rail
or overlap failures.

**ca-qc**: 16 series, 4 pinned sources, lint green.

---

# Research dossier — Québec (`ca-qc`)

PRD-PLATES gate L2/L3, Canada east wave. Researcher pass, 2026-08-02.
Deliverable: `ca-qc.yml` (16 series, lint-green).
**Not applied.** A human session verifies and applies (PRD-PLATES §5.3).

---

## 1. Headline: Québec legislates its plate CLASSES, and that changes the grade

Every other jurisdiction in this wave leaves the serial system to administrative
discretion. Québec puts the **class prefix table in a regulation** and the
**serial alphabet in the Code itself**. That is why `ca-qc.yml` carries nine
`enabling-instrument` grades where the other five files in the wave carry almost
none, and why its `common.class_prefixes` block is a closed, primary decode table
rather than a reported one.

### The two load-bearing primaries

**CSR art. 32.1 al. 1** — the serial alphabet, in the Code:

> « Tout numéro de plaque d'immatriculation se compose de lettres majuscules de
> l'alphabet latin, de chiffres arabes ou d'une combinaison des deux. Il doit être
> compatible avec le système de numérotation des plaques établi par la Société et
> doit être facile à lire. »

*Our translation: every plate number consists of uppercase Latin letters, Arabic
numerals, or a combination of the two; it must be compatible with the numbering
system established by the Société and must be easy to read.*

This is `regex_statutory` for the whole jurisdiction, and it is exactly the
dataset-wide alphabet in `_meta/separators.yml` — so **no `serial_alphabet:`
declaration is needed for Québec, and that is a sourced finding rather than a
default**.

**Règlement C-24.2, r. 29, arts. 97–159** — the prefix table. Quoted per article
in `common.class_prefixes`:

| prefix | class | article | verb |
|---|---|---|---|
| *(none)* | private passenger, motorhome ≤ 3 000 kg | 97 al. 1 | *ne porte aucun préfixe* |
| VA2, VE2 | licensed radio amateur | 97 al. 2 | *peut être délivrée* |
| CD | diplomatic | 98 | **peut porter** |
| CC | consular | 99 | **peut porter** |
| M *or none* | motorcycle, moped | 100 | *porte … ou aucun préfixe* |
| F, FZ | commercial and 9 enumerated classes | 102 | *porte* |
| L | truck / farm vehicle > 3 000 kg | 110 | *porte* |
| PRP (vignette) | proportional / IRP | 112.1 | *est muni* |
| R, U | trailer | 113 | *porte* |
| A, AE, AP, AU | bus, minibus | 114 | *porte* |
| C | restricted circulation | 124, 136, 137 | *porte* |
| V | off-road, snowmobile ≤ 450 kg | 139, 140, 141 | *porte* |
| X | removable dealer plate | 159 | *délivre … portant le préfixe* |

**The verb is a finding.** Only the diplomatic and consular prefixes are
introduced by « **Peut** porter » (MAY bear). A CD plate is evidence of a
diplomatic vehicle; the absence of one is evidence of nothing. A parse API that
treats the prefix table as exhaustive gets exactly this pair wrong. Stated in
`ca-qc-diplomatic-cd.eligibility.permissive_note`.

---

## 2. The best period claim in the wave

**Règlement art. 7.1**, inserted by *décret* 968-2017, a. 1:

> « La Société délivre, pour un véhicule routier à propulsion électrique équipé
> d'une batterie rechargeable par branchement au réseau électrique ou alimenté par
> une pile à hydrogène, une plaque d'immatriculation avec lettrage vert.
> Cette plaque est délivrée pour tout véhicule routier visé au premier alinéa
> immatriculé **à compter du 26 octobre 2017** ou, si le véhicule n'en est pas déjà
> muni, lors du remplacement de la plaque. »

A **day**, in the **instrument**, for a **design**. `ca-qc-electric-2017` carries
`period_evidence: enabling-instrument` on that sentence alone.

### The disagreement, recorded and NOT averaged (PRD-PLATES §5.3)

The en.wikipedia Québec article dates a green Québec electric plate to **2011**,
six years earlier, with distinct serial forms (`E00 VEA` passenger, `A00000` bus,
`FVE0000` commercial), citing a SAAQ page that no longer exists. Two readings fit:
a voluntary 2011 SAAQ programme that D. 968-2017 later made regulatory, or an
article error. Nothing reachable from this location distinguishes them. The file
**dates the series from the instrument, records the 2011 claim in `sources`, and
does not author the 2011 forms**. If the 2011 programme is real it becomes a
predecessor series.

---

## 3. The SAAQ is GEO-BLOCKED — a negative finding worth publishing

Every `saaq.gouv.qc.ca` URL attempted on 2026-08-02 — French and English, direct
`curl` with a cookie jar and full browser headers, and `WebFetch` — 303-redirected
to `messages.saaq.gouv.qc.ca` and served:

> « ACCÈS REFUSÉ (ERREUR 403) — Nous sommes désolés. Nous ne pouvons pas vous
> donner accès à cette page pour le moment. Cela peut être dû à un problème de
> connexion ou à des **restrictions spécifiques appliquées dans certains pays**. »

**No SAAQ page is quoted anywhere in `ca-qc.yml`.** The agency's own
plate-category page is cited as a known, unread source. The single consequence
for the data: `ca-qc-personalized-2018` ships `matching: recall-only` with
`regex: '\A[A-Z0-9]+\z'` — the statutory alphabet with no length bound — because
the only page that would state a Québec vanity character budget is behind the
geo-block, and inventing a maximum was declined.

A verifier with Canadian network access should fetch
`saaq.gouv.qc.ca/en/vehicle-registration/categories-licence-plates/` first; it is
the one page that would corroborate the whole prefix table from the agency side
and would let the personalized series be promoted to `strict`.

---

## 4. Sources actually read (all 2026-08-02)

| # | URL | class | what it gave |
|---|---|---|---|
| 1 | `legisquebec.gouv.qc.ca/fr/document/rc/C-24.2, r. 29` | PRIMARY, edict, French, *« Ce document a valeur officielle »*, « À jour au 1er avril 2026 » | arts. 2.2, 5, 7, 7.1, 7.1.1, 7.2–7.7, 8, 9, 9.1, 10, 97–114, 124, 136–141, 143–161 |
| 2 | `legisquebec.gouv.qc.ca/fr/document/lc/C-24.2` | PRIMARY, edict, French | CSR arts. 10.1, 10.3, 10.4, 28, 30–34, 37–39, 42, 43, 50, 54, 54.1, 54.2, 57, 421.1 |
| 3 | `en.wikipedia.org/wiki/Vehicle_registration_plates_of_Quebec` | SECONDARY (tagged) | all serial arrangements, all base dates, the retired-prefix list, the plate dimensions |
| — | `saaq.gouv.qc.ca/**` | AUTHORITY | **GEO-BLOCKED, nothing read** |

All French quotations are given in the original with an explicitly-labelled
translation note. Translations are ours and are never presented as the
instrument's words (PRD-PLATES §4: quote articles, not summaries).

---

## 5. Modelling decisions a verifier will want to challenge

| decision | why |
|---|---|
| **Three** passenger series, not two | the 2022 `12A BCD` arrangement ran ~9 months before withdrawal; "one series back" is ambiguous in Québec, so `B12 CDE` (2009–2022, 13 years, the bulk of the fleet) is authored as a second predecessor and the reason is stated |
| `ca-qc-passenger-2009`'s strict twin is trusted | the article's excluded first letters (A, C, F, L, R, T, V) are **exactly the class prefixes the regulation reserves** — a secondary claim independently corroborated by the primary. The strongest secondary-to-primary link in the file |
| `ca-qc-truck-l` uses `pattern: '\L999999'` | `L` is the human-pattern DSL's own token; PRD-PLATES §2.2's escape (owner ruling 2026-08-02) is used, single-quoted so YAML keeps the backslash. **First use of the escape in the corpus** (0 of 945 patterns used it before) |
| `binding: vehicle` for Québec, against `owner` for Ontario/NS/PE | Règlement art. 5 makes validity depend on the plate being *associée à un véhicule routier*, while art. 7 al. 2 §2 and CSR art. 43 let the holder move it. The current state is vehicle-bound; the portability is in `binding_note` |
| `class: personalized` for the VA2/VE2 amateur series | the holder does not choose the string freely (ISED assigns the callsign) but it is theirs, not the Société's. Least-wrong vocabulary member; flagged so a verifier can rule otherwise |
| Bus/truck/restricted/off-road series carry `class: standard` | `_meta/classes.yml` has no member for any of them and §2.3 forbids ad-hoc vocabulary growth; the `categories` list carries the meaning |
| period.start **1991** on five prefix series | D. 1420-91 is the *décret* that made the Règlement, and those articles carry that base citation with no amending *décret*. It is a claim about the PREFIX RULE's earliest in-force date, not about the arrangement, and the notes say so |

---

## 6. Gaps and ranked verifier targets

1. **SAAQ geo-block** (§3) — unblocks the personalized length rule and would
   corroborate the whole prefix table from the agency side.
2. **The 2011 vs 2017 electric disagreement** (§2) — needs a SAAQ or Gazette
   officielle source.
3. **Taxi (T) prefix withdrawal.** Not authored. The regulation as consulted
   contains no T prefix — the negative was checked, not assumed — and redirects to
   *Règlement sur le transport rémunéré de personnes par automobile* (T-11.2, r. 4),
   which was not fetched. The article's dates (10 Oct 2020 / 13 Oct 2020 /
   31 Mar 2021) cite Transports Québec pages that were not fetched.
4. **Plate dimensions.** No Québec instrument states one. 30 × 15 cm and
   20 × 10 cm are the article's, recorded as `plate_basis: secondary-wikipedia`.
5. **AE / AP / AU bus arrangements.** The prefixes are primary (art. 114); the
   article's account of them (AP police bus, AU emergency bus, "all considered A
   plates since the 1980s") is internally inconsistent. Recorded, not resolved;
   `regex` covers the A form only.
6. **Colours.** CSR art. 32 leaves every inscription to the Société. Blue-on-white
   and green-lettering are `hex_basis: observed`; the *fact* of greenness is
   primary (art. 7.1 says « lettrage vert ») and the shade is not.
7. **Historic / pre-2000 Québec** (the 1979 `123A456` and 1983 `ABC 123` bases,
   the M-prefixed motorcycle plates, the retired GQ/GP/G/CO/H/AM/ZZ/Z prefixes) —
   deliberately out of scope, L4 work.

---

## 7. Folklore flagged, not asserted

* Every digit-and-letter arrangement in the file is the article's. The prefixes
  are primary; **the bodies are not**, and each `charset.notes` says which is
  which. This split is the file's organising principle.
* The article's serial ranges are footnoted to *Le Soleil* newspaper pieces and to
  `licenseplates.cc`; they are used only as `progression` prose.
* The retired-prefix list (U, GQ, GP, G, CO, H, AM, ZZ, Z) is carried in
  `common.class_prefixes.retired_prefixes_note` as the article's claim. Only FZ
  is corroborated by the live regulation (art. 102).

---

## 8. Lint

```
plates lint: 98 files, 1075 series
plates lint: matching recall-only=222 strict=853 | twins regex_statutory=85 regex_strict=329
plates lint: OK
```

Two failures were found and fixed during iteration, both instructive:
1. **YAML parse failure** at the `common.class_prefixes.verbatim_samples` block —
   the instrument's own straight double quotes around prefix letters (`"M"`)
   inside a double-quoted YAML scalar. Fixed by rendering the instrument's inner
   quotation marks typographically (`“M”`) on guillemet-bearing lines only, which
   is also closer to how LégisQuébec prints them.
2. **Round-trip failure** on `ca-qc-truck-l`: `pattern: "L999999"` generated
   `K823515`, because `L` is the DSL's letter token. Fixed with the §2.2 escape
   (`'\L999999'`). This is the first live use of the escape in the corpus and it
   behaved exactly as its self-check promises.

**ca-ns**: 9 series, 13 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 10676B)
**ca-nb**: 9 series, 3 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 9273B)
**ca-pe**: 8 series, 5 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 10867B)
**ca-nl**: 12 series, 5 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 11428B)
