### PR TITLE
ci: the build-failure handler could not file its own issue — three gh calls, no --repo

### DIFF
--- a/.github/workflows/monthly-build.yml
+++ b/.github/workflows/monthly-build.yml
@@ -280,11 +280,11 @@ jobs:
           - Delta gate: a kind's model count moved >±20% (source outage or format change)
           - Geo-gated fetch: TH/LV endpoints reject datacenter IPs (keep-last-good covers cached CI, but a cold cache fails)
           - An upstream URL scheme changed (UK rotates asset URLs per release; NZ renames its MVR_* service monthly)"
-          existing=$(gh issue list --label pipeline-failure --state open --json number --jq '.[0].number' || true)
+          existing=$(gh issue list --repo ${{ github.repository }} --label pipeline-failure --state open --json number --jq '.[0].number' || true)
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "Failed again: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh issue comment "$existing" --repo ${{ github.repository }} --body "Failed again: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
-            gh issue create --title "$title" --body "$body" --label pipeline-failure
+            gh issue create --repo ${{ github.repository }} --title "$title" --body "$body" --label pipeline-failure
           fi
 
   # ── The release channel fan-out. Calling the reusable workflow rather than


### PR DESCRIPTION
ci: the build-failure handler could not file its own issue — three gh calls, no --repo

Main has failed three consecutive weekly builds (08-10, 08-12, 08-17) and NOBODY
WAS TOLD, because the step that exists to tell us dies first:

    failed to run git: fatal: not a git repository (or any of the parent
    directories): .git
    ##[error]Process completed with exit code 1.

The workflow checks the two repos into data-repo/ and pipeline-repo/
subdirectories, so the step's working directory is NOT a git checkout and gh
cannot infer which repo to act on.

THREE CALLS NEEDED IT, not one — and the ordering is why this was invisible
rather than merely broken:

  gh issue list    ... || true     <- FAILS SILENTLY, swallowed by the guard,
                                      so the existing-issue lookup comes back empty
  gh issue comment ...             <- never reached
  gh issue create  ...             <- FAILS LOUDLY and kills the step

So the first failure hid the state and the third killed the reporter. A red
build filed no issue and pinged nobody for a week. Found by S2W reading the log
of a build nobody was told about.

All three now carry an explicit --repo.

Worth stating because it is the shape, not the typo, that matters: this is a
REPORTER that fails exactly when it is needed, and it is the same class as the
licence gate that passed without verifying anything and the lint that could not
see _decode/. A check whose own failure is silent is not a check.
