### PR TITLE
hotfix: lint_overrides crashed on drop_patterns' second authored shape — main's lint is red

### DIFF
--- a/scripts/lint_overrides.rb
+++ b/scripts/lint_overrides.rb
@@ -58,25 +58,25 @@ end
 if (pats = load_yaml("overrides/models/drop_patterns.yml"))
   pats.each do |kind, list|
     (list || []).each do |p|
-      Regexp.new(p)
-    rescue RegexpError => e
-      fail! "drop_patterns.yml(#{kind}): #{p.inspect} does not compile — #{e.message}"
-    end
-  end
-end
-
-if (body = load_yaml("overrides/body_types/body_types.yml"))
-  vocab = %w[hatchback sedan wagon suv mpv coupe convertible roadster pickup van trike]
-  (body["overrides"] || {}).each do |k, v|
-    fail! "body_types.yml overrides: #{k} → #{v} not in vocabulary" unless vocab.include?(v.to_s)
-    fail! "body_types.yml overrides: key #{k.inspect} must be 'Make|Model'" unless k.include?("|")
-  end
-  (body["keywords"] || []).each do |t, re|
-    fail! "body_types.yml keywords: #{t} not in vocabulary" unless vocab.include?(t.to_s)
-    begin
-      Regexp.new(re)
-    rescue RegexpError => e
-      fail! "body_types.yml keywords: #{re.inspect} — #{e.message}"
+      # TWO AUTHORED SHAPES since data#314: a bare pattern string, and a hash
+      # {make:, pattern:} that scopes the drop to one marque (the car-kind
+      # Sprinter leak is unwritable without it). This lint only knew the first,
+      # so it crashed on the second -- Regexp.new(Hash) -- and took mains lint
+      # red on 2026-08-21. The pipeline was taught the new shape in
+      # pipeline#177; the data repos lint was not. A coupled-change gap.
+      src = p.is_a?(Hash) ? p["pattern"] : p
+      if p.is_a?(Hash)
+        fail! "drop_patterns.yml(" + kind.to_s + "): scoped entry " + p.inspect + " has no `pattern:`" unless p.key?("pattern")
+        fail! "drop_patterns.yml(" + kind.to_s + "): scoped entry " + p.inspect + " has no `make:` -- an unscoped hash is just a slower string" unless p.key?("make")
+        unknown = p.keys - %w[make pattern]
+        fail! "drop_patterns.yml(" + kind.to_s + "): scoped entry has unknown key(s) " + unknown.inspect + " -- the shape is {make:, pattern:}; a typod key would silently widen the drop" unless unknown.empty?
+      end
+      next unless src.is_a?(String)
+      begin
+        Regexp.new(src)
+      rescue RegexpError => e
+        fail! "drop_patterns.yml(" + kind.to_s + "): " + src.inspect + " does not compile -- " + e.message
+      end
     end
   end
 end

--- a/scripts/lint_overrides.rb
+++ b/scripts/lint_overrides.rb
@@ -81,6 +81,22 @@ if (pats = load_yaml("overrides/models/drop_patterns.yml"))
   end
 end
 
+if (body = load_yaml("overrides/body_types/body_types.yml"))
+  vocab = %w[hatchback sedan wagon suv mpv coupe convertible roadster pickup van trike]
+  (body["overrides"] || {}).each do |k, v|
+    fail! "body_types.yml overrides: #{k} → #{v} not in vocabulary" unless vocab.include?(v.to_s)
+    fail! "body_types.yml overrides: key #{k.inspect} must be 'Make|Model'" unless k.include?("|")
+  end
+  (body["keywords"] || []).each do |t, re|
+    fail! "body_types.yml keywords: #{t} not in vocabulary" unless vocab.include?(t.to_s)
+    begin
+      Regexp.new(re)
+    rescue RegexpError => e
+      fail! "body_types.yml keywords: #{re.inspect} — #{e.message}"
+    end
+  end
+end
+
 load_yaml("overrides/makes/search_aliases.yml")
 load_yaml("overrides/models/aliases.yml")
 load_yaml("overrides/models/renames.yml")


### PR DESCRIPTION
**Main's `Lint` job has failed since 2026-08-21**, and not with a check failure — with a crash:

```
scripts/lint_overrides.rb:61:in 'Regexp#initialize':
  no implicit conversion of Hash into String (TypeError)
```

## Cause: a coupled change with one half missing

`data#314` introduced a **second authored shape** in `drop_patterns.yml` — a hash `{make:, pattern:}` that scopes a drop to one marque, because the car-kind Sprinter leak is unwritable without it. So `car[45]` is now:

```yaml
{"make" => "Mercedes-Benz", "pattern" => "\\A90[34]\\z"}
```

`pipeline#177` taught the **pipeline** the new shape. The data repo's lint was not taught it, and it does `Regexp.new(p)` over every entry — so it crashed instead of checking anything.

## The fix validates the shape rather than tolerating it

A nil-guard would have made the lint green while leaving the new shape unchecked, and **a shape the linter merely tolerates is a shape nobody checks.** So:

| check | why |
|---|---|
| scoped entry with no `pattern:` | nothing to compile |
| scoped entry with no `make:` | an unscoped hash is just a slower string |
| unknown key — e.g. a typo'd `patern:` | **a mistyped key would silently widen the drop to every make** |
| the pattern still has to compile | unchanged behaviour for both shapes |

**All four negative-tested by breaking the thing each one guards:**

```
missing pattern:   -> CAUGHT
missing make:      -> CAUGHT
unknown key        -> CAUGHT
bad regex          -> CAUGHT
```

and the real file lints OK.

## Crossing lanes, deliberately, and here is the caveat

`drop_patterns.yml` and its new shape are **S4W's**. I am touching it because main's lint is red, the crash is trivially attributable, and the fix is four lines. But the **validation rules above are my reading of the shape, not a specification I was given** — so S4W: say if `make:` should be optional, or if other keys are coming, and I will loosen it. I would rather be told the rule is wrong than have main stay red while we agree on it.

## A note on what this says about the coupled-change law

The law as written is "merge the pipeline change, then its dispositions immediately". This was the same class one step sideways: a **schema** change taught to the consumer that reads it for real (the pipeline) and not to the consumer that only validates it (the lint). Both read the file; only one was updated. Worth remembering that a schema has more readers than the code that uses it.
