### PR TITLE
plates L3: ca-west — ca-bc ca-ab ca-sk ca-mb ca-yt ca-nt ca-nu (S5W)

### DIFF
--- a/plates/ca-ab.yml
+++ b/plates/ca-ab.yml
@@ -1,0 +1,430 @@
+# plates/ca-ab.yml — Alberta (PRD-PLATES gate L3, Canada west).
+#
+# ── FOUR STRUCTURAL FACTS THAT SHAPE THIS FILE ─────────────────────────────
+#
+# 1. ALBERTA DELEGATES THE PLATE TWICE, AND THE SECOND DELEGATE PUBLISHES
+#    ALMOST NOTHING. Operator Licensing and Vehicle Control Regulation,
+#    AR 320/2002, Division 3 (Licence Plates), s. 63, verbatim:
+#      "63(1) The Registrar shall issue a licence plate for a vehicle if the
+#       Registrar issues a certificate of registration for the vehicle.
+#       (2) The Registrar shall issue licence plates in the number and of the
+#       type and colour approved by the Minister."
+#    So the REGULATION delegates the number, type and colour to the MINISTER,
+#    and the Minister's approval is not itself published as an instrument. No
+#    dimension, no character metric, no serial grammar exists anywhere in
+#    Alberta law. The whole of Division 3 (ss. 63-75) was read; it legislates
+#    ELIGIBILITY and DISPLAY and nothing about what a plate looks like. This is
+#    the Washington/British Columbia pattern with one more hop.
+#
+# 2. THE SERIAL GRAMMAR IS THEREFORE UNSOURCED TO ANY ALBERTA PUBLICATION, AND
+#    THIS FILE SAYS SO ON ITS FACE. `ABC-1234` is universally reported and was
+#    NOT located on any alberta.ca page, in the Traffic Safety Act, or in
+#    AR 320/2002. It is carried with `period_evidence: secondary-wikipedia` and
+#    `format.evidence: secondary`, per the PRD-PLATES § 4 Wikipedia row's
+#    tagging condition. Contrast plates/ca-yt.yml, whose grammar for every class
+#    is in the regulation itself, and plates/ca-nt.yml, whose thirteen plate
+#    types are enumerated with their letter prefixes in the regulation. Alberta
+#    is the WEAKEST-sourced format in this seven-jurisdiction group and the
+#    ranking is stated so a verifier knows where to spend effort.
+#
+# 3. ALBERTA IS A ONE-PLATE PROVINCE THAT LEGISLATES A SECOND PLATE FOR
+#    OLD CARS, AND THAT SECOND PLATE IS A GENUINE HISTORIC ARTEFACT.
+#    AR 320/2002 s. 70(2)(a) forbids displaying "any other vehicle plate or
+#    device bearing numbers or letters or both that are identical to or have the
+#    general appearance of a licence plate". s. 66 then carves out, verbatim:
+#      "66 Despite section 70(2), the owner of a motor vehicle that is 25 years
+#       old or older and registered as a private passenger vehicle may attach to
+#       the front of it one, but not more than one, licence plate issued in
+#       Alberta in the year in which the vehicle was manufactured."
+#    A lawful Alberta front plate is thus, by statute, a PERIOD-CORRECT PLATE
+#    FROM THE VEHICLE'S BUILD YEAR — no current registration, no validity. Any
+#    consumer reading Alberta front plates will read expired historic serials as
+#    live registrations unless it knows this rule. It is modelled as a DISPLAY
+#    RULE, not a series, because no new plate is manufactured for it.
+#
+# 4. THE ONE SOURCED CHARSET RULE IN THE FILE IS ALBERTA'S OWN AND IT IS ABOUT
+#    ZERO. alberta.ca, on personalized plates, verbatim among the prohibited
+#    configurations: "the letter O (use the number zero)". The same page lists
+#    the substitution pairs Alberta polices to prevent look-alikes: 1/I, 1/L,
+#    6/G, 5/S, 2/Z, 0/Q, 8/B, 3/E, 4/A. Note what that list implies and this
+#    file does NOT assert: it is a rule about PERSONALIZED plates, and it is not
+#    evidence about the regular-series alphabet.
+#
+# REGEX POLICY: as plates/gb.yml. `format.regex` is the round-trippable tier;
+# `regex_strict` carries a sourced narrowing where one exists (here: only the
+# personalized O-exclusion, which cannot go in `regex` because the lint
+# generates O from the human pattern).
+jurisdiction: ca-ab
+authority:
+  name: Registrar of Motor Vehicle Services, Government of Alberta (plates issued through registry agents)
+  url: "https://www.alberta.ca/licence-plates"
+binding: vehicle
+binding_note: >-
+  AR 320/2002 s. 113 lets a registered owner "pass" a plate from one vehicle to
+  another of the same class that they own, and s. 68(1) lets a trailer plate be
+  transferred between the owner's own trailers with the Registrar's consent,
+  while s. 68(2) forbids passing a trailer plate "from one trailer owner to
+  another". The plate follows the OWNER's registration within a class, not the
+  vehicle.
+instrument:
+  statute:
+    citation: "Traffic Safety Act, R.S.A. 2000, c. T-6"
+    note: "The Act creates the Registrar and the registration regime; the plate provisions live in the regulation below. The Act's own text was not fetched in this pass (recorded gap)."
+  regulation:
+    citation: "Operator Licensing and Vehicle Control Regulation, Alta. Reg. 320/2002, Part 3 Division 3 (Licence Plates), ss. 63, 63.1, 64, 65, 66, 66.1, 67, 68, 69, 70, 71, 72, 73, 74, 75; s. 115 (Personal licence plates)"
+    amendments_seen_in_text: "s. 63.1 added AR 160/2014 s2, amended 77/2022; s. 64 substituted AR 282/2020 s2; s. 66.1 as amended AR 253/2004 s3, 48/2005, 131/2010, 73/2012, 207/2020, 160/2026; s. 70 amended AR 282/2020 s3"
+    source: "https://kings-printer.alberta.ca/documents/Regs/2002_320.pdf  # Division 3 ss. 63-75 and s. 115 read verbatim 2026-08-02 (PDF, text layer present)"
+  agency_page:
+    citation: "Government of Alberta, 'Licence plates' (alberta.ca), accessed 2026-08-02"
+    source: "https://www.alberta.ca/licence-plates  # plate location, one-plate rule, veterans-plate dates, personalized-plate prohibitions incl. the O rule and the look-alike substitution list, the three named specialty plates"
+  licence: "Alberta King's Printer serves AR 320/2002 without click-through; it is an edict of government. alberta.ca content is Crown copyright, cited not reproduced."
+
+artwork_risk:
+  posture: unresearched-crown-copyright-presumed
+  basis: >-
+    Crown copyright under s. 12 of the Copyright Act (Canada) is the default and
+    no Alberta disclaimer was found. Alberta is additionally the group's
+    THIRD-PARTY-MARK case, from its own regulation and its own web pages: two of
+    the three specialty plates alberta.ca names are professional sports club
+    marks (Calgary Flames, Edmonton Oilers), and AR 320/2002 s. 63.1(3) makes
+    every specialty plate the product of "a written agreement with[] an
+    organization". Alberta legislates that its specialty artwork is a
+    contracted third-party property — the same posture Montana reaches by a
+    different route (MCA 61-3-475's hold-harmless clause).
+  emblem_rule: >-
+    PRD-PLATES § 3 placeholder default applies to the wild-rose device, the
+    provincial wordmark, the Calgary Flames and Edmonton Oilers marks, and the
+    Royal Canadian Legion's "integrated maple leaf and poppy logo", which
+    AR 320/2002 s. 66.1(1) puts on the veterans' plate BY NAME. The Legion logo
+    is a third-party registered mark placed on a government plate by regulation;
+    no theory of Crown copyright reaches it.
+  sources:
+    - "https://kings-printer.alberta.ca/documents/Regs/2002_320.pdf  # s. 63.1(3) written agreement with an organization; s. 66.1(1) the Royal Canadian Legion logo by name"
+    - "https://www.alberta.ca/licence-plates  # Calgary Flames and Edmonton Oilers specialty plates"
+
+display_rules:
+  count: >-
+    ONE plate. alberta.ca, verbatim: "You cannot display more than one licence
+    plate on your vehicle or any other type of plate that could be mistaken for
+    a valid licence plate." AR 320/2002 s. 70(2) is the regulation behind it.
+  location: >-
+    AR 320/2002 s. 70(1), verbatim: "The owner of a vehicle shall attach a
+    licence plate securely as follows: (a) if the vehicle is not a truck tractor
+    or a motor cycle, to the rear of the vehicle so that the lower edge of the
+    plate is not lower than the axle; (b) if the vehicle is a truck tractor, to
+    the front of the vehicle; (c) if the vehicle is a motor cycle, on the rear
+    mudguard or rear fender so that it is clearly visible."
+  truck_tractor_inversion: >-
+    Alberta puts the truck tractor's ONLY plate on the FRONT — the same outlier
+    Florida legislates (§ 320.0706 F.S.). Two jurisdictions on different
+    continents of the same continent reach the identical rule; it is not a
+    typo in either file.
+  historic_front_plate: >-
+    s. 66 (quoted in the header): a private passenger vehicle 25 years old or
+    older may carry, ON THE FRONT ONLY, one Alberta plate issued in the year the
+    vehicle was manufactured. This is a re-display permission for an EXPIRED
+    historic plate, not an issuance, so it has no series.
+  condition: "s. 71(1): no person shall drive a vehicle if the licence plate is not securely attached, 'legible and clearly visible at all times'. s. 71(2) excuses obstruction caused only by a trailer attached to the rear."
+  foreign_plates: "s. 70(2)(b) forbids displaying a plate issued by another jurisdiction 'unless the display is required by this Regulation or by the laws of the jurisdiction that issued the plate'."
+  sources:
+    - "https://kings-printer.alberta.ca/documents/Regs/2002_320.pdf  # ss. 66, 70, 71"
+    - "https://www.alberta.ca/licence-plates  # the one-plate sentence and the plate-location list"
+
+common:
+  separator_note: >-
+    Alberta's serial is universally rendered with a hyphen (`ABC-1234`) and NO
+    Alberta publication states a separator glyph or a group gap. Under
+    PRD-PLATES § 2.8 the honest encoding of an authority that names no glyph is
+    a separator-only class, so every regex here spells the position `[- ]?`
+    while `pattern` shows the canonical printed hyphen. A § 2.6-forgiving
+    consumer deletes it either way.
+  dimensions_note: >-
+    NEGATIVE FINDING. No dimension appears in AR 320/2002 or on alberta.ca.
+    `design.plate` is absent from every series here, as in plates/ca-bc.yml and
+    plates/gb.yml.
+  charset_disagreement: >-
+    RECORDED, NOT AVERAGED (PRD-PLATES § 5.3). Two secondary readings of the
+    Alberta regular-series alphabet are in circulation: the world dossier
+    (aux/research/plates-2026-07/plates-research-us-world.md § 2.1) reports
+    "excludes I, O, Q, U"; the per-province encyclopedia article reports that
+    "A, E, I, O, Q, U are skipped" — i.e. all vowels plus Q. No Alberta source
+    resolves it. NEITHER is asserted: no `regex_strict` narrows the
+    regular-series alphabet in this file, and the disagreement is carried here
+    as the standing verifier target.
+
+series:
+
+  # =========================================================================
+  # STANDARD PASSENGER.
+  # =========================================================================
+  - id: ca-ab-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2010 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL-9999"
+      regex: '\A[A-Z]{3}[- ]?\d{4}\z'
+      evidence: secondary
+      progression: "not published"
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B3F8B"
+      legend_top: "ALBERTA"
+      legend_bottom: "Wild Rose Country"
+      emblem: { present: true, rendered: placeholder, description: "wild rose device / provincial wordmark" }
+      rear_differs: false
+    notes: >-
+      THE FORMAT AND THE PERIOD ARE BOTH SECONDARY AND THE FILE DOES NOT
+      PRETEND OTHERWISE. Three letters, a hyphen and four numerals is the
+      arrangement every source reports and no Alberta publication states. The
+      reported first issue is June 2010; the encyclopedia row carries no
+      footnote for it, so it is tagged `secondary-wikipedia` under the
+      PRD-PLATES § 4 Wikipedia condition (tagged + article URL, so that every
+      such fact is enumerable in one pass if the decision is revisited). The
+      base design itself is reported as introduced in late 1983 and refreshed
+      with an updated provincial logo in July 2019 — BASE AND FORMAT HAVE
+      DIFFERENT LIFETIMES in Alberta as they do in Oregon and British Columbia,
+      and neither reported base date is asserted as a series boundary here.
+      No `regex_strict` is offered: see common.charset_disagreement.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Alberta  # FINDING AID (PRD-PLATES §4 Wikipedia row): the ABC-1234 arrangement, the reported June 2010 first issue, the reported 1983 base and 2019 logo refresh; accessed 2026-08-02"
+      - "https://kings-printer.alberta.ca/documents/Regs/2002_320.pdf  # s. 63(1)-(2): the Registrar issues; the Minister approves number, type and colour"
+
+  - id: ca-ab-standard-3x3
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1975, ended: true }
+    year_end_min: 2003
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL-999"
+      regex: '\A[A-Z]{3}[- ]?\d{3}\z'
+      evidence: secondary
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B3F8B"
+      legend_top: "ALBERTA"
+      legend_bottom: "Wild Rose Country"
+      rear_differs: false
+    notes: >-
+      THE "ONE SERIES BACK" REQUIREMENT, MET WEAKLY AND LABELLED AS SUCH. Three
+      letters and three numerals ran from a reported 1975 on a yellow base and
+      continued onto the white/red/blue base; the reported end is 2003, seven
+      years before the reported ABC-1234 start, and NO SOURCE EXPLAINS THE GAP.
+      Because the end year is contested by that gap, the schema's known-over-
+      undated shape is used: `ended: true` with `year_end_min: 2003` rather than
+      a hard `end`, which is exactly the case PRD-PLATES § 2.2 introduced it
+      for. "Wild Rose Country" is reported as the slogan from 1973, i.e. it
+      spans both series and is not an era signal.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Alberta  # FINDING AID: ABC-123 reported 1975-2003, yellow base, slogan from 1973; accessed 2026-08-02"
+
+  # =========================================================================
+  # CLASSES ALBERTA LEGISLATES BUT DOES NOT SPECIFY A GRAMMAR FOR.
+  # =========================================================================
+  - id: ca-ab-veterans
+    class: specialty
+    categories: [car, van, truck, motorcycle, moped]
+    period: { start: 2005 }
+    period_evidence: agency-stated-date
+    matching: recall-only
+    format:
+      pattern: "LLL-999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: none-published
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B3F8B"
+      legend: "Veteran"
+      emblem: { present: true, rendered: placeholder, description: "integrated maple leaf and poppy logo of the Royal Canadian Legion (named in AR 320/2002 s. 66.1(1))" }
+    notes: >-
+      THE DESIGN IS IN THE REGULATION EVEN THOUGH THE SERIAL IS NOT.
+      AR 320/2002 s. 66.1(1), verbatim: "The Registrar may issue a veterans'
+      licence plate that includes the word 'Veteran' and bears a depiction of
+      the integrated maple leaf and poppy logo of the Royal Canadian Legion to
+      an individual who meets the criteria set out in this section." s. 66.1(6)
+      restricts it to passenger-class motor vehicles, Class 2 farm vehicles,
+      motor cycles (not off-highway vehicles) and mopeds. s. 66.1(4) is the
+      unusual bit: "The evaluation of service documentation ... is the EXCLUSIVE
+      RESPONSIBILITY of the Royal Canadian Legion, Alberta-NWT Command" — a
+      government plate whose eligibility adjudication is contracted out to a
+      private body, with its own appeal process. `period.start: 2005` is
+      alberta.ca's own statement: "The Government of Alberta introduced a
+      special veterans' licence plate in 2005 and a motorcycle veterans' licence
+      plate in 2012". The motorcycle variant is recorded here rather than given
+      its own series because no format difference is sourced. s. 66.1(9)-(10)
+      let the Registrar recall the plate when eligibility lapses, and
+      alberta.ca adds that on the veteran's death the plate "may be retained
+      only as a memento but can no longer be used on a vehicle".
+    sources:
+      - "https://kings-printer.alberta.ca/documents/Regs/2002_320.pdf  # s. 66.1(1), (4), (6), (9), (10)"
+      - "https://www.alberta.ca/licence-plates  # 2005 introduction, 2012 motorcycle variant, memento rule"
+
+  - id: ca-ab-antique
+    class: historic
+    categories: [car, van, truck]
+    period: { start: 2002 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: none-published
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B3F8B"
+      legend: "ANTIQUE"
+    notes: >-
+      AR 320/2002 s. 65(1), verbatim: "The Registrar shall issue a licence plate
+      that has 'antique' on it if the Registrar issues a certificate of
+      registration for an antique motor vehicle." The LEGEND is therefore
+      statutory even though the serial is not. s. 65(2)-(3) give the owner a
+      genuine choice the schema should not flatten: instead of the antique
+      plate, the Registrar may approve "a licence plate that was issued in
+      Alberta, in the year an antique motor vehicle was manufactured and that is
+      in a condition satisfactory to the Registrar", and the owner "may attach
+      either ... but not both". A vehicle-keyed consumer can therefore meet an
+      Alberta-registered antique wearing a plate from the 1930s as its LIVE
+      registration. `period.start: 2002` is the year AR 320/2002 was made and is
+      an UPPER BOUND on the regime's start, not its creation — Alberta plainly
+      registered antiques before 2002 and the predecessor instrument was not
+      traced.
+    sources:
+      - "https://kings-printer.alberta.ca/documents/Regs/2002_320.pdf  # s. 65(1)-(5)"
+
+  - id: ca-ab-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2002 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: agency-page-for-restrictions-only
+      charset:
+        excluded: ["O"]
+        notes: >-
+          alberta.ca, verbatim, among the things a personalized configuration
+          must not contain: "the letter O (use the number zero)". This is the
+          Idaho rule exactly ("The letter O and the number zero look the same on
+          a license plate, therefore only the number zero will be accepted") and
+          it is carried as `charset.excluded` rather than in a regex: § 2.7
+          makes `regex` the round-trippable tier and `recall-only` forbids a
+          strict twin, so there is nowhere in the regex tiers to put it.
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B3F8B"
+    notes: >-
+      AR 320/2002 s. 115 is the personal-plate section (its text was located in
+      the regulation's index and its operative body was not extracted in this
+      pass — recorded gap). alberta.ca carries the substantive rules and they
+      are worth recording because Alberta polices LOOK-ALIKES explicitly, by
+      enumerated substitution pair: "Letters and numbers cannot be substituted
+      to create a plate similar to an existing plate such as H1 QT and HI QT.
+      Common substitutions include: Number 1 and the letter I; Number 1 and the
+      letter L; Number 6 and the letter G; Number 5 and the letter S; Number 2
+      and the letter Z; Number 0 and the letter Q; Number 8 and the letter B;
+      Number 3 and the letter E; Number 4 and the letter A." That is a
+      publishable OCR-confusability table straight from a motor-vehicle
+      authority. A personalized plate may not use "a configuration used by Motor
+      Vehicles Services for regular series licence plates", and may not be
+      registered on dealer plates, antiques, consular corps, disabled or
+      specialty plates. No character COUNT is stated on the page.
+    sources:
+      - "https://www.alberta.ca/licence-plates  # the O rule, the substitution table, the ineligible classes, the no-regular-series rule"
+      - "https://kings-printer.alberta.ca/documents/Regs/2002_320.pdf  # s. 115 Personal licence plates (index entry)"
+
+  - id: ca-ab-specialty-index
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2014 }
+    period_evidence: enabling-instrument
+    matching: recall-only
+    format:
+      pattern: "LLL-999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: none-published
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B3F8B"
+      emblem: { present: true, rendered: placeholder }
+    programs_named_by_the_authority:
+      - "Calgary Flames"
+      - "Edmonton Oilers"
+      - "Support our Troops"
+    program_count: 3
+    program_count_basis: "alberta.ca names exactly three specialty plates and links a page for each. Alberta publishes no total and no catalogue; three is what the authority lists, not an estimate."
+    notes: >-
+      THE INDEX ENTRY, per PRD-PLATES § 2.5 (individual specialty DESIGNS are
+      L4 work). `period.start: 2014` is the enabling instrument, not a program
+      date: s. 63.1 was ADDED to AR 320/2002 by AR 160/2014 s. 2 and amended by
+      AR 77/2022. s. 63.1(3): the Registrar, "on the application of, and having
+      entered into a written agreement with, an organization, may create a
+      special type of licence plate with respect to that organization".
+      s. 63.1(4) requires the Registrar to PUBLISH the creation criteria "on the
+      Registrar's website maintained on the Government of Alberta website" —
+      a statutory publication duty whose output was NOT located in this pass and
+      which is the single highest-value follow-up for Alberta. s. 63.1(5):
+      "Specialty licence plates must be in the form and design approved by the
+      Registrar." s. 63.1(6) lets the Registrar restrict a specialty plate to
+      named vehicle classes in writing.
+    sources:
+      - "https://kings-printer.alberta.ca/documents/Regs/2002_320.pdf  # s. 63.1(1)-(6), enactment AR 160/2014 s2, amendment 77/2022"
+      - "https://www.alberta.ca/licence-plates  # the three named programs"
+
+  - id: ca-ab-dealer
+    class: dealer
+    categories: [car, van, truck, trailer]
+    period: { start: 2002 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL-9999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: none-published
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B3F8B"
+    notes: >-
+      AR 320/2002 ss. 72-74. s. 72(4) states the binding plainly and it is the
+      classic dealer-plate shape: "A dealer's certificate of registration and
+      the licence plates issued with it apply to ALL MOTOR VEHICLES HELD FOR
+      SALE by the holder of the certificate of registration from time to time" —
+      the plate is bound to the BUSINESS, not to any vehicle. s. 72(5) excludes
+      vehicles held for hire. s. 73 runs the parallel regime for trailer dealers
+      and s. 74 for dealers' plates generally. No serial grammar is published,
+      hence recall-only. Separate from ca-ab-personalized, which s. 115 and
+      alberta.ca both bar from dealer plates.
+    sources:
+      - "https://kings-printer.alberta.ca/documents/Regs/2002_320.pdf  # ss. 72(1)-(6), 73, 74"
+
+  - id: ca-ab-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2002 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "9999-LL"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: none-published
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1B3F8B"
+    notes: >-
+      AR 320/2002 s. 68: a trailer plate may be transferred between trailers of
+      the same owner with the Registrar's consent (s. 68(1)) but never "from one
+      trailer owner to another" (s. 68(2)); a trailer-rental business may not
+      rent out a trailer without a trailer plate on it (s. 68(3)). s. 69 adds
+      the Alberta oddity: the Registrar "may issue a TRAILER licence plate to
+      the owner of a COMMERCIAL VEHICLE if the owner is engaged in the business
+      of towing trailers", and that owner "may attach the trailer licence plate
+      to a trailer towed by the commercial vehicle" — a trailer plate bound to
+      the tractor's operator rather than to any trailer. Recall-only: no
+      grammar published; the pattern shown is a placeholder shape only.
+    sources:
+      - "https://kings-printer.alberta.ca/documents/Regs/2002_320.pdf  # ss. 68(1)-(3), 69(1)-(2)"

--- a/plates/ca-bc.yml
+++ b/plates/ca-bc.yml
@@ -1,0 +1,697 @@
+# plates/ca-bc.yml — British Columbia (PRD-PLATES gate L3, Canada west).
+#
+# CANADA IS FEDERATED THE WAY THE UNITED STATES IS, AND THIS FILE IS THE
+# per-subdivision shape the schema already carries (`us-fl.yml` is its
+# reference). There is no federal Canadian plate: the Constitution Act 1867
+# s. 92(13) property-and-civil-rights head puts vehicle registration in the
+# provinces and the territorial statutes replicate it, so `ca.yml` would have
+# nothing true to say about a format. Jurisdiction code is the ISO 3166-2:CA
+# suffix, lowercased, matching the `us-<state>` convention already on disk.
+#
+# ── FIVE STRUCTURAL FACTS THAT SHAPE THIS FILE ─────────────────────────────
+#
+# 1. BRITISH COLUMBIA DELEGATES THE ENTIRE PLATE DESIGN TO A CROWN INSURER,
+#    IN ONE SENTENCE OF STATUTE, AND WRITES NOTHING ELSE DOWN.
+#    Motor Vehicle Act, R.S.B.C. 1996, c. 318, s. 12(1), verbatim:
+#      "Each number plate must (a) be marked with the licence number of the
+#       motor vehicle or trailer for which it is issued, and (b) be of a
+#       material and design determined by the Insurance Corporation of
+#       British Columbia."
+#    That is the whole design law of British Columbia. No size, no colour, no
+#    character height, no serial grammar — the DELEGATE decides, and the
+#    delegate is an insurance corporation, not a ministry. This is the
+#    Washington State pattern (RCW 46.16A.200(1) hands design to the director)
+#    arriving in Canada, and it sets the evidence ceiling for the whole file:
+#    every format claim here comes from ICBC's OWN PUBLICATION, not from law.
+#
+# 2. THE PUBLICATION EXISTS, IT IS DATED, AND IT IS THE FIND OF THIS PASS.
+#    ICBC "Vehicle licensing & insurance bulletin", bulletin 33, 9 June 2025,
+#    "New licence plate number configurations", is a four-page law-enforcement
+#    bulletin that TABULATES the current and incoming character pattern of
+#    eight BC plate types in ICBC's own notation (`#` = a number 0-9,
+#    `@` = any letter other than I, O or Q). It is the closest thing British
+#    Columbia has to a statutory format annex, it is primary (the delegate's
+#    own act under s. 12(1)(b)), and every `format` block below that carries
+#    `evidence: agency-bulletin` is anchored on one of its rows. Verbatim, on
+#    the alphabet: "The new licence plate patterns may include the letters
+#    'U', 'Y' and 'Z', which were not previously used. The letters 'I', 'O'
+#    and 'Q' remain excluded from use because they present identification
+#    issues." And on length: "All BC licence plate types consist of no more
+#    than six characters." That sentence is the outer bound in every
+#    `regex_statutory` in this file.
+#
+# 3. NO SIZE IS PRESCRIBED ANYWHERE, SO NO SERIES HERE CARRIES ONE.
+#    Division 3 of the Motor Vehicle Act Regulations (B.C. Reg. 26/58) —
+#    "Display and Use of Number Plates", ss. 3.01 to 3.15 — was read in full.
+#    It legislates ATTACHMENT (3.011), ORIENTATION (3.02, 3.021), LEGIBILITY
+#    (3.03), and then twelve sections of transfer/remission/disposal
+#    administration. It prescribes no dimension, no colour and no character
+#    metric. `design.plate` is therefore ABSENT from every series in this file
+#    and its absence is a sourced finding, exactly as in plates/gb.yml. The
+#    "12 x 6 inch North American plate" is a real convention and an UNSOURCED
+#    one here; it is recorded as a note, never as a dimension.
+#
+# 4. THE PLATE IS ICBC'S PROPERTY, NOT THE OWNER'S, AND THE BINDING IS TO THE
+#    VEHICLE VIA THE LICENCE. s. 12(6), verbatim: "Number plates and
+#    validation decals issued under this section are the property of the
+#    Insurance Corporation of British Columbia whether they were issued
+#    before, on or after the date this section comes into force." Reg. 3.031
+#    then lets a registered owner move plates between their OWN vehicles on
+#    payment, and reg. 3.05 forces removal on transfer of title — so a BC
+#    plate follows the OWNER's registration, not the car. `binding: vehicle`
+#    is retained because the plate is issued against a vehicle licence, with
+#    the transferability recorded in `binding_note`.
+#
+# 5. THE SEPARATOR QUESTION IS OPEN AND IS SAID SO, NOT GUESSED.
+#    ICBC's bulletin writes every pattern SOLID (`@###@@`, example `A123BC`).
+#    A physical BC passenger plate prints a visible gap between character
+#    groups, and secondary sources render the serial hyphenated (`A12-3BC`).
+#    ICBC states no separator glyph and no gap POSITION. Under PRD-PLATES
+#    § 2.6 the dataset ships the printed form; where the authority itself
+#    prints the form solid and states nothing else, the solid form is what is
+#    shipped, and the gap is recorded as an open question rather than placed
+#    at a guessed offset. A § 2.6-forgiving consumer canonicalises both forms
+#    to the same serial, so nothing is lost at match time — only the ability
+#    to SAY where the gap falls, which no primary establishes.
+#
+# REGEX POLICY (identical to plates/gb.yml, plates/de.yml, plates/us-fl.yml):
+# `format.regex` is the lint-round-trippable regex — the lint generates
+# serials from `format.pattern` (9 -> any digit, L -> any A-Z) and requires
+# the regex to accept all of them, so `regex` can never carry the I/O/Q
+# exclusion. `format.regex_strict` carries ICBC's own alphabet.
+# `format.regex_statutory` carries the six-character bound the bulletin states
+# for every BC plate type.
+jurisdiction: ca-bc
+authority:
+  name: Insurance Corporation of British Columbia (ICBC), as delegate of the Province under the Motor Vehicle Act
+  url: "https://www.icbc.com/vehicle-registration/licence-plates"
+binding: vehicle
+binding_note: >-
+  The plate is issued against a vehicle LICENCE and is ICBC's property
+  throughout (MVA s. 12(6)). It is not permanently married to the vehicle: reg.
+  3.031(1) lets a registered owner or lessee move plates from one of their own
+  vehicles to another on compliance with licensing and payment, and reg. 3.05
+  forces the transferor to REMOVE the plates before giving up possession on a
+  sale. So on a sale the plate stays with the seller — the opposite of the
+  British rule and of most US states — while remaining, in law, ICBC's.
+instrument:
+  statute:
+    citation: "Motor Vehicle Act, R.S.B.C. 1996, c. 318, s. 12 (Number plates); s. 3 (registration, licence and insurance); s. 13 (offences)"
+    source: "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/96318_01  # s. 12(1)(a)-(b), (2)-(6) read verbatim 2026-08-02"
+  regulation:
+    citation: "Motor Vehicle Act Regulations, B.C. Reg. 26/58 (O.C. 1004/58), Division 3 (Display and Use of Number Plates), Division 22 (Antique Motor Vehicles), Division 22A (Collector Motor Vehicles), Division 34 (Personalized Number Plates)"
+    consolidation: "This consolidation is current to July 28, 2026. Last amended April 20, 2026 by B.C. Reg. 59/2026."
+    source: "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_01  # Division 3 ss. 3.01-3.15 read in full 2026-08-02"
+    source_div22: "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_06  # Divisions 22 and 22A"
+    source_div34: "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_10  # Division 34"
+  agency_bulletin:
+    citation: "ICBC, Vehicle licensing & insurance bulletin 33, 9 June 2025 — 'New licence plate number configurations'"
+    issued: "2025-06-09"
+    author: "Christopher Dicdiquin, Manager, Vehicle Registration Policy and Programs, ICBC"
+    self_declared_authority: >-
+      The bulletin's own Reference block names exactly four authorities:
+      "Motor Vehicle Act s. 3(7) / s. 12 / s. 13", "Motor Vehicle Act
+      Regulations Div. 3", "Vehicle licensing and insurance bulletins", and
+      "License Plate Standard, ed. 3 (AAMVA)". ICBC therefore cites the SAME
+      AAMVA Edition 3 the US files cite — a voluntary standard with no
+      enforcement power, adopted here by a Canadian Crown corporation.
+    source: "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # pp. 1-3: alphabet, six-character rule, the eight-row current/new pattern table, the Reference block"
+  licence: "bclaws.gov.bc.ca content is Copyright (c) King's Printer, Victoria, British Columbia, Canada, published under the King's Printer licence; the statute and regulation are edicts of government. The ICBC bulletin is an ICBC publication, served without click-through, and is cited (facts extracted) rather than reproduced."
+
+# ---------------------------------------------------------------------------
+# artwork_risk — PRD-PLATES § 4 requires this per federated subdivision.
+# ---------------------------------------------------------------------------
+artwork_risk:
+  posture: unresearched-crown-copyright-presumed
+  basis: >-
+    Canada has no Feist and no state-works doctrine: Crown copyright subsists
+    under s. 12 of the Copyright Act (R.S.C. 1985, c. C-42) in works "prepared
+    or published by or under the direction or control of His Majesty or any
+    government department". British Columbia's own bclaws pages carry
+    "Copyright (c) King's Printer, Victoria, British Columbia, Canada". No BC
+    equivalent of {{PD-FLGov}} exists on Commons. Nothing was found either
+    asserting or disclaiming copyright in the PLATE DESIGN specifically, so the
+    posture is recorded as UNRESEARCHED and the § 3 placeholder default governs.
+  emblem_rule: >-
+    PRD-PLATES § 3 placeholder rule applies to the provincial flag device on
+    the standard base and to all three BC Parks artworks (Kermode bear, Purcell
+    Mountains, Porteau Cove), which are commissioned photographic/illustrative
+    works, not statutory drawings. Render emblem slots as
+    `{present: true, rendered: placeholder}`.
+  contrast_note: >-
+    The neighbouring territories are the instructive contrast and are NOT
+    guesswork: the Northwest Territories holds a REGISTERED CANADIAN TRADE-MARK
+    over its polar-bear plate (TMA558214) and licensed it to Nunavut. See
+    plates/ca-nt.yml. No comparable BC registration was searched for; that is a
+    named gap, not a clearance.
+  sources:
+    - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/96318_01  # King's Printer copyright notice on the served text"
+
+# ---------------------------------------------------------------------------
+# Display rules — the part of BC law that IS specific.
+# ---------------------------------------------------------------------------
+display_rules:
+  attachment: >-
+    Reg. 3.011, verbatim: "Number plates issued for a vehicle under the
+    Commercial Transport Act or Motor Vehicle Act must be attached (a) one plate
+    to the front and one plate to the rear of the vehicle, if 2 number plates
+    are issued for a vehicle, and (b) to the rear of the vehicle, if a single
+    number plate is issued for a vehicle." Note the shape of the rule: BC does
+    not legislate HOW MANY plates a class gets — it legislates where they go
+    once ICBC has decided. The two-plate passenger convention is ICBC's, not
+    the regulation's.
+  orientation: >-
+    Reg. 3.02: "A number plate shall at all times be securely fastened in a
+    horizontal position to the vehicle for which it is issued." Reg. 3.021
+    (added by B.C. Reg. 193/2015): "Despite section 3.02, a number plate may be
+    attached in vertical position on the left front fork of a motorcycle, with
+    the first number or letter at the bottom of the fork." A VERTICAL,
+    BOTTOM-UP motorcycle plate is a real and lawful BC reading order — a
+    consumer doing OCR on a BC motorcycle must handle 90-degree rotation.
+  legibility: >-
+    Reg. 3.03: the plate "must be kept entirely unobstructed and free from dirt
+    or foreign material, so that the numbers and letters on it may be plainly
+    seen and read at all times and so that the numbers and letters may be
+    accurately photographed using a speed monitoring device or traffic light
+    safety device prescribed under section 83.1 of the Act." BC legislates
+    machine readability by name, which is unusual and is why bulletin 33 spends
+    a paragraph on ALPR compatibility.
+  validation_decal: >-
+    Reg. 3.012: a validation decal goes on the FRONT plate for a Commercial
+    Transport Act vehicle over 5 500 kg licensed GVW and on the REAR plate for
+    every other vehicle. Reg. 3.012(2) carves out decals issued before
+    1 May 2022 — ICBC stopped issuing decals in 2022, so a current BC plate
+    carries no visible validity marker.
+  off_road: "Reg. 3.0111: s. 3.011 does not apply to an off-road vehicle registered under the Off-Road Vehicle Act displaying a number plate or number sticker issued under that Act (a separate regime, out of scope here)."
+  sources:
+    - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_01  # Division 3 ss. 3.011, 3.0111, 3.012, 3.02, 3.021, 3.03"
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-wide facts, cited once and referenced per series.
+# ---------------------------------------------------------------------------
+common:
+  alphabet:
+    excluded: ["I", "O", "Q"]
+    statement: >-
+      ICBC bulletin 33, verbatim: "In the patterns below, # represents a number
+      (0-9) and @ represents any letter (other than I, O, or Q.)" and "The
+      letters 'I', 'O' and 'Q' remain excluded from use because they present
+      identification issues."
+    newly_admitted: ["U", "Y", "Z"]
+    newly_admitted_statement: >-
+      Verbatim: "The new licence plate patterns may include the letters 'U',
+      'Y' and 'Z', which were not previously used." This is the single most
+      useful era signal in the file: a BC serial containing U, Y or Z is
+      2025-or-later on ICBC's own statement.
+    source: "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # p.1 alphabet paragraph, p.2 pattern-table legend"
+  length_bound:
+    max_characters: 6
+    statement: >-
+      Verbatim: "Will licence plates still have six characters maximum? Yes. By
+      altering the pattern of number and letter positions for each licence
+      plate type, ICBC was able to increase available licence plate
+      combinations using the same number of characters." And in Background:
+      "All BC licence plate types consist of no more than six characters."
+    source: "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # pp.1-2"
+  why_the_2025_recut:
+    statement: >-
+      Verbatim: "The changes are necessary to ensure every licence plate has a
+      unique alpha-numeric number, because the existing patterns are nearly used
+      up." And: "To ensure there is sufficient inventory of unique licence plate
+      numbers for the next twenty years, character pattern updates are planned
+      for 16 licence plate types. Ten of these are scheduled for rollout as
+      required over the next year." SIXTEEN types are being re-cut; the bulletin
+      tabulates EIGHT. The other eight are a known, named gap in this file.
+    source: "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # p.2 Background"
+  plate_count_note: >-
+    ICBC issues 40-odd plate types (bulletin 33: "ICBC maintains approximately
+    40 licence plate types"). This file authors the ten for which a grammar or a
+    dated design was secured. The remainder are a recorded gap, not an omission.
+  dimensions_note: >-
+    NEGATIVE FINDING, recorded so nobody repeats the hunt. Neither MVA s. 12
+    nor Division 3 of B.C. Reg. 26/58 prescribes any plate dimension, and no
+    ICBC page carrying one was found. The 12 x 6 in / 300 x 150 mm North
+    American convention is real and is NOT asserted here. `design.plate` is
+    absent from every series by design.
+  colour_note: >-
+    Blue characters on a reflective white ground with the provincial flag device
+    is the standard base as depicted on ICBC's own pages. No colour is in any
+    instrument; every hex below is `hex_basis: observed`.
+
+series:
+
+  # =========================================================================
+  # STANDARD PASSENGER — the current recut and the series it replaces.
+  # =========================================================================
+  - id: ca-bc-standard-2025
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2025 }
+    period_evidence: first-issue-announced
+    matching: strict
+    format:
+      pattern: "L999LL"
+      regex: '\A[A-Z]\d{3}[A-Z]{2}\z'
+      regex_strict: '\A[A-HJ-NPR-Z]\d{3}[A-HJ-NPR-Z]{2}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: agency-bulletin
+      charset:
+        excluded: ["I", "O", "Q"]
+        notes: >-
+          ICBC bulletin 33 row "Passenger": current pattern @@###@, NEW pattern
+          @###@@, "Example of new pattern: A123BC". `@` is defined in the
+          bulletin's own legend as "any letter (other than I, O, or Q.)"
+          `regex_strict` is that legend spelled out; `regex` cannot carry it
+          because the lint generates I, O and Q from the human pattern.
+      separator_note: >-
+        ICBC prints the pattern and its example SOLID. The physical plate shows
+        a group gap and secondary renderings hyphenate it (`A12-3BC`), but ICBC
+        states neither a glyph nor a gap POSITION, so none is asserted. A
+        PRD-PLATES § 2.6 forgiving consumer strips the gap and matches this
+        regex unchanged.
+      progression: "not published. ICBC states only that the recut exists to extend the six-character space; no block-allocation order was found."
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+      legend_top: "BRITISH COLUMBIA"
+      legend_bottom: "Beautiful British Columbia"
+      emblem: { present: true, rendered: placeholder, description: "provincial flag device" }
+      rear_differs: false
+      design_note: >-
+        Bulletin 33, verbatim: "All regular BC plates will remain six characters
+        with the same design, reflectivity, and materials, making them scannable
+        as usual." So the 2025 recut is a SERIAL-GRAMMAR change on an UNCHANGED
+        BASE — the base and the format have different lifetimes, and a schema
+        that conflates them cannot model British Columbia. Same finding as
+        Oregon's 1987 fir base outliving two serial arrangements.
+    notes: >-
+      Rollout, verbatim: "ICBC will be gradually introducing new licence plate
+      character configurations on some British Columbia licence plates. This will
+      begin with the B.C. Parks - Porteau Cove series within the next few weeks,
+      followed by regular passenger licence plates as early as August 2025."
+      `period.start: 2025` rests on that sentence and on the bulletin's own date
+      (9 June 2025) — an authority statement of intended first issue, not a
+      confirmed first-issue observation, which is why the evidence grade is
+      `first-issue-announced` and not `agency-stated-date`. The predecessor
+      series continues to issue from stock in parallel; see ca-bc-standard-2014.
+    sources:
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # pattern, alphabet, rollout month, unchanged-base statement"
+      - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/96318_01  # MVA s. 12(1)(b): the design is ICBC's to determine"
+
+  - id: ca-bc-standard-2014
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2014, end: 2025 }
+    period_evidence: mixed-secondary-start-agency-end
+    matching: strict
+    format:
+      pattern: "LL999L"
+      regex: '\A[A-Z]{2}\d{3}[A-Z]\z'
+      regex_strict: '\A[A-HJ-NPR-TVWX]{2}\d{3}[A-HJ-NPR-TVWX]\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: agency-bulletin-for-format
+      charset:
+        excluded: ["I", "O", "Q", "U", "Y", "Z"]
+        notes: >-
+          Six letters, not three, and the extra three are the era signal. ICBC
+          bulletin 33 says the new patterns "may include the letters 'U', 'Y'
+          and 'Z', which were not previously used" — so the pre-2025 alphabet is
+          A-Z minus I, O, Q, U, Y, Z, which is exactly what `regex_strict`
+          spells (A-H, J-N, P, R-T, V, W, X).
+      separator_note: "As ca-bc-standard-2025: ICBC prints @@###@ solid; the gap position is unstated."
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+      legend_top: "BRITISH COLUMBIA"
+      legend_bottom: "Beautiful British Columbia"
+      emblem: { present: true, rendered: placeholder, description: "provincial flag device" }
+      rear_differs: false
+    notes: >-
+      THE TWO ENDS OF THIS PERIOD HAVE DIFFERENT EVIDENCE GRADES AND THE KEY
+      SAYS SO. The END is strong: ICBC bulletin 33 (9 June 2025) tabulates
+      @@###@ as the "Current pattern" being replaced for Passenger, which dates
+      the changeover to 2025 from the authority. The START is weak: 2014 comes
+      only from the per-jurisdiction encyclopedia article used as a finding aid,
+      whose format-history row carries no footnote; no ICBC or provincial source
+      dating the AB1-23C arrangement was found. Treat 2014 as unverified.
+      Parallel issuance with ca-bc-standard-2025 is REAL — old plate stock is
+      issued until exhausted ("New licence plate configurations will roll out as
+      old inventories get exhausted") — which is why the two series overlap.
+    sources:
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # 'Current pattern' column = @@###@; old-inventory exhaustion rule"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_British_Columbia  # FINDING AID ONLY (PRD-PLATES §4 Wikipedia row): the unfootnoted 2014 start; accessed 2026-08-02"
+
+  # =========================================================================
+  # COMMERCIAL / FARM / TRAILER / PRORATE / INDUSTRIAL — the other seven rows
+  # of the bulletin's table. Each is a distinct plate TYPE in ICBC's own terms
+  # with its own grammar, which is why each is its own series.
+  # =========================================================================
+  - id: ca-bc-commercial-truck-2025
+    class: standard
+    categories: [truck]
+    period: { start: 2025 }
+    period_evidence: first-issue-announced
+    matching: strict
+    format:
+      pattern: "9LL999"
+      regex: '\A\d[A-Z]{2}\d{3}\z'
+      regex_strict: '\A\d[A-HJ-NPR-Z]{2}\d{3}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: agency-bulletin
+      charset: { excluded: ["I", "O", "Q"] }
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+      emblem: { present: true, rendered: placeholder }
+    notes: >-
+      Bulletin 33 row "Commercial Truck": current @#####, new #@@###, "Example
+      of new pattern: 1AB234". Commercial vehicles over 5 500 kg licensed GVW
+      are licensed under the COMMERCIAL TRANSPORT ACT rather than the Motor
+      Vehicle Act (reg. 3.012(1)(a) turns on exactly that threshold) and carry
+      their validation decal on the FRONT plate. The superseded @##### grammar
+      is not given a series of its own because no source dates it.
+    sources:
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # Commercial Truck row"
+
+  - id: ca-bc-farm-2025
+    class: agricultural
+    categories: [truck]
+    period: { start: 2025 }
+    period_evidence: first-issue-announced
+    matching: strict
+    format:
+      pattern: "99999L"
+      regex: '\A\d{5}[A-Z]\z'
+      regex_strict: '\A\d{5}[A-HJ-NPR-Z]\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: agency-bulletin
+      charset: { excluded: ["I", "O", "Q"] }
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+    notes: >-
+      Bulletin 33 row "Farm Truck": current G#####, new #####A, "Example of new
+      pattern: 12345A". The recut RETIRES the leading G — the old grammar's only
+      geographic-free type marker — and moves the letter to the tail, so a BC
+      farm plate is no longer recognisable by its first character. Farm vehicles
+      are also the one class BC bars from personalised plates (reg. 34.05(1)(a)).
+    sources:
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # Farm Truck row"
+      - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_10  # reg. 34.05(1)(a): no personalised plate on a farm vehicle"
+
+  - id: ca-bc-trailer-utility-2025
+    class: trailer
+    categories: [trailer]
+    period: { start: 2025 }
+    period_evidence: first-issue-announced
+    matching: strict
+    format:
+      pattern: "9ULLL9"
+      regex: '\A\dU[A-Z]{3}\d\z'
+      regex_strict: '\A\dU[A-HJ-NPR-Z]{3}\d\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: agency-bulletin
+      charset: { excluded: ["I", "O", "Q"] }
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+    notes: >-
+      Bulletin 33 row "Utility Trailer": current U####A, new #U@@@#, "Example of
+      new pattern: 1UABC2". The literal U is a TYPE MARKER that survives the
+      recut but MOVES from position 1 to position 2 — and note the collision it
+      creates with fact 2 above: U is simultaneously a newly admitted SERIAL
+      letter elsewhere in the system from 2025. A parser must not read "contains
+      U" as "utility trailer"; only "U in position 2 of a six-character serial"
+      carries that meaning, and even that is a shape hit.
+      Trailers are barred from personalised plates (reg. 34.05(1)(f)).
+    sources:
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # Utility Trailer row"
+      - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_10  # reg. 34.05(1)(f)"
+
+  - id: ca-bc-prorate-2025
+    class: standard
+    categories: [truck, bus]
+    period: { start: 2025 }
+    period_evidence: first-issue-announced
+    matching: strict
+    format:
+      pattern: "9999P9"
+      regex: '\A\d{4}P\d\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: agency-bulletin
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+    notes: >-
+      Bulletin 33 row "Prorate": current #####P, new ####P#, "Example of new
+      pattern: 1234P5". A prorate plate is an International Registration Plan
+      apportioned plate for interjurisdictional commercial carriers; the literal
+      P is the type marker and moves from the tail to position 5. No
+      `regex_strict` is carried because the grammar has no free letter position
+      left to restrict.
+    sources:
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # Prorate row"
+
+  - id: ca-bc-industrial-2025
+    class: standard
+    categories: [truck]
+    period: { start: 2025 }
+    period_evidence: first-issue-announced
+    matching: strict
+    format:
+      pattern: "9X9999"
+      regex: '\A\dX\d{4}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: agency-bulletin
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+    notes: >-
+      Bulletin 33 row "Industrial": current X#####, new #X####, "Example of new
+      pattern: 1X2345". Industrial plates are for machines used off-highway that
+      make limited highway movements; Division 24 of B.C. Reg. 26/58 ("Vehicles
+      of Unusual Size, Weight or Operating Characteristics") is the neighbouring
+      regime and reg. 3.121 forbids moving plates between a Division 24 vehicle
+      and any other class — a hard, sourced class boundary.
+    sources:
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # Industrial row"
+      - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_01  # reg. 3.121, reg. 3.13 classes of vehicles"
+
+  # =========================================================================
+  # BC PARKS — the specialty programme, and the one series in this file with a
+  # first-issue date to the DAY from a provincial news release.
+  # =========================================================================
+  - id: ca-bc-parks-2025
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2025 }
+    period_evidence: first-issue-announced
+    matching: strict
+    format:
+      pattern: "P999LL"
+      regex: '\A[PRS]\d{3}[A-Z]{2}\z'
+      regex_strict: '\A[PRS]\d{3}[A-HJ-NPR-Z]{2}\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: agency-bulletin
+      charset: { excluded: ["I", "O", "Q"] }
+      first_character_is_the_design: >-
+        The leading letter identifies WHICH park artwork the plate carries, and
+        it is a closed three-member set from bulletin 33: S = Porteau Cove,
+        P = Kermode, R = Purcell. This is the only geographic-ish decode
+        dimension British Columbia has, and it decodes the DESIGN, not the
+        registrant's location. Small and closed, so it is inline here rather
+        than in a _decode file.
+    variants:
+      - name: "BC Parks - Porteau Cove"
+        format: { pattern: "S999LL", regex: '\AS\d{3}[A-Z]{2}\z' }
+      - name: "BC Parks - Purcell"
+        format: { pattern: "R999LL" }
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+      emblem: { present: true, rendered: placeholder, description: "one of three park scenes: Kermode bear / Purcell Mountains / Porteau Cove" }
+    notes: >-
+      Bulletin 33 rows "Parks - Porteau Cove" (current RS###@, new S###@@,
+      example S123AA), "Parks - Kermode" (current RK###@, new P###@@, example
+      P123AA) and "Parks - Purcell" (current RM###@, new R###@@, example
+      R123AA). Porteau Cove is the FIRST type in the whole 2025 recut: "This
+      will begin with the B.C. Parks - Porteau Cove series within the next few
+      weeks" (bulletin dated 9 June 2025). The three superseded grammars
+      (RS###@ / RK###@ / RM###@) belong to ca-bc-parks-2017.
+    sources:
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # the three Parks rows + rollout order"
+
+  - id: ca-bc-parks-2017
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2017, end: 2025 }
+    period_evidence: agency-stated-date
+    matching: strict
+    format:
+      pattern: "RK999L"
+      regex: '\AR[KMS]\d{3}[A-Z]\z'
+      regex_strict: '\AR[KMS]\d{3}[A-HJ-NPR-TVWX]\z'
+      regex_statutory: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: agency-bulletin
+      charset: { excluded: ["I", "O", "Q", "U", "Y", "Z"] }
+      decode_inline:
+        RK: "Kermode bear"
+        RM: "Purcell Mountains"
+        RS: "Porteau Cove"
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+      emblem: { present: true, rendered: placeholder, description: "one of three park scenes" }
+    notes: >-
+      START IS PRIMARY AND TO THE DAY. Province of British Columbia news release
+      2017ENV0020-000696 (19 March 2017), verbatim: "The three licence plate
+      designs - a Kermode bear found only in British Columbia, the snow-capped
+      Purcell Mountains, and a stunning view from Porteau Cove overlooking Howe
+      Sound - were unveiled by Environment Minister Mary Polak and Transportation
+      and Infrastructure Minister Todd Stone on Jan. 18, 2017, in Vancouver" and
+      "became available for purchase at Autoplan broker offices on Jan. 29,
+      2017". Unveiling and FIRST ISSUE are eight days apart and this file records
+      the issue date, not the unveiling. END is the 2025 recut per bulletin 33.
+      `regex_strict` restricts the tail letter to the pre-2025 alphabet, which is
+      what makes an RK/RM/RS plate era-datable on sight.
+    sources:
+      - "https://news.gov.bc.ca/releases/2017ENV0020-000696  # unveiled 18 Jan 2017, on sale 29 Jan 2017, the three designs, the ICBC partnership"
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # the RS/RK/RM 'Current pattern' column"
+
+  # =========================================================================
+  # CLASSES WHOSE GRAMMAR ICBC HAS NOT PUBLISHED. Each is recall-only, bounded
+  # by the one thing that IS sourced for every BC plate: six characters.
+  # =========================================================================
+  - id: ca-bc-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 1970 }
+    period_evidence: not-established
+    matching: recall-only
+    format:
+      pattern: "999LL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: none-published
+      charset: { excluded: ["I", "O", "Q"] }
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+      mounting_note: >-
+        Reg. 3.021 permits a BC motorcycle plate to be mounted VERTICALLY on the
+        left front fork, first character at the BOTTOM. Reading order is
+        bottom-to-top in that mounting.
+    notes: >-
+      RECALL-ONLY AND HONEST ABOUT WHY. Bulletin 33 does not tabulate the
+      motorcycle pattern, and no other ICBC publication carrying it was found.
+      The regex is the six-character bound the bulletin states for EVERY BC
+      type — a genuine outer claim, not a guess — so a match here means "this
+      string has a shape British Columbia issues" and nothing more.
+      `period.start: 1970` is a floor carried only to satisfy the schema's
+      integer-year requirement and is marked `not-established`; it must not be
+      read as a claim. The 2025 recut list names sixteen types of which the
+      bulletin tabulates eight; motorcycle may be among the untabulated eight.
+    sources:
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # the six-character bound and the I/O/Q exclusion; motorcycle NOT tabulated"
+      - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_01  # reg. 3.021 vertical fork mounting"
+
+  - id: ca-bc-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 1979 }
+    period_evidence: enabling-instrument
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: regulation-for-restrictions-only
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+    notes: >-
+      Division 34 of B.C. Reg. 26/58 is the personalised-plate regime and it was
+      ADDED BY B.C. Reg. 295/79 — every operative section of Division 34 carries
+      the enactment note "[en. B.C. Reg. 295/79, s. (c)]", which is what
+      `period.start: 1979` rests on (`enabling-instrument`: the year the
+      regime was created, not a first-issue observation). Reg. 34.04 states the
+      refusal grounds verbatim: a combination "identical to one already in use",
+      "identical to a number plate in an existing or projected series of number
+      plates to be issued", one that "could create identification problems", one
+      that "is unseemly, vulgar, indecent or may offend any person", or one that
+      "might distract the drivers of other vehicles so as to reduce the level of
+      their driving care or attention". Reg. 34.05(1) bars personalised plates
+      on farm vehicles, 'vintage'-plated antique cars, collector-plated vehicles,
+      trailers, Commercial Transport Act vehicles over 5 500 kg, and Division 24
+      vehicles other than neighbourhood zero-emission vehicles. Reg. 34.10(1)(c)
+      dates the fee regime to plates "issued on or after January 1, 1984".
+      No character-count rule is stated in the regulation; the six-character
+      bound comes from bulletin 33.
+    sources:
+      - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_10  # Division 34 ss. 34.01-34.08, enactment note B.C. Reg. 295/79"
+      - "https://partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf  # six-character bound"
+
+  - id: ca-bc-vintage-antique
+    class: historic
+    categories: [car, van, truck]
+    period: { start: 1966 }
+    period_evidence: enabling-instrument
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: none-published
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+    notes: >-
+      British Columbia runs TWO parallel old-vehicle regimes and they are not the
+      same thing. Division 22 (ANTIQUE MOTOR VEHICLES), enacted by B.C. Reg.
+      55/66 — hence `period.start: 1966` — defines an antique motor vehicle as
+      "a motor vehicle 30 years of age or older maintained as nearly as possible
+      with original component parts, and owned as a collector's item and operated
+      solely for use in exhibition or club activities, parades and other like
+      functions", and reg. 22.03(1)(b) directs ICBC to issue "a distinctive
+      number plate or plates". Reg. 34.05(1)(b) calls the resulting plates
+      "'vintage' number plates" in terms. Reg. 22.03(1)(a) is the unusual part:
+      the licence is "valid for as long as the vehicle is in existence and
+      continues to be operated as an antique motor vehicle" — a NON-EXPIRING
+      registration, which is why BC antique plates carry no validity marker of
+      any kind. No serial grammar is published, hence recall-only.
+    sources:
+      - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_06  # Division 22 ss. 22.01-22.04, enactment note B.C. Reg. 55/66"
+      - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_10  # reg. 34.05(1)(b) naming them 'vintage' plates"
+
+  - id: ca-bc-collector
+    class: historic
+    categories: [car, van, truck]
+    period: { start: 2006 }
+    period_evidence: enabling-instrument
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: none-published
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#12326E"
+    notes: >-
+      The SECOND old-vehicle regime, and a distinct one: Division 22A (COLLECTOR
+      MOTOR VEHICLES) was enacted by B.C. Reg. 139/2006 (hence
+      `period.start: 2006`) and amended by B.C. Reg. 105/2017. Its four
+      qualifying items are a genuinely useful vehicle-catalogue hook and are
+      quoted rather than paraphrased: (1) a vehicle "at least 25 years old" and
+      "maintained or restored to a condition that conforms to the original
+      manufacturer's specifications"; (2) at least 15 years old AND "no longer
+      produced, or of limited availability", same condition test; (3) a MODIFIED
+      motor vehicle manufactured 1974 or earlier and registered in BC as a 1974
+      or earlier model whose body, chassis, power train or steering/braking has
+      been altered by a non-manufacturer; (4) a CONSTRUCTED motor vehicle
+      manufactured 1942 or earlier (or built to resemble one) and registered as
+      a 1942-or-earlier model. Reg. 22A.04(1) is the schema-stressing part: one
+      collector licence and plate "may, with the prior approval of the Insurance
+      Corporation of British Columbia, be used on ANY of the collector motor
+      vehicles in respect of which the licence was issued" — a ONE-PLATE-MANY-
+      VEHICLES binding that a vehicle-keyed consumer must not assume away.
+      Distinct from ca-bc-vintage-antique: different regime, different
+      eligibility, different enacting instrument, overlapping in time.
+    sources:
+      - "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_06  # Division 22A ss. 22A.01-22A.04, enactment note B.C. Reg. 139/2006"

