### PR TITLE
wave-1 render-pass settlements: cy date mark, br square dot + moto split, sm structured fields, ua line counts

### DIFF
--- a/plates/br.yml
+++ b/plates/br.yml
@@ -627,13 +627,18 @@ series:
       characters: { height_mm: 53, font: "FE Engschrift" }
       emblem: { present: true, rendered: placeholder, note: "on the motorcycle plate the MERCOSUL emblem's angle bisector coincides with the plate corner's bisector (Anexo I 3.1); flag 23x16 mm" }
       layout: two-line
-      layout_basis: observed
+      layout_basis: photographic-observed
       layout_note: >-
         The instrument fixes the plate at 200 x 170 mm and the characters at
         53 mm but does NOT spell the line arrangement, and Figura 2 is a
         dimensioned drawing with an empty character field. Seven 53 mm
         characters cannot fit on a 200 mm line, so the combination is printed
-        on two lines; the 3+4 split is recorded as OBSERVED, not sourced.
+        on two lines. UPGRADED (wave-1 render pass) from "observed, not
+        sourced" to photographically confirmed: an issued motorcycle plate
+        reads "RJJ" on the upper row and "2J41" on the lower — Commons
+        File:License plate of Brazil 04.jpg (CC BY 4.0, photographer
+        Dickelbers), serial RJJ2J41. The 3+4 split this note already named
+        now has a citable photograph.
       rear_differs: false
       note: "rear plate only — CTB art. 115 § 6 ('Os veículos de duas ou três rodas são dispensados da placa dianteira') and Res. 969/2022 art. 2 § 1"
     region_encoding: none
@@ -853,6 +858,17 @@ series:
         writes it "AAA-1111". The regex therefore accepts hyphen, space or
         nothing at the group boundary (PRD-PLATES § 2.8 separator-only class),
         and `pattern` shows the canonical printed hyphen.
+      separator_printed_form: >-
+        SETTLED PHOTOGRAPHICALLY (wave-1 render pass): issued plates print a
+        small SQUARE DOT between the letter and digit groups — not a hyphen,
+        and not a bare gap. Close-up: Commons File:Placa de veículo Brasil
+        Pernambuco-Jaboatão dos Guararapes KLV-8465 atrás.jpg (public domain,
+        photographer Ralf1963) reads "KLV·8465" with the square dot clearly
+        resolved. The canonical hyphen above stays the PARSE form; this field
+        records the DEPICTION form, exactly as Portugal's square-dot
+        settlement did (pt.yml). Evidence: photographic-observed, single
+        close-up witness for the standard series; whether the official and
+        diplomatic PNU faces print the same glyph is unconfirmed.
       progression: >-
         Sequential inside a three-letter block allocated to each state.
         Res. 231/2007 art. 4, verbatim: "O Órgão Maximo Executivo de Transito da

--- a/plates/cy.yml
+++ b/plates/cy.yml
@@ -356,6 +356,29 @@ series:
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
       foreground: "#000000"
       border: { color: "#000000", width: 4, tolerance: 0.5, outer_lip: 1, unit: mm, note: "Μέρος ΙΙ παρ. 5.7" }
+      date_mark:
+        present: true
+        position: center
+        layout: "MM stacked over YY, small, in the gap between the letter triple and the digit triple"
+        content_note: >-
+          OBSERVED ON ISSUED PLATES, ABSENT FROM EVERY INSTRUMENT READ: two
+          independent Commons photographs agree (NBE 049 with 07/15,
+          motorcycle; PEM 499 with 04/22, yellow goods colourway), and a black
+          historic plate (ET 145, 05/70) shows the same convention — there
+          plausibly the vehicle's original qualifying date, which is an
+          inference, not a confirmed reading. A secondary source (a Cyprus
+          insurance-broker blog) calls it the registration month/year. Neither
+          Κ.Δ.Π. 291/2010 Μέρος Ι/ΙΙ nor the read pages of Κ.Δ.Π. 71/2013
+          mention a date field — it may sit in the unread 23-page letterform
+          annexe, or be Road Transport Department practice outside the plate
+          instruments. Recorded with the same observed-not-prescribed posture
+          this file already takes on the typeface.
+        evidence: photographic-observed
+        sources:
+          - "https://commons.wikimedia.org/wiki/File:2013_Cyprus_motorcycle_plate.jpg  # NBE 049, 07/15"
+          - "https://commons.wikimedia.org/wiki/File:2013_Cyprus_license_plate_for_commercial_vehicles_(truck).jpg  # PEM 499, 04/22"
+          - "https://commons.wikimedia.org/wiki/File:Cyprus_antique_vehicle_license_plate.jpg  # ET 145, 05/70 — the inference case"
+          - "https://digicare-insurance.com/blog/cyprus-number-plates-regulations-2026  # secondary, semantics only"
       band:
         side: left
         color: "#003399"

