### PR TITLE
pt-2020: the no-separator reading photographically confirmed

### DIFF
--- a/plates/pt.yml
+++ b/plates/pt.yml
@@ -179,6 +179,14 @@ series:
         so the class is `strict` rather than a widening. FLAGGED FOR THE
         VERIFIER: this reading rests on the statutory drawing plus a deletion,
         and a photograph of an issued plate would settle it in one look.
+        SETTLED 2026-08-03: it did. Commons "2020 Portugal license plate
+        example.jpg" (CC BY-SA 4.0) photographs issued AE 36 EM — no
+        separator glyph anywhere, tight intra-group spacing, a small clear
+        gap between the pairs whose measured proportion (~0.19 of the
+        character em) matches the Anexo V 20 mm chain. Independently
+        reported by the project owner from plates in the wild the same day.
+        The statutory reading holds; the printed form is the GAP, full stop.
+        Evidence: statutory + photographic-observed.
       progression: >-
         Nationally sequential and non-geographic, like every Portuguese series
         since 1937. The known anchor is the first number, AA-01-AA, so the two


### PR DESCRIPTION
The pt-national-2020 separator_note's own verifier flag asked for one photograph of an issued plate; Commons AE 36 EM (CC BY-SA 4.0) delivers it and the owner independently reported the same from the wild. The statutory reading (DL 2/2020's deleted traços clause + Anexo V's glyph-less 20mm chain) holds. Lint OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)