### PR TITLE
plates ad: the §5.3 verification pass — a reserved block that matched neither instrument, and three gazette dates off by one

### DIFF
--- a/plates/_verification/README.md
+++ b/plates/_verification/README.md
@@ -1,0 +1,57 @@
+# `plates/_verification/` — the PRD-PLATES § 5.3 dossier shelf
+
+One Markdown dossier per jurisdiction, named `<code>.md`, sitting beside the
+`plates/<code>.yml` it verifies.
+
+## Why this directory exists, and why Markdown
+
+PRD-PLATES § 5.3 defines a three-role protocol: **researcher** builds the
+series list with per-claim citations, an **independent verifier** re-derives
+period boundaries and formats from primary sources, and the **maintainer**
+applies. The researcher half of that protocol already had a home — the
+private archive at `vehiclesdb-pipeline/aux/research/plates-2026-07/`
+(`dossier-l1-<code>.md`, per PRD-PLATES § 8). The verifier half had none, and
+PRD-PLATES § 7.2 records the consequence: "the § 5.3 HUMAN verification pass
+is outstanding for both waves". A verification that lives only in a PR body
+cannot be re-read by the next pass, so it lands here, in the open repo, next
+to the data whose claims it tests.
+
+**Markdown, not YAML, and that is load-bearing.** `scripts/lint_plates.rb`
+enumerates `plates/*.yml` **and `plates/*/*.yml`**, and treats every hit that
+is not under `_meta/`, `_decode/` or `_art/` as a jurisdiction file carrying
+series. A `plates/_verification/<code>.yml` would therefore be linted as a
+124th-plus jurisdiction and fail the gate. A `.md` file is invisible to that
+glob, so the dossier shelf cannot perturb the `124 files, 1381 series` count.
+
+## The shape
+
+Ported from the five-nines verifier ledgers
+(`data/review/audit-v2026.07.5/ledger/verifier-*.yml`), which are the
+"established shape" § 5.3 refers to:
+
+1. **Header** — jurisdiction, gate, protocol, researcher, verifier, status.
+2. **METHOD / independence** — which routes were read, in which order, and
+   what was deliberately *not* read before re-deriving.
+3. **The instrument chain** — every period boundary in the file traced to the
+   entry-into-force article that fixes it, quoted.
+4. **Per-series verdicts** — period, format, class, colours, one row per
+   series, verdict CONFIRMED / DISAGREEMENT / UNVERIFIABLE.
+5. **Disagreements, verbatim** — both readings preserved side by side.
+6. **Recommendations** — for the maintainer. The verifier changes no data.
+7. **Gate proof** — the lint output before and after.
+
+## The two rules that bind every dossier here
+
+- **MAJORITY IS NOT AUTHORITY; the authority is the authority.** Where sources
+  disagree the disagreement is recorded verbatim and both readings are kept.
+  Dates are never averaged, split, or resolved by counting sources. The
+  Spanish 2000 cutover and the French SIV rollout are the named precedents.
+- **I-11: researcher ≠ verifier.** A single session never signs both roles.
+  A dossier whose findings originate new claims ships
+  `status: awaiting_verification` with `verifier: null`.
+
+## Invariant for anyone acting on a dossier's recommendations
+
+Series ids are **append-only** and are never deleted. Where a recommendation
+corrects a `period.start` on a series whose id embeds the old year, the fix is
+to the `period` field only — **the id does not change**.

