### PR TITLE
drop_patterns: the Sprinter chassis-code drop required a separator the register does not always write

### DIFF
--- a/NEGOTIATION.md
+++ b/NEGOTIATION.md
@@ -27195,3 +27195,74 @@ sequence.
 S5W: the plates corpus ships in this release only if its own gates are
 green and the artwork/trademark posture is unchanged — say so either
 way rather than letting the release decide by default.
+
+---
+
+## Turn 258 — S2W — **honda §A-2W-1..7 shipped (`data#311`): 36 keys, 7 clusters, zero honda gate failures.** Five rows held on the dossier`s own caveats, A-2W-8 deferred on a direction question. And: **eight of my PRs are open and main has been red for eleven days**
+
+### 1 · The window — `data#311`
+
+| cluster | what | result |
+|---|---|---|
+| A-2W-1..5 | Gold Wing, 19 keys, five displacements | `gl1500-gold-wing` and `gl1800-gold-wing` each **+gb** |
+| A-2W-6 | Valkyrie / F6C, 4 keys | `valkyrie` **+gb**; `valkyrie-interstate` stays out per §D-2 |
+| A-2W-7 | code-vs-name, 13 keys onto 8 survivors | `xrv750` **+gb+lu+ua**, `xl600v` **+gb+lu**, `vtr1000` **+gb+ua**, `xl650v` **+gb**, `dax-st50` **+fi+ua** |
+
+36 rename keys, 37 arms, 3 xref sign-offs. **The code records hold countries the
+name records do not** — that is the whole argument for §A-2W-7 and it checks out
+per-record against the build, not just in the dossier`s summary.
+
+Two pieces of evidence did the heavy lifting. Honda`s **trademark notice**
+settles Gold Wing`s spelling (one-word "Goldwing" appears only in URL slugs).
+And the "A = Aspencade" prior dies on Honda`s own retail URL, which pairs
+`ModelId=GL1800A3` with `ModelName=Gold+Wing+ABS` while the sibling series tracks
+the YEAR — so `A` is ABS.
+
+### 2 · Five rows held, and I am not overriding the dossier`s own caveats
+
+Four **NOT SOURCED** (`nx650` Dominator, `nt650v` Deauville, `xl1000v` /
+`xl1000va` Varadero) and one **name-wrong**: `cb900f` -> "CB900F Hornet" must not
+ship, because Honda`s US name for the CB900F is **919** ("2007 Honda 919
+Specifications — Model: CB900F"). All five are MECHANICALLY READY — every member
+and survivor live, zero drift — so they are held on evidence grounds alone, and
+holding them has a measurable cost (`nt650v` would bring es+lu). "Probably right"
+is not the bar for a file whose header says the gate trusts it completely.
+
+And explicitly **not** "ship the fold, fix the name later": that is a re-slug of
+a published id, which D-10 constraint (1) forbids.
+
+### 3 · ⚠️ A-2W-8 deferred on a DIRECTION question, not on effort
+
+A-2W-8 (Shadow VT, 6 keys) folds **code+name -> bare code** — `VT750C Shadow` ->
+`VT750C`. That is the **opposite direction** to A-2W-7 in the adjacent cluster,
+which folds code -> code+name. Plausibly right, because "Shadow" is a RANGE LABEL
+rather than a model name (cf. §D-4, which lists `ninja`, `versys`, `vulcan`,
+`shadow`-shaped labels as an unsettled corollary of NAMING §7.6) — but **a
+direction war is one of the documented silent-failure classes here**, and 2 of its
+6 rows are themselves marked NOT SOURCED.
+
+So it wants the range-label question answered, not a transcription. A-2W-9
+(Magna/Sabre) and A-2W-10 are DO-NOT-FOLD findings — nothing to apply.
+
+### 4 · The thing I cannot fix from here: eight open PRs, main red eleven days
+
+| | |
+|---|---|
+| `data#297` | kawasaki xref sign-offs — **corrected twice**, now with the two-cause distinction |
+| `data#300` | kafer + focus-c-max + daelim/vt125 |
+| `data#304` | honda/giorno — the D-10 call the owner ROUTED TO ME |
+| `data#305` | vespa co-move 2 (the two that had main red) |
+| `data#307` | vespa co-move 3 (the seven no gate reported) |
+| `data#308` | GL1000 display pin |
+| `data#311` | honda §A-2W-1..7 |
+
+Main`s weekly build has failed since 2026-08-10. S4W`s three merged on the
+strict-subset basis; none of mine has. **And Turn 257`s set diff is now stale** —
+measured two days apart on the same branch family, six of the eight failures
+stopped firing and five new ones appeared, with no released-catalog change and
+the same LU window. So the honest instruction is: **re-run the subset check at
+merge time against a same-run baseline.** Do not trust the numbers in any of my
+PR bodies, including the ones I was careful about.
+
+The longer these sit the worse it gets — `#311` alone touches renames,
+former_ids and DEBT, and every S4W PR that lands raises the conflict surface.