--- a/plates/sm.yml
+++ b/plates/sm.yml
@@ -707,6 +707,16 @@ series:
       background: { color: "#C8C8C0", finish: retroreflective, hex_basis: observed, spec_note: "'pellicola rifrangente termoadesiva di color grigio perla' — PEARL GREY, the only non-white ground in San Marino's plate history" }
       foreground: "#003399"
       layout: "left to right: RSM in blue (76 mm high, 15 mm stroke), the arms in a 50x75 mm rectangle in blue outlined red, CD in light blue (65 mm high, 19 mm stroke), then two blue digits (75 mm high, 15 mm stroke)"
+      sigla_colour:
+        value: "#4A90D9"
+        hex_basis: observed
+        note: >-
+          'azzurro' — the CD sigla only; RSM and the digits are the darker
+          'blu' (#003399) this entry's foreground already carries. Promoted
+          from the layout prose to a structured field so a renderer can read
+          the two-tone split (the same shape sm-diplomatic-cd-1986 uses for
+          its own, later, red sigla). Evidence: derived from the decreto's own
+          wording, Decreto 7 ottobre 1976 n. 55 articolo unico.
       band: { side: none }
       emblem: { present: true, rendered: placeholder }
       rear_differs: false
@@ -956,6 +966,16 @@ series:
       background: { color: "#FFF4C1", finish: retroreflective, hex_basis: observed, spec_note: "'pellicola riflettente con effetto ingiallente' — a deliberately YELLOWING film, evoking aged plates. A striking spec: the instrument prescribes the appearance of age." }
       foreground: "#003399"
       sigla_colour: { value: "#CC0000", note: "the H is red" }
+      legend:
+        text: "RSM"
+        color: "#003399"
+        position: >-
+          front: on the single line with the H and digits; rear: RSM alone on
+          the upper row, H plus digits on the lower. Promoted from format_note
+          prose to the structured field the ordinary series already use for
+          "Repubblica di San Marino", so a renderer finds it. Evidence:
+          derived from Decreto 15 marzo 2006 n. 65 art. 2 (this entry's own
+          cited instrument).
       band: { side: none }
       emblem: { present: true, rendered: placeholder, note: "a STYLISED arms in red and blue on the rear plate, not the full-colour arms of the ordinary series" }
       rear_differs: true

--- a/plates/ua.yml
+++ b/plates/ua.yml
@@ -502,7 +502,7 @@ series:
           Додаток 5 lists підтип 1-3-1 in the ordinary group. The difference is
           entirely geometric.
     design:
-      plate: { w: 300, h: 150, unit: mm }
+      plate: { w: 300, h: 150, unit: mm, lines: 2, lines_note: "statutory row count promoted from the layout notes (wave-1 render pass) — Додаток 1 підтип 1-3-1: region+series upper, digits lower" }
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, chromaticity_ref: "білий" }
       foreground: "#000000"
       characters: { digit_height_mm: 58, letter_height_mm: 40 }
@@ -532,7 +532,7 @@ series:
       charset:
         notes: "Додаток 5 gives subtypes 1-1-2 and 1-3-2 ONE shared 93-pair block, so this twin is identical to ua-electric-2015's."
     design:
-      plate: { w: 300, h: 150, unit: mm }
+      plate: { w: 300, h: 150, unit: mm, lines: 2, lines_note: "statutory row count promoted from the layout notes (wave-1 render pass) — Додаток 1 підтип 1-3-1 (electric twin)" }
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, chromaticity_ref: "білий" }
       foreground: "#009639"
       characters: { digit_height_mm: 58, letter_height_mm: 40 }
