### PR TITLE
ci: a failing SCHEDULED build uploaded no artifacts — the condition was narrower than the step's own name

### DIFF
--- a/.github/workflows/monthly-build.yml
+++ b/.github/workflows/monthly-build.yml
@@ -170,8 +170,18 @@ jobs:
             ruby pipeline/run.rb
           fi
 
+      # The condition below must stay in step with the PUBLISH expression on the
+      # build step. It said `github.event_name == 'pull_request'`, which is much
+      # narrower than this step's own name: a failing SCHEDULED build — the one
+      # case where you most need build/out to see which record tripped a gate —
+      # uploaded nothing at all. Main was red for eleven days and the only way
+      # to inspect a build was to open a PR to provoke one.
       - name: Upload build artifacts for inspection (non-publish runs)
-        if: always() && github.event_name == 'pull_request'
+        if: >-
+          always() && !(
+            (github.event_name == 'schedule' && startsWith(github.event.schedule, '23 4 12')) ||
+            (github.event_name == 'workflow_dispatch' && inputs.publish)
+          )
         uses: actions/upload-artifact@v4
         with:
           name: vehiclesdb-build


### PR DESCRIPTION
The step is called "Upload build artifacts for inspection (non-publish runs)"
and carries `always()`, which reads as "any run that is not publishing". The
condition was:

    if: always() && github.event_name == 'pull_request'

so schedule and workflow_dispatch runs uploaded NOTHING, pass or fail.

WHY THIS COST SOMETHING. Main was red for eleven days across three weekly
scheduled builds. Diagnosing a gate failure needs `build/out` — the gate names
an id, and you need the record to see the display name that MINTED it. None of
those runs kept it. The only way to inspect a build was to open a pull request
purely to provoke one, which is what "the reporter fails exactly when it is
needed" looks like in a workflow rather than in a script.

Found while working the nine 4-wheel gate failures I claimed in NEGOTIATION:
five are alias-liveness resurrections, and to key them correctly I need each
live record's PRODUCED DISPLAY NAME, because several spellings slug to the same
id ("A Model", "A. Model" and "A.Model" all slug to a-model). The gate gives the
id; only build/out gives the name. I could not get it from any of the failing
runs.

The new condition is the negation of the build step's own PUBLISH expression, so
the step now does what its name says and the two stay in step. Publishing runs
still upload nothing, which was the actual intent — those sync and release
instead.

Deliberately NOT changed: the "Open/update pipeline-failure issue" step stays
`failure() && github.event_name == 'schedule'`. A hand-dispatched build that
fails should not open an issue; that one's condition matches its intent.