--- a/plates/ca-mb.yml
+++ b/plates/ca-mb.yml
@@ -1,0 +1,499 @@
+# plates/ca-mb.yml — Manitoba (PRD-PLATES gate L3, Canada west).
+#
+# ── THE FIND: A 1997 GOVERNMENT NEWS RELEASE THAT DATES TWO SERIES AT ONCE.
+#
+# Province of Manitoba news release, 13 June 1997, "New Licence Plates Being
+# Distributed", attributed to Highways and Transportation Minister Glen Findlay.
+# Four sentences from it carry this whole file's period spine, verbatim:
+#
+#   "Manitoba's new licence plates will begin appearing on registered vehicles
+#    this month, Highways and Transportation Minister Glen Findlay announced
+#    today."
+#   "Registered owners will receive their new plates when they reach their
+#    annual Autopac renewal dates between Aug. 1, 1997, and July 31, 1998. The
+#    first registration renewals will be mailed June 17."
+#   "With the new issue, Manitoba returns to a 'front and rear' two-plate system
+#    for most vehicles. The new dual plates will be issued to approximately
+#    730,000 vehicles such as passenger cars, trucks and vans. A single plate
+#    will be issued to about 120,000 vehicles such as motorcycles and trailers."
+#   "The new licence plate features images of trees, water and wheat, replacing
+#    the black or black and red on white licence plates first issued in 1983."
+#
+# That last clause is the prize. A government press office, in 1997, dating the
+# PREVIOUS base to 1983 — which is exactly the kind of claim that otherwise
+# survives only as an unfootnoted encyclopedia row. ca-mb-standard-1983's
+# `period.start` is therefore `agency-stated-date`, not `secondary-wikipedia`,
+# and it is the only pre-2000 Canadian series in this seven-file wave with a
+# government source behind its start year.
+#
+# The release also gives a genuine ROLLOUT WINDOW rather than a point: first
+# renewals mailed 17 June 1997, distribution running to 31 July 1998, i.e. a
+# full replacement cycle keyed to each owner's Autopac renewal date. Both bases
+# were on the road together for thirteen months, by design.
+#
+# ── FOUR FURTHER FACTS ─────────────────────────────────────────────────────
+#
+# 1. MANITOBA LEGISLATES ITS SPECIALTY PLATES ONE BY ONE, IN THE ACT ITSELF.
+#    The Drivers and Vehicles Act, C.C.S.M. c. D104, ss. 60.1, 60.2 and 60.3
+#    each create a NAMED specialty plate and PRESCRIBE ITS CONTENT — "SUPPORT
+#    OUR TROOPS" in capital letters (2014), "MMIWG2S" in capital letters with
+#    "either a red hand or a red dress" (2023), and "Manitoba Parks" (2024).
+#    That is a completely different architecture from Alberta's (a general
+#    specialty power exercised by contract, AR 320/2002 s. 63.1) and from
+#    Washington's statutory table of dozens. Manitoba's list is short,
+#    statutory, individually dated by its enacting Act, and therefore gives
+#    each of these series a real `enabling-statute` start — the strongest
+#    period grade in this file.
+#
+# 2. THE DESIGN IS THE REGISTRAR'S, SUBJECT TO THOSE THREE SECTIONS.
+#    s. 60(1), verbatim: "Subject to sections 60.1 to 60.3, a number plate may
+#    consist of numbers, letters or WORDS and must be of a design, colour and
+#    material determined by the registrar." Note "words" — Manitoba's statute
+#    contemplates a plate whose content is not a serial at all, which is what
+#    makes the specialty sections coherent. s. 60(2): "A number plate is the
+#    property of the Crown."
+#
+# 3. MANITOBA LEGISLATES WHAT MUST BE READABLE, NOT MERELY THAT THE PLATE MUST
+#    BE. s. 61(1) requires that all of the following be "clearly visible and
+#    readable and unobscured by any part of the vehicle, its attachments or its
+#    load": "(a) the jurisdiction or authority that issued the number plates;
+#    (b) the vehicle's registration number and class; (c) the period of validity
+#    or date of expiry of the registration." A three-part legibility duty, and
+#    it is a useful specification of what a Manitoba plate carries: issuer,
+#    number, CLASS, and validity. The class and validity ride on STICKERS
+#    (defined in s. 1 as "registration class sticker" and "validation sticker"),
+#    so Manitoba — unlike Saskatchewan since 2012 and Idaho since 2026 — still
+#    legislates a visible validity marker.
+#
+# 4. MANITOBA HAS A REPAIRER PLATE, WHICH ALMOST NOBODY DOES. ss. 64, 65 and 66
+#    create dealers', REPAIRERS' and collector number plates as three distinct
+#    statutory types, and s. 35(2)-(4) makes a registration card issued in
+#    relation to each of them "deemed to have been issued for a vehicle" when the
+#    vehicle displays the right quantity and type. A repairer plate bound to a
+#    repair business, separate from a dealer plate, is a class flag no other
+#    jurisdiction in this seven-file wave carries.
+#
+# REGEX / SEPARATOR POLICY: Manitoba's serial is printed in two groups of three
+# with a gap and no source states a glyph, so every regex spells the position
+# with the sanctioned separator-only class `[- ]?` (§ 2.8) while `pattern` shows
+# the canonical printed space.
+jurisdiction: ca-mb
+authority:
+  name: Registrar of Motor Vehicles, Manitoba, with Manitoba Public Insurance (MPI) as administrator under The Drivers and Vehicles Act
+  url: "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php"
+authority_url_note: >-
+  The authority URL points at the ACT because MPI's own plate pages did not
+  resolve in this pass (mpi.mb.ca/plates/ and /personalized-plates/ both
+  returned HTTP 404 on 2026-08-02). A verifier should substitute MPI's current
+  plate landing page.
+binding: vehicle
+binding_note: >-
+  s. 34(1)(a) ties lawful operation to the vehicle displaying "the quantity and
+  type of number plates that the regulations prescribe for use on a vehicle of
+  its registration class" AND to those plates displaying "the vehicle's
+  registration card number". The plate is bound to the REGISTRATION CARD, and
+  s. 59(1)(b) lets the registrar authorise a registered owner who already holds
+  the right quantity and type to re-use those plates on a newly registered
+  vehicle — so plates move with the owner inside a registration class.
+  s. 60(3): on expiry without renewal, the former registered owner "may keep the
+  number plates issued with the registration card but must return them to the
+  registrar if the registrar requests their return."
+instrument:
+  statute:
+    citation: "The Drivers and Vehicles Act, C.C.S.M. c. D104 — s. 1 (definitions of 'number plate', 'registration class sticker', 'validation sticker'), s. 34 (registration and number plate requirements), s. 35(2)-(4), ss. 59, 60, 60.1, 60.2, 60.3, 61, 63, 64, 65, 66"
+    amendment_notes_seen: "s. 60 as amended S.M. 2014, c. 38, s. 2; S.M. 2023, c. 33, s. 2; S.M. 2024, c. 28, s. 2. s. 60.1 enacted S.M. 2014, c. 38, s. 3. s. 60.2 enacted S.M. 2023, c. 33, s. 3. s. 60.3 enacted S.M. 2024, c. 28, s. 3. ss. 64-66 as enacted S.M. 2018, c. 10, Sch. C, s. 15."
+    source: "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # bilingual consolidation; ss. 59-61, 64-66 read verbatim 2026-08-02"
+    pdf: "https://web2.gov.mb.ca/laws/statutes/ccsm/_pdf.php?cap=d104"
+  regulation:
+    status: not-read
+    note: >-
+      NEGATIVE FINDING. ss. 34, 59 and 61 all delegate the QUANTITY AND TYPE of
+      number plates per registration class to regulations under the Act. The
+      consolidated-regulations index for c. D104 (web2.gov.mb.ca/laws/regs/) was
+      fetched and serves its regulation list through JavaScript; no regulation
+      title or PDF link was extractable. So Manitoba's per-class plate counts
+      rest on the 1997 news release, not on the regulation that governs them.
+      This is the file's single highest-value follow-up.
+  news_release:
+    citation: "Province of Manitoba, 'New Licence Plates Being Distributed — Phase-In Process Will Result in New and Old Plates for Several Months', 13 June 1997"
+    source: "https://news.gov.mb.ca/news/index.html?item=22982&posted=1997-06-13  # full body served and read 2026-08-02"
+  licence: "Manitoba Laws and Manitoba news releases are Province of Manitoba publications; the Act is an edict of government. Cited, quoted for operative sentences, not reproduced."
+
+artwork_risk:
+  posture: unresearched-crown-copyright-presumed
+  basis: >-
+    Crown copyright under s. 12 of the Copyright Act (Canada) is the default;
+    no Manitoba disclaimer was found. Manitoba is, however, the group's clearest
+    case of THIRD-PARTY SUBJECT MATTER PLACED ON A PLATE BY STATUTE: s. 60.2(2)
+    requires the MMIWG2S plate to depict "either a red hand or a red dress" —
+    symbols belonging to a social movement, not to the Crown — and ss. 60.1 and
+    60.3 both require "a graphic symbolic of the message conveyed by those
+    words", with the specific artwork determined by the registrar on an
+    organization's application. The artwork on Manitoba's specialty plates is
+    thus statutorily mandated in SUBJECT and contracted in EXECUTION.
+  emblem_rule: >-
+    PRD-PLATES § 3 placeholder default applies to every graphic: the reported
+    bison device and maple leaf on the standard base, and all three statutory
+    specialty graphics. Render `{present: true, rendered: placeholder}`.
+  sources:
+    - "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # ss. 60.1(1)(b), 60.2(2)(b), 60.3(1)(b)"
+
+display_rules:
+  count: >-
+    TWO plates (front and rear) for most classes; ONE for motorcycles and
+    trailers. From the 1997 release, verbatim: "With the new issue, Manitoba
+    returns to a 'front and rear' two-plate system for most vehicles. The new
+    dual plates will be issued to approximately 730,000 vehicles such as
+    passenger cars, trucks and vans. A single plate will be issued to about
+    120,000 vehicles such as motorcycles and trailers." Note the word RETURNS:
+    Manitoba had been a one-plate province before 1997 and went back to two,
+    against the direction every other jurisdiction in this wave moved (SGI went
+    single in 2004; Alberta, Yukon, NWT and Nunavut are all single). Manitoba is
+    the counter-example and the 1997 release states the rationale: "The return
+    to a front as well as rear plate increases the opportunity for vehicle
+    identification".
+  quantity_is_regulated_not_legislated: "s. 59(1) and s. 34(1)(a)(ii) both send the quantity and type to regulations, which were not reachable (see instrument.regulation)."
+  legibility: >-
+    s. 61(1): the plates must be secured and maintained so that "(a) the
+    jurisdiction or authority that issued the number plates; (b) the vehicle's
+    registration number and class; (c) the period of validity or date of expiry
+    of the registration" are "clearly visible and readable and unobscured by any
+    part of the vehicle, its attachments or its load."
+  look_alikes: "s. 62 governs 'Devices resembling plates and plates of other jurisdictions'; s. 63 gives a seizure power. Their text was not extracted (recorded gap)."
+  sources:
+    - "https://news.gov.mb.ca/news/index.html?item=22982&posted=1997-06-13  # the two-plate return, the per-class counts, the rationale"
+    - "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # ss. 34(1)(a), 59(1), 61(1)"
+
+common:
+  dimensions_note: "NEGATIVE FINDING. No dimension appears in c. D104. The reported 12 x 6 in / 30 x 15 cm convention is recorded and asserted nowhere; `design.plate` is absent throughout."
+  alphabet_note: >-
+    The per-province encyclopedia article reports that current Manitoba
+    passenger serials exclude I, O and Q. No Manitoba source states an alphabet,
+    so this is carried as `charset.excluded` with a secondary grade and is NOT
+    encoded in any `regex_strict` — the same rule applied in plates/ca-ab.yml
+    and plates/ca-sk.yml, and the opposite of plates/ca-bc.yml where the agency
+    states it.
+  what_is_on_the_plate: >-
+    s. 1 defines "number plate" as "a plate to be displayed on a vehicle showing
+    the numbers and letters that make up the vehicle's registration number", and
+    s. 34(1)(a)(iii) requires the plates to display "the vehicle's registration
+    card number and, in accordance with the regulations, stickers showing the
+    vehicle's registration class and that the registration is valid". So a
+    Manitoba plate face carries, by statute: the registration number, a
+    registration-CLASS sticker, and a VALIDATION sticker. Two stickers, not one.
+
+series:
+
+  - id: ca-mb-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1997 }
+    period_evidence: agency-stated-date
+    period_rollout:
+      first_renewals_mailed: "1997-06-17"
+      distribution_window_start: "1997-08-01"
+      distribution_window_end: "1998-07-31"
+      note: >-
+        PRD-PLATES § 2.2's `period.rollout` case, met by a primary source. The
+        1997 release gives three distinct dates rather than one: plates begin
+        appearing in June 1997, the first renewal notices are mailed
+        17 June 1997, and every registered owner receives plates at their
+        Autopac renewal date "between Aug. 1, 1997, and July 31, 1998". The
+        release's own subheading says it plainly: "Phase-In Process Will Result
+        in New and Old Plates for Several Months."
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3}[- ]?\d{3}\z'
+      evidence: secondary
+      charset:
+        excluded: ["I", "O", "Q"]
+        notes: "Secondary only; see common.alphabet_note."
+      progression: "not published"
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend_top: "MANITOBA"
+      legend_bottom: "Friendly Manitoba"
+      emblem: { present: true, rendered: placeholder, description: "river/prairie scene with trees, water and wheat (stated in the 1997 release); bison device and maple leaf reported by secondary sources" }
+      material_note: "The 1997 release states the plates carry 'a reflectorized coating [that] will make the plates much more visible in headlights'."
+      design_basis: mixed-primary-scene-secondary-colours
+      rear_differs: false
+    notes: >-
+      PERIOD AND SCENE ARE PRIMARY; THE SERIAL ARRANGEMENT IS NOT. The 1997
+      release dates the base and describes its imagery in the government's own
+      words ("features images of trees, water and wheat"), which is why the
+      grade is `agency-stated-date`. It says NOTHING about the serial
+      arrangement, so `LLL 999` is carried at `format.evidence: secondary` from
+      the per-province encyclopedia table. Do not let the strong period grade
+      launder the weak format grade — they are separate claims about the same
+      series and the file keeps them separate on purpose.
+      THE 2012 REFRESH IS A BASE CHANGE, NOT A SERIES BOUNDARY. Secondary
+      sources place a redesign at 2012 (reported as introducing bilingual
+      elements) with the SAME three-letter/three-numeral arrangement either side
+      of it. Base and format have different lifetimes here as they do in Oregon,
+      British Columbia and Alberta, so it is recorded as a design note rather
+      than minted as a series — the § 2.3 test again.
+    sources:
+      - "https://news.gov.mb.ca/news/index.html?item=22982&posted=1997-06-13  # first issue June 1997, the Aug 1997-July 1998 rollout window, the trees/water/wheat imagery, the reflectorized coating, the two-plate return"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Manitoba  # FINDING AID (PRD-PLATES §4 Wikipedia row): the ABC 123 arrangement, the I/O/Q exclusion, the reported 2012 refresh, 'Friendly Manitoba'; accessed 2026-08-02"
+      - "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # s. 60(1): the design, colour and material are the registrar's"
+
+  - id: ca-mb-standard-1983
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1983, end: 1998 }
+    period_evidence: agency-stated-date
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3}[- ]?[A-Z]{3}\z'
+      evidence: secondary
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      colour_note: >-
+        PRIMARY, AND UNUSUALLY SPECIFIC FOR A COLOUR CLAIM. The 1997 release
+        describes what was being replaced as "the black or black and red on
+        white licence plates first issued in 1983" — so the predecessor base was
+        black-on-white with a red element, from the government's own pen. That
+        is a better colour source than this programme normally gets for a
+        superseded series.
+      legend_bottom: "Friendly"
+      design_basis: primary-colours-secondary-legend
+      rear_differs: false
+    notes: >-
+      THE "ONE SERIES BACK", WITH A GOVERNMENT-DATED START — the only one in
+      this seven-file wave. "first issued in 1983", stated by the Province of
+      Manitoba in 1997 while replacing them. The END is the far edge of the
+      1997-98 rollout window: the release has old and new plates coexisting
+      until 31 July 1998, so `end: 1998` is the honest close and the overlap
+      with ca-mb-standard is REAL and sourced, not an artefact.
+      The numerals-first arrangement is secondary, as in the successor series.
+      Manitoba ran one plate per vehicle throughout this series (the 1997
+      release's word is "returns" to two plates), so a 1983-97 Manitoba vehicle
+      is a rear-plate-only vehicle.
+    sources:
+      - "https://news.gov.mb.ca/news/index.html?item=22982&posted=1997-06-13  # 'first issued in 1983'; the black / black-and-red on white description; the coexistence window"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Manitoba  # FINDING AID: the 123 ABC arrangement and the 'Friendly' slogan for this window; accessed 2026-08-02"
+
+  # =========================================================================
+  # THE STATUTORY SPECIALTY PLATES. Three sections, three Acts, three dates.
+  # =========================================================================
+  - id: ca-mb-support-our-troops
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2014 }
+    period_evidence: enabling-statute
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: statute-for-content-only
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend: "SUPPORT OUR TROOPS"
+      emblem: { present: true, rendered: placeholder, description: "'a graphic symbolic of the message conveyed by those words' (s. 60.1(1)(b))" }
+      design_basis: statute
+    notes: >-
+      s. 60.1(1), verbatim: "Upon receipt of an organization's application that
+      is acceptable to the registrar, the registrar SHALL make available a
+      specialty number plate that (a) includes the words 'SUPPORT OUR TROOPS' in
+      capital letters; (b) bears a graphic symbolic of the message conveyed by
+      those words; and (c) includes any other depiction or design as may be
+      determined by the registrar." Enacted by S.M. 2014, c. 38, s. 3 — hence
+      `enabling-statute` and 2014, a real creation date rather than an upper
+      bound. s. 60.1(2) lets the minister direct all or part of the charges to a
+      named registered charity. The SERIAL grammar is not stated anywhere, so
+      the series is `recall-only`; what IS statutory is the legend and the
+      requirement of a symbolic graphic.
+    sources:
+      - "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # s. 60.1(1)-(2), enactment note S.M. 2014, c. 38, s. 3"
+
+  - id: ca-mb-mmiwg2s
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2023 }
+    period_evidence: enabling-statute
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: statute-for-content-only
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend: "MMIWG2S"
+      emblem: { present: true, rendered: placeholder, description: "'either a red hand or a red dress' (s. 60.2(2)(b))" }
+      design_basis: statute
+    notes: >-
+      THE MOST PRESCRIPTIVE PLATE-DESIGN PROVISION IN THIS ENTIRE SEVEN-FILE
+      WAVE, AND IT IS ABOUT A SOCIAL MOVEMENT'S SYMBOLS. s. 60.2(1) defines the
+      abbreviation: "In this section, the abbreviation 'MMIWG2S' means missing
+      and murdered Indigenous women, girls and two-spirit people." s. 60.2(2):
+      the registrar "shall make available a specialty number plate that (a)
+      includes 'MMIWG2S' in capital letters; and (b) depicts EITHER A RED HAND
+      OR A RED DRESS." s. 60.2(3) directs the whole of the charges, after
+      consultation with families' representatives, to a registered charity
+      benefiting those families. Enacted S.M. 2023, c. 33, s. 3. Compare every
+      other design provision in this wave — "the colour and style the Registrar
+      thinks fit" (NWT reg. 11(1)), "the type and colour approved by the
+      Minister" (AB s. 63(2)), "a material and design determined by [ICBC]"
+      (BC s. 12(1)(b)) — and note that Manitoba's legislature specified the
+      GRAPHIC. That is why this series' design carries `design_basis: statute`
+      where almost nothing else in the wave can.
+    sources:
+      - "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # s. 60.2(1)-(3), enactment note S.M. 2023, c. 33, s. 3"
+
+  - id: ca-mb-parks
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2024 }
+    period_evidence: enabling-statute
+    matching: recall-only
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: statute-for-content-only
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#003C71"
+      legend: "Manitoba Parks"
+      emblem: { present: true, rendered: placeholder, description: "'a graphic symbolic of the message conveyed by those words' (s. 60.3(1)(b))" }
+      design_basis: statute
+    notes: >-
+      s. 60.3(1): the registrar "shall make available a specialty number plate
+      that (a) includes the words 'Manitoba Parks'; (b) bears a graphic symbolic
+      of the message conveyed by those words; and (c) includes any other
+      depiction, design or words as may be determined by the registrar."
+      s. 60.3(2) directs the charges to "a registered charity that supports
+      projects in provincial parks". Enacted S.M. 2024, c. 28, s. 3 — the newest
+      series in this wave after the 2025 British Columbia recut and the 2025
+      Nunavut bear. Note the mirror with British Columbia: two provinces, two
+      parks plate programmes, reached by opposite routes — Manitoba by a
+      statutory section, British Columbia by an ICBC/Ministry partnership with
+      no statutory hook (plates/ca-bc.yml, ca-bc-parks-2017).
+      NOTE ALSO the lower-case "Parks": s. 60.3(1)(a) requires the words
+      "Manitoba Parks" without the capital-letters instruction that ss. 60.1 and
+      60.2 both carry. Quoted as written.
+    sources:
+      - "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # s. 60.3(1)-(2), enactment note S.M. 2024, c. 28, s. 3"
+
+  # =========================================================================
+  # THE BUSINESS AND COLLECTOR PLATE TYPES.
+  # =========================================================================
+  - id: ca-mb-dealer
+    class: dealer
+    categories: [car, van, truck, trailer]
+    period: { start: 2018 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL 9999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: none-published
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#003C71", design_basis: secondary }
+    notes: >-
+      s. 64 creates dealers' number plates; s. 35(2) is the operative deeming
+      rule: "A registration card issued to a dealer in relation to dealers'
+      number plates is deemed to have been issued for a vehicle when (a) the
+      vehicle displays, in accordance with the regulations, the quantity and
+      type of dealers' number plates that the regulations prescribe for use on
+      vehicles of its registration class; and (b) the dealers' number plates on
+      the vehicle display its registration card number and, in accordance with
+      the regulations, stickers showing that the registration is valid." Note
+      what is MISSING from (b) against the ordinary rule in s. 34(1)(a)(iii):
+      no registration-CLASS sticker. A dealer plate carries a validation sticker
+      only. `period.start: 2018` is the section's enactment note (S.M. 2018,
+      c. 10, Sch. C, s. 15) and is an UPPER BOUND — Manitoba plainly issued
+      dealer plates before 2018; that Act was a re-enactment.
+    sources:
+      - "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # ss. 35(2), 64; enactment note S.M. 2018, c. 10, Sch. C, s. 15"
+
+  - id: ca-mb-repairer
+    class: dealer
+    categories: [car, van, truck]
+    period: { start: 2018 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LL 9999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: none-published
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#003C71", design_basis: secondary }
+    notes: >-
+      THE TYPE ALMOST NOBODY ELSE HAS. s. 65 creates REPAIRERS' number plates as
+      a statutory type distinct from dealers', with its own deeming rule in
+      s. 35(3) in identical terms to the dealer rule. A garage moving a
+      customer's vehicle under its own plate is common practice everywhere; a
+      legislature giving it its own plate TYPE, separate from the dealer plate,
+      is not. Filed under `class: dealer` because _meta/classes.yml defines that
+      class as "trade/garage plates bound to a business, not a vehicle", which
+      fits exactly and covers both — distinguished from ca-mb-dealer by these
+      notes and by the statutory section, as the lint's overlap rule requires.
+      Same 2018 upper-bound reasoning as ca-mb-dealer.
+    sources:
+      - "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # ss. 35(3), 65; enactment note S.M. 2018, c. 10, Sch. C, s. 15"
+
+  - id: ca-mb-collector
+    class: historic
+    categories: [car, van, truck]
+    period: { start: 2018 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999 999"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: none-published
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#003C71", design_basis: secondary }
+    notes: >-
+      s. 66 governs collector number plates and is written almost entirely as
+      PROHIBITIONS, which is itself the interesting part: "(1) The registrar may
+      issue a collector number plate only to a person prescribed by regulation.
+      (2) No person shall attach a collector number plate to a motor vehicle
+      except when permitted to do so by the regulations. (3) No person shall
+      attach a collector number plate to a motor vehicle that has the status of
+      a salvageable motor vehicle unless the motor vehicle (a) has been
+      repaired; and (b) is being driven in a road test in accordance with the
+      regulations. (4) No person shall attach a collector number plate to a
+      motor vehicle for the purpose of using it to transport persons or property
+      for compensation." Note (3): Manitoba contemplates a collector plate on a
+      REPAIRED WRITE-OFF under road test — a direct hook into the written-off
+      motor vehicle regime that follows in the same Act. Eligibility is entirely
+      in unread regulations (s. 66(1)), which is the same gap recorded at
+      instrument.regulation. s. 35(4) supplies the deeming rule and, unlike the
+      dealer and repairer rules, DOES require a registration-class sticker.
+    sources:
+      - "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # ss. 35(4), 66(1)-(5); enactment note S.M. 2018, c. 10, Sch. C, s. 15"
+
+  - id: ca-mb-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 1997 }
+    period_evidence: agency-stated-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: statute-for-permissibility-only
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#003C71", design_basis: secondary }
+    notes: >-
+      THE STATUTORY HOOK IS s. 60(1)'s "or WORDS": "a number plate may consist
+      of numbers, letters or words". `period.start: 1997` is an UPPER BOUND from
+      the 1997 news release, which describes the programme as already running
+      and being carried across the re-plating: "Manitoba Highways and
+      Transportation has contacted current holders of personalized licence
+      plates to determine if they wish to renew their slogan for a $50 fee.
+      Personalized plate holders who did not receive a renewal notice may contact
+      the Division of Driver and Vehicle Licensing Personalized Licence Plate
+      Section." The release also records the 1997-98 recycling of lapsed
+      slogans: "Slogans not renewed by Aug. 1, 1998, will be made available to
+      the general public for a fee of $100." Manitoba's own word for a
+      personalized combination is a SLOGAN, which is a nice tell that s. 60(1)'s
+      "words" branch is the one being exercised. No character count, alphabet or
+      refusal-grounds list was reached (MPI's pages 404'd), so the regex is an
+      unbounded catch-all and the series is recall-only.
+    sources:
+      - "https://news.gov.mb.ca/news/index.html?item=22982&posted=1997-06-13  # the programme in existence in 1997, the $50 renewal, the $100 release of lapsed slogans, the 'slogan' terminology"
+      - "https://web2.gov.mb.ca/laws/statutes/ccsm/d104.php  # s. 60(1) 'numbers, letters or words'"

--- a/plates/ca-nt.yml
+++ b/plates/ca-nt.yml
@@ -1,0 +1,610 @@
+# plates/ca-nt.yml — Northwest Territories (PRD-PLATES gate L3, Canada
+# territories). THE NON-RECTANGULAR CASE.
+#
+# ── WHY THIS FILE MATTERS BEYOND ITS POPULATION ────────────────────────────
+#
+# PRD-PLATES § 2.2 names the Northwest Territories by name as the reason the
+# schema carries an optional `design.shape:` — "non-rectangular plates exist
+# (Canada's NT polar-bear plate)". This is that file, and it is the first in
+# the dataset to populate the key. Everything a renderer needs to know about
+# why it cannot assume a rectangle is here, sourced.
+#
+# ── FOUR STRUCTURAL FACTS ──────────────────────────────────────────────────
+#
+# 1. THE PLATE TYPES AND THEIR SERIAL PREFIXES ARE IN THE REGULATION, AS A
+#    CLOSED LIST. Motor Vehicle Registration and Licence Plate Regulations,
+#    R-054-94, reg. 8(2), verbatim opening: "The Registrar may issue the
+#    following types of licence plates:" — then thirteen lettered paragraphs,
+#    each naming a type AND its identifying characters:
+#      (a) amateur radio, displaying a valid amateur radio service call sign
+#          allocated to the registrant by the Government of Canada with a call
+#          sign prefix of "VE8";
+#      (b) commercial, displaying the letter "C" followed by numbers;
+#      (c) construction, displaying the letter "H" followed by numbers;
+#      (d) crown, displaying a crown for motor vehicles carrying a member of
+#          the Royal Family of Canada or a representative of the Sovereign;
+#      (e) dealer, displaying the letter "D" followed by numbers;
+#      (f) government, displaying the letter "G" followed by numbers;
+#      (g) motorcycle, displaying numbers;
+#      (h) personalized, displaying letters or a combination of letters and
+#          numbers;
+#      (i) regular, displaying numbers;
+#      (j) rental, displaying the letter "RE" followed by numbers;
+#      (k) school bus, displaying the letter "S" followed by numbers;
+#      (l) trailer, displaying the letter "T" followed by numbers;
+#      (m) veteran, displaying the letters "VET" or "V" followed by numbers.
+#    Together with Yukon's C.O. 1978/120 s. 10 and the United Kingdom's
+#    Schedule 3 Table A, this is one of only three closed statutory format
+#    tables secured anywhere in this programme's territory work.
+#
+# 2. THE DESIGN, BY CONTRAST, IS PURE DISCRETION. reg. 11(1), verbatim: "The
+#    Registrar may issue licence plates in the colour and style the Registrar
+#    thinks fit." reg. 11(2) adds special-occasion plates "in the number,
+#    colour and style the Registrar thinks fit", and reg. 11(3), added by
+#    R-012-2025, adds the striking power to "issue licence plates NOT INTENDED
+#    FOR USE ON A MOTOR VEHICLE" — the territory legislates the collector
+#    souvenir plate. The Act reinforces the discretion at s. 44: "The Registrar
+#    may, from time to time, issue a new series of licence plates." So: serial
+#    grammar legislated, appearance not. That asymmetry is the file's shape.
+#
+# 3. THE POLAR BEAR IS A REGISTERED CANADIAN TRADE-MARK OWNED BY THE
+#    TERRITORIAL GOVERNMENT, AND THAT IS PRIMARY, NOT FOLKLORE.
+#    CIPO application 1050364, registration TMA558214: owner "Government of the
+#    Northwest Territories", filed 2000-03-10, registered 2002-02-20, status
+#    REGISTERED / "LIVE/REGISTRATION/Issued and Active", goods "Licence plates",
+#    services "Transportation services, namely vehicular registration and title
+#    transfers, the issuance and renewal of vehicular license plates and
+#    conducting driving tests". This is the strongest artwork_risk evidence in
+#    the Canada-west group and stands beside Wyoming's W.S. 8-3-117 as the
+#    programme's clearest example of a plate device protected by a regime that
+#    survives any copyright finding.
+#    IT HAS BEEN EXERCISED. Nunavut's minister of economic development and
+#    transportation, David Akeeagok, in the Legislative Assembly on
+#    2024-11-05, verbatim as reported: "Earlier this year, we signed an
+#    agreement with the Government of the Northwest Territories allowing us to
+#    create our own bear-shaped plate without infringing any trademark
+#    legalities." A neighbouring jurisdiction had to LICENCE the shape to use
+#    it. See plates/ca-nu.yml.
+#
+# 4. WHAT THE SHAPE COSTS THE RENDER LAYER, STATED PLAINLY. A bear-silhouette
+#    plate has no rectangle to fit a viewBox to, no constant character baseline
+#    across the serial, and a bolt-hole geometry that does not follow AAMVA's
+#    (which BC's ICBC bulletin cites and which assumes a rectangle). The
+#    US/world research dossier called NT and NU "the single best argument in
+#    this whole document that the schema needs a non-rectangular `shape`
+#    field", and also flagged that they "make the 'we render our own SVG' plan
+#    concretely harder for two jurisdictions". Both remain true; `design.shape`
+#    records the fact, the outline itself is trade-marked (fact 3) and is NOT
+#    reproduced.
+#
+# SEPARATOR NOTE (§ 2.6): reg. 8(2) prescribes letters "followed by numbers"
+# and prescribes no glyph and no grouping. Regexes here accept an optional
+# single space at the letter/digit boundary and assert no grouping inside the
+# digit run.
+jurisdiction: ca-nt
+authority:
+  name: Registrar of Motor Vehicles, Government of the Northwest Territories (Department of Infrastructure, Driver and Vehicle Services)
+  url: "https://www.inf.gov.nt.ca/en/services/driver-and-vehicle-services"
+binding: vehicle
+binding_note: >-
+  Act s. 42(1)-(2): the certificate of registration must IDENTIFY the licence
+  plate issued or transferred to the vehicle, and "No person shall operate a
+  motor vehicle on a highway under a certificate of registration unless the
+  licence plate attached to the motor vehicle is the licence plate identified in
+  the certificate of registration." Act s. 39 and reg. 8(6) then permit transfer
+  of a plate to another of the owner's vehicles on application and fee. The
+  binding is plate-to-certificate, and the certificate follows the owner.
+instrument:
+  statute:
+    citation: "Motor Vehicles Act, R.S.N.W.T. 1988, c. M-16, ss. 39-49 (transfer, issue, dealer plates, certificates, new series, use, placing of plates)"
+    key_text: >-
+      s. 44, verbatim: "The Registrar may, from time to time, issue a new series
+      of licence plates." s. 40 conditions issue on entitlement to a certificate
+      of registration, "prescribed eligibility requirements for the licence
+      plate" and the prescribed fee (as amended SNWT 2015, c. 28, s. 9).
+    source: "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.a.pdf  # ss. 39-49 read verbatim 2026-08-02 (bilingual office consolidation PDF)"
+  regulation:
+    citation: "Motor Vehicle Registration and Licence Plate Regulations, R-054-94, made by the Commissioner under s. 349 of the Motor Vehicles Act"
+    amended_by: "R-037-95; R-007-2000; R-011-2001 (in force 2001-04-01); R-081-2009; R-054-2010 (in force 2010-07-01); R-029-2011 (in force 2011-04-01); R-034-2013 (in force 2013-05-01); R-056-2016 (in force 2016-05-01); R-060-2016; R-050-2017 [repealed by R-055-2017]; R-056-2017 (in force 2017-07-01); R-037-2020; R-085-2020; R-110-2020; R-012-2025; R-036-2025 [E]; R-037-2026 (in force 2026-06-15)"
+    consolidation_caveat: >-
+      The served text states its own status, verbatim: "This consolidation is
+      not an official statement of the law. It is an office consolidation
+      prepared by Legislation Division, Department of Justice, for convenience
+      of reference only. The authoritative text of regulations can be
+      ascertained from the Revised Regulations of the Northwest Territories,
+      1990 and the monthly publication of Part II of the Northwest Territories
+      Gazette." Recorded because it is the honest evidence grade of every
+      regulation citation below.
+    source: "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # regs. 1, 2, 7, 8, 9, 11, 12, 13 and Schedule F read verbatim 2026-08-02"
+  trademark:
+    citation: "Canadian Intellectual Property Office, application 1050364, registration TMA558214"
+    owner: "Government of the Northwest Territories"
+    filed: "2000-03-10"
+    registered: "2002-02-20"
+    status: "REGISTERED — LIVE/REGISTRATION/Issued and Active"
+    goods: "Licence plates"
+    services: "Transportation services, namely vehicular registration and title transfers, the issuance and renewal of vehicular license plates and conducting driving tests"
+    source: "https://ised-isde.canada.ca/cipo/trademark-search/1050364  # accessed 2026-08-02"
+  licence: "NWT consolidations are published by the Department of Justice, Legislation Division; edicts of government, cited not reproduced. The CIPO record is a federal public register."
+
+artwork_risk:
+  posture: asserted-registered-trademark
+  basis: >-
+    THE STRONGEST ASSERTION IN THE CANADA-WEST GROUP AND ONE OF THE STRONGEST IN
+    THE PROGRAMME. The Government of the Northwest Territories holds a live
+    Canadian trade-mark registration (TMA558214, filed 2000, registered 2002)
+    whose GOODS are, in terms, "Licence plates". A trade-mark regime is
+    independent of copyright and survives any public-domain finding, which is
+    exactly the seal/emblem hazard PRD-PLATES § 4 flags as generally
+    unresearched — here documented, with a register entry.
+  exercised: >-
+    NOT A PAPER RIGHT. Nunavut ran the bear shape from 1999 to 2012 under an
+    agreement with the NWT, dropped it, and in 2024 signed a fresh agreement to
+    return to a bear-shaped plate — its own minister describing the purpose as
+    being able to make one "without infringing any trademark legalities". A
+    neighbouring government treated this mark as a real obstacle and negotiated
+    around it.
+  emblem_rule: >-
+    PRD-PLATES § 3 placeholder default applies with unusual force here, because
+    in the Northwest Territories the EMBLEM AND THE PLATE OUTLINE ARE THE SAME
+    OBJECT. There is no emblem slot to placeholder out: the trade-marked bear IS
+    the plate silhouette. Consequence for the render layer: NT cannot be
+    rendered at fidelity under the § 3 rules at all, and the honest output is a
+    schematic rectangle with `design.shape` recorded and the outline omitted.
+    That is a real coverage limit and it is stated rather than worked around.
+  sources:
+    - "https://ised-isde.canada.ca/cipo/trademark-search/1050364  # the registration itself"
+    - "https://nunatsiaq.com/stories/article/polar-bear-licence-plates-coming-back-to-nunavut/  # 2024-11-08; Minister Akeeagok quoted on the licensing agreement and the 1999-2012 arrangement"
+
+display_rules:
+  default: >-
+    Act s. 47(2), verbatim: "Subject to subsection (2.1), no person shall operate
+    or park a motor vehicle, other than a motorcycle, trailer or a prescribed
+    class of motor vehicle, on a highway unless a licence plate is securely
+    attached to the REAR BUMPER of the vehicle." NT specifies the BUMPER, not
+    merely the rear of the vehicle — a stricter mounting rule than any other
+    jurisdiction in this group.
+  heavy_commercial_front: >-
+    s. 47(2.1): "No person shall operate or park on a highway a commercial
+    vehicle having a gross weight that exceeds 4500 kg unless that vehicle has a
+    licence plate attached to the FRONT bumper." Note the threshold: 4 500 kg,
+    against British Columbia's 5 500 kg licensed GVW decal threshold and
+    Florida's 26 001 lb front-plate threshold. These are three different numbers
+    for three different rules and must not be normalised.
+  motorcycle: "s. 47(3): securely attached to the REAR FENDER."
+  trailer: "s. 47(4): attached to the back of the trailer 'at a position not lower than the rear axle'."
+  one_jurisdiction_only: "s. 47.1(1): no person shall operate a motor vehicle with licence plates issued by more than one jurisdiction attached to it."
+  sources:
+    - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.a.pdf  # ss. 47(2), (2.1), (3), (4), 47.1(1)"
+
+common:
+  vehicle_classes:
+    statement: >-
+      reg. 8(1): "The Registrar may issue licence plates for the following
+      classes of vehicles: (a) commercial vehicles; (b) construction vehicles;
+      (c) dealer inventory vehicles; (d) government vehicles; (e) motorcycles;
+      (f) private vehicles; (g) rental vehicles; (h) school buses; (i) society
+      vehicles; (j) trailers." Note that reg. 8(1) (classes of VEHICLE) and
+      reg. 8(2) (types of PLATE) are different lists that do not map one-to-one:
+      Schedule F Part 1 is a cross-tabulation of the two with shaded cells for
+      "combinations not authorized". "Society vehicles" is a class no other
+      jurisdiction in this group has — reg. 1 defines it as "a motor vehicle
+      owned by a society incorporated under the Societies Act".
+    source: "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(1), Schedule F Part 1"
+  design_discretion:
+    statement: >-
+      reg. 11, verbatim: "(1) The Registrar may issue licence plates in the
+      colour and style the Registrar thinks fit. (2) The Registrar may issue
+      licence plates for special occasions in the number, colour and style the
+      Registrar thinks fit. (3) The Registrar may issue licence plates not
+      intended for use on a motor vehicle." Subsection (3) was added by
+      R-012-2025.
+    source: "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 11(1)-(3)"
+  reservation:
+    statement: >-
+      reg. 9 is a genuine curiosity worth recording: NT runs a plate-NUMBER
+      RESERVATION market. "(1) The Registrar may determine the licence plate
+      numbers and the year of the licence plates which may be reserved and which
+      may not be reserved. (2) A person may apply to the Registrar to reserve a
+      licence plate or licence plates." Schedule F Part 2 prices it at $107,
+      against $45 to replace a lost personalized plate and $27 for any other.
+      reg. 9(4) lets the Registrar re-issue a reserved plate once the associated
+      registration has been expired more than a year. So an NT REGULAR serial —
+      bare digits — can be individually reserved, which means a low or
+      attractive number carries market value inside an otherwise anonymous
+      numeric series.
+    source: "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 9(1)-(4), Schedule F Part 2 items 1-4"
+  design_note: >-
+    Colours, the aurora/landscape artwork and the "Spectacular Northwest
+    Territories" legend come from secondary reporting only; reg. 11(1) puts them
+    entirely in the Registrar's discretion and no NT publication carrying them
+    was reachable (the Department of Infrastructure's Driver and Vehicle
+    Services pages resolve but serve a generic programme index with no
+    plate content — checked 2026-08-02, recorded as a negative finding).
+  digit_length_note: >-
+    reg. 8(2) says "numbers", full stop — no length. The six-digit current
+    regular serial is a SECONDARY claim, carried in `regex` (narrower than the
+    regulation, therefore still `strict` under § 2.7) with the regulation's own
+    unbounded form in `regex_statutory`. A secondary source records the regular
+    range reaching 378949 as of 2024-11-05, which is consistent with six digits
+    and is not asserted as a range claim.
+
+series:
+
+  # =========================================================================
+  # REGULAR — the standard series. Bare digits, on a bear.
+  # =========================================================================
+  - id: ca-nt-regular
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1986 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "999999"
+      regex: '\A\d{6}\z'
+      regex_statutory: '\A\d+\z'
+      evidence: regulation-for-grammar-secondary-for-length
+      grammar_verbatim: "reg. 8(2)(i): \"regular, displaying numbers\"."
+      progression: "ascending; a secondary source records the range reaching 378949 as of 2024-11-05. Not asserted."
+    design:
+      shape: polar-bear-silhouette
+      shape_note: >-
+        THE SCHEMA KEY PRD-PLATES § 2.2 CREATED FOR THIS CASE. The plate outline
+        is a polar bear in profile, not a rectangle. It is the territory's
+        registered trade-mark (TMA558214) and is therefore recorded as a FACT
+        and never reproduced. A renderer must not assume a rectangular viewBox,
+        a uniform character baseline, or AAMVA bolt-hole geometry for the
+        Northwest Territories.
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#0033A0"
+      legend_bottom: "Spectacular Northwest Territories"
+      emblem: { present: true, rendered: placeholder, description: "the bear outline IS the plate; there is no separable emblem slot" }
+      rear_differs: false
+      design_basis: secondary
+    notes: >-
+      PERIOD: 1986 comes only from the per-territory encyclopedia article's
+      format table (six digits from 1986), which carries no footnote for that
+      row; it is tagged `secondary-wikipedia` per the PRD-PLATES § 4 Wikipedia
+      condition. Nothing in R-054-94 or the Act dates any serial length, and
+      R-054-94 itself post-dates 1986 by eight years — an instrument that
+      DOCUMENTS an older practice, which is precisely the case the
+      instrument-date rule exists to stop us mis-dating.
+      DESIGN REFRESH, RECORDED BUT NOT MADE A SERIES BOUNDARY: secondary
+      reporting puts a graphic and material update at 2010, and the regulation's
+      own amendment history contains R-054-2010, in force 1 July 2010. The
+      coincidence of years is suggestive and is NOT evidence — the content of
+      R-054-2010 was not inspected, and a fee amendment would sit in the same
+      slot. Recorded as a lead, not a claim.
+      SHAPE: the bear silhouette is reported as introduced in 1970 for the
+      territorial centennial and retained since. That is a DESIGN fact spanning
+      several serial series and is not used to date this one.
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(i) 'regular, displaying numbers'"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_the_Northwest_Territories  # FINDING AID (PRD-PLATES §4 Wikipedia row): six digits from 1986, the 1970 bear shape, the 2010 update, the reported serial range; accessed 2026-08-02"
+      - "https://ised-isde.canada.ca/cipo/trademark-search/1050364  # the shape is a registered trade-mark of the GNWT"
+
+  - id: ca-nt-regular-1970
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1970, end: 1985 }
+    period_evidence: secondary-wikipedia
+    matching: recall-only
+    format:
+      pattern: "99999"
+      regex: '\A\d{1,6}\z'
+      evidence: secondary-and-internally-inconsistent
+    design:
+      shape: polar-bear-silhouette
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#0033A0"
+      design_basis: secondary
+    notes: >-
+      THE "ONE SERIES BACK", AND ITS SOURCE CONTRADICTS ITSELF — WHICH IS WHY
+      THIS SERIES IS recall-only. The per-territory encyclopedia format table
+      gives, for this window, "1970-1985: Five-digit format with hyphen
+      (1-234)". That example has FOUR digits, not five, so the row is internally
+      inconsistent and cannot be encoded as a grammar. MAJORITY IS NOT
+      AUTHORITY and neither is a table that disagrees with its own example: the
+      regex is deliberately a one-to-six-digit union, a shape hit and nothing
+      more, and the contradiction is recorded rather than resolved by picking
+      the reading we prefer. What IS safely carried is that the window is
+      numeric-only and that it is the era in which the bear silhouette was
+      introduced (reported 1970, territorial centennial).
+      The earlier reported windows (1966-1969 "12-345", 1952-1965 "123",
+      1950-1951 "1234", 1945-1950 "123") are NOT authored: one unfootnoted
+      table is not enough for five series.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_the_Northwest_Territories  # FINDING AID: the format-history table, including the self-contradictory 1970-1985 row; accessed 2026-08-02"
+
+  # =========================================================================
+  # THE PREFIXED TYPES — one series per reg. 8(2) paragraph.
+  # =========================================================================
+  - id: ca-nt-commercial
+    class: standard
+    categories: [truck, van, bus]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "C99999"
+      regex: '\AC ?\d+\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(b): \"commercial, displaying the letter 'C' followed by numbers\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: >-
+      PERIOD EVIDENCE, STATED ONCE FOR ALL THE PREFIXED TYPES: reg. 8 closes
+      with the note "R-034-2013,s.7; R-012-2025,s.4", so the section as it now
+      reads was substituted by R-034-2013 (in force 1 May 2013) and amended by
+      R-012-2025. 2013 is therefore an UPPER BOUND on when each prefixed
+      grammar began, never its creation — the NWT plainly issued commercial
+      plates before 2013, and the pre-2013 text of reg. 8 was not retrieved
+      (recorded gap, and the single highest-value follow-up for this file).
+      Every prefixed series below carries the same 2013 upper bound for the same
+      reason and does not repeat this note.
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(b), closing amendment note to reg. 8"
+
+  - id: ca-nt-construction
+    class: standard
+    categories: [truck, machine]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "H99999"
+      regex: '\AH ?\d+\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(c): \"construction, displaying the letter 'H' followed by numbers\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: "A dedicated CONSTRUCTION-vehicle plate type is unusual and reflects the territory's economy; reg. 8(1)(b) makes construction vehicles their own vehicle class as well. See ca-nt-commercial for the shared period reasoning."
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(c), reg. 8(1)(b)"
+
+  - id: ca-nt-dealer
+    class: dealer
+    categories: [car, van, truck]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "D99999"
+      regex: '\AD ?\d+\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(e): \"dealer, displaying the letter 'D' followed by numbers\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: >-
+      Act s. 41: where the Registrar issues a dealer a certificate of
+      registration that does NOT describe a vehicle, the Registrar issues "one
+      licence plate of the class for dealers" — a plate with no vehicle behind
+      it. reg. 13(2) then confines its use: no person shall operate a vehicle
+      displaying a dealer inventory vehicle plate "except for promotional
+      activities or for the purpose of testing the motor vehicle for suitability
+      for (a) lease; (b) sale; or (c) exchange." See ca-nt-commercial for the
+      shared period reasoning.
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(e), reg. 13(1)-(2)"
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.a.pdf  # Act s. 41"
+
+  - id: ca-nt-government
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "G99999"
+      regex: '\AG ?\d+\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(f): \"government, displaying the letter 'G' followed by numbers\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: >-
+      reg. 1 defines a government vehicle broadly — "a motor vehicle operated in
+      the Northwest Territories by ANY LEVEL of government unless that vehicle
+      is exempted by the Registrar" — so federal, territorial, municipal and
+      Indigenous-government fleets share one G series. Contrast Yukon, which
+      splits territorial (Y), federal (F+letters) and municipal (D+letters) into
+      three statutory grammars. reg. 12 then permits the opposite move: "If the
+      Registrar is satisfied that an appropriate situation exists, the Registrar
+      may issue a licence plate of a type other than government to a government
+      vehicle" — a legislated unmarked-fleet power, the NWT analogue of
+      Wyoming's covert-plate statute. A parse product must not claim that
+      absence of a G prefix proves a vehicle is not government-operated.
+      See ca-nt-commercial for the shared period reasoning.
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 1 definition, reg. 8(2)(f), reg. 12"
+
+  - id: ca-nt-rental
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "RE9999"
+      regex: '\ARE ?\d+\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(j): \"rental, displaying the letter 'RE' followed by numbers\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: >-
+      reg. 1: "'rental vehicle' means a motor vehicle leased for a period NOT
+      EXCEEDING 30 DAYS" — a bright-line definition a fleet-data consumer can
+      actually use. Note the regulation's own slip, reproduced faithfully:
+      paragraph (j) says "the LETTER 'RE'", which is two letters. Quoted as
+      written; not corrected. See ca-nt-commercial for the shared period
+      reasoning.
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 1 definition, reg. 8(2)(j)"
+
+  - id: ca-nt-school-bus
+    class: standard
+    categories: [bus]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "S9999"
+      regex: '\AS ?\d+\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(k): \"school bus, displaying the letter 'S' followed by numbers\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: "See ca-nt-commercial for the shared period reasoning. The School Bus Regulations (motor-vehicles.r13) are the neighbouring instrument and were not read in this pass."
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(k)"
+
+  - id: ca-nt-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "T9999"
+      regex: '\AT ?\d+\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(l): \"trailer, displaying the letter 'T' followed by numbers\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: "Act s. 47(4) puts the trailer plate on the back of the trailer at a position not lower than the rear axle. See ca-nt-commercial for the shared period reasoning."
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(l)"
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.a.pdf  # Act s. 47(4)"
+
+  - id: ca-nt-veteran
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "V9999"
+      regex: '\A(?:VET|V) ?\d+\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(m): \"veteran, displaying the letters 'VET' or 'V' followed by numbers\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: >-
+      Two alternative prefixes in one paragraph, hence one series with an
+      alternation. Alberta and Yukon both route veterans' eligibility through
+      the Royal Canadian Legion by regulation; the NWT regulation states no
+      eligibility test here, leaving it to reg. 8's "prescribed eligibility
+      requirements" hook in Act s. 40(b). See ca-nt-commercial for the shared
+      period reasoning.
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(m)"
+
+  - id: ca-nt-amateur-radio
+    class: specialty
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "VE8LLL"
+      regex: '\AVE8 ?[A-Z]{1,3}\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(a): \"amateur radio, displaying a valid amateur radio service call sign allocated to the registrant by the Government of Canada with a call sign prefix of 'VE8'\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: >-
+      THE SERIAL IS A FEDERAL CALL SIGN AND THE TERRITORY SAYS SO IN TERMS:
+      "allocated to the registrant by the Government of Canada". VE8 is the
+      federal amateur prefix block for the Northwest Territories, exactly as VY1
+      is Yukon's (plates/ca-yt.yml, ca-yt-ham) — two territories whose amateur
+      plates are mutually exclusive by federal construction, which makes them a
+      reliable discriminator. reg. 8(3) is a nice piece of schema realism: "An
+      amateur radio licence plate or a personalized licence plate may be issued
+      in respect of a motorcycle, but such licence plates must be of a SIMILAR
+      DESIGN to a motorcycle licence plate" — the class flag survives the size
+      change. The suffix length is not stated in the regulation; the 1-to-3
+      letter suffix is the federal call-sign structure, and is why `matching`
+      remains `strict` (the regex sits at or inside the issuing grammar).
+      Classed as `specialty` for want of an amateur-radio class in
+      _meta/classes.yml; see plates/ca-yt.yml common.vocabulary_gap.
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(a), reg. 8(3)"
+
+  - id: ca-nt-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "99999"
+      regex: '\A\d+\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(g): \"motorcycle, displaying numbers\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: >-
+      SAME GRAMMAR AS ca-nt-regular AND THAT IS THE FINDING, NOT AN ERROR:
+      reg. 8(2)(g) and 8(2)(i) both say "displaying numbers", so an NT
+      motorcycle serial and an NT regular serial are indistinguishable by shape
+      alone and can only be told apart by plate SIZE and by the registry. A
+      parse product must not claim class from an all-numeric NWT serial. The two
+      series overlap in period and are distinguished by `categories` and by
+      these notes, as the lint's overlap rule requires. Act s. 47(3) puts the
+      plate on the rear fender.
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(g) and 8(2)(i) side by side"
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.a.pdf  # Act s. 47(3)"
+
+  - id: ca-nt-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(h): \"personalized, displaying letters or a combination of letters and numbers\"."
+    design: { shape: polar-bear-silhouette, background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#0033A0", design_basis: secondary }
+    notes: >-
+      RECALL-ONLY, AND NOTE THE PRECISE READING THE REGULATION FORCES. "Letters
+      OR a combination of letters and numbers" — on its face an all-NUMERIC
+      personalized plate is not authorised, since every permitted form contains
+      at least one letter. Our regex is wider than that (it accepts all-digit
+      strings) because it must also serve as a catch-all with no published
+      length bound, so the series is honestly `recall-only`. NO LENGTH IS
+      PRESCRIBED anywhere in R-054-94, which is why no `regex_statutory` bound
+      appears here — the neighbouring Yukon regulation caps its personalized
+      plates at six characters and the NWT does not. Fees: Schedule F Part 1
+      distinguishes applicants under 60 from those 60 or older, and reg. 8(5)
+      halves the fee for the latter — an age-graded plate fee, which no other
+      jurisdiction in this group has.
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(h), reg. 8(5), Schedule F Part 1 items 8-9"
+
+  - id: ca-nt-crown
+    class: government
+    categories: [car]
+    period: { start: 2013 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9])*\z'
+      evidence: regulation
+      grammar_verbatim: "reg. 8(2)(d): \"crown, displaying a crown for motor vehicles carrying a member of the Royal Family of Canada or a representative of the Sovereign\"."
+    design:
+      shape: polar-bear-silhouette
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#0033A0"
+      emblem: { present: true, rendered: placeholder, description: "a crown — which reg. 8(2)(d) makes the plate's entire content" }
+      design_basis: regulation-for-device-only
+    notes: >-
+      A PLATE WHOSE PRESCRIBED CONTENT IS A PICTURE, NOT A SERIAL. Every other
+      paragraph of reg. 8(2) names characters; paragraph (d) names a CROWN, and
+      nothing else. On the regulation's own words the crown plate carries no
+      registration mark at all, which means (i) there is no serial for a parse
+      API to return, (ii) `format` here is a schema-satisfying placeholder and
+      is marked `recall-only` for that reason rather than because the grammar is
+      broad, and (iii) it is a live instance of _meta/separators.yml's
+      `never_separator` concern in its strongest form — the whole face is the
+      symbol. Distinct from ca-nt-government both in period reasoning and in
+      content: reg. 8(2)(d) is a ceremonial plate for vehicles carrying "a
+      member of the Royal Family of Canada or a representative of the
+      Sovereign", i.e. the Commissioner of the Northwest Territories, not the
+      territorial fleet. Schedule F Part 1 item 4 prices it at $13 under the
+      Government column.
+    sources:
+      - "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf  # reg. 8(2)(d), Schedule F Part 1 item 4"

