### PR TITLE
licences: narrow the ua_mvs pin to the licence fields — it was hashing 35KB of package metadata

### DIFF
--- a/data/licenses/pins.json
+++ b/data/licenses/pins.json
@@ -109,11 +109,15 @@
     "extract": {
       "mode": "json_keys",
       "keys": [
-        "result"
+        "result.license_id",
+        "result.license_title",
+        "result.license_url",
+        "result.isopen"
       ]
     },
-    "sha256": "83b6f555226b22edf1cb138c3342915a395b9e0f2eae8013a29611ea130363f2",
-    "pinned_at": "2026-08-01T19:53:09Z"
+    "sha256": "16547fae07ddea94b1a1489a8f96f40a77204f5fc46f935641edcbffcf5008ce",
+    "pinned_at": "2026-08-18T23:10:00Z",
+    "why": "NARROWED 2026-08-18. This pin previously hashed the WHOLE CKAN `result` object — 35,170 bytes of package metadata — to verify a 172-byte licence statement. It fired on 2026-08-03 when data.gov.ua edited the package (metadata_modified 2026-08-03T14:05:30), and the LICENCE DID NOT CHANGE: license_id cc-by, license_title Creative Commons Attribution, isopen true, matching what SOURCES.md has recorded all along. A licence gate that trips on a resource being added is a gate people learn to re-pin without reading, which is the failure mode it exists to prevent. Now pinned to the four licence fields only."
   },
   "ar_dnrpa": {
     "url": "https://datos.jus.gob.ar/api/3/action/package_show?id=inscripciones-iniciales-de-autos",


### PR DESCRIPTION
licences: narrow the ua_mvs pin to the licence fields — it was hashing 35KB of package metadata

Clears 1 of the gate failures holding main red. The gate was RIGHT to fire and
the terms did NOT change; the pin was asking the wrong question.

WHAT THE PIN WAS DOING. `extract: {mode: json_keys, keys: ["result"]}` hashes the
WHOLE CKAN package object — 35,170 bytes of resources, tags, timestamps and view
counts — to verify a 172-byte licence statement.

WHAT ACTUALLY HAPPENED. data.gov.ua edited the package on 2026-08-03
(metadata_modified 2026-08-03T14:05:30, pinned 2026-08-01T19:53). The licence is
untouched:

  license_id     cc-by
  license_title  Creative Commons Attribution
  license_url    http://www.opendefinition.org/licenses/cc-by
  isopen         true

Corroborated independently of the pin: SOURCES.md has recorded ua_mvs as CC-BY
all along, and it matches what the API serves now.

THE FIX. Pin the four licence fields via the dotted-path support json_keys
already has. 35,170 bytes -> 172 bytes.

  control    license gate: 12/13 pins verified, 1 FAILED
             FAIL license gate: ua_mvs terms CHANGED — pinned 83b6f555226b got f6ed2f0d20e2
  treatment  license gate: 13/13 pins verified (+1 declared_absent)

WHY THIS MATTERS BEYOND ONE PIN. A licence gate that trips when a resource is
added is a gate people learn to re-pin without reading — which is exactly the
failure mode it exists to prevent, and this gate was rewritten in pipeline#124
precisely because it had been passing without verifying anything. Too-broad and
too-narrow fail the same way in the end: nobody believes the alarm.

I SURVEYED THE OTHER 13 rather than assume this was unique. It is: `nl_rdw`
(licenseId, license, attribution, attributionLink) and `lu_snca` (license) name
licence-specific fields despite being top-level, and the nine `phrases` pins
assert the terms text directly. `ua_mvs` was the only one hashing a whole
document.

A CORRECTION TO MY OWN DIAGNOSIS, made mid-investigation: I first concluded the
object "changes on a timescale of hours", because a hash I computed by hand
differed from the build's. That was wrong — I had hashed JSON.generate(result)
directly while the extractor wraps it as {"result": ...}. Hashing the extractor's
own output reproduces the build's f6ed2f0d20e2 exactly, and three consecutive
fetches are byte-identical. The object changed ONCE, on 08-03. The remedy is the
same either way, but "churns constantly" and "was edited once" are different
facts and only one of them is true.
