### PR TITLE
scripts: the rename-value liveness sweep read one session's worktree, whatever checkout you ran it from

### DIFF
--- a/scripts/audit_rename_value_liveness.rb
+++ b/scripts/audit_rename_value_liveness.rb
@@ -12,13 +12,39 @@
 # resurrection risk or an already-dead line.
 require "json"
 require "yaml"
-D = "/Users/javi/GitHub/.vdb-worktrees/s2w-data"
-P = "/Users/javi/GitHub/.vdb-worktrees/s2w-pipeline"
+
+# BOTH ROOTS WERE HARDCODED to one session's worktrees:
+#
+#     D = "/Users/javi/GitHub/.vdb-worktrees/s2w-data"
+#     P = "/Users/javi/GitHub/.vdb-worktrees/s2w-pipeline"
+#
+# so the sweep read those files no matter which checkout you ran it from. Run
+# against a branch that ADDS two rename keys and it still printed
+# "renames scanned: 7546" — the same number as main, because it never opened
+# the branch's file. It exits 0 and prints a plausible summary either way, and
+# that is the whole failure: a null result and a clean result are
+# indistinguishable unless you make the tool say what it read.
+D = File.expand_path(ENV["VDB_DATA_REPO"] || File.join(__dir__, ".."))
+# P is deliberately NOT derived from D. The data repo under audit is often a
+# worktree (that is the whole point of pointing VDB_DATA_REPO at a branch), and
+# worktrees carry no build/out — so `D/../vehiclesdb-pipeline` would abort on
+# exactly the case this tool exists for. Default to the pipeline beside the
+# canonical checkout this script lives in.
+P = File.expand_path(ENV["VDB_PIPELINE_REPO"] || File.join(__dir__, "..", "..", "vehiclesdb-pipeline"))
 
 def slug(s) = s.to_s.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-\z/, "")
 
 live = {}      # "make/slug" => [kinds]
-Dir["#{P}/build/out/catalog/*/models.json"].each do |f|
+catalog_files = Dir["#{P}/build/out/catalog/*/models.json"].sort
+# An EMPTY glob is the dangerous case, not a harmless one: `live` stays {} and
+# then EVERY rename value looks like it names no record, so the sweep reports
+# maximal risk with total confidence. Refuse to run rather than answer wrongly.
+if catalog_files.empty?
+  abort "audit_rename_value_liveness: no build catalog under #{P}/build/out/catalog/*/models.json — " \
+        "every rename value would falsely read as dead. Build the pipeline first, or point " \
+        "VDB_PIPELINE_REPO at a checkout that has build/out (VDB_DATA_REPO sets the data repo)."
+end
+catalog_files.each do |f|
   kind = File.basename(File.dirname(f))
   d = JSON.parse(File.read(f)); r = d.is_a?(Hash) ? (d["models"] || d.values.first) : d
   r.each { |x| (live[x["id"]] ||= []) << kind }
@@ -45,6 +71,14 @@ renames.each do |make, block|
   end
 end
 
+# WHAT WAS EXAMINED, printed before what was found. The counts above are only
+# meaningful against a stated corpus: "34 resurrection risks" from a stale or
+# foreign build looks exactly like 34 from this branch's build.
+puts "  data repo:     #{D}#{ENV['VDB_DATA_REPO'] ? ' (VDB_DATA_REPO)' : ''}"
+puts "  build catalog: #{P}/build/out/catalog#{ENV['VDB_PIPELINE_REPO'] ? ' (VDB_PIPELINE_REPO)' : ''}"
+puts "                 #{catalog_files.size} kind(s): #{catalog_files.map { |f| File.basename(File.dirname(f)) }.join(', ')}"
+puts "                 #{live.size} live records, built #{File.mtime(catalog_files.first).strftime('%Y-%m-%d %H:%M')}"
+puts "  former_ids:    #{former.size} arms over #{retired.size} distinct retired slugs"
 puts "  renames scanned: #{renames.sum { |_, b| b.is_a?(Hash) ? b.count { |_, v| v.is_a?(String) } : 0 }}"
 puts "  values with NO live record: #{risky.size}\n\n"
 res = risky.select { |r| r[3].start_with?("RESURRECTION") }

--- a/scripts/audit_rename_value_liveness.rb
+++ b/scripts/audit_rename_value_liveness.rb
@@ -56,11 +56,19 @@ retired = former.keys.map { |k| k.split("/", 2).last }.to_set rescue
           (require("set"); former.keys.map { |k| k.split("/", 2).last }.to_set)
 
 risky = []
+declined_null = 0     # values that are not strings — deliberate drops
+declined_block = 0    # top-level entries that are not make blocks
 renames.each do |make, block|
-  next unless block.is_a?(Hash)
+  unless block.is_a?(Hash)
+    declined_block += 1
+    next
+  end
   mk = slug(make)
   block.each do |key, val|
-    next unless val.is_a?(String)          # nulls are deliberate drops
+    unless val.is_a?(String)               # nulls are deliberate drops
+      declined_null += 1
+      next
+    end
     target = "#{mk}/#{slug(val)}"
     next if live.key?(target)              # value names a live record — fine
     # value has no live record. Two sub-cases:
