### PR TITLE
renames: two liveness resurrections — a retired id came back through a spelling nobody had keyed

### DIFF
--- a/overrides/models/renames.yml
+++ b/overrides/models/renames.yml
@@ -3750,6 +3750,7 @@ Ford:
   C-Max Energi:   C-Max                     # us_fueleconomy vehicles.csv baseModel — https://www.fueleconomy.gov/feg/download.shtml: "C-MAX Energi Plug-In Hybrid" and "C-MAX Hybrid FWD" both base at C-MAX
   C-Max Trend:    C-Max                     # us_fueleconomy vehicles.csv baseModel — https://www.fueleconomy.gov/feg/download.shtml: "C-MAX Energi Plug-In Hybrid" and "C-MAX Hybrid FWD" both base at C-MAX
   Focus C-Max:    C-Max                     # us_fueleconomy vehicles.csv baseModel — https://www.fueleconomy.gov/feg/download.shtml: "C-MAX Energi Plug-In Hybrid" and "C-MAX Hybrid FWD" both base at C-MAX
+  Focus C Max:  C-Max                    # THE SPACED SPELLING, and the reason the liveness gate fired 2026-08-18: nl_rdw publishes "FOCUS C MAX" with no hyphen, which PRODUCES "Focus C Max" -> car/ford/focus-c-max, an id former_ids.yml retires INTO c-max. An alias may never name a live id, so the retired id came back. The hyphenated keys above never saw this spelling.
   Focus 2:     Focus                     # us_fueleconomy vehicles.csv baseModel — https://www.fueleconomy.gov/feg/download.shtml: Focus RS/ST/Electric/Station Wagon all base at Focus
   Focus Se:    Focus                     # us_fueleconomy vehicles.csv baseModel — https://www.fueleconomy.gov/feg/download.shtml: Focus RS/ST/Electric/Station Wagon all base at Focus
   Focus ZX3:   Focus                     # us_fueleconomy vehicles.csv baseModel — https://www.fueleconomy.gov/feg/download.shtml: Focus RS/ST/Electric/Station Wagon all base at Focus
@@ -10852,6 +10853,7 @@ Volkswagen:
   Classica: Beetle  # Beetle 'Classic'/'Classica' special edition — https://en.wikipedia.org/wiki/Volkswagen_Beetle
   De Luxe: Beetle  # Beetle De Luxe/Export trim; nl raw `VOLKSWAGEN DE LUXE SEDAN`. The existing `Deluxe: De Luxe` line already normalises the fused spelling into this key — https://en.wikipedia.org/wiki/Volkswagen_Beetle
   Kaefer: Beetle  # 'Käfer' (ASCII-folded) is German for Beetle — "der Käfer" — https://en.wikipedia.org/wiki/Volkswagen_Beetle
+  Kafer: Beetle  # THE NAIVE DIACRITIC STRIP, distinct from `Kaefer` above: that one expands ä -> ae (the German convention), this one DROPS the umlaut. A register now publishes plain KAFER, producing "Kafer" -> car/volkswagen/kafer, retired into beetle — the same liveness resurrection as Ford, from the other ASCII folding. Both spellings are the SAME CAR.
   Käfer: Beetle  # German name of the Beetle — "der Käfer"; lu_snca writes the umlaut, ua_mvs the folded form — https://en.wikipedia.org/wiki/Volkswagen_Beetle
   Newbeetle: Beetle  # EPA/DOE `vehicles.csv`: model "New Beetle" baseModel **Beetle** (61 rows) and "New Beetle Convertible" baseModel **Beetle** — https://www.fueleconomy.gov/feg/download.shtml
   Special: Beetle  # Beetle 'Special'/'Special Bug' trim; bare in es_dgt and nz_nzta — https://en.wikipedia.org/wiki/Volkswagen_Beetle


### PR DESCRIPTION
renames: two liveness resurrections — a retired id came back through a spelling nobody had keyed

Clears 2 of the 8 gate failures holding main red (S2W's Turn 251 triage; both
are 4-wheel and therefore mine).

THE GATE'S COMPLAINT, and it is exactly right:

  car/ford/focus-c-max is ALIVE in this build yet aliased to car/ford/c-max
  car/volkswagen/kafer is ALIVE in this build yet aliased to car/volkswagen/beetle

Both ids are ABSENT from the published 2026.08.2 catalog — correctly folded. They
came BACK because the registers publish spellings that no rename key covered, and
a produced string that nobody keys mints the id the fold retired. This is the
RENAME-VALUE LIVENESS / resurrection class filed as DEBT #197, firing for real
for the first time.

MEASURED, not assumed — what each spelling produces:

  FORD  "FOCUS C-MAX"  -> Ford|C-Max        keyed already
  FORD  "FOCUS C MAX"  -> Ford|Focus C Max  NOT KEYED  -> mints ford/focus-c-max
  VW    "KÄFER"        -> Volkswagen|Beetle keyed already
  VW    "KAEFER"       -> Volkswagen|Beetle keyed already
  VW    "KAFER"        -> Volkswagen|Kafer  NOT KEYED  -> mints volkswagen/kafer

The Volkswagen case is the sharper one and the file now says so: `Kaefer` was
already keyed — that is the GERMAN convention, ä -> ae. What arrived is `Kafer`,
the NAIVE DIACRITIC STRIP that just drops the umlaut. Two different ASCII
foldings of one word; only one had a key. Ford is the same shape in punctuation
rather than diacritics: the hyphenated spelling was keyed, the SPACED one was not.

CHECKED BEFORE WRITING, per the standing rules:
  * both targets LIVE            c-max (9 countries), beetle (10)
  * neither value is itself a KEY — no chain trap
  * neither key already present  — no duplicate
  * renames are KIND-BLIND: verified both keys route identically on van rows;
    "FOCUS C MAX" occurs only in nl_rdw PASSENGER-car files in the cache.

CONTROL VS TREATMENT, same frozen cache both arms:

  car ids     4984 -> 4983
  GONE        ford/focus-c-max     (the resurrection, cured)
  NEW         none                 (nothing minted)
  liveness FAILs   1 -> 0

HONEST LIMIT: my local cache is two weeks old and predates the NZTA republish, so
it does not contain "KAFER" at all — the Volkswagen half is proved by the
classifier and by the gate's own message, NOT by a build on this cache. The Ford
half is proved end to end. Both arms exit 1 on unrelated pre-existing failures
from the stale cache; the comparison isolates this change.