--- a/plates/_verification/ad.md
+++ b/plates/_verification/ad.md
@@ -1,0 +1,541 @@
+# §5.3 verification dossier — `ad` (Andorra)
+
+**Gate** L1 (microstates group) · **Loop** QA-LOOP-2 · **Date** 2026-08-08
+**Role of this session** RESEARCHER ONLY. Under I-11 the author never certifies
+their own work, so `plates/ad.yml` ships `verification.status:
+awaiting_verification` and `verification.verifier: null`. Everything below is a
+claim awaiting a second signer — including the corrections.
+
+**Subject** `plates/ad.yml`, 16 series, previously headed *"DRAFT for
+verification"*. This is the first §5.3 pass on any L1 jurisdiction; PRD-PLATES
+§7.2 records the human verification pass as outstanding for both waves.
+
+---
+
+## 0. Why `ad`, and what "the deterministic list" was
+
+The unit was defined as index 0 of the sorted list of L1-wave jurisdiction files
+lacking a §5.3 dossier. Computed from the data itself rather than from prose,
+since every jurisdiction file declares its gate in its first line:
+
+```
+$ grep -l "gate L1" plates/*.yml | xargs -n1 basename | sort
+ad at be ch cy cz dk ee fi fr gb gr hr hu ie is it li lt lu lv mc mt no
+pl pt ro se si sk sm va          → 32 files
+```
+
+(`de`, `es`, `nl`, `us-fl` declare gate L0 — the pilot — and are excluded; the
+US/CA files declare L2 and the rest L3.)
+
+No §5.3 verification dossier exists anywhere in either repo — the eight
+`dossier-l1-*.md` files in `vehiclesdb-pipeline/aux/research/plates-2026-07/`
+are the **researcher** half from wave 1 (at be ch fi fr gb it se) and cover
+neither the wave-2 microstates nor the verification pass. So the list of L1
+files lacking a §5.3 dossier is all 32, and **index 0 is `ad`** on either
+reading — whether "lacking a dossier" means lacking any dossier or lacking a
+verified one.
+
+**Location convention.** No dossier had ever been written *alongside the data*,
+so this file establishes `plates/_verification/<code>.md`, mirroring the
+underscore-prefixed non-jurisdiction directories the dataset already uses
+(`_meta`, `_decode`, `_art`). Both lint globs are `*.yml`-only, so Markdown here
+is inert. Move it if the maintainers prefer another home.
+
+---
+
+## 1. Method
+
+Every period boundary, format regex, class and colour was re-derived from the
+**primary instrument already pinned in the file**, plus **one independent
+route**. Two method notes matter for anyone repeating this:
+
+1. **The gazette text was read raw, not through a summariser.** The BOPA blob
+   store serves UTF-16LE HTML. Each document was fetched, decoded, tag-stripped
+   and read locally, so every Catalan quotation in `ad.yml` and below is a
+   byte-for-byte extract. This was not fussiness: an initial summariser pass
+   over the same URL returned art. 15's range correctly but paraphrased arts.
+   7.1–7.3 into a summary that hid art. 7.5 — the provision that turns out to be
+   the only statutory basis for the motorcycle series' `regex_strict`.
+2. **A finding was withdrawn during the pass.** I recorded that the 2011
+   instrument's "images on the retroreflective ground" clause had been repealed
+   in 2022, because it is absent from arts. 6, 7 and 15 of the new Reglament. It
+   was not repealed — it was consolidated into art. 5.2 and scoped to white
+   retroreflective grounds. It is not reported below. Noted here because a
+   verification pass that reports only its successes is not evidence of anything.
+
+### Sources, with exact URLs
+
+| # | Instrument / route | URL |
+|---|---|---|
+| S1 | Decret 456/2022, del 9-11-2022 — the plate Reglament IN FORCE | https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html |
+| S2 | Decret del 23-02-2011 — the repealed Reglament | https://bopadocuments.blob.core.windows.net/bopa-documents/023014/html/6BEF6.html |
+| S3 | Llei 12/2021, del 13 de maig, Codi de la circulació | https://bopadocuments.blob.core.windows.net/bopa-documents/033062/html/CGL20210528_13_01_20.html |
+| S4 | Llei del Codi de la circulació, de 10-6-99 (repealed) | https://bopadocuments.blob.core.windows.net/bopa-documents/011040/html/199A6.html |
+| S5 | Llei 24/2014, del 30 d'octubre, plaques personalitzades | https://bopadocuments.blob.core.windows.net/bopa-documents/026067/html/lo26067002.html |
+| S6 | Correcció d'errata del 30-11-2022 (BOPA 142/2022) | https://bopadocuments.blob.core.windows.net/bopa-documents/034142/html/GD20221201_12_12_06.html |
+| S7 | Correcció d'errata de l'1-3-2023 (BOPA 33/2023) | https://bopadocuments.blob.core.windows.net/bopa-documents/035033/html/GV20230303_12_27_52.html |
+| S8 | BOPA sumari núm. 135, any 2022 (gazette date + the title erratum) | https://bopadocuments.blob.core.windows.net/bopa-documents/sumaris/034/034135.pdf |
+| S9 | BOPA sumari núm. 142, any 2022 (indexes S6) | https://bopadocuments.blob.core.windows.net/bopa-documents/sumaris/034/034142.pdf |
+| S10 | BOPA sumari núm. 62, any 2021 (gazette date of S3) | https://bopadocuments.blob.core.windows.net/bopa-documents/sumaris/033/033062.pdf |
+| S11 | BOPA sumari núm. 67, any 2014 (gazette date of S5) | https://bopadocuments.blob.core.windows.net/bopa-documents/sumaris/026/026067.pdf |
+| S12 | Annex 1 to the 2011 Reglament — the statutory drawings (cited, never embedded, per PRD-PLATES §6) | https://bopadocuments.blob.core.windows.net/bopa-documents/annexos/023014_plaques.pdf |
+| S13 | Automòbil Club d'Andorra — plate concession page | https://aca.ad/serveis/plaques-de-matricula |
+| S14 | leslleis.com — independent legal database copy of the decree | https://leslleis.com/DR20221109C |
+| S15 | Annex to Decret 456/2022 — advertised path, **404 BlobNotFound** | https://bopadocuments.blob.core.windows.net/bopa-documents/034135/Documents/Plaques%202021_GR20221110_09_12_43.pdf |
+
+---
+
+## 2. Per-series verdicts
+
+`period` = start/end boundary · `format` = pattern + regex · `class` · `colour`.
+**OK** = re-derived and matches. **CORRECTED** = data changed in this PR.
+**FLAGGED** = recorded in the file, needs a decision above researcher level.
+
+| series | period | format | class | colour | net |
+|---|---|---|---|---|---|
+| `ad-standard-letter` | OK | OK | OK | OK | agency-stated 2011 upheld (§3.1) |
+| `ad-standard-numeric` | OK | OK | OK | OK | quote truncation fixed (§3.7) |
+| `ad-motorcycle` | OK | OK | OK | OK | `regex_strict` now sourced; coverage gap FLAGGED (§3.8) |
+| `ad-moped` | OK | OK | OK | **FLAGGED** | legend was black pre-2022 (§3.9) |
+| `ad-diplomatic-cmd` | OK | OK | OK | OK | — |
+| `ad-diplomatic-cd` | OK | OK | OK | OK | — |
+| `ad-consular-cc` | OK | **FLAGGED** | OK | OK | 2 digits pre-2022, 3 from 2022 (§3.5) |
+| `ad-diplomatic-staff-a` | OK | OK | OK | OK | Pantone 299 vs 2945 split upheld |
+| `ad-temporary-mt` | OK | **FLAGGED** | OK | OK | MT serial-vs-legend dissent (§4.1) |
+| `ad-dealer-prova` | OK | **CORRECTED** | OK | OK | `\d{1,3}` → `\d{3}` (§3.3) |
+| `ad-historic-failed-itv` | OK | OK | OK | **FLAGGED** | legend was VEHICLE ANTIC pre-2022 (§3.9) |
+| `ad-historic-passed-itv` | **FLAGGED** | **CORRECTED** | OK | OK | the headline catch (§3.2) |
+| `ad-special-vehicle` | OK | OK | OK | OK | both draft corrections upheld (§5) |
+| `ad-snow-vehicle` | OK | OK | OK | OK | — |
+| `ad-giny-mecanic` | OK | OK | OK | OK | — |
+| `ad-personalized` | **CORRECTED** | **FLAGGED** | OK | OK | 3 missing constraints (§3.6), law-vs-decree (§4.2) |
+
+No series was added, removed or renamed. `plates lint` holds at **124 files,
+1381 series** with the `_art` gate green.
+
+---
+
+## 3. Findings
+
+### 3.1 UPHELD — the file's central finding survives, and gets stronger
+
+The draft's most important claim is that the 2011 Decret did **not** create the
+lettered format, so `ad-standard-letter` must be dated `agency-stated-date` from
+ACA and not `instrument-in-force` from the Decret whose year happens to match.
+Re-derivation confirms it on every leg:
+
+- S2 art. 3.2 and S1 art. 6.2 both describe one continuous scheme advancing on
+  **exhaustion**, never on a date.
+- S2's exposició de motius lists that instrument's actual innovations — the
+  reduced plate, plastic/rubber enduro-trial plates, images on the reflective
+  ground, and the AND mark. The lettered serial is not among them.
+- S13 carries the year, verbatim and still live: *"Des de l'any 2011, les plaques
+  de matrícula dels vehicles d'Andorra estan formades per quatre xifres de color
+  negre precedides per una lletra sobre fons de color blanc."*
+
+One correction improves it. The draft printed the **2011** wording under a
+**2022** attribution and called the re-enactment "verbatim". It is not verbatim,
+and the difference runs the file's way: S1 art. 6.2 says *"un grup de cinc
+caràcters **numèrics**"* where S2 art. 3.2 said only *"un grup de 5 caràcters"*.
+The word the five-digit base-stage claim depends on is in the current instrument
+and absent from the old one. Both texts are now carried separately.
+
+### 3.2 CORRECTED — `ad-historic-passed-itv`: a value that matches neither instrument
+
+The headline catch, and the one the §5.3 protocol is written for.
+
+> **S2, art. 12.1 (2011, repealed):** "A les plaques de matrícula s'inscriu un
+> grup de 5 caràcters que va des del **58001 final al 99999**."
+> (*"final al"* is the instrument's own slip for *"fins al"*.)
+
+> **S1, art. 15.1 (2022, in force):** "A les plaques de matrícula s'hi inscriu un
+> grup de cinc caràcters numèrics que va des del **58001 fins al 58999**."
+
+The draft recorded **"58001 to 59999"** with `regex: '\A5[89]\d{3}\z'` — a value
+that sits between the two instruments and matches neither. Whatever produced it,
+that is the shape PRD-PLATES §5.3 names: *the era boundaries are where sources
+disagree … never average them.*
+
+The regex over-accepted 1,001 strings (59000–59999, plus 58000). Corrected to
+`'\A58\d{3}\z'`, which carries the block in force; 58000 remains as one string of
+documented slack because the pattern DSL cannot express a lower bound.
+
+**Left for the verifier:** the block *narrowed* at the 2022 commencement, so on
+the §2.2 rule that a differing format is a differing series, the 2011–2022 wide
+block deserves its own ended series and this one should start 2022. That is a
+series **addition** — permitted by append-only, but not a call a researcher may
+make alone. The period stays at 2011 and is knowingly wider than the format it
+now carries, flagged rather than quietly re-cut.
+
+### 3.3 CORRECTED — `ad-dealer-prova`: three characters, not one to three
+
+> **S1, art. 16.1:** "A les plaques de matrícula s'hi inscriu un grup de **tres
+> caràcters numèrics** que va des del 000 fins al 999."
+
+`'\A\d{1,3}\z'` → `'\A\d{3}\z'`. The range is written with leading zeros, so
+`000` and `007` are forms the block contains and `7` is not. Dated note: the
+digit count is a 2022 addition — S2 art. 13.1 said only *"un grup de caràcters
+numèrics que van des del 000 fins al 999"*.
+
+### 3.4 CORRECTED — three gazette dates, all off by one, one of them a commencement
+
+A **systematic** defect rather than three coincidences.
+
+| instrument | draft | gazette | evidence |
+|---|---|---|---|
+| Decret 456/2022 | published 2022-11-15 | **2022-11-16** | S8 page headers (all 13 pages); S7 says "publicat al BOPA núm. 135, del 16 de novembre del 2022" |
+| Llei 12/2021 | published 2021-06-01 | **2021-06-02** | S10 page headers ("Núm. 62 / 2 de juny del 2021") |
+| Llei 24/2014 | published 2014-11-25 | **2014-11-26** | S11 ("67 Any 26 / 26.11.2014") |
+
+The first one moves a commencement: S1's article únic commences the Reglament
+*"l'endemà de ser publicat"*, so the plate regulation in force took effect on
+**17 November 2022**, not 16 November.
+
+**And it dissolves a recorded "disagreement".** The draft carried a
+`recorded_discrepancy`: BOPA index metadata giving 1 June 2021 against Decret
+456/2022's preamble saying *"publicada al BOPA del 2 de juny del 2021"* — "a
+one-day disagreement between two official sources, recorded rather than
+resolved". There is no disagreement. Both official sources say 2 June; only the
+draft said 1 June. The entry is **retracted with evidence** rather than
+preserved, because a spurious disagreement left in the record is a permanent
+fake uncertainty — the mirror-image failure of averaging a real one.
+
+Worth carrying to the other microstate files from the same wave: three
+off-by-ones in one file is a process signal, not a typo.
+
+### 3.5 FLAGGED — `ad-consular-cc` describes only half its own period
+
+> **S2, art. 8 (the second one so numbered):** "el primer grup el formen les
+> lletres CC; el segon grup el formen **dos caràcters numèrics** que van des del
+> 00 fins al 99"
+
+> **S1, art. 11.2:** "el primer grup el formen les lletres CC (cos consular); el
+> segon grup el formen **tres caràcters numèrics** que van des del 000 fins al
+> 999"
+
+The series is dated from 2011 and carries the three-digit regex, so a CC plate
+issued between 2011 and 16 November 2022 will not match it. Recorded, not
+widened — the regex carries the instrument in force, and the clean fix is the
+same §2.2 split proposed in §3.2.
+
+*(Incidentally: S2 numbers two consecutive articles "Article 8" — A-staff then
+consular — and then resumes at 9. The defect is in the as-published text, was
+never fixed by the errata of 9-3-2011, and is now recorded in
+`instrument.numbering_defect` so the next reader does not think they misread.)*
+
+### 3.6 CORRECTED — `ad-personalized` was missing three statutory constraints
+
+The draft listed S5 art. 7.1 (a)(b)(c)(g)(h)(i). It omitted:
+
+- **(d)** *"No s'accepten combinacions que coincideixin o puguin coincidir amb
+  la numeració de les matrícules ordinàries."* The regex accepts `A0000` —
+  precisely the ordinary lettered grammar of S1 art. 6.2 — and `AA000`, its next
+  stage. The single most over-accepting case, and forbidden in terms.
+- **(f)** *"No s'accepten combinacions que continguin la menció 'AND' i altres
+  pròpies de l'Estat o dels poders públics andorrans."*
+- **(e)** and **(j)** — discretionary and registry-state rules, unexpressible in
+  a regex by nature.
+
+`matching: recall-only` was already correct; these make the declaration honest
+about what it is recalling. Commencement also added: S5's disposició final
+segona gives *"al cap d'un mes de ser publicada"* → **26 December 2014**, so the
+2014 start rests on the last six days of that year.
+
+### 3.7 CORRECTED — a quote truncated where it stopped helping
+
+The draft cites S4 art. 147 for *"Aquest Codi inclou el catàleg de plaques de
+matrícula vigents a Andorra."* The **attribution is correct** — I initially
+filed this as a misattribution and was wrong; the sentence is the penultimate
+paragraph of art. 147, which runs to the "Article 148" heading.
+
+But the sentence does not end there:
+
+> "…vigents a Andorra. **No obstant això, el Govern pot modificar o afegir altres
+> modalitats de matrícula, d'acord amb la disposició addicional primera.**"
+
+The omitted half is the **delegation**, and it is load-bearing: it is the
+mechanism by which a 2011 Govern decree could lawfully add plate types while the
+1999 Codi was in force, and S2's preamble relies on it by name — *"El legislador
+… va atribuir al Govern mitjançant l'article 147 i la disposició addicional de
+la llei, la capacitat de modificar les plaques de matrícula incloses en el
+catàleg o afegir-hi altres modalitats."* The `instrument-in-force-upper-bound`
+dating of every 2011 series in this file depends on that delegation being real,
+so quoting only the first half understated the file's own foundation.
+
+### 3.8 FLAGGED — a coverage gap: five-digit motorcycle plates match nothing
+
+> **S1, art. 7.3:** "A la placa horitzontal s'hi inscriu un grup de cinc
+> caràcters numèrics que va des del 00000 fins al 99999 i, a continuació, la
+> primera xifra se substitueix per una lletra…"
+
+Motorcycles run the same two-stage scheme as cars. `ad-motorcycle` models only
+the lettered stage; `ad-standard-numeric` models the five-digit stage but lists
+`categories: [car, van, truck, bus, trailer, semitrailer]` — motorcycle absent.
+So a five-digit Andorran motorcycle plate is matched by **no series in this
+file**: a jurisdiction-completeness miss under PRD-PLATES §5.1. Fix is one word
+or one new ended series; both are claim changes, so both are proposed rather
+than taken.
+
+Also on this series: `regex_strict` carried the 23-letter alphabet with no source
+of its own, and borrowing art. 6.3's would have been an inference — that
+exclusion is drafted narrowly for the ordinary and reduced car plates and does
+not mention motorcycles. It turns out motorcycles have **their own** exclusion,
+S1 art. 7.5: *"Se suprimeixen les lletres I, O i Q del sistema de numeració de
+les plaques horitzontal i vertical de matrícula ordinària per a motocicleta…"*
+The twin is statutory after all; it is now cited as such.
+
+### 3.9 FLAGGED — dated design drift (recorded, **not** edited)
+
+Four design facts in the file are the *current* spec attached to a period that
+starts in 2011. Colours and legends are the owner's visual lane, so these are
+recorded in the YAML and listed here, and no `design:` block was touched.
+
+| series | 2011 (S2) | 2022 (S1) | file carries |
+|---|---|---|---|
+| `ad-moped` | legend ANDORRA in **black** on yellow (art. 5.1) | **blue** on yellow (art. 8.1) | blue |
+| `ad-historic-failed-itv` | legend **VEHICLE ANTIC** (art. 11.1) | **VEHICLE HISTÒRIC** (art. 14.1) | VEHICLE HISTÒRIC |
+| `ad-special-vehicle` | **VEHICLES ESPECIALS** (art. 14.1) | **VEHICLE ESPECIAL** (art. 17.1) | singular |
+| `ad-snow-vehicle` | **MOTOS DE NEU** (art. 15.1) | **MOTO DE NEU** (art. 18.1) | singular |
+
+Also dated: the **plastic/rubber enduro-trial base** is historic. S2 art. 1 ¶2
+allowed it; S1 art. 4 does not re-enact it (aluminium as norm, adhesive for art.
+25 cases, nothing else). The file described it in the present tense.
+
+### 3.10 NEW — the AND mark's scope, which predicts the whole catalogue
+
+S2's preamble closes the AND paragraph: *"Aquesta modificació sols s'aplica a les
+matrícules destinades a vehicles que són **aptes per a la circulació
+internacional**."* That one sentence predicts exactly which series carry AND —
+ordinary (art. 6.1), motorcycle (7.2, 7.4), the four diplomatic/consular series
+(9–12) and MT (13) — and which do not: moped (8), both historic (14–15), PROVA
+(16), special (17), snowmobile (18), giny mecànic (19). Every omission is a
+vehicle that does not travel internationally. The design blocks already matched
+this pattern; it was inferred there and is now sourced.
+
+### 3.11 NEW — a sourced negative the draft missed
+
+S1 art. 15.3: *"La placa de matrícula per als ciclomotors que es registrin com a
+vehicles històrics és la mateixa que la placa de matrícula ordinària per als
+ciclomotors."* A historic moped is in `ad-moped`, not in either historic series.
+No new series warranted — the instrument says the plate is the same one.
+
+### 3.12 NEW — Andorra claims property in the plate characters and state symbols
+
+The finding with reach beyond this file.
+
+> **S3, Llei 12/2021 art. 108(3):** "Els caràcters que figuren en les matrícules,
+> així com els símbols d'Estat que han de portar els vehicles, són **propietat
+> del Govern**, que cedeix en cada cas el dret a usar-los, d'acord amb les
+> condicions que es determinin per la via reglamentària."
+
+> **S1, Decret 456/2022 art. 3.5:** "Els caràcters que figuren en les matrícules,
+> i els símbols d'Estat que han de portar els vehicles, són **propietat del
+> Govern**, que cedeix en cada cas el dret a usar-los…"
+
+Two instruments, one in a law and one in a decree. PRD-PLATES §6 records — from
+the EU dossier, and expressly as a **sample** finding — that *"No surveyed
+country claims copyright in the plate design itself."* Andorra is a
+counter-example to that sample and should be carried back into §6 as one. It is
+the same shape of fact that `artwork_risk:` exists to record for US states under
+§7.1: an adverse statutory signal sitting beside an art route that looks clean
+(`plates/_art/ad/` holds a PD-verified Commons coat of arms).
+
+**Read narrowly.** These provisions assert ownership of the characters *as they
+appear on matrícules* and of the state symbols vehicles must carry, and set up
+case-by-case licensing. They are not a copyright registration, they say nothing
+about the underlying historic coat of arms, and Andorran law was not searched
+here for what *"propietat del Govern"* grants against a third party. What they do
+establish is that the "no country claims the design" line cannot be repeated for
+Andorra unqualified.
+
+**Recorded and escalated, not acted on.** `common.emblem` and every `design:`
+block are untouched — the emblem posture is the owner's visual lane and the
+licensing question is counsel's, not a verifier's. The §3 placeholder default
+ships either way, so nothing renders differently today.
+
+### 3.13 The two errata, and a sourcing caveat with teeth
+
+- **S6 (30-11-2022)** corrects arts. 3.6 and 4.2 from *"l'article 24 del
+  Reglament"* to *"l'article 25"* — the adhesive-plate article is 25; 24 is
+  Reserva de matrícula ordinària. No series affected.
+- **S7 (1-3-2023)** is more interesting. The draft recorded that *"BOPA's own
+  sumari mistypes this decree as 'Decret 456/2011, del 9-11-2022'"* and reasoned
+  that *"the document header reads 456/2022"*. **It did not.** S7 quotes the
+  published title under *"On hi diu:"* as **"Decret 456/2011, del 9-11-2022…"*
+  and prescribes **"Decret 456/2022"** under *"Hi ha de dir:"*. The wrong year
+  was in the instrument's own title; the sumari (S8, confirmed verbatim)
+  reproduced it; and the citation is now settled **by an instrument** rather than
+  by inference. Third-party databases still carry the uncorrected form — S14
+  prints "Decret 456/2011, del 9 de novembre del 2022" today — which is the
+  practical reason to keep the note.
+- **Caveat with teeth:** the pinned URL (S1) serves the **as-published** text and
+  therefore still prints the two errors S6 fixed. Anyone reading S1 alone is
+  reading text the Govern has formally amended.
+
+### 3.14 The annex gap — narrowed, not closed
+
+- The **2011** annex is live: S12, a 1.83 MB 15-page PDF, figure pairs 1a/1b
+  through 14a/14b (4 split 4.1/4.2), one pair per plate type. It is **pure vector
+  graphics** — text extraction returns only running heads and captions — so the
+  draft's characterisation is confirmed for content and corrected for
+  availability. Cited, never embedded (PRD-PLATES §6).
+- The **2022** annex is **not published at its own link**: S15 returns
+  `BlobNotFound` / HTTP 404. A searched-for negative, with the exact URL tried.
+- This matters more than a missing picture: S1 art. 21 makes the annex normative
+  for the glyphs — *"Les especificacions de les plaques de matrícula i dels
+  distintius…, els colors i els caràcters alfabètics i numèrics són els que
+  s'indiquen en l'annex del Reglament."* The character shapes are in the
+  unreachable annex, which is why `common.font.name` correctly stays `null` and
+  the §6 schematic fallback correctly applies.
+
+---
+
+## 4. Disagreements recorded verbatim, resolved by nobody
+
+Per PRD-PLATES §5.3. Neither is averaged; neither is silently picked.
+
+### 4.1 Is "MT" part of the serial, or a legend?
+
+**Route A — the plate regulation treats it as furniture.** S1 art. 13.1 puts MT
+in a panel and states the serial separately: *"Al costat esquerre superior, sobre
+fons vermell (fons Pantone 485), hi figuren els caràcters MT de color negre mat.
+[…] A les plaques de matrícula s'hi inscriu un grup de quatre caràcters numèrics
+que va des del 0000 fins al 9999."* That is the **same two-part shape** art. 16.1
+uses for PROVA — legend in one sentence, *"un grup de N caràcters numèrics"* in
+another — and this file reads art. 16 as making PROVA a legend. Applied
+consistently, MT is a legend and the serial is four bare digits.
+
+**Route B — the personalisation statute treats it as a prefix.** S5 art. 7.1(i)
+forbids a personalised mark consisting of *"les lletres 'MT', 'CD', 'CMD', 'A',
+'CC', seguides de xifres o la paraula 'PROVA'"* — grouping MT with the
+unambiguous diplomatic prefixes and setting PROVA apart as *"la paraula"*. This
+is the draft's basis and it is real.
+
+**Data unchanged, and why.** Keeping MT in `regex` costs nothing under §2.7 (it
+is narrower than the issuing grammar, never wider) and buys discrimination four
+bare digits cannot: dropping it would collide this series with
+`ad-special-vehicle`, `ad-snow-vehicle` and `ad-giny-mecanic`, all `'\A\d{4}\z'`.
+The disagreement is a reading of two instruments, not a fact either states.
+
+### 4.2 Which vehicles may carry a personalised plate?
+
+**S5 art. 3.1 (the law)** admits four categories: *"a) Categoria 'L' […] amb
+excepció dels de la categoria 'L1' (ciclomotors). b) Categoria 'M' […] c)
+Categoria 'N' o la que correspongui a vehicles de motor destinats al transport de
+mercaderies […] d) Categoria 'O' o la que correspongui a remolcs i
+semiremolcs."* — motorcycles, cars, **goods vehicles and trailers**.
+
+**S1 art. 26.1 (the decree)** is narrower: the personalised mark *"s'aplica a la
+placa de matrícula ordinària i a la placa de matrícula ordinària reduïda dels
+vehicles automòbils, així com a la placa de matrícula ordinària de les
+motocicletes"* — cars and motorcycles only.
+
+The series lists `[car, van, motorcycle]`, following the decree. A law outranks a
+decree, so the wider list is probably right — but "probably" is not the standard,
+the decree is the instrument the rest of this file is built on, and **majority is
+not authority** cuts against quietly picking one. Left as-is, recorded in full.
+
+---
+
+## 5. What the pass upheld
+
+Verification that only reports defects mis-states the file's quality. `ad.yml`
+is a strong piece of work and most of it re-derives cleanly:
+
+- **All four diplomatic/consular grammars exact** (S1 arts. 9–12): CMD + 1 digit,
+  CD + 2, CC + 3, A + 2, each closing with the state letter assigned by the
+  foreign ministry. The Pantone 2945 / 299 split by rank is real and statutory.
+- **Both of the draft's corrections to the secondary record on
+  `ad-special-vehicle` are upheld** on raw text: *"El fons de les plaques és
+  retroreflector, de color blanc"* (white, not sky blue) and *"un grup de quatre
+  caràcters numèrics"* (four digits, not three).
+- **The absence of `regex_strict` on `ad-historic-failed-itv` is correct and
+  deliberate** — S1 art. 14.2 says only *"sense utilitzar les lletres de
+  l'alfabet que puguin crear confusió"* and, unlike arts. 6.3 and 7.5, never
+  names I, O and Q. An enumerated twin there would be inference dressed as
+  statute. The pass confirms the restraint rather than "fixing" it.
+- **The `not_modelled` refusals all hold**, including the sourced negative on
+  electric plates (S3 disposició final setena puts the ZERO/ECO classification on
+  a windscreen sticker, quoted exactly) and the refusal to invent the pre-1999
+  "AND + four digits" series.
+- **The chain is confirmed by the repealing instrument itself.** S1's disposició
+  derogatòria primera names the 2011 base decree, the errata of 9-3-2011, the
+  Decret of 27-7-2011 *"pel qual s'aprova la modificació dels articles 12 i 17, i
+  d'addició de l'article 19"* and the Decret of 10-12-2014 — matching the draft's
+  `chain` exactly, including the parenthetical about arts. 12/17/19.
+- **Every Llei 12/2021 quotation is verbatim-accurate**, including art. 108(1),
+  disposició final novena and the ZERO/ECO passage.
+- **`region_encoding: none` is right.** Nothing in any instrument encodes the
+  seven parròquies.
+- **The Vienna Convention lead is accurate** and the PRD-PLATES §4 caution
+  stands: S2's preamble relies on Annex 3 point 3 in the 2006 consolidated
+  version by name, which corroborates the amendment's existence without being it.
+
+Two small additions to the chain and repeal record: S1's disposició derogatòria
+**segona** also repeals the Decret of 24-11-2010 on mark reservation (added —
+it is where the `binding` question moved from), and the Llei 12/2021 repeal of
+the 1999 Codi is **not total**, carving out art. 209 until the pleasure-boat
+reglament commences (not plate-related, but "repealed the 1999 Codi" is not the
+whole sentence).
+
+---
+
+## 6. Action list for the verifier and the maintainer
+
+**Needs a second signer before it can be called verified (I-11):** everything
+above, including the corrections.
+
+**Needs a decision above researcher level:**
+
+1. **§2.2 series splits** for `ad-historic-passed-itv` (block narrowed
+   58001–99999 → 58001–58999 in 2022) and `ad-consular-cc` (CC + 2 digits →
+   CC + 3 digits in 2022). Both are series *additions*; append-only permits
+   them, I-11 forbids me from signing them.
+2. **The five-digit motorcycle gap** (§3.8) — add `motorcycle` to
+   `ad-standard-numeric.categories`, or open an ended series.
+3. **`binding` at series scope.** PRD-PLATES §2.1 puts `binding` at file scope;
+   Andorra needs both values. An Andorran personalised vehicle holds **two**
+   marks — one bound to the vehicle (S1 art. 24.2: *"Queda totalment prohibit
+   cedir una matrícula"*) and one bound to its owner (S5 art. 6.3: *"caràcter
+   personal i intransferible… Únicament s'exceptua la transmissió de la matrícula
+   per successió"*, with S1 art. 26.5 contemplating *"afectació a un altre
+   vehicle"*). Proposal only.
+4. **PRD-PLATES §6 amendment** — Andorra is a counter-example to the "no country
+   claims the design" sample finding (§3.12). Also worth a counsel note.
+5. **Sweep the other wave-2 microstates for the off-by-one gazette dates**
+   (§3.4). Three in one file is a process signal.
+6. **Design drift** (§3.9) — four legend/colour facts are current-spec attached
+   to 2011-start periods. Owner's visual lane; untouched here.
+
+---
+
+## 7. Reproducing this
+
+```bash
+# the gazette serves UTF-16LE HTML; decode before reading, and never trust a
+# summariser with a statutory number
+curl -sSL -o d456.html \
+  "https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html"
+ruby -rcgi -e 'raw=File.binread("d456.html")
+  enc = raw[0,2]=="\xFF\xFE".b ? "UTF-16LE" : "UTF-8"
+  t=raw.force_encoding(enc).encode("UTF-8",invalid: :replace,undef: :replace)
+  t=t.gsub(%r{<(script|style)[^>]*>.*?</\1>}mi,"").gsub(%r{<br\s*/?>}i,"\n")
+     .gsub(%r{</(p|div|tr|li|h[1-6])>}i,"\n").gsub(/<[^>]+>/,"")
+  puts CGI.unescapeHTML(t).gsub(/ /," ").split("\n").map(&:strip).reject(&:empty?)'
+
+# BOPA folder numbering is `any = year - 1988`; sumaris carry the gazette DATE
+# in every page header, which is the only reliable source for it
+curl -sSL -o s135.pdf \
+  "https://bopadocuments.blob.core.windows.net/bopa-documents/sumaris/034/034135.pdf"
+pdftotext -layout s135.pdf - | head -1
+```
+
+Gates, before and after — unchanged:
+
+```
+plates lint: 124 files, 1381 series
+plates lint: matching recall-only=286 strict=1095 | twins regex_statutory=106 regex_strict=427 | separators emitted "-"," " forgiving 18
+plates lint: _art ledger 6060 rows (excluded=5355 open=412 site_only=293), 412 open assets verified
+plates lint: OK
+curation lint: OK (109 files, duplicate-key + shape + make-key + provenance)
+```

--- a/plates/_verification/be.md
+++ b/plates/_verification/be.md
@@ -1,0 +1,395 @@
+# Belgium — PRD-PLATES § 5.3 verification dossier
+
+|                |                                                                     |
+|----------------|---------------------------------------------------------------------|
+| jurisdiction   | `be` — `plates/be.yml`, 33 series                                    |
+| gate           | L1 (EU/EEA + UK + CH), wave 1 — landed as `data#218–#225`             |
+| protocol       | PRD-PLATES § 5.3; claims model § 5.1; lint gate § 5.2                 |
+| researcher     | L1 wave-1 agent, 2026-08-02 (`pipeline aux/research/plates-2026-07/dossier-l1-be.md`) |
+| verifier       | this pass — QA-LOOP-2, 2026-08-08                                    |
+| **status**     | **`awaiting_verification`** — see *I-11 posture* below                |
+| second signer  | `null`                                                                |
+| data changed   | **none.** The verifier re-derives and records; the maintainer applies. |
+
+## Why Belgium, and not some other jurisdiction
+
+The unit was selected deterministically, not chosen. The L1 slice is
+PRD-PLATES § 7's "EU/EEA + UK + CH … ~35 jurisdictions", which resolves
+against `plates/` to exactly 35 files (Bulgaria has no `bg.yml`; the count
+matches the 35 that `PLATES-PROGRAM-STATE.md` reports as "EU/EEA complete").
+No § 5.3 verification dossier existed for any of them — § 7.2 states the
+position outright: "the § 5.3 HUMAN verification pass is outstanding for both
+waves" — so the list of L1 files lacking a dossier is all 35, sorted:
+
+```
+ad at be ch cy cz de dk ee es fi fr gb gr hr hu ie is it li lt lu lv
+mc mt nl no pl pt ro se si sk sm va
+```
+
+Index 2 (zero-based, the program's convention) is **`be`**. The choice is
+stable under the narrower reading that excludes the L0 pilot (`nl es de`):
+that list begins `ad at be …` and index 2 is `be` either way.
+
+## I-11 posture
+
+Invariant I-11 forbids one session signing both roles. This pass is the
+**independent verifier** against a researcher dossier that already exists and
+that I did not write. Where a finding below merely *tests* a researcher claim,
+the verification is complete. Where a finding **originates** a claim the
+researcher did not make — F-1's resolution of the entry-into-force question is
+the only one — it ships as researcher-only: `verifier: null`,
+`status: awaiting_verification`, and it must be signed by a second party
+before any data moves on it.
+
+---
+
+## METHOD — independence
+
+I re-derived the period spine and the inscription grammar from the statutory
+text **before** reading the researcher's dossier prose, then compared. The
+comparison changed nothing in my verdicts and is not padded to look as though
+it did.
+
+### Routes read
+
+| # | route | what it is | why it is independent |
+|---|---|---|---|
+| R1 | `ejustice.just.fgov.be` Justel, **French** consolidated | the state's own consolidation — the route already pinned in `be.yml` | the primary. Not independent of the file; it is the file's own source |
+| R2 | `ejustice.just.fgov.be` Justel, **Dutch** consolidated | the co-equal authentic text | Belgian instruments are authentic in both languages. A claim that survives both is not a translation or OCR artefact of one |
+| R3 | `etaamb.openjustice.be` | independent republisher of the *Moniteur belge* **as published** | carries the ORIGINAL text, not the consolidation — the only route that can show what an article said before it was amended |
+| R4 | `mobilit.belgium.be` (DIV) | the **issuing authority's** own public pages | administrative, not legislative. Confirms what is actually issued rather than what is permitted |
+| R5 | local re-implementation | `verify_be.rb`, written from the PRD, not from `scripts/lint_plates.rb` | a second implementation of the regex-tier, RAL/hex and cross-series-ambiguity checks |
+
+R3 is the route that broke the case open. R1 alone cannot answer an
+entry-into-force question, because Justel's *header* field is not recomputed
+when the entry-into-force *article* is later amended — see F-1.
+
+### Rules binding me
+
+- **Fetch, never assume.** Every date below is quoted from an instrument.
+- **MAJORITY IS NOT AUTHORITY.** Three routes carrying one date does not beat
+  one instrument carrying another.
+- **Never average.** Where two dates are both primary, both are recorded and
+  neither is split.
+- **The fact stays OUT.** Where the statute imposes no constraint, I do not
+  invent one to make the model tidier — see F-4.
+- I wrote nothing into `plates/be.yml`.
+
+---
+
+## PART 1 — the instrument chain, re-derived
+
+Every period boundary in `be.yml` traces to one of five dates. All five were
+re-derived from the entry-into-force article of the instrument that fixes
+them, not from a summary.
+
+| boundary | instrument | entry-into-force article, verbatim | verdict |
+|---|---|---|---|
+| **01-10-2001** | AR 20-07-2001, NUMAC 2001014153, M.B. 08-08-2001 p. 27022 | art. 37 — Justel header "Entrée en vigueur : 1 octobre 2001" | CONFIRMED |
+| **15-11-2010** | AR 06-11-2010 **and** AM 08-11-2010, NUMAC 2010014234, M.B. 12-11-2010 | AM art. 16: *"Le présent arrêté entre en vigueur le 15 novembre 2010."* | CONFIRMED — stated twice, in identical words, by the royal and the ministerial instrument |
+| **31-03-2014** | AM 23-03-2014 (moped chapter) and AM 28-03-2014, NUMAC 2014014171, M.B. 07-04-2014 | AM 28-03-2014 art. 9: *"Le présent arrêté entre en vigueur le 31 mars 2014"* | CONFIRMED |
+| **01-01-2021** | AM 15-12-2019, NUMAC 2020040939, M.B. 15-05-2020 | **contested — see F-1** | DISAGREEMENT |
+| **01-01-2023** | AM 21-10-2022, NUMAC 2022033709, M.B. 22-12-2022 | in force 1 January 2023 | CONFIRMED |
+
+The 2001, 2010, 2014 and 2023 boundaries are clean on every route. The file's
+own header claim — that the 2010 date is corroborated twice — is true, and I
+verified both limbs rather than taking the pair on trust.
+
+---
+
+## PART 2 — per-series verdicts
+
+33 series × four claim axes (period, format, class, colours). Colours were
+verified per-article against the RAL code the statute names, and the RAL→hex
+mapping was checked for consistency across the whole file (R5, check 3):
+`RAL 3003 → #9B111E`, `RAL 3020 → #CC0605`, `RAL 6005 → #114232`,
+`RAL 6029 → #007243` — each RAL code maps to exactly one hex everywhere it
+appears. No inconsistency.
+
+| # | series id | class | period | period | format | colours |
+|---|---|---|---|---|---|---|
+| 0 | `be-standard-2010` | standard | 2010–open | ✔ | ✔ | ✔ |
+| 1 | `be-trailer-q-2021` | trailer | 2021–open | ✔ | ✔ | ✔ |
+| 2 | `be-taxi-t-2021` | taxi | 2021–open | ✔ | ✔ **exemplary** | ✔ |
+| 3 | `be-historic-o-2021` | historic | 2021–open | ✔ | ✔ (F-4) | ✔ |
+| 4 | `be-historic-o-moto-2021` | historic | 2021–open | ✔ | ✔ (F-4) | ✔ |
+| 5 | `be-motorcycle-m-2021` | motorcycle | 2021–open | ✔ | ✔ | ✔ |
+| 6 | `be-moped-s-2014` | moped | 2014–open | ✔ | ✔ | ✔ |
+| 7 | `be-agricultural-g-2020` | agricultural | **2020**–open | **F-1** | ✔ | ✔ |
+| 8 | `be-national-u-2021` | temporary | 2021–open | ✔ | ✔ | ✔ |
+| 9 | `be-dealer-marchand-z-2021` | dealer | 2021–open | ✔ | ✔ (F-3) | ✔ |
+| 10 | `be-dealer-essai-y-2021` | dealer | 2021–open | ✔ | ✔ (F-3) | ✔ |
+| 11 | `be-dealer-professionnelle-v-2021` | dealer | 2021–open | ✔ | ✔ (F-3) | ✔ |
+| 12 | `be-temporary-w-2021` | temporary | 2021–open | ✔ | ✔ (F-3) | ✔ |
+| 13 | `be-export-x-2021` | export | 2021–open | ✔ | ✔ (F-3) | ✔ |
+| 14 | `be-international-2021` | temporary | 2021–open | ✔ | ✔ (F-2) | ✔ |
+| 15 | `be-diplomatic-cd-2010` | diplomatic | 2010–open | ✔ | ✔ | ✔ |
+| 16 | `be-supplementary-court` | government | 2001–open | ✔ | ✔ | ✔ |
+| 17 | `be-supplementary-aep` | government | 2001–open | ✔ | ✔ | ✔ |
+| 18 | `be-personalized-2014` | personalized | 2014–open | ✔ | ✔ recall-only | ✔ |
+| 19 | `be-motorcycle-2010` | motorcycle | 2010–2020 | ✔ | ✔ | ✔ |
+| 20 | `be-historic-2010` | historic | 2014–2020 | ✔ | ✔ | ✔ |
+| 21 | `be-trailer-2010` | trailer | 2014–2020 | ✔ | ✔ | ✔ |
+| 22 | `be-taxi-2010` | taxi | 2010–2020 | ✔ | ✔ | ✔ |
+| 23 | `be-commercial-2010` | dealer | 2010–2020 | ✔ | ✔ | ✔ RAL 6029 |
+| 24 | `be-temporary-2010` | temporary | 2010–2020 | ✔ | ✔ | ✔ |
+| 25 | `be-international-2010` | temporary | 2010–2020 | ✔ | ✔ | ✔ |
+| 26 | `be-standard-2001` | standard | 2001–2010 | ✔ | ✔ | ✔ |
+| 27 | `be-trailer-2001` | trailer | 2001–2010 | ✔ | ✔ | ✔ |
+| 28 | `be-motorcycle-2001` | motorcycle | 2001–2010 | ✔ | ✔ | ✔ |
+| 29 | `be-historic-2001` | historic | 2001–2010 | ✔ | ✔ | ✔ |
+| 30 | `be-diplomatic-2001` | diplomatic | 2001–2010 | ✔ | ✔ | ✔ two-colour |
+| 31 | `be-commercial-2001` | dealer | 2001–2010 | ✔ | ✔ | ✔ |
+| 32 | `be-temporary-2001` | temporary | 2001–2010 | ✔ | ✔ | ✔ |
+
+**Totals: 132 claims tested. 131 CONFIRMED, 1 DISAGREEMENT (F-1). Zero
+unverifiable. Class: all 33 in the `_meta/classes.yml` vocabulary; the two
+class caveats the researcher flagged (`be-national-u-2021` temporary-vs-dealer,
+`be-agricultural-g-2020`'s fiscal rather than agronomic criterion) are both
+correctly reasoned and I uphold them as recorded.**
+
+### Format grammar re-derived verbatim
+
+Quoted from R1 and cross-read on R2. These are the statutory sentences the
+regexes must encode; every one matches what `be.yml` carries.
+
+- **art. 4 § 1** — *"La marque d'immatriculation ordinaire a un fond blanc.
+  L'inscription et le liseré sont de couleur rouge rubis (RAL 3003)."*
+- **art. 4 § 2** (composition) — *"…d'une lettre ou d'un chiffre (index) suivi
+  d'un tiret de séparation situé sur la ligne médiane horizontale de la marque
+  d'immatriculation et d'une combinaison de soit trois lettres suivies de
+  trois chiffres ou soit trois chiffres suivis de trois lettres."*
+  NL: *"een (index)letter of -cijfer, gevolgd door een scheidingsstreepje ter
+  hoogte van de horizontale middellijn"*.
+- **exhaustion rule** — *"En cas d'épuisement de ces séries, la lettre ou le
+  chiffre (index) est placé(e) derrière."* NL: *"In geval van uitputting van
+  deze reeksen wordt de (index)letter of het (index)cijfer achteraan
+  geplaatst."* Correctly carried in `regex_statutory` and correctly **kept out
+  of `regex`**, because it is not issued.
+- **art. 4 § 4** (taxi) — *"Pour ce qui est de la catégorie 'service de taxi
+  autorisé', le groupe de lettres commence par un 'X' et pour la catégorie
+  'location avec chauffeur', le groupe de lettres commence par un 'L'."*
+- **art. 5 § 1** — *"Les marques d'immatriculation temporaires de courte durée
+  ont un fond rouge signalisation (RAL 3020). L'inscription et le liseré sont
+  blancs."*
+- **art. 5 § 4** (W / X) — *"la première lettre 'W' est suivie d'une deuxième
+  lettre à l'exclusion des lettres 'M', 'Q' et 'S'; … la première lettre 'X'
+  est suivie d'une deuxième lettre à l'exclusion des lettres 'M', 'Q' et
+  'S'."*
+- **art. 8 § 3** (Y / Z / V) — *"la plaque essai : la première lettre 'Y' est
+  suivie d'une combinaison de trois lettres dont la première lettre ne doit
+  pas être la lettre 'M' et 'S'; la plaque marchand : la première lettre 'Z'
+  … ; la plaque professionnelle : la première lettre 'V' …"*
+- **art. 9 § 2** (G) — *"la lettre 'G' est suivie d'un tiret …, de la lettre
+  'L'"*.
+- **art. 10 § 1 / § 3** (U) — *"L'inscription et le liseré sont de couleur
+  vert mousse (RAL 6005)."* / *"la première lettre est la lettre 'U' suivie
+  d'une deuxième lettre."*
+- **art. 12 § 3** (historic motorcycle) — *"Les séries de lettres commencent
+  par un 'M'."*
+- **art. 19 § 3** (historic moped) — *"Pour les cyclomoteurs, les séries de
+  lettres commencent avec la lettre 'S'."*
+- **dimensions** — 520 × 110, 340 × 210, 210 × 140, 100 × 120 mm, confirmed on
+  R1, R2 **and** R4 (DIV: *"Plaque rectangulaire (52 x 11 cm)"*, *"Plaque de
+  format carré (34 x 21 cm)"*, *"Plaque de format moto (21x14 cm)"*, *"Plaque
+  format cyclo (10x12 cm)"* — and DIV adds *"Ce format est obligatoire pour
+  les cyclomoteurs, speed-pedelecs et quadricycles légers"*).
+
+### Mechanical re-derivation (R5)
+
+Run against `plates/be.yml`, 33 series:
+
+```
+1. regex compile/anchor/round-trip:              OK
+2. tier order strict <= regex <= statutory:      OK
+3. RAL -> hex mapping:                           1:1 for all four RAL codes
+5. cross-series ambiguity among 19 OPEN series:  20 pairs (18 = recall-only, by design; 2 real — F-2, F-4)
+6. class vocabulary / sources / period_evidence: 33/33 present and valid
+```
+
+---
+
+## PART 3 — disagreements, recorded verbatim and NOT averaged
+
+### F-1 — the 2019 instrument's entry into force. **Two primary dates. The file uses both.**
+
+This is the Belgian analogue of the Spanish 2000 cutover, and it is a live
+defect rather than a curiosity, because `be.yml` applies **two different dates
+drawn from one instrument**.
+
+Thirteen series in the file derive from the **arrêté ministériel du 15
+décembre 2019** (NUMAC 2020040939, M.B. 15-05-2020), which replaced articles
+1–18 of the 2001 arrêté ministériel wholesale and created the whole G3
+letter-index regime (O, Q, T, M, S, G, U, V, Y, Z, W, X).
+
+**Reading A — the text as published (route R3, etaamb):**
+
+> art. 5: *"Le présent arrêté entre en vigueur le 1er octobre 2020."*
+
+**Reading B — the text as consolidated (route R1, Justel):**
+
+> art. 5: *"Le présent arrêté entre en vigueur le [1 1er janvier 2021]1"*
+> footnote: *"(1)<AM 2020-10-12/05, art. 1, 002; En vigueur : 16-10-2020>"*
+
+The amending instrument, read directly, settles what happened but not which
+date is operative:
+
+> **AM 12 octobre 2020**, NUMAC 2020043081, M.B. 16-10-2020, art. 1, verbatim:
+> *"A l'article 5 de l'arrêté ministériel du 15 décembre 2019 modifiant
+> l'arrêté ministériel du 23 juillet 2001 relatif à l'immatriculation de
+> véhicules, les mots « 1er octobre 2020 » sont remplacés par les mots
+> « 1er janvier 2021 »."*
+> art. 2: *"Le présent arrêté entre en vigueur le jour de sa publication au
+> Moniteur belge."* — i.e. **16 October 2020**.
+
+**The irreducible problem, stated and not resolved:** the postponement took
+effect on 16 October 2020, *fifteen days after* the date it postponed. On its
+face the 2019 arrêté was in force from 1 to 15 October 2020, and was then
+sent forward to 1 January 2021. Both of the following are defensible on
+primary text alone:
+
+- **A.** The G3 formats were legally issuable from **01-10-2020**. `period.start`
+  = 2020 for all thirteen G3 series.
+- **B.** The consolidated text — the state's own current statement of the law —
+  reads 1 January 2021, and that is the operative date. `period.start` = 2021
+  for all thirteen.
+
+**Not averaged, not split, and not resolved here.** What *is* dispositive is
+narrower and does not require choosing: **the file cannot hold both.** It
+currently gives `be-agricultural-g-2020` `period.start: 2020` while its twelve
+siblings from the identical instrument carry 2021.
+
+**Root cause, identified.** The `be-agricultural-g-2020` source line reads
+"art. 2 of the 2019 instrument, which the Justel footnote dates in force
+01-10-2020". That date is not from a footnote and not from any article — it is
+Justel's **header** field, `Entrée en vigueur : 01-10-2020`, which still shows
+the original date because Justel does not recompute the header when the
+entry-into-force *article* is itself amended. It is a database artefact, and
+it is the only place in `be.yml` where a period claim rests on one.
+
+**Third route.** R4 (DIV) describes the current regime without dating its
+commencement, so it neither supports nor refutes either reading. Recorded as
+silent rather than as agreement.
+
+### F-2 — `be-international-2021` is not distinguishable from `be-standard-2010`. CONFIRMED AS TRUE.
+
+R5 flagged `7-WFF-619` as accepted by both. This is not a modelling error: art.
+6 alinéa 2 makes the long-duration temporary plate take the ordinary
+inscription — *"les dispositions de l'article 4, § 1er, points 1° et 2° de cet
+arrêté sont d'application"* — and the researcher recorded exactly that, as a
+negative finding, in the series notes. **Upheld.** The 2010–2020 predecessor
+was distinguishable (index digit 8, AM 08-11-2010 art. 5), and the file
+correctly models the loss of that capability on 01-01-2021. This is a
+capability regression in Belgian law, faithfully represented.
+
+### F-3 — five sourced letter constraints are documented in prose but not expressed in `regex_strict`. Completeness gap, not an error.
+
+| series | statutory constraint (verified verbatim) | `regex_strict` |
+|---|---|---|
+| `be-dealer-essai-y-2021` | art. 8 § 3, 1° — group's first letter ≠ M, ≠ S | absent |
+| `be-dealer-marchand-z-2021` | art. 8 § 3, 2° — same | absent |
+| `be-dealer-professionnelle-v-2021` | art. 8 § 3, 3° — same | absent |
+| `be-temporary-w-2021` | art. 5 § 4 — second letter excludes M, Q, S | absent |
+| `be-export-x-2021` | art. 5 § 4 — second letter excludes M, Q, S | absent |
+
+Each constraint *is* recorded, accurately and with the quotation, in
+`format.charset.notes`. Nothing is wrong; the narrowing is simply not machine
+-readable, so a consumer using the tier ladder gets a looser bound than the
+statute supports. `be-taxi-t-2021` shows the house style done right —
+`\AT-[XL][A-Z]{2}-\d{3}\z` — as do `be-historic-o-moto-2021`
+(`\AO-M[A-Z]{2}[- ]\d{3}\z`), `be-moped-s-2014` and `be-agricultural-g-2020`.
+Recommendation only; § 2.7's tier order is respected either way and I verified
+the ladder holds on every series that has one (R5, check 2).
+
+### F-4 — `O-Mxx-999` is genuinely ambiguous in Belgian law. The fact stays OUT.
+
+R5 flagged `be-historic-o-2021` and `be-historic-o-moto-2021` as both
+accepting `O-IFP-670`. The tempting fix — exclude `M` from the car series'
+letter group — would be **fabrication**. I read art. 4 § 2 in full on both R1
+and R2 for exactly this question:
+
+> *"Sauf lorsqu'une marque d'immatriculation a été réservée conformément à
+> l'article 23 de l'arrêté royal du 20 juillet 2001 …, les marques
+> d'immatriculation avec lettre (index) 'O' peuvent être délivrées lors de
+> l'immatriculation ou de la réimmatriculation des véhicules automobiles mis
+> en circulation depuis plus de trente ans."*
+
+There is no letter-group constraint. Art. 12 § 3 constrains the *motorcycle*
+series to `M` and art. 19 § 3 the *moped* series to `S`, but neither reserves
+those letters against the car series. An `O-M__-___` string is therefore
+lawfully either, and the two are separated only by the physical plate —
+520 × 110 mm versus 210 × 140 mm stacked. The data is correct as it stands;
+what is missing is only that the file says so for F-2 and does not say so
+here.
+
+---
+
+## PART 4 — recommendations to the maintainer
+
+The verifier changes no data. In § 5.3 order of severity:
+
+1. **F-1 — resolve the 2019 entry-into-force date to ONE value across all
+   thirteen G3 series, and record the losing reading in `notes` rather than
+   deleting it.** On the evidence I would take Reading B (the consolidated
+   text, 01-01-2021): it is the state's current statement of its own law, it
+   is what the other twelve series already use, and the 2020 outlier rests on
+   a Justel header artefact rather than on an article. **That preference is
+   not a finding and must not be applied on my signature alone — I-11.**
+   **Whichever way it goes, the id `be-agricultural-g-2020` does not change:
+   series ids are append-only and are never deleted. Only `period.start`
+   moves.** The current source line should also stop attributing the date to
+   "the Justel footnote", which is not where it came from.
+2. **F-3 — lift the five sourced letter constraints into `regex_strict`,** in
+   the style `be-taxi-t-2021` already uses. Pure tightening; the § 2.7 ladder
+   is preserved.
+3. **F-4 — add one sentence to `be-historic-o-2021` notes** recording that the
+   O index is shared with the motorcycle series and that the statute imposes no
+   letter-group exclusion, so the two are distinguishable only by plate format.
+   `be-international-2021` already carries the equivalent sentence for F-2;
+   this is consistency, not new information.
+4. **Nothing else.** The pre-2001 history is correctly withheld as folklore,
+   the 1973 lead is correctly pinned without being claimed, the RAL-vs-sRGB
+   caveat is correctly stated, and the A/E/P DIV-versus-statute discrepancy is
+   explicitly "recorded, not averaged" — which is the § 5.3 discipline applied
+   by the researcher without being asked.
+
+## PART 5 — gate proof
+
+Unchanged before and after this dossier lands; the dossier is Markdown and is
+not reachable by the `plates/*.yml` + `plates/*/*.yml` glob.
+
+```
+plates lint: 124 files, 1381 series
+plates lint: matching recall-only=286 strict=1095 | twins regex_statutory=106 regex_strict=427 | separators emitted "-"," " forgiving 18
+plates lint: _art ledger 6060 rows (excluded=5355 open=412 site_only=293), 412 open assets verified
+plates lint: OK
+
+curation lint: OK (109 files, duplicate-key + shape + make-key + provenance)
+```
+
+## Sources, with exact URLs
+
+Primary — Justel consolidated (R1, French) and its Dutch counterpart (R2):
+
+- AM 23-07-2001 (FR) — https://www.ejustice.just.fgov.be/cgi_loi/article.pl?language=fr&lg_txt=f&numac_search=2001014154&caller=SUM&view_numac=2001014154f
+- AM 23-07-2001 (NL) — https://www.ejustice.just.fgov.be/cgi_loi/article.pl?language=nl&lg_txt=n&numac_search=2001014154&caller=SUM&view_numac=2001014154n
+- AR 20-07-2001 (FR) — https://www.ejustice.just.fgov.be/cgi_loi/article.pl?language=fr&lg_txt=f&numac_search=2001014153&caller=SUM&view_numac=2001014153f
+- AM 15-12-2019 — https://www.ejustice.just.fgov.be/cgi_loi/change_lg.pl?language=fr&la=F&cn=2019121519&table_name=loi
+- **AM 12-10-2020** (the postponing instrument; NUMAC 2020043081) — https://www.ejustice.just.fgov.be/cgi_loi/change_lg.pl?language=fr&la=F&cn=2020101205&table_name=loi
+- AM 08-11-2010 — https://www.ejustice.just.fgov.be/cgi_loi/change_lg.pl?language=fr&la=F&cn=2010110801&table_name=loi
+- AM 28-03-2014 — https://www.ejustice.just.fgov.be/cgi_loi/change_lg.pl?language=fr&la=F&cn=2014032807&table_name=loi
+- AM 21-10-2022 — https://www.ejustice.just.fgov.be/cgi_loi/change_lg.pl?language=fr&la=F&cn=2022102106&table_name=loi
+
+Independent republisher of the *Moniteur belge* as published (R3):
+
+- AM 15-12-2019, original text of art. 5 — https://etaamb.openjustice.be/fr/arrete-ministeriel-du-15-decembre-2019_n2020040939.html
+- AM 23-07-2001, amendment table — https://etaamb.openjustice.be/fr/2001014154.html
+
+Issuing authority (R4):
+
+- DIV plate formats — https://mobilit.belgium.be/fr/route/immatriculer-et-radier/plaques-et-certificats-dimmatriculation/format-de-plaque
+
+All routes accessed 2026-08-08. Licence posture: Belgian statutory texts on
+ejustice are official state publications consulted and **cited**, never
+redistributed — PRD-PLATES § 6's "cite, never embed" rule. No ShareAlike, no
+NonCommercial, no scraped corpus, no artwork.

--- a/plates/ad.yml
+++ b/plates/ad.yml
@@ -1,6 +1,15 @@
 # plates/ad.yml — Andorra (PRD-PLATES gate L1, microstates group).
-# DRAFT for verification. All primary text fetched from the BOPA document store
+# All primary text fetched from the BOPA document store
 # (bopadocuments.blob.core.windows.net), 2026-08-02.
+#
+# §5.3 VERIFICATION PASS RAN 2026-08-08 — dossier at plates/_verification/ad.md.
+# Every series' period boundaries, format regex, class and colours were
+# re-derived from the pinned instruments read as RAW TEXT (not through a
+# summariser) plus an independent route per claim. Eleven corrections landed;
+# the two that change matching behaviour are ad-historic-passed-itv's block and
+# ad-dealer-prova's digit count. The verification entries are RESEARCHER-ONLY
+# (I-11: the author never certifies their own work) — see `verification:` at the
+# foot of this file. Nothing in the art/render lane was touched.
 #
 # ---------------------------------------------------------------------------
 # THE INSTRUMENTS, and two corrections to the obvious assumptions
@@ -13,8 +22,12 @@
 #   * Llei del Codi de la circulació, de 10-6-99 — BOPA núm. 40, any 1999,
 #     published 13 July 1999, in force fifteen days later. REPEALED. Its
 #     art. 147 is historically important because it put the PLATE CATALOGUE
-#     INSIDE THE LAW: "Aquest Codi inclou el catàleg de plaques de matrícula
-#     vigents a Andorra."
+#     INSIDE THE LAW *and delegated its amendment to the Govern in the same
+#     breath*: "Aquest Codi inclou el catàleg de plaques de matrícula vigents a
+#     Andorra. No obstant això, el Govern pot modificar o afegir altres
+#     modalitats de matrícula, d'acord amb la disposició addicional primera."
+#     (The second sentence was missing from the draft; it is the delegation on
+#     which every 2011-dated series in this file rests.)
 #   * Decret 456/2022, del 9-11-2022 — BOPA núm. 135, any 2022, published
 #     15 November 2022, IN FORCE 16 NOVEMBER 2022. THE PLATE REGULATION IN
 #     FORCE, and the source of nearly every design fact below.
@@ -36,8 +49,9 @@
 # because here the instrument's date and the reported series start AGREE — and
 # citing the instrument would still be wrong.
 #
-# The numbering rule, art. 3.2 of the 2011 Decret and re-enacted verbatim as
-# art. 6.2 of Decret 456/2022:
+# The numbering rule, art. 3.2 of the 2011 Decret, re-enacted in substance (NOT
+# word for word — see common.numbering.quote_correction_2026_08_08) as art. 6.2
+# of Decret 456/2022. The 2011 text, which is the one quoted here:
 #   "A les plaques de matrícula s'inscriu un grup de 5 caràcters que va des del
 #    00000 fins al 99999. A continuació, la primera xifra se substitueix per una
 #    lletra de la A a la Z, i es manté el caràcter numèric dels 4 darrers
@@ -108,35 +122,127 @@ binding_note: >-
   Llei 12/2021 art. 96(1): "Per posar en circulació els vehicles de motor, els
   ciclomotors, els remolcs i els semiremolcs, cal haver-los matriculat i que
   portin les plaques de matrícula amb els caràcters que els assigni el Registre
-  de Vehicles" — the characters are assigned to the VEHICLE by the Registre de
-  Vehicles. No provision reserves a number to a person across vehicles.
+  de Vehicles, d'acord amb el que es determini reglamentàriament" — the
+  characters are assigned to the VEHICLE by the Registre de Vehicles, and
+  art. 96(5) makes the pairing constitutive: "El certificat de matriculació i
+  les plaques de matrícula formen conjuntament un document compost que
+  identifica el vehicle". `vehicle` is therefore the right value for the
+  ORDINARY marks, and Decret 456/2022 art. 24.2 nails it shut in four words:
+  "Queda totalment prohibit cedir una matrícula."
+binding_correction: >-
+  THE §5.3 PASS DELETED A FALSE SENTENCE HERE. The draft asserted "No provision
+  reserves a number to a person across vehicles." Two provisions do, and both
+  are in instruments this file already pins.
+  (1) Decret 456/2022 art. 24 is titled "Reserva de matrícula ordinària" and
+      opens: "Una persona física o una persona jurídica pot reservar una
+      matrícula ordinària sempre que el vehicle que es vulgui matricular estigui
+      al mateix nom de la persona que fa la reserva." A person reserves. What
+      art. 24 does NOT do is make the mark portable — arts. 24.4-24.6 bound the
+      reservation to a moving window (requestable within 1,000 of the current
+      mark, usable within 100, lapsing at +50) and art. 24.2 forbids cession —
+      so the reservation is a queue right over a not-yet-issued mark, and
+      `binding: vehicle` survives it.
+  (2) PERSONALISED MARKS ARE GENUINELY PERSON-BOUND, and this is the real
+      exception. Llei 24/2014 art. 6.3: "La reserva i l'atribució d'una
+      matrícula personalitzada tenen sempre caràcter personal i intransferible.
+      Està prohibida qualsevol comercialització, donació, venda o cessió de
+      matrícula personalitzada. Únicament s'exceptua la transmissió de la
+      matrícula per successió." And Decret 456/2022 art. 26.5 contemplates the
+      mark's "reserva, atribució, baixa o AFECTACIÓ A UN ALTRE VEHICLE". Read
+      together: person-bound and vehicle-portable, inheritable by succession,
+      sellable never.
+  The two readings are not averaged and neither is dropped: the file-level
+  `binding` stays `vehicle` because it describes the ordinary marks that carry
+  the whole numbering scheme, and because Llei 24/2014 art. 4.1 requires the
+  personalised plate to sit on a vehicle that ALREADY holds an ordinary mark
+  ("La placa s'ha de col·locar obligatòriament en el vehicle autoritzat a
+  portar-la, que ha d'estar donat d'alta al Registre de Vehicles del Govern amb
+  una matrícula ordinària atribuïda"). An Andorran personalised vehicle holds
+  TWO marks, one bound to it and one bound to its owner. SCHEMA NOTE for the
+  maintainer: PRD-PLATES §2.1 gives `binding` at file scope, so this jurisdiction
+  cannot express the split; a per-series `binding` override is the clean fix and
+  is left as a proposal, not taken unilaterally.
 instrument:
   code:
     citation: "Llei 12/2021, del 13 de maig, del Codi de la circulació"
     gazette: "BOPA núm. 62, any 2021"
-    published: "2021-06-01"
-    entry_in_force: "three months after publication (disposició final novena)"
+    published: "2021-06-02"
+    entry_in_force: "2021-09-02 — three months after publication (disposició final novena, verbatim: 'Aquesta Llei entrarà en vigor al cap de tres mesos de publicar-se al Butlletí Oficial del Principat d'Andorra.')"
     url: "https://bopadocuments.blob.core.windows.net/bopa-documents/033062/html/CGL20210528_13_01_20.html"
     delegation: "art. 108(1): dimensions and characteristics are regulated by reglament; art. 96(1): the Registre de Vehicles assigns the characters"
-    repeals: "the Llei del Codi de la circulació of 10 June 1999 and its successive modifications, expressly"
-    recorded_discrepancy: >-
-      BOPA's index metadata gives publication as 1 June 2021, while the preamble
-      of Decret 456/2022 refers to the law as "publicada al Butlletí Oficial del
-      Principat d'Andorra del 2 de juny del 2021". A one-day disagreement
-      between two official sources, recorded rather than resolved; `published`
-      carries BOPA's own date.
+    repeals: >-
+      the Llei del Codi de la circulació of 10 June 1999 and its successive
+      modifications, expressly — BUT NOT ENTIRELY. The disposició derogatòria
+      carves out one article verbatim: "excepció feta de les previsions
+      contingudes al seu article 209, que restaran vigents fins al moment en que
+      entri en vigor el reglament previst a la Disposició final quarta". Art. 209
+      is not plate-related (disposició final quarta is the pleasure-boat
+      register, PRD-PLATES §7 gate L6 territory), so nothing in this file rests
+      on it — but "repealed the 1999 Codi" is not the whole sentence.
+    retracted_discrepancy: >-
+      RETRACTED BY THE §5.3 PASS — THE DISAGREEMENT DID NOT EXIST. The draft
+      recorded "a one-day disagreement between two official sources": BOPA index
+      metadata giving 1 June 2021 against Decret 456/2022's preamble saying
+      "publicada al Butlletí Oficial del Principat d'Andorra del 2 de juny del
+      2021". Re-derivation from the gazette itself settles it — the sumari of
+      BOPA núm. 62, any 2021 prints "Núm. 62 / 2 de juny del 2021" in the header
+      of every one of its 15 pages. Both official sources say 2 June; only the
+      draft said 1 June. `published` is corrected to 2021-06-02 and the
+      "discrepancy" is withdrawn rather than averaged, because averaging a
+      disagreement that is really a transcription slip would have manufactured a
+      permanent fake uncertainty in the record (PRD-PLATES §5.3).
+      Sumari: https://bopadocuments.blob.core.windows.net/bopa-documents/sumaris/033/033062.pdf
   plate_reglament:
     citation: "Decret 456/2022, del 9-11-2022, d'aprovació del Reglament de la fabricació i la instal·lació de les plaques de matrícula en vehicles i ginys mecànics no aptes per a la via pública"
     gazette: "BOPA núm. 135, any 2022"
-    published: "2022-11-15"
-    entry_in_force: "2022-11-16"
+    published: "2022-11-16"
+    entry_in_force: "2022-11-17"
     in_force_clause: "article únic: '…que entrarà en vigor l'endemà de ser publicat al Butlletí Oficial del Principat d'Andorra'"
     url: "https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html"
-    recorded_typo: >-
-      BOPA's own sumari mistypes this decree as "Decret 456/2011, del 9-11-2022".
-      The document header reads 456/2022 and that is the correct citation.
-      Recorded because the erroneous form is in an official index and a verifier
-      will meet it.
+    date_correction: >-
+      CORRECTED BY THE §5.3 PASS, AND IT MOVED THE COMMENCEMENT. The draft had
+      published 2022-11-15 / in force 2022-11-16. BOPA núm. 135, any 2022 is
+      dated 16 NOVEMBER 2022 — printed in the page header of all 13 pages of its
+      sumari — and the Correcció d'errata de l'1-3-2023 independently describes
+      the decree as "publicat al Butlletí Oficial del Principat d'Andorra (BOPA)
+      núm. 135, del 16 de novembre del 2022". Two official routes agree. Since
+      the article únic commences the Reglament "l'endemà de ser publicat", the
+      current plate regulation entered into force on 17 NOVEMBER 2022.
+      Sumari: https://bopadocuments.blob.core.windows.net/bopa-documents/sumaris/034/034135.pdf
+    title_erratum: >-
+      NOT A SUMARI TYPO — A TITLE ERROR IN THE DECREE ITSELF, SINCE OFFICIALLY
+      CORRECTED. The draft recorded that "BOPA's own sumari mistypes this decree
+      as 'Decret 456/2011, del 9-11-2022'" and reasoned that "the document header
+      reads 456/2022". The header as published does NOT: the Correcció d'errata
+      de l'1-3-2023 (BOPA núm. 33, any 2023) quotes the published title under
+      "On hi diu:" as "Decret 456/2011, del 9-11-2022, d'aprovació del Reglament
+      de la fabricació i la instal·lació de les plaques de matrícula en vehicles
+      i ginys mecànics no aptes per a la via pública." and prescribes under
+      "Hi ha de dir:" the identical sentence reading "Decret 456/2022". So the
+      wrong year was in the instrument's own title, the sumari merely reproduced
+      it, and the citation is now settled BY AN INSTRUMENT rather than by
+      inference. Third-party legal databases still carry the uncorrected form
+      (leslleis.com/DR20221109C prints "Decret 456/2011, del 9 de novembre del
+      2022"), which is the practical reason to keep this note.
+      Errata: https://bopadocuments.blob.core.windows.net/bopa-documents/035033/html/GV20230303_12_27_52.html
+    as_published_caveat: >-
+      THE PINNED URL SERVES THE UNCORRECTED TEXT. The blob store carries the
+      as-published document, so it still prints the two cross-reference errors
+      that the Correcció d'errata del 30-11-2022 fixed: arts. 3.6 and 4.2 cite
+      "l'article 24 del Reglament" where the adhesive-plate article is art. 25
+      (art. 24 is Reserva de matrícula ordinària). Neither error touches any
+      series in this file, but a consumer reading the pinned URL alone is
+      reading text the Govern has formally amended.
+      Errata: https://bopadocuments.blob.core.windows.net/bopa-documents/034142/html/GD20221201_12_12_06.html
+  numbering_defect: >-
+      RECORDED SO A VERIFIER DOES NOT THINK THEY MISREAD IT: the 2011 Reglament
+      NUMBERS TWO CONSECUTIVE ARTICLES "Article 8" — the first "Matrícula per als
+      administratius i tècnics d'ambaixades", the second "Matrícula del cos
+      consular" — and then resumes at article 9. Its article count is therefore
+      18 headings over 17 numbers. Citations to "2011 art. 8" must say which one.
+      The defect is in the as-published text on BOPA and was never corrected by
+      the errata of 9-3-2011; Decret 456/2022 renumbers cleanly (A-staff art. 12,
+      consular art. 11).
   chain:
     - "Decret del 23-02-2011 (base) — BOPA núm. 14/2011, published 1 March 2011, in force 2 March 2011"
     - "Correcció d'errata del 9-03-2011 — BOPA núm. 16/2011, 15 March 2011"
@@ -149,6 +255,13 @@ instrument:
   related:
     - "Decret 534/2022, del 14-12-2022, Reglament relatiu a la matriculació i al Registre de Vehicles — BOPA núm. 148/2022, 21 December 2022"
     - "Decret 11/2024, del 10-1-2024, Reglament de vehicles històrics — BOPA núm. 7/2024, 16 January 2024"
+    - >-
+      Decret del 24-11-2010, Reglament regulador del procediment de reserva de
+      matrícules del Registre de Vehicles — REPEALED by Decret 456/2022,
+      disposició derogatòria segona. Added by the §5.3 pass: the draft's chain
+      omitted it, and it matters because the reservation regime it governed is
+      what moved into arts. 24 and 26 of the current Reglament, which is where
+      the `binding` question is decided.
 
 # ---------------------------------------------------------------------------
 # Jurisdiction-wide facts.
@@ -156,13 +269,33 @@ instrument:
 common:
   numbering:
     rule: >-
-      Decret 456/2022 art. 6.2, re-enacting art. 3.2 of the 2011 Decret verbatim:
-      "A les plaques de matrícula s'inscriu un grup de 5 caràcters que va des del
+      Decret 456/2022 art. 6.2, verbatim and in force: "A les plaques de
+      matrícula s'hi inscriu un grup de cinc caràcters numèrics que va des del
       00000 fins al 99999. A continuació, la primera xifra se substitueix per una
-      lletra de la A a la Z, i es manté el caràcter numèric dels 4 darrers
+      lletra de la A a la Z, i es manté el caràcter numèric dels quatre darrers
       caràcters (A0000-Z9999), sense utilitzar les lletres de l'alfabet que puguin
-      crear confusió, combinant dues lletres i tres números (AA000-ZZ999), i així
+      crear confusió, i es combinen dos lletres i tres números (AA000-ZZ999), i
+      així successivament."
+    rule_2011: >-
+      Decret del 23-02-2011 art. 3.2, verbatim and repealed: "A les plaques de
+      matrícula s'inscriu un grup de 5 caràcters que va des del 00000 fins al
+      99999. A continuació, la primera xifra se substitueix per una lletra de la
+      A a la Z, i es manté el caràcter numèric dels 4 darrers caràcters
+      (A0000-Z9999), sense utilitzar les lletres de l'alfabet que puguin crear
+      confusió, combinant dues lletres i tres números (AA000-ZZ999), i així
       successivament."
+    quote_correction_2026_08_08: >-
+      THE DRAFT PRINTED ONE QUOTE UNDER TWO ATTRIBUTIONS. It billed the sentence
+      above as "Decret 456/2022 art. 6.2, re-enacting art. 3.2 of the 2011 Decret
+      verbatim" and then printed the 2011 wording. The re-enactment is faithful in
+      substance but is NOT verbatim — "s'inscriu" became "s'hi inscriu", "5
+      caràcters" became "cinc caràcters NUMÈRICS", "4 darrers" became "quatre
+      darrers", and "combinant dues lletres" became "i es combinen dos lletres".
+      Both texts are now carried separately so neither is quoted as the other.
+      THE CORRECTION STRENGTHENS THE FILE'S CENTRAL FINDING RATHER THAN DENTING
+      IT: the word the base-stage claim leans on — "numèrics" — is in the 2022
+      text and NOT in the 2011 text, so the current instrument states the
+      five-digit grammar even more plainly than the draft could show.
     three_stages:
       - { stage: 1, grammar: "00000-99999", modelled_as: ad-standard-numeric }
       - { stage: 2, grammar: "A0000-Z9999", modelled_as: ad-standard-letter }
@@ -215,10 +348,29 @@ common:
       "s'ha incorporat l'indicatiu AND, en la forma que preveu el punt 3 de
       l'annex 3 de la Convenció sobre la circulació vial… feta l'any 1968 a
       Viena, en la versió consolidada de l'any 2006."
+    scope_limit: >-
+      ADDED BY THE §5.3 PASS — THE 2011 INCORPORATION IS SCOPED, AND THE SCOPE
+      EXPLAINS THE CATALOGUE. The same paragraph of the 2011 exposició de motius
+      closes: "Aquesta modificació sols s'aplica a les matrícules destinades a
+      vehicles que són aptes per a la circulació internacional." That single
+      sentence predicts exactly which series carry AND and which do not, and the
+      current Reglament bears it out: AND is inscribed on the ordinary plate
+      (art. 6.1), the motorcycle plates (art. 7.2, 7.4), the four diplomatic and
+      consular series (arts. 9-12) and the temporary MT plate (art. 13) — and is
+      absent from the moped (art. 8), both historic series (arts. 14-15), the
+      dealer PROVA plate (art. 16), the special-vehicle plate (art. 17), the
+      snowmobile (art. 18) and the giny mecànic (art. 19). Every one of those
+      omissions is a vehicle that does not travel internationally. The design
+      blocks below already match this pattern; it was inferred there and is now
+      sourced.
     legacy_rule: >-
       Decret 456/2022 art. 20.3: plates of a model earlier than the current one,
       which do not carry the inscribed AND, must display the separate oval AND
       sticker. So both arrangements are lawfully on the road simultaneously.
+      Corroborated for the pre-2011 world by the 1999 Codi art. 147, which had
+      ACA hand over the oval with the plates: "l'Automòbil Club d'Andorra lliura
+      al titular un joc de plaques de matrícula, corresponent al número de
+      matrícula concedit pel Registre, i el distintiu nacional AND."
     treaty_note: >-
       The 2006 CONSOLIDATED version of Vienna Annex 3 is what permits the sign
       to be incorporated into the plate. PRD-PLATES §4 records that the 1968
@@ -253,7 +405,7 @@ common:
       in the plate decree, and the referenced graphic annex was not extractable.
       Recorded gap.
   annex_gap:
-    status: RECORDED GAP
+    status: RECORDED GAP — NARROWED BY THE §5.3 PASS, NOT CLOSED
     detail: >-
       Decret 456/2022 refers to an annex, "Catàleg oficial de plaques de matrícula
       i distintius del Principat d'Andorra", as figures 1-18. IT IS A GRAPHICS
@@ -264,6 +416,65 @@ common:
       circuit and hazmat placards). SO NO PLATE ARTWORK OR GLYPH SPECIFICATION
       FROM EITHER CATALOGUE IS AVAILABLE, and every layout fact in this file
       comes from the articles' prose rather than from the figures.
+    verification_2026_08_08: >-
+      TWO THINGS CHANGED AND ONE DID NOT.
+      (a) THE 2011 ANNEX IS REACHABLE. The repealed 2011 Reglament's "Annex 1.
+          Dimensions i característiques de les diverses plaques de matrícula" is
+          a live 1.83 MB, 15-page PDF on the BOPA blob store — the gap note
+          implied otherwise. It is figure pairs 1a/1b through 14a/14b (with 4
+          split 4.1/4.2), one pair per plate type, and it is PURE VECTOR
+          GRAPHICS: a text extraction returns only running heads and the figure
+          captions. So the draft's characterisation is CONFIRMED for content and
+          CORRECTED for availability. Per PRD-PLATES §6 the drawings are cited
+          and never embedded.
+          https://bopadocuments.blob.core.windows.net/bopa-documents/annexos/023014_plaques.pdf
+      (b) THE 2022 ANNEX IS NOT PUBLISHED AT ITS OWN LINK. Decret 456/2022's page
+          advertises an associated document "Plaques 2021.pdf" at
+          /bopa/034135/Documents/Plaques%202021_GR20221110_09_12_43.pdf; the blob
+          store answers BlobNotFound (HTTP 404) for that path. A searched-for
+          negative with the exact URL tried, so the next reader does not repeat
+          the search.
+      (c) THE ANNEX IS NORMATIVE FOR THE GLYPHS, which raises the cost of the
+          gap: art. 21 provides that "Les especificacions de les plaques de
+          matrícula i dels distintius del Principat d'Andorra, els colors i els
+          caràcters alfabètics i numèrics són els que s'indiquen en l'annex del
+          Reglament." The character shapes are IN the unreachable annex.
+  character_rights:
+    status: ADVERSE STATUTORY SIGNAL — recorded, not acted on
+    claim: >-
+      ANDORRA AFFIRMATIVELY CLAIMS PROPERTY IN THE PLATE CHARACTERS AND THE STATE
+      SYMBOLS, in two instruments, in nearly identical words.
+      Llei 12/2021 art. 108(3): "Els caràcters que figuren en les matrícules, així
+      com els símbols d'Estat que han de portar els vehicles, són propietat del
+      Govern, que cedeix en cada cas el dret a usar-los, d'acord amb les
+      condicions que es determinin per la via reglamentària."
+      Decret 456/2022 art. 3.5: "Els caràcters que figuren en les matrícules, i
+      els símbols d'Estat que han de portar els vehicles, són propietat del
+      Govern, que cedeix en cada cas el dret a usar-los, d'acord amb les
+      condicions que es determinen en la normativa vigent."
+    why_it_matters: >-
+      PRD-PLATES §6 records, from the EU dossier, that "No surveyed country claims
+      copyright in the plate design itself" — expressly flagged there as a SAMPLE
+      finding rather than an exhaustive survey. Andorra is a counter-example to
+      that sample and should be carried back into §6 as one. This is the same
+      shape of fact that `artwork_risk:` exists to record for US states under
+      PRD-PLATES §7.1: a statutory signal adverse to free reuse, sitting beside
+      an art route that looks clean.
+    scope_and_limits: >-
+      READ NARROWLY, AND DO NOT OVER-READ IT. The provisions assert ownership of
+      the characters AS THEY APPEAR ON MATRÍCULES and of the state symbols
+      vehicles must carry, and they set up a case-by-case licensing mechanism.
+      They are not a copyright registration, they do not speak to the underlying
+      historic coat of arms, and Andorran law is not searched here for what
+      "propietat del Govern" grants against a third party. What they do establish
+      is that the "no country claims the design" line cannot be repeated for
+      Andorra without qualification.
+    handling: >-
+      RECORDED AND ESCALATED, NOT ACTED ON. `common.emblem` and every `design:`
+      block are untouched by this pass — the emblem posture is the owner's visual
+      lane and the licensing call is counsel's, not a verifier's. The §3
+      placeholder default is what ships today regardless, so nothing renders
+      differently either way.
   font:
     name: null
     note: "No typeface is named in any Andorran instrument read, and the graphic annex that might carry a Schriftmuster is unextractable (see annex_gap). Per PRD-PLATES §6 the render layer uses the schematic fallback."
@@ -438,6 +649,34 @@ series:
       the two series is undated, while the AND MARK change that accompanied it
       is dated by the 2011 Decret. Overlaps ad-standard-letter, which is
       genuine — plates already issued stayed valid.
+    verifier_note_2026_08_08: >-
+      THE BEST CLAIM IN THIS FILE SURVIVES RE-DERIVATION, AND A SECOND ROUTE
+      REACHES IT. `national_mark.present: false` for the pre-2011 plate is
+      confirmed three ways: the 2011 exposició de motius lists the AND among that
+      instrument's innovations; the 2011 art. 3.1 introduces it on the ordinary
+      plate ("A la matrícula ordinària, al costat esquerre inferior, amb lletres
+      de color blau hi figura el distintiu nacional AND"); and INDEPENDENTLY the
+      1999 Codi art. 147 shows the AND being handed over as a SEPARATE OVAL with
+      the plates — "l'Automòbil Club d'Andorra lliura al titular un joc de
+      plaques de matrícula […] i el distintiu nacional AND". A 1999 instrument
+      describing the oval and a 2011 instrument claiming the inscription is as
+      clean as this kind of dating gets.
+      ONE QUOTE IS TRUNCATED WHERE IT STOPS HELPING. The file cites art. 147 for
+      "Aquest Codi inclou el catàleg de plaques de matrícula vigents a Andorra."
+      The attribution is CORRECT (the sentence is the penultimate paragraph of
+      art. 147, which runs to the "Article 148" heading), but the sentence does
+      not end there: "…vigents a Andorra. No obstant això, el Govern pot
+      modificar o afegir altres modalitats de matrícula, d'acord amb la
+      disposició addicional primera." The omitted half is the DELEGATION, and it
+      is load-bearing — it is the mechanism by which a 2011 Govern decree could
+      lawfully add plate types while the 1999 Codi was still in force, and the
+      2011 preamble says so in terms: "El legislador […] va atribuir al Govern
+      mitjançant l'article 147 i la disposició addicional de la llei, la capacitat
+      de modificar les plaques de matrícula incloses en el catàleg o afegir-hi
+      altres modalitats." The `instrument-in-force-upper-bound` dating of every
+      2011 series in this file depends on that delegation being real, so quoting
+      only the first half understated the file's own foundation.
+      START BOUND UNCHANGED: 1999 remains an upper bound and the reasoning holds.
     sources:
       - "https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html  # Decret 456/2022 art. 6.2 — the 00000-99999 base stage"
       - "https://bopadocuments.blob.core.windows.net/bopa-documents/023014/html/6BEF6.html  # Decret del 23-02-2011 art. 3.2 and exposició de motius — the same grammar, and the AND mark as a 2011 innovation"
@@ -457,7 +696,41 @@ series:
       format_note: >-
         THE SAME SERIAL GRAMMAR AS CARS — art. 7 gives motorcycles their own
         SIZES but not their own numbering. There is no dedicated motorcycle
-        letter block, contrary to some secondary accounts.
+        letter block, contrary to some secondary accounts. Verified verbatim
+        against art. 7.3, which repeats art. 6.2's sentence for the horizontal
+        plate word for word.
+      charset:
+        excluded: [I, O, Q]
+        notes: >-
+          ADDED BY THE §5.3 PASS — regex_strict was carrying the 23-letter
+          alphabet with no source of its own, and art. 6.3's exclusion is drafted
+          narrowly enough that borrowing it would have been an inference: it
+          suppresses I, O and Q "de la placa de matrícula ordinària per a
+          vehicles automòbils, remolcs i semiremolcs, i de la placa de matrícula
+          ordinària reduïda per a vehicles de tipus turisme (categoria M1)" —
+          motorcycles are not in that list. The motorcycle plates have their OWN
+          exclusion, art. 7.5, verbatim: "Se suprimeixen les lletres I, O i Q del
+          sistema de numeració de les plaques horitzontal i vertical de matrícula
+          ordinària per a motocicleta, a fi d'evitar tota confusió amb els
+          números 1 i 0, respectivament." So regex_strict is statutory here, and
+          it is statutory for the VERTICAL variant too. Same 2011-vs-2022 caveat
+          as the car series: the 2011 text stated only the principle, so a plate
+          from the lettered stage before 17 November 2022 might carry I, O or Q,
+          which is why `regex` keeps [A-Z].
+      numeric_stage_not_modelled: >-
+        COVERAGE GAP FOUND BY THE §5.3 PASS. art. 7.3 gives motorcycles the SAME
+        two-stage scheme as cars, base stage included: "A la placa horitzontal
+        s'hi inscriu un grup de cinc caràcters numèrics que va des del 00000 fins
+        al 99999 i, a continuació, la primera xifra se substitueix per una
+        lletra…". This series models only the lettered stage, and
+        ad-standard-numeric — which models the five-digit stage — lists
+        categories [car, van, truck, bus, trailer, semitrailer] with motorcycle
+        absent. A five-digit Andorran MOTORCYCLE plate from the numeric stage is
+        therefore matched by no series in this file, which is a
+        jurisdiction-completeness miss under PRD-PLATES §5.1. The fix is one word
+        (add `motorcycle` to ad-standard-numeric's categories) or one new ended
+        series; either is a claim change, so it is proposed in
+        plates/_verification/ad.md rather than taken by the researcher alone.
     design:
       plate: { w: 225, h: 115, unit: mm, note: "horizontal motorcycle plate (art. 7)" }
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
@@ -473,10 +746,25 @@ series:
           plate: { w: 100, h: 168, unit: mm }
           note: >-
             art. 7.4 — a PORTRAIT plate in two zones split by a blue band, the
-            letter or letters above and the four digits below. The 2011 Decret
-            introduced plastic and rubber enduro/trial plates specifically, per
-            its exposició de motius, which is a genuinely unusual material
-            provision.
+            letter or letters above and the four digits below. NOTE THE VARIANT'S
+            GRAMMAR IS NOT THIS SERIES': art. 7.4 skips the numeric stage
+            entirely and starts at a letter — "Immediatament a sota de l'escut hi
+            apareix una lletra de la A a la Z […] i es combinen dos lletres
+            (AA-ZZ), i així successivament. Sota de la lletra o les lletres hi ha
+            quatre caràcters numèrics (0000-9999)" — so it reaches AA0000 (two
+            letters over four digits), a six-character form the parent series
+            cannot express. Recorded; not modelled, on the same "no evidence of
+            issuance" ground as common.numbering.stage_three_not_modelled.
+          material_note: >-
+            THE PLASTIC/RUBBER ALLOWANCE IS HISTORIC, NOT CURRENT — corrected by
+            the §5.3 pass, which found it in the repealed instrument only. Decret
+            del 23-02-2011 art. 1, second paragraph: "Per a les motocicletes
+            aptes per circular per terrenys accidentats (enduro o trial), la base
+            de la placa de matrícula pot ser de plàstic o de goma dura." Decret
+            456/2022 art. 4 does not re-enact it — its two paragraphs allow
+            aluminium as the norm and an adhesive plate for art. 25 cases, and
+            nothing else. So the provision ran 2011 to 16 November 2022 and the
+            draft's present tense was out of date by one instrument.
     region_encoding: none
     notes: >-
       MOTORCYCLES. Two shapes — a 225x115 mm horizontal plate and a 100x168 mm
@@ -517,6 +805,20 @@ series:
       ANDORRA in blue on a yellow panel, and the flag shield at the bottom left
       rather than the national arms at the top left. It is the one Andorran
       series that does not follow the common layout.
+    verifier_note_2026_08_08: >-
+      COLOUR RE-DERIVED, AND ONE DATED CHANGE FOUND. art. 8.1 in force confirms
+      every colour recorded: white retroreflective ground, matt black characters,
+      "El bordó és de color blau mat", "A la part superior hi figura la llegenda
+      'ANDORRA' amb lletres blaves sobre un quadre amb fons groc", flag shield
+      lower left. BUT THE LEGEND WAS BLACK BEFORE 2022 — the 2011 art. 5.1 reads
+      "amb lletres NEGRES sobre un quadre amb fons groc". This series is dated
+      from 2011 and the design block records the post-2022 blue, so the first
+      eleven years of its period carry a colour the file does not state. The
+      design block is deliberately NOT edited by this pass (owner's visual lane);
+      the finding is recorded for whoever owns the fix.
+      Also verified: art. 8.1 says the moped's characters are "pintats" and not
+      "estampats en relleu" — mopeds are the one Andorran plate whose characters
+      are painted rather than embossed, in both the 2011 and 2022 texts.
     sources:
       - "https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html  # Decret 456/2022 art. 8"
 
@@ -590,6 +892,19 @@ series:
       regex: '\ACC[- ]?\d{3}[- ]?[A-Z]\z'
       format_evidence: statutory
       format_note: "art. 11: CC, THREE digits (000-999), then the State letter — the widest block in the diplomatic family"
+      period_scoped_change: >-
+        THE DIGIT COUNT CHANGED IN 2022 AND THE REGEX ONLY DESCRIBES THE SECOND
+        HALF OF THIS SERIES' PERIOD. The 2011 Reglament gave the consular series
+        TWO digits, not three — art. 8 (the second article so numbered; see
+        instrument.numbering_defect), verbatim: "el primer grup el formen les
+        lletres CC; el segon grup el formen DOS caràcters numèrics que van des
+        del 00 fins al 99". Decret 456/2022 art. 11.2 widened it to "TRES
+        caràcters numèrics que van des del 000 fins al 999". So a CC plate issued
+        between 2011 and 16 November 2022 reads CC + 2 digits + letter and will
+        NOT match this series' regex. Recorded, not averaged and not widened: the
+        regex carries the instrument in force, and the clean fix is the same
+        §2.2 series split proposed for ad-historic-passed-itv, which a researcher
+        may not make alone under I-11.
     design:
       plate: { w: 340, h: 120, unit: mm }
       background: { color: "#1F3A93", finish: retroreflective, hex_basis: pantone-converted, spec_note: "Pantone 2945" }
@@ -667,6 +982,32 @@ series:
         in Arabic numerals, in a red field at the upper right. That is a
         validity device, not a serial component, and it does not appear in the
         pattern.
+      verifier_dissent_2026_08_08: >-
+        THE TWO PRIMARY ROUTES DISAGREE ABOUT WHETHER "MT" IS SERIAL, AND THE
+        DRAFT ONLY CITES ONE OF THEM. Recorded verbatim, unresolved.
+        ROUTE A — the plate regulation, which structurally treats MT as furniture.
+        Decret 456/2022 art. 13.1 places MT in a panel and then states the serial
+        separately: "Al costat esquerre superior, sobre fons vermell (fons
+        Pantone 485), hi figuren els caràcters MT de color negre mat. […] A les
+        plaques de matrícula s'hi inscriu un grup de quatre caràcters numèrics
+        que va des del 0000 fins al 9999." That is the SAME two-part shape art.
+        16.1 uses for PROVA — legend in one sentence, "un grup de N caràcters
+        numèrics" in another — and this file reads art. 16 as making PROVA a
+        legend. Applied consistently, art. 13 makes MT a legend too and the
+        serial is four bare digits.
+        ROUTE B — the personalisation statute, which treats MT as a serial prefix.
+        Llei 24/2014 art. 7.1(i) forbids a personalised mark consisting of "les
+        lletres 'MT', 'CD', 'CMD', 'A', 'CC', seguides de xifres o la paraula
+        'PROVA'" — grouping MT with the unambiguous diplomatic prefixes and
+        setting PROVA apart as "la paraula". That is the draft's basis and it is
+        real.
+        WHY THE DATA IS LEFT AS IT IS: keeping MT in `regex` costs nothing under
+        §2.7 (it is narrower than the issuing grammar, never wider) and buys
+        discrimination that four bare digits cannot give, whereas dropping it
+        would make this series collide with ad-special-vehicle, ad-snow-vehicle
+        and ad-giny-mecanic, which are all '\A\d{4}\z'. The disagreement is
+        recorded rather than resolved because it is a reading of two instruments,
+        not a fact either one states.
     design:
       plate: { w: 340, h: 120, unit: mm, note: "225x115 mm for motorcycles" }
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
@@ -699,8 +1040,18 @@ series:
     matching: strict
     format:
       pattern: "999"
-      regex: '\A\d{1,3}\z'
+      regex: '\A\d{3}\z'
       printed_form: "PROVA 999"
+      corrected_2026_08_08: >-
+        regex was '\A\d{1,3}\z', which is wider than the instrument. Decret
+        456/2022 art. 16.1, verbatim: "A les plaques de matrícula s'hi inscriu un
+        grup de TRES caràcters numèrics que va des del 000 fins al 999" — a group
+        of three, and the range is written with leading zeros, so 000 and 007 are
+        forms the block contains and "7" is not. Narrowed to exactly three.
+        DATED NOTE: the count is a 2022 addition. The 2011 art. 13.1 said only
+        "un grup de caràcters numèrics que van des del 000 fins al 999", with no
+        number word — the range still implies three places, but the draft's
+        one-to-three reading has no basis in either text.
       format_evidence: statutory
       format_note: >-
         THE SERIAL IS THE THREE DIGITS; "PROVA" IS A LEGEND. art. 16.1 says so
@@ -761,6 +1112,19 @@ series:
       ITV OUTCOME rather than by vehicle age, giving red plates to vehicles that
       failed and white ones to those that passed. That is a genuinely unusual
       design decision and it is why two historic series appear here.
+    verifier_note_2026_08_08: >-
+      FORMAT, CLASS AND COLOUR ALL CONFIRMED against art. 14 in force: Pantone
+      485 red ground, matt black embossed characters, 330 x 140 mm, one letter
+      then two digits 00-99. Two things to record.
+      (a) THE LEGEND WAS RENAMED. 2011 art. 11.1 printed "VEHICLE ANTIC" and the
+          article was headed "vehicle antic o de museu"; 2022 art. 14.1 prints
+          "VEHICLE HISTÒRIC". The design block carries the current word for a
+          series dated from 2011. Not edited here (visual lane); recorded.
+      (b) THE ABSENCE OF regex_strict IS CORRECT AND DELIBERATE, and the pass
+          confirms it rather than "fixing" it: art. 14.2 says only "una lletra de
+          la A a la Z, sense utilitzar les lletres de l'alfabet que puguin crear
+          confusió" and — unlike arts. 6.3 and 7.5 — never names I, O and Q. An
+          enumerated strict twin here would be an inference dressed as a statute.
     sources:
       - "https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html  # Decret 456/2022 art. 14"
 
@@ -772,15 +1136,40 @@ series:
     matching: strict
     format:
       pattern: "58999"
-      regex: '\A5[89]\d{3}\z'
+      regex: '\A58\d{3}\z'
       format_evidence: statutory
       format_note: >-
-        A RESERVED NUMERIC BLOCK, 58001 to 59999 (art. 15) — carved out of the
-        ordinary five-digit space rather than given its own prefix. The human
-        pattern spells a representative value from the 58xxx half because the
-        pattern DSL cannot express a numeric range; `regex` covers the whole
-        block. The lower bound 58001 is not encoded, so the regex accepts 58000,
-        which the block does not contain.
+        A RESERVED NUMERIC BLOCK, 58001 to 58999 under the instrument in force
+        (art. 15.1) — carved out of the ordinary five-digit space rather than
+        given its own prefix. The human pattern spells a representative value
+        because the pattern DSL cannot express a numeric range. The lower bound
+        58001 is not encoded, so the regex accepts 58000, which the block does
+        not contain — one string of slack, and the only slack left.
+      corrected_2026_08_08: >-
+        THE HEADLINE §5.3 CATCH. The draft recorded the block as "58001 to 59999"
+        with regex '\A5[89]\d{3}\z'. THE TWO INSTRUMENTS SAY DIFFERENT THINGS AND
+        NEITHER SAYS THAT.
+          Decret del 23-02-2011, art. 12.1, verbatim: "A les plaques de matrícula
+          s'inscriu un grup de 5 caràcters que va des del 58001 final al 99999."
+          ("final al" is the instrument's own slip for "fins al".)
+          Decret 456/2022, art. 15.1, verbatim: "A les plaques de matrícula s'hi
+          inscriu un grup de cinc caràcters numèrics que va des del 58001 fins al
+          58999."
+        So the block was 58001-99999 from 2011 and was NARROWED to 58001-58999
+        when the current Reglament commenced on 17 November 2022. The draft's
+        59999 is between the two and matches neither instrument — the precise
+        failure mode PRD-PLATES §5.3 names ("never average them"). The regex now
+        carries the CURRENT statutory block and over-accepted 1,000 strings
+        before this pass (59000-59999) plus 58000.
+        THE PERIOD CONSEQUENCE IS LEFT TO THE MAINTAINER: on the §2.2 rule that a
+        differing format is a differing series, the 2011-2022 wide block deserves
+        its own ended series (ad-historic-passed-itv-2011 or similar) and this
+        one should start 2022. That would be a series ADDITION, which the
+        append-only rule permits but which a researcher must not make alone under
+        I-11, so it is proposed in plates/_verification/ad.md and not taken here.
+        The period on this series is therefore left at 2011 and is KNOWN to be
+        wider than the format it now carries — flagged rather than quietly
+        re-cut.
     design:
       plate: { w: 330, h: 140, unit: mm }
       background: { color: "#FFFFFF", finish: retroreflective, hex_basis: observed }
@@ -798,6 +1187,15 @@ series:
       the one case where a bare five-digit string can be attributed with
       confidence. Note the consequence for ad-moped, whose 00000-99999 space
       nominally includes this block.
+    verifier_note_2026_08_08: >-
+      ONE PROVISION THE DRAFT MISSED, AND IT IS A SOURCED NEGATIVE WORTH HAVING:
+      art. 15.3 provides that historic MOPEDS keep the ordinary moped plate —
+      "La placa de matrícula per als ciclomotors que es registrin com a vehicles
+      històrics és la mateixa que la placa de matrícula ordinària per als
+      ciclomotors." So a historic ciclomotor is NOT in this series and NOT in
+      ad-historic-failed-itv; it is in ad-moped. No new series is warranted (the
+      instrument says the plate is the same one), and the block-overlap note
+      above gains a second reason to exist.
     sources:
       - "https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html  # Decret 456/2022 art. 15"
 
@@ -838,6 +1236,14 @@ series:
       blue Pantone 300 legends. Two corrections to the secondary record are
       carried here: the ground is white and not sky blue, and the serial is FOUR
       digits and not three. Both come from art. 17.1 verbatim.
+    verifier_note_2026_08_08: >-
+      BOTH OF THE DRAFT'S CORRECTIONS TO THE SECONDARY RECORD ARE UPHELD on the
+      raw text of art. 17.1: "El fons de les plaques és retroreflector, de color
+      blanc" and "un grup de quatre caràcters numèrics que va des del 0000 fins
+      al 9999". Pantone 485 characters and Pantone 300 legends confirmed. One
+      dated detail: the top legend was plural before 2022 — 2011 art. 14.1 prints
+      "VEHICLES ESPECIALS", 2022 art. 17.1 prints "VEHICLE ESPECIAL". Recorded,
+      design block not edited.
     sources:
       - "https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html  # Decret 456/2022 art. 17.1"
       - "https://bopadocuments.blob.core.windows.net/bopa-documents/011040/html/199A6.html  # Llei del Codi de la circulació de 10-6-99 art. 204.7"
@@ -867,6 +1273,13 @@ series:
       Pyrenean microstate having a statutory snowmobile plate is exactly the
       kind of jurisdiction-specific series a general dataset misses; it shares
       the special-vehicle design and differs only in its legend.
+    verifier_note_2026_08_08: >-
+      Confirmed verbatim against art. 18.1 — white retroreflective ground,
+      Pantone 485 red border and characters, "MOTO DE NEU" in Pantone 300 blue,
+      four digits 0000-9999, 225 x 115 mm. Same dated plural as the
+      special-vehicle series: 2011 art. 15.1 printed "MOTOS DE NEU".
+      Placement fact available if wanted (art. 22.5): a snowmobile carries a
+      single rear plate.
     sources:
       - "https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html  # Decret 456/2022 art. 18"
 
@@ -913,10 +1326,17 @@ series:
     period_evidence: instrument-in-force
     period_note: >-
       Llei 24/2014, del 30 d'octubre, BOPA núm. 67, any 2014, published
-      25 November 2014. Note that Andorra puts personalised plates in a LAW
-      passed by the Consell General and sanctioned by both Co-Princes, where
-      San Marino uses a decree — a markedly higher instrument for the same
-      subject.
+      26 November 2014 (the sumari of BOPA núm. 67, any 26 is dated 26.11.2014;
+      the draft's 25 November was the third instance of the same off-by-one and
+      is corrected). Note that Andorra puts personalised plates in a LAW passed
+      by the Consell General and sanctioned by both Co-Princes, where San Marino
+      uses a decree — a markedly higher instrument for the same subject.
+      COMMENCEMENT, which the draft did not state: disposició final segona,
+      verbatim — "Aquesta Llei entra en vigor al cap d'un mes de ser publicada al
+      Butlletí Oficial del Principat d'Andorra." One month from 26 November 2014
+      is 26 DECEMBER 2014, so `period.start: 2014` is correct but rests on the
+      last six days of the year; no personalised plate can predate 26 December
+      2014 and first issuance in 2015 would not contradict anything here.
     matching: recall-only
     format:
       pattern: "LL999"
@@ -932,6 +1352,49 @@ series:
         lletres" (h). The regex enforces the length bound and the letters-then-
         digits ordering but accepts a five-character string with only one
         letter, which (h) forbids. A match is therefore a shape hit.
+      unexpressed_constraints_2026_08_08: >-
+        THE §5.3 PASS FOUND THREE MORE CONSTRAINTS IN art. 7.1 THAT THE DRAFT DID
+        NOT LIST, one of which the regex actively violates. `recall-only` was
+        already the right call; these widen the gap it declares.
+        (d) "No s'accepten combinacions que coincideixin o puguin coincidir amb
+            la numeració de les matrícules ordinàries." A personalised mark may
+            not look like an ordinary one — yet the regex accepts A0000, which is
+            precisely the ordinary lettered grammar of art. 6.2, and AA000, which
+            is its next stage. The single most over-accepting case, and it is
+            forbidden in terms.
+        (f) "No s'accepten combinacions que continguin la menció 'AND' i altres
+            pròpies de l'Estat o dels poders públics andorrans." AND is barred as
+            a substring; the regex accepts it.
+        (e) and (j) are discretionary or registry-state rules — combinations that
+            blur letters against digits, and combinations already reserved or
+            attributed — and are unexpressible in a regex by nature.
+        None of these is encoded, because a regex that excluded the ordinary
+        grammar would be asserting a negative the dataset cannot verify per
+        plate; they are recorded so the `recall-only` declaration is honest about
+        WHAT it is recalling.
+      eligibility_disagreement_2026_08_08: >-
+        LAW AND REGLAMENT DISAGREE ON WHICH VEHICLES MAY CARRY ONE. Recorded
+        verbatim, not averaged, and the narrower `categories` list is left alone
+        pending the maintainer's call.
+        Llei 24/2014 art. 3.1 admits four categories: "a) Categoria 'L' […] amb
+        excepció dels de la categoria 'L1' (ciclomotors). b) Categoria 'M' […]
+        c) Categoria 'N' o la que correspongui a vehicles de motor destinats al
+        transport de mercaderies […] d) Categoria 'O' o la que correspongui a
+        remolcs i semiremolcs." That is motorcycles, cars, GOODS VEHICLES and
+        TRAILERS.
+        Decret 456/2022 art. 26.1 is narrower: the personalised mark "s'aplica a
+        la placa de matrícula ordinària i a la placa de matrícula ordinària
+        reduïda dels vehicles automòbils, així com a la placa de matrícula
+        ordinària de les motocicletes" — cars and motorcycles only, no mention of
+        N or O.
+        This series lists [car, van, motorcycle], which follows the reglament and
+        omits truck, trailer and semitrailer. A law outranks a decree, so the
+        wider list is probably right; but "probably" is not the standard, the
+        reglament is the instrument the rest of this file is built on, and
+        MAJORITY IS NOT AUTHORITY cuts against quietly picking one.
+        Confirmed on both routes: art. 3.2 excludes the diplomatic, consular,
+        embassy-staff, temporary, prova, special, snowmobile, giny and museum
+        vehicles, so no personalised plate can appear on those series.
       reserved_strings:
         rule: >-
           art. 7.1(i): a personalised plate may not consist only of the letters
@@ -958,4 +1421,44 @@ series:
       art. 7.1(i) is the cleanest statutory statement in this whole dossier of
       which alphabetic markers Andorra regards as serial prefixes.
     sources:
-      - "https://bopadocuments.blob.core.windows.net/bopa-documents/026067/html/lo26067002.html  # Llei 24/2014, del 30 d'octubre, art. 7.1 lit. a-i"
+      - "https://bopadocuments.blob.core.windows.net/bopa-documents/026067/html/lo26067002.html  # Llei 24/2014, del 30 d'octubre, arts. 2, 3.1-3.2, 4.1, 6.3, 7.1 lit. a-j, disposició final segona"
+      - "https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html  # Decret 456/2022 art. 26 — the reglament's own personalised-plate article, incl. 26.1 (eligible vehicles) and 26.5 (afectació a un altre vehicle)"
+
+# ===========================================================================
+# §5.3 VERIFICATION — researcher-only, per I-11.
+# ===========================================================================
+verification:
+  protocol: "PRD-PLATES §5.3"
+  status: awaiting_verification
+  verifier: null
+  researcher_pass:
+    date: "2026-08-08"
+    role: researcher
+    loop: QA-LOOP-2
+    dossier: plates/_verification/ad.md
+    method: >-
+      Every series' period boundaries, format regex, class and colours were
+      re-derived from the PRIMARY instruments already pinned in this file, read
+      as raw gazette text rather than through a summariser (the BOPA blob store
+      serves UTF-16 HTML; it was fetched, decoded and tag-stripped locally, so
+      every quote above is a byte-for-byte extract), PLUS one independent route
+      per claim — the BOPA sumari PDFs for gazette dates, the two Correccions
+      d'errata for the citation and the as-published caveat, the repealed 2011
+      Reglament for period-scoped drift, the Automòbil Club d'Andorra's
+      concession page for the agency-stated date, and leslleis.com as a
+      third-party check on the decree's title.
+  signing_rule: >-
+    THIS SESSION RESEARCHED AND MAY NOT CERTIFY. I-11: the author never certifies
+    their own work — in the correction pass, not one of five major wrong
+    conclusions was caught by its author. `verifier` stays null and `status`
+    stays awaiting_verification until a second session re-derives. The
+    corrections landed here are themselves claims and inherit that status.
+  disagreements_recorded_not_resolved:
+    - "MT as serial prefix vs MT as legend — Decret 456/2022 art. 13.1 against Llei 24/2014 art. 7.1(i). See ad-temporary-mt.format.verifier_dissent_2026_08_08."
+    - "Personalised-plate eligibility — Llei 24/2014 art. 3.1 (categories L, M, N, O) against Decret 456/2022 art. 26.1 (cars and motorcycles). See ad-personalized.format.eligibility_disagreement_2026_08_08."
+  open_for_the_verifier:
+    - "ad-historic-passed-itv: the block narrowed 58001-99999 → 58001-58999 at the 2022 commencement. Proposed §2.2 series split; period left at 2011 and knowingly wider than the format."
+    - "ad-consular-cc: CC carried TWO digits under the 2011 Reglament and three from 2022. Same proposed split."
+    - "ad-standard-numeric / ad-motorcycle: art. 7.3 gives motorcycles the five-digit base stage, and no series in this file matches a five-digit motorcycle plate. One-word categories fix or one new ended series."
+    - "common.character_rights: Llei 12/2021 art. 108(3) and Decret 456/2022 art. 3.5 claim the plate characters and state symbols as Govern property. Counter-example to the PRD-PLATES §6 sample finding; needs carrying back into §6 and, separately, a counsel view. Art/emblem posture deliberately untouched."
+    - "annex_gap: the 2022 annex is 404 at its advertised path while the repealed 2011 annex is live. art. 21 makes the annex normative for the character shapes, so the glyph spec is reachable only in the repealed instrument."


### PR DESCRIPTION
## What

The first **PRD-PLATES §5.3 verification pass** on an L1 jurisdiction — Andorra
(`plates/ad.yml`, 16 series, previously headed *"DRAFT for verification"*).
§7.2 records the human verification pass as outstanding for both waves; this is
one jurisdiction of it.

**Unit selection was deterministic**, computed from the data rather than prose —
every file declares its gate on line 1:

```
$ grep -l "gate L1" plates/*.yml | xargs -n1 basename | sort
ad at be ch cy cz dk ee fi fr gb gr hr hu ie is it li lt lu lv mc mt no
pl pt ro se si sk sm va          → 32 files
```

No §5.3 dossier exists anywhere in either repo (the eight `dossier-l1-*.md` in
`vehiclesdb-pipeline` are the **researcher** half of wave 1), so all 32 lack one
and **index 0 is `ad`** on either reading of "lacking".

## Why it found things

Every period boundary, format regex, class and colour was re-derived from the
primary instrument **already pinned in the file**, plus one independent route.
The BOPA blob store serves UTF-16LE HTML, so each document was fetched, decoded
and tag-stripped locally and read raw — **no summariser in the loop**. That was
not fussiness: an initial summariser pass over the same URL paraphrased arts.
7.1–7.3 into a summary that hid art. 7.5, the only statutory basis for the
motorcycle series' `regex_strict`.

## The catch

`ad-historic-passed-itv` recorded its reserved block as **"58001 to 59999"**,
`regex: '\A5[89]\d{3}\z'`.

> **Decret del 23-02-2011, art. 12.1** — "un grup de 5 caràcters que va des del
> **58001 final al 99999**" (*"final al"* is the instrument's own slip)
> **Decret 456/2022, art. 15.1** — "un grup de cinc caràcters numèrics que va des
> del **58001 fins al 58999**"

The block **narrowed** at the 2022 commencement, and the recorded value sits
between the two instruments matching **neither** — the exact shape §5.3 names
(*"never average them"*). The regex over-accepted 1,001 strings (59000–59999 plus
58000). Now `'\A58\d{3}\z'`.

## Everything else corrected

| # | correction | source |
|---|---|---|
| 1 | `ad-dealer-prova` `\d{1,3}` → `\d{3}` | art. 16.1: "un grup de **tres** caràcters numèrics" |
| 2 | Decret 456/2022 published 11-15 → **11-16**, in force 11-16 → **11-17** | sumari 135/2022 page headers + the 2023 errata |
| 3 | Llei 12/2021 published 06-01 → **06-02** | sumari 62/2021 page headers |
| 4 | Llei 24/2014 published 11-25 → **11-26**, commencement 2014-12-26 added | sumari 67/2014; disposició final segona |
| 5 | **`recorded_discrepancy` RETRACTED** — the "one-day disagreement between two official sources" did not exist: both say 2 June 2021, only the draft said 1 June | sumari 62/2021 |
| 6 | numbering rule was the **2011** text printed under a **2022** attribution and called "verbatim" | both texts now carried separately |
| 7 | `binding_note`'s "No provision reserves a number to a person across vehicles" — two do | art. 24 ("Reserva de matrícula ordinària"); Llei 24/2014 arts. 4.1, 6.3 + art. 26.5 |
| 8 | three missing art. 7.1 constraints on the personalised series, incl. (d) which the regex actively violates by accepting `A0000` | Llei 24/2014 art. 7.1(d)(e)(f)(j) |
| 9 | art. 147 quote truncated **at the delegation** every 2011-dated series rests on | 1999 Codi art. 147 ¶ penultimate |
| 10 | `ad-consular-cc` was CC + **2** digits pre-2022 | 2011 art. 8 (the second one so numbered) |
| 11 | plastic/rubber enduro base is historic — not re-enacted in 2022 | 2011 art. 1 ¶2 vs 2022 art. 4 |

Three gazette dates off by one in one file is a **process signal** — worth
sweeping the other wave-2 microstates.

## Recorded, not resolved (never averaged)

- **Is "MT" serial or legend?** Art. 13.1 puts MT in a panel and states the
  serial separately — the *same two-part shape* art. 16.1 uses for PROVA, which
  this file reads as a legend. Against that, Llei 24/2014 art. 7.1(i) groups MT
  with the diplomatic prefixes and sets PROVA apart as *"la paraula"*. Data
  unchanged (dropping MT would collide the series with three `\A\d{4}\z` ones).
- **Personalised eligibility.** The law admits categories L/M/**N**/**O**; the
  decree admits cars and motorcycles only. A law outranks a decree, but
  "probably" is not the standard and majority is not authority.

## Escalated — a PRD-PLATES §6 counter-example

> **Llei 12/2021 art. 108(3)** and **Decret 456/2022 art. 3.5**: "Els caràcters
> que figuren en les matrícules, així com els símbols d'Estat que han de portar
> els vehicles, són **propietat del Govern**, que cedeix en cada cas el dret a
> usar-los…"

§6 records — expressly as a **sample** finding — that no surveyed country claims
copyright in the plate design. Andorra does, in two instruments. Same shape as
the `artwork_risk:` adverse signals of §7.1, sitting beside an art route that
looks clean (`plates/_art/ad/` holds a PD-verified Commons arms).

**Recorded only.** `common.emblem` and every `design:` block are untouched —
the emblem posture is the owner's visual lane and the licensing question is
counsel's. Diff confirms **zero** removed lines matching
`design:|emblem:|background:|foreground:|color:|hex_basis`.

## Also new

- **The AND mark's scope predicts the whole catalogue**: the 2011 preamble limits
  the inscription to vehicles *"aptes per a la circulació internacional"*, which
  exactly matches which of the 16 series carry AND and which do not.
- **The 2022 title erratum**: the wrong year (`456/2011`) was in the *decree's own
  title*, not just the sumari, and was formally corrected on 1-3-2023. Third-party
  databases still carry the uncorrected form.
- **The pinned URL serves uncorrected text** — it still prints the two
  cross-references the 30-11-2022 errata fixed.
- **The annex gap narrowed**: the 2011 statutory annex is live (cited, never
  embedded, per §6) and confirmed pure vector; the 2022 annex 404s at its own
  advertised path. Art. 21 makes the annex normative for the glyphs.
- **Sourced negative** (art. 15.3): historic mopeds keep the ordinary moped plate.

## I-11

This session **researched and may not certify**. `verification.status:
awaiting_verification`, `verifier: null`. The corrections are themselves claims
and inherit that status. Left for a second signer: the two §2.2 series splits
(historic block, CC digit count) and the five-digit-motorcycle coverage gap —
all *additions*, permitted by append-only, not signable by their author.

## Dossier

`plates/_verification/ad.md` — new convention, alongside the data,
underscore-prefixed like `_meta`/`_decode`/`_art`. Both lint globs are
`*.yml`-only so Markdown there is inert. Move it if you prefer another home.
It carries per-series verdicts, all 15 sources with exact URLs, the verbatim
disagreements, **what the pass upheld**, and a reproduction recipe.

## Gates

Before and after, identical:

```
plates lint: 124 files, 1381 series
plates lint: matching recall-only=286 strict=1095 | twins regex_statutory=106 regex_strict=427 | separators emitted "-"," " forgiving 18
plates lint: _art ledger 6060 rows (excluded=5355 open=412 site_only=293), 412 open assets verified
plates lint: OK

curation lint: OK (109 files, duplicate-key + shape + make-key + provenance)
```

Series-id append-only verified explicitly — `removed: []`, `added: []`, order
preserved. Explicit duplicate-key scan over `ad.yml` (safe_load keeps the LAST
dup): none.

## Decisions, with exact source URLs

- **58001–58999 is the block in force; 58001–99999 was the 2011 block; 59999 is neither** — https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html (art. 15.1) · https://bopadocuments.blob.core.windows.net/bopa-documents/023014/html/6BEF6.html (art. 12.1)
- **PROVA is exactly three digits** — https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html (art. 16.1)
- **BOPA núm. 135/2022 is dated 16 November 2022 → in force 17 November** — https://bopadocuments.blob.core.windows.net/bopa-documents/sumaris/034/034135.pdf · https://bopadocuments.blob.core.windows.net/bopa-documents/035033/html/GV20230303_12_27_52.html
- **Llei 12/2021 published 2 June 2021 — no discrepancy existed** — https://bopadocuments.blob.core.windows.net/bopa-documents/sumaris/033/033062.pdf
- **Llei 24/2014 published 26 November 2014, in force 26 December 2014** — https://bopadocuments.blob.core.windows.net/bopa-documents/sumaris/026/026067.pdf · https://bopadocuments.blob.core.windows.net/bopa-documents/026067/html/lo26067002.html
- **Motorcycles have their own I/O/Q exclusion (art. 7.5) and their own five-digit base stage (art. 7.3)** — https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html
- **The Govern owns the plate characters and state symbols** — https://bopadocuments.blob.core.windows.net/bopa-documents/033062/html/CGL20210528_13_01_20.html (art. 108.3) · https://bopadocuments.blob.core.windows.net/bopa-documents/034135/html/GR20221110_09_12_43.html (art. 3.5)
- **"Des de l'any 2011…" — the agency-stated date holds** — https://aca.ad/serveis/plaques-de-matricula
- **The 2011 annex is reachable; the 2022 annex is not** — https://bopadocuments.blob.core.windows.net/bopa-documents/annexos/023014_plaques.pdf · https://bopadocuments.blob.core.windows.net/bopa-documents/034135/Documents/Plaques%202021_GR20221110_09_12_43.pdf (404 BlobNotFound)
- **The decree's published title carried the wrong year; third parties still do** — https://leslleis.com/DR20221109C
- **Errata of 30-11-2022 (arts. 3.6/4.2 cross-references)** — https://bopadocuments.blob.core.windows.net/bopa-documents/034142/html/GD20221201_12_12_06.html
- **1999 Codi arts. 147, 151(b), 156, 204.7 — three quotes verbatim-accurate, one truncated at the delegation** — https://bopadocuments.blob.core.windows.net/bopa-documents/011040/html/199A6.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)