@@ -79,6 +87,14 @@ puts "  build catalog: #{P}/build/out/catalog#{ENV['VDB_PIPELINE_REPO'] ? ' (VDB
 puts "                 #{catalog_files.size} kind(s): #{catalog_files.map { |f| File.basename(File.dirname(f)) }.join(', ')}"
 puts "                 #{live.size} live records, built #{File.mtime(catalog_files.first).strftime('%Y-%m-%d %H:%M')}"
 puts "  former_ids:    #{former.size} arms over #{retired.size} distinct retired slugs"
+# AND WHAT IT DECLINED TO EXAMINE. A denominator alone is the cure for "ran and
+# found nothing"; it is no cure at all for "ran, found some, and said less than
+# it knew" — for that the tool has to state its PREDICATE, because a silence
+# inside the scope and a silence outside it look identical from the outside.
+puts "  predicate:     a rename VALUE is checked against `<this make>/<slug(value)>` — SAME MAKE BLOCK ONLY."
+puts "                 A cross-make rename is OUT OF SCOPE and is not reported either way."
+puts "                 declined: #{declined_null} non-String value(s) (deliberate drops)" \
+     "#{declined_block.positive? ? ", #{declined_block} non-block top-level entr(y/ies)" : ''}"
 puts "  renames scanned: #{renames.sum { |_, b| b.is_a?(Hash) ? b.count { |_, v| v.is_a?(String) } : 0 }}"
 puts "  values with NO live record: #{risky.size}\n\n"
 res = risky.select { |r| r[3].start_with?("RESURRECTION") }


### PR DESCRIPTION
Found while VERIFYING data#297/#300/#305, not by going looking: I ran the sweep
on main and on all three branches, got byte-identical output every time, and
was about to record "no branch introduces a resurrection risk" on the strength
of it. The number never moved because the tool never opened those files.

    D = "/Users/javi/GitHub/.vdb-worktrees/s2w-data"
    P = "/Users/javi/GitHub/.vdb-worktrees/s2w-pipeline"

Both roots were hardcoded absolute constants with no env override. Run the
sweep from a branch that ADDS two rename keys and it still printed
`renames scanned: 7546` — main's number — because it read s2w-data either way.
It exits 0 and prints a plausible summary regardless, which is the whole
defect: A NULL RESULT AND A CLEAN RESULT ARE INDISTINGUISHABLE UNLESS YOU MAKE
THE TOOL SAY WHAT IT READ.

This is the tool that audits DEBT #197 — the resurrection class that had
`ford/focus-c-max` and `volkswagen/kafer` alive under live aliases and main red
for three weekly builds. The auditor for that class could not see a branch.

THREE CHANGES.

1. BOTH ROOTS RESOLVE PROPERLY. `VDB_DATA_REPO` (matching Support.rb's own
   name) else the script's repo via __dir__; `VDB_PIPELINE_REPO` else the
   pipeline beside it. Now cwd-independent AND branch-addressable.

   P is deliberately NOT derived from D. The data repo under audit is usually a
   worktree — that is the point of pointing it at a branch — and worktrees
   carry no build/out, so `D/../vehiclesdb-pipeline` would abort on exactly the
   case the tool exists for. I wrote it that way first and the test caught it.

2. AN EMPTY CATALOG GLOB NOW ABORTS. It was the more dangerous branch and it
   was silent: no build/out means `live` stays {}, so EVERY rename value reads
   as naming no record and the sweep reports maximal risk with total
   confidence. Exits 1 with the path it looked for.

3. IT REPORTS WHAT IT EXAMINED, BEFORE WHAT IT FOUND — both roots (flagged when
   env-set), kinds, live-record count, BUILD MTIME, and former_ids arms. "34
   resurrection risks" from a stale or foreign build looks exactly like 34 from
   yours. This is the DECISIONS rule I proposed in NEGOTIATION after five
   instances, applied to the tool that most needed it.

CONTROL VS TREATMENT, which the fix makes possible for the first time:

    main                     renames scanned: 7546   no-live-record: 451
    VDB_DATA_REPO=#300       renames scanned: 7548   no-live-record: 451
    VDB_DATA_REPO=#297       renames scanned: 7546   no-live-record: 451
    VDB_PIPELINE_REPO=<no build/out>   -> exit 1, names the path

7548 is exactly the two keys data#300 adds. Before this change both read 7546.
`former_ids: 6022 arms` is unchanged under #297's nested shape, confirming the
sweep's key-only reads survive it.

AND THE VERIFICATION RESULT THAT MOTIVATED IT, now actually measured:
`values with NO live record` is 451 on main and on both branches — neither PR
introduces a rename-value liveness risk.

BLAST RADIUS, checked rather than assumed: two other scripts name those
worktree paths — `find_duplicate_makes.rb` (a comment in a usage example) and
`find_duplicate_spellings.rb` (`ENV["VDB_DATA_REPO"] || "…/s4w-data"`, already
overridable). This one was the only unconditional pair. Not wired into CI or
any rake task, so no gate was affected — it is an advisory tool that has been
giving one session's answer to every session.