### PR TITLE
ci: a red weekly build pages nobody — the failure handler cannot infer the repo

### DIFF
--- a/.github/workflows/monthly-build.yml
+++ b/.github/workflows/monthly-build.yml
@@ -188,6 +188,7 @@ jobs:
         working-directory: data-repo
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           VERSION=$(cat VERSION)
@@ -266,10 +267,21 @@ jobs:
 
       # A failed scheduled build must page a human. One issue, updated — never
       # a new issue per failure night (the OpenASN pattern, verbatim).
+      # --repo IS LOAD-BEARING, do not drop it: this step runs at the WORKSPACE
+      # ROOT, and monthly-build checks the two repos out into data-repo/ and
+      # pipeline-repo/ subdirectories (see the `path:` keys above). With no
+      # .git in the cwd, `gh` cannot infer the repository and every call here
+      # dies with "failed to run git: fatal: not a git repository". The
+      # `|| true` on the list call then leaves $existing empty, so the create
+      # runs and exits 1 — on a build that was ALREADY failing, so the extra
+      # error is invisible. Net effect: a red build pages nobody. That is
+      # exactly what happened 2026-08-10 / 08-12 / 08-17 — three consecutive
+      # red weekly builds, zero pipeline-failure issues, noticed a week late.
       - name: Open/update pipeline-failure issue
         if: failure() && github.event_name == 'schedule'
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           title="Scheduled data build failed"
           body="The scheduled build failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -280,11 +292,11 @@ jobs:
           - Delta gate: a kind's model count moved >±20% (source outage or format change)
           - Geo-gated fetch: TH/LV endpoints reject datacenter IPs (keep-last-good covers cached CI, but a cold cache fails)
           - An upstream URL scheme changed (UK rotates asset URLs per release; NZ renames its MVR_* service monthly)"
-          existing=$(gh issue list --label pipeline-failure --state open --json number --jq '.[0].number' || true)
+          existing=$(gh issue list --repo "$GH_REPO" --label pipeline-failure --state open --json number --jq '.[0].number' || true)
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "Failed again: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh issue comment --repo "$GH_REPO" "$existing" --body "Failed again: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
-            gh issue create --title "$title" --body "$body" --label pipeline-failure
+            gh issue create --repo "$GH_REPO" --title "$title" --body "$body" --label pipeline-failure
           fi
 
   # ── The release channel fan-out. Calling the reusable workflow rather than

--- a/.github/workflows/release-channels.yml
+++ b/.github/workflows/release-channels.yml
@@ -131,6 +131,7 @@ jobs:
       - name: Attach release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ steps.v.outputs.tag }}
         run: |
           set -euo pipefail
@@ -295,6 +296,7 @@ jobs:
         if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ steps.v.outputs.tag }}
         run: |
           set -euo pipefail
@@ -308,9 +310,9 @@ jobs:
           - **HF_TOKEN**: expired OAuth token — mint a fine-grained WRITE token at hf.co/settings/tokens and \`gh secret set HF_TOKEN\`.
 
           Procedure: RELEASE-RUNBOOK.md §5 (pipeline repo)."
-          existing=$(gh issue list --search "\"$title\" in:title state:open" --json number --jq '.[0].number' || true)
+          existing=$(gh issue list --repo "$GH_REPO" --search "\"$title\" in:title state:open" --json number --jq '.[0].number' || true)
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "$body"
+            gh issue comment --repo "$GH_REPO" "$existing" --body "$body"
           else
-            gh issue create --title "$title" --body "$body"
+            gh issue create --repo "$GH_REPO" --title "$title" --body "$body"
           fi


### PR DESCRIPTION
## The symptom nobody saw

Main's weekly build failed **2026-08-10, 08-12 and 08-17**. There is no `pipeline-failure` issue. Not a stale one — `gh issue list --label pipeline-failure --state open` returns `[]`. One was never filed.

That is why three red builds went a week without triage.

## The cause

`monthly-build.yml` checks the two repos out into subdirectories:

```yaml
- uses: actions/checkout@v4     # path: data-repo
- uses: actions/checkout@v4     # path: pipeline-repo
```

The failure handler has no `working-directory`, so it runs at the **workspace root** — where there is no `.git`. From the CI log:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

Two failures, one per `gh` call. `|| true` on the `list` swallows the first, leaving `$existing` empty; the `create` then runs, fails, and exits 1 — **on a build that was already failing**, so the second error is just another red step in a red job. The one mechanism meant to page a human is the one mechanism that cannot run.

## Reproduced before changing anything

```
$ cd /a/dir/with/no/.git

$ gh issue list --label pipeline-failure --state open --json number
failed to run git: fatal: not a git repository (or any of the parent directories): .git

$ gh issue list --repo vehiclesdb/vehiclesdb --label pipeline-failure --state open --json number
[]
```

Same error string as CI, and `--repo` clears it. The `[]` is also the evidence that no issue was ever filed.

## The change

`GH_REPO: ${{ github.repository }}` in the step env, and an explicit `--repo "$GH_REPO"` on all three `gh issue` calls. Belt and braces on purpose: `GH_REPO` is gh's documented default-repo variable, and the flag guarantees it regardless of how the env is later edited.

**Scope, stated precisely because overstating a fix is its own defect:**

| file | was it broken? | why it changed |
|---|---|---|
| `monthly-build.yml` | **yes** — job has no root checkout | the fix |
| `release-channels.yml` | **no** — its `fan-out` job checks out the released tree at the root (line 106), so `gh` infers the repo today | defensive, so the next person who adds a `path:` cannot silently break it |

A comment above the step records the mechanism and the three dates, because the next reader's instinct on seeing `--repo` next to `GH_REPO` will be to simplify it away.

## What I cannot verify from here

I cannot execute a GitHub Actions workflow, so **the proof is the next scheduled failure filing an issue** — and that is the honest state of this PR. What is verified: the YAML parses, both jobs still resolve (`build`, `channels`, `fan-out`), and the rewritten command succeeds from a directory with no `.git`, which is the exact condition that broke it.

## Related

`data#297` clears three of main's eleven gate failures (mine, kawasaki xref-loss). The remaining eight are triaged in NEGOTIATION Turn 251 with a reading for each — none are mine, and main cannot go green until they are claimed.