@@ -615,7 +615,7 @@ series:
           ОS ОU ОY»); D and G are Latin. Note ОQ — the only place a Q follows a
           non-Latin first letter anywhere in Додаток 5.
     design:
-      plate: { w: 140, h: 114, unit: mm }
+      plate: { w: 140, h: 114, unit: mm, lines: 2, lines_note: "statutory row count promoted from the layout notes (wave-1 render pass) — Додаток 1 підтип 3-1" }
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, chromaticity_ref: "білий" }
       foreground: "#000000"
       characters: { digit_height_mm: 30, letter_height_mm: 30 }
@@ -650,7 +650,7 @@ series:
           М U+041C and a Latin H, and VХ carries a CYRILLIC Х — the most
           script-mixed row in the annex.
     design:
-      plate: { w: 140, h: 114, unit: mm }
+      plate: { w: 140, h: 114, unit: mm, lines: 2, lines_note: "statutory row count promoted from the layout notes (wave-1 render pass) — Додаток 1 підтип 3-1 (electric twin)" }
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, chromaticity_ref: "білий" }
       foreground: "#009639"
       characters: { digit_height_mm: 30, letter_height_mm: 30 }
@@ -874,7 +874,7 @@ series:
           each with the same 24 second letters (every Latin letter except Q and
           W). Exact, not approximate.
     design:
-      plate: { w: 220, h: 174, unit: mm }
+      plate: { w: 220, h: 174, unit: mm, lines: 3, lines_note: "statutory row count promoted from the layout notes (wave-1 render pass) — Додаток 1 підтип 5-1-1: region/code, number, series stacked" }
       plate_variants:
         - { w: 140, h: 114, unit: mm, note: "підтип 5-1-2 — the small motorcycle plate; characters 30 mm instead of 40 mm; region upper LEFT and series upper RIGHT instead of region top and series bottom" }
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, chromaticity_ref: "білий" }
@@ -907,7 +907,7 @@ series:
         series_first_letter: [R, S]
         notes: "Forty-eight pairs for subtypes 5-2-1 and 5-2-2 in Додаток 5 — R and S each with the same 24 second letters. Structurally the mirror of the J/L block."
     design:
-      plate: { w: 220, h: 174, unit: mm }
+      plate: { w: 220, h: 174, unit: mm, lines: 3, lines_note: "statutory row count promoted from the layout notes (wave-1 render pass) — Додаток 1 підтип 5-1-1 (electric twin)" }
       plate_variants:
         - { w: 140, h: 114, unit: mm, note: "підтип 5-2-2 — small plate, 30 mm characters" }
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed, chromaticity_ref: "білий" }
@@ -942,7 +942,7 @@ series:
           до ДСТУ 4278:2012 drawing for підтип 6-1 labels exactly that order:
           «22 – код; 8320 – порядковий номер; АВ – серія».
     design:
-      plate: { w: 220, h: 174, unit: mm }
+      plate: { w: 220, h: 174, unit: mm, lines: 3, lines_note: "statutory row count promoted from the layout notes (wave-1 render pass) — Додаток 1 тип 6 підтип 6-1" }
       background: { color: "#D52B1E", finish: non-retroreflective, hex_basis: observed, chromaticity_ref: "червоний" }
       foreground: "#FFFFFF"
       characters: { digit_height_mm: 40, letter_height_mm: 40, region_code_height_mm: 30 }


### PR DESCRIPTION
Facts learned during the wave-1 render passes (Cyprus, San Marino, Brazil, Ukraine), evidence classes marked in-file. Highlights: the Cypriot centre date mark (photographic, two agreeing close-ups, honestly flagged as absent from every instrument read); Brazil's PNU square-dot printed form (the pt.yml depiction-vs-parse pattern); the Mercosur moto 3+4 split now photo-cited; San Marino's two-tone sigla and RSM legend promoted from prose to the structured fields consumers read; Ukraine's statutory row counts promoted to `design.plate.lines`.

`ruby scripts/lint_plates.rb`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)