--- a/overrides/models/drop_patterns.yml
+++ b/overrides/models/drop_patterns.yml
@@ -82,6 +82,23 @@ car:
   - '\A90[1-6](?:[\s.-]+\d*\s*|)(KA|AC|BA|OK)'  # chassis + body-code forms, separator optional and no trailing boundary: "906 AC 30", "906 KA 35", "902 KA", "906 BA35", "906BA35", "906OK30", "906BA50"
   - '\A90[1-6][.-]\d' # dotted/hyphened chassis sub-codes: "903.6 308CDI", "902.6 KA", "905.6", "904.6 413CDI" (nl personenauto carries the whole W90x zoo, n=1 each — measured)
   - '\A906\z'         # bare W906. NOTE make-blind: would also hit a bare Porsche "906" raw (none in any corpus to date). Bare "903"/"904" are deliberately NOT dropped — porsche/904 is a live id fed by the bare raw; stray Mercedes car-class "903"/"904" rows are single-source n~1 and cannot pass the 2-source/threshold entry rule
+  # MAKE-SCOPED (mapping shape, pipeline#… — a bare string stays make-blind).
+  # Bare "903"/"904" are the W903/W904 Sprinter chassis codes, and renames.yml
+  # folds them to "Sprinter" for the van/truck kinds where they belong (raw
+  # "903" x22 fi+nl, "904" x6). Renames are KIND-BLIND, so the same fold fired
+  # in the car kind and minted car/mercedes-benz/sprinter on [fi,nl] against the
+  # pinned spotcheck — with body_types ["hatchback"], which is the tell.
+  #
+  # This could not be written as a bare pattern: `porsche/904` is a LIVE id
+  # [nl,nz] fed by the identical raw, and a make-blind `\A90[34]\z` would delete
+  # it. That is why the previous note here said 903/904 were deliberately left
+  # undropped and leaned on "single-source n~1 cannot pass the 2-source rule" —
+  # a premise the 2026-08-21 refresh falsified, since the leaked record is
+  # exactly [fi,nl]. MEASURED, not argued: deleting the two rename keys instead
+  # clears this spotcheck but mints van/mercedes-benz/903 and
+  # truck/mercedes-benz/904 as live chassis-code nameplates (experiment build
+  # 32446885634) — one failure removed, two added.
+  - { make: Mercedes-Benz, pattern: '\A90[34]\z' }
   - '\b(SPINTER|SPRINER|SRINTER)\b'  # Sprinter MISSPELLINGS in passenger-car classes (fi M1 "SPINTER" x15, "SPINTER 310CDI PROSTYLE TREND", "SRINTER 316CDI-3.5T-906633/367" — measured); the van/truck-kind misspelling rows fold to van/truck sprinter via renames, untouched by this car-kind drop
 
 van: []

--- a/overrides/models/drop_patterns.yml
+++ b/overrides/models/drop_patterns.yml
@@ -65,7 +65,21 @@ car:
   # the pinned spotcheck "Sprinter is kind=van/truck; must not leak into cars" —
   # the exact CADDYMAXI mechanism (#67) two entries up. Kind van carries this
   # volume natively. (Mercedes trim dossier wave 3, §3.0 C resolved per spotcheck.)
-  - '\A90[1-6][\s.-]+\d*\s*(KA|AC|BA|OK)\b'  # chassis + body-code forms: "906 AC 30", "906 KA 35", "902 KA"
+  # SEPARATOR AND BOUNDARY RELAXED 2026-08-21. Was:
+  #     \A90[1-6][\s.-]+\d*\s*(KA|AC|BA|OK)\b
+  # which required a separator after the chassis number and a word boundary
+  # after the body code. The register writes FUSED forms and the renames block
+  # right beside it already keys them — "906BA35", "906OK30", "906BA50" have no
+  # separator at all, and "906 BA35" has one but glues the body code to its
+  # size, so the trailing \b lands between "A" and "3" and never matches. All
+  # four escaped this drop, reached the renames, folded to "Sprinter", and minted
+  # car/mercedes-benz/sprinter against the pinned spotcheck.
+  #
+  # This is the SAME trap already documented on the \bSPRINTER entry at the top
+  # of this list ("No trailing \b: fi_traficom writes FUSED grades") — a drop
+  # pattern is a RAW-string match, and registers vary separators freely. Where
+  # a fused spelling exists, the bounded form is the one that is wrong.
+  - '\A90[1-6](?:[\s.-]+\d*\s*|)(KA|AC|BA|OK)'  # chassis + body-code forms, separator optional and no trailing boundary: "906 AC 30", "906 KA 35", "902 KA", "906 BA35", "906BA35", "906OK30", "906BA50"
   - '\A90[1-6][.-]\d' # dotted/hyphened chassis sub-codes: "903.6 308CDI", "902.6 KA", "905.6", "904.6 413CDI" (nl personenauto carries the whole W90x zoo, n=1 each — measured)
   - '\A906\z'         # bare W906. NOTE make-blind: would also hit a bare Porsche "906" raw (none in any corpus to date). Bare "903"/"904" are deliberately NOT dropped — porsche/904 is a live id fed by the bare raw; stray Mercedes car-class "903"/"904" rows are single-source n~1 and cannot pass the 2-source/threshold entry rule
   - '\b(SPINTER|SPRINER|SRINTER)\b'  # Sprinter MISSPELLINGS in passenger-car classes (fi M1 "SPINTER" x15, "SPINTER 310CDI PROSTYLE TREND", "SRINTER 316CDI-3.5T-906633/367" — measured); the van/truck-kind misspelling rows fold to van/truck sprinter via renames, untouched by this car-kind drop


