### PR TITLE
ci: pin the DuckDB CLI to a release asset — the install script 404'd and every gate step was skipped for two weekly runs

### DIFF
--- a/.github/workflows/monthly-build.yml
+++ b/.github/workflows/monthly-build.yml
@@ -95,10 +95,28 @@ jobs:
         with:
           ruby-version: "3.4"
 
+      # PINNED to a GitHub release asset, not the install script. The script
+      # route (`curl -sL https://install.duckdb.org | sh`) 404'd on its internal
+      # tarball on 2026-08-24 and 2026-08-31: `tar` aborted, this step failed,
+      # and every step after it — cache restore, tests, claims lint, THE BUILD —
+      # was SKIPPED for two consecutive weekly runs. The failure handler then
+      # filed issue #321 pointing at "the gate that tripped", and there was no
+      # gate in the log at all: main's real gate state was unknown for two weeks.
+      # A pinned URL + checksum either serves the same bytes or fails loudly
+      # HERE, with the cause in this step's own output. Bump the version and the
+      # hash together; `sha256sum -c` refuses a mismatch.
       - name: Install duckdb (parquet emitter)
         run: |
-          curl -sL https://install.duckdb.org | sh
-          echo "$HOME/.duckdb/cli/latest" >> "$GITHUB_PATH"
+          set -euo pipefail
+          DUCKDB_VERSION=v1.5.5
+          DUCKDB_SHA256=08c0ca117111fcede14239d0093792352befdc174218c344d232c13279643d05
+          curl -fsSL --retry 3 -o /tmp/duckdb_cli.zip \
+            "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip"
+          echo "${DUCKDB_SHA256}  /tmp/duckdb_cli.zip" | sha256sum -c -
+          mkdir -p "$HOME/.duckdb/bin"
+          unzip -oq /tmp/duckdb_cli.zip -d "$HOME/.duckdb/bin"
+          echo "$HOME/.duckdb/bin" >> "$GITHUB_PATH"
+          "$HOME/.duckdb/bin/duckdb" --version
 
       - name: Restore source cache
         uses: actions/cache@v4


### PR DESCRIPTION
## What

`.github/workflows/monthly-build.yml` step 5 (`Install duckdb`) ran `curl -sL https://install.duckdb.org | sh`. On **2026-08-24** and **2026-08-31** the script's internal tarball URL returned 404, `tar` aborted, and the job failed at step 5 — so steps 6–10 (**cache restore, pipeline tests, claims lint, the build**) were SKIPPED on both weekly runs (runs 32692323521 and 33384778438: `curl: (22) The requested URL returned error: 404` → `tar: Error is not recoverable: exiting now`).

Issue #321 ("see the job log for the gate that tripped") has been pointing at a log with **no gate in it** for two weeks. Main's real gate state has been unknown since 08-21 (last PR-check build on main's tip: 3 id-contract failures, all 2W; data#319 closes them).

## The fix

Pin the CLI to the GitHub release asset with its checksum:

- `https://github.com/duckdb/duckdb/releases/download/v1.5.5/duckdb_cli-linux-amd64.zip`
- sha256 `08c0ca117111fcede14239d0093792352befdc174218c344d232c13279643d05` (measured from a fresh download on 2026-09-05; `sha256sum -c` refuses a mismatch)
- `set -euo pipefail`, `curl -f --retry 3`, and `duckdb --version` at the end so the step's own output says what it installed.

A pinned URL either serves the same bytes or fails loudly HERE with the cause in this step's output. Bump version and hash together.

## Verification

This PR touches the workflow file, which is on the workflow's own `pull_request` path filter — so the build job runs on this PR and is the proof: the install step must pass and the run must reach the real gate set. After merge: a `workflow_dispatch` (publish=false) on main, then #321 gets the finding and closes on a green validate run.

## Not in this PR

The gates themselves. Whatever the first real validate run reports is the next item, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwaixVBzqsFRurCpYn6wcL
