### PR TITLE
pt: 2005-window separator prints as a square dot (photographic settlement)

### DIFF
--- a/plates/pt.yml
+++ b/plates/pt.yml
@@ -258,7 +258,12 @@ series:
         The hyphen IS statutory in this window: art. 3.º n.º 1, verbatim,
         "sendo os grupos separados entre si por traços", and the Anexo IV
         Modelo I drawing draws the glyph between groups. Contrast the 2020
-        model, where the clause was deleted.
+        model, where the clause was deleted. ON ISSUED PLATES the traço
+        prints as a small embossed SQUARE DOT at digit mid-height — settled
+        by dated reference photographs (render-program pass, 2026-08-03);
+        depiction consumers should draw the square dot, never an ASCII
+        hyphen. The 2020 note’s photograph question remains open for ITS
+        model.
       progression: "sequential and non-geographic; the letter pair advances as the digit groups roll"
     design:
       plate: { w: 520, h: 110, unit: mm }


### PR DESCRIPTION
One-sentence enrichment to `pt-national-2005.format.separator_note`: the statutory *traço* prints on issued plates as a small embossed **square dot** at digit mid-height — settled by dated reference photographs during the render-program pass (2026-08-03). Without this, a depiction consumer reading only the statute text would print ASCII hyphens and be wrong against every issued plate.

The 2020 model's own separator question (gap per drawing+deletion) remains flagged for a photograph of an issued 2020 plate — deliberately untouched.

Lint green. S5W (plates program).

🤖 Generated with [Claude Code](https://claude.com/claude-code)