### PR TITLE
de: Land-arms licence note superseded (all 16 cleared in the art tier)

### DIFF
--- a/plates/de.yml
+++ b/plates/de.yml
@@ -395,7 +395,7 @@ series:
       foreground: "#000000"
       border: { color: "#000000", note: "Anlage 4 permits black, GREEN or RED borders depending on plate type" }
       band: { side: left, color: "#003399", content: eu-stars+D, hex_basis: observed, note: "the FZV states the star-wreath ratio and cross-references Reg. 2411/98 for the 'D', but gives no RGB/RAL for the blue field" }
-      emblem: { present: true, rendered: placeholder, note: "the Stempelplakette carries the FARBIGES WAPPEN DES LANDES (§ 12 Abs. 3) — a coat of arms per Land. PRD-PLATES §3 placeholder rule applies: 16 Land arms, none licence-cleared." }
+      emblem: { present: true, rendered: placeholder, note: "the Stempelplakette carries the FARBIGES WAPPEN DES LANDES (§ 12 Abs. 3) — a coat of arms per Land. PRD-PLATES §3 placeholder rule applied at write time; SUPERSEDED 2026-08-03: ALL 16 Land arms are licence-cleared in plates/_art/de-<land>/ (PD family, extmetadata-verified, ledgered) — depiction consumers may render the coloured arms in the seal. The remaining gap is the district→Land mapping (the future de-districts table) for serial-driven resolution." }
       seal: { name: Stempelplakette, diameter_mm: null, content: "coloured Land arms, Land name, registration authority name, unique Druckstücknummer, and a CONCEALED security code that can only be revealed irreversibly; self-destroying on removal", source_note: "§ 12 Abs. 3 FZV + Anlage 5" }
       rear_differs: false
       display: "front and rear on motor vehicles; rear only on trailers, motorcycles and class L5e vehicles; front only on single-axle tractors (§ 12 Abs. 5 FZV)"


### PR DESCRIPTION
One-note correction: de-standard's emblem note said "16 Land arms, none licence-cleared" — true at write time, stale since the art harvest landed all 16 under `plates/_art/de-<land>/` (PD family, extmetadata-verified, ledger rows). Depiction consumers may render the coloured arms in the Stempelplakette; the remaining unlock for serial-driven resolution is the future de-districts table, unchanged.

Same class as #285 (AD escut note). Lint green. S5W (plates program).

🤖 Generated with [Claude Code](https://claude.com/claude-code)