--- a/plates/ca-nu.yml
+++ b/plates/ca-nu.yml
@@ -1,0 +1,280 @@
+# plates/ca-nu.yml — Nunavut (PRD-PLATES gate L3, Canada territories).
+# THE OTHER NON-RECTANGULAR CASE, AND THE ONE THAT WENT AWAY AND CAME BACK.
+#
+# ── READ plates/ca-nt.yml FIRST. Nunavut's motor-vehicle law IS the Northwest
+#    Territories' law, continued. The Nunavut Act (S.C. 1993, c. 28) carried
+#    every NWT ordinance and regulation in force on 1 April 1999 into the new
+#    territory as Nunavut law, to be amended or repealed by Nunavut thereafter.
+#    So the Motor Vehicles Act and the Motor Vehicle Registration and Licence
+#    Plate Regulations behind ca-nt.yml are, in their 1999 form, ALSO Nunavut's.
+#
+#    THIS FILE DOES NOT PRETEND THAT IS THE SAME AS HAVING READ NUNAVUT'S OWN
+#    CONSOLIDATION. Every Nunavut legislative and government host refused this
+#    pass: nunavutlegislation.ca returned HTTP 403 to curl with browser headers
+#    on every path tried and 404 through the fetch tool; gov.nu.ca returned 403
+#    to curl and served only a generic search index through the fetch tool; the
+#    Wayback CDX API timed out. Nunavut has amended the inherited regulations
+#    since 1999 and NONE of those amendments were seen. Consequently NO series
+#    in this file cites a Nunavut instrument, no plate TYPE list is asserted
+#    from reg. 8(2) (the NWT list may or may not still be Nunavut's), and every
+#    format claim here is graded secondary. That is the honest ceiling and it is
+#    the file's biggest gap.
+#
+# ── FOUR FACTS THAT ARE WORTH THE FILE ─────────────────────────────────────
+#
+# 1. NUNAVUT'S BEAR-SHAPED PLATE WAS LICENSED, DROPPED, AND RE-LICENSED, AND
+#    THE INTELLECTUAL-PROPERTY TRAIL IS PRIMARY AT THE FAR END. The polar-bear
+#    silhouette is a REGISTERED CANADIAN TRADE-MARK of the Government of the
+#    NORTHWEST TERRITORIES — CIPO registration TMA558214, application 1050364,
+#    filed 2000-03-10, registered 2002-02-20, goods "Licence plates", status
+#    LIVE. Nunavut used the shape from 1999 to 2012 under an agreement with the
+#    NWT, went rectangular in 2012, and in 2024 signed a NEW agreement to
+#    return. Nunavut's minister of economic development and transportation,
+#    David Akeeagok, in the Legislative Assembly on 2024-11-05, verbatim as
+#    reported: "Earlier this year, we signed an agreement with the Government of
+#    the Northwest Territories allowing us to create our own bear-shaped plate
+#    without infringing any trademark legalities." A licence plate whose SHAPE
+#    is licensed from another government is, so far as this programme has found,
+#    unique in the world.
+#
+# 2. THE 2012 CHANGE WAS A KNOCK-ON, NOT A NUNAVUT DECISION ABOUT NUNAVUT. The
+#    reported sequence is that the NWT decided to update its own version of the
+#    bear plate and Nunavut, rather than follow, took a new rectangular design.
+#    Recorded because it explains an otherwise inexplicable thirteen-year
+#    interruption in a territory's identity design — and because it means the
+#    NT and NU period boundaries are causally linked and should be verified
+#    together, not independently.
+#
+# 3. THE PLATE PRINTS INUKTITUT SYLLABICS, AND THEY ARE NOT IN THE SERIAL.
+#    The reported 2025 design carries "Nunavut" twice: in Latin letters and in
+#    Inuktitut syllabics — ᓄᓇᕗᑦ, exactly U+14C4 U+14C7 U+1557 U+1466 (CANADIAN
+#    SYLLABICS NU, NA, VU, T). Per the L3 brief's non-Latin rule, this is
+#    recorded as a DESIGN fact with its script and codepoints named, and it does
+#    NOT touch the serial alphabet: the serial is decimal digits. No
+#    `serial_alphabet:` declaration is made for Nunavut, because the dataset-wide
+#    set is correct here — and because declaring one for a legend would be a
+#    category error. NO ASCII FOLDING IS PERFORMED OR IMPLIED (the hr.yml rule).
+#
+# 4. THE INUKSUK IS IN THE SEPARATOR POSITION AND IS NOT A SEPARATOR.
+#    The reported 2025 design places an inuksuk BETWEEN the two three-digit
+#    groups of the serial. That is the Wyoming bucking-horse case exactly
+#    (plates/us-wy.yml: the emblem sits where the separator would be) and the
+#    _meta/separators.yml `never_separator` note anticipates it: the gap holds a
+#    PICTURE. No consumer may treat the inuksuk as a separator character or as
+#    part of the serial. The regexes below spell the position with the sanctioned
+#    separator-only class `[- ]?` (§ 2.8), which is the honest encoding of a
+#    printed gap whose glyph is a symbol rather than punctuation.
+#
+# SOURCING GRADE, STATED ONCE: with no reachable Nunavut instrument and no
+# reachable Nunavut agency page, this file's format and period claims rest on
+# (a) the per-territory encyclopedia article, used as a finding aid and tagged
+# `secondary-wikipedia` per the PRD-PLATES § 4 Wikipedia condition, and (b) one
+# Nunavut news outlet reporting a minister's statement in the Legislative
+# Assembly, which is a secondary report of a primary event and is graded
+# `secondary-dated`. The CIPO trade-mark record is the file's only primary
+# source and it belongs to the Northwest Territories.
+jurisdiction: ca-nu
+authority:
+  name: Motor Vehicles Division, Department of Economic Development and Transportation, Government of Nunavut
+  url: "https://www.gov.nu.ca/en/economic-development-and-transportation/motor-vehicles"
+authority_url_note: >-
+  Recorded as the correct address; it returned HTTP 403 to direct request and a
+  generic index through the fetch tool on 2026-08-02. Nothing in this file is
+  sourced to it.
+binding: vehicle
+binding_note: >-
+  Inherited from the Northwest Territories regime as at 1 April 1999 (Act
+  s. 42(1)-(2): the certificate of registration identifies the plate, and the
+  plate on the vehicle must be the one identified). Nunavut amendments since
+  1999 were not seen; treat as provisional.
+instrument:
+  inheritance:
+    citation: "Nunavut Act, S.C. 1993, c. 28 — the laws of the Northwest Territories in force on 1 April 1999 continued as laws of Nunavut, subject to later amendment or repeal by Nunavut"
+    note: >-
+      The Act's own text was NOT fetched in this pass; the inheritance is stated
+      here as the structural reason the NWT instruments are relevant and is NOT
+      relied on for any format or period claim. Recorded gap.
+  northwest_territories_source_instruments:
+    citation: "Motor Vehicles Act, R.S.N.W.T. 1988, c. M-16 and Motor Vehicle Registration and Licence Plate Regulations, R-054-94 — read in full for plates/ca-nt.yml"
+    caution: >-
+      THESE ARE CITED AS BACKGROUND, NEVER AS NUNAVUT AUTHORITY. The NWT texts
+      served today are post-1999 consolidations carrying amendments (R-034-2013,
+      R-012-2025, R-037-2026 and others) that Nunavut never enacted. Reading
+      today's NWT reg. 8(2) as Nunavut's plate-type list would be exactly the
+      instrument-date error the PRD's § 4 rule exists to prevent.
+    source: "https://www.justice.gov.nt.ca/en/files/legislation/motor-vehicles/motor-vehicles.r12.pdf"
+  trademark:
+    citation: "CIPO application 1050364 / registration TMA558214, Government of the Northwest Territories, filed 2000-03-10, registered 2002-02-20, goods 'Licence plates', LIVE"
+    source: "https://ised-isde.canada.ca/cipo/trademark-search/1050364  # accessed 2026-08-02"
+  unreachable_hosts_checked:
+    - "https://www.nunavutlegislation.ca/en/consolidated-law/motor-vehicles-act-consolidation-0  # HTTP 403"
+    - "https://www.nunavutlegislation.ca/en/regulations  # HTTP 403"
+    - "https://www.gov.nu.ca/en/economic-development-and-transportation/motor-vehicles  # HTTP 403 direct; generic index via fetch tool"
+    - "http://web.archive.org/cdx/search/cdx?url=gov.nu.ca*  # HTTP 504 gateway timeout"
+
+artwork_risk:
+  posture: asserted-licensed-from-another-government
+  basis: >-
+    UNIQUE IN THE DATASET SO FAR. Nunavut's plate SHAPE is another government's
+    registered trade-mark, used under a bilateral agreement: TMA558214 is owned
+    by the Government of the Northwest Territories and Nunavut's own minister
+    describes the 2024 agreement as what lets Nunavut "create our own
+    bear-shaped plate without infringing any trademark legalities". Whatever
+    Nunavut's posture on its own artwork, the OUTLINE is encumbered by a live
+    third-party registration, and no theory of Crown copyright or edict-of-
+    government reaches it.
+  emblem_rule: >-
+    PRD-PLATES § 3 placeholder default applies to every graphic element
+    reported on the 2025 plate — the bear outline (encumbered as above), the
+    inuksuk in the serial gap, and the star. As in the Northwest Territories,
+    there is no separable emblem slot to placeholder out: the trade-marked shape
+    IS the plate. The honest render is a schematic rectangle with
+    `design.shape` recorded and the outline omitted.
+  syllabics_note: >-
+    The Inuktitut wordmark ᓄᓇᕗᑦ is a legend, not artwork, and is reproduced here
+    as text with its codepoints because identity IS form for a script (the
+    PRD-PLATES § 4 Wikipedia-row condition 3 principle, applied outside its
+    original context). It is never transliterated in this dataset.
+  sources:
+    - "https://ised-isde.canada.ca/cipo/trademark-search/1050364"
+    - "https://nunatsiaq.com/stories/article/polar-bear-licence-plates-coming-back-to-nunavut/  # 2024-11-08, reporting Minister Akeeagok in the Legislative Assembly 2024-11-05"
+
+series:
+
+  # =========================================================================
+  # THE RETURNED BEAR — current.
+  # =========================================================================
+  - id: ca-nu-standard-2025
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2025 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "999-999"
+      regex: '\A\d{3}[- ]?\d{3}\z'
+      evidence: secondary
+      separator_note: >-
+        THE GAP HOLDS AN INUKSUK. The reported design places an inuksuk between
+        the two three-digit groups. Under _meta/separators.yml that symbol is
+        NOT a separator and must never be stripped as one or read as serial; the
+        position is spelled with the sanctioned separator-only class `[- ]?`
+        (PRD-PLATES § 2.8), which is what an authority that prints a picture
+        rather than punctuation earns. `pattern` shows the canonical printed
+        hyphen because the DSL has no way to show a picture, and that is a
+        display convention, not a claim that a hyphen is printed.
+    design:
+      shape: polar-bear-silhouette
+      shape_note: >-
+        Bear-shaped again from 2025, facing LEFT per the secondary description
+        (the Northwest Territories bear faces the other way — a real
+        discriminator between two bear-shaped plates, reported and not
+        verified). The outline is the Northwest Territories' registered
+        trade-mark used under licence; see artwork_risk.
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#0033A0"
+      border: { color: "#F2B21B", hex_basis: observed, description: "yellow border line, reported" }
+      legend_top: "NUNAVUT"
+      legend_top_syllabics:
+        text: "ᓄᓇᕗᑦ"
+        script: "Canadian Aboriginal Syllabics (Inuktitut)"
+        codepoints: ["U+14C4", "U+14C7", "U+1557", "U+1466"]
+        note: >-
+          Recorded in the original script with codepoints, per the L3 non-Latin
+          rule. NOT part of the serial alphabet and never ASCII-folded. The
+          Latin "Nunavut" and the syllabic ᓄᓇᕗᑦ are the same word twice, not two
+          fields.
+      emblem: { present: true, rendered: placeholder, description: "inuksuk between the serial groups; blue star at upper right; the bear outline itself" }
+      design_basis: secondary
+      rear_differs: false
+    notes: >-
+      PERIOD: the return was ANNOUNCED with a date and ISSUED without one. What
+      is well sourced is the announcement — Minister David Akeeagok told the
+      Legislative Assembly on 2024-11-05 that the bear plate was returning as
+      part of Nunavut's 25th-anniversary programme, that the project began early
+      in 2024 and was expected to be complete in December 2024, and that "we
+      signed an agreement with the Government of the Northwest Territories
+      allowing us to create our own bear-shaped plate without infringing any
+      trademark legalities". The report expressly states no roll-out date had
+      been announced and no design released. `period.start: 2025` therefore
+      comes from the per-territory encyclopedia article's later format row, not
+      from the announcement, and is graded `secondary-wikipedia`. The 2024
+      announcement is the corroborating context and is NOT used as the start
+      year — announcing is not issuing, and this programme has been burned by
+      that conflation before.
+      FORMAT: the reported serial is six digits in two groups of three, i.e. the
+      SAME grammar as the rectangular series it replaces. If that is right, the
+      2025 change is a DESIGN change on an unchanged format — the mirror image
+      of British Columbia's 2025 change, which is a format change on an
+      unchanged design. Both are in this wave, both are 2025, and a schema that
+      conflated base with format could model neither.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nunavut  # FINDING AID (PRD-PLATES §4 Wikipedia row): 2025 start, bear shape returning, six-digit serial, yellow border, inuksuk, star, syllabic legend, left-facing bear; accessed 2026-08-02"
+      - "https://nunatsiaq.com/stories/article/polar-bear-licence-plates-coming-back-to-nunavut/  # 2024-11-08: the announcement, the 25th-anniversary rationale, the NWT agreement quote, the explicit absence of a roll-out date"
+      - "https://ised-isde.canada.ca/cipo/trademark-search/1050364  # the shape is the GNWT's registered trade-mark"
+
+  # =========================================================================
+  # THE RECTANGULAR INTERREGNUM — one series back.
+  # =========================================================================
+  - id: ca-nu-standard-2012
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 2012, end: 2025 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "999-999"
+      regex: '\A\d{3}[- ]?\d{3}\z'
+      evidence: secondary
+      separator_note: "Six digits in two groups of three, as reported. Separator glyph unstated; separator-only class per § 2.8."
+    design:
+      shape: rectangular
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#1A1A1A"
+      legend_top: "NUNAVUT"
+      design_basis: secondary
+      rear_differs: false
+    notes: >-
+      THE THIRTEEN YEARS WITHOUT A BEAR, AND WHY THEY HAPPENED SOMEWHERE ELSE.
+      Reported: rectangular plates with black screened characters from July
+      2012, adopted because the Northwest Territories decided to update ITS
+      version of the bear plate and Nunavut chose a new design rather than
+      follow. So a Nunavut series boundary is caused by a Northwest Territories
+      decision — the two files' 2010-2012 boundaries should be verified
+      together. `shape: rectangular` is stated explicitly rather than left
+      absent, because in this jurisdiction the default cannot be assumed either
+      way and the absence of the key would be ambiguous.
+      Overlaps ca-nu-standard-2025 at the boundary year on the ordinary
+      old-stock reasoning; the two are distinguished by shape and by these notes.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nunavut  # FINDING AID: rectangular July 2012 - 2025, black screened characters, the NWT-update rationale; accessed 2026-08-02"
+
+  - id: ca-nu-standard-1999
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1999, end: 2012 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "99999L"
+      regex: '\A\d{5}[A-Z]\z'
+      evidence: secondary
+    design:
+      shape: polar-bear-silhouette
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#0033A0"
+      design_basis: secondary
+      rear_differs: false
+    notes: >-
+      THE FOUNDING SERIES, AND THE ONE THE 2025 PLATE IS ANSWERING. Reported as
+      embossed blue numerals on a bear-shaped plate from April 1999 — the month
+      Nunavut came into existence — running to 2012, in a five-digit-plus-letter
+      arrangement (`12345N`). Two things make it worth authoring rather than
+      leaving to L4: it is the reason the trade-mark licence exists (the
+      1999-2012 use was, per the 2024 reporting, "under a copyright agreement
+      with the Northwest Territories"), and its terminal letter makes it the
+      only Nunavut serial shape that is unambiguous against both later series.
+      Everything about it is secondary.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Nunavut  # FINDING AID: 1999-2012 bear-shaped, embossed blue, 12345N; accessed 2026-08-02"
+      - "https://nunatsiaq.com/stories/article/polar-bear-licence-plates-coming-back-to-nunavut/  # 2024-11-08: 'Nunavut distributed polar bear plates from 1999 to 2012 under a copyright agreement with the Northwest Territories'"

--- a/plates/ca-sk.yml
+++ b/plates/ca-sk.yml
@@ -1,0 +1,256 @@
+# plates/ca-sk.yml — Saskatchewan (PRD-PLATES gate L3, Canada west).
+#
+# ── THE HONEST HEADLINE: THIS IS THE THINNEST FILE IN THE CANADA-WEST GROUP,
+#    AND THE REASON IS INFRASTRUCTURE, NOT SASKATCHEWAN.
+#
+# Two things had to be reached to source Saskatchewan properly and neither was:
+#
+#   * THE STATUTE AND REGULATIONS. Saskatchewan publishes its consolidated law
+#     through publications.saskatchewan.ca, whose document IDs are only
+#     discoverable through a JavaScript front end. The REST API was probed
+#     directly (`/api/v1/products?...`, `/api/v1/products/{id}`,
+#     `/api/v1/products/{id}/formats/{fid}/download`, `/api/v1/freelaw/...`)
+#     and every path either 404s or rejects the parameter shape; the legacy
+#     qp.gov.sk.ca statute paths no longer resolve; the pubsask blob-storage
+#     paths 404. No Saskatchewan statute or regulation was read in this pass.
+#     WebSearch was unavailable (session budget exhausted at the first call),
+#     so ID discovery by search was not possible either.
+#   * SGI'S OWN PAGES. sgi.sk.ca is a Liferay single-page application: the
+#     licence-plate and personalized-plate URLs return HTTP 200 with a shell
+#     containing navigation only, and no plate rules in the served HTML.
+#
+# What WAS reached is worth having and is the spine of this file: two
+# Government of Saskatchewan NEWS RELEASES, served in full, dated, attributed,
+# and quoting the responsible minister. They settle the single-plate question
+# to the DAY. Everything about the SERIAL, by contrast, is secondary.
+#
+# ── THE ONE HARD FACT, VERBATIM ────────────────────────────────────────────
+#
+# Government of Saskatchewan, "SASKATCHEWAN MOVES TO A SINGLE PLATE ON JUNE
+# 30TH", 28 June 2004:
+#   "Saskatchewan's new, single licence plate system will take effect on
+#    June 30th."
+#   "Because the legislative and administrative changes required were completed
+#    faster than expected, the single plate system is being introduced a month
+#    earlier than previously announced," Minister responsible for SGI Maynard
+#    Sonntag said.
+#   "Starting June 30th, SGI will issue a single plate on transactions requiring
+#    a new plate. On existing registrations, customers will have the choice to
+#    remove their existing front plate."
+#   "Alberta, Quebec, Newfoundland and Labrador, Nova Scotia, Prince Edward
+#    Island and the three territories use single licence plates."
+#
+# Three things that release gives us that no encyclopedia table can. (1) A
+# CHANGEOVER DATE, 30 June 2004, from the government that made it. (2) The
+# TRANSITION MECHANICS: new plates single from that date, existing registrations
+# grandfathered with an OPTION to remove the front plate — so Saskatchewan front
+# plates remained lawfully in service indefinitely after 2004, and a
+# two-plate Saskatchewan vehicle is not evidence of a pre-2004 registration.
+# (3) A CROSS-JURISDICTION ROLL-CALL that independently corroborates the
+# single-plate finding in plates/ca-ab.yml, plates/ca-yt.yml, plates/ca-nt.yml
+# and plates/ca-nu.yml — cited in each of those files, from outside.
+#
+# ── PERIOD DISCIPLINE, STATED UP FRONT ─────────────────────────────────────
+# Every serial-format claim below is graded `secondary-wikipedia` under the
+# PRD-PLATES § 4 Wikipedia row's tagging condition. None of them is traced to a
+# Saskatchewan instrument or to SGI, because neither was reachable. A verifier
+# with working access to publications.saskatchewan.ca should treat every such
+# grade as an open item; they are enumerated in the dossier.
+jurisdiction: ca-sk
+authority:
+  name: Saskatchewan Government Insurance (SGI), as administrator of the Saskatchewan Auto Fund and the driver and vehicle registry
+  url: "https://sgi.sk.ca/personalized-plates"
+authority_url_note: >-
+  sgi.sk.ca serves a JavaScript application; this URL returns HTTP 200 with no
+  substantive body text. It is recorded as the correct address. NOTHING in this
+  file is sourced to it.
+binding: vehicle
+binding_note: >-
+  Not established from any Saskatchewan instrument in this pass. Saskatchewan
+  registers vehicles through SGI and issues plates against the registration; the
+  transfer rules were not read. Recorded gap.
+instrument:
+  status: not-read
+  note: >-
+    NEGATIVE FINDING, recorded so nobody repeats the hunt. The Traffic Safety
+    Act (S.S. 2004, c. T-18.1) and its vehicle-registration regulations are the
+    instruments that would carry Saskatchewan's plate law. Neither was obtained:
+    see the header for the exact paths probed on publications.saskatchewan.ca,
+    pubsaskdev.blob.core.windows.net and qp.gov.sk.ca, all of which failed on
+    2026-08-02.
+  news_releases:
+    - citation: "Government of Saskatchewan, 'SASKATCHEWAN MOVES TO A SINGLE PLATE ON JUNE 30TH', 28 June 2004"
+      source: "https://www.saskatchewan.ca/government/news-and-media/2004/june/28/saskatchewan-moves-to-a-single-plate-on-june-30th  # full body served and read 2026-08-02"
+    - citation: "Government of Saskatchewan, 'SASKATCHEWAN LICENCE PLATES ARE GOING STICKERLESS', 2 October 2012"
+      source: "https://www.saskatchewan.ca/government/news-and-media/2012/october/02/saskatchewan-licence-plates-are-going-stickerless  # headline and date confirmed by direct fetch 2026-08-02; the body did not extract from the served markup, so ONLY the headline claim is used"
+  licence: "saskatchewan.ca news releases are Government of Saskatchewan publications. Facts extracted, quoted for the operative sentences, not reproduced wholesale."
+
+artwork_risk:
+  posture: unresearched-crown-copyright-presumed
+  basis: >-
+    Crown copyright under s. 12 of the Copyright Act (Canada) is the default and
+    no Saskatchewan disclaimer was found — nor could one be looked for properly,
+    since neither the Queen's/King's Printer nor SGI was reachable in a form
+    that serves text. Recorded as UNRESEARCHED. Note one structural difference
+    from every other jurisdiction in this group: Saskatchewan's plate authority
+    is a CROWN INSURANCE CORPORATION with commercial operations, as British
+    Columbia's is, which makes the "edict of government" argument weaker for
+    SGI's own materials than for a statute.
+  emblem_rule: "PRD-PLATES § 3 placeholder default applies to the wheat device reported at the centre of the standard base."
+  sources:
+    - "https://www.saskatchewan.ca/government/news-and-media/2004/june/28/saskatchewan-moves-to-a-single-plate-on-june-30th  # the province's own publication of the plate regime"
+
+display_rules:
+  count: >-
+    ONE plate since 30 June 2004, with the pre-2004 front plate lawfully
+    retained at the owner's option. Verbatim: "Starting June 30th, SGI will
+    issue a single plate on transactions requiring a new plate. On existing
+    registrations, customers will have the choice to remove their existing front
+    plate." CONSEQUENCE A CONSUMER MUST NOT MISS: because removal was OPTIONAL
+    rather than mandatory, a Saskatchewan vehicle carrying two plates is not
+    thereby datable, and the 2004 boundary is a boundary in ISSUANCE, not in
+    what is on the road.
+  before_2004: "Front and rear plates were required. The instrument that required them was not read (see instrument.status)."
+  validation_sticker: >-
+    Saskatchewan went STICKERLESS: Government of Saskatchewan news release of
+    2 October 2012, headline verbatim, "SASKATCHEWAN LICENCE PLATES ARE GOING
+    STICKERLESS". Only the headline is relied on — the release body did not
+    extract from the served markup — so the claim carried here is exactly that
+    and no more: from around that date a Saskatchewan plate stops carrying a
+    validity decal. The effective date is NOT asserted.
+  sources:
+    - "https://www.saskatchewan.ca/government/news-and-media/2004/june/28/saskatchewan-moves-to-a-single-plate-on-june-30th  # single-plate date and transition mechanics, quoted verbatim"
+    - "https://www.saskatchewan.ca/government/news-and-media/2012/october/02/saskatchewan-licence-plates-are-going-stickerless  # headline only"
+
+common:
+  separator_note: >-
+    The Saskatchewan serial is universally rendered as two groups of three with
+    a printed gap (`123 ABC`). No Saskatchewan source states a separator glyph.
+    Under PRD-PLATES § 2.8 the position is spelled with the sanctioned
+    separator-only class, and `pattern` shows the canonical printed space.
+  dimensions_note: >-
+    NEGATIVE FINDING. No dimension is sourced. The reported 12 x 6 in /
+    30 x 15 cm North American convention is recorded here and asserted nowhere;
+    `design.plate` is absent from every series.
+  alphabet_note: >-
+    THE ONE GENUINELY INTERESTING SERIAL FACT ABOUT SASKATCHEWAN IS AN ALPHABET
+    WIDENING, AND IT IS SECONDARY. The per-province encyclopedia article reports
+    that letters I, O, Q, U and V were not used until 2009, when I, Q, U and V
+    were added to current serials — leaving O as the only permanent exclusion.
+    If that is right, a Saskatchewan serial containing I, Q, U or V is
+    2009-or-later, which is a genuine era signal and the file's most useful
+    parse fact. It is NOT encoded in any `regex_strict`, because this programme
+    only ships a strict twin where the AUTHORITY states the alphabet (contrast
+    plates/ca-bc.yml, where ICBC states it in terms). Carried as
+    `charset.excluded` with its secondary grade instead.
+
+series:
+
+  - id: ca-sk-standard
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1998 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "999 LLL"
+      regex: '\A\d{3}[- ]?[A-Z]{3}\z'
+      evidence: secondary
+      charset:
+        excluded: ["O"]
+        excluded_before_2009: ["I", "O", "Q", "U", "V"]
+        notes: >-
+          Secondary only; see common.alphabet_note. The two lists are recorded
+          separately rather than merged because the DIFFERENCE between them is
+          the era signal, and merging would destroy it.
+      progression: "not published"
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#00693E"
+      legend_top: "SASKATCHEWAN"
+      legend_bottom: "Land of Living Skies"
+      emblem: { present: true, rendered: placeholder, description: "screened wheat graphic, centre" }
+      material: "aluminum (reported)"
+      design_basis: secondary
+      rear_differs: false
+    notes: >-
+      NUMERALS FIRST, LETTERS SECOND, REPORTED FROM MAY 1998 — the inverse of
+      the arrangement it replaced, which is the whole change. Both the
+      arrangement and the 1998 date come from the per-province encyclopedia
+      article's format table, tagged accordingly; no SGI or Saskatchewan source
+      was reachable to confirm either. The same table lists a further row
+      beginning "early 2009" with the SAME arrangement, which on inspection is
+      an ALPHABET change and not a format change (see common.alphabet_note) —
+      so it is recorded as a charset fact inside this series rather than minted
+      as a second series, on the PRD-PLATES § 2.3 test (own series iff format OR
+      design OR period differs; a charset widening inside one arrangement is
+      none of the three).
+      THE STRONGEST THING IN THIS RECORD IS NOT THE FORMAT. It is the display
+      regime: single plate since 30 June 2004, stickerless since around October
+      2012, both from the province's own releases. A current Saskatchewan
+      vehicle therefore shows ONE plate carrying NO validity marker — the same
+      end state Idaho reached in July 2026 by abolishing both its sticker and
+      its replacement cycle, arrived at eleven years earlier by a different
+      route.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Saskatchewan  # FINDING AID (PRD-PLATES §4 Wikipedia row): 123 ABC reported from May 1998, the 2009 alphabet widening, the green-on-white wheat design, 'Land of Living Skies', aluminium; accessed 2026-08-02"
+      - "https://www.saskatchewan.ca/government/news-and-media/2004/june/28/saskatchewan-moves-to-a-single-plate-on-june-30th  # the single-plate regime this series is issued under"
+
+  - id: ca-sk-standard-1977
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1977, end: 1998 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL 999"
+      regex: '\A[A-Z]{3}[- ]?\d{3}\z'
+      evidence: secondary
+      charset:
+        excluded: ["I", "O", "Q", "U", "V"]
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#00693E"
+      legend_top: "SASKATCHEWAN"
+      design_basis: secondary
+      rear_differs: false
+    notes: >-
+      THE "ONE SERIES BACK". Three letters then three numerals, reported from
+      1977 to May 1998, and issued under the TWO-PLATE regime that ran until
+      30 June 2004 — so this series' vehicles are the ones the 2004 release's
+      grandfathering clause is about. Entirely secondary. Everything before
+      1977 (a numeric `12-345` reported from 1923 and shorter numerics before
+      that) is NOT authored: one unfootnoted table is not enough to mint
+      decades of series.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Saskatchewan  # FINDING AID: ABC 123 reported 1977 - May 1998; accessed 2026-08-02"
+      - "https://www.saskatchewan.ca/government/news-and-media/2004/june/28/saskatchewan-moves-to-a-single-plate-on-june-30th  # the two-plate regime in force throughout this series"
+
+  - id: ca-sk-personalized
+    class: personalized
+    categories: [car, van, truck, motorcycle]
+    period: { start: 1998 }
+    period_evidence: not-established
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9](?:[- ]?[A-Z0-9])*\z'
+      evidence: none-obtained
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#00693E"
+      design_basis: secondary
+    notes: >-
+      AUTHORED AS AN EXISTENCE CLAIM ONLY, AND MARKED AS SUCH. SGI serves a page
+      at /personalized-plates (HTTP 200), so the programme exists; its rules —
+      character count, permitted characters, eligible classes, the design
+      catalogue — are behind a JavaScript front end that serves no body text,
+      and no Saskatchewan instrument was reachable to supply them. `period.start`
+      is a schema-satisfying floor tied to the current standard series and is
+      graded `not-established`: it must not be read as a claim. The regex is an
+      unbounded catch-all because Saskatchewan publishes no length bound that
+      was reachable — contrast plates/ca-yt.yml, whose regulation caps
+      personalized plates at six characters, and plates/ca-bc.yml, whose agency
+      bulletin caps every plate type at six.
+    sources:
+      - "https://sgi.sk.ca/personalized-plates  # HTTP 200, JavaScript shell; existence of the programme only"

