### PR TITLE
spotchecks: the two ES claims expired out of DGT's rolling window — narrowed with evidence, not deleted to go green

### DIFF
--- a/spotchecks.yml
+++ b/spotchecks.yml
@@ -221,7 +221,15 @@ checks:
     exists: false
     reason: "KBA FZ10 numeric type-codes are not nameplates (Tesla 512 precedent); seat/468 held DE rank 33 and polluted popularity"
   - id: seat/127
-    availability_includes: [es]
+    # es -> nl 2026-08-18. Same DGT window expiry: "127 SPORT" appears in
+    # es_dgt_202604 ONLY (1 row), zero in 03/05/06/07. The row is NOT weakened,
+    # because nl carries the SAME Sport variant and more of it — nl_rdw
+    # personenauto holds "127 SPORT COUPE 1430" x7 and "127 SPORT COUPE 1430"
+    # (accented) x1 beside bare "127" x4. So the fold this row guards is still
+    # exercised by live evidence, from a source with EIGHT Sport rows against
+    # Spain's one. Dropping es to [] would have left the row asserting nothing;
+    # moving it to nl keeps the guard pointed at what the fold actually does.
+    availability_includes: [nl]
     reason: "'127 Sport' -> '127' fold intentionally creates the classic supermini nameplate with its ES evidence"
   - id: cupra/tavascan
     availability_includes: [gb]
@@ -730,7 +738,16 @@ checks:
     availability_includes: [de, es, fi, gb, lu, nl]
     reason: "…and the ICE Combo must lose NO country to that split. Measured control-vs-treatment at (country, SOURCE) level: the same six (country, source) pairs before and after, 27,529 -> 25,205 vehicles. de/gb are the proof of no over-reach — neither KBA's Modellreihe nor DfT's GenModel ever writes a -E suffix."
   - id: opel/ampera-e
-    availability_includes: [nl, fi, es, ua]
+    # es DROPPED 2026-08-18 — EXPIRY, not regression, and `ua` still carries the
+    # tripwire this row exists for. Measured in cache/es_dgt_2026*.txt: the exact
+    # string AMPERA-E appears in 202604 ONLY (2 rows); 202603/05/06/07 are zero,
+    # and DGT serves a rolling three-month window now standing at 05-07. The
+    # record is LIVE on fi,nl,ua. THE TRAP THIS ROW SHOULD WARN THE NEXT READER
+    # ABOUT: bare AMPERA is present in EVERY month (8/5/2/2/10) — that is
+    # car/opel/ampera, the range-extender, a different nameplate, and grepping it
+    # yields a confident wrong answer. The reason text below still stands as the
+    # record of why es and ua were the tripwire; ua alone now proves the pin fires.
+    availability_includes: [nl, fi, ua]
     reason: "D-2 closes the cross-repo lockstep item filed in aux dossier-citroen-opel §5.1: the 2,856 AMPERA-E vehicles finally reach the Ampera-e record instead of car/opel/ampera. es and ua are NEW here and are the tripwire — they only arrive if the pin fires. Display must read 'Ampera-e' (overrides/styling.yml AMPERA-E pin), not 'Ampera-E'."
   - id: opel/ampera
     availability_includes: [es, fi, nl, ua]


### PR DESCRIPTION
spotchecks: the two ES claims expired out of DGT's rolling window — narrowed with evidence, not deleted to go green

Clears the last 2 of the five 4-wheel gate failures holding main red. Spotcheck
failures 2 -> 0.

THE MECHANISM, measured myself in cache/es_dgt_2026*.txt rather than inherited:

  month    AMPERA-E   "127 SPORT"   bare AMPERA
  202603      0            0             8
  202604      2            1             5
  202605      0            0             2
  202606      0            0             2
  202607      0            0            10

Both strings appear in APRIL ONLY. DGT serves a rolling three-month window now
standing at 05-07, so the evidence these rows pin has aged out of the feed. Both
records survive: opel/ampera-e LIVE on fi,nl,ua; seat/127 LIVE on nl.

This is the same mechanism as S2W's three Kawasaki type approvals (data#297) —
five of the eleven failures were one cause, per their Turn 252 correction.

I DID NOT DELETE THE CLAIMS TO GO GREEN. The spotchecks rule is that the row is
right and your build is wrong until proven otherwise, and each row keeps a live
guard:

  opel/ampera-e  [nl, fi, es, ua] -> [nl, fi, ua]
      The row's own reason says "es and ua are the tripwire — they only arrive if
      the pin fires". `ua` STILL ARRIVES, so the pin is still demonstrably firing
      and the tripwire is intact with one leg removed, not gutted.

  seat/127       [es] -> [nl]
      Dropping es to [] would have left the row asserting NOTHING. It does not
      have to: nl carries the SAME Sport variant and more of it — nl_rdw holds
      "127 SPORT COUPE 1430" x7 plus an accented x1 beside bare "127" x4, against
      Spain's single row. The fold this row guards is still exercised by live
      evidence, from the stronger source.

THE TRAP, RECORDED IN THE FILE so the next reader does not repeat it: bare
AMPERA is present in EVERY month. That is car/opel/ampera, the range-extender —
a different nameplate, still LIVE on es,fi,nl,ua. Grepping AMPERA where the
question is AMPERA-E returns a confident wrong answer, and it already did once
this week.

INTERIM, and it is compatible with either owner outcome on S2W's durable-store
question. If an archive of published claims lands, these rows can reassert es
from it with a first_seen date. Until then the honest record is: the evidence
existed, it was real, here is the month and the file, and it is gone from the
feed.

Control vs treatment on one frozen cache: spotcheck FAILs 2 -> 0, no other gate
class changes. Both arms exit 1 on the unrelated 2W failures that are S2W's.