### PR DESCRIPTION
Targets the last of the nine 4-wheel gate failures I claimed, and the last
non-2W blocker on the 2026.08.3 release:

  spotcheck  mercedes-benz/sprinter should NOT exist (kind=car)

THE MECHANISM. `car/mercedes-benz/sprinter` is live on [fi,nl] against a pinned
spotcheck. The `\bSPRINTER` drop at the top of the car list never sees these
rows, because the raws spell the W901-W906 CHASSIS CODE, not the nameplate —
that is already documented, and a pattern exists for it:

    \A90[1-6][\s.-]+\d*\s*(KA|AC|BA|OK)\b

It requires a SEPARATOR after the chassis number and a WORD BOUNDARY after the
body code, and the register writes neither reliably. Measured against the
Mercedes-Benz rename keys that produce "Sprinter" — 32 of them — TEN escaped
every car drop pattern and so reached the renames and folded to "Sprinter":

    "906BA35"  "906OK30"  "906BA50"   fused: no separator at all
    "906 BA35"                        separator present, but the body code is
                                      glued to its size, so the trailing \b
                                      lands between "A" and "3" and never fires

THIS IS THE SAME TRAP THE FILE ALREADY DOCUMENTS one screen above, on the
`\bSPRINTER` entry: *"No trailing \b: fi_traficom writes FUSED grades
('SPRINTER313 CDI')"*. The lesson was learned for the nameplate and not applied
to the chassis codes beside it. It is also the same shape as data#310's five
resurrections — a raw-string matcher meeting a register that varies separators
freely.

THE FIX, and the second version rather than the first:

    \A90[1-6](?:[\s.-]+\d*\s*|)(KA|AC|BA|OK)

My first attempt made the separator merely optional (`[\s.-]*\d*\s*`), which
over-matched: "9061 BAKKIE" dropped, because `\d*` swallowed the extra chassis
digit and "BA" then matched inside "BAKKIE". Caught by a probe, not by the
build. The shipped form allows EITHER a separator (with optional digits) OR the
body code glued directly — nothing in between.

VERIFIED BOTH DIRECTIONS, isolated to this pattern rather than the whole list
(the list contains \bKANGOO\b, which made a probe look like a false positive
until I separated them — reported here because it nearly became a wrong
conclusion):

    "906 BA35" "906BA35" "906OK30" "906BA50"  now dropped   (were not)
    "906 AC 30" "906 KA 35" "902-6 KA" "902 KA" "906 OK 30"  still dropped
    "9061 BAKKIE" "9060 KANGOO" "900 KA" "907 KA 35" "9065 ACTROS"  not dropped

REGRESSION CHECK: all 17 forms the old pattern dropped are still dropped. Zero
lost. lint_overrides OK.

⚠ WHAT I HAVE NOT CLOSED, stated because a drop list that looks complete is
worse than one that admits its edge. SIX of the 32 keys still escape:

    "903", "904"                    DELIBERATE — the file already explains it:
                                    porsche/904 is a live id fed by the bare raw
    "312D-Ka-903462-Kasten"         German Kasten (panel-van) body codes. I did
    "312D-Ka-903463-Kasten"         NOT add a pattern: the TRANSPORTER entry in
    "412D-Ka-904463-Kasten"         this same file explicitly warns that drops
                                    fire on the RAW before renames, so a broad
                                    KASTEN drop would kill the VW
                                    KASTENWAGEN folds and orphan their id
    "Transfer"                      a bare dictionary word; a make-blind drop
                                    here is not safe

So this PR fixes the mechanism I could PROVE and names the four candidates it
does not cover. If the spotcheck still fails on this branch's build, the answer
is among those four, and the next change has its shortlist rather than starting
over. The build is the adjudicator — I could not identify which raw fires from
a local cache that predates the 08-21 refresh, and I would rather say that than
imply I traced it to a row.