### PR TITLE
cn: trailer two-row (photographed) + NEV dedicated-mark emblem flips

### DIFF
--- a/plates/cn.yml
+++ b/plates/cn.yml
@@ -459,7 +459,7 @@ series:
         printed_example: "京A·1234挂"
         regex_informational: '\A[京津冀晋蒙辽吉黑沪苏浙皖闽赣鲁豫鄂湘粤桂琼渝川贵云藏陕甘青宁新][A-Z][·\- ]?[A-Z0-9]{4,5}挂\z'
     design:
-      plate: { w: 440, h: 220, unit: mm }
+      plate: { w: 440, h: 220, unit: mm, lines: 2, lines_note: "PHOTOGRAPHED two-row (wave-3 render pass): an issued Beijing trailer plate reads 京·C over 0544挂 — Commons File:Yellow vehicle registration plate 拖挂车 Trailer in Beijing, P.R. China.jpg (CC-BY-SA-4.0). ONE witness; a second photo upgrades this to confirmed." }
       count: 1
       background: { color: "#FFD500", finish: retroreflective, hex_basis: observed }
       foreground: "#000000"
@@ -1057,7 +1057,7 @@ series:
         hex_basis: observed
       foreground: "#000000"
       band: { side: none }
-      emblem: { present: false }
+      emblem: { present: true, kind: mark, note: "专用标识 — the dedicated NEV identifier mark (MPS 2017-08-13 announcement), a plug-and-E icon AT the separator position, not a heraldic emblem. Flipped from false (wave-3 render pass): present:false was written when emblem meant heraldry; the mark IS on every issued NEV plate — Commons 小型新能源汽车号牌示例.jpg, credited to the MPS design explanation itself." }
       marking: { note: "'增加了专用标识' — the Ministry's announcement records a dedicated NEV identifier mark on the plate; the readable sources do not describe or place it" }
       rear_differs: false
       dimensions_status: >-
@@ -1122,7 +1122,7 @@ series:
         hex_basis: observed
       foreground: "#000000"
       band: { side: none }
-      emblem: { present: false }
+      emblem: { present: true, kind: mark, note: "same 专用标识 as cn-nev-small-2016 — Commons 大型新能源汽车号牌示例.jpg, same MPS credit" }
       rear_differs: false
       dimensions_status: "absent for the same reason as the small NEV plate"
     region_encoding:


### PR DESCRIPTION
Render-changing facts from the wave-3 China pass: the 440×220 trailer plate photographed as genuinely two-row (京·C over 0544挂, one witness — noted); the NEV series' emblem.present flipped to true with kind: mark (the 专用标识 is on every issued plate — MPS-credited Commons illustrations; present:false predated the heraldry/mark distinction). Lint OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)