--- a/plates/ca-yt.yml
+++ b/plates/ca-yt.yml
@@ -1,0 +1,656 @@
+# plates/ca-yt.yml — Yukon (PRD-PLATES gate L3, Canada territories).
+#
+# ── THE HEADLINE: YUKON LEGISLATES ITS SERIAL GRAMMARS, ALL OF THEM, IN ONE
+#    SECTION, AND IT IS THE BEST FORMAT SOURCE IN THE CANADA-WEST GROUP.
+#
+# Motor Vehicles Regulations, C.O. 1978/120 (effective 5 June 1978), made under
+# the Motor Vehicles Act, section 10, opening words verbatim:
+#
+#   "10. All vehicles registered under the Motor Vehicles Act shall be
+#    classified and all certificates of registration and licence plates shall be
+#    issued as follows:"
+#
+# and then, for each of nineteen lettered paragraphs, a sentence of the form
+# "The plate's identification marks shall be ...". That sentence is a directly
+# regex-able statutory grammar, per class, with per-paragraph amendment notes
+# that DATE each grammar. It is the same kind of artefact as the United
+# Kingdom's Schedule 3 Table A (plates/gb.yml fact 1) and the Northwest
+# Territories' reg. 8(2) list (plates/ca-nt.yml) — and it is the reason this
+# file carries `matching: strict` on sixteen of its nineteen series while the
+# neighbouring Alberta file carries it on two.
+#
+# THE PARAGRAPH AMENDMENT NOTES ARE THE PERIOD EVIDENCE. Yukon's consolidation
+# prints, under each paragraph, notes such as "[Paragraph 10(g) amended by
+# O.I.C. 1990/112]" and "[Paragraph 10(q) added by O.I.C. 2007/121]". A
+# paragraph ADDED by an instrument gets `period_evidence: enabling-instrument`
+# and that instrument's year; a paragraph AMENDED by an instrument gets the
+# amendment year and `instrument-in-force-upper-bound` UNLESS an independent
+# source dates the resulting arrangement to the same year — which happens once,
+# for the private series, and is called out there.
+#
+# ── FOUR FURTHER FACTS ─────────────────────────────────────────────────────
+#
+# 1. ONE PLATE, WITH A LEGISLATED OPTION FOR TWO. s. 11(1), verbatim (as
+#    replaced by O.I.C. 1990/112): "When a certificate of registration is issued
+#    for a vehicle, only one licence plate shall be issued for the vehicle."
+#    s. 11(3): "Notwithstanding subsection (1), two identical plates may be
+#    issued for the same vehicle." Yukon is a one-plate territory whose
+#    regulation nonetheless contemplates a matched pair, and s. 11(4) then says
+#    where each goes. The 2004 Saskatchewan news release naming the single-plate
+#    jurisdictions lists "the three territories" — corroborating, from outside.
+#
+# 2. THE SAME LEADING LETTER MEANS TWO DIFFERENT THINGS AND THE SECOND
+#    CHARACTER IS WHAT DISAMBIGUATES. Read the grammars together:
+#      F + four DIGITS       = Farm            (10(j))
+#      F + two LETTERS + ≤2 digits = Government of Canada (10(o))
+#      D + three DIGITS      = Dealer          (10(a), 10(a.1))
+#      D + two LETTERS + ≤2 digits = Municipal Government  (10(p))
+#    A parse layer that keys on the first character alone will mislabel Yukon
+#    federal-fleet plates as farm plates and municipal plates as dealer plates.
+#    The disambiguator is whether character 2 is a digit or a letter. This is a
+#    real, sourced trap and it is why this file gives each of the four its own
+#    series rather than folding them.
+#
+# 3. THE PERSONALIZED GRAMMAR IS DEFINED BY EXCLUSION, WHICH IS WHY IT IS
+#    recall-only. 10(k): "any combination of six or fewer letters or digits
+#    THAT DO NOT CONFLICT WITH PARAGRAPHS (a) TO (j) and are approved by the
+#    registrar". Our regex cannot express "does not collide with any of ten
+#    other grammars", so it is deliberately wider than what the registrar
+#    issues — the textbook § 2.7 recall-only case, sourced rather than assumed.
+#
+# 4. YUKON GOVERNMENT WEB PAGES WERE UNREACHABLE THROUGHOUT THIS PASS.
+#    yukon.ca returned HTTP 403 to every request (browser user-agent, full
+#    Accept headers, both http and https), and legislation.yukon.ca returned
+#    403 as well; laws.yukon.ca returned 403 to the site pages but served the
+#    regulation PDF itself at
+#    /cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf. So this
+#    file rests on the REGULATION and on the ACT, with no agency page behind it.
+#    Colours, design elements and dimensions are consequently secondary-only and
+#    are marked as such; nothing about the look of a Yukon plate is asserted
+#    from a Yukon source, because none was reachable.
+#
+# SEPARATOR NOTE (§ 2.6): the regulation prescribes character SEQUENCES and
+# names no separator glyph and no gap. Every regex here accepts an optional
+# single space at the letter/digit boundary, which is the honest encoding of an
+# authority that prescribes the sequence and is silent on typography — the same
+# posture plates/de.yml takes for the Plaketten gap and plates/gb.yml for the
+# Table B millimetre gap.
+jurisdiction: ca-yt
+authority:
+  name: Registrar of Motor Vehicles, Government of Yukon
+  url: "https://laws.yukon.ca/cms/images/LEGISLATION/PRINCIPAL/2002/2002-0153/2002-0153.pdf"
+authority_url_note: >-
+  The authority URL points at the ACT rather than at an agency page because
+  every Government of Yukon web host refused this pass (see header fact 4). A
+  verifier with working access should replace it with the yukon.ca motor-vehicles
+  landing page and re-check every `secondary` grade in this file against it.
+binding: vehicle
+binding_note: >-
+  Motor Vehicles Act s. 53(4), verbatim: "Every licence plate issued under this
+  Act remains the property of the Government of the Yukon and the person in
+  possession of it shall return it to the Minister whenever the Minister so
+  requires for cause." s. 48 governs transfer of TRAILER plates between the
+  owner's own trailers on payment of the prescribed fee, and forbids passing
+  them between owners.
+instrument:
+  statute:
+    citation: "Motor Vehicles Act, R.S.Y. 2002, c. 153, ss. 47-64 (registration, issue, validation, display and misuse of licence plates)"
+    key_text: >-
+      s. 53(1): "At the time of the issue of a certificate of registration the
+      registrar shall issue to the owner of the registered vehicle licence plates
+      in the number and of the design PRESCRIBED." s. 53(3): "Licence plates
+      shall be of the type and colour PRESCRIBED." Yukon is the only jurisdiction
+      in this seven-file group whose statute sends design to a REGULATION rather
+      than to an official's discretion — and the regulation then delivers, in
+      s. 10, which is why this file is the group's best-sourced.
+    source: "https://laws.yukon.ca/cms/images/LEGISLATION/PRINCIPAL/2002/2002-0153/2002-0153.pdf  # ss. 53(1)-(5) read verbatim 2026-08-02 (bilingual consolidation PDF)"
+  regulation:
+    citation: "Motor Vehicles Regulations, C.O. 1978/120 (Commissioner's Order), effective 5 June 1978, made under the Motor Vehicles Act"
+    effective: "1978-06-05"
+    revokes: "C.O. 1978/24; 1977/176; 1976/260; 1977/45; 1974/250; 1971/63; 1973/11; 1976/36; 1976/111; 1976/248; 1977/44; 1976/30; 1976/31; 1968/118; 1969/121; 1974/330; 1970/188; 1972/19; 1973/122; 1977/38; 1969/190; 1974/336; 1973/77; 1973/133; 1977/40"
+    amending_instruments_relied_on: "O.I.C. 1989/173 (ss. 10-12 replaced); 1990/112 (s. 11 replaced; paras 10(e), (g), (i), (j) amended); 2000/61 (paras 10(e), (f) amended; paras 10(l), (m) added); 2002/128 (s. 15 fees); 2004/212 (para 10(n) added); 2007/121 (paras 10(a), (a.1), (f), (i), (o), (p), (q)); 2010/158 (s. 9.9 added); 2015/230 (paras 10(b), (b.01), (d), (k), (l), (m), s. 11(2)(b), (3), (4), s. 15(1)(p), (q), s. 16(4)(b))"
+    source: "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10 paragraphs (a)-(q) with amendment notes, s. 11, s. 15(1)(p)-(q), s. 16 — read verbatim 2026-08-02"
+  licence: "Yukon consolidations are edicts of government published by the Government of Yukon. Cited, not reproduced."
+
+artwork_risk:
+  posture: unresearched-crown-copyright-presumed
+  basis: >-
+    Crown copyright under s. 12 of the Copyright Act (Canada) is the Canadian
+    default and no Yukon disclaimer was found — nor could one have been, since
+    every Yukon government web host refused connection this pass. Recorded as
+    UNRESEARCHED rather than presumed either way.
+  emblem_rule: >-
+    PRD-PLATES § 3 placeholder default applies to the prospector graphic, which
+    secondary sources report as continuously present on Yukon plates since 1952
+    and which is the territory's identifying device. It is NOT a statutory
+    drawing — C.O. 1978/120 contains no design annex — so the German
+    PD-inside-the-instrument argument (§ 5(1) UrhG) has no Yukon analogue.
+  sources:
+    - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # the regulation contains no design annex: a negative finding, checked"
+
+display_rules:
+  count: "s. 11(1): only ONE licence plate is issued per certificate of registration. s. 11(3): two identical plates MAY be issued."
+  location: >-
+    s. 11(2), verbatim: "(a) in the case of a tractor designed to tow trailers
+    or a dump truck, the plate shall be attached to the front of the vehicle so
+    that the bottom of the plate is at least as high off the ground as the front
+    axle is; (b) in the case of any other vehicle, the plate shall be attached
+    to the rear of the vehicle so that the bottom of the plate is at least as
+    high off the ground as the rear axle, or, in respect of snowmobiles, as
+    authorized by the registrar." When two identical plates are issued, s. 11(4)
+    puts one on the rear (mandatory) and permits one on the front.
+  truck_tractor_inversion: >-
+    Yukon, like Alberta and Florida, puts the tractor's plate on the FRONT.
+    Three jurisdictions, three statutes, one rule — recorded so a reviewer does
+    not read any of them as a transcription error.
+  height_rule_direction: >-
+    Yukon legislates a MINIMUM height relative to the AXLE, not a fixed
+    ground clearance. Wyoming legislates a minimum from the ground; Washington
+    and Florida legislate maxima. These are not the same rule and must not be
+    normalised together.
+  sources:
+    - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 11(1)-(5)"
+    - "https://www.saskatchewan.ca/government/news-and-media/2004/june/28/saskatchewan-moves-to-a-single-plate-on-june-30th  # CORROBORATION from outside Yukon: 'Alberta, Quebec, Newfoundland and Labrador, Nova Scotia, Prince Edward Island and the three territories use single licence plates.'"
+
+common:
+  design_note: >-
+    NO COLOUR, NO DIMENSION AND NO DESIGN ELEMENT IN THIS FILE COMES FROM A
+    YUKON SOURCE. The statute prescribes that colour and type be "prescribed"
+    and the regulation then prescribes only the identification marks — it
+    carries no colour, no size and no drawing. Every `design` block below is
+    therefore `hex_basis: observed` with a secondary basis, and `design.plate`
+    is absent throughout. The reported black-on-reflective-white with a screened
+    prospector at the left, red "Yukon" on a sky-blue band at the bottom and the
+    slogan "The Klondike", and the reported 12 x 6 in / 30 x 15 cm size
+    standardised in 1955, are recorded here once and asserted nowhere.
+  charset_disagreement: >-
+    RECORDED, NOT AVERAGED. Two secondary readings of the Yukon private-series
+    alphabet disagree: the world dossier (plates-research-us-world.md § 2.1)
+    reports "excludes I, O, Q, U"; the per-territory encyclopedia article
+    reports "letters I, Q, U, Y excluded" — the two agree on I, Q and U and
+    disagree on O and Y. C.O. 1978/120 s. 10(g) states only "three letters",
+    with no exclusion. No `regex_strict` narrows any letter position in this
+    file, and the disagreement stands as a verifier target.
+  vocabulary_gap: >-
+    _meta/classes.yml has no class for AMATEUR-RADIO plates, which C.O.
+    1978/120 s. 10(h) and the NWT's reg. 8(2)(a) both create as their own
+    statutory type. `ca-yt-ham` is filed under `specialty` as the nearest
+    available value; adding an `amateur-radio` class is a _meta PR with a
+    definition, per PRD-PLATES § 2.3, and should not be done ad hoc here.
+
+series:
+
+  # =========================================================================
+  # PRIVATE — the standard series, and the one paragraph whose amendment year
+  # is independently corroborated.
+  # =========================================================================
+  - id: ca-yt-private
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1990 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "LLL99"
+      regex: '\A[A-Z]{3} ?\d{1,2}\z'
+      evidence: regulation
+      grammar_verbatim: "C.O. 1978/120 s. 10(g): \"The plate's identification marks shall be three letters followed by one digit or two digits\"; \"Issued for private vehicles or vehicles owned or leased and operated by Government of Yukon\"."
+      progression: "not published"
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      legend_top: "YUKON"
+      legend_bottom: "The Klondike"
+      emblem: { present: true, rendered: placeholder, description: "screened gold prospector at left" }
+      rear_differs: false
+      design_basis: secondary
+    notes: >-
+      THE PERIOD IS EARNED TWICE OVER, WHICH IS RARE IN THIS GROUP. The
+      consolidation prints "[Paragraph 10(g) amended by O.I.C. 1990/112]"
+      immediately after the three-letters-then-one-or-two-digits sentence, and
+      the independent per-territory encyclopedia format table reports the ABC12
+      arrangement as running "1990-present". An instrument year and an
+      independent secondary landing on the same year is the strongest period
+      evidence any series in this file has, so the grade is
+      `enabling-instrument` rather than `instrument-in-force-upper-bound`.
+      NOTE WHAT THE GRAMMAR ACTUALLY PERMITS, because it is wider than the
+      reported arrangement: "one digit OR two digits", so a three-letter +
+      SINGLE-digit Yukon plate is lawful under the CURRENT regulation, which is
+      exactly the pre-1990 reported arrangement (see ca-yt-private-1982). The
+      regex accepts both, and a consumer must not read a five-character Yukon
+      private plate as necessarily pre-1990.
+      NOTE ALSO the class overlap the regulation itself creates: 10(g) covers
+      "private vehicles OR vehicles owned or leased and operated by Government
+      of Yukon", so a Yukon government fleet vehicle may lawfully wear either a
+      private plate (10(g)) or a "Y" government plate (10(i)).
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(g) grammar + amendment note O.I.C. 1990/112"
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Yukon  # FINDING AID (PRD-PLATES §4 Wikipedia row): ABC12 reported 1990-present, corroborating the instrument year; accessed 2026-08-02"
+
+  - id: ca-yt-private-1982
+    class: standard
+    categories: [car, van, truck, bus]
+    period: { start: 1982, end: 1989 }
+    period_evidence: secondary-wikipedia
+    matching: strict
+    format:
+      pattern: "LLL-9"
+      regex: '\A[A-Z]{3}[- ]?\d\z'
+      evidence: secondary
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      legend_bottom: "The Klondike"
+      emblem: { present: true, rendered: placeholder, description: "screened gold prospector" }
+      design_basis: secondary
+    notes: >-
+      THE "ONE SERIES BACK", AND THE HONEST ODDITY ABOUT IT: this arrangement is
+      still lawful. O.I.C. 1990/112 WIDENED s. 10(g) from one digit to "one digit
+      or two digits" rather than replacing it, so three letters + one digit
+      remains inside the current issuing grammar and ca-yt-private's regex
+      accepts it. The 1982-1989 window and the hyphenated rendering come only
+      from the per-territory encyclopedia article, whose row carries no
+      footnote; the pre-1982 forms it reports (A123 from 1976 with region-coded
+      letters, 1234 from 1946, 123 from 1924) are NOT authored here because
+      nothing dates them beyond that one table.
+    sources:
+      - "https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Yukon  # FINDING AID: ABC-1 reported 1982-1989; accessed 2026-08-02"
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(g) as it now reads, showing the one-digit form survives"
+
+  # =========================================================================
+  # THE OTHER STATUTORY GRAMMARS, one series per paragraph of s. 10.
+  # =========================================================================
+  - id: ca-yt-motorcycle
+    class: motorcycle
+    categories: [motorcycle]
+    period: { start: 2015 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "M9999"
+      regex: '\AM ?\d{4,5}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(b): \"The plate's identification marks shall be the letter 'M' followed by four or five digits\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraph 10(b) amended by O.I.C. 2015/230]" is the only date the
+      consolidation gives, and an amendment date is an UPPER BOUND on the
+      arrangement's start, not its creation — Yukon obviously plated motorcycles
+      before 2015. The 2015 amendment is what added the five-digit option (the
+      neighbouring paragraph 10(b.01), for off-road vehicles, was ADDED by the
+      same instrument, which is what a capacity expansion looks like).
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(b)"
+
+  - id: ca-yt-commercial
+    class: standard
+    categories: [truck, bus, van]
+    period: { start: 2007 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "C9999"
+      regex: '\AC ?[A-Z0-9]{4}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(f): \"The plate's identification marks shall be the letter 'C' followed by any four letters or digits.\" \"Issued for commercial vehicles or for vehicles rented or leased by a person, firm, or corporation and used as a private vehicle or a commercial vehicle\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraph 10(f) REPLACED by O.I.C. 2007/121]" — a replacement, not an
+      amendment, so the grammar as it now reads dates from 2007 and the grade is
+      `enabling-instrument`. The earlier text was amended by O.I.C. 2000/61.
+      This is the only Yukon grammar with a genuinely MIXED tail ("any four
+      letters or digits"), which is why its regex uses [A-Z0-9] rather than a
+      digit or letter run.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(f)"
+
+  - id: ca-yt-rented
+    class: standard
+    categories: [car, van, truck]
+    period: { start: 2000 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "RLL99"
+      regex: '\AR[A-Z]{2} ?\d{1,2}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(e): \"The plate's identification marks shall be the letter 'R' followed by two other letters followed by one digit or by two digits\"; issued for vehicles \"rented or leased by a person, firm, or corporation and used as private or as commercial vehicles, unless the vehicle is registered and plates are issued for it under paragraph (f)\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      Amended by O.I.C. 1990/112 and again by O.I.C. 2000/61; 2000 is the later
+      amendment and therefore the upper bound. Note the explicit either/or with
+      paragraph (f): the SAME rental vehicle may lawfully carry an R-series or a
+      C-series plate depending on how it was registered, so "R prefix" is not a
+      reliable rental indicator and "C prefix" is not a reliable commercial one.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(e)"
+
+  - id: ca-yt-farm
+    class: agricultural
+    categories: [truck, tractor]
+    period: { start: 1990 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "F9999"
+      regex: '\AF ?\d{4}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(j): \"The plate's identification marks shall be the letter F followed by four digits\"; \"Issued for a motor vehicle whose owner uses it in the cultivation of land or the raising of livestock or poultry for commercial purpose, but not for any other commercial purpose\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraph 10(j) amended by O.I.C. 1990/112]". READ THIS GRAMMAR NEXT TO
+      ca-yt-government-canada: both begin with F, and the ONLY thing separating
+      a Yukon farm plate from a Yukon federal-fleet plate is whether character 2
+      is a digit or a letter. See header fact 2.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(j)"
+
+  - id: ca-yt-government-yukon
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2007 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "Y9999"
+      regex: '\AY ?\d{1,4}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(i): \"The plate's identification marks shall be the letter 'Y' followed by up to four digits\"; \"Issued only to the Government of Yukon\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraph 10(i) amended by O.I.C. 1990/112]" then "[replaced by O.I.C.
+      2007/121]" — the replacement is the operative instrument, hence 2007 and
+      `enabling-instrument`. "Up to four digits" means a Y-series plate may be
+      two characters long, which is the shortest lawful Yukon serial.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(i)"
+
+  - id: ca-yt-government-canada
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2007 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "FLL99"
+      regex: '\AF[A-Z]{2} ?\d{1,2}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(o): \"The plate's identification marks shall be the letter 'F' followed by two letters followed by up to two digits\"; \"Issued only to the Government of Canada\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraph 10(o) ADDED by O.I.C. 2007/121]" — a creation, hence
+      `enabling-instrument` on a firm footing. A TERRITORY issuing plates
+      specifically to the FEDERAL government is worth flagging: the federal
+      fleet in Yukon wears Yukon plates from a Yukon-legislated series, not
+      federal plates. Collides on the leading F with ca-yt-farm; see header
+      fact 2.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(o)"
+
+  - id: ca-yt-municipal
+    class: government
+    categories: [car, van, truck, bus]
+    period: { start: 2007 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "DLL99"
+      regex: '\AD[A-Z]{2} ?\d{1,2}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(p): \"The plate's identification marks shall be the letter 'D' followed by two letters followed by up to two digits\"; \"Issued only to a municipality\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraph 10(p) ADDED by O.I.C. 2007/121]". Collides on the leading D
+      with ca-yt-dealer; see header fact 2. Three tiers of government
+      (territorial 10(i), federal 10(o), municipal 10(p)) each get their own
+      statutory grammar in Yukon — a completeness no province in this group
+      matches.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(p)"
+
+  - id: ca-yt-rcmp
+    class: police
+    categories: [car, van, truck]
+    period: { start: 2007 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "MPL99"
+      regex: '\AMP[A-Z] ?\d{1,2}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(q): \"The plates' identification marks shall be the letters 'MP' followed by one letter followed by up to two digits\"; \"Issued only to the Royal Canadian Mounted Police.\""
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraph 10(q) ADDED by O.I.C. 2007/121]". The consolidation adds
+      "(Refer also to Section 3 of Regulation attached to O.I.C. 2007/121)",
+      which was NOT retrieved — a named gap. Note what this series means for any
+      plate-parse product: Yukon PUBLISHES the police prefix, where Wyoming
+      legislates covert plates that must not disclose public ownership
+      (W.S. 31-2-207). Opposite policies, both statutory.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(q)"
+
+  - id: ca-yt-dealer
+    class: dealer
+    categories: [car, van, truck, bus, motorcycle, trailer, snowmobile, atv]
+    period: { start: 2007 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "D999"
+      regex: '\AD(?:LR)? ?\d{3}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(a) and s. 10(a.1): \"The plate's identification marks shall be either the letter 'D' followed by three digits or the letters DLR followed by three digits\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      TWO PARAGRAPHS, ONE GRAMMAR, HENCE ONE SERIES. 10(a) covers "Dealer -
+      Cars, Trucks, Buses, and other vehicles not provided for" and 10(a.1),
+      added by O.I.C. 2007/121, covers "Dealer - Motor cycle, trailer,
+      snowmobile and off-road vehicle"; both prescribe the identical
+      D+3-digits / DLR+3-digits alternative, so PRD-PLATES § 2.3's test (own
+      series iff format OR design OR period differs) puts them in one record
+      with both vehicle scopes in `categories`. 10(a) points at Motor Vehicles
+      Act s. 54 for the use rules. Collides on the leading D with
+      ca-yt-municipal; see header fact 2.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(a), 10(a.1)"
+
+  - id: ca-yt-ham
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 1978 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "VY1LLL"
+      regex: '\AVY1 ?[A-Z]{1,3}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(h): \"The plate's identification marks shall be the letters 'VY' followed by the numeral '1' followed by one, two, or three letters.\" \"Issued for a vehicle whose registered owner holds a valid ham radio operator's licence and call number\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      THE SERIAL IS A FEDERAL CALL SIGN, NOT A YUKON ALLOCATION. VY1 is the
+      Innovation, Science and Economic Development Canada amateur-radio prefix
+      block for Yukon, so the territory's plate grammar embeds a federal
+      identifier and the registrar allocates nothing. The Northwest Territories
+      does the identical thing with VE8 (reg. 8(2)(a), plates/ca-nt.yml), and
+      the two territories' amateur plates are therefore mutually exclusive by
+      construction — a genuinely reliable two-territory discriminator. Paragraph
+      10(h) carries NO amendment note, so it is original to C.O. 1978/120 and
+      1978 is an upper bound on when this grammar began, not its first issue.
+      Classed as `specialty` for want of an amateur-radio class; see
+      common.vocabulary_gap.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(h), no amendment note"
+
+  - id: ca-yt-veteran
+    class: specialty
+    categories: [car, van, truck]
+    period: { start: 2004 }
+    period_evidence: enabling-instrument
+    matching: strict
+    format:
+      pattern: "9999"
+      regex: '\A\d{4}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(n): \"The plate's identification marks shall be four digits\"; \"The plate will be issued only for private vehicles registered to a veteran as determined by the registrar in accordance with criteria approved by the registrar and the Royal Canadian Legion.\""
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraph 10(n) ADDED by O.I.C. 2004/212]" — a creation, so 2004 is a
+      real start. FOUR BARE DIGITS is the shortest and least distinctive Yukon
+      grammar: it collides with nothing else in s. 10 only because every other
+      paragraph begins with a letter. Note the Royal Canadian Legion appears in
+      the eligibility test here exactly as it does in Alberta's AR 320/2002
+      s. 66.1(4) — the same private body adjudicating a government plate in two
+      jurisdictions.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(n)"
+
+  - id: ca-yt-snowmobile
+    class: standard
+    categories: [snowmobile]
+    period: { start: 1978 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: strict
+    format:
+      pattern: "S9999"
+      regex: '\AS ?\d{4,5}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(c): \"The plate's identification marks shall be the letter 'S' followed by four or five digits\"; \"Issued for snowmobiles\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      Paragraph 10(c) carries no amendment note and is therefore original to the
+      1978 order; 1978 is an upper bound on the grammar's start. s. 11(2)(b)
+      leaves snowmobile plate placement "as authorized by the registrar" — the
+      one Yukon vehicle type with no legislated mounting position.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(c), s. 11(2)(b)"
+
+  # =========================================================================
+  # THE REGISTRAR-DISCRETION GRAMMARS. Each says "any combination, approved by
+  # the registrar, of six or fewer letters or digits" — a real statutory LENGTH
+  # BOUND with an unexpressible approval condition, so all are recall-only.
+  # =========================================================================
+  - id: ca-yt-personalized
+    class: personalized
+    categories: [car, van, truck]
+    period: { start: 2015 }
+    period_evidence: instrument-in-force-upper-bound
+    matching: recall-only
+    format:
+      pattern: "LLLLLL"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(k): \"The plate's identification marks shall be any combination of six or fewer letters or digits that do not conflict with paragraphs (a) to (j) and are approved by the registrar\"; \"Issued only on approval by the registrar for private vehicles.\""
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      RECALL-ONLY FOR A SOURCED REASON, not for want of evidence: the regex
+      cannot express "does not conflict with paragraphs (a) to (j)", so it is
+      deliberately WIDER than the issuing grammar and a match is a shape hit.
+      This is the cleanest example of § 2.7's distinction in the whole Canada
+      group — Yukon's own text tells us the regex is too wide. The six-character
+      bound IS sourced and is real. Fee: s. 15(1)(p), "for the issuing of a
+      personalized or vintage motor vehicle licence plate, and in addition to
+      the registration fees payable under section 14, $125.00"; replacement
+      s. 15(1)(q), $25.00. "[Paragraph 10(k) amended by O.I.C. 2015/230]".
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(k), s. 15(1)(p)-(q)"
+
+  - id: ca-yt-vintage
+    class: historic
+    categories: [car, truck, motorcycle, snowmobile]
+    period: { start: 2000 }
+    period_evidence: enabling-instrument
+    matching: recall-only
+    format:
+      pattern: "LLL999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(l) 'Vintage motor vehicle (car/truck)' and s. 10(m) 'Vintage motor vehicle (motor cycle/snowmobile)': \"The plate's identification marks shall be any combination, approved by the registrar, of six or fewer letters or digits\"; \"Issued only on approval by the registrar for private vehicles.\""
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraphs 10(l) and 10(m) ADDED by O.I.C. 2000/61]", both later
+      replaced by O.I.C. 2015/230. 2000 is the creation year. Two paragraphs,
+      identical grammar, different vehicle scope — merged into one series with
+      both scopes in `categories`, on the same § 2.3 test used for the dealer
+      series. DISTINCT FROM ca-yt-antique below: vintage is a registrar-approved
+      combination on a current plate; antique is a plate bearing the words
+      "Antique Auto" under s. 16, with its own statutory commencement date.
+      Vintage plates share the personalized plate's $125 fee (s. 15(1)(p)).
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(l), 10(m), s. 15(1)(p)"
+
+  - id: ca-yt-antique
+    class: historic
+    categories: [car, van, truck]
+    period: { start: 1980 }
+    period_evidence: enacted-commencement
+    matching: recall-only
+    format:
+      pattern: "999999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: none-published
+    design:
+      background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
+      foreground: "#000000"
+      legend: "Antique Auto"
+      design_basis: regulation-for-legend-only
+    notes: >-
+      A COMMENCEMENT DATE IN THE REGULATION'S OWN WORDS, which is why this is
+      the only series here graded `enacted-commencement`. s. 16(4), verbatim:
+      "Effective February 1, 1980 upon registration, (a) licence plates bearing
+      the words 'Antique Auto' shall be issued to the owner, or (b) if the owner
+      produces Yukon licence plates that were issued during the year of
+      manufacture of that antique motor vehicle that are in a condition
+      satisfactory to the registrar, the registrar may approve the use of such
+      plates." The (b) branch is the Alberta s. 65(2) rule again and carries the
+      same consequence: a Yukon-registered antique may lawfully wear a
+      decades-old plate as its LIVE registration. s. 16(3)(c): "Registration
+      shall be valid for as long as the vehicle is in existence and further
+      renewal of registration shall not be required" — a non-expiring
+      registration, as in British Columbia's Division 22. s. 16(5) confines
+      operation to daylight unless the vehicle has conforming lights. Fee $25
+      (s. 16(4)(c)). No serial grammar is prescribed for the "Antique Auto"
+      plate, hence recall-only.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 16(3)(c), (4)(a)-(c), (5), (6); amendment note O.I.C. 2015/230 on 16(4)(b)"
+
+  - id: ca-yt-trailer
+    class: trailer
+    categories: [trailer]
+    period: { start: 2015 }
+    period_evidence: enabling-instrument
+    matching: recall-only
+    format:
+      pattern: "LL9999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(d): \"The plate's identification marks shall be any combination, approved by the registrar, of six or fewer letters or digits\"; \"Issued for trailers\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraph 10(d) REPLACED by O.I.C. 2015/230]" — the grammar as it now
+      reads dates from 2015, and the replacement removed whatever fixed shape
+      preceded it in favour of registrar discretion. Motor Vehicles Act s. 48
+      governs transfer of trailer plates between the owner's own trailers.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(d)"
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/PRINCIPAL/2002/2002-0153/2002-0153.pdf  # Act s. 48 transfer of trailer licence plates"
+
+  - id: ca-yt-offroad
+    class: standard
+    categories: [atv]
+    period: { start: 2015 }
+    period_evidence: enabling-instrument
+    matching: recall-only
+    format:
+      pattern: "LL9999"
+      regex: '\A[A-Z0-9](?: ?[A-Z0-9]){0,5}\z'
+      evidence: regulation
+      grammar_verbatim: "s. 10(b.01): \"The plate's identification marks shall be any combination, approved by the registrar, of six or fewer letters or digits;\" \"Issued for off-road vehicles\"."
+    design: { background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }, foreground: "#000000", design_basis: secondary }
+    notes: >-
+      "[Paragraph 10(b.01) ADDED by O.I.C. 2015/230]" — a creation, so 2015 is
+      a real start for off-road vehicle registration in Yukon. Included because
+      it is part of the same statutory table and costs nothing; a consumer
+      scoped to road vehicles should filter on `categories`.
+    sources:
+      - "https://laws.yukon.ca/cms/images/LEGISLATION/SUBORDINATE/1978/1978-0120/1978-0120.pdf  # s. 10(b.01)"


### PR DESCRIPTION
**PRD-PLATES gate L3 (S5W; manifest branch s4w-plates/l3-manifest).** Researcher-drafted to the L1/L2 standard: primary instruments quoted verbatim (native-language gazettes read in the original), instrument-dated periods with honest period_evidence, folklore flagged not asserted, non-Latin scripts modelled as decode/field facts with the ASCII projection stated. Independent staged lint over origin/main with ALL 28 wave files: `plates lint: 123 files, 1360 series ... OK`.

**ca-bc**: 13 series, 8 pinned sources, lint green.

---

# PRD-PLATES L3 — BRITISH COLUMBIA (`ca-bc`) — jurisdiction dossier

**Deliverable:** `ca-bc.yml`, 13 series. **Pass:** 2026-08-02.
**Lint:** green in the sandbox (see `../lint-proof-ca-west.txt`).
**Group context:** `../dossier-ca-west-group.md`.

## 1. What the law actually says, and what it does not

British Columbia's entire plate-design law is **one clause**. Motor Vehicle Act,
R.S.B.C. 1996, c. 318, s. 12(1):

> "Each number plate must (a) be marked with the licence number of the motor
> vehicle or trailer for which it is issued, and **(b) be of a material and
> design determined by the Insurance Corporation of British Columbia**."

No size, no colour, no character height, no serial grammar — and the delegate is
a **Crown insurance corporation**, not a ministry. s. 12(6) adds that plates and
decals "are the property of the Insurance Corporation of British Columbia".

**Division 3 of B.C. Reg. 26/58 was read in full (ss. 3.01–3.15) and prescribes
no dimension, no colour and no character metric.** `design.plate` is therefore
absent from all 13 series and its absence is a *sourced finding*, as in
`plates/gb.yml`. What Division 3 does give is unusually good display law:

- **3.011** — two plates ⇒ front and rear; one plate ⇒ rear. Note the shape:
  BC does not legislate *how many* plates a class gets, only where they go once
  ICBC has decided.
- **3.021** (added B.C. Reg. 193/2015) — a motorcycle plate may be mounted
  **vertically on the left front fork, first character at the bottom**. A lawful
  BC motorcycle plate is read bottom-up; OCR must handle 90° rotation.
- **3.03** — the plate must be readable "and so that the numbers and letters may
  be accurately photographed using a **speed monitoring device or traffic light
  safety device**". BC legislates machine readability by name — which is why
  bulletin 33 spends a paragraph on ALPR compatibility.
- **3.012(2)** — decals issued before 1 May 2022 are carved out; ICBC stopped
  issuing them, so a current BC plate carries **no visible validity marker**.

## 2. The find: ICBC bulletin 33

`partners.icbc.com/assets/5GMseymkqs8E4Otb8osoGQ/bulletin-33-new-licence-plate-configurations.pdf`
— *Vehicle licensing & insurance bulletin* 33, **9 June 2025**, "New licence
plate number configurations", 4 pp., signed by the Manager, Vehicle Registration
Policy and Programs. It is the closest thing BC has to a statutory format annex,
and it is primary: the delegate's own act under s. 12(1)(b).

It gives, in ICBC's own notation (`#` = 0–9, `@` = any letter other than I, O, Q):

| type | current | new | example |
|---|---|---|---|
| Passenger | `@@###@` | `@###@@` | A123BC |
| Parks – Porteau Cove | `RS###@` | `S###@@` | S123AA |
| Parks – Kermode | `RK###@` | `P###@@` | P123AA |
| Parks – Purcell | `RM###@` | `R###@@` | R123AA |
| Commercial Truck | `@#####` | `#@@###` | 1AB234 |
| Farm Truck | `G#####` | `#####A` | 12345A |
| Utility Trailer | `U####A` | `#U@@@#` | 1UABC2 |
| Prorate | `#####P` | `####P#` | 1234P5 |
| Industrial | `X#####` | `#X####` | 1X2345 |

Plus three sentences that do a great deal of work:

- **The alphabet, and an era signal:** "The new licence plate patterns may
  include the letters 'U', 'Y' and 'Z', which were not previously used. The
  letters 'I', 'O' and 'Q' remain excluded from use because they present
  identification issues." ⇒ **a BC serial containing U, Y or Z is 2025-or-later
  on ICBC's own statement.** This is the only authority-stated alphabet in the
  whole seven-jurisdiction wave, and the only one that earns a `regex_strict`.
- **The length bound:** "All BC licence plate types consist of no more than six
  characters." ⇒ every `regex_statutory` in the file.
- **Base ≠ format:** "All regular BC plates will remain six characters with the
  **same design, reflectivity, and materials**, making them scannable as usual."
  ⇒ 2025 is a serial-grammar change on an unchanged base.

And the scope caveat, recorded rather than glossed: "character pattern updates
are planned for **16** licence plate types" — the bulletin tabulates **8**.

## 3. Series and period evidence

| id | period | evidence | matching |
|---|---|---|---|
| `ca-bc-standard-2025` | 2025– | `first-issue-announced` (bulletin: "as early as August 2025") | strict |
| `ca-bc-standard-2014` | 2014–2025 | `mixed-secondary-start-agency-end` | strict |
| `ca-bc-commercial-truck-2025` | 2025– | `first-issue-announced` | strict |
| `ca-bc-farm-2025` | 2025– | `first-issue-announced` | strict |
| `ca-bc-trailer-utility-2025` | 2025– | `first-issue-announced` | strict |
| `ca-bc-prorate-2025` | 2025– | `first-issue-announced` | strict |
| `ca-bc-industrial-2025` | 2025– | `first-issue-announced` | strict |
| `ca-bc-parks-2025` | 2025– | `first-issue-announced` | strict |
| `ca-bc-parks-2017` | 2017–2025 | **`agency-stated-date`** — first issue to the day | strict |
| `ca-bc-motorcycle` | — | **`not-established`** | recall-only |
| `ca-bc-personalized` | 1979– | `enabling-instrument` (B.C. Reg. 295/79) | recall-only |
| `ca-bc-vintage-antique` | 1966– | `enabling-instrument` (B.C. Reg. 55/66) | recall-only |
| `ca-bc-collector` | 2006– | `enabling-instrument` (B.C. Reg. 139/2006) | recall-only |

**The best-dated series in the file is a specialty programme.** BC news release
2017ENV0020-000696 (19 March 2017): the three designs "were unveiled by
Environment Minister Mary Polak and Transportation and Infrastructure Minister
Todd Stone on **Jan. 18, 2017**, in Vancouver" and "became available for
purchase at Autoplan broker offices on **Jan. 29, 2017**". Unveiling and first
issue are eight days apart; **the file records the issue date**.

**Two old-vehicle regimes, not one, and they are genuinely different.**
Division 22 ANTIQUE (B.C. Reg. 55/66; 30 years old; "'vintage' number plates" is
reg. 34.05(1)(b)'s own name for them; reg. 22.03(1)(a) makes the licence "valid
for as long as the vehicle is in existence" — a **non-expiring registration**)
versus Division 22A COLLECTOR (B.C. Reg. 139/2006; four qualifying items at 25 /
15 / modified-pre-1975 / constructed-pre-1943). Reg. 22A.04(1) is the schema
stressor: one collector licence and plate "may … be used on **any** of the
collector motor vehicles in respect of which the licence was issued" — a
**one-plate-many-vehicles** binding.

## 4. Regex decisions worth a reviewer's attention

- **`regex_strict` alphabet.** `[A-HJ-NPR-Z]` excludes I, O, Q.
  **A defect was caught here by `verify_ca.rb` and not by the lint:** the first
  draft wrote `[A-HJ-NP-Z]`, whose `P-Z` range silently re-admits **Q**. Six
  occurrences across five series were corrected. The pre-2025 series uses
  `[A-HJ-NPR-TVWX]` (also excluding U, Y, Z).
- **The separator is OPEN and is said so.** ICBC prints every pattern and
  example **solid**; the physical plate shows a group gap; secondary renderings
  hyphenate (`A12-3BC`). ICBC states neither a glyph nor a gap *position*, so
  none is asserted and the solid form ships with the question recorded. A §2.6
  forgiving consumer canonicalises both, so nothing is lost at match time.
- **`ca-bc-parks-2025`** uses `pattern: "P999LL"` with
  `regex: \A[PRS]\d{3}[A-Z]{2}\z` — the leading letter *is* the design
  (S = Porteau Cove, P = Kermode, R = Purcell), a closed three-member set, so it
  is inline rather than a `_decode` file.
- **`ca-bc-trailer-utility-2025`** has a real trap: the literal `U` survives the
  recut but moves from position 1 to position 2 — *while* U becomes a valid
  serial letter elsewhere from 2025. "Contains U" ≠ utility trailer.
- Classes with no published grammar (`motorcycle`, `personalized`, both
  old-vehicle regimes) are `recall-only` with the **sourced** six-character
  bound as their regex. That is a real outer claim, not a shrug.

## 5. Sources pinned (all fetched 2026-08-02)

| url | what it establishes |
|---|---|
| `bclaws.gov.bc.ca/civix/document/id/complete/statreg/96318_01` | MVA s. 12(1)–(6): the whole design delegation, plates are ICBC property |
| `bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_01` | B.C. Reg. 26/58 Div. 3 ss. 3.01–3.15 in full; reg. 3.121, 3.13 |
| `bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_06` | Div. 22 (antique) + Div. 22A (collector), with enactment notes |
| `bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_10` | Div. 34 (personalized) ss. 34.01–34.08, enactment B.C. Reg. 295/79 |
| `bclaws.gov.bc.ca/civix/document/id/complete/statreg/26_58_00` | division index (used to locate Div. 3/22/22A/34) |
| `partners.icbc.com/assets/…/bulletin-33-new-licence-plate-configurations.pdf` | **the format table, the alphabet, the six-character rule, the rollout month, the unchanged-base statement, ICBC's own Reference block naming AAMVA Ed. 3** |
| `news.gov.bc.ca/releases/2017ENV0020-000696` | BC Parks plates: unveiled 18 Jan 2017, on sale 29 Jan 2017, three named designs, ICBC partnership |
| `icbc.com/vehicle-registration/licence-plates` | authority landing page; "more than 40 different types of licence plates" |
| `en.wikipedia.org/wiki/Vehicle_registration_plates_of_British_Columbia` | **FINDING AID ONLY** — its citation list is where bulletin 33 and the 2017 news release came from; also the unfootnoted 2014 start, tagged `secondary-wikipedia` |

Consolidation currency: "current to July 28, 2026. Last amended April 20, 2026
by B.C. Reg. 59/2026."

## 6. Gaps and verifier targets

1. **The 2014 start of `LL999L`.** Unfootnoted secondary. ICBC or an older
   bulletin would fix it. *(The END is solid — bulletin 33 calls `@@###@` the
   "Current pattern".)*
2. **The other 8 of 16 re-cut plate types.** Bulletins 34+ presumably carry them.
3. **The gap position** in the printed serial. Resolving it upgrades 6 series.
4. **Motorcycle grammar** — `period_evidence: not-established`; the 1970 floor
   in that record is a schema artefact and must not be read as a claim.
5. **`design.plate`** — no BC source prescribes a size. Do not fill from the
   12 × 6 in convention.
6. **`artwork_risk`** is `unresearched-crown-copyright-presumed`. No BC
   trade-mark search was run over the flag device or the three park artworks —
   named as a gap, not a clearance. (Contrast NT, where a search *was* run and
   found a live registration.)

**ca-ab**: 8 series, 3 pinned sources, lint green.

---

# PRD-PLATES L3 — ALBERTA (`ca-ab`) — jurisdiction dossier

**Deliverable:** `ca-ab.yml`, 8 series. **Pass:** 2026-08-02. **Lint:** green.
**Group context:** `../dossier-ca-west-group.md`.

## 1. The finding: Alberta legislates plates thoroughly and describes them nowhere

The whole of **Operator Licensing and Vehicle Control Regulation, Alta. Reg.
320/2002, Part 3 Division 3 (Licence Plates), ss. 63–75**, plus s. 115, was read
from the King's Printer PDF. It is a substantial body of law about
**eligibility** and **display**. It contains **no dimension, no colour, no
character metric and no serial grammar.** The design is delegated *twice*:

> s. 63(2): "The Registrar shall issue licence plates in the number and of the
> **type and colour approved by the Minister**."

— and the Minister's approval is not published as an instrument.

**Consequence, stated on the face of the file:** `ABC-1234` is asserted by every
secondary source and **located in no Alberta publication** — not in AR 320/2002,
not on alberta.ca, not anywhere reachable. It ships with
`period_evidence: secondary-wikipedia` and `format.evidence: secondary`, tagged
per the PRD-PLATES §4 Wikipedia condition. **Alberta is the weakest-sourced
format in the seven-jurisdiction wave and the file says so in its header**, next
to a pointer at Yukon and the NWT, which legislate theirs.

## 2. What the regulation DOES give, and it is worth having

- **s. 66 — the lawful historic front plate.** Verbatim: *"Despite section
  70(2), the owner of a motor vehicle that is 25 years old or older and
  registered as a private passenger vehicle may attach to the front of it one,
  but not more than one, licence plate issued in Alberta in the year in which
  the vehicle was manufactured."*
  Alberta is a one-plate province whose statute carves out a **period-correct
  build-year plate** as the only lawful front plate. Any consumer reading
  Alberta front plates will read expired historic serials as live registrations
  unless it knows this. Modelled as a **display rule, not a series** — no new
  plate is manufactured for it.
- **s. 65 — the antique plate's LEGEND is statutory** even though its serial is
  not: *"The Registrar shall issue a licence plate that has 'antique' on it …"*.
  And s. 65(2)–(3) give the owner a real choice: the antique plate, **or** a
  plate "issued in Alberta, in the year an antique motor vehicle was
  manufactured", "but not both". A 1930s Alberta plate can be a **live**
  registration.
- **s. 66.1(1) — a third-party mark, on a government plate, by name:** the
  veterans' plate "includes the word 'Veteran' and bears a depiction of the
  **integrated maple leaf and poppy logo of the Royal Canadian Legion**".
  s. 66.1(4) goes further: eligibility adjudication is "the **exclusive
  responsibility** of the Royal Canadian Legion, Alberta-NWT Command", with its
  own appeal process. A government plate whose gatekeeping is contracted out.
- **s. 63.1 — specialty by contract, with a statutory publication duty.** The
  Registrar acts "on the application of, and having entered into a **written
  agreement with**, an organization" (63.1(3)); "Specialty licence plates must
  be in the form and design approved by the Registrar" (63.1(5)); and — the
  useful bit — 63.1(4) requires the Registrar to **publish the creation criteria
  "on the Registrar's website"**. That publication was not located and is the
  file's highest-value follow-up.
- **s. 70(1)(b) — the truck-tractor inversion:** a truck tractor's only plate
  goes on the **front**. Florida legislates the identical outlier
  (§ 320.0706 F.S.), and so does Yukon (C.O. 1978/120 s. 11(2)(a)). Three
  jurisdictions, three statutes, one rule — recorded in all three files so a
  reviewer does not read any of them as a transcription error.
- **s. 69 — a trailer plate bound to the tractor's operator:** the Registrar
  "may issue a **trailer** licence plate to the owner of a **commercial
  vehicle** if the owner is engaged in the business of towing trailers", and
  that owner may attach it "to a trailer towed by the commercial vehicle".
- **s. 72(4) — the classic dealer binding, in terms:** the dealer certificate
  and plates "apply to **all motor vehicles held for sale** by the holder … from
  time to time".

## 3. The one sourced charset rule, and the OCR table that comes with it

alberta.ca's personalized-plate rules are the only alphabet source in the file,
and they are about **zero**, verbatim among prohibited configurations:

> "**the letter O (use the number zero)**"

That is Idaho's rule exactly (`us-id.yml`: "The letter O and the number zero look
the same on a license plate, therefore only the number zero will be accepted").
It is carried as `charset.excluded: ["O"]` and **not** in a regex — §2.7 makes
`regex` the round-trippable tier and `recall-only` forbids a strict twin, so
there is nowhere in the tiers to put it.

The same page publishes an **OCR-confusability table straight from a
motor-vehicle authority**, recorded verbatim in the series notes:

> "Letters and numbers cannot be substituted to create a plate similar to an
> existing plate such as H1 QT and HI QT. Common substitutions include: Number 1
> and the letter I; Number 1 and the letter L; Number 6 and the letter G;
> Number 5 and the letter S; Number 2 and the letter Z; Number 0 and the letter
> Q; Number 8 and the letter B; Number 3 and the letter E; Number 4 and the
> letter A."

Also sourced: a personalized plate may not use "a configuration used by Motor
Vehicles Services for regular series licence plates", and is barred from dealer,
antique, consular corps, disabled and specialty plates. **No character count is
stated.**

## 4. Folklore flagged, not laundered

**The regular-series alphabet is contested and neither reading is asserted.**

| source | claim |
|---|---|
| `aux/research/plates-2026-07/plates-research-us-world.md` §2.1 | "excludes **I, O, Q, U**" |
| per-province encyclopedia article | "**A, E, I, O, Q, U** are skipped" (all vowels + Q) |

No Alberta source resolves it. **No `regex_strict` narrows any letter position
in this file**, and the disagreement is carried in `common.charset_disagreement`
as the standing verifier target — PRD-PLATES §5.3: record disagreements, never
average them.

**The 2003→2010 gap is real and unexplained.** The encyclopedia table gives
`ABC-123` for 1975–2003 and `ABC-1234` from 2010 with nothing between. Because
the end year is contested by that hole, `ca-ab-standard-3x3` uses the schema's
known-over-undated shape — `ended: true` with `year_end_min: 2003` rather than a
hard `end` — which is precisely the case PRD-PLATES §2.2 introduced it for.

**Base and format have different lifetimes here too.** The base is reported as
introduced in late 1983 and refreshed with an updated provincial logo in July
2019, spanning the reported 2010 format change. Neither base date is asserted as
a series boundary. (Same finding as Oregon 1987, BC 2025, Manitoba 2012.)

## 5. `artwork_risk`

`split` — base **unresearched** (Crown copyright under Copyright Act (Canada)
s. 12 is the default; no Alberta disclaimer found), specialty tier **third-party
marks, on the province's own admission**: s. 63.1(3) makes every specialty plate
a contracted product, and alberta.ca sells **Calgary Flames** and **Edmonton
Oilers** plates. Plus the Royal Canadian Legion logo placed on the veterans'
plate *by regulation*. §3 placeholder default applies to all of it.

## 6. Sources pinned (fetched 2026-08-02)

| url | what it establishes |
|---|---|
| `kings-printer.alberta.ca/documents/Regs/2002_320.pdf` | **AR 320/2002 Division 3 ss. 63, 63.1, 64, 65, 66, 66.1, 67, 68, 69, 70, 71, 72–75, and s. 115 (index)** — text layer present, read verbatim |
| `alberta.ca/licence-plates` | the one-plate rule, plate location, the O rule, the substitution table, personalized ineligible classes, veterans plate **2005** and motorcycle veterans **2012**, the three named specialty programmes |
| `en.wikipedia.org/wiki/Vehicle_registration_plates_of_Alberta` | FINDING AID: `ABC-1234` reported from June 2010, `ABC-123` 1975–2003, the 1983 base and 2019 logo refresh, the contested alphabet |
| `saskatchewan.ca/…/saskatchewan-moves-to-a-single-plate-on-june-30th` | **outside corroboration** of Alberta's single-plate rule |

**Dead ends recorded:** `alberta.ca/personalized-licence-plates` → 404;
`servicealberta.ca/pdf/mv/Pers_Plate_Info_Sheet.pdf` → served HTML, not the PDF;
`open.alberta.ca` → 403. The Traffic Safety Act (R.S.A. 2000, c. T-6) itself was
not fetched (the plate provisions are all in the regulation) — recorded gap.

## 7. Ranked verifier targets

1. **The s. 63.1(4) published criteria** on the Registrar's website — a
   *statutory* publication duty whose output was not found. May also carry the
   regular-series format and settle the alphabet.
2. **Any Alberta source for `ABC-1234`.** Currently the file's central claim
   rests entirely on an unfootnoted encyclopedia row.
3. **The 2003–2010 gap.** What Alberta issued in those seven years is unknown to
   this file.
4. **s. 115's operative text** (Personal licence plates) — located in the
   regulation's index, body not extracted.
5. **The Minister's approval under s. 63(2)** — if it exists as a published
   instrument, it is Alberta's format annex and everything above resolves.

**ca-sk**: 3 series, 4 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 8962B)
**ca-mb**: 9 series, 4 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 10713B)
**ca-yt**: 19 series, 4 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 11468B)
**ca-nt**: 14 series, 6 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 10168B)
**ca-nu**: 3 series, 8 pinned sources, lint green.
(full dossier archived to the pipeline program dir — 